### PR TITLE
Simulate function triggers across time range

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/driver/AnomalyDetectionJobManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/driver/AnomalyDetectionJobManager.java
@@ -42,7 +42,6 @@ import com.linkedin.thirdeye.detector.function.AnomalyFunction;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 
 public class AnomalyDetectionJobManager {
-  public static final String MONITORING_WINDOW_KEY = "monitoringWindow";
   private static final Logger LOG = LoggerFactory.getLogger(AnomalyDetectionJobManager.class);
   private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry
       .getInstance();
@@ -244,7 +243,7 @@ public class AnomalyDetectionJobManager {
     for (Interval simulationInterval : simulationIntervals) {
       DateTime intervalStart = simulationInterval.getStart();
       DateTime intervalEnd = simulationInterval.getEnd();
-      LOG.info("Running {} with monitoring window: {} to {}", id, intervalStart, intervalEnd);
+      LOG.info("Running {} with interval: {} to {}", id, intervalStart, intervalEnd);
       try {
         String triggerKey =
             String.format("simulate_period_anomaly_function_trigger_%d_%s-%s", id, intervalStart,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/lib/util/JobUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/lib/util/JobUtils.java
@@ -1,17 +1,23 @@
 package com.linkedin.thirdeye.detector.lib.util;
 
+import java.util.List;
+import java.util.Properties;
+
 import org.apache.commons.mail.DefaultAuthenticator;
 import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.HtmlEmail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Splitter;
 import com.linkedin.thirdeye.detector.driver.FailureEmailConfiguration;
 
 public class JobUtils {
   public static final String EMAIL_ADDRESS_SEPARATOR = ",";
+  private static Splitter SEMICOLON_SPLITTER = Splitter.on(";").omitEmptyStrings();
+  private static Splitter EQUALS_SPLITTER = Splitter.on("=").omitEmptyStrings();
+
   private static final Logger LOG = LoggerFactory.getLogger(JobUtils.class);
-  
 
   /** Sends email according to the provided config. This method does not support html emails. */
   public static void sendFailureEmail(FailureEmailConfiguration config, String subject,
@@ -38,5 +44,14 @@ public class JobUtils {
     } else {
       LOG.error("No failure email configs provided!");
     }
+  }
+
+  public static Properties decodeCompactedProperties(String propStr) {
+    Properties props = new Properties();
+    for (String part : SEMICOLON_SPLITTER.split(propStr)) {
+      List<String> kvPair = EQUALS_SPLITTER.splitToList(part);
+      props.setProperty(kvPair.get(0), kvPair.get(1));
+    }
+    return props;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/resources/AnomalyDetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/resources/AnomalyDetectionJobResource.java
@@ -1,7 +1,5 @@
 package com.linkedin.thirdeye.detector.resources;
 
-import io.dropwizard.hibernate.UnitOfWork;
-
 import java.util.List;
 
 import javax.ws.rs.DELETE;
@@ -18,6 +16,8 @@ import javax.ws.rs.core.Response;
 import com.linkedin.thirdeye.detector.api.AnomalyFunctionSpec;
 import com.linkedin.thirdeye.detector.db.AnomalyFunctionSpecDAO;
 import com.linkedin.thirdeye.detector.driver.AnomalyDetectionJobManager;
+
+import io.dropwizard.hibernate.UnitOfWork;
 
 @Path("/anomaly-jobs")
 @Produces(MediaType.APPLICATION_JSON)
@@ -66,6 +66,15 @@ public class AnomalyDetectionJobResource {
   public Response adHoc(@PathParam("id") Long id, @QueryParam("start") String start,
       @QueryParam("end") String end) throws Exception {
     manager.runAdHoc(id, start, end);
+    return Response.ok().build();
+  }
+
+  @POST
+  @Path("/{id}/simulate-period")
+  @UnitOfWork
+  public Response simulatePeriod(@PathParam("id") Long id, @QueryParam("start") String start,
+      @QueryParam("end") String end) throws Exception {
+    manager.simulatePeriod(id, start, end);
     return Response.ok().build();
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/driver/TestAnomalyDetectionJobManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/driver/TestAnomalyDetectionJobManager.java
@@ -1,0 +1,37 @@
+package com.linkedin.thirdeye.detector.driver;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestAnomalyDetectionJobManager {
+
+  @Test
+  public void getSimulationIntervals() throws ParseException {
+    // Date irrelevant. We want jobs from 00H - 01H window with cron @ 00min, 20min, and 45min
+    // marks, with data size of an
+    // hour.
+    String cron = "0 00,20,45 * * * ?";
+    DateTime start = new DateTime("2016-06-01T00:00:00");
+    DateTime end = start.plusHours(1);
+    long dataWindowMillis = TimeUnit.HOURS.toMillis(1);
+    List<DateTime> fireTimes =
+        Arrays.asList(new DateTime("2016-06-01T00:00:00"), new DateTime("2016-06-01T00:20:00"),
+            new DateTime("2016-06-01T00:45:00"));
+    List<Interval> expected = new ArrayList<>();
+    for (DateTime endDate : fireTimes) {
+      expected.add(new Interval(endDate.minus(dataWindowMillis), endDate));
+    }
+
+    List<Interval> actual =
+        AnomalyDetectionJobManager.getSimulationIntervals(start, end, dataWindowMillis, cron);
+    Assert.assertEquals(actual, expected);
+  }
+}


### PR DESCRIPTION
Adding a new endpoint to run an anomaly function spec for all the fire times that would have appeared during a given [start,end) time range, based on the cron schedule in the function spec. The otherwise equivalent functionality would require manually calculating the fire times and submitting a curl call to the adhoc endpoint.

Another key difference is that the adhoc calls allow for explicitly defining the data input range. This simulation endpoint only defines the start/end of scheduled fire times, so the data input is determined based on the anomaly function spec's data window. 
