### PR TITLE
Enhance StarTreeV2ClusterIntegrationTest to cover multi-trees case

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -62,7 +62,7 @@ public class StarTreeClusterIntegrationTest extends BaseClusterIntegrationTest {
   private static final int NUM_QUERIES_TO_GENERATE = 100;
 
   protected Schema _schema;
-  protected StarTreeQueryGenerator _queryGenerator;
+  private StarTreeQueryGenerator _queryGenerator;
   private String _currentTable;
 
   @Nonnull
@@ -149,9 +149,12 @@ public class StarTreeClusterIntegrationTest extends BaseClusterIntegrationTest {
   @Test
   public void testGeneratedQueries() throws Exception {
     for (int i = 0; i < NUM_QUERIES_TO_GENERATE; i++) {
-      String starQuery = _queryGenerator.nextQuery();
-      testStarQuery(starQuery);
+      testStarQuery(generateQuery());
     }
+  }
+
+  protected String generateQuery() {
+    return _queryGenerator.nextQuery();
   }
 
   @Test


### PR DESCRIPTION
1. Generates 2 trees with different sets of dimensions and metrics
2. Generates queries to hit both trees
3. Sets max leaf records to 10 to generate more levels of nodes