### PR TITLE
Segment name generator with _postfix

### DIFF
--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
@@ -224,8 +224,10 @@ public class HadoopSegmentCreationMapReduceJob {
       segmentGeneratorConfig.setFormat(fileFormat);
       segmentGeneratorConfig.setOnHeap(true);
 
+//      If the time column name exists, _segmentNamePostfix = "postfix", and _sequenceId = 1, the segment name would be
+//      tableName_minDate_maxDate_postfix_1
       if (null != _postfix) {
-        segmentGeneratorConfig.setSegmentNamePostfix(String.format("%s-%s", _postfix, seqId));
+        segmentGeneratorConfig.setSegmentNamePostfix(String.format("%s_%s", _postfix, seqId));
       } else {
         segmentGeneratorConfig.setSequenceId(seqId);
       }


### PR DESCRIPTION
If the time column name exists, _segmentNamePostfix = "postfix", and _sequenceId = 1, the segment name should be tableName_minDate_maxDate_postfix_1 , rather than ableName_minDate_maxDate_postfix-1