### PR TITLE
Adding https option to hadoop segment upload

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
@@ -115,14 +115,14 @@ public class FileUploadDownloadClient implements Closeable {
     return new URI(scheme, null, host, port, path, null, null);
   }
 
-  public static URI getRetrieveTableConfigURI(String host, int port, String tableName) throws URISyntaxException {
+  public static URI getRetrieveTableConfigURI(String scheme, String host, int port, String tableName) throws URISyntaxException {
     String path = TABLES_PATH + SLASH + tableName;
-    return getURI(HTTP, host, port, path);
+    return getURI(scheme, host, port, path);
   }
 
-  public static URI getRetrieveSchemaHttpURI(String host, int port, String tableName) throws URISyntaxException {
+  public static URI getRetrieveSchemaHttpURI(String scheme, String host, int port, String tableName) throws URISyntaxException {
     String path = SCHEMA_PATH + SLASH + tableName;
-    return getURI(HTTP, host, port, path);
+    return getURI(scheme, host, port, path);
   }
 
   public static URI getUploadSchemaHttpURI(String host, int port) throws URISyntaxException {

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
@@ -31,4 +31,5 @@ public class JobConfigConstants {
   public static final String PUSH_TO_HOSTS = "push.to.hosts";
   public static final String PUSH_TO_PORT = "push.to.port";
 
+  public static final String ENABLE_HTTPS = "enable.https";
 }

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.apache.helix.task.JobConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +63,8 @@ public class SegmentCreationJob extends Configured {
 
   private String[] _hosts;
   private int _port;
+  // Defaults to false
+  private boolean _enableHttps = false;
 
   public SegmentCreationJob(String jobName, Properties properties) throws Exception {
     super(new Configuration());
@@ -86,6 +87,10 @@ public class SegmentCreationJob extends Configured {
       _port = Integer.parseInt(portString);
     }
     _tableName = _properties.getProperty(JobConfigConstants.SEGMENT_TABLE_NAME);
+    String enableHttps = _properties.getProperty(JobConfigConstants.ENABLE_HTTPS);
+    if (enableHttps != null) {
+      _enableHttps = Boolean.parseBoolean(enableHttps);
+    }
 
     Utils.logVersions();
 
@@ -220,7 +225,7 @@ public class SegmentCreationJob extends Configured {
           .build());
     }
 
-    ControllerRestApi controllerRestApiObject = new ControllerRestApi(pushLocations, _tableName);
+    ControllerRestApi controllerRestApiObject = new ControllerRestApi(pushLocations, _enableHttps, _tableName);
 
     TableConfig tableConfig = controllerRestApiObject.getTableConfig();
     job.getConfiguration()


### PR DESCRIPTION
* Clients can declare enable.https in their job.properties file. If this parameter is declared, https will be used by default for all segment upload requests and tableconfig/schema get requests.