### PR TITLE
Add metadata info and metric when querying non-existing columns

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
@@ -54,7 +54,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NUM_SEGMENTS_QUERIED("numSegmentsQueried", false),
   NUM_SEGMENTS_PROCESSED("numSegmentsProcessed", false),
   NUM_SEGMENTS_MATCHED("numSegmentsMatched", false),
-  NUM_MISSING_SEGMENTS("segments", false);
+  NUM_MISSING_SEGMENTS("segments", false),
+  QUERY_NON_EXISTING_COLUMNS("queries", false);
 
   private final String meterName;
   private final String unit;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
@@ -40,8 +40,7 @@ import org.json.JSONObject;
  * Supports serialization via JSON.
  */
 @JsonPropertyOrder({ "selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded", "numSegmentsQueried",
-    "numSegmentsProcessed", "numSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numGroupsLimitReached",
-    "totalDocs", "timeUsedMs", "segmentStatistics", "traceInfo" })
+    "numSegmentsProcessed", "numSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "segmentStatistics", "pruningReasons", "traceInfo" })
 public class BrokerResponseNative implements BrokerResponse {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -57,7 +56,7 @@ public class BrokerResponseNative implements BrokerResponse {
   private long _numSegmentsQueried = 0L;
   private long _numSegmentsProcessed = 0L;
   private long _numSegmentsMatched = 0L;
-  
+
   private long _totalDocs = 0L;
   private boolean _numGroupsLimitReached = false;
   private long _timeUsedMs = 0L;
@@ -68,6 +67,7 @@ public class BrokerResponseNative implements BrokerResponse {
   private Map<String, String> _traceInfo = new HashMap<>();
   private List<QueryProcessingException> _processingExceptions = new ArrayList<>();
   private List<String> _segmentStatistics = new ArrayList<>();
+  private List<String> _pruningReasons = new ArrayList<>();
 
   public BrokerResponseNative() {
   }
@@ -248,6 +248,16 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty("segmentStatistics")
   public void setSegmentStatistics(List<String> segmentStatistics) {
     _segmentStatistics = segmentStatistics;
+  }
+
+  @JsonProperty("pruningReasons")
+  public List<String> getPruningReasons() {
+    return _pruningReasons;
+  }
+
+  @JsonProperty("pruningReasons")
+  public void setPruningReasons(List<String> pruningReasons) {
+    _pruningReasons = pruningReasons;
   }
 
   @JsonProperty("traceInfo")

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
@@ -37,6 +37,7 @@ public interface DataTable {
   String TIME_USED_MS_METADATA_KEY = "timeUsedMs";
   String TRACE_INFO_METADATA_KEY = "traceInfo";
   String REQUEST_ID_METADATA_KEY = "requestId";
+  String PRUNING_REASON_METADATA_KEY = "pruningReasons";
 
   void addException(@Nonnull ProcessingException processingException);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/PartitionSegmentPruner.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/PartitionSegmentPruner.java
@@ -110,4 +110,9 @@ public class PartitionSegmentPruner extends AbstractSegmentPruner {
     }
     return true;
   }
+
+  @Override
+  public String toString() {
+    return "PartitionSegmentPruner";
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/SegmentPrunerService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/SegmentPrunerService.java
@@ -44,15 +44,15 @@ public class SegmentPrunerService {
   }
 
   /**
-   * Returns <code>true</code> if the segment can be pruned based on the query request.
+   * Returns the segment pruner if the segment can be pruned based on the query request. Otherwise, returns null.
    */
-  public boolean prune(IndexSegment segment, ServerQueryRequest queryRequest) {
+  public SegmentPruner matchPruningCriterion(IndexSegment segment, ServerQueryRequest queryRequest) {
     for (SegmentPruner segmentPruner : _segmentPruners) {
       if (segmentPruner.prune(segment, queryRequest)) {
-        LOGGER.debug("Pruned segment: {}", segment.getSegmentName());
-        return true;
+        LOGGER.debug("Pruned segment: {} by: {}", segment.getSegmentName(), segmentPruner.toString());
+        return segmentPruner;
       }
     }
-    return false;
+    return null;
   }
 }


### PR DESCRIPTION
This PR adds metadata info and metric when querying non-existing columns. 
The metric is used to monitor how many tables do we currently query with non-existing columns, so that we can take some follow up actions, like including warning message in the response, etc.
The metadata info will be like ` "pruningReasons": ["DataSchemaSegmentPruner"]`. 
Thus the response output will be like:
```
{
    "selectionResults": {
        "columns": ["l_comments", "l_discount"],
        "results": []
    },
    "exceptions": [],
    "numServersQueried": 1,
    "numServersResponded": 1,
    "numSegmentsQueried": 1,
    "numSegmentsProcessed": 0,
    "numSegmentsMatched": 0,
    "numDocsScanned": 0,
    "numEntriesScannedInFilter": 0,
    "numEntriesScannedPostFilter": 0,
    "numGroupsLimitReached": false,
    "totalDocs": 7280281,
    "timeUsedMs": 8,
    "segmentStatistics": [],
    "traceInfo": {},
    "pruningReasons": ["DataSchemaSegmentPruner"]
}
```