### PR TITLE
Add csv reader config on Hadoop segment creation job

### DIFF
--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
@@ -18,6 +18,8 @@ package com.linkedin.pinot.hadoop.job;
 import com.linkedin.pinot.common.Utils;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -41,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.core.data.readers.CSVRecordReaderConfig;
 import com.linkedin.pinot.hadoop.job.mapper.HadoopSegmentCreationMapReduceJob.HadoopSegmentCreationMapper;
 
 
@@ -65,7 +66,7 @@ public class SegmentCreationJob extends Configured {
   private final Schema _dataSchema;
   private final String _depsJarPath;
   private final String _outputDir;
-  private final CSVRecordReaderConfig _readerConfig;
+  private final String _readerConfig;
 
   public SegmentCreationJob(String jobName, Properties properties) throws Exception {
     super(new Configuration());
@@ -80,7 +81,7 @@ public class SegmentCreationJob extends Configured {
     _depsJarPath = _properties.getProperty(PATH_TO_DEPS_JAR, null);
     String readerConfigFilePath = _properties.getProperty(PATH_TO_READER_CONFIG, null);
     _readerConfig = (null == readerConfigFilePath) ? null
-                    : new ObjectMapper().readValue(new File(readerConfigFilePath), CSVRecordReaderConfig.class);
+                    : new String(Files.readAllBytes(Paths.get(readerConfigFilePath)));
 
     Utils.logVersions();
 
@@ -157,7 +158,7 @@ public class SegmentCreationJob extends Configured {
 
     job.getConfiguration().setInt(JobContext.NUM_MAPS, inputDataFiles.size());
     job.getConfiguration().set("data.schema", new ObjectMapper().writeValueAsString(_dataSchema));
-    job.getConfiguration().set("reader.config", new ObjectMapper().writeValueAsString(_readerConfig));
+    job.getConfiguration().set("reader.config", _readerConfig);
 
     job.setMaxReduceAttempts(1);
     job.setMaxMapAttempts(0);

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
@@ -49,6 +49,7 @@ public class HadoopSegmentCreationMapReduceJob {
     private String _outputPath;
     private String _tableName;
     private String _postfix;
+    private String _readerConfig;
 
     private Path _currentHdfsWorkDir;
     private String _currentDiskWorkDir;
@@ -84,6 +85,7 @@ public class HadoopSegmentCreationMapReduceJob {
       _outputPath = _properties.get("path.to.output");
       _tableName = _properties.get("segment.table.name");
       _postfix = _properties.get("segment.name.postfix", null);
+      _readerConfig = _properties.get("reader.config", null);
       if (_outputPath == null || _tableName == null) {
         throw new RuntimeException(
             "Missing configs: " +
@@ -200,11 +202,12 @@ public class HadoopSegmentCreationMapReduceJob {
       return segmentName;
     }
 
-    private RecordReaderConfig getReaderConfig(FileFormat fileFormat) {
+    private RecordReaderConfig getReaderConfig(FileFormat fileFormat) throws IOException {
       RecordReaderConfig readerConfig = null;
       switch (fileFormat) {
         case CSV:
-          readerConfig = new CSVRecordReaderConfig();
+          readerConfig = (null == _readerConfig) ? new CSVRecordReaderConfig()
+                         : new ObjectMapper().readValue(_readerConfig, CSVRecordReaderConfig.class);
           break;
         case AVRO:
           break;

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
@@ -130,6 +130,7 @@ public class HadoopSegmentCreationMapReduceJob {
       LOGGER.info("local disk segment path: {}", _localDiskSegmentDirectory);
       LOGGER.info("local disk segment tar path: {}", _localDiskSegmentTarPath);
       LOGGER.info("data schema: {}", _localDiskSegmentTarPath);
+      LOGGER.info("reader config: {}", _readerConfig);
       LOGGER.info("*********************************************************************");
 
       try {


### PR DESCRIPTION
On `pinot-admin CreateSegment` command has `-readerConfig` option.
But `pinot-hadoop SegmentCreation` command doesn't have it.
