### PR TITLE
Misc Cleanup: Removed unused member variable from FixedByteSingleValueMultiColWriter.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnMultiValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnMultiValueReaderWriter.java
@@ -95,7 +95,7 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
   private static final int NUM_COLS_IN_HEADER = 3;
 
   private static final int INCREMENT_PERCENTAGE = 100;
-      //Increments the Initial size by 100% of initial capacity every time we runs out of capacity
+  //Increments the Initial size by 100% of initial capacity every time we runs out of capacity
 
   private PinotDataBuffer _headerBuffer;
   private List<PinotDataBuffer> _dataBuffers = new ArrayList<>();
@@ -140,8 +140,8 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
     LOGGER.info("Allocating header buffer of size {} for: {}", _headerSize, _context);
     _headerBuffer = _memoryManager.allocate(_headerSize, _context);
     // dataBufferId, startIndex, length
-    _curHeaderWriter = new FixedByteSingleValueMultiColWriter(_headerBuffer, _rowCountPerChunk, 3,
-        new int[]{SIZE_OF_INT, SIZE_OF_INT, SIZE_OF_INT});
+    _curHeaderWriter =
+        new FixedByteSingleValueMultiColWriter(_headerBuffer, 3, new int[]{SIZE_OF_INT, SIZE_OF_INT, SIZE_OF_INT});
     FixedByteSingleValueMultiColReader curHeaderReader =
         new FixedByteSingleValueMultiColReader(_headerBuffer, _rowCountPerChunk,
             new int[]{SIZE_OF_INT, SIZE_OF_INT, SIZE_OF_INT});
@@ -153,18 +153,15 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
   /**
    * This method automatically computes the space needed based on the _columnSizeInBytes
    * @param rowCapacity Additional capacity to be added in terms of number of rows
-   * @throws RuntimeException
    */
-  private void addDataBuffers(int rowCapacity)
-      throws RuntimeException {
+  private void addDataBuffers(int rowCapacity) {
     PinotDataBuffer dataBuffer;
     try {
       final long size = rowCapacity * _columnSizeInBytes;
       LOGGER.info("Allocating data buffer of size {} for column {}", size, _context);
       dataBuffer = _memoryManager.allocate(size, _context);
       _dataBuffers.add(dataBuffer);
-      _currentDataWriter =
-          new FixedByteSingleValueMultiColWriter(dataBuffer, rowCapacity, 1, new int[]{_columnSizeInBytes});
+      _currentDataWriter = new FixedByteSingleValueMultiColWriter(dataBuffer, 1, new int[]{_columnSizeInBytes});
       _dataWriters.add(_currentDataWriter);
 
       FixedByteSingleValueMultiColReader dataFileReader =

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
@@ -170,7 +170,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
     FixedByteSingleValueMultiColReader reader =
         new FixedByteSingleValueMultiColReader(buffer, _numRowsPerChunk, new int[]{_columnSizesInBytes});
     FixedByteSingleValueMultiColWriter writer =
-        new FixedByteSingleValueMultiColWriter(buffer, _numRowsPerChunk, /*cols=*/1, new int[]{_columnSizesInBytes});
+        new FixedByteSingleValueMultiColWriter(buffer, /*cols=*/1, new int[]{_columnSizesInBytes});
 
     final int startRowId = _numRowsPerChunk * (_dataBuffers.size() - 1);
     _writers.add(new WriterWithOffset(writer, startRowId));

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
@@ -156,8 +156,7 @@ public class FixedByteSingleValueMultiColumnReaderWriter extends BaseSingleValue
   }
 
   @Override
-  public void close()
-      throws IOException {
+  public void close() throws IOException {
     _capacityInRows = 0;
     _writers.clear();
     _readers.clear();
@@ -196,7 +195,7 @@ public class FixedByteSingleValueMultiColumnReaderWriter extends BaseSingleValue
         new FixedByteSingleValueMultiColReader(buffer, _numRowsPerChunk, _columnSizesInBytes);
 
     FixedByteSingleValueMultiColWriter writer =
-        new FixedByteSingleValueMultiColWriter(buffer, _numRowsPerChunk, _numColumns, _columnSizesInBytes);
+        new FixedByteSingleValueMultiColWriter(buffer, _numColumns, _columnSizesInBytes);
 
     _writers.add(writer);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/DirectMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/DirectMemoryManager.java
@@ -20,7 +20,6 @@ import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import com.yammer.metrics.core.MetricsRegistry;
-import java.nio.ByteOrder;
 
 
 // Allocates memory using direct allocation
@@ -44,7 +43,7 @@ public class DirectMemoryManager extends RealtimeIndexOffHeapMemoryManager {
    * @param allocationContext String describing context of allocation (typically segment:column name).
    * @return PinotDataBuffer via direct allocation
    *
-   * @see {@link RealtimeIndexOffHeapMemoryManager#allocate(long, String)}
+   * @see RealtimeIndexOffHeapMemoryManager#allocate(long, String)
    */
   @Override
   protected PinotDataBuffer allocateInternal(long size, String allocationContext) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/FixedByteSingleValueMultiColWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/FixedByteSingleValueMultiColWriter.java
@@ -24,14 +24,10 @@ import java.nio.ByteOrder;
 
 public class FixedByteSingleValueMultiColWriter {
   private int[] columnOffsets;
-  private int rows;
   private PinotDataBuffer indexDataBuffer;
   private int rowSizeInBytes;
 
-  public FixedByteSingleValueMultiColWriter(File file, int rows, int cols,
-      int[] columnSizes)
-      throws IOException {
-    this.rows = rows;
+  public FixedByteSingleValueMultiColWriter(File file, int rows, int cols, int[] columnSizes) throws IOException {
     this.columnOffsets = new int[cols];
     rowSizeInBytes = 0;
     for (int i = 0; i < columnSizes.length; i++) {
@@ -45,9 +41,7 @@ public class FixedByteSingleValueMultiColWriter {
         PinotDataBuffer.mapFile(file, false, 0, totalSize, ByteOrder.BIG_ENDIAN, getClass().getSimpleName());
   }
 
-  public FixedByteSingleValueMultiColWriter(PinotDataBuffer dataBuffer, int rows, int cols,
-      int[] columnSizes) {
-    this.rows = rows;
+  public FixedByteSingleValueMultiColWriter(PinotDataBuffer dataBuffer, int cols, int[] columnSizes) {
     this.columnOffsets = new int[cols];
     rowSizeInBytes = 0;
     for (int i = 0; i < columnSizes.length; i++) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
@@ -17,7 +17,7 @@ package com.linkedin.pinot.core.io.writer.impl.v1;
 
 import com.linkedin.pinot.core.io.compression.ChunkCompressorFactory;
 import java.io.File;
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import javax.annotation.concurrent.NotThreadSafe;
 
 
@@ -61,10 +61,10 @@ public class FixedByteChunkSingleValueWriter extends BaseChunkSingleValueWriter 
    * @param totalDocs Total number of docs to write.
    * @param numDocsPerChunk Number of documents per chunk.
    * @param sizeOfEntry Size of entry (in bytes).
-   * @throws IOException
+   * @throws FileNotFoundException Throws {@link FileNotFoundException} if the specified file is not found.
    */
   public FixedByteChunkSingleValueWriter(File file, ChunkCompressorFactory.CompressionType compressionType,
-      int totalDocs, int numDocsPerChunk, int sizeOfEntry) throws IOException {
+      int totalDocs, int numDocsPerChunk, int sizeOfEntry) throws FileNotFoundException {
 
     super(file, compressionType, totalDocs, numDocsPerChunk, (sizeOfEntry * numDocsPerChunk), sizeOfEntry,
         CURRENT_VERSION);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.io.writer.impl.v1;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.io.compression.ChunkCompressorFactory;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -59,10 +60,10 @@ public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
    * @param totalDocs Total number of docs to write.
    * @param numDocsPerChunk Number of documents per chunk.
    * @param lengthOfLongestEntry Length of longest entry (in bytes).
-   * @throws IOException
+   * @throws FileNotFoundException Throws {@link FileNotFoundException} if the specified file is not found.
    */
   public VarByteChunkSingleValueWriter(File file, ChunkCompressorFactory.CompressionType compressionType, int totalDocs,
-      int numDocsPerChunk, int lengthOfLongestEntry) throws IOException {
+      int numDocsPerChunk, int lengthOfLongestEntry) throws FileNotFoundException {
 
     super(file, compressionType, totalDocs, numDocsPerChunk,
         ((numDocsPerChunk * Integer.BYTES) + (lengthOfLongestEntry * numDocsPerChunk)), // chunkSize


### PR DESCRIPTION
1. Removed the unsed member variable 'rows' from
FixedByteSingleValueMultiColWriter.

2. Fixed various method signatures to throw appropriate exception.