### PR TITLE
Changing SegmentFetcher init to include protocol

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HdfsSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HdfsSegmentFetcher.java
@@ -41,7 +41,7 @@ public class HdfsSegmentFetcher implements SegmentFetcher {
   private int _retryWaitMs = RETRY_WAITIME_MS_DEFAULT;
 
   @Override
-  public void init(org.apache.commons.configuration.Configuration configs) {
+  public void init(org.apache.commons.configuration.Configuration configs, String protocol) {
     try {
       _retryCount = configs.getInt(RETRY, _retryCount);
       _retryWaitMs = configs.getInt(RETRY_WAITIME_MS, _retryWaitMs);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpSegmentFetcher.java
@@ -37,7 +37,7 @@ public class HttpSegmentFetcher implements SegmentFetcher {
   protected int _retryWaitMs;
 
   @Override
-  public void init(Configuration configs) {
+  public void init(Configuration configs, String protocol) {
     initHttpClient(configs);
     _retryCount = configs.getInt(RETRY, RETRY_DEFAULT);
     _retryWaitMs = configs.getInt(RETRY_WAITIME_MS, RETRY_WAITIME_MS_DEFAULT);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/LocalFileSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/LocalFileSegmentFetcher.java
@@ -29,7 +29,7 @@ public class LocalFileSegmentFetcher implements SegmentFetcher {
   private static final Logger LOGGER = LoggerFactory.getLogger(LocalFileSegmentFetcher.class);
 
   @Override
-  public void init(Configuration configs) {
+  public void init(Configuration configs, String protocol) {
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/NoOpFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/NoOpFetcher.java
@@ -29,7 +29,7 @@ public class NoOpFetcher implements SegmentFetcher {
   public static Logger LOGGER = LoggerFactory.getLogger(NoOpFetcher.class);
 
   @Override
-  public void init(Configuration configs) {
+  public void init(Configuration configs, String protocol) {
     LOGGER.info("NoOpFetcher initialized.");
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/PinotFSSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/PinotFSSegmentFetcher.java
@@ -28,16 +28,13 @@ public class PinotFSSegmentFetcher implements SegmentFetcher {
   private PinotFS _pinotFS;
 
   @Override
-  public void init(Configuration config) {
-
+  public void init(Configuration config, String protocol) {
+    _pinotFS = PinotFSFactory.create(protocol);
   }
 
   @Override
   public void fetchSegmentToLocal(String uriString, File tempFile) throws Exception {
     URI uri = new URI(uriString);
-
-    // TODO: move _pinotFS creation to init, however, it needs the right config passed in into init.
-    _pinotFS = PinotFSFactory.create(uri.getScheme());
     _pinotFS.copyToLocalFile(uri, tempFile);
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcher.java
@@ -25,8 +25,9 @@ public interface SegmentFetcher {
   /**
    * Initializes configurations
    * @param configs
+   * @param protocol
    */
-  void init(Configuration configs);
+  void init(Configuration configs, String protocol);
 
   /**
    * Fetches segment from a uri location to the local filesystem. Can come from a remote fs or a local fs.

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactory.java
@@ -72,7 +72,7 @@ public class SegmentFetcherFactory {
       LOGGER.info("Initializing segment fetcher for protocol: {}", protocol);
       Configuration segmentFetcherConfig = segmentFetcherClassConfig.subset(protocol);
       logFetcherInitConfig(segmentFetcher, protocol, segmentFetcherConfig);
-      segmentFetcher.init(segmentFetcherConfig);
+      segmentFetcher.init(segmentFetcherConfig, protocol);
       _segmentFetcherMap.put(protocol, segmentFetcher);
     }
   }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactoryTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactoryTest.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.common.segment.fetcher;
 
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.filesystem.LocalPinotFS;
+import com.linkedin.pinot.filesystem.PinotFSFactory;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.net.URISyntaxException;
@@ -41,6 +44,11 @@ public class SegmentFetcherFactoryTest {
 
   @Test
   public void testDefaultSegmentFetcherFactory() throws Exception {
+    // Adding file pinot fs
+    PropertiesConfiguration pinotFSConfig = new PropertiesConfiguration();
+    pinotFSConfig.addProperty(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY + ".class",
+        LocalPinotFS.class.getName());
+    PinotFSFactory.init(pinotFSConfig);
     _segmentFetcherFactory.init(new PropertiesConfiguration(), new PropertiesConfiguration());
     Assert.assertTrue(_segmentFetcherFactory.containsProtocol("file"));
     Assert.assertTrue(_segmentFetcherFactory.containsProtocol("http"));
@@ -68,6 +76,11 @@ public class SegmentFetcherFactoryTest {
 
   @Test
   public void testGetSegmentFetcherBasedOnURI() throws Exception {
+    // Adding file pinot fs
+    PropertiesConfiguration pinotFSConfig = new PropertiesConfiguration();
+    pinotFSConfig.addProperty(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY + ".class",
+        LocalPinotFS.class.getName());
+    PinotFSFactory.init(pinotFSConfig);
     _segmentFetcherFactory.init(new PropertiesConfiguration(), new PropertiesConfiguration());
 
     Assert.assertTrue(
@@ -88,7 +101,7 @@ public class SegmentFetcherFactoryTest {
     public int initCalled = 0;
 
     @Override
-    public void init(Configuration configs) {
+    public void init(Configuration configs, String protocol) {
       initCalled++;
     }
 


### PR DESCRIPTION
* Currently, we create the correct pinotFS inside the fetchSegmentToLocal method in SegmentFetcher. Instead, we want the init method to create the correct class and place that inside the segment fetcher map. This PR will add a protocol argument to the init constructor of SegmentFetcher to accomplish this.