### PR TITLE
Config loader includes also look in profiles

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/CombinedConfigLoader.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/CombinedConfigLoader.java
@@ -42,7 +42,14 @@ public class CombinedConfigLoader {
       private ConfigIncluder parent = null;
 
       public ConfigObject include(ConfigIncludeContext context, String what) {
-        return ConfigFactory.parseFileAnySyntax(new File(what)).root();
+        File file = new File(what);
+
+        // Attempt to locate the file
+        if (!file.exists()) {
+          file = new File("profiles", what);
+        }
+
+        return ConfigFactory.parseFileAnySyntax(file).root();
       }
 
       public ConfigIncluder withFallback(ConfigIncluder fallback) {


### PR DESCRIPTION
When including configuration files from a table configuration or another
configuration file, look in both the current directory and the profiles
directory for the file to include.