### PR TITLE
[TE] Ability to configure reference links like oncall run-book in the email alert

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/BaseEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/BaseEmailContentFormatter.java
@@ -271,6 +271,9 @@ public abstract class BaseEmailContentFormatter implements EmailContentFormatter
       templateData.put("recall", precisionRecallEvaluator.getRecall());
       templateData.put("falseNegative", precisionRecallEvaluator.getFalseNegativeRate());
     }
+    if (alertConfigDTO.getReferenceLinks() != null) {
+      templateData.put("referenceLinks", alertConfigDTO.getReferenceLinks());
+    }
 
     return templateData;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
@@ -49,6 +49,7 @@ public class AlertConfigBean extends AbstractBean {
   DetectionAlertFilterRecipients receiverAddresses;
   String fromAddress;
   SubjectType subjectType = SubjectType.ALERT;
+  Map<String, String> refLinks;
 
   public String getApplication() {
     return application;
@@ -152,6 +153,14 @@ public class AlertConfigBean extends AbstractBean {
 
   public void setSubjectType(SubjectType subjectType) {
     this.subjectType = subjectType;
+  }
+
+  public Map<String, String> getReferenceLinks() {
+    return refLinks;
+  }
+
+  public void setReferenceLinks(Map<String, String> refLinks) {
+    this.refLinks = refLinks;
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DetectionAlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DetectionAlertConfigBean.java
@@ -46,6 +46,8 @@ public class DetectionAlertConfigBean extends AbstractBean {
 
   Map<String, Object> properties;
 
+  Map<String, String> refLinks;
+
   public boolean isActive() {
     return active;
   }
@@ -132,6 +134,14 @@ public class DetectionAlertConfigBean extends AbstractBean {
 
   public void setAlertSuppressors(Map<String, Map<String, Object>> alertSuppressors) {
     this.alertSuppressors = alertSuppressors;
+  }
+
+  public Map<String, String> getReferenceLinks() {
+    return refLinks;
+  }
+
+  public void setReferenceLinks(Map<String, String> refLinks) {
+    this.refLinks = refLinks;
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -137,6 +137,7 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
     alertConfig.setName(this.config.getName());
     alertConfig.setFromAddress(this.config.getFrom());
     alertConfig.setSubjectType(this.config.getSubjectType());
+    alertConfig.setReferenceLinks(this.config.getReferenceLinks());
 
     EmailEntity emailEntity = emailContentFormatter.getEmailEntity(alertConfig, null,
         "Thirdeye Alert : " + this.config.getName(), null, null, anomalyResultListOfGroup,

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/holiday-anomaly-report.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/holiday-anomaly-report.ftl
@@ -1,3 +1,5 @@
+<#import "lib/utils.ftl" as utils>
+
 <head>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 </head>
@@ -58,8 +60,7 @@
           </#if>
 
           <#list metricAnomalyDetails?keys as metric>
-            <tr>
-              <td style="border-bottom: 1px solid rgba(0,0,0,0.15); padding: 24px; font-family:'Proxima Nova','Arial', 'Helvetica Neue',Helvetica, sans-serif;" colspan="2" align="left">
+            <@utils.addRow title="" align="left">
                 <p style="margin-left: 24px;">
                   <span style="color: #606060; font-size: 20px; line-height: 24px; margin-right: 16px;">Metric</span>
                   <span style="color: #1D1D1D; font-size: 20px; font-weight: bold; line-height: 24px;">${metric}</span>
@@ -113,15 +114,22 @@
                     </#list>
                   </table>
                 </#list>
-              </td>
-            </tr>
+            </@utils.addRow>
           </#list>
 
+          <#if referenceLinks?has_content>
+            <@utils.addRow title="Useful Links" align="center">
+              <#list referenceLinks?keys as referenceLinkKey>
+                <div style="padding-top: 16px;">
+                  <a href="${referenceLinks[referenceLinkKey]}" style="text-decoration: none; color:#0073B1; font-size:14px; font-weight:bold; line-height:20px; margin-bottom: 0;">${referenceLinkKey}</a>
+                </div>
+              </#list>
+            </@utils.addRow>
+          </#if>
+
           <#if holidays?has_content>
-            <tr>
-              <td style="padding: 24px; font-family:'Proxima Nova','Arial', 'Helvetica Neue',Helvetica, sans-serif;" colspan="2" align="center">
-                <p style="font-size:20px; line-height:24px; color:#1D1D1D; font-weight: 500; margin:0; padding:0;">Holidays</p>
-                <#list holidays as holiday>
+            <@utils.addRow title="Holidays" align="center">
+              <#list holidays as holiday>
                   <div style="padding-top: 16px;">
                     <a href="https://www.google.com/search?q=${holiday.name}" style="text-decoration: none; color:#0073B1; font-size:14px; font-weight:bold; line-height:20px; margin-bottom: 0;">${holiday.name}</a>
                     <span style="font-size: 14px; color:#606060; line-height:20px;">(${holiday.startTime?number_to_date})</span>
@@ -131,11 +139,9 @@
                         <span style="color: rgba(0,0,0,0.6); line-height:16px; font-size: 12px;">${holiday.targetDimensionMap[dimension]?join(",")}</span>
                     </#list>
                   </#if>
-                </#list>
-              </td>
-            </tr>
+              </#list>
+            </@utils.addRow>
           </#if>
-
 
         <tr>
           <td colspan="2" style="border-bottom: 1px solid #E9E9E9;">

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/lib/utils.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/lib/utils.ftl
@@ -1,0 +1,12 @@
+<#macro addRow title align>
+    <tr>
+      <td style="border-bottom: 1px solid rgba(0,0,0,0.15); padding: 24px; font-family:'Proxima Nova','Arial', 'Helvetica Neue',Helvetica, sans-serif;" colspan="2" align="${align}">
+        <#if title?has_content>
+          <p style="font-size:20px; line-height:24px; color:#1D1D1D; font-weight: 500; margin:0; padding:0;">${title}</p>
+        </#if>
+
+        <#nested>
+
+      </td>
+    </tr>
+</#macro>


### PR DESCRIPTION
Changes:
* Added ability to configure a map of reference links (per subscription group) which will be included in the email alert (legacy + new).
* Sample config (Detection Alert Config or Alert Config):
```
    "referenceLinks": {
        "Oncall Runbook": "<link>"
    }
```