### PR TITLE
[PINOT-6513] Initial changes for segment refresh time prefetch

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/PrefetchMode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/PrefetchMode.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.common.segment;
+
+import com.linkedin.pinot.common.utils.CommonConstants;
+
+public enum PrefetchMode {
+  NO_PREFETCH,
+  PREFETCH_TO_LIMIT,
+  ALWAYS_PREFETCH;
+
+  public static final PrefetchMode DEFAULT_PREFETCH_MODE = PrefetchMode.valueOf(CommonConstants.Server.DEFAULT_PREFETCH_MODE);
+
+  public static PrefetchMode getEnum(String strVal) {
+    if (strVal.equalsIgnoreCase("alwaysPrefetch")) {
+      return NO_PREFETCH;
+    }
+    if (strVal.equalsIgnoreCase("prefetchToLimit")) {
+      return PREFETCH_TO_LIMIT;
+    }
+    if (strVal.equalsIgnoreCase("AlwaysPrefetch")) {
+      return ALWAYS_PREFETCH;
+    }
+    throw new IllegalArgumentException("Unknown String Value: " + strVal);
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -243,6 +243,7 @@ public class CommonConstants {
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String DEFAULT_READ_MODE = "heap";
+    public static final String DEFAULT_PREFETCH_MODE = "PREFETCH_TO_LIMIT";
     public static final String DEFAULT_INSTANCE_BASE_DIR =
         System.getProperty("java.io.tmpdir") + File.separator + "PinotServer";
     public static final String DEFAULT_INSTANCE_DATA_DIR = DEFAULT_INSTANCE_BASE_DIR + File.separator + "index";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/SegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/SegmentDataManager.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.data.manager;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 
 
@@ -25,8 +24,10 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 public abstract class SegmentDataManager {
   private int _referenceCount = 1;
 
-  @VisibleForTesting
-  synchronized int getReferenceCount() {
+  /**
+   * Returns the current reference count for the segment.
+   */
+  public synchronized int getReferenceCount() {
     return _referenceCount;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.indexsegment.immutable;
 
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
@@ -51,7 +52,7 @@ public class ImmutableSegmentLoader {
   public static ImmutableSegment load(@Nonnull File indexDir, @Nonnull ReadMode readMode) throws Exception {
     IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig();
     defaultIndexLoadingConfig.setReadMode(readMode);
-    return load(indexDir, defaultIndexLoadingConfig, null);
+    return load(indexDir, defaultIndexLoadingConfig, null, PrefetchMode.DEFAULT_PREFETCH_MODE);
   }
 
   /**
@@ -59,14 +60,14 @@ public class ImmutableSegmentLoader {
    */
   public static ImmutableSegment load(@Nonnull File indexDir, @Nonnull IndexLoadingConfig indexLoadingConfig)
       throws Exception {
-    return load(indexDir, indexLoadingConfig, null);
+    return load(indexDir, indexLoadingConfig, null, PrefetchMode.DEFAULT_PREFETCH_MODE);
   }
 
   /**
    * For segments from OFFLINE table.
    */
   public static ImmutableSegment load(@Nonnull File indexDir, @Nonnull IndexLoadingConfig indexLoadingConfig,
-      @Nullable Schema schema) throws Exception {
+      @Nullable Schema schema, PrefetchMode prefetchMode) throws Exception {
     Preconditions.checkArgument(indexDir.isDirectory(), "Index directory: {} does not exist or is not a directory",
         indexDir);
 
@@ -100,7 +101,7 @@ public class ImmutableSegmentLoader {
 
     // Load the segment
     ReadMode readMode = indexLoadingConfig.getReadMode();
-    SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(indexDir, segmentMetadata, readMode);
+    SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(indexDir, segmentMetadata, readMode, prefetchMode);
     SegmentDirectory.Reader segmentReader = segmentDirectory.createReader();
     Map<String, ColumnIndexContainer> indexContainerMap = new HashMap<>();
     for (Map.Entry<String, ColumnMetadata> entry : segmentMetadata.getColumnMetadataMap().entrySet()) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.segment.index.converter;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
@@ -123,8 +124,11 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
   private void copyIndexData(File v2Directory, SegmentMetadataImpl v2Metadata, File v3Directory)
       throws Exception {
     SegmentMetadataImpl v3Metadata = new SegmentMetadataImpl(v3Directory);
-    try (SegmentDirectory v2Segment = SegmentDirectory.createFromLocalFS(v2Directory, v2Metadata, ReadMode.mmap);
-        SegmentDirectory v3Segment = SegmentDirectory.createFromLocalFS(v3Directory, v3Metadata, ReadMode.mmap) ) {
+    // load the v2 segment without prefetching the pages - the required pages will be loaded as needed
+    try (SegmentDirectory v2Segment = SegmentDirectory.createFromLocalFS(v2Directory, v2Metadata,
+        ReadMode.mmap, PrefetchMode.NO_PREFETCH);
+        SegmentDirectory v3Segment = SegmentDirectory.createFromLocalFS(v3Directory, v3Metadata,
+            ReadMode.mmap, PrefetchMode.NO_PREFETCH) ) {
 
       // for each dictionary and each fwdIndex, copy that to newDirectory buffer
       Set<String> allColumns = v2Metadata.getAllColumns();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/SegmentPreProcessor.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.segment.index.loader;
 
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
@@ -56,7 +57,7 @@ public class SegmentPreProcessor implements AutoCloseable {
 
     // Always use mmap to load the segment because it is safest and performs well without impact from -Xmx params.
     // This is not the final load of the segment.
-    _segmentDirectory = SegmentDirectory.createFromLocalFS(indexDir, _segmentMetadata, ReadMode.mmap);
+    _segmentDirectory = SegmentDirectory.createFromLocalFS(indexDir, _segmentMetadata, ReadMode.mmap, PrefetchMode.DEFAULT_PREFETCH_MODE);
   }
 
   public void process() throws Exception {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectory.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.segment.store;
 
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
@@ -103,14 +104,15 @@ public abstract class SegmentDirectory implements AutoCloseable {
   // In future, we will have this class load metadata rather than
   // passing it in.
   public static SegmentDirectory createFromLocalFS(File directory,
-      SegmentMetadataImpl metadata, ReadMode readMode) {
-    return new SegmentLocalFSDirectory(directory, metadata, readMode);
+      SegmentMetadataImpl metadata, ReadMode readMode, PrefetchMode prefetchMode) {
+    return new SegmentLocalFSDirectory(directory, metadata, readMode, prefetchMode);
   }
 
-  public static SegmentDirectory createFromLocalFS(File directory, ReadMode readMode)
+  public static SegmentDirectory createFromLocalFS(File directory, ReadMode readMode, PrefetchMode prefetchMode)
       throws IOException, ConfigurationException {
-    return new SegmentLocalFSDirectory(directory, readMode);
+    return new SegmentLocalFSDirectory(directory, readMode, prefetchMode);
   }
+
   public static SegmentMetadataImpl loadSegmentMetadata(File directory)
       throws IOException, ConfigurationException {
     return SegmentLocalFSDirectory.loadSegmentMetadata(directory);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/RawIndexCreatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/RawIndexCreatorTest.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.segment.index.creator;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.data.GenericRow;
@@ -228,7 +229,8 @@ public class RawIndexCreatorTest {
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, recordReader);
     driver.build();
-    _segmentDirectory = SegmentDirectory.createFromLocalFS(driver.getOutputDirectory(), ReadMode.mmap);
+    _segmentDirectory = SegmentDirectory.createFromLocalFS(driver.getOutputDirectory(), ReadMode.mmap,
+        PrefetchMode.DEFAULT_PREFETCH_MODE);
     _segmentReader = _segmentDirectory.createReader();
     recordReader.rewind();
     return recordReader;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
@@ -21,6 +21,7 @@ import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.primitive.ByteArray;
@@ -250,7 +251,7 @@ public class SegmentGenerationWithBytesTypeTest {
     driver.init(config, recordReader);
     driver.build();
 
-    SegmentDirectory.createFromLocalFS(driver.getOutputDirectory(), ReadMode.mmap);
+    SegmentDirectory.createFromLocalFS(driver.getOutputDirectory(), ReadMode.mmap, PrefetchMode.DEFAULT_PREFETCH_MODE);
     recordReader.rewind();
     return recordReader;
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/LoaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/LoaderTest.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.segment.index.loader;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
@@ -142,7 +143,8 @@ public class LoaderTest {
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segmentDirectory);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor("name");
     Assert.assertEquals(columnMetadata.getPaddingCharacter(), V1Constants.Str.LEGACY_STRING_PAD_CHAR);
-    SegmentDirectory segmentDir = SegmentDirectory.createFromLocalFS(segmentDirectory, segmentMetadata, ReadMode.heap);
+    SegmentDirectory segmentDir = SegmentDirectory.createFromLocalFS(segmentDirectory, segmentMetadata, ReadMode.heap,
+        PrefetchMode.DEFAULT_PREFETCH_MODE);
     SegmentDirectory.Reader reader = segmentDir.createReader();
     PinotDataBuffer dictionaryBuffer = reader.getIndexFor("name", ColumnIndexType.DICTIONARY);
     StringDictionary dict = new StringDictionary(dictionaryBuffer, columnMetadata.getCardinality(),
@@ -162,7 +164,7 @@ public class LoaderTest {
     segmentMetadata = new SegmentMetadataImpl(segmentDirectory);
     columnMetadata = segmentMetadata.getColumnMetadataFor("name");
     Assert.assertEquals(columnMetadata.getPaddingCharacter(), V1Constants.Str.LEGACY_STRING_PAD_CHAR);
-    segmentDir = SegmentDirectory.createFromLocalFS(segmentDirectory, segmentMetadata, ReadMode.heap);
+    segmentDir = SegmentDirectory.createFromLocalFS(segmentDirectory, segmentMetadata, ReadMode.heap, PrefetchMode.DEFAULT_PREFETCH_MODE);
     reader = segmentDir.createReader();
     dictionaryBuffer = reader.getIndexFor("name", ColumnIndexType.DICTIONARY);
     dict = new StringDictionary(dictionaryBuffer, columnMetadata.getCardinality(),
@@ -182,7 +184,7 @@ public class LoaderTest {
     segmentMetadata = new SegmentMetadataImpl(segmentDirectory);
     columnMetadata = segmentMetadata.getColumnMetadataFor("name");
     Assert.assertEquals(columnMetadata.getPaddingCharacter(), V1Constants.Str.DEFAULT_STRING_PAD_CHAR);
-    segmentDir = SegmentDirectory.createFromLocalFS(segmentDirectory, segmentMetadata, ReadMode.heap);
+    segmentDir = SegmentDirectory.createFromLocalFS(segmentDirectory, segmentMetadata, ReadMode.heap, PrefetchMode.DEFAULT_PREFETCH_MODE);
     reader = segmentDir.createReader();
     dictionaryBuffer = reader.getIndexFor("name", ColumnIndexType.DICTIONARY);
     dict = new StringDictionary(dictionaryBuffer, columnMetadata.getCardinality(),
@@ -204,12 +206,12 @@ public class LoaderTest {
     schema.addField(new DimensionFieldSpec("SVString", FieldSpec.DataType.STRING, true, ""));
     schema.addField(new DimensionFieldSpec("MVString", FieldSpec.DataType.STRING, false, ""));
 
-    IndexSegment indexSegment = ImmutableSegmentLoader.load(_indexDir, _v1IndexLoadingConfig, schema);
+    IndexSegment indexSegment = ImmutableSegmentLoader.load(_indexDir, _v1IndexLoadingConfig, schema, PrefetchMode.DEFAULT_PREFETCH_MODE);
     Assert.assertEquals(indexSegment.getDataSource("SVString").getDictionary().get(0), "");
     Assert.assertEquals(indexSegment.getDataSource("MVString").getDictionary().get(0), "");
     indexSegment.destroy();
 
-    indexSegment = ImmutableSegmentLoader.load(_indexDir, _v3IndexLoadingConfig, schema);
+    indexSegment = ImmutableSegmentLoader.load(_indexDir, _v3IndexLoadingConfig, schema, PrefetchMode.DEFAULT_PREFETCH_MODE);
     Assert.assertEquals(indexSegment.getDataSource("SVString").getDictionary().get(0), "");
     Assert.assertEquals(indexSegment.getDataSource("MVString").getDictionary().get(0), "");
     indexSegment.destroy();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.segment.index.loader;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
@@ -194,7 +195,7 @@ public class SegmentPreProcessorTest {
     // Create inverted index the first time.
     checkInvertedIndexCreation(false);
     long addedLength = 0L;
-    try (SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(segmentDirectoryPath, ReadMode.mmap);
+    try (SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(segmentDirectoryPath, ReadMode.mmap, PrefetchMode.DEFAULT_PREFETCH_MODE);
         SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
       // 8 bytes overhead is for checking integrity of the segment.
       try (PinotDataBuffer col1Buffer = reader.getIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX)) {
@@ -219,7 +220,7 @@ public class SegmentPreProcessorTest {
   }
 
   private void checkInvertedIndexCreation(boolean reCreate) throws Exception {
-    try (SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(_indexDir, ReadMode.mmap);
+    try (SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(_indexDir, ReadMode.mmap, PrefetchMode.DEFAULT_PREFETCH_MODE);
         SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
       if (reCreate) {
         Assert.assertTrue(reader.hasIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX));
@@ -238,7 +239,7 @@ public class SegmentPreProcessorTest {
       processor.process();
     }
 
-    try (SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(_indexDir, ReadMode.mmap);
+    try (SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(_indexDir, ReadMode.mmap, PrefetchMode.DEFAULT_PREFETCH_MODE);
         SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
       Assert.assertTrue(reader.hasIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX));
       Assert.assertTrue(reader.hasIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX));
@@ -336,7 +337,8 @@ public class SegmentPreProcessorTest {
     Assert.assertEquals(columnMetadata.getDefaultNullValueString(), "null");
 
     // Check dictionary and forward index exist.
-    try (SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(_indexDir, ReadMode.mmap);
+    try (SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(_indexDir, ReadMode.mmap,
+        PrefetchMode.DEFAULT_PREFETCH_MODE);
         SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
       Assert.assertTrue(reader.hasIndexFor(NEW_INT_METRIC_COLUMN_NAME, ColumnIndexType.DICTIONARY));
       Assert.assertTrue(reader.hasIndexFor(NEW_INT_METRIC_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectoryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectoryTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.segment.store;
 
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
@@ -45,7 +46,7 @@ public class SegmentLocalFSDirectoryTest {
     FileUtils.deleteQuietly(TEST_DIRECTORY);
     TEST_DIRECTORY.mkdirs();
     metadata = ColumnIndexDirectoryTestHelper.writeMetadata(SegmentVersion.v1);
-    segmentDirectory = new SegmentLocalFSDirectory(TEST_DIRECTORY, metadata, ReadMode.mmap);
+    segmentDirectory = new SegmentLocalFSDirectory(TEST_DIRECTORY, metadata, ReadMode.mmap, PrefetchMode.DEFAULT_PREFETCH_MODE);
   }
 
   @AfterClass
@@ -157,14 +158,14 @@ public class SegmentLocalFSDirectoryTest {
         FileUtils.deleteQuietly(sizeTestDirectory);
       }
       FileUtils.copyDirectoryToDirectory(segmentDirectory.getPath().toFile(), sizeTestDirectory);
-      SegmentDirectory sizeSegment = SegmentLocalFSDirectory.createFromLocalFS(sizeTestDirectory, metadata, ReadMode.mmap);
+      SegmentDirectory sizeSegment = SegmentLocalFSDirectory.createFromLocalFS(sizeTestDirectory, metadata, ReadMode.mmap, PrefetchMode.DEFAULT_PREFETCH_MODE);
       Assert.assertEquals(sizeSegment.getDiskSizeBytes(), segmentDirectory.getDiskSizeBytes());
 
       Assert.assertFalse(SegmentDirectoryPaths.segmentDirectoryFor(sizeTestDirectory, SegmentVersion.v3).exists());
       File v3SizeDir = new File(sizeTestDirectory, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME);
       // the destination is not exactly v3 but does not matter
       FileUtils.copyDirectoryToDirectory(segmentDirectory.getPath().toFile(), v3SizeDir);
-      SegmentDirectory sizeV3Segment = SegmentDirectory.createFromLocalFS(v3SizeDir, metadata, ReadMode.mmap);
+      SegmentDirectory sizeV3Segment = SegmentDirectory.createFromLocalFS(v3SizeDir, metadata, ReadMode.mmap, PrefetchMode.DEFAULT_PREFETCH_MODE);
       Assert.assertEquals(sizeSegment.getDiskSizeBytes(), sizeV3Segment.getDiskSizeBytes());
 
       // now drop v3

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
@@ -22,6 +22,7 @@ import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.response.broker.AggregationResult;
 import com.linkedin.pinot.common.response.broker.BrokerResponseNative;
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.common.utils.primitive.ByteArray;
@@ -36,7 +37,6 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegment;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
-import com.linkedin.pinot.core.io.compression.ChunkCompressorFactory;
 import com.linkedin.pinot.core.operator.DocIdSetOperator;
 import com.linkedin.pinot.core.operator.ProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -329,7 +329,8 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
     driver.init(config, recordReader);
     driver.build();
 
-    SegmentDirectory.createFromLocalFS(driver.getOutputDirectory(), ReadMode.mmap);
+    SegmentDirectory.createFromLocalFS(driver.getOutputDirectory(), ReadMode.mmap,
+        PrefetchMode.DEFAULT_PREFETCH_MODE);
     recordReader.rewind();
 
     TDigest actual = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkOfflineIndexReader.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkOfflineIndexReader.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.perf;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.segment.PrefetchMode;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.io.reader.ReaderContext;
@@ -108,7 +109,7 @@ public class BenchmarkOfflineIndexReader {
 
     File indexDir = new File(dataDir, TABLE_NAME);
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
-    SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(indexDir, segmentMetadata, ReadMode.mmap);
+    SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(indexDir, segmentMetadata, ReadMode.mmap, PrefetchMode.DEFAULT_PREFETCH_MODE);
     SegmentDirectory.Reader segmentReader = segmentDirectory.createReader();
 
     // Forward index

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -28,8 +28,6 @@ import com.linkedin.pinot.core.data.manager.SegmentDataManager;
 import com.linkedin.pinot.core.data.manager.TableDataManager;
 import com.linkedin.pinot.core.data.manager.config.TableDataManagerConfig;
 import com.linkedin.pinot.core.data.manager.offline.TableDataManagerProvider;
-import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegment;
-import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import com.linkedin.pinot.core.segment.index.loader.LoaderUtils;
 import java.io.File;
@@ -219,13 +217,8 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       // Copy from segment backup directory back to index directory
       FileUtils.copyDirectory(segmentBackupDir, indexDir);
 
-      // Load from index directory
-      ImmutableSegment immutableSegment =
-          ImmutableSegmentLoader.load(indexDir, new IndexLoadingConfig(_instanceDataManagerConfig, tableConfig),
-              schema);
-
       // Replace the old segment in memory
-      _tableDataManagerMap.get(tableNameWithType).addSegment(immutableSegment);
+      _tableDataManagerMap.get(tableNameWithType).addSegment(indexDir, new IndexLoadingConfig(_instanceDataManagerConfig, tableConfig));
 
       // Rename segment backup directory to segment temporary directory (atomic)
       // The reason to first rename then delete is that, renaming is an atomic operation, but deleting is not. When we


### PR DESCRIPTION
Initial set of changes to load "hot" segment pages into memory. This change is to address increased latencies we see when such segments are refreshed/reloaded. The code determines if a segment is hot or not based on its reference count. This is just a heuristic - its possible that once the current queries drain, no new ones hit the loaded segment. 

Additionally, it appears that the earlier code would reload pages upto 66G (and headers only till 100G limit) - this seems a bit excessive given the amount of available physical memory on servers.

I plan to run to tests to validate the changes - posting this mainly for early feedback.