### PR TITLE
Use data manager for startup status check

### DIFF
--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.data.DataManager;
 import com.linkedin.pinot.common.metrics.MetricsHelper;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.query.QueryExecutor;
+import com.linkedin.pinot.core.data.manager.offline.InstanceDataManager;
 import com.linkedin.pinot.core.data.manager.offline.TableDataManagerProvider;
 import com.linkedin.pinot.core.operator.transform.TransformUtils;
 import com.linkedin.pinot.core.operator.transform.function.TransformFunctionFactory;
@@ -126,11 +127,11 @@ public class ServerBuilder {
     initMetrics();
   }
 
-  public DataManager buildInstanceDataManager() throws InstantiationException, IllegalAccessException,
-      ClassNotFoundException {
+  public InstanceDataManager buildInstanceDataManager() throws InstantiationException, IllegalAccessException,
+                                                               ClassNotFoundException {
     String className = _serverConf.getInstanceDataManagerClassName();
     LOGGER.info("Trying to Load Instance DataManager by Class : " + className);
-    DataManager instanceDataManager = (DataManager) Class.forName(className).newInstance();
+    InstanceDataManager instanceDataManager = (InstanceDataManager) Class.forName(className).newInstance();
     instanceDataManager.init(_serverConf.getInstanceDataManagerConfig());
     return instanceDataManager;
   }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerInstance.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.server.starter;
 
+import com.linkedin.pinot.core.data.manager.offline.InstanceDataManager;
 import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.lang.reflect.InvocationTargetException;
@@ -44,7 +45,7 @@ public class ServerInstance {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerInstance.class);
 
   private ServerConf _serverConf;
-  private DataManager _instanceDataManager;
+  private InstanceDataManager _instanceDataManager;
   private QueryExecutor _queryExecutor;
   private RequestHandlerFactory _requestHandlerFactory;
   private NettyServer _nettyServer;
@@ -123,14 +124,14 @@ public class ServerInstance {
   /**
    * @return instanceDataManager
    */
-  public DataManager getInstanceDataManager() {
+  public InstanceDataManager getInstanceDataManager() {
     return _instanceDataManager;
   }
 
   /**
    * @param instanceDataManager
    */
-  public void setInstanceDataManager(DataManager instanceDataManager) {
+  public void setInstanceDataManager(InstanceDataManager instanceDataManager) {
     this._instanceDataManager = instanceDataManager;
   }
 

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -145,7 +145,7 @@ public class HelixServerStarter {
 
     // Register the service status handler
     ServiceStatus.setServiceStatusCallback(
-        new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixAdmin, _helixClusterName,
+        new ServerServiceStatusCallback(_helixAdmin, _serverInstance.getInstanceDataManager(), _helixClusterName,
             _instanceId));
 
     ControllerLeaderLocator.create(_helixManager);

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/ServerServiceStatusCallback.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/ServerServiceStatusCallback.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.server.starter.helix;
+
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.ServiceStatus;
+import com.linkedin.pinot.core.data.manager.offline.InstanceDataManager;
+import com.linkedin.pinot.core.data.manager.offline.SegmentDataManager;
+import com.linkedin.pinot.core.data.manager.offline.TableDataManager;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.IdealState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Callback to determine whether or not a server is done starting up.
+ */
+public class ServerServiceStatusCallback implements ServiceStatus.ServiceStatusCallback {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerServiceStatusCallback.class);
+
+  private final HelixAdmin _helixAdmin;
+  private final InstanceDataManager _instanceDataManager;
+  private final String _clusterName;
+  private final String _instanceName;
+  private boolean _finishedStartingUp;
+
+  public ServerServiceStatusCallback(HelixAdmin helixAdmin, InstanceDataManager instanceDataManager, String clusterName,
+      String instanceName) {
+    _helixAdmin = helixAdmin;
+    _instanceDataManager = instanceDataManager;
+    _clusterName = clusterName;
+    _instanceName = instanceName;
+  }
+
+  @Override
+  public synchronized ServiceStatus.Status getServiceStatus() {
+    if (_finishedStartingUp) {
+      return ServiceStatus.Status.GOOD;
+    }
+
+    // Figure out the serving status of all tables we're supposed to serve
+    List<String> resourcesInCluster = _helixAdmin.getResourcesInCluster(_clusterName);
+    Set<String> tablesToServe = new HashSet<>();
+    Set<String> tablesNotServed = new HashSet<>();
+    Set<String> tablesPartiallyServed = new HashSet<>();
+    Set<String> tablesServed = new HashSet<>();
+    int segmentsRemainingToLoad = 0;
+    int servableSegmentCount = 0;
+
+    for (String tableName : resourcesInCluster) {
+      // Skip brokerResource
+      if (CommonConstants.Helix.NON_PINOT_RESOURCE_RESOURCE_NAMES.contains(tableName)) {
+        continue;
+      }
+
+      // Fetch ideal state
+      IdealState idealState = _helixAdmin.getResourceIdealState(_clusterName, tableName);
+      if (idealState == null) {
+        continue;
+      }
+
+      // Gather segments to serve from the ideal state
+      Set<String> segmentsToServe = new HashSet<>();
+      for (String segmentName : idealState.getPartitionSet()) {
+        String segmentState = idealState.getInstanceStateMap(segmentName).get(_instanceName);
+
+        if (segmentState != null && !"OFFLINE".equals(segmentState) && !"DROPPED".equals(segmentState)) {
+          tablesToServe.add(tableName);
+          segmentsToServe.add(segmentName);
+          servableSegmentCount++;
+        }
+      }
+
+      // If we have no segments to serve, ignore this table
+      if (segmentsToServe.isEmpty()) {
+        continue;
+      }
+
+      // Compare the list of segments to serve with what is actually being served
+      Set<String> segmentsNotServed = new HashSet<>(segmentsToServe);
+      TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(tableName);
+      if (tableDataManager != null) {
+        List<SegmentDataManager> segments = tableDataManager.acquireAllSegments();
+        for (SegmentDataManager segment : segments) {
+          try {
+            segmentsNotServed.remove(segment.getSegmentName());
+          } finally {
+            tableDataManager.releaseSegment(segment);
+          }
+        }
+      }
+
+      segmentsRemainingToLoad += segmentsNotServed.size();
+
+      if (segmentsToServe.size() == segmentsNotServed.size()) {
+        tablesNotServed.add(tableName);
+      } else if (!segmentsNotServed.isEmpty()) {
+        tablesPartiallyServed.add(tableName);
+      } else {
+        tablesServed.add(tableName);
+      }
+    }
+
+    if (tablesNotServed.isEmpty() && tablesPartiallyServed.isEmpty()) {
+      LOGGER.info("Instance {} is done starting up, {} tables served", _instanceName, tablesServed.size());
+      _finishedStartingUp = true;
+      return ServiceStatus.Status.GOOD;
+    } else {
+      LOGGER.info(
+          "Instance {} is still starting up, {}/{} segments left to load. Out of {} tables to load, {} tables are fully loaded, {} tables are partially loaded and {} tables are not loaded at all",
+          _instanceName, segmentsRemainingToLoad, servableSegmentCount, tablesToServe.size(), tablesServed.size(),
+          tablesPartiallyServed.size(), tablesNotServed.size());
+      return ServiceStatus.Status.STARTING;
+    }
+  }
+}


### PR DESCRIPTION
Use the table and instance data managers to check whether or not an
instance is done starting instead of checking the external view.