### PR TITLE
Enhance controller periodic task and scheduler

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -52,8 +52,7 @@ public class PinotTaskManager extends ControllerPeriodicTask {
   public PinotTaskManager(@Nonnull PinotHelixTaskResourceManager helixTaskResourceManager,
       @Nonnull PinotHelixResourceManager helixResourceManager, @Nonnull ControllerConf controllerConf,
       @Nonnull ControllerMetrics controllerMetrics) {
-    super("PinotTaskManager", controllerConf.getTaskManagerFrequencyInSeconds(),
-        Math.min(60, controllerConf.getTaskManagerFrequencyInSeconds()), helixResourceManager);
+    super("PinotTaskManager", controllerConf.getTaskManagerFrequencyInSeconds(), helixResourceManager);
     _helixTaskResourceManager = helixTaskResourceManager;
     _clusterInfoProvider = new ClusterInfoProvider(helixResourceManager, helixTaskResourceManager, controllerConf);
     _taskGeneratorRegistry = new TaskGeneratorRegistry(_clusterInfoProvider);
@@ -82,12 +81,13 @@ public class PinotTaskManager extends ControllerPeriodicTask {
   }
 
   /**
-   * Check the Pinot cluster status and schedule new tasks.
-   * @param allTableNames List of all the table names
+   * Check the Pinot cluster status and schedule new tasks for the given tables.
+   *
+   * @param tables List of table names
    * @return Map from task type to task scheduled
    */
   @Nonnull
-  private Map<String, String> scheduleTasks(List<String> allTableNames) {
+  private Map<String, String> scheduleTasks(List<String> tables) {
     _controllerMetrics.addMeteredGlobalValue(ControllerMeter.NUMBER_TIMES_SCHEDULE_TASKS_CALLED, 1L);
 
     Set<String> taskTypes = _taskGeneratorRegistry.getAllTaskTypes();
@@ -102,7 +102,7 @@ public class PinotTaskManager extends ControllerPeriodicTask {
     }
 
     // Scan all table configs to get the tables with tasks enabled
-    for (String tableName : allTableNames) {
+    for (String tableName : tables) {
       TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableName);
       if (tableConfig != null) {
         TableTaskConfig taskConfig = tableConfig.getTaskConfig();
@@ -155,7 +155,7 @@ public class PinotTaskManager extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(List<String> allTableNames) {
-    scheduleTasks(allTableNames);
+  public void process(List<String> tables) {
+    scheduleTasks(tables);
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -15,10 +15,10 @@
  */
 package com.linkedin.pinot.controller.helix.core.periodictask;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.core.periodictask.BasePeriodicTask;
 import java.util.List;
+import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,21 +28,29 @@ import org.slf4j.LoggerFactory;
  * which table resources should be managed by this Pinot controller.
  */
 public abstract class ControllerPeriodicTask extends BasePeriodicTask {
-  public static final Logger LOGGER = LoggerFactory.getLogger(ControllerPeriodicTask.class);
-  protected final PinotHelixResourceManager _pinotHelixResourceManager;
-  private boolean _amILeader;
-  private static final int DEFAULT_INITIAL_DELAY_IN_SECOND = 120;
+  private static final Logger LOGGER = LoggerFactory.getLogger(ControllerPeriodicTask.class);
+  private static final Random RANDOM = new Random();
 
-  public ControllerPeriodicTask(String taskName, long runFrequencyInSeconds,
-      PinotHelixResourceManager pinotHelixResourceManager) {
-    this(taskName, runFrequencyInSeconds, DEFAULT_INITIAL_DELAY_IN_SECOND, pinotHelixResourceManager);
-  }
+  public static final int MIN_INITIAL_DELAY_IN_SECONDS = 120;
+  public static final int MAX_INITIAL_DELAY_IN_SECONDS = 300;
+
+  protected final PinotHelixResourceManager _pinotHelixResourceManager;
+
+  private boolean _isLeader = false;
 
   public ControllerPeriodicTask(String taskName, long runFrequencyInSeconds, long initialDelayInSeconds,
       PinotHelixResourceManager pinotHelixResourceManager) {
     super(taskName, runFrequencyInSeconds, initialDelayInSeconds);
     _pinotHelixResourceManager = pinotHelixResourceManager;
-    setAmILeader(false);
+  }
+
+  public ControllerPeriodicTask(String taskName, long runFrequencyInSeconds,
+      PinotHelixResourceManager pinotHelixResourceManager) {
+    this(taskName, runFrequencyInSeconds, getRandomInitialDelayInSeconds(), pinotHelixResourceManager);
+  }
+
+  private static long getRandomInitialDelayInSeconds() {
+    return MIN_INITIAL_DELAY_IN_SECONDS + RANDOM.nextInt(MAX_INITIAL_DELAY_IN_SECONDS - MIN_INITIAL_DELAY_IN_SECONDS);
   }
 
   @Override
@@ -60,36 +68,27 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
   }
 
   private void skipLeaderTask() {
-    if (getAmILeader()) {
+    if (_isLeader) {
       LOGGER.info("Current pinot controller lost leadership.");
+      _isLeader = false;
       onBecomeNotLeader();
     }
-    setAmILeader(false);
-    LOGGER.info("Skip running periodic task: {} on non-leader controller", getTaskName());
+    LOGGER.info("Skip running periodic task: {} on non-leader controller", _taskName);
   }
 
-  private void processLeaderTask(List<String> allTableNames) {
-    if (!getAmILeader()) {
+  private void processLeaderTask(List<String> tables) {
+    if (!_isLeader) {
       LOGGER.info("Current pinot controller became leader. Starting {} with running frequency of {} seconds.",
-          getTaskName(), getIntervalInSeconds());
+          _taskName, _intervalInSeconds);
+      _isLeader = true;
       onBecomeLeader();
     }
-    setAmILeader(true);
     long startTime = System.currentTimeMillis();
-    LOGGER.info("Starting to process {} tables in periodic task: {}", allTableNames.size(), getTaskName());
-    process(allTableNames);
-    LOGGER.info("Finished processing {} tables in periodic task: {} in {}ms", allTableNames.size(), getTaskName(),
+    int numTables = tables.size();
+    LOGGER.info("Start processing {} tables in periodic task: {}", numTables, _taskName);
+    process(tables);
+    LOGGER.info("Finish processing {} tables in periodic task: {} in {}ms", numTables, _taskName,
         (System.currentTimeMillis() - startTime));
-  }
-
-  @VisibleForTesting
-  public boolean getAmILeader() {
-    return _amILeader;
-  }
-
-  @VisibleForTesting
-  public void setAmILeader(boolean amILeader) {
-    _amILeader = amILeader;
   }
 
   /**
@@ -105,8 +104,9 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
   }
 
   /**
-   * Processes the periodic task as lead controller.
-   * @param allTableNames List of all the table names
+   * Processes the task on the given tables.
+   *
+   * @param tables List of table names
    */
-  public abstract void process(List<String> allTableNames);
+  public abstract void process(List<String> tables);
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -58,18 +58,19 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(List<String> allTableNames) {
-    runRelocation(allTableNames);
+  public void process(List<String> tables) {
+    runRelocation(tables);
   }
 
   /**
-   * Check all tables. Perform relocation of segments if table is realtime and relocation is required
+   * Check the given tables. Perform relocation of segments if table is realtime and relocation is required
    * TODO: Model this to implement {@link com.linkedin.pinot.controller.helix.core.rebalance.RebalanceSegmentStrategy} interface
    * https://github.com/linkedin/pinot/issues/2609
-   * @param allTableNames List of all the table names
+   *
+   * @param tables List of table names
    */
-  private void runRelocation(List<String> allTableNames) {
-    for (final String tableNameWithType : allTableNames) {
+  private void runRelocation(List<String> tables) {
+    for (String tableNameWithType : tables) {
       // Only consider realtime tables.
       if (!TableNameBuilder.REALTIME.tableHasTypeSuffix(tableNameWithType)) {
         continue;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
@@ -51,8 +51,7 @@ public class RetentionManager extends ControllerPeriodicTask {
 
   public RetentionManager(PinotHelixResourceManager pinotHelixResourceManager, int runFrequencyInSeconds,
       int deletedSegmentsRetentionInDays) {
-    super("RetentionManager", runFrequencyInSeconds, Math.min(60, runFrequencyInSeconds),
-        pinotHelixResourceManager);
+    super("RetentionManager", runFrequencyInSeconds, pinotHelixResourceManager);
     _deletedSegmentsRetentionInDays = deletedSegmentsRetentionInDays;
   }
 
@@ -63,17 +62,18 @@ public class RetentionManager extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(List<String> allTableNames) {
-    execute(allTableNames);
+  public void process(List<String> tables) {
+    execute(tables);
   }
 
   /**
-   * Manages retention for all tables.
-   * @param allTableNames List of all the table names
+   * Manages retention for the given tables.
+   *
+   * @param tables List of table names
    */
-  private void execute(List<String> allTableNames) {
+  private void execute(List<String> tables) {
     try {
-      for (String tableNameWithType : allTableNames) {
+      for (String tableNameWithType : tables) {
         LOGGER.info("Start managing retention for table: {}", tableNameWithType);
         manageRetentionForTable(tableNameWithType);
       }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -60,8 +60,7 @@ public class ValidationManager extends ControllerPeriodicTask {
 
   public ValidationManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
       PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager, ValidationMetrics validationMetrics) {
-    super("ValidationManager", config.getValidationControllerFrequencyInSeconds(),
-        config.getValidationControllerFrequencyInSeconds() / 2, pinotHelixResourceManager);
+    super("ValidationManager", config.getValidationControllerFrequencyInSeconds(), pinotHelixResourceManager);
     _segmentLevelValidationIntervalInSeconds = config.getSegmentLevelValidationIntervalInSeconds();
     Preconditions.checkState(_segmentLevelValidationIntervalInSeconds > 0);
     _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
@@ -75,15 +74,16 @@ public class ValidationManager extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(List<String> allTableNames) {
-    runValidation(allTableNames);
+  public void process(List<String> tables) {
+    runValidation(tables);
   }
 
   /**
-   * Runs a validation pass over the currently loaded tables.
-   * @param allTableNames List of all the table names
+   * Runs a validation pass over the given tables.
+   *
+   * @param tables List of table names
    */
-  private void runValidation(List<String> allTableNames) {
+  private void runValidation(List<String> tables) {
     // Run segment level validation using a separate interval
     boolean runSegmentLevelValidation = false;
     long currentTimeMs = System.currentTimeMillis();
@@ -97,7 +97,7 @@ public class ValidationManager extends ControllerPeriodicTask {
     // Cache instance configs to reduce ZK access
     List<InstanceConfig> instanceConfigs = _pinotHelixResourceManager.getAllHelixInstanceConfigs();
 
-    for (String tableNameWithType : allTableNames) {
+    for (String tableNameWithType : tables) {
       try {
         TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
         if (tableConfig == null) {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
@@ -16,75 +16,91 @@
 package com.linkedin.pinot.controller.helix.core.periodictask;
 
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
-import com.linkedin.pinot.core.periodictask.PeriodicTask;
-import com.linkedin.pinot.core.periodictask.PeriodicTaskScheduler;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import junit.framework.Assert;
-import org.testng.annotations.BeforeTest;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
 
 
 public class ControllerPeriodicTaskTest {
-  private PinotHelixResourceManager helixResourceManager;
-  private AtomicInteger numOfProcessingMessages;
+  private static final long RUN_FREQUENCY_IN_SECONDS = 30;
 
-  @BeforeTest
-  public void setUp() {
-    numOfProcessingMessages = new AtomicInteger(0);
-    helixResourceManager = mock(PinotHelixResourceManager.class);
-    List<String> allTableNames = new ArrayList<>();
-    allTableNames.add("testTable_REALTIME");
-    allTableNames.add("testTable_OFFLINE");
-    when(helixResourceManager.getAllTables()).thenReturn(allTableNames);
+  private final PinotHelixResourceManager _resourceManager = mock(PinotHelixResourceManager.class);
+  private final AtomicBoolean _onBecomeLeaderCalled = new AtomicBoolean();
+  private final AtomicBoolean _onBecomeNonLeaderCalled = new AtomicBoolean();
+  private final AtomicBoolean _processCalled = new AtomicBoolean();
+
+  private final ControllerPeriodicTask _task =
+      new ControllerPeriodicTask("TestTask", RUN_FREQUENCY_IN_SECONDS, _resourceManager) {
+        @Override
+        public void onBecomeLeader() {
+          _onBecomeLeaderCalled.set(true);
+        }
+
+        @Override
+        public void onBecomeNotLeader() {
+          _onBecomeNonLeaderCalled.set(true);
+        }
+
+        @Override
+        public void process(List<String> tables) {
+          _processCalled.set(true);
+        }
+      };
+
+  private void resetState() {
+    _onBecomeLeaderCalled.set(false);
+    _onBecomeNonLeaderCalled.set(false);
+    _processCalled.set(false);
   }
 
   @Test
-  public void testWhenControllerIsLeader() throws InterruptedException {
-    long totalRunTimeInMilliseconds = 3_500L;
-    long runFrequencyInSeconds = 1L;
-    long initialDelayInSeconds = 1L;
-    when(helixResourceManager.isLeader()).thenReturn(true);
+  public void testRandomInitialDelay() {
+    assertTrue(_task.getInitialDelayInSeconds() >= ControllerPeriodicTask.MIN_INITIAL_DELAY_IN_SECONDS);
+    assertTrue(_task.getInitialDelayInSeconds() < ControllerPeriodicTask.MAX_INITIAL_DELAY_IN_SECONDS);
 
-    PeriodicTask periodicTask = createMockPeriodicTask(runFrequencyInSeconds, initialDelayInSeconds);
-
-    PeriodicTaskScheduler periodicTaskScheduler = new PeriodicTaskScheduler();
-    periodicTaskScheduler.start(Collections.singletonList(periodicTask));
-    Thread.sleep(totalRunTimeInMilliseconds);
-    periodicTaskScheduler.stop();
-    Assert.assertEquals(totalRunTimeInMilliseconds / 1000L, numOfProcessingMessages.get());
+    assertEquals(_task.getIntervalInSeconds(), RUN_FREQUENCY_IN_SECONDS);
   }
 
   @Test
-  public void testWhenControllerIsNotLeader() throws InterruptedException {
-    long totalRunTimeInMilliseconds = 3_500L;
-    long runFrequencyInSeconds = 1L;
-    long initialDelayInSeconds = 1L;
+  public void testChangeLeadership() {
+    // Initial state
+    resetState();
+    _task.init();
+    assertFalse(_onBecomeLeaderCalled.get());
+    assertFalse(_onBecomeNonLeaderCalled.get());
+    assertFalse(_processCalled.get());
 
-    when(helixResourceManager.isLeader()).thenReturn(false);
-    PeriodicTask periodicTask = createMockPeriodicTask(runFrequencyInSeconds, initialDelayInSeconds);
+    // From non-leader to non-leader
+    resetState();
+    _task.run();
+    assertFalse(_onBecomeLeaderCalled.get());
+    assertFalse(_onBecomeNonLeaderCalled.get());
+    assertFalse(_processCalled.get());
 
-    PeriodicTaskScheduler periodicTaskScheduler = new PeriodicTaskScheduler();
-    periodicTaskScheduler.start(Collections.singletonList(periodicTask));
-    Thread.sleep(totalRunTimeInMilliseconds);
-    periodicTaskScheduler.stop();
-    Assert.assertEquals(0, numOfProcessingMessages.get());
-  }
+    // From non-leader to leader
+    resetState();
+    when(_resourceManager.isLeader()).thenReturn(true);
+    _task.run();
+    assertTrue(_onBecomeLeaderCalled.get());
+    assertFalse(_onBecomeNonLeaderCalled.get());
+    assertTrue(_processCalled.get());
 
-  private PeriodicTask createMockPeriodicTask(long runFrequencyInSeconds, long initialDelayInSeconds) {
-    return new ControllerPeriodicTask("Task", runFrequencyInSeconds, initialDelayInSeconds, helixResourceManager) {
-      public void init() {
-        numOfProcessingMessages.set(0);
-      }
+    // From leader to leader
+    resetState();
+    _task.run();
+    assertFalse(_onBecomeLeaderCalled.get());
+    assertFalse(_onBecomeNonLeaderCalled.get());
+    assertTrue(_processCalled.get());
 
-      @Override
-      public void process(List<String> allTableNames) {
-        numOfProcessingMessages.incrementAndGet();
-      }
-    };
+    // From leader to non-leader
+    resetState();
+    when(_resourceManager.isLeader()).thenReturn(false);
+    _task.run();
+    assertFalse(_onBecomeLeaderCalled.get());
+    assertTrue(_onBecomeNonLeaderCalled.get());
+    assertFalse(_processCalled.get());
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/BasePeriodicTask.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/BasePeriodicTask.java
@@ -19,9 +19,9 @@ package com.linkedin.pinot.core.periodictask;
  * A base class to implement periodic task interface.
  */
 public abstract class BasePeriodicTask implements PeriodicTask {
-  private final String _taskName;
-  private long _intervalInSeconds;
-  private long _initialDelayInSeconds;
+  protected final String _taskName;
+  protected final long _intervalInSeconds;
+  protected final long _initialDelayInSeconds;
 
   public BasePeriodicTask(String taskName, long runFrequencyInSeconds, long initialDelayInSeconds) {
     _taskName = taskName;
@@ -42,5 +42,11 @@ public abstract class BasePeriodicTask implements PeriodicTask {
   @Override
   public String getTaskName() {
     return _taskName;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Task: %s, Interval: %ds, Initial Delay: %ds", _taskName, _intervalInSeconds,
+        _initialDelayInSeconds);
   }
 }


### PR DESCRIPTION
For ControllerPeriodicTask:
1. Random pick an initial delay of range 2-5 mins so each task does not start at the same time
2. Make leadership information private to the class
For PeriodicTaskScheduler:
1. Filter out tasks with non-positive interval, so we can easily disable any task by setting the interval to an non-positive value
2. Set the size of thread pool to be the same as number of tasks
3. Reduce the run-time of PeriodicTaskSchedulerTest