### PR TITLE
Remove getDictionary from Datasource class

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/AbstractBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/AbstractBlock.java
@@ -13,32 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.linkedin.pinot.core.operator.blocks;
+package com.linkedin.pinot.core.common;
 
-import java.util.Map;
-
-import com.linkedin.pinot.core.common.AbstractBlock;
-import com.linkedin.pinot.core.common.Block;
-import com.linkedin.pinot.core.common.BlockDocIdSet;
-import com.linkedin.pinot.core.common.BlockDocIdValueSet;
-import com.linkedin.pinot.core.common.BlockId;
-import com.linkedin.pinot.core.common.BlockMetadata;
-import com.linkedin.pinot.core.common.BlockValSet;
-import com.linkedin.pinot.core.common.Predicate;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 /**
- * ProjectionBlock holds a column name to Block Map.
- * It provides DocIdSetBlock and DataBlock for a given column.
+ *
+ * A block represents a set of rows.A segment will contain one or more blocks
+ * Currently, it assumes only one column per block. We might change this in
+ * future
  */
-public class ProjectionBlock extends AbstractBlock {
+public abstract class AbstractBlock implements Block {
 
-  private final Map<String, Block> _blockMap;
-  private final Block _docIdSetBlock;
-
-  public ProjectionBlock(Map<String, Block> blockMap, Block docIdSetBlock) {
-    super();
-    this._blockMap = blockMap;
-    this._docIdSetBlock = docIdSetBlock;
+  @Override
+  public BlockId getId() {
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -47,7 +36,7 @@ public class ProjectionBlock extends AbstractBlock {
   }
 
   @Override
-  public BlockId getId() {
+  public BlockDocIdSet getBlockDocIdSet() {
     throw new UnsupportedOperationException();
   }
 
@@ -62,21 +51,12 @@ public class ProjectionBlock extends AbstractBlock {
   }
 
   @Override
-  public BlockDocIdSet getBlockDocIdSet() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public BlockMetadata getMetadata() {
     throw new UnsupportedOperationException();
   }
 
-  public Block getBlock(String column) {
-    return _blockMap.get(column);
+  @Override
+  public Dictionary getDictionary() {
+    throw new UnsupportedOperationException();
   }
-
-  public Block getDocIdSetBlock() {
-    return _docIdSetBlock;
-  }
-
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/Block.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/Block.java
@@ -15,6 +15,8 @@
  */
 package com.linkedin.pinot.core.common;
 
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+
 /**
  *
  * A block represents a set of rows.A segment will contain one or more blocks
@@ -69,5 +71,6 @@ public interface Block {
    */
   BlockMetadata getMetadata();
 
+  Dictionary getDictionary();
 
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
@@ -35,6 +35,7 @@ public class DataFetcher {
   private final IndexSegment _indexSegment;
 
   private final Map<String, DataSource> _columnToDataSourceMap = new HashMap<>();
+  private final Map<String, Block> _columnToBlockMap = new HashMap<>();
   private final Map<String, Dictionary> _columnToDictionaryMap = new HashMap<>();
   private final Map<String, BlockValSet> _columnToBlockValSetMap = new HashMap<>();
 
@@ -71,10 +72,19 @@ public class DataFetcher {
   public Dictionary getDictionaryForColumn(String column) {
     Dictionary dictionary = _columnToDictionaryMap.get(column);
     if (dictionary == null) {
-      dictionary = getDataSourceForColumn(column).getDictionary();
+      dictionary = getBlockForColumn(column).getDictionary();
       _columnToDictionaryMap.put(column, dictionary);
     }
     return dictionary;
+  }
+
+  public Block getBlockForColumn(String column) {
+    Block block  = _columnToBlockMap.get(column);
+    if (block == null) {
+      block = getDataSourceForColumn(column).nextBlock(BLOCK_ZERO);
+      _columnToBlockMap.put(column, block);
+    }
+    return block;
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataSource.java
@@ -21,11 +21,11 @@ import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 public abstract class DataSource extends BaseOperator {
 
-  public abstract boolean setPredicate(Predicate predicate);
-
   public abstract DataSourceMetadata getDataSourceMetadata();
 
   public abstract InvertedIndexReader getInvertedIndex();
 
-  public abstract Dictionary getDictionary();
+//  public abstract Dictionary getDictionary();
+  
+//  getFilterOperator(Predicate p, startDocId, endDocId);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupKeyGenerator.java
@@ -131,8 +131,8 @@ public class DefaultGroupKeyGenerator implements GroupKeyGenerator {
       if (!isSingleValueGroupByColumn) {
         _hasMultiValueGroupByColumn = true;
       }
-      _dictionaries[i] = dataSource.getDictionary();
       Block block = dataSource.nextBlock(BLOCK_ZERO);
+      _dictionaries[i] = block.getDictionary();
       if (isSingleValueGroupByColumn) {
         _singleBlockValSets[i] = block.getBlockValueSet();
         _reusableSingleDictIds[i] = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/AggregationResultBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/AggregationResultBlock.java
@@ -17,7 +17,7 @@ package com.linkedin.pinot.core.operator.blocks;
 
 import java.io.Serializable;
 
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -26,7 +26,7 @@ import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.Predicate;
 
 
-public class AggregationResultBlock implements Block {
+public class AggregationResultBlock extends AbstractBlock {
 
   private Serializable _aggregationResult;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/BaseFilterBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/BaseFilterBlock.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockMetadata;
@@ -23,7 +23,7 @@ import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.operator.docidsets.FilterBlockDocIdSet;
 
-public abstract class BaseFilterBlock implements Block {
+public abstract class BaseFilterBlock extends AbstractBlock {
 
   @Override
   public boolean applyPredicate(Predicate predicate) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/InstanceResponseBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/InstanceResponseBlock.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.operator.blocks;
 
 import com.linkedin.pinot.common.utils.DataTable;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
@@ -32,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  *
  */
-public class InstanceResponseBlock implements Block {
+public class InstanceResponseBlock extends AbstractBlock {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceResponseBlock.class);
 
   private DataTable _instanceResponseDataTable;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -22,7 +22,7 @@ import com.linkedin.pinot.common.response.ResponseStatistics;
 import com.linkedin.pinot.common.utils.DataTable;
 import com.linkedin.pinot.common.utils.DataTableBuilder;
 import com.linkedin.pinot.common.utils.DataTableBuilder.DataSchema;
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -45,7 +45,7 @@ import java.util.Map;
  *
  *
  */
-public class IntermediateResultsBlock implements Block {
+public class IntermediateResultsBlock extends AbstractBlock {
   private List<AggregationFunction> _aggregationFunctionList;
   private List<Serializable> _aggregationResultList;
   private List<ProcessingException> _processingExceptions;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/MultiValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/MultiValueBlock.java
@@ -16,7 +16,7 @@
 package com.linkedin.pinot.core.operator.blocks;
 
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -29,7 +29,7 @@ import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 
 
-public class MultiValueBlock implements Block {
+public class MultiValueBlock extends AbstractBlock {
 
   final SingleColumnMultiValueReader mVReader;
   private final BlockId id;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeMultiValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeMultiValueBlock.java
@@ -19,7 +19,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -31,7 +31,7 @@ import com.linkedin.pinot.core.operator.docvalsets.RealtimeMultiValueSet;
 import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionaryReader;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
-public class RealtimeMultiValueBlock implements Block {
+public class RealtimeMultiValueBlock extends AbstractBlock {
 
   private final MutableRoaringBitmap filteredBitmap;
   final FieldSpec spec;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
@@ -19,7 +19,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -29,9 +29,10 @@ import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.operator.docvalsets.RealtimeSingleValueSet;
 import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionaryReader;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 
-public class RealtimeSingleValueBlock implements Block {
+public class RealtimeSingleValueBlock extends AbstractBlock {
 
   private final MutableRoaringBitmap filteredBitmap;
   final FieldSpec spec;
@@ -147,5 +148,9 @@ public class RealtimeSingleValueBlock implements Block {
         return spec.getDataType();
       }
     };
+  }
+  @Override
+  public Dictionary getDictionary() {
+    return dictionary;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/SortedSingleValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/SortedSingleValueBlock.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -31,16 +31,18 @@ import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
  * Nov 15, 2014
  */
 
-public class SortedSingleValueBlock implements Block {
+public class SortedSingleValueBlock extends AbstractBlock {
 
   final SortedForwardIndexReader sVReader;
   private final BlockId id;
   private final BlockMetadata blockMetadata;
+  private ImmutableDictionaryReader dictionaryReader;
 
   public SortedSingleValueBlock(BlockId id, SortedForwardIndexReader singleValueReader,
       ImmutableDictionaryReader dictionaryReader, ColumnMetadata columnMetadata) {
     sVReader = singleValueReader;
     this.id = id;
+    this.dictionaryReader = dictionaryReader;
     this.blockMetadata = new BlockMetadataImpl(columnMetadata, dictionaryReader);
   }
 
@@ -73,4 +75,8 @@ public class SortedSingleValueBlock implements Block {
   public BlockMetadata getMetadata() {
     return blockMetadata;
   }
+  
+  public com.linkedin.pinot.core.segment.index.readers.Dictionary getDictionary() {
+    return dictionaryReader;
+  };
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/UnSortedSingleValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/UnSortedSingleValueBlock.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -28,7 +28,7 @@ import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 
 
-public class UnSortedSingleValueBlock implements Block {
+public class UnSortedSingleValueBlock extends AbstractBlock {
 
   final SingleColumnSingleValueReader sVReader;
   private final BlockId id;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/DocIdSetBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/DocIdSetBlock.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.docidsets;
 
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -24,7 +24,7 @@ import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.Predicate;
 
 
-public class DocIdSetBlock implements Block {
+public class DocIdSetBlock extends AbstractBlock {
 
   final int[] _docIdArray;
   final int _searchableLength;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/BitmapBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/BitmapBasedFilterOperator.java
@@ -63,7 +63,7 @@ public class BitmapBasedFilterOperator extends BaseFilterOperator {
     Predicate predicate = getPredicate();
     InvertedIndexReader invertedIndex = dataSource.getInvertedIndex();
     Block dataSourceBlock = dataSource.nextBlock();
-    Dictionary dictionary = dataSource.getDictionary();
+    Dictionary dictionary = dataSourceBlock.getDictionary();
     PredicateEvaluator evaluator = PredicateEvaluatorProvider.getPredicateFunctionFor(predicate, dictionary);
     int[] dictionaryIds;
     boolean exclusion = false;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -64,10 +64,10 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
   @Override
   public BaseFilterBlock nextFilterBlock(BlockId BlockId) {
     Predicate predicate = getPredicate();
-    Dictionary dictionary = dataSource.getDictionary();
     DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
     FilterBlockDocIdSet docIdSet;
     Block nextBlock = dataSource.nextBlock();
+    Dictionary dictionary = nextBlock.getDictionary();
     BlockValSet blockValueSet = nextBlock.getBlockValueSet();
     BlockMetadata blockMetadata = nextBlock.getMetadata();
     PredicateEvaluator evaluator = PredicateEvaluatorProvider.getPredicateFunctionFor(predicate, dictionary);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
@@ -71,7 +71,8 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
   public BaseFilterBlock nextFilterBlock(BlockId BlockId) {
     Predicate predicate = getPredicate();
     final SortedInvertedIndexReader invertedIndex = (SortedInvertedIndexReader) dataSource.getInvertedIndex();
-    Dictionary dictionary = dataSource.getDictionary();
+    //TODO: push this into the data source.
+    Dictionary dictionary = dataSource.getNextBlock().getDictionary();
     List<IntPair> pairs = new ArrayList<IntPair>();
     PredicateEvaluator evaluator = PredicateEvaluatorProvider.getPredicateFunctionFor(predicate, dictionary);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/StarTreeIndexOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/StarTreeIndexOperator.java
@@ -102,7 +102,8 @@ public class StarTreeIndexOperator extends BaseFilterOperator {
     String column = childFilter.getColumn();
     // Only equality predicates are supported
     Predicate predicate = Predicate.newPredicate(childFilter);
-    Dictionary dictionary = segment.getDataSource(column).getDictionary();
+    //TODO: push this into the data source.
+    Dictionary dictionary = segment.getDataSource(column).getNextBlock().getDictionary();
     PredicateEntry predicateEntry = null;
 
     PredicateEvaluator predicateEvaluator =

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -127,8 +127,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
   private boolean isGroupKeyFitForLong(IndexSegment indexSegment, BrokerRequest brokerRequest) {
     int totalBitSet = 0;
     for (final String column : brokerRequest.getGroupBy().getColumns()) {
-      Dictionary dictionary = indexSegment.getDataSource(column).getDictionary();
-      totalBitSet += BitHacks.findLogBase2(dictionary.length()) + 1;
+      int cardinality = indexSegment.getDataSource(column).getDataSourceMetadata().cardinality();
+      totalBitSet += BitHacks.findLogBase2(cardinality) + 1;
     }
     if (totalBitSet > 64) {
       return false;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -368,12 +368,6 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
         dictionaryMap.get(columnName));
   }
 
-  public DataSource getDataSource(String columnName, Predicate p) {
-    DataSource ds = getDataSource(columnName);
-    ds.setPredicate(p);
-    return ds;
-  }
-
   @Override
   public String[] getColumnNames() {
     return dataSchema.getColumnNames().toArray(new String[0]);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
@@ -112,10 +112,10 @@ public class RealtimeColumnDataSource extends DataSource {
     return true;
   }
 
-  @Override
-  public boolean setPredicate(Predicate predicate) {
-    throw new UnsupportedOperationException("cannot set predicate on the data source");
-  }
+//  @Override
+//  public boolean setPredicate(Predicate predicate) {
+//    throw new UnsupportedOperationException("cannot set predicate on the data source");
+//  }
 
   private double getLargerDoubleValue(double value) {
     long bitsValue = Double.doubleToLongBits(value);
@@ -190,8 +190,8 @@ public class RealtimeColumnDataSource extends DataSource {
     return invertedIndex;
   }
 
-  @Override
-  public Dictionary getDictionary() {
-    return dictionary;
-  }
+//  @Override
+//  public Dictionary getDictionary() {
+//    return dictionary;
+//  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/data/source/ColumnDataSourceImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/data/source/ColumnDataSourceImpl.java
@@ -102,10 +102,10 @@ public class ColumnDataSourceImpl extends DataSource {
     return true;
   }
 
-  @Override
-  public boolean setPredicate(Predicate p) {
-    throw new UnsupportedOperationException("cannnot setPredicate on data source");
-  }
+//  @Override
+//  public boolean setPredicate(Predicate p) {
+//    throw new UnsupportedOperationException("cannnot setPredicate on data source");
+//  }
 
   @Override
   public DataSourceMetadata getDataSourceMetadata() {
@@ -156,8 +156,8 @@ public class ColumnDataSourceImpl extends DataSource {
     return indexContainer.getInvertedIndex();
   }
 
-  @Override
-  public Dictionary getDictionary() {
-    return indexContainer.getDictionary();
-  }
+//  @Override
+//  public Dictionary getDictionary() {
+//    return indexContainer.getDictionary();
+//  }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
@@ -49,6 +49,7 @@ import com.linkedin.pinot.core.operator.filter.ScanBasedFilterOperator;
 import com.linkedin.pinot.core.realtime.impl.FileBasedStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.impl.FileBasedStreamProviderImpl;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.segments.v1.creator.SegmentTestUtils;
 
 public class RealtimeSegmentTest {
@@ -126,8 +127,11 @@ public class RealtimeSegmentTest {
 
   @Test
   public void testMetricPredicateWithInvIdx() throws Exception {
+    DataSource ds = segmentWithInvIdx.getDataSource("count");
+    Block block = ds.nextBlock();
+    Dictionary dictionary = block.getDictionary();
+    
     DataSource ds1 = segmentWithInvIdx.getDataSource("count");
-
     BitmapBasedFilterOperator op = new BitmapBasedFilterOperator(ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("890662862");
@@ -144,7 +148,7 @@ public class RealtimeSegmentTest {
     int counter = 0;
     while (docId != Constants.EOF) {
       blockValIterator.skipTo(docId);
-      Assert.assertEquals(ds1.getDictionary().get(blockValIterator.nextIntVal()), 890662862);
+      Assert.assertEquals(dictionary.get(blockValIterator.nextIntVal()), 890662862);
       docId = iterator.next();
       counter++;
     }
@@ -153,8 +157,11 @@ public class RealtimeSegmentTest {
 
   @Test
   public void testMetricPredicateWithoutInvIdx() throws Exception {
+    DataSource ds = segmentWithInvIdx.getDataSource("count");
+    Block block = ds.nextBlock();
+    Dictionary dictionary = block.getDictionary();
+    
     DataSource ds1 = segmentWithoutInvIdx.getDataSource("count");
-
     ScanBasedFilterOperator op = new ScanBasedFilterOperator(ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("890662862");
@@ -171,7 +178,7 @@ public class RealtimeSegmentTest {
     int counter = 0;
     while (docId != Constants.EOF) {
       blockValIterator.skipTo(docId);
-      Assert.assertEquals(ds1.getDictionary().get(blockValIterator.nextIntVal()), 890662862);
+      Assert.assertEquals(dictionary.get(blockValIterator.nextIntVal()), 890662862);
       docId = iterator.next();
       counter++;
     }
@@ -181,7 +188,6 @@ public class RealtimeSegmentTest {
   @Test
   public void testNoMatchFilteringMetricPredicateWithInvIdx() throws Exception {
     DataSource ds1 = segmentWithInvIdx.getDataSource("count");
-
     BitmapBasedFilterOperator op = new BitmapBasedFilterOperator(ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("890662862");
@@ -228,8 +234,11 @@ public class RealtimeSegmentTest {
 
   @Test
   public void testRangeMatchFilteringMetricPredicateWithInvIdx() throws Exception {
-    DataSource ds1 = segmentWithInvIdx.getDataSource("count");
+    DataSource ds = segmentWithInvIdx.getDataSource("count");
+    Block block = ds.nextBlock();
+    Dictionary dictionary = block.getDictionary();
 
+    DataSource ds1 = segmentWithInvIdx.getDataSource("count");
     BitmapBasedFilterOperator op = new BitmapBasedFilterOperator(ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("[0\t\t*)");
@@ -246,7 +255,7 @@ public class RealtimeSegmentTest {
     int counter = 0;
     while (docId != Constants.EOF) {
       blockValIterator.skipTo(docId);
-      Assert.assertEquals(ds1.getDictionary().get(blockValIterator.nextIntVal()), 890662862);
+      Assert.assertEquals(dictionary.get(blockValIterator.nextIntVal()), 890662862);
       docId = iterator.next();
       counter++;
     }
@@ -255,8 +264,11 @@ public class RealtimeSegmentTest {
 
   @Test
   public void testRangeMatchFilteringMetricPredicateWithoutInvIdx() throws Exception {
-    DataSource ds1 = segmentWithoutInvIdx.getDataSource("count");
+    DataSource ds = segmentWithInvIdx.getDataSource("count");
+    Block block = ds.nextBlock();
+    Dictionary dictionary = block.getDictionary();
 
+    DataSource ds1 = segmentWithoutInvIdx.getDataSource("count");
     ScanBasedFilterOperator op = new ScanBasedFilterOperator(ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("[0\t\t*)");
@@ -273,7 +285,7 @@ public class RealtimeSegmentTest {
     int counter = 0;
     while (docId != Constants.EOF) {
       blockValIterator.skipTo(docId);
-      Assert.assertEquals(ds1.getDictionary().get(blockValIterator.nextIntVal()), 890662862);
+      Assert.assertEquals(dictionary.get(blockValIterator.nextIntVal()), 890662862);
       docId = iterator.next();
       counter++;
     }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/BaseSumStarTreeIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/BaseSumStarTreeIndexTest.java
@@ -20,6 +20,7 @@ import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.request.FilterQueryTree;
 import com.linkedin.pinot.common.utils.request.RequestUtils;
+import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.BlockDocIdIterator;
 import com.linkedin.pinot.core.common.BlockSingleValIterator;
 import com.linkedin.pinot.core.common.Constants;
@@ -156,15 +157,17 @@ public class BaseSumStarTreeIndexTest {
     for (int i = 0; i < numMetrics; i++) {
       String metricName = metricNames.get(i);
       DataSource dataSource = segment.getDataSource(metricName);
-      metricDictionaries[i] = dataSource.getDictionary();
-      metricValIterators[i] = (BlockSingleValIterator) dataSource.getNextBlock().getBlockValueSet().iterator();
+      Block nextBlock = dataSource.getNextBlock();
+      metricDictionaries[i] = nextBlock.getDictionary();
+      metricValIterators[i] = (BlockSingleValIterator) nextBlock.getBlockValueSet().iterator();
     }
 
     for (int i = 0; i < numGroupByColumns; i++) {
       String groupByColumn = groupByColumns.get(i);
       DataSource dataSource = segment.getDataSource(groupByColumn);
-      groupByDictionaries[i] = dataSource.getDictionary();
-      groupByValIterators[i] = (BlockSingleValIterator) dataSource.getNextBlock().getBlockValueSet().iterator();
+      Block nextBlock = dataSource.getNextBlock();
+      groupByDictionaries[i] = nextBlock.getDictionary();
+      groupByValIterators[i] = (BlockSingleValIterator) nextBlock.getBlockValueSet().iterator();
     }
 
     Map<String, double[]> result = new HashMap<String, double[]>();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/BaseHllStarTreeIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/BaseHllStarTreeIndexTest.java
@@ -171,15 +171,17 @@ public class BaseHllStarTreeIndexTest {
     for (int i = 0; i < numMetrics; i++) {
       String metricName = metricNames.get(i);
       DataSource dataSource = segment.getDataSource(metricName);
-      metricDictionaries[i] = dataSource.getDictionary();
-      metricValIterators[i] = (BlockSingleValIterator) dataSource.getNextBlock().getBlockValueSet().iterator();
+      Block nextBlock = dataSource.getNextBlock();
+      metricDictionaries[i] = nextBlock.getDictionary();
+      metricValIterators[i] = (BlockSingleValIterator) nextBlock.getBlockValueSet().iterator();
     }
 
     for (int i = 0; i < numGroupByColumns; i++) {
       String groupByColumn = groupByColumns.get(i);
       DataSource dataSource = segment.getDataSource(groupByColumn);
-      groupByDictionaries[i] = dataSource.getDictionary();
-      groupByValIterators[i] = (BlockSingleValIterator) dataSource.getNextBlock().getBlockValueSet().iterator();
+      Block nextBlock = dataSource.getNextBlock();
+      groupByDictionaries[i] = nextBlock.getDictionary();
+      groupByValIterators[i] = (BlockSingleValIterator) nextBlock.getBlockValueSet().iterator();
     }
 
     Map<String, HyperLogLog[]> result = new HashMap<>();

--- a/pinot-core/src/test/java/com/linkedin/pinot/util/datasource/ArrayBasedSingleValueBlock.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/util/datasource/ArrayBasedSingleValueBlock.java
@@ -16,7 +16,7 @@
 package com.linkedin.pinot.util.datasource;
 
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
-import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.AbstractBlock;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -26,7 +26,7 @@ import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 
-public class ArrayBasedSingleValueBlock implements Block {
+public class ArrayBasedSingleValueBlock extends AbstractBlock {
 
   private final int[] dictionary;
   final int[] values;

--- a/pinot-core/src/test/java/com/linkedin/pinot/util/datasource/DataSourceUtils.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/util/datasource/DataSourceUtils.java
@@ -75,10 +75,10 @@ public class DataSourceUtils {
         return true;
       }
 
-      @Override
-      public boolean setPredicate(Predicate predicate) {
-        throw new UnsupportedOperationException();
-      }
+//      @Override
+//      public boolean setPredicate(Predicate predicate) {
+//        throw new UnsupportedOperationException();
+//      }
 
       @Override
       public DataSourceMetadata getDataSourceMetadata() {
@@ -127,11 +127,11 @@ public class DataSourceUtils {
         return null;
       }
 
-      @Override
-      public Dictionary getDictionary() {
-        // TODO Auto-generated method stub
-        return null;
-      }
+//      @Override
+//      public Dictionary getDictionary() {
+//        // TODO Auto-generated method stub
+//        return null;
+//      }
     };
   }
 

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/SegmentDumpTool.java
@@ -76,7 +76,7 @@ public class SegmentDumpTool {
       BlockValSet blockValSet = block.getBlockValueSet();
       BlockSingleValIterator itr = (BlockSingleValIterator) blockValSet.iterator();
       iterators.put(columnName, itr);
-      dictionaries.put(columnName, dataSource.getDictionary());
+      dictionaries.put(columnName, block.getDictionary());
     }
 
     System.out.print("Doc\t");

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
@@ -86,7 +86,7 @@ public class StarTreeIndexViewer {
       BlockValSet blockValSet = block.getBlockValueSet();
       BlockSingleValIterator itr = (BlockSingleValIterator) blockValSet.iterator();
       valueIterators.put(columnName, itr);
-      dictionaries.put(columnName, dataSource.getDictionary());
+      dictionaries.put(columnName, block.getDictionary());
     }
     File starTreeFile = new File(segmentDir, V1Constants.STAR_TREE_INDEX_FILE);
     StarTreeInterf tree = StarTreeSerDe.fromFile(starTreeFile, ReadMode.mmap);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/query/comparison/SegmentInfoProvider.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/query/comparison/SegmentInfoProvider.java
@@ -137,7 +137,7 @@ public class SegmentInfoProvider {
    */
   private void loadValuesForSingleValueDimension(IndexSegment indexSegment,
       Map<String, Set<Object>> singleValueDimensionValuesMap, String column) {
-    Dictionary dictionary = indexSegment.getDataSource(column).getDictionary();
+    Dictionary dictionary = indexSegment.getDataSource(column).getNextBlock().getDictionary();
 
     Set<Object> values = singleValueDimensionValuesMap.get(column);
     if (values == null) {


### PR DESCRIPTION
- Moved the getDictionary from Datasource to Block interface
- create AbstractBlock

This will be series of changes to remove the current assumption that data is always dictionary encoded.
The intermediate goal is the remove the usage of data-source during the execution phase. All operates must work off of block interfaces. 
