### PR TITLE
[TE] frontend harleyjj/manage remove WoW and change buildMetricDataUr…

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
@@ -159,12 +159,11 @@ export default Component.extend({
     const legendText = this.get('legendText');
 
     const {
-      dotted = { text: 'expected', color: 'blue'},
       solid = { text: 'current', color: 'blue' }
     }  = legendText;
 
     chart.insert('div', '.chart').attr('class', 'anomaly-graph__legend').selectAll('span')
-      .data([dotted, solid])
+      .data([solid])
       .enter().append('svg')
       .attr('class', 'anomaly-graph__legend-item')
       .attr('width', 80)
@@ -187,7 +186,7 @@ export default Component.extend({
           .attr('x2', 30)
           .attr('y2', 10)
           .attr('stroke-dasharray', (d) => {
-            const dasharrayNum = (d === dotted) ? '10%' : 'none';
+            const dasharrayNum = 'none';
             return dasharrayNum;
           });
       });
@@ -254,7 +253,8 @@ export default Component.extend({
       primaryMetric,
       ...relatedMetric,
       ...selectedMetrics,
-      ...selectedDimensions];
+      ...selectedDimensions
+    ];
 
     data.forEach((datum) => {
       const name = datum.metricName || datum.name;
@@ -279,7 +279,7 @@ export default Component.extend({
   dimensions: [],
   selectedDimensions: [],
 
-  showGraphLegend: true,
+  showGraphLegend: false,
   colors: {},
   showSubChart: false,
   subchartStart: null,
@@ -388,7 +388,7 @@ export default Component.extend({
     const showGraphLegend = this.get('showGraphLegend');
     return {
       position: 'inset',
-      show: showGraphLegend
+      show: false
     };
   }),
 
@@ -541,8 +541,7 @@ export default Component.extend({
     'showLegend',
     'height',
     function() {
-      const height = this.get('height')
-        || this.get('showLegend') ? 400 : 200;
+      const height = this.get('height') || 400;
       return {
         height
       };
@@ -562,13 +561,11 @@ export default Component.extend({
       if (primaryMetric.isSelected) {
         const { baselineValues, currentValues } = primaryMetric.subDimensionContributionMap['All'];
         return [
-          [`${primaryMetric.metricName}-current`, ...currentValues],
-          [`${primaryMetric.metricName}-expected`, ...baselineValues]
+          [`${primaryMetric.metricName}-current`, ...currentValues]
         ];
       }
       return [
-        [`${primaryMetric.metricName}-current`],
-        [`${primaryMetric.metricName}-expected`]
+        [`${primaryMetric.metricName}-current`]
       ];
     }
   ),
@@ -588,7 +585,6 @@ export default Component.extend({
 
         const { baselineValues, currentValues } = metric.subDimensionContributionMap['All'];
         columns.push([`${metric.metricName}-current`, ...currentValues]);
-        columns.push([`${metric.metricName}-expected`, ...baselineValues]);
       });
       return columns;
     }
@@ -606,7 +602,6 @@ export default Component.extend({
       selectedDimensions.forEach((dimension) => {
         const { baselineValues, currentValues } = dimension;
         columns.push([`${dimension.name}-current`, ...currentValues]);
-        columns.push([`${dimension.name}-expected`, ...baselineValues]);
       });
       return columns;
     }

--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
@@ -21,7 +21,7 @@
         showDimensions=false
         isLoading=loading
         showSubchart=true
-        showLegend=true
+        showLegend=false
         enableZoom=true
         legendText=legendText
         componentId=componentId

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -274,6 +274,8 @@ export default Route.extend({
         const maxTime = isReplayDone && metricId ? await fetch(maxTimeUrl).then(checkStatus) : moment().valueOf();
         Object.assign(model, { metricDataUrl: buildMetricDataUrl({
           maxTime,
+          endStamp: config.endStamp,
+          startStamp: config.startStamp,
           id: metricId,
           filters: config.filters,
           granularity: config.bucketUnit,

--- a/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
@@ -61,7 +61,7 @@ module('Acceptance | create alert', function(hooks) {
     );
     assert.equal(
       $graphContainer.find('svg').length,
-      3,
+      2,
       'Graph and legend svg elements are rendered.'
     );
     assert.notOk(


### PR DESCRIPTION
…l to take user inputs.

This addresses the following problems:

- Only 1 month (for daily/hourly) or 1 week (for 5 minutes) level data is shown in the graph, which doesn't honor user selected time range.
- The wow comparison is misleading and should be removed.
- Primary metric is not used and should be hidden.

It does NOT fix this problem, as the trailing zero is in the response data, regardless of date range:

- The last point is zero if no data.
