### PR TITLE
[TE] expose preview anomaly score

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -235,6 +235,19 @@ public class AnomalyResource {
     return alertFilter.getProbability(mergedAnomaly);
   }
 
+  // get preview anomaly scores
+  @GET
+  @Path("eval/projected/anomalies/score/{autotuneId}")
+  public double getPreviewedAnomalyScore(@NotNull @PathParam("autotuneId") long autotuneId, @NotNull  @QueryParam("mergedAnomalyId") long mergedAnomalyId) {
+    MergedAnomalyResultDTO mergedAnomaly = anomalyMergedResultDAO.findById(mergedAnomalyId);
+    // Initiate tuned alert filter
+    AutotuneConfigDTO target = DAO_REGISTRY.getAutotuneConfigDAO().findById(autotuneId);
+    // Initiate alert filter to BaseAlertFilter
+    Map<String, String> alertFilterParams = target.getConfiguration();
+    BaseAlertFilter alertFilter = alertFilterFactory.fromSpec(alertFilterParams);
+    return alertFilter.getProbability(mergedAnomaly);
+  }
+
   //View raw anomalies for collection
   @GET
   @Path("/raw-anomalies/view")


### PR DESCRIPTION
In "Customize Sensitivity" page, when user hits preview, the anomaly scores under to the "not sent" list is still applying the "current" alert filter setting, thus user will see the anomaly score remain the same under "preview". This endpoint exposes the "previewed" anomaly scores.