### PR TITLE
[TE] rootcause - request chunking for aggregates and scores

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/services/rootcause-fetcher/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/rootcause-fetcher/service.js
@@ -3,6 +3,8 @@ import { get, getProperties, set, setProperties } from '@ember/object';
 import fetch from 'fetch';
 import RSVP from 'rsvp';
 
+// TODO halt loading while not on RCA page
+
 /**
  * Comparator for of MyPromise for priority queue
  */

--- a/thirdeye/thirdeye-frontend/app/pods/services/rootcause-scores-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/rootcause-scores-cache/service.js
@@ -10,6 +10,7 @@ import _ from 'lodash';
 
 const ROOTCAUSE_SCORES_ENDPOINT = '/rootcause/query';
 const ROOTCAUSE_SCORES_PRIORITY = 20;
+const ROOTCAUSE_SCORES_CHUNK_SIZE = 10;
 
 export default Service.extend({
   scores: null, // {}
@@ -65,7 +66,7 @@ export default Service.extend({
 
     // metrics
     const fetcher = this.get('fetcher');
-    const chunks = _.chunk([...missing].sort(), 4);
+    const chunks = _.chunk([...missing].sort(), ROOTCAUSE_SCORES_CHUNK_SIZE);
 
     chunks.forEach((urns, i) => {
       const url = this._makeUrl('metricAnalysis', requestContext, urns);

--- a/thirdeye/thirdeye-frontend/app/pods/services/rootcause-scores-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/rootcause-scores-cache/service.js
@@ -65,14 +65,15 @@ export default Service.extend({
 
     // metrics
     const fetcher = this.get('fetcher');
+    const chunks = _.chunk([...missing].sort(), 4);
 
-    [...missing].sort().forEach((urn, i) => {
-      const url = this._makeUrl('metricAnalysis', requestContext, [urn]);
+    chunks.forEach((urns, i) => {
+      const url = this._makeUrl('metricAnalysis', requestContext, urns);
       fetcher.fetch(url, ROOTCAUSE_SCORES_PRIORITY, i)
         .then(checkStatus)
-        .then(res => this._extractScores(res, [urn]))
+        .then(res => this._extractScores(res, urns))
         .then(res => this._complete(requestContext, res))
-        .catch(error => this._handleError([urn], error));
+        .catch(error => this._handleError(urns, error));
     });
   },
 


### PR DESCRIPTION
The RCA dashboard currently loads multiple offsets per metric at once. Unfortunately, this is still insufficient for very large dashboards with 1000+ metrics. This PR adds batching of both metrics and offsets within a single request. Additionally, it enables batching for on-demand scoring of metrics for outliers. This trades off responsiveness for a larger pipe - ultimately this should be superseded by a websocket-like implementation.