### PR TITLE
Add query option 'attachValueInForColumns' to automatically attach VALUE_IN UDF to MV group-by columns

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -45,6 +45,7 @@ import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.DataTable;
 import com.linkedin.pinot.core.common.datatable.DataTableFactory;
+import com.linkedin.pinot.core.operator.transform.function.ValueInTransformFunction;
 import com.linkedin.pinot.pql.parsers.Pql2Compiler;
 import com.linkedin.pinot.serde.SerDe;
 import com.linkedin.pinot.transport.common.CompositeFuture;
@@ -153,6 +154,7 @@ public class BrokerRequestHandler {
     BrokerRequest brokerRequest;
     try {
       brokerRequest = REQUEST_COMPILER.compileToBrokerRequest(query);
+      preprocessRequest(brokerRequest);
     } catch (Exception e) {
       LOGGER.info("Parsing error on requestId {}: {}, {}", requestId, query, e.getMessage());
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1L);
@@ -268,6 +270,15 @@ public class BrokerRequestHandler {
         brokerResponse.getTotalDocs(), scatterGatherStats, StringUtils.substring(query, 0, _queryLogLength));
 
     return brokerResponse;
+  }
+
+  /**
+   * Preprocess the broker request.
+   *
+   * @param brokerRequest Broker request to preprocess
+   */
+  private void preprocessRequest(BrokerRequest brokerRequest) {
+    RequestPreprocessUtils.attachValueInUDF(brokerRequest);
   }
 
   /**

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/RequestPreprocessUtils.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/RequestPreprocessUtils.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.requesthandler;
+
+import com.google.common.base.Splitter;
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.request.FilterOperator;
+import com.linkedin.pinot.common.request.FilterQuery;
+import com.linkedin.pinot.common.request.FilterQueryMap;
+import com.linkedin.pinot.common.request.GroupBy;
+import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.core.operator.transform.function.ValueInTransformFunction;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+
+public class RequestPreprocessUtils {
+
+  /**
+   * Attach VALUE_IN UDF to multi-valued columns in "filterGroupsForMVColumns" query option.
+   * <p>To attach VALUE_IN UDF, the column must have one single IN filter and must be in the GROUP BY clause.
+   *
+   * @param brokerRequest Broker request to attach VALUE_IN UDF
+   */
+  public static void attachValueInUDF(@Nonnull BrokerRequest brokerRequest) {
+    Map<String, String> queryOptions = brokerRequest.getQueryOptions();
+    if (queryOptions == null) {
+      return;
+    }
+    String value = queryOptions.remove(CommonConstants.Broker.Request.QueryOptionKey.ATTACH_VALUE_IN_FOR_COLUMNS);
+    if (queryOptions.isEmpty()) {
+      brokerRequest.unsetQueryOptions();
+    }
+    if (value == null || value.isEmpty()) {
+      return;
+    }
+    FilterQueryMap filterQueryMap = brokerRequest.getFilterSubQueryMap();
+    GroupBy groupBy = brokerRequest.getGroupBy();
+    if (filterQueryMap == null || groupBy == null) {
+      throw new RuntimeException("Cannot attach VALUE_IN UDF to query without filter or group-by");
+    }
+
+    List<String> columns = Splitter.on(',').omitEmptyStrings().trimResults().splitToList(value);
+    int numColumns = columns.size();
+    FilterQuery[] filterQueries = new FilterQuery[numColumns];
+    for (FilterQuery filterQuery : filterQueryMap.getFilterQueryMap().values()) {
+      String column = filterQuery.getColumn();
+      if (column != null) {
+        int index = columns.indexOf(column);
+        if (index != -1) {
+          if (filterQuery.getOperator() != FilterOperator.IN || filterQueries[index] != null) {
+            throw new RuntimeException("To attach VALUE_IN UDF, column must have one single IN filter");
+          }
+          filterQueries[index] = filterQuery;
+        }
+      }
+    }
+
+    List<String> groupByColumns = groupBy.getColumns();
+    List<String> groupByExpressions = groupBy.getExpressions();
+    int numGroupByExpressions = groupByExpressions.size();
+    for (int i = 0; i < numGroupByExpressions; i++) {
+      String groupByExpression = groupByExpressions.get(i);
+      int index = columns.indexOf(groupByExpression);
+      if (index != -1) {
+        FilterQuery filterQuery = filterQueries[index];
+        groupByExpressions.set(i, TransformExpressionTree.compileToExpressionTree(
+            String.format("%s(%s,'%s')", ValueInTransformFunction.FUNCTION_NAME, groupByExpression,
+                String.join("','", filterQuery.getValue()))).toString());
+        groupByColumns.remove(groupByExpression);
+        if (groupByColumns.isEmpty()) {
+          groupBy.unsetColumns();
+        }
+      }
+    }
+  }
+}

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/RequestPreprocessUtilsTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/RequestPreprocessUtilsTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.requesthandler;
+
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class RequestPreprocessUtilsTest {
+  private static final Pql2Compiler COMPILER = new Pql2Compiler();
+
+  @Test(dataProvider = "testAttachValueInUDF")
+  public void testAttachValueInUDF(String queryWithoutValueIn, String queryWithValueIn) {
+    BrokerRequest actual = COMPILER.compileToBrokerRequest(queryWithoutValueIn);
+    RequestPreprocessUtils.attachValueInUDF(actual);
+    BrokerRequest expected = COMPILER.compileToBrokerRequest(queryWithValueIn);
+    RequestPreprocessUtils.attachValueInUDF(expected);
+
+    Assert.assertEquals(actual.getQueryOptions(), expected.getQueryOptions());
+    Assert.assertEquals(actual.getGroupBy().getColumns(), expected.getGroupBy().getColumns());
+    Assert.assertEquals(actual.getGroupBy().getExpressions(), expected.getGroupBy().getExpressions());
+  }
+
+  @DataProvider(name = "testAttachValueInUDF")
+  public Object[][] testAttachValueInUDF() {
+    return new Object[][]{
+        {
+            "SELECT COUNT(*) FROM table WHERE column IN (1, 2, 3) GROUP BY column OPTION(attachValueInForColumns='column')",
+            "SELECT COUNT(*) FROM table WHERE column IN (1, 2, 3) GROUP BY ValueIn(column, 1, 2, 3)"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column IN (1, 2, 3) GROUP BY column OPTION(attachValueInForColumns='column')",
+            "SELECT COUNT(*) FROM table WHERE column IN (1, 2, 3) GROUP BY ValueIn(column, 1, 2, 3) OPTION(attachValueInForColumns='column')"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column IN (1, 2, 3) GROUP BY column OPTION(attachValueInForColumns='column', foo='bar')",
+            "SELECT COUNT(*) FROM table WHERE column IN (1, 2, 3) GROUP BY ValueIn(column, 1, 2, 3) OPTION(foo='bar')"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column IN ('a', 'b', 'c') GROUP BY column OPTION(attachValueInForColumns='column')",
+            "SELECT COUNT(*) FROM table WHERE column IN ('a', 'b', 'c') GROUP BY ValueIn(column, 'a', 'b', 'c')"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY column1, column2 OPTION(attachValueInForColumns='column1, column2')",
+            "SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY ValueIn(column1, 1, 2, 3), ValueIn(column2, 'a', 'b', 'c')"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY column1, column2 OPTION(attachValueInForColumns='column2, column1')",
+            "SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY ValueIn(column1, 1, 2, 3), ValueIn(column2, 'a', 'b', 'c')"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY column2, column1 OPTION(attachValueInForColumns='column1, column2')",
+            "SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY ValueIn(column2, 'a', 'b', 'c'), ValueIn(column1, 1, 2, 3)"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY column1, column2 OPTION(attachValueInForColumns='column2')",
+            "SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY column1, ValueIn(column2, 'a', 'b', 'c')"
+        }
+    };
+  }
+
+  @Test(dataProvider = "testAttachValueInUDFException", expectedExceptions = RuntimeException.class)
+  public void testAttachValueInUDFException(String illegalQuery) {
+    BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(illegalQuery);
+    RequestPreprocessUtils.attachValueInUDF(brokerRequest);
+  }
+
+  @DataProvider(name = "testAttachValueInUDFException")
+  public Object[][] testAttachValueInUDFException() {
+    return new Object[][] {
+        {
+            "SELECT COUNT(*) FROM table GROUP BY column OPTION(attachValueInForColumns='column')"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column IN (1, 2) OPTION(attachValueInForColumns='column')"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column NOT IN (1, 2) GROUP BY column OPTION(attachValueInForColumns='column')"
+        },
+        {
+            "SELECT COUNT(*) FROM table WHERE column IN (1, 2) OR column IN (2, 3) GROUP BY column OPTION(attachValueInForColumns='column')"
+        }
+    };
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/request/transform/TransformExpressionTree.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/request/transform/TransformExpressionTree.java
@@ -166,7 +166,7 @@ public class TransformExpressionTree {
       case IDENTIFIER:
         return _value;
       case LITERAL:
-        return "\'" + _value + "\'";
+        return "'" + _value + "'";
       default:
         throw new IllegalStateException();
     }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -214,10 +214,15 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_ID = "pinot.broker.id";
     public static final BrokerResponseFactory.ResponseType DEFAULT_BROKER_RESPONSE_TYPE =
         BrokerResponseFactory.ResponseType.BROKER_RESPONSE_TYPE_NATIVE;
+
     public static class Request {
       public static final String PQL = "pql";
       public static final String TRACE = "trace";
       public static final String DEBUG_OPTIONS = "debugOptions";
+
+      public static class QueryOptionKey {
+        public static final String ATTACH_VALUE_IN_FOR_COLUMNS = "attachValueInForColumns";
+      }
     }
   }
 

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -351,7 +351,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
   @Test
   public void testUDF() throws Exception {
-    String pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY timeConvert(DaysSinceEpoch,'DAYS','SECONDS')";
+    String pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY timeConvert(DaysSinceEpoch, 'DAYS', 'SECONDS')";
     JSONObject response = postQuery(pqlQuery);
     JSONObject groupByResult = response.getJSONArray("aggregationResults").getJSONObject(0);
     JSONObject groupByEntry = groupByResult.getJSONArray("groupByResult").getJSONObject(0);
@@ -361,7 +361,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         "timeconvert(DaysSinceEpoch,'DAYS','SECONDS')");
 
     pqlQuery =
-        "SELECT COUNT(*) FROM mytable GROUP BY dateTimeConvert(DaysSinceEpoch,'1:DAYS:EPOCH','1:HOURS:EPOCH','1:HOURS')";
+        "SELECT COUNT(*) FROM mytable GROUP BY dateTimeConvert(DaysSinceEpoch, '1:DAYS:EPOCH', '1:HOURS:EPOCH', '1:HOURS')";
     response = postQuery(pqlQuery);
     groupByResult = response.getJSONArray("aggregationResults").getJSONObject(0);
     groupByEntry = groupByResult.getJSONArray("groupByResult").getJSONObject(0);
@@ -370,7 +370,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     Assert.assertEquals(groupByResult.getJSONArray("groupByColumns").getString(0),
         "datetimeconvert(DaysSinceEpoch,'1:DAYS:EPOCH','1:HOURS:EPOCH','1:HOURS')");
 
-    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY add(DaysSinceEpoch,DaysSinceEpoch,15)";
+    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY add(DaysSinceEpoch, DaysSinceEpoch, 15)";
     response = postQuery(pqlQuery);
     groupByResult = response.getJSONArray("aggregationResults").getJSONObject(0);
     groupByEntry = groupByResult.getJSONArray("groupByResult").getJSONObject(0);
@@ -379,7 +379,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     Assert.assertEquals(groupByResult.getJSONArray("groupByColumns").getString(0),
         "add(DaysSinceEpoch,DaysSinceEpoch,'15')");
 
-    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY sub(DaysSinceEpoch,25)";
+    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY sub(DaysSinceEpoch, 25)";
     response = postQuery(pqlQuery);
     groupByResult = response.getJSONArray("aggregationResults").getJSONObject(0);
     groupByEntry = groupByResult.getJSONArray("groupByResult").getJSONObject(0);
@@ -387,7 +387,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     Assert.assertEquals(groupByEntry.getJSONArray("group").getInt(0), 16138 - 25);
     Assert.assertEquals(groupByResult.getJSONArray("groupByColumns").getString(0), "sub(DaysSinceEpoch,'25')");
 
-    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY mult(DaysSinceEpoch,24,3600)";
+    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY mult(DaysSinceEpoch, 24, 3600)";
     response = postQuery(pqlQuery);
     groupByResult = response.getJSONArray("aggregationResults").getJSONObject(0);
     groupByEntry = groupByResult.getJSONArray("groupByResult").getJSONObject(0);
@@ -395,7 +395,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     Assert.assertEquals(groupByEntry.getJSONArray("group").getInt(0), 16138 * 24 * 3600);
     Assert.assertEquals(groupByResult.getJSONArray("groupByColumns").getString(0), "mult(DaysSinceEpoch,'24','3600')");
 
-    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY div(DaysSinceEpoch,2)";
+    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY div(DaysSinceEpoch, 2)";
     response = postQuery(pqlQuery);
     groupByResult = response.getJSONArray("aggregationResults").getJSONObject(0);
     groupByEntry = groupByResult.getJSONArray("groupByResult").getJSONObject(0);
@@ -403,7 +403,16 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     Assert.assertEquals(groupByEntry.getJSONArray("group").getInt(0), 16138 / 2);
     Assert.assertEquals(groupByResult.getJSONArray("groupByColumns").getString(0), "div(DaysSinceEpoch,'2')");
 
-    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY valueIn(DivAirports,'DFW','ORD')";
+    pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY valueIn(DivAirports, 'DFW', 'ORD')";
+    response = postQuery(pqlQuery);
+    groupByResult = response.getJSONArray("aggregationResults").getJSONObject(0);
+    groupByEntry = groupByResult.getJSONArray("groupByResult").getJSONObject(0);
+    Assert.assertEquals(groupByEntry.getInt("value"), 336);
+    Assert.assertEquals(groupByEntry.getJSONArray("group").getString(0), "ORD");
+    Assert.assertEquals(groupByResult.getJSONArray("groupByColumns").getString(0), "valuein(DivAirports,'DFW','ORD')");
+
+    pqlQuery =
+        "SELECT COUNT(*) FROM mytable WHERE DivAirports IN ('DFW', 'ORD') GROUP BY DivAirports OPTION(attachValueInForColumns='DivAirports')";
     response = postQuery(pqlQuery);
     groupByResult = response.getJSONArray("aggregationResults").getJSONObject(0);
     groupByEntry = groupByResult.getJSONArray("groupByResult").getJSONObject(0);


### PR DESCRIPTION
Also keep the order of values in IN clause while performing the deduplication, to make the attached UDF deterministic
Added tests in RequestPreprocessUtilsTest and OfflineClusterIntegrationTest

E.g.
SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY column1, column2 OPTION(attachValueInForColumns='column1, column2')
->
SELECT COUNT(*) FROM table WHERE column1 IN (1, 2, 3) AND column2 IN ('a', 'b', 'c') GROUP BY ValueIn(column1, 1, 2, 3), ValueIn(column2, 'a', 'b', 'c')