### PR TITLE
[TE] frontend - alert filter UX improvements

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/entity-filter/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/entity-filter/template.hbs
@@ -40,7 +40,6 @@
           <li class="entity-filter__group-filter entity-filter__group-filter--link {{if filter.isActive 'entity-filter__group-filter--selected'}}" {{action "onFilterSelection" block filter.name}}>
             {{filter.name}} <span>({{filter.total}})</span>
           </li>
-
         {{/each}}
       {{/if}}
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
@@ -88,11 +88,13 @@ export default Route.extend({
         title: 'Applications',
         type: 'select',
         matchWidth: true,
+        hasNullOption: true, // allow searches for 'none'
         filterKeys: []
       },
       {
         name: 'subscription',
         title: 'Subscription Groups',
+        hasNullOption: true, // allow searches for 'none'
         type: 'select',
         filterKeys: []
       },
@@ -121,6 +123,7 @@ export default Route.extend({
     filterBlocksLocal.filter(block => block.type === 'select').forEach((filter) => {
       const alertPropertyArray = model.alerts.map(alert => alert[filterToPropertyMap[filter.name]]);
       const filterKeys = [ ...new Set(powerSort(alertPropertyArray, null))];
+      // Add filterKeys prop to each facet or filter block
       Object.assign(filter, { filterKeys });
     });
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
@@ -3,6 +3,7 @@
     {{entity-filter
       title="Quick Filters"
       maxStrLen=25
+      currentFilterState=alertFilters
       resetFilters=resetFiltersGlobal
       filterBlocks=filterBlocksGlobal
       onSelectFilter=(action "userDidSelectFilter")
@@ -10,7 +11,7 @@
     {{entity-filter
       title="Filters"
       maxStrLen=25
-      selectDisabled=isSelectDisabled
+      currentFilterState=alertFilters
       resetFilters=resetFiltersLocal
       filterBlocks=filterBlocksLocal
       onSelectFilter=(action "userDidSelectFilter")
@@ -53,24 +54,25 @@
   </div>
 
   <div class="manage-alert-results">
-    {{#if paginatedSelectedAlerts}}
-      <section class="te-search-header">
-        <span class="te-search-title">Alerts ({{totalFilteredAlerts}})</span>
-        {{#if allowFilterSummary}}
-          <span class="te-search-filters">{{activeFiltersString}}</span>
-          {{#if (gt activeFiltersString.length maxFilterStrngLength)}}
-            <span class="te-search-header__icon">
-              <i class="glyphicon glyphicon-resize-full"></i>
-              {{#popover-on-element side="left" class="te-search-header__tooltip te-tooltip"}}{{activeFiltersString}}{{/popover-on-element}}
-            </span>
-          {{/if}}
+    <section class="te-search-header">
+      <span class="te-search-title">Alerts ({{totalFilteredAlerts}})</span>
+      {{#if allowFilterSummary}}
+        <span class="te-search-filters">{{activeFiltersString}}</span>
+        {{#if (gt activeFiltersString.length maxFilterStrngLength)}}
+          <span class="te-search-header__icon">
+            <i class="glyphicon glyphicon-resize-full"></i>
+            {{#popover-on-element side="left" class="te-search-header__tooltip te-tooltip"}}{{activeFiltersString}}{{/popover-on-element}}
+          </span>
         {{/if}}
+      {{/if}}
+      {{#if paginatedSelectedAlerts}}
         <span class="te-search-header__displaynum pull-right">
           Showing {{paginatedSelectedAlerts.length}} of
           {{totalFilteredAlerts}} {{if (gt totalFilteredAlerts 1) 'alerts' 'alert'}}
         </span>
-      </section>
-    {{/if}}
+      {{/if}}
+    </section>
+
     {{#if isLoading}}
       <div class="spinner-wrapper-self-serve spinner-wrapper-self-serve--fixed">{{ember-spinner}}</div>
     {{/if}}


### PR DESCRIPTION
Two main UX improvements here:

- Preserve filter states when navigating back to alert filter page
- When finding an alert by name, rather than disable fields, set filters according to alert properties and enable field manipulation as per normal (includes the ability to filter for properties which are "null" or non-existent, for example, "find all alerts with no subscription group or application")

<img width="281" alt="screen shot 2018-11-15 at 5 08 18 pm" src="https://user-images.githubusercontent.com/11814420/48587558-3d6f3880-e8f9-11e8-986d-2d1294ad6454.png">

tests passing...