### PR TITLE
Adding "segment.merge.cover" field to segment metadata

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -354,6 +354,7 @@ public class CommonConstants {
     public static final String SEGMENT_UPLOAD_START_TIME = "segment.upload.start.time";
 
     public static final String CUSTOM_MAP = "custom.map";
+    public static final String MERGE_COVER = "segment.merge.cover";
 
     public static final String SEGMENT_BACKUP_DIR_SUFFIX = ".segment.bak";
     public static final String SEGMENT_TEMP_DIR_SUFFIX = ".segment.tmp";

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
@@ -24,6 +24,7 @@ import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Segment.Realtime.Status;
 import com.linkedin.pinot.common.utils.CommonConstants.Segment.SegmentType;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -157,6 +158,7 @@ public class SegmentZKMetadataTest {
     record.setLongField(CommonConstants.Segment.CREATION_TIME, 1000);
     record.setIntField(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, 1234);
     record.setSimpleField(CommonConstants.Segment.FLUSH_THRESHOLD_TIME, "6h");
+    record.setListField(CommonConstants.Segment.MERGE_COVER, Arrays.asList(new String[] {"test1", "test2"}));
     return record;
   }
 
@@ -175,6 +177,7 @@ public class SegmentZKMetadataTest {
     realtimeSegmentMetadata.setCreationTime(1000);
     realtimeSegmentMetadata.setSizeThresholdToFlushSegment(1234);
     realtimeSegmentMetadata.setTimeThresholdToFlushSegment("6h");
+    realtimeSegmentMetadata.setMergeCoveredSegments(Arrays.asList(new String[] {"test1", "test2"}));
     return realtimeSegmentMetadata;
   }
 
@@ -194,6 +197,7 @@ public class SegmentZKMetadataTest {
     record.setSimpleField(CommonConstants.Segment.Offline.DOWNLOAD_URL, "http://localhost:8000/testTable_O_3000_4000");
     record.setLongField(CommonConstants.Segment.Offline.PUSH_TIME, 4000);
     record.setLongField(CommonConstants.Segment.Offline.REFRESH_TIME, 8000);
+    record.setListField(CommonConstants.Segment.MERGE_COVER, Arrays.asList(new String[] {"test1", "test2"}));
     return record;
   }
 
@@ -212,6 +216,7 @@ public class SegmentZKMetadataTest {
     offlineSegmentMetadata.setDownloadUrl("http://localhost:8000/testTable_O_3000_4000");
     offlineSegmentMetadata.setPushTime(4000);
     offlineSegmentMetadata.setRefreshTime(8000);
+    offlineSegmentMetadata.setMergeCoveredSegments(Arrays.asList(new String[] {"test1", "test2"}));
     return offlineSegmentMetadata;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -73,6 +73,7 @@ public class SegmentGeneratorConfig {
   private Map<String, ChunkCompressorFactory.CompressionType> _rawIndexCompressionType = new HashMap<>();
   private List<String> _invertedIndexCreationColumns = new ArrayList<>();
   private List<String> _columnSortOrder = new ArrayList<>();
+  private List<String> _mergeCoveredSegments = new ArrayList<>();
   private String _dataDir = null;
   private String _inputFilePath = null;
   private FileFormat _format = FileFormat.AVRO;
@@ -231,6 +232,10 @@ public class SegmentGeneratorConfig {
     return _columnSortOrder;
   }
 
+  public List<String> getMergeCoveredSegments() {
+    return _mergeCoveredSegments;
+  }
+
   public void setRawIndexCreationColumns(List<String> rawIndexCreationColumns) {
     Preconditions.checkNotNull(rawIndexCreationColumns);
     _rawIndexCreationColumns.addAll(rawIndexCreationColumns);
@@ -244,6 +249,10 @@ public class SegmentGeneratorConfig {
   public void setColumnSortOrder(List<String> sortOrder) {
     Preconditions.checkNotNull(sortOrder);
     _columnSortOrder.addAll(sortOrder);
+  }
+
+  public void setMergeCoveredSegments(List<String> mergeCoveredSegments) {
+    _mergeCoveredSegments = mergeCoveredSegments;
   }
 
   public void createInvertedIndexForColumn(String column) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -316,6 +316,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     properties.setProperty(SEGMENT_TOTAL_NULLS, String.valueOf(totalNulls));
     properties.setProperty(SEGMENT_TOTAL_CONVERSIONS, String.valueOf(totalConversions));
     properties.setProperty(SEGMENT_TOTAL_NULL_COLS, String.valueOf(totalNullCols));
+    properties.setProperty(SEGMENT_MERGE_COVER, config.getMergeCoveredSegments());
 
     StarTreeIndexSpec starTreeIndexSpec = config.getStarTreeIndexSpec();
     if (starTreeIndexSpec != null) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
@@ -104,6 +104,7 @@ public class V1Constants {
       public static final String SEGMENT_START_TIME = "segment.start.time";
       public static final String SEGMENT_END_TIME = "segment.end.time";
       public static final String SEGMENT_TIME_GRANULARITY = "segment.time.granularity";
+      public static final String SEGMENT_MERGE_COVER = "segment.merge.cover";
     }
 
     public static class Column {


### PR DESCRIPTION
In order to indicate segments covered by a merged segment,
we need to add the new field to segment metadata. This PR
adds "segment.merge.cover" to both segment metadata and
segment zk metadata.