### PR TITLE
Handle null ZNRecord in realtime segment manager

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
@@ -135,6 +135,12 @@ public class ZKMetadataProvider {
     String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
     ZNRecord znRecord = propertyStore
         .get(constructPropertyStorePathForSegment(realtimeTableName, segmentName), null, AccessOption.PERSISTENT);
+
+    if (znRecord == null) {
+      LOGGER.warn("Failed to read ZNRecord for segment {} of table {}", segmentName, realtimeTableName);
+      return null;
+    }
+
     if (SegmentName.isHighLevelConsumerSegmentName(segmentName)) {
       return new RealtimeSegmentZKMetadata(znRecord);
     } else {


### PR DESCRIPTION
Handle null ZNRecords in realtime segment manager instead of
throwing NPE. Add documentation as to why this can happen and how it
is handled.
