### PR TITLE
Re-implement MutableDictionary with primitive type, when possible.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/FilterPlanNode.java
@@ -234,3 +234,4 @@ public class FilterPlanNode implements PlanNode {
     LOGGER.debug(treeStructure);
   }
 }
+

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongMutableDictionary.java
@@ -15,13 +15,22 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongSet;
+
+
 public class LongMutableDictionary extends MutableDictionaryReader {
 
-  private Long min = Long.MAX_VALUE;
-  private Long max = Long.MIN_VALUE;
+  private Long2IntBiMap _dictionaryIdBiMap;
+  private String _column;
+  private long _min = Long.MAX_VALUE;
+  private long _max = Long.MIN_VALUE;
 
   public LongMutableDictionary(String column) {
-    super(column);
+    _column = column;
+    _dictionaryIdBiMap = new Long2IntBiMap();
   }
 
   @Override
@@ -31,42 +40,32 @@ public class LongMutableDictionary extends MutableDictionaryReader {
       return;
     }
 
-    if (rawValue instanceof String) {
-      Long e = Long.parseLong(rawValue.toString());
-      addToDictionaryBiMap(e);
-      updateMinMax(e);
-      return;
-    }
-
-    if (rawValue instanceof Long) {
-      addToDictionaryBiMap(rawValue);
-      updateMinMax((Long) rawValue);
-      return;
-    }
-
     if (rawValue instanceof Object[]) {
       for (Object o : (Object[]) rawValue) {
-        if (o instanceof String) {
-          final Long longValue = Long.parseLong(o.toString());
-          addToDictionaryBiMap(longValue);
-          updateMinMax(longValue);
-          continue;
-        }
-
-        if (o instanceof Long) {
-          addToDictionaryBiMap(o);
-          updateMinMax((Long) o);
-        }
+        indexValue(o);
       }
+    } else {
+      indexValue(rawValue);
+    }
+  }
+
+  private void indexValue(Object value) {
+    if (value instanceof String) {
+      Long e = Long.parseLong((String) value);
+      _dictionaryIdBiMap.put(e);
+      updateMinMax(e);
+    } else if (value instanceof Long) {
+      Long longValue = (Long) value;
+      _dictionaryIdBiMap.put(longValue);
+      updateMinMax(longValue);
     }
   }
 
   private void updateMinMax(Long entry) {
-    if (entry < min) {
-      min = entry;
-    }
-    if (entry > max) {
-      max = entry;
+    if (entry < _min) {
+      _min = entry;
+    } else if (entry > _max) {
+      _max = entry;
     }
   }
 
@@ -76,49 +75,58 @@ public class LongMutableDictionary extends MutableDictionaryReader {
       return hasNull;
     }
     if (rawValue instanceof String) {
-      return dictionaryIdBiMap.inverse().containsKey(Long.parseLong((String) rawValue));
+      return _dictionaryIdBiMap.containsKey(Long.parseLong((String) rawValue));
     }
-    return dictionaryIdBiMap.inverse().containsKey(rawValue);
+    return _dictionaryIdBiMap.containsKey((Long) rawValue);
   }
 
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getIndexOfFromBiMap(Long.parseLong(rawValue.toString()));
+      return _dictionaryIdBiMap.getValue(Long.parseLong(rawValue.toString()));
     }
-    return getIndexOfFromBiMap(rawValue);
+    return _dictionaryIdBiMap.getValue((Long) rawValue);
   }
 
   @Override
   public Object get(int dictionaryId) {
-    return getRawValueFromBiMap(dictionaryId);
+    return _dictionaryIdBiMap.getKey(dictionaryId);
   }
 
   @Override
   public long getLongValue(int dictionaryId) {
-    return (Long) getRawValueFromBiMap(dictionaryId);
+    return _dictionaryIdBiMap.getKey(dictionaryId);
   }
 
   @Override
   public double getDoubleValue(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).doubleValue();
+    return (_dictionaryIdBiMap.getKey(dictionaryId)).doubleValue();
   }
 
   @Override
   public int getIntValue(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).intValue();
+    return (_dictionaryIdBiMap.getKey(dictionaryId)).intValue();
   }
 
   @Override
   public float getFloatValue(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).floatValue();
+    return (_dictionaryIdBiMap.getKey(dictionaryId)).floatValue();
   }
 
   @Override
   public String toString(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).toString();
+    return (_dictionaryIdBiMap.getKey(dictionaryId)).toString();
   }
 
+  @Override
+  public int length() {
+    return _dictionaryIdBiMap.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return _dictionaryIdBiMap.isEmpty();
+  }
 
   @Override
   public boolean inRange(String lower, String upper, int indexOfValueToCompare, boolean includeLower,
@@ -127,7 +135,7 @@ public class LongMutableDictionary extends MutableDictionaryReader {
     long lowerInLong = Long.parseLong(lower);
     long upperInLong = Long.parseLong(upper);
 
-    long valueToCompare = getLong(indexOfValueToCompare);
+    long valueToCompare = _dictionaryIdBiMap.getKey(indexOfValueToCompare);
 
     boolean ret = true;
 
@@ -156,20 +164,66 @@ public class LongMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public String getStringValue(int dictionaryId) {
-    return getRawValueFromBiMap(dictionaryId).toString();
-  }
-
-  private long getLong(int dictionaryId) {
-    return (Long) dictionaryIdBiMap.get(dictionaryId);
+    return (_dictionaryIdBiMap.getKey(dictionaryId)).toString();
   }
 
   @Override
   public Object getMinVal() {
-    return min;
+    return _min;
   }
 
   @Override
   public Object getMaxVal() {
-    return max;
+    return _max;
+  }
+
+  public void print() {
+    System.out.println("************* printing dictionary for column : " + _column + " ***************");
+    for (long key : _dictionaryIdBiMap.keySet()) {
+      System.out.println(key + "," + _dictionaryIdBiMap.getValue(key));
+    }
+    System.out.println("************************************");
+  }
+
+  public static class Long2IntBiMap {
+    private Long2IntMap _valueToDictIdMap;
+    private LongArrayList _dictIdToValueMap;
+
+    public Long2IntBiMap() {
+      _valueToDictIdMap = new Long2IntOpenHashMap();
+      _dictIdToValueMap = new LongArrayList();
+      _valueToDictIdMap.defaultReturnValue(INVALID_ID);
+    }
+
+    public void put(long value) {
+      if (!_valueToDictIdMap.containsKey(value)) {
+        _dictIdToValueMap.add(value);
+        _valueToDictIdMap.put(value, _dictIdToValueMap.size() - 1);
+      }
+    }
+
+    public Long getKey(int dictId) {
+      return (dictId < _dictIdToValueMap.size()) ? _dictIdToValueMap.getLong(dictId) : null;
+    }
+
+    public int getValue(long value) {
+      return _valueToDictIdMap.get(value);
+    }
+
+    public boolean containsKey(long value) {
+      return _valueToDictIdMap.containsKey(value);
+    }
+
+    public int size() {
+      return _valueToDictIdMap.size();
+    }
+
+    public boolean isEmpty() {
+      return _valueToDictIdMap.isEmpty();
+    }
+
+    public LongSet keySet() {
+      return _valueToDictIdMap.keySet();
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
@@ -15,35 +15,13 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
-import java.util.concurrent.atomic.AtomicInteger;
 
 
 public abstract class MutableDictionaryReader implements Dictionary {
-  private final String column;
-  protected BiMap<Integer, Object> dictionaryIdBiMap;
+  protected static final Integer INVALID_ID = -1;
   protected boolean hasNull = false;
-  private final AtomicInteger dictionaryIdGenerator;
-
-  public MutableDictionaryReader(String column) {
-    this.column = column;
-    this.dictionaryIdBiMap = HashBiMap.<Integer, Object> create();
-    dictionaryIdGenerator = new AtomicInteger(-1);
-  }
-
-  protected void addToDictionaryBiMap(Object val) {
-    if (!dictionaryIdBiMap.inverse().containsKey(val)) {
-      dictionaryIdBiMap.put(dictionaryIdGenerator.incrementAndGet(), val);
-    }
-  }
-
-  @Override
-  public int length() {
-    return dictionaryIdGenerator.get() + 1;
-  }
 
   @Override
   public void readIntValues(int[] dictionaryIds, int startPos, int limit, int[] outValues, int outStartPos) {
@@ -121,18 +99,6 @@ public abstract class MutableDictionaryReader implements Dictionary {
 
   }
 
-  protected Integer getIndexOfFromBiMap(Object val) {
-    Integer ret = dictionaryIdBiMap.inverse().get(val);
-    if (ret == null) {
-      ret = -1;
-    }
-    return ret;
-  }
-
-  protected Object getRawValueFromBiMap(int dictionaryId) {
-    return dictionaryIdBiMap.get(new Integer(dictionaryId));
-  }
-
   public boolean hasNull() {
     return hasNull;
   }
@@ -154,10 +120,6 @@ public abstract class MutableDictionaryReader implements Dictionary {
   public abstract boolean inRange(String lower, String upper, int indexOfValueToCompare, boolean includeLower,
       boolean includeUpper);
 
-  public boolean inRange(String lower, String upper, int valueToCompare) {
-    return inRange(lower, upper, valueToCompare, true, true);
-  }
-
   @Override
   public abstract long getLongValue(int dictionaryId);
 
@@ -173,15 +135,7 @@ public abstract class MutableDictionaryReader implements Dictionary {
   @Override
   public abstract String toString(int dictionaryId);
 
-  public void print() {
-    System.out.println("************* printing dictionary for column : " + column + " ***************");
-    for (Integer key : dictionaryIdBiMap.keySet()) {
-      System.out.println(key + "," + dictionaryIdBiMap.get(key));
-    }
-    System.out.println("************************************");
-  }
+  public abstract void print();
 
-  public boolean isEmpty() {
-    return dictionaryIdBiMap.isEmpty();
-  }
+  public abstract boolean isEmpty();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringMutableDictionary.java
@@ -15,42 +15,48 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+
+
 public class StringMutableDictionary extends MutableDictionaryReader {
 
-  private String min = null;
-  private String max = null;
+  String2IntBiMap _dictionaryIdBiMap;
+  private String _column;
+  private String _min = null;
+  private String _max = null;
 
   public StringMutableDictionary(String column) {
-    super(column);
+    _column = column;
+    _dictionaryIdBiMap = new String2IntBiMap();
   }
 
   @Override
   public void index(Object rawValue) {
     if (rawValue instanceof Object[]) {
       for (Object o : (Object[]) rawValue) {
-        addToDictionaryBiMap(o.toString());
+        _dictionaryIdBiMap.put(o.toString());
         updateMinMax(o.toString());
       }
-      return;
+    } else {
+      _dictionaryIdBiMap.put(rawValue.toString());
+      updateMinMax(rawValue.toString());
     }
-
-    addToDictionaryBiMap(rawValue.toString());
-    updateMinMax(rawValue.toString());
   }
 
   private void updateMinMax(String entry) {
-    if (min == null && max == null) {
-      min = entry;
-      max = entry;
+    if (_min == null && _max == null) {
+      _min = entry;
+      _max = entry;
       return;
     }
 
-    if (entry.compareTo(min) < 0) {
-      min = entry;
-    }
-
-    if (entry.compareTo(max) > 0) {
-      max = entry;
+    if (entry.compareTo(_min) < 0) {
+      _min = entry;
+    } else if (entry.compareTo(_max) > 0) {
+      _max = entry;
     }
   }
 
@@ -59,47 +65,57 @@ public class StringMutableDictionary extends MutableDictionaryReader {
     if (rawValue == null) {
       return hasNull;
     }
-    return dictionaryIdBiMap.inverse().containsKey(rawValue.toString());
+    return _dictionaryIdBiMap.containsKey(rawValue.toString());
   }
 
   @Override
   public int indexOf(Object rawValue) {
-    return getIndexOfFromBiMap(rawValue.toString());
+    return _dictionaryIdBiMap.getValue(rawValue.toString());
   }
 
   @Override
   public Object get(int dictionaryId) {
-    return getRawValueFromBiMap(dictionaryId);
+    return _dictionaryIdBiMap.getKey(dictionaryId);
   }
 
   @Override
   public long getLongValue(int dictionaryId) {
-    return -1;
+    return INVALID_ID;
   }
 
   @Override
   public double getDoubleValue(int dictionaryId) {
-    return -1;
+    return INVALID_ID;
   }
 
   @Override
   public int getIntValue(int dictionaryId) {
-    return -1;
+    return INVALID_ID;
   }
 
   @Override
   public float getFloatValue(int dictionaryId) {
-    return -1;
+    return INVALID_ID;
   }
 
   @Override
   public String toString(int dictionaryId) {
-    return (String) getRawValueFromBiMap(dictionaryId);
+    return _dictionaryIdBiMap.getKey(dictionaryId);
+  }
+
+  @Override
+  public int length() {
+    return _dictionaryIdBiMap.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return _dictionaryIdBiMap.isEmpty();
   }
 
   @Override
   public String getStringValue(int dictionaryId) {
-    return (String) getRawValueFromBiMap(dictionaryId);
+    return _dictionaryIdBiMap.getKey(dictionaryId);
   }
 
   @Override
@@ -133,17 +149,66 @@ public class StringMutableDictionary extends MutableDictionaryReader {
   }
 
   private String getString(int dictionaryId) {
-    return dictionaryIdBiMap.get(dictionaryId).toString();
+    return _dictionaryIdBiMap.getKey(dictionaryId);
   }
 
   @Override
   public Object getMinVal() {
-    return min;
+    return _min;
   }
 
   @Override
   public Object getMaxVal() {
-    return max;
+    return _max;
   }
 
+  public void print() {
+    System.out.println("************* printing dictionary for column : " + _column + " ***************");
+    for (String key : _dictionaryIdBiMap.keySet()) {
+      System.out.println(key + "," + _dictionaryIdBiMap.getValue(key));
+    }
+    System.out.println("************************************");
+  }
+
+  public static class String2IntBiMap {
+    private Object2IntMap<String> _valueToDictIdMap;
+    private ObjectArrayList<String> _dictIdToValueMap;
+
+    public String2IntBiMap() {
+      _valueToDictIdMap = new Object2IntOpenHashMap<>();
+      _valueToDictIdMap.defaultReturnValue(INVALID_ID);
+      _dictIdToValueMap = new ObjectArrayList<>();
+    }
+
+    public void put(String value) {
+      if (!_valueToDictIdMap.containsKey(value)) {
+        _dictIdToValueMap.add(value);
+        _valueToDictIdMap.put(value, _dictIdToValueMap.size() - 1);
+      }
+    }
+
+    public String getKey(int dictId) {
+      return (dictId < _dictIdToValueMap.size()) ? _dictIdToValueMap.get(dictId) : null;
+    }
+
+    public int getValue(String value) {
+      return _valueToDictIdMap.getInt(value);
+    }
+
+    public boolean containsKey(String value) {
+      return _valueToDictIdMap.containsKey(value);
+    }
+
+    public int size() {
+      return _valueToDictIdMap.size();
+    }
+
+    public boolean isEmpty() {
+      return _valueToDictIdMap.isEmpty();
+    }
+
+    public ObjectSet<String> keySet() {
+      return _valueToDictIdMap.keySet();
+    }
+  }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryTest.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import org.apache.commons.lang.RandomStringUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for mutable dictionary implementations.
+ */
+public class MutableDictionaryTest {
+
+  private static final String COLUMN_NAME = "testColumn";
+  private static final int DICTIONARY_SIZE = 1000;
+  private static final Integer MAX_VALUE = 100;
+  private Random _random;
+
+  @BeforeClass
+  public void setup() {
+    _random = new Random();
+  }
+
+  @Test
+  public void testInt() {
+    IntMutableDictionary dictionary = new IntMutableDictionary(COLUMN_NAME);
+    Assert.assertTrue(dictionary.isEmpty());
+
+    List<Integer> expected = new ArrayList<>(DICTIONARY_SIZE);
+    int min = Integer.MAX_VALUE;
+    int max = Integer.MIN_VALUE;
+
+    Set<Integer> valueSet = new HashSet<>();
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      int value = _random.nextInt() % MAX_VALUE;
+      dictionary.index(value);
+      valueSet.add(value);
+
+      expected.add(value);
+      min = Math.min(value, min);
+      max = Math.max(value, max);
+    }
+
+    Assert.assertEquals(dictionary.length(), valueSet.size());
+    Assert.assertTrue(!dictionary.contains(MAX_VALUE));
+    Assert.assertEquals(dictionary.getMinVal(), min);
+    Assert.assertEquals(dictionary.getMaxVal(), max);
+
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      Assert.assertTrue(dictionary.contains(expected.get(i)));
+    }
+
+    for (int i = 0; i < dictionary.length(); i++) {
+      String lower = String.valueOf(dictionary.getIntValue(i) - 1);
+      String upper = String.valueOf(dictionary.getIntValue(i) + 1);
+      Assert.assertTrue(dictionary.inRange(lower, upper, i, true, true));
+      Assert.assertTrue(!dictionary.inRange(upper, upper, i, false, false));
+    }
+  }
+
+  @Test
+  public void testLong() {
+    LongMutableDictionary dictionary = new LongMutableDictionary(COLUMN_NAME);
+    Assert.assertTrue(dictionary.isEmpty());
+
+    List<Long> expected = new ArrayList<>(DICTIONARY_SIZE);
+    long min = Long.MAX_VALUE;
+    long max = Long.MIN_VALUE;
+
+    Set<Long> valueSet = new HashSet<>();
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      long value = _random.nextLong() % MAX_VALUE;
+      dictionary.index(value);
+      valueSet.add(value);
+
+      expected.add(value);
+      min = Math.min(value, min);
+      max = Math.max(value, max);
+    }
+
+    Assert.assertEquals(dictionary.length(), valueSet.size());
+    Assert.assertTrue(!dictionary.contains(MAX_VALUE.longValue()));
+    Assert.assertEquals(dictionary.getMinVal(), min);
+    Assert.assertEquals(dictionary.getMaxVal(), max);
+
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      Assert.assertTrue(dictionary.contains(expected.get(i)));
+    }
+
+    for (int i = 0; i < dictionary.length(); i++) {
+      String lower = String.valueOf(dictionary.getLongValue(i) - 1);
+      String upper = String.valueOf(dictionary.getLongValue(i) + 1);
+      Assert.assertTrue(dictionary.inRange(lower, upper, i, true, true));
+      Assert.assertTrue(!dictionary.inRange(upper, upper, i, false, false));
+    }
+  }
+
+  @Test
+  public void testFloat() {
+    FloatMutableDictionary dictionary = new FloatMutableDictionary(COLUMN_NAME);
+    Assert.assertTrue(dictionary.isEmpty());
+
+    List<Float> expected = new ArrayList<>(DICTIONARY_SIZE);
+    float min = Float.MAX_VALUE;
+    float max = Float.MIN_VALUE;
+
+    Set<Float> valueSet = new HashSet<>();
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      float value = _random.nextFloat() % MAX_VALUE;
+      dictionary.index(value);
+      valueSet.add(value);
+
+      expected.add(value);
+      min = Math.min(value, min);
+      max = Math.max(value, max);
+    }
+
+    Assert.assertEquals(dictionary.length(), valueSet.size());
+    Assert.assertTrue(!dictionary.contains(MAX_VALUE.floatValue()));
+
+    Assert.assertEquals(dictionary.getMinVal(), min);
+    Assert.assertEquals(dictionary.getMaxVal(), max);
+
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      Assert.assertTrue(dictionary.contains(expected.get(i)));
+    }
+
+    for (int i = 0; i < dictionary.length(); i++) {
+      String lower = String.valueOf(dictionary.getFloatValue(i) - 1);
+      String upper = String.valueOf(dictionary.getFloatValue(i) + 1);
+      Assert.assertTrue(dictionary.inRange(lower, upper, i, true, true));
+      Assert.assertTrue(!dictionary.inRange(upper, upper, i, false, false));
+    }
+  }
+
+  @Test
+  public void testDouble() {
+    DoubleMutableDictionary dictionary = new DoubleMutableDictionary(COLUMN_NAME);
+    Assert.assertTrue(dictionary.isEmpty());
+
+    List<Double> expected = new ArrayList<>(DICTIONARY_SIZE);
+    double min = Double.MAX_VALUE;
+    double max = Double.MIN_VALUE;
+
+    Set<Double> valueSet = new HashSet<>();
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      double value = _random.nextDouble() % MAX_VALUE;
+      dictionary.index(value);
+      valueSet.add(value);
+
+      expected.add(value);
+      min = Math.min(value, min);
+      max = Math.max(value, max);
+    }
+
+    Assert.assertEquals(dictionary.length(), valueSet.size());
+    Assert.assertTrue(!dictionary.contains(MAX_VALUE.doubleValue()));
+    Assert.assertEquals(dictionary.getMinVal(), min);
+    Assert.assertEquals(dictionary.getMaxVal(), max);
+
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      Assert.assertTrue(dictionary.contains(expected.get(i)));
+    }
+
+    for (int i = 0; i < dictionary.length(); i++) {
+      String lower = String.valueOf(dictionary.getDoubleValue(i) - 1);
+      String upper = String.valueOf(dictionary.getDoubleValue(i) + 1);
+      Assert.assertTrue(dictionary.inRange(lower, upper, i, true, true));
+      Assert.assertTrue(!dictionary.inRange(upper, upper, i, false, false));
+    }
+  }
+
+  @Test
+  public void testString() {
+    StringMutableDictionary dictionary = new StringMutableDictionary(COLUMN_NAME);
+    Assert.assertTrue(dictionary.isEmpty());
+
+    List<String> expected = new ArrayList<>(DICTIONARY_SIZE);
+    Set<String> valueSet = new HashSet<>();
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      String value = RandomStringUtils.random(100);
+      dictionary.index(value);
+      valueSet.add(value);
+      expected.add(value);
+    }
+
+    Assert.assertEquals(dictionary.length(), valueSet.size());
+
+    for (int i = 0; i < DICTIONARY_SIZE; i++) {
+      Assert.assertTrue(dictionary.contains(expected.get(i)));
+    }
+  }
+}


### PR DESCRIPTION
There are two motivitations behind this change, both of which will
benefit by reduced memory consumption by avoiding java objects where
primitives could be used.

1. Mutable dictionary implementations are currently used for realtime
segments in consuming state. This increase memory consumption (due to
non-primitive key/values) throughout the life of the segment in
consumption.

2. No-dictionary group key generator can now use the mutable dictionary
as a on the fly dictionary.

Added unit tests for the new implementations.