### PR TITLE
Fix NPE on configs with per-profile table types

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/AdjustTableNameChildKeyTransformer.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/AdjustTableNameChildKeyTransformer.java
@@ -43,7 +43,9 @@ public class AdjustTableNameChildKeyTransformer implements ChildKeyTransformer {
         .getOrElse(List.empty())
         .map(Object::toString);
 
-    String tableName = childKeys.get("table.name").map(Object::toString).getOrNull();
+    String tableName = childKeys.get("table.name").map(Object::toString).getOrElse(
+            () -> childKeys.get("table.name.realtime").map(Object::toString).getOrElse(
+                () -> childKeys.get("table.name.offline").map(Object::toString).getOrNull()));
 
     Map<String, Object> remappedConfig = (Map<String, Object>) childKeys;
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/CombinedConfigSeparatorChildKeyTransformer.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/CombinedConfigSeparatorChildKeyTransformer.java
@@ -45,6 +45,14 @@ public class CombinedConfigSeparatorChildKeyTransformer implements ChildKeyTrans
     // Move keys around so that they match with the combined config
     Map<String, Object> remappedConfig = config.flatMap((k, v) -> {
       if(k.startsWith("table.schema.")) {
+        // Remove realtime/offline suffixes
+        if (k.endsWith(".realtime")) {
+          k = k.substring(0, k.length() - ".realtime".length());
+        }
+        if (k.endsWith(".offline")) {
+          k = k.substring(0, k.length() - ".offline".length());
+        }
+
         // table.schema.foo -> schema.foo
         return List.of(Tuple.of(k.replaceFirst("table.schema", "schema"), v));
       } else if (k.endsWith(".realtime") && hasRealtime) {


### PR DESCRIPTION
Fix NPEs on configurations that have per-profile table types, leading to
a merged output that has table-type specific keys for profiles that have
only one table type when other profiles have two table types.