### PR TITLE
adding StarTreeIndexv1 I/O for hadoop

### DIFF
--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
@@ -20,6 +20,7 @@ public class JobConfigConstants {
   public static final String PATH_TO_INPUT = "path.to.input";
   public static final String PATH_TO_OUTPUT = "path.to.output";
   public static final String PATH_TO_READER_CONFIG = "path.to.reader.config";
+  public static final String PATH_TO_STARTREE_INDEX_SPEC = "path.to.startree.index.spec";
   // Leave this for backward compatibility. We prefer to use the schema fetched from the controller.
   public static final String PATH_TO_SCHEMA = "path.to.schema";
 


### PR DESCRIPTION
This allows a StarTreeIndexSpecFile (for StarTreeIndexv1) to be passed as a parameter to the hadoop segment creation job. Haven't gotten a chance to fully determine what needs to be done to pass a spec file for StarTreeIndexv2 but I want to try that in the future too