### PR TITLE
Adding startree support during realtime segment creation

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
@@ -33,6 +33,7 @@ public class IndexingConfig {
   private String loadMode;
   private String lazyLoad;
   private Map<String, String> streamConfigs = new HashMap<String, String>();
+  private Map<String, String> starTreeIndexSpecConfigs = new HashMap<String, String>();
 
   public IndexingConfig() {
 
@@ -60,6 +61,13 @@ public class IndexingConfig {
 
   public void setInvertedIndexColumns(List<String> invertedIndexColumns) {
     this.invertedIndexColumns = invertedIndexColumns;
+  }
+  public Map<String, String> getStarTreeIndexSpecConfigs() {
+    return starTreeIndexSpecConfigs;
+  }
+
+  public void setStarTreeIndexSpecConfigs(Map<String, String> starTreeIndexSpecConfigs) {
+    this.starTreeIndexSpecConfigs = starTreeIndexSpecConfigs;
   }
 
   public String getLoadMode() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -21,6 +21,7 @@ import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.plist.PropertyListConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -82,6 +83,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
   private final String sortedColumn;
   private final List<String> invertedIndexColumns;
+  private final StarTreeIndexSpec starTreeIndexSpec;
   private Logger segmentLogger = LOGGER;
 
   // An instance of this class exists only for the duration of the realtime segment that is currently being consumed.
@@ -116,6 +118,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     //inverted index columns
     invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
 
+    //StarTree index spec
+    starTreeIndexSpec = new StarTreeIndexSpec(indexingConfig.getStarTreeIndexSpecConfigs());
     this.segmentMetatdaZk = segmentMetadata;
 
     // create and init stream provider config
@@ -202,7 +206,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           // lets convert the segment now
           RealtimeSegmentConverter converter =
               new RealtimeSegmentConverter(realtimeSegment, tempSegmentFolder.getAbsolutePath(), schema,
-                  segmentMetadata.getTableName(), segmentMetadata.getSegmentName(), sortedColumn, invertedIndexColumns);
+                  segmentMetadata.getTableName(), segmentMetadata.getSegmentName(), sortedColumn, invertedIndexColumns,
+                  starTreeIndexSpec);
 
           segmentLogger.info("Trying to build segment");
           final long buildStartTime = System.nanoTime();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
 import com.linkedin.pinot.core.data.readers.RecordReader;
@@ -38,9 +39,11 @@ public class RealtimeSegmentConverter {
   private String segmentName;
   private String sortedColumn;
   private List<String> invertedIndexColumns;
+  private StarTreeIndexSpec starTreeIndexSpec;
 
   public RealtimeSegmentConverter(RealtimeSegmentImpl realtimeSegment, String outputPath, Schema schema,
-      String tableName, String segmentName, String sortedColumn, List<String> invertedIndexColumns) {
+      String tableName, String segmentName, String sortedColumn, List<String> invertedIndexColumns,
+      StarTreeIndexSpec starTreeIndexSpec) {
     if (new File(outputPath).exists()) {
       throw new IllegalAccessError("path already exists:" + outputPath);
     }
@@ -54,8 +57,8 @@ public class RealtimeSegmentConverter {
     for (String dimension : schema.getDimensionNames()) {
       newSchema.addField(dimension, schema.getFieldSpecFor(dimension));
     }
-    for (String metic : schema.getMetricNames()) {
-      newSchema.addField(metic, schema.getFieldSpecFor(metic));
+    for (String metric : schema.getMetricNames()) {
+      newSchema.addField(metric, schema.getFieldSpecFor(metric));
     }
 
     newSchema.addField(newTimeSpec.getName(), newTimeSpec);
@@ -66,11 +69,13 @@ public class RealtimeSegmentConverter {
     this.sortedColumn = sortedColumn;
     this.tableName = tableName;
     this.segmentName = segmentName;
+    this.starTreeIndexSpec = starTreeIndexSpec;
   }
 
   public RealtimeSegmentConverter(RealtimeSegmentImpl realtimeSegment, String outputPath, Schema schema,
       String tableName, String segmentName, String sortedColumn) {
-    this(realtimeSegment, outputPath, schema, tableName, segmentName, sortedColumn, new ArrayList<String>());
+    this(realtimeSegment, outputPath, schema, tableName, segmentName, sortedColumn, new ArrayList<String>(),
+        new StarTreeIndexSpec());
   }
 
   public void build() throws Exception {
@@ -88,6 +93,8 @@ public class RealtimeSegmentConverter {
         genConfig.createInvertedIndexForColumn(column);
       }
     }
+    genConfig.setEnableStarTreeIndex(starTreeIndexSpec.enableStarTree());
+    genConfig.setStarTreeIndexSpec(starTreeIndexSpec);
     genConfig.setTimeColumnName(dataSchema.getTimeFieldSpec().getOutGoingTimeColumnName());
     genConfig.setSegmentTimeUnit(dataSchema.getTimeFieldSpec().getOutgoingGranularitySpec().getTimeType());
     genConfig.setSegmentVersion(SegmentVersion.v1);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
@@ -158,6 +158,8 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     if (timeColumnName != null) {
       dimensionNames.add(timeColumnName);
       dimensionTypes.add(schema.getTimeFieldSpec().getDataType());
+      Object starValue = schema.getTimeFieldSpec().getDefaultNullValue();
+      dimensionNameToStarValueMap.put(timeColumnName, starValue);
       int index = dimensionNameToIndexMap.size();
       dimensionNameToIndexMap.put(timeColumnName, index);
       HashBiMap<Object, Integer> dictionary = HashBiMap.create();


### PR DESCRIPTION
sample config inside：

  "tableIndexConfig" : {
    "invertedIndexColumns" : [],
    "loadMode"  : "MMAP",
    "lazyLoad"  : "false",
    "sortedColumn" : ["secondsSinceEpoch"],
    "starTreeIndexSpecConfigs" : {
      "enableStarTree": "true",
      "maxLeafRecords": "50000",
      "skipStarNodeCreationForDimensions": "uuid",
      "skipMaterializationCardinalityThreshold": "10000"
    },
    "streamConfigs" : {
      "stream.kafka.consumer.type": "highLevel",
      "stream.kafka.decoder.class.name": "com.linkedin.pinot.core.realtime.impl.kafka.KafkaJSONMessageDecoder",
      "stream.kafka.hlc.zk.connect.string": "localhost:2181/kafka",
      "stream.kafka.topic.name": "pinot-test",
      "stream.kafka.consumer.prop.auto.offset.reset":"smallest",
      "streamType": "kafka",
      "realtime.segment.flush.threshold.size":"500000",
      "realtime.segment.flush.threshold.time":"18000000"
    }
  },
