### PR TITLE
[TE] dataframe - tolerate complex column names

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
@@ -37,6 +37,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
@@ -91,11 +92,13 @@ public class DataFrame {
       for(int i=0; i<seriesNames.size(); i++) {
         String rawName = seriesNames.get(i);
 
-        String[] parts = rawName.split(":", 2);
-        if(parts.length == 2) {
+        String[] parts = rawName.split(":");
+        String typeString = parts[parts.length - 1];
+
+        if(parts.length > 1 && getValidTypes().contains(typeString)) {
           // user specified type
-          String name = parts[0];
-          Series.SeriesType type = Series.SeriesType.valueOf(parts[1].toUpperCase());
+          String name = StringUtils.join(Arrays.copyOf(parts, parts.length - 1), ":");
+          Series.SeriesType type = Series.SeriesType.valueOf(typeString);
           Series series = buildSeries(type, i);
           df.addSeries(name, series);
 
@@ -2558,6 +2561,14 @@ public class DataFrame {
     }
 
     return DataFrame.toSeries(values);
+  }
+
+  private static Set<String> getValidTypes() {
+    Set<String> values = new HashSet<>();
+    for (Series.SeriesType type : Series.SeriesType.values()) {
+      values.add(type.name());
+    }
+    return values;
   }
 
   public static class Tuple implements Comparable<Tuple> {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
@@ -347,6 +347,20 @@ public class DataFrameTest {
     assertEquals(df.getObjects("object"), 1, 2, 3, 4);
   }
 
+  @Test
+  public void testDataFrameBuilderStaticTypingMultiple() {
+    DataFrame df = DataFrame.builder("double:string:LONG").append(2.5d).build();
+    Assert.assertTrue(df.contains("double:string"));
+    Assert.assertEquals(df.get("double:string").type(), Series.SeriesType.LONG);
+  }
+
+  @Test
+  public void testDataFrameBuilderStaticTypingUnknown() {
+    DataFrame df = DataFrame.builder("double:1:2:string").append(1.1d).build();
+    Assert.assertTrue(df.contains("double:1:2:string"));
+    Assert.assertEquals(df.get("double:1:2:string").type(), Series.SeriesType.DOUBLE);
+  }
+
   @Test(expectedExceptions = NumberFormatException.class)
   public void testDataFrameBuilderStaticTypingFailDouble() {
     DataFrame.builder("double:DOUBLE").append("true").build();


### PR DESCRIPTION
DataFrame now gracefully supports column names with double colons (":") when type names are unknown.