### PR TITLE
Change format of the ApplyConfig computed config

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/Serializer.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/Serializer.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.common.config;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
+import com.typesafe.config.ConfigValueFactory;
 import io.vavr.Tuple;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.List;
@@ -50,6 +51,16 @@ public class Serializer {
   public static <T> String serializeToString(T object) {
     Config config = ConfigFactory.parseMap(serialize(object).toJavaMap());
     return config.root().render(ConfigRenderOptions.defaults().setJson(false).setOriginComments(false));
+  }
+
+  public static <T> String serializeToPropertiesString(T object) {
+    ConfigRenderOptions configRenderOptions =
+        ConfigRenderOptions.defaults().setJson(false).setOriginComments(false).setFormatted(false);
+    return serialize(object)
+        .map(keyValueTuple -> keyValueTuple._1 + "=" +
+            ConfigValueFactory.fromAnyRef(keyValueTuple._2).render(configRenderOptions))
+        .sorted()
+        .mkString("\n");
   }
 
   private static <T> Map<String, ?> serialize(T object, Class<? extends T> clazz, String pathContext) throws Exception {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ApplyTableConfigCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ApplyTableConfigCommand.java
@@ -24,7 +24,6 @@ import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
 import com.linkedin.pinot.tools.Command;
 import java.io.File;
 import java.io.InputStream;
-import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -80,7 +79,7 @@ public class ApplyTableConfigCommand extends AbstractBaseAdminCommand implements
       throw new RuntimeException("Table config does not contain a valid offline or realtime table definition.");
     }
 
-    String computedConfig = Serializer.serializeToString(combinedConfig);
+    String computedConfig = Serializer.serializeToPropertiesString(combinedConfig);
 
     if (_showComputedConfig) {
       System.out.println(computedConfig);


### PR DESCRIPTION
Change the format of the computed config in ApplyConfig to make it
easier to be reused by external tools. The new format is Java
properties-style HOCON as opposed to the nested structure HOCON format.