### PR TITLE
Add API to generate batch id for segment upload if batch upload is within quota.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -54,6 +54,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
   private long _segmentUploadStartTime = -1;
   private Map<String, String> _customMap;
   private String _crypterName;
+  private String _batchId;
+  private int _numSegmentsInBatch;
 
   public SegmentZKMetadata() {
   }
@@ -86,6 +88,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     }
     _segmentUploadStartTime = znRecord.getLongField(CommonConstants.Segment.SEGMENT_UPLOAD_START_TIME, -1);
     _customMap = znRecord.getMapField(CommonConstants.Segment.CUSTOM_MAP);
+    _batchId = znRecord.getSimpleField(CommonConstants.Segment.BATCH_ID);
+    _numSegmentsInBatch = znRecord.getIntField(CommonConstants.Segment.NUMBER_OF_SEGMENTS_IN_BATCH, -1);
   }
 
   public String getSegmentName() {
@@ -216,6 +220,22 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     _customMap = customMap;
   }
 
+  public String getBatchId() {
+    return _batchId;
+  }
+
+  public void setBatchId(String batchId) {
+    _batchId = batchId;
+  }
+
+  public int getNumSegmentsInBatch() {
+    return _numSegmentsInBatch;
+  }
+
+  public void setNumSegmentsInBatch(int numSegmentsInBatch) {
+    _numSegmentsInBatch = numSegmentsInBatch;
+  }
+
   @Override
   public boolean equals(Object segmentMetadata) {
     if (isSameReference(this, segmentMetadata)) {
@@ -232,7 +252,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
         && isEqual(_startTime, metadata._startTime) && isEqual(_endTime, metadata._endTime) && isEqual(_segmentType,
         metadata._segmentType) && isEqual(_totalRawDocs, metadata._totalRawDocs) && isEqual(_crc, metadata._crc)
         && isEqual(_creationTime, metadata._creationTime) && isEqual(_partitionMetadata, metadata._partitionMetadata)
-        && isEqual(_segmentUploadStartTime, metadata._segmentUploadStartTime) && isEqual(_customMap, metadata._customMap);
+        && isEqual(_segmentUploadStartTime, metadata._segmentUploadStartTime) && isEqual(_customMap, metadata._customMap)
+        && isEqual(_batchId, metadata._batchId) && isEqual(_numSegmentsInBatch, metadata._numSegmentsInBatch);
   }
 
   @Override
@@ -251,6 +272,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     result = hashCodeOf(result, _partitionMetadata);
     result = hashCodeOf(result, _segmentUploadStartTime);
     result = hashCodeOf(result, _customMap);
+    result = hashCodeOf(result, _batchId);
+    result = hashCodeOf(result, _numSegmentsInBatch);
     return result;
   }
 
@@ -277,6 +300,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     znRecord.setLongField(CommonConstants.Segment.TOTAL_DOCS, _totalRawDocs);
     znRecord.setLongField(CommonConstants.Segment.CRC, _crc);
     znRecord.setLongField(CommonConstants.Segment.CREATION_TIME, _creationTime);
+    znRecord.setSimpleField(CommonConstants.Segment.BATCH_ID, _batchId);
+    znRecord.setIntField(CommonConstants.Segment.NUMBER_OF_SEGMENTS_IN_BATCH, _numSegmentsInBatch);
 
     if (_partitionMetadata != null) {
       try {
@@ -314,6 +339,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     configMap.put(CommonConstants.Segment.TOTAL_DOCS, Long.toString(_totalRawDocs));
     configMap.put(CommonConstants.Segment.CRC, Long.toString(_crc));
     configMap.put(CommonConstants.Segment.CREATION_TIME, Long.toString(_creationTime));
+    configMap.put(CommonConstants.Segment.BATCH_ID, _batchId);
+    configMap.put(CommonConstants.Segment.NUMBER_OF_SEGMENTS_IN_BATCH, Integer.toString(_numSegmentsInBatch));
 
     if (_partitionMetadata != null) {
       try {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -248,6 +248,8 @@ public class CommonConstants {
     public static final String FLUSH_THRESHOLD_SIZE = "segment.flush.threshold.size";
     public static final String FLUSH_THRESHOLD_TIME = "segment.flush.threshold.time";
     public static final String PARTITION_METADATA = "segment.partition.metadata";
+    public static final String BATCH_ID = "segment.batchId";
+    public static final String NUMBER_OF_SEGMENTS_IN_BATCH = "segment.numSegmentsInBatch";
     /**
      * This field is used for parallel push protection to lock the segment globally.
      * We put the segment upload start timestamp so that if the previous push failed without unlock the segment, the

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
@@ -123,6 +123,8 @@ public class SegmentZKMetadataTest {
     record.setLongField(CommonConstants.Segment.CREATION_TIME, 3000);
     record.setIntField(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, 1234);
     record.setSimpleField(CommonConstants.Segment.FLUSH_THRESHOLD_TIME, "6h");
+    record.setSimpleField(CommonConstants.Segment.BATCH_ID, null);
+    record.setIntField(CommonConstants.Segment.NUMBER_OF_SEGMENTS_IN_BATCH, 0);
     return record;
   }
 
@@ -160,6 +162,8 @@ public class SegmentZKMetadataTest {
     record.setLongField(CommonConstants.Segment.CREATION_TIME, 1000);
     record.setIntField(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, 1234);
     record.setSimpleField(CommonConstants.Segment.FLUSH_THRESHOLD_TIME, "6h");
+    record.setSimpleField(CommonConstants.Segment.BATCH_ID, null);
+    record.setIntField(CommonConstants.Segment.NUMBER_OF_SEGMENTS_IN_BATCH, 0);
     return record;
   }
 
@@ -195,6 +199,8 @@ public class SegmentZKMetadataTest {
     record.setLongField(CommonConstants.Segment.TOTAL_DOCS, 50000);
     record.setLongField(CommonConstants.Segment.CRC, 54321);
     record.setLongField(CommonConstants.Segment.CREATION_TIME, 1000);
+    record.setSimpleField(CommonConstants.Segment.BATCH_ID, null);
+    record.setIntField(CommonConstants.Segment.NUMBER_OF_SEGMENTS_IN_BATCH, 0);
     record.setSimpleField(CommonConstants.Segment.Offline.DOWNLOAD_URL, "http://localhost:8000/testTable_O_3000_4000");
     record.setLongField(CommonConstants.Segment.Offline.PUSH_TIME, 4000);
     record.setLongField(CommonConstants.Segment.Offline.REFRESH_TIME, 8000);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/TableSize.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/TableSize.java
@@ -15,26 +15,43 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.exception.InvalidConfigException;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.controller.api.upload.batch.SegmentsInBatch;
+import com.linkedin.pinot.controller.api.upload.batch.SuccessBatchIdGenerationResponse;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.util.TableSizeReader;
+import com.linkedin.pinot.controller.validation.StorageQuotaChecker;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.httpclient.HttpConnectionManager;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.jersey.server.ManagedAsync;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,5 +102,67 @@ public class TableSize {
           Response.Status.NOT_FOUND);
     }
     return tableSizeDetails;
+  }
+
+  @POST
+  @ManagedAsync
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Path("/tables/{tableName}/batch")
+  @ApiOperation(value = "Create batch id to upload segments if segments upload is within storage quota", notes = "Given a list of segment names and sizes, create batch id for table to upload segments if segments upload is within storage quota.")
+  public void createBatchForTable(
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "List of segment names to be uploaded and their sizes") SegmentsInBatch segments,
+      @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
+    try {
+      asyncResponse.resume(generateBatchIdForTable(tableName, segments));
+    } catch (Throwable t) {
+      asyncResponse.resume(t);
+    }
+  }
+
+  private SuccessBatchIdGenerationResponse generateBatchIdForTable(String tableName, SegmentsInBatch segments) {
+    Preconditions.checkNotNull(tableName);
+    Preconditions.checkArgument(segments != null && !segments.getSegmentEntries().isEmpty());
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+
+    TableConfig offlineTableConfig =
+        ZKMetadataProvider.getOfflineTableConfig(_pinotHelixResourceManager.getPropertyStore(), offlineTableName);
+
+    LOGGER.info("Start checking quota config for table: {}", rawTableName);
+    StorageQuotaChecker.QuotaCheckerResponse quotaCheckerResponse;
+    try {
+      TableSizeReader tableSizeReader =
+          new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _pinotHelixResourceManager);
+      StorageQuotaChecker quotaChecker =
+          new StorageQuotaChecker(offlineTableConfig, tableSizeReader, _controllerMetrics, _pinotHelixResourceManager);
+
+      quotaCheckerResponse = quotaChecker.isBatchSegmentSizeWithinQuota(offlineTableName, segments.getSegmentEntries(),
+          _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+    } catch (InvalidConfigException ie) {
+      throw new ControllerApplicationException(LOGGER,
+          "Quota check failed for batch upload segments of table: " + offlineTableName + ", reason: " + ie.getMessage(),
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+
+    if (!quotaCheckerResponse.isSegmentWithinQuota) {
+      throw new ControllerApplicationException(LOGGER,
+          "Quota check failed for batch upload segments of table: " + offlineTableName + ", reason: "
+              + quotaCheckerResponse.reason, Response.Status.FORBIDDEN);
+    }
+
+    // Batch upload is within storage quota.
+    try {
+      // Generate batchId.
+      String batchId = UUID.randomUUID().toString() + "-" + segments.getSegmentEntries().size();
+
+      return new SuccessBatchIdGenerationResponse("Segment upload is within quota. Successfully generated batch id for table: " + rawTableName,
+          batchId, quotaCheckerResponse.currentSizeAcrossReplicas, quotaCheckerResponse.storageQuotaAcrossReplicas);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER,
+          "Unable to initialize batch upload of table: " + rawTableName + ", reason: " + e.getMessage(),
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/batch/SegmentEntry.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/batch/SegmentEntry.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.api.upload.batch;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class SegmentEntry {
+  @JsonProperty("name")
+  private String _segmentName;
+
+  @JsonProperty("size")
+  private long _segmentSize;
+
+  public SegmentEntry(@JsonProperty("name") String segmentName, @JsonProperty("size") long segmentSize) {
+    _segmentName = segmentName;
+    _segmentSize = segmentSize;
+  }
+
+  @JsonProperty("name")
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  @JsonProperty("size")
+  public long getSegmentSize() {
+    return _segmentSize;
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/batch/SegmentsInBatch.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/batch/SegmentsInBatch.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.api.upload.batch;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+
+public class SegmentsInBatch {
+  @JsonProperty("segments")
+  private List<SegmentEntry> _segmentEntries;
+
+  public SegmentsInBatch(@JsonProperty("segments") List<SegmentEntry> segmentEntries) {
+    _segmentEntries = segmentEntries;
+  }
+
+  @JsonProperty("segments")
+  public List<SegmentEntry> getSegmentEntries() {
+    return _segmentEntries;
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/batch/SuccessBatchIdGenerationResponse.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/batch/SuccessBatchIdGenerationResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.api.upload.batch;
+
+public class SuccessBatchIdGenerationResponse {
+  private String _status;
+  private String _batchId;
+  private long _currentSizeAcrossReplicas;
+  private long _storageQuotaAcrossReplicas;
+
+  public SuccessBatchIdGenerationResponse(String status, String batchId, long currentSizeAcrossReplicas, long storageQuotaAcrossReplicas) {
+    _status = status;
+    _batchId = batchId;
+    _currentSizeAcrossReplicas = currentSizeAcrossReplicas;
+    _storageQuotaAcrossReplicas =  storageQuotaAcrossReplicas;
+  }
+
+  public String getStatus() {
+    return _status;
+  }
+
+  public String getBatchId() {
+    return _batchId;
+  }
+
+  public long getCurrentSizeAcrossReplicas() {
+    return _currentSizeAcrossReplicas;
+  }
+
+  public long getStorageQuotaAcrossReplicas() {
+    return _storageQuotaAcrossReplicas;
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1428,10 +1428,10 @@ public class PinotHelixResourceManager {
   }
 
   public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl) {
-    addNewSegment(segmentMetadata, downloadUrl, null);
+    addNewSegment(segmentMetadata, downloadUrl, null, null);
   }
 
-  public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl, String crypter) {
+  public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl, String crypter, String batchId) {
     String segmentName = segmentMetadata.getName();
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
 
@@ -1442,6 +1442,11 @@ public class PinotHelixResourceManager {
     offlineSegmentZKMetadata.setDownloadUrl(downloadUrl);
     offlineSegmentZKMetadata.setCrypterName(crypter);
     offlineSegmentZKMetadata.setPushTime(System.currentTimeMillis());
+    if (batchId != null) {
+      int numSegmentsInBatch = Integer.valueOf(batchId.substring(batchId.lastIndexOf("-") + 1));
+      offlineSegmentZKMetadata.setBatchId(batchId);
+      offlineSegmentZKMetadata.setNumSegmentsInBatch(numSegmentsInBatch);
+    }
     if (!ZKMetadataProvider.setOfflineSegmentZKMetadata(_propertyStore, offlineSegmentZKMetadata)) {
       throw new RuntimeException(
           "Failed to set segment ZK metadata for table: " + offlineTableName + ", segment: " + segmentName);


### PR DESCRIPTION
This PR:
- Add API to generate batch id for segment upload if batch upload is within quota.
- Modify upload segment API to include batch info to ZK metadata.

Details of the new API:
POST `/tables/{tableName}/batch`
Body:
```
{
  "segments": [
    {
      "name": "string",
      "size": 0
    }
  ]
}
```
Response:
```
{
  "status": "Segment upload is within quota. Successfully generated batch id for table:  testTable",
  "batchId": "b2483e32-342b-44ad-b1bb-0a40c067176b-1",
  "currentSizeAcrossReplicas": 500,
  "storageQuotaAcrossReplicas": 6000
}
```