### PR TITLE
[PINOT-7328] Reduce lock contention in physical planning phase by reducing the total number of tasks

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/CombinePlanNode.java
@@ -93,7 +93,7 @@ public class CombinePlanNode implements PlanNode {
             List<Operator> operators = new ArrayList<>();
             int start = index * opsPerThread;
             int limit = Math.min(opsPerThread, numPlanNodes - start);
-            for(int count = index * opsPerThread; count < start + limit; count = count + 1) {
+            for(int count = start; count < start + limit; count++) {
               operators.add(_planNodes.get(count).run());
             }
             return operators;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/CombinePlanNode.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.apache.zookeeper.Op;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/CombinePlanNode.java
@@ -36,7 +36,8 @@ import org.slf4j.LoggerFactory;
 public class CombinePlanNode implements PlanNode {
   private static final Logger LOGGER = LoggerFactory.getLogger(CombinePlanNode.class);
 
-  private static final int MAX_PLAN_TASKS = Math.min(10, (int) (Runtime.getRuntime().availableProcessors() * .5));
+  private static final int MAX_PLAN_THREADS = Math.min(10, (int) (Runtime.getRuntime().availableProcessors() * .5));
+  private static final int MIN_TASKS_PER_THREAD = 10;
   private static final int TIME_OUT_IN_MILLISECONDS_FOR_PARALLEL_RUN = 10_000;
 
   private final List<PlanNode> _planNodes;
@@ -67,7 +68,7 @@ public class CombinePlanNode implements PlanNode {
     int numPlanNodes = _planNodes.size();
     List<Operator> operators = new ArrayList<>(numPlanNodes);
 
-    if (numPlanNodes < MAX_PLAN_TASKS) {
+    if (numPlanNodes <= MIN_TASKS_PER_THREAD) {
       // Small number of plan nodes, run them sequentially
       for (PlanNode planNode : _planNodes) {
         operators.add(planNode.run());
@@ -78,15 +79,21 @@ public class CombinePlanNode implements PlanNode {
       // Calculate the time out timestamp
       long endTime = System.currentTimeMillis() + TIME_OUT_IN_MILLISECONDS_FOR_PARALLEL_RUN;
 
+      int threads = Math.min(numPlanNodes/MIN_TASKS_PER_THREAD + ((numPlanNodes % MIN_TASKS_PER_THREAD == 0) ? 0 : 1), // ceil without using double arithmetic
+          MAX_PLAN_THREADS);
+      int opsPerThread = Math.max(numPlanNodes/threads + ((numPlanNodes % threads == 0) ? 0 : 1), // ceil without using double arithmetic
+          MIN_TASKS_PER_THREAD);
       // Submit all jobs
-      Future[] futures = new Future[MAX_PLAN_TASKS];
-      for (int i = 0; i < MAX_PLAN_TASKS; i++) {
+      Future[] futures = new Future[threads];
+      for (int i = 0; i < threads; i++) {
         final int index = i;
         futures[i] = _executorService.submit(new TraceCallable<List<Operator>>() {
           @Override
           public List<Operator> callJob() throws Exception {
             List<Operator> operators = new ArrayList<>();
-            for(int count = index; count < numPlanNodes; count = count + MAX_PLAN_TASKS) {
+            int start = index * opsPerThread;
+            int limit = Math.min(opsPerThread, numPlanNodes - start);
+            for(int count = index * opsPerThread; count < start + limit; count = count + 1) {
               operators.add(_planNodes.get(count).run());
             }
             return operators;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/plan/CombinePlanNodeTest.java
@@ -36,7 +36,7 @@ public class CombinePlanNodeTest {
   @Test
   public void testParallelExecution() {
     AtomicInteger count = new AtomicInteger(0);
-    int numPlans = 42;
+    int numPlans = 99;
     List<PlanNode> planNodes = new ArrayList<>();
     for (int i = 0; i < numPlans; i++) {
       planNodes.add(new PlanNode() {


### PR DESCRIPTION
Performance tests show that for requests that require little server work (docs/entries scanned <100k), the latency increases quickly with QPS while CPU is hardly used. In one example, with a query that took ~2ms to execute, beyond 600QPS the latency shot up to 200+ms while CPU utilization was <20%. 

Profiling/thread dumps showed that majority of the time was spent in taking tasks off the task queue in the physical planning phase - queries were essentially serialized on the LinkedBlockingQueue's lock.

This change bounds the total number of tasks that can be created/put on the queue, thus reducing contention and doing more work per task.

With this change in place, we were able to push the example query to 2000+ qps.

Testing done:
- Added unit tests to cover functionality.
- Perf tests as noted above.