### PR TITLE
Change LLC segment name ordering

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/LLCSegmentName.java
@@ -16,11 +16,12 @@
 
 package com.linkedin.pinot.common.utils;
 
+import com.google.common.collect.ComparisonChain;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 
-public class LLCSegmentName extends SegmentName implements Comparable {
+public class LLCSegmentName extends SegmentName implements Comparable<LLCSegmentName> {
   private final static String DATE_FORMAT = "yyyyMMdd'T'HHmm'Z'";
   private final String _tableName;
   private final int _partitionId;
@@ -94,28 +95,18 @@ public class LLCSegmentName extends SegmentName implements Comparable {
   }
 
   @Override
-  public int compareTo(Object o) {
-    LLCSegmentName other = (LLCSegmentName)o;
+  public int compareTo(final LLCSegmentName other) {
     if (!this.getTableName().equals(other.getTableName())) {
-      throw new RuntimeException("Cannot compare segment names " + this.getSegmentName() + " and " + other.getSegmentName());
+      throw new RuntimeException(
+          "Cannot compare segment names from different tables: " + this.getSegmentName() + " and "
+              + other.getSegmentName());
     }
-    if (this.getPartitionId() > other.getPartitionId()) {
-      return 1;
-    } else if (this.getPartitionId() < other.getPartitionId()) {
-      return -1;
-    } else {
-      if (this.getSequenceNumber() > other.getSequenceNumber()) {
-        return 1;
-      } else if (this.getSequenceNumber() < other.getSequenceNumber()) {
-        return -1;
-      } else {
-        if (!this.getCreationTime().equals(other.getCreationTime())) {
-          // If sequence number is the same, time cannot be different.
-          throw new RuntimeException("Cannot compare segment names " + this.getSegmentName() + " and " + other.getSegmentName());
-        }
-        return 0;
-      }
-    }
+
+    return ComparisonChain.start()
+        .compare(this.getPartitionId(), other.getPartitionId())
+        .compare(this.getSequenceNumber(), other.getSequenceNumber())
+        .compare(this.getCreationTime(), other.getCreationTime())
+        .result();
   }
 
   @Override


### PR DESCRIPTION
Change the LLC segment name ordering to take into account the
timestamp in segments instead of throwing an exception if segments
have the same partition and sequence number.

In certain situations, there can be segments with the same sequence
number present in the external view. For example, by disabling an
instance in Helix and then emptying a table, this will defer the
deletion of the segment on the disabled instance, so the previous
segment will be shown as offline in the external view. When the newly
created segments match with a sequence number from the previously
existing segments, this will cause an exception while building the LLC
routing table because segments are filtered after being added to the
sorted set of segments.

This fixes this issue by allowing the sorting of segments to proceed.