### PR TITLE
Adding an exception to server response when there are missing segments

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/exception/QueryException.java
@@ -38,6 +38,7 @@ public class QueryException {
   public static final int SEGMENT_PLAN_EXECUTION_ERROR_CODE = 160;
   public static final int COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR_CODE = 170;
   public static final int ACCESS_DENIED_ERROR_CODE = 180;
+  public static final int MISSING_SEGMENTS_ERROR_CODE = 190;
   public static final int QUERY_EXECUTION_ERROR_CODE = 200;
   // TODO: Handle these errors in broker
   public static final int SERVER_SHUTTING_DOWN_ERROR_CODE = 210;
@@ -66,6 +67,7 @@ public class QueryException {
       new ProcessingException(SEGMENT_PLAN_EXECUTION_ERROR_CODE);
   public static final ProcessingException COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR =
       new ProcessingException(COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR_CODE);
+  public static final ProcessingException MISSING_SEGMENTS_ERROR = new ProcessingException(MISSING_SEGMENTS_ERROR_CODE);
   public static final ProcessingException QUERY_EXECUTION_ERROR = new ProcessingException(QUERY_EXECUTION_ERROR_CODE);
   public static final ProcessingException SERVER_SCHEDULER_DOWN_ERROR =
       new ProcessingException(SERVER_SHUTTING_DOWN_ERROR_CODE);
@@ -100,6 +102,7 @@ public class QueryException {
     PQL_PARSING_ERROR.setMessage("PQLParsingError");
     SEGMENT_PLAN_EXECUTION_ERROR.setMessage("SegmentPlanExecutionError");
     COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR.setMessage("CombineSegmentPlanTimeoutError");
+    MISSING_SEGMENTS_ERROR.setMessage("MissingSegmentsError");
     QUERY_EXECUTION_ERROR.setMessage("QueryExecutionError");
     SERVER_SCHEDULER_DOWN_ERROR.setMessage("ServerShuttingDown");
     SERVER_OUT_OF_CAPACITY_ERROR.setMessage("ServerOutOfCapacity");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/BaseTableDataManager.java
@@ -171,8 +171,6 @@ public abstract class BaseTableDataManager implements TableDataManager {
       SegmentDataManager segmentDataManager = _segmentDataManagerMap.get(segmentName);
       if (segmentDataManager != null && segmentDataManager.increaseReferenceCount()) {
         segmentDataManagers.add(segmentDataManager);
-      } else {
-        handleMissingSegment(segmentName);
       }
     }
     return segmentDataManagers;
@@ -184,15 +182,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
     if (segmentDataManager != null && segmentDataManager.increaseReferenceCount()) {
       return segmentDataManager;
     } else {
-      handleMissingSegment(segmentName);
       return null;
     }
-  }
-
-  private void handleMissingSegment(String segmentName) {
-    // could not find segment
-    LOGGER.error("Could not find segment " + segmentName + " for table " + _tableNameWithType);
-    _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.NUM_MISSING_SEGMENTS, 1);
   }
 
   @Override


### PR DESCRIPTION
When broker sends a request to server for a segment that does not
exist on server, no message or indication on this is sent back
to broker. This pr adds the exception information in DataTable that
is sent back to broker that it can know if there was any missing
segment from server side while processing the query.