### PR TITLE
Auto reload segments when schema or table config updated

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -254,7 +254,7 @@ public class PinotTableRestletResource {
   public SuccessResponse updateTableConfig(
       @ApiParam(value = "Name of the table to update", required = true) @PathParam("tableName") String tableName,
       String tableConfigStr,
-      @ApiParam(value = "Whether to force to reload segments") @DefaultValue("false") @QueryParam("forceReload") Boolean forceReloadSegments)
+      @ApiParam(value = "Whether to reload segments right after config updated") @DefaultValue("false") @QueryParam("reload") boolean reload)
       throws Exception {
     TableConfig tableConfig;
     try {
@@ -299,7 +299,7 @@ public class PinotTableRestletResource {
 
     // Auto reload segments.
     StringBuilder successMessage = new StringBuilder("Table config updated for " + tableName);
-    if (forceReloadSegments != null && forceReloadSegments) {
+    if (reload) {
       autoReloadAllSegmentsForTable(tableConfig.getTableName(), successMessage);
     }
     return new SuccessResponse(successMessage.toString());


### PR DESCRIPTION
This PR adds code to enable auto reload segments when schema/table config is updated.
When schema is changed, since schema name and raw table name should be the same, we fetch existing table names by schema name.