### PR TITLE
Fix Pinot schema REST API documentation

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
@@ -15,10 +15,16 @@
  */
 package com.linkedin.pinot.controller.api;
 
+import com.google.common.base.Preconditions;
+import io.swagger.converter.ModelConverters;
+import io.swagger.jaxrs.config.BeanConfig;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -28,11 +34,6 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.base.Preconditions;
-import io.swagger.jaxrs.config.BeanConfig;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
 
 
 public class ControllerAdminApiApplication extends ResourceConfig {
@@ -118,6 +119,8 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     beanConfig.setBasePath(baseUri.getPath());
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
+
+    ModelConverters.getInstance().addConverter(new FormDataMultiPartConverter());
 
     CLStaticHttpHandler apiStaticHttpHandler = new CLStaticHttpHandler(ControllerAdminApiApplication.class.getClassLoader(),
         "/api/");

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/FormDataMultiPartConverter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/FormDataMultiPartConverter.java
@@ -1,0 +1,44 @@
+package com.linkedin.pinot.controller.api;
+
+import com.fasterxml.jackson.databind.JavaType;
+import io.swagger.converter.ModelConverter;
+import io.swagger.converter.ModelConverterContext;
+import io.swagger.models.Model;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.util.Json;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+
+/**
+ * A converter used to suppress the example displayed in swagger UI.
+ */
+public class FormDataMultiPartConverter implements ModelConverter {
+
+  @Override
+  public Property resolveProperty(Type type, ModelConverterContext context, Annotation[] annotations, Iterator<ModelConverter> chain) {
+    JavaType jtype = Json.mapper().constructType(type);
+    if (jtype != null) {
+      Class<?> cls = jtype.getRawClass();
+      if(FormDataMultiPart.class.isAssignableFrom(cls)) {
+        return new StringProperty();
+      }
+    }
+    if (chain.hasNext()) {
+      return chain.next().resolveProperty(type, context, annotations, chain);
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public Model resolve(Type type, ModelConverterContext context, Iterator<ModelConverter> chain) {
+    if (chain.hasNext()) {
+      return chain.next().resolve(type, context, chain);
+    } else {
+      return null;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -115,7 +115,7 @@ public class PinotSchemaRestletResource {
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully updated schema"), @ApiResponse(code = 404, message = "Schema not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
   public SuccessResponse updateSchema(
       @ApiParam(value = "Name of the schema", required = true) @PathParam("schemaName") String schemaName,
-      FormDataMultiPart multiPart) {
+      @ApiParam(value = "Schema", required = true) FormDataMultiPart multiPart) {
     return addOrUpdateSchema(schemaName, multiPart);
   }
 
@@ -124,8 +124,9 @@ public class PinotSchemaRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/schemas")
   @ApiOperation(value = "Add a new schema", notes = "Adds a new schema")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully deleted schema"), @ApiResponse(code = 404, message = "Schema not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
-  public SuccessResponse addSchema(FormDataMultiPart multiPart) {
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully added schema"), @ApiResponse(code = 404, message = "Schema not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
+  public SuccessResponse addSchema(
+      @ApiParam(value = "Schema", required = true)  FormDataMultiPart multiPart) {
     return addOrUpdateSchema(null, multiPart);
   }
 
@@ -135,7 +136,8 @@ public class PinotSchemaRestletResource {
   @ApiOperation(value = "Validate schema", notes = "This API returns the schema that matches the one you get "
       + "from 'GET /schema/{schemaName}'. This allows us to validate schema before apply.")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully validated schema"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
-  public String validateSchema(FormDataMultiPart multiPart) {
+  public String validateSchema(
+      @ApiParam(value = "Schema", required = true) FormDataMultiPart multiPart) {
     Schema schema = getSchemaFromMultiPart(multiPart);
     if (!schema.validate(LOGGER)) {
       throw new ControllerApplicationException(LOGGER, "Invalid schema. Check controller logs",


### PR DESCRIPTION
This change disables the FormDataMultiPart example displayed by swagger in the restapi UI. This is done by providing a ModelConverter (based on this: https://github.com/swagger-api/swagger-core/wiki/overriding-models).

Testing done: Tested the schema post/put methods via curl and that succeeded. UI now does not show an example.