### PR TITLE
Fix the bug where realtime time conversion is skipped when incoming and outgoing time name are the same

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -102,8 +102,8 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     super();
     _segmentVersion = indexLoadingConfig.getSegmentVersion();
     this.schema = schema;
-    _recordTransformer = CompoundTransformer.getDefaultTransformer(schema);
-    this.serverMetrics =serverMetrics;
+    _recordTransformer = CompoundTransformer.getRealtimeTransformer(schema);
+    this.serverMetrics = serverMetrics;
     this.segmentName = realtimeSegmentZKMetadata.getSegmentName();
     this.tableName = tableConfig.getTableName();
     this.timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1061,7 +1061,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     _clientId = _streamPartitionId + "-" + NetUtil.getHostnameOrAddress();
 
     // Create record transformer
-    _recordTransformer = CompoundTransformer.getDefaultTransformer(schema);
+    _recordTransformer = CompoundTransformer.getRealtimeTransformer(schema);
     makeStreamConsumer("Starting");
     makeStreamMetadataProvider("Starting");
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/recordtransformer/CompoundTransformer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/recordtransformer/CompoundTransformer.java
@@ -30,12 +30,30 @@ public class CompoundTransformer implements RecordTransformer {
   private final List<RecordTransformer> _transformers;
 
   /**
-   * Returns a record transformer that performs time transform, expressions transform and data type transform.
+   * Returns a record transformer for OFFLINE segment generation that performs expressions transform and data type
+   * transform.
+   * <p>NOTE: NO TIME TRANSFORMATION
+   * <p>NOTE: DO NOT CHANGE THE ORDER OF THE RECORD TRANSFORMERS
+   * <ul>
+   *   <li>
+   *     We put {@link SanitationTransformer} after {@link DataTypeTransformer} so that before sanitation, all values
+   *     follow the data types defined in the {@link Schema}.
+   *   </li>
+   * </ul>
+   */
+  public static CompoundTransformer getOfflineTransformer(Schema schema) {
+    return new CompoundTransformer(Arrays.asList(new ExpressionTransformer(schema), new DataTypeTransformer(schema),
+        new SanitationTransformer(schema)));
+  }
+
+  /**
+   * Returns a record transformer for REALTIME segment consumption that performs time transform, expressions transform
+   * and data type transform.
    * <p>NOTE: DO NOT CHANGE THE ORDER OF THE RECORD TRANSFORMERS
    * <ul>
    *   <li>
    *     We put {@link ExpressionTransformer} after {@link TimeTransformer} so that expression can work on outgoing time
-   *     column
+   *     column.
    *   </li>
    *   <li>
    *     We put {@link SanitationTransformer} after {@link DataTypeTransformer} so that before sanitation, all values
@@ -43,7 +61,7 @@ public class CompoundTransformer implements RecordTransformer {
    *   </li>
    * </ul>
    */
-  public static CompoundTransformer getDefaultTransformer(Schema schema) {
+  public static CompoundTransformer getRealtimeTransformer(Schema schema) {
     return new CompoundTransformer(
         Arrays.asList(new TimeTransformer(schema), new ExpressionTransformer(schema), new DataTypeTransformer(schema),
             new SanitationTransformer(schema)));

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/recordtransformer/TimeTransformer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/recordtransformer/TimeTransformer.java
@@ -55,11 +55,7 @@ public class TimeTransformer implements RecordTransformer {
     if (_timeConverter == null) {
       return record;
     }
-    // Skip transformation if outgoing value already exist
-    // NOTE: outgoing value might already exist for OFFLINE data
-    if (record.getValue(_outgoingTimeColumn) == null) {
-      record.putField(_outgoingTimeColumn, _timeConverter.convert(record.getValue(_incomingTimeColumn)));
-    }
+    record.putField(_outgoingTimeColumn, _timeConverter.convert(record.getValue(_incomingTimeColumn)));
     return record;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
@@ -42,8 +42,7 @@ public class RecordReaderSegmentCreationDataSource implements SegmentCreationDat
   @Override
   public SegmentPreIndexStatsCollector gatherStats(StatsCollectorConfig statsCollectorConfig) {
     try {
-      RecordTransformer recordTransformer =
-          CompoundTransformer.getDefaultTransformer(statsCollectorConfig.getSchema());
+      RecordTransformer recordTransformer = CompoundTransformer.getOfflineTransformer(statsCollectorConfig.getSchema());
 
       SegmentPreIndexStatsCollector collector = new SegmentPreIndexStatsCollectorImpl(statsCollectorConfig);
       collector.init();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -107,7 +107,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
   }
 
   public void init(SegmentGeneratorConfig config, SegmentCreationDataSource dataSource) {
-    init(config, dataSource, CompoundTransformer.getDefaultTransformer(dataSource.getRecordReader().getSchema()));
+    init(config, dataSource, CompoundTransformer.getOfflineTransformer(dataSource.getRecordReader().getSchema()));
   }
 
   public void init(SegmentGeneratorConfig config, SegmentCreationDataSource dataSource,


### PR DESCRIPTION
1. Always perform time transformation for REALTIME segment consumption
2. Always not perform time transformation for OFFLINE segment generation
  - The reason to disable time trasformation for OFFLINE is that, with the same incoming and outgoing time name, there is no way to determine whether the time conversion already happens. OFFLINE segment might be pre-aggregated and the time might have already been converted. If we need time transformation for OFFLINE segment generation in the future, we can add an extra flag for that.