### PR TITLE
[PINOT-7370] Track bytes read per query

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -41,7 +41,7 @@ import org.apache.commons.codec.binary.Hex;
  */
 @SuppressWarnings("unused")
 public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLifecycleAware {
-  private static final int DEFAULT_MAX_LENGTH = 512;
+  public static final int DEFAULT_MAX_LENGTH_BYTES = 512;
 
   // TODO: revisit to see if we allow 0-length byte array
   private static final byte[] NULL_BYTE_ARRAY_VALUE = new byte[0];
@@ -71,7 +71,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
 
   // NOTE: for STRING column, this is the max number of characters; for BYTES column, this is the max number of bytes
   @ConfigKey("maxLength")
-  private int _maxLength = DEFAULT_MAX_LENGTH;
+  private int _maxLength = DEFAULT_MAX_LENGTH_BYTES;
 
   protected Object _defaultNullValue;
 
@@ -89,11 +89,11 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
   }
 
   public FieldSpec(String name, DataType dataType, boolean isSingleValueField) {
-    this(name, dataType, isSingleValueField, DEFAULT_MAX_LENGTH, null);
+    this(name, dataType, isSingleValueField, DEFAULT_MAX_LENGTH_BYTES, null);
   }
 
   public FieldSpec(String name, DataType dataType, boolean isSingleValueField, @Nullable Object defaultNullValue) {
-    this(name, dataType, isSingleValueField, DEFAULT_MAX_LENGTH, defaultNullValue);
+    this(name, dataType, isSingleValueField, DEFAULT_MAX_LENGTH_BYTES, defaultNullValue);
   }
 
   public FieldSpec(String name, DataType dataType, boolean isSingleValueField, int maxLength,
@@ -275,7 +275,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
     if (!_isSingleValueField) {
       jsonObject.addProperty("singleValueField", false);
     }
-    if (_maxLength != DEFAULT_MAX_LENGTH) {
+    if (_maxLength != DEFAULT_MAX_LENGTH_BYTES) {
       jsonObject.addProperty("maxLength", _maxLength);
     }
     appendDefaultNullValue(jsonObject);
@@ -440,6 +440,22 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
           return MetricFieldSpec.UNDEFINED_METRIC_SIZE;
         default:
           throw new IllegalStateException("Cannot get number of bytes for: " + this);
+      }
+    }
+
+    public int getSizeInBytes() {
+      switch (this) {
+        case INT:
+          return Integer.BYTES;
+        case LONG:
+          return Long.BYTES;
+        case FLOAT:
+          return Float.BYTES;
+        case DOUBLE:
+          return Double.BYTES;
+        default:
+          // TODO: note - this returns a very approximate value! We should be able to
+          return DEFAULT_MAX_LENGTH_BYTES/4;
       }
     }
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
@@ -40,7 +40,8 @@ import org.json.JSONObject;
  * Supports serialization via JSON.
  */
 @JsonPropertyOrder({ "selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded", "numSegmentsQueried",
-    "numSegmentsProcessed", "numSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numGroupsLimitReached",
+    "numSegmentsProcessed", "numSegmentsMatched", "numDocsScanned", "numBytesReadInFilter", "numBytesReadPostFilter",
+    "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numGroupsLimitReached",
     "totalDocs", "timeUsedMs", "segmentStatistics", "traceInfo" })
 public class BrokerResponseNative implements BrokerResponse {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -57,7 +58,10 @@ public class BrokerResponseNative implements BrokerResponse {
   private long _numSegmentsQueried = 0L;
   private long _numSegmentsProcessed = 0L;
   private long _numSegmentsMatched = 0L;
-  
+
+  private long _numBytesReadInFilter = 0L;
+  private long _numBytesReadPostFilter = 0L;
+
   private long _totalDocs = 0L;
   private boolean _numGroupsLimitReached = false;
   private long _timeUsedMs = 0L;
@@ -227,6 +231,26 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty("numGroupsLimitReached")
   public void setNumGroupsLimitReached(boolean numGroupsLimitReached) {
     _numGroupsLimitReached = numGroupsLimitReached;
+  }
+
+  @JsonProperty("numBytesReadInFilter")
+  public long getNumBytesReadInFilter() {
+    return _numBytesReadInFilter;
+  }
+
+  @JsonProperty("numBytesReadInFilter")
+  public void setNumBytesReadInFilter(long numBytesReadInFilter) {
+    _numBytesReadInFilter = numBytesReadInFilter;
+  }
+
+  @JsonProperty("numBytesReadPostFilter")
+  public long getNumBytesReadPostFilter() {
+    return _numBytesReadPostFilter;
+  }
+
+  @JsonProperty("numBytesReadPostFilter")
+  public void setNumBytesReadPostFilter(long numBytesReadPostFilter) {
+    _numBytesReadPostFilter = numBytesReadPostFilter;
   }
 
   @JsonProperty("timeUsedMs")

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 public interface DataTable {
   String EXCEPTION_METADATA_KEY = "Exception";
   String NUM_DOCS_SCANNED_METADATA_KEY = "numDocsScanned";
+  String NUM_INDICES_LOADED_KEY = "numIndicesLoaded";
   String NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY = "numEntriesScannedInFilter";
   String NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY = "numEntriesScannedPostFilter";
   String NUM_SEGMENTS_QUERIED = "numSegmentsQueried";

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
@@ -28,6 +28,8 @@ public interface DataTable {
   String EXCEPTION_METADATA_KEY = "Exception";
   String NUM_DOCS_SCANNED_METADATA_KEY = "numDocsScanned";
   String NUM_INDICES_LOADED_KEY = "numIndicesLoaded";
+  String NUM_BYTES_READ_IN_FILTER_KEY = "numBytesReadInFilter";
+  String NUM_BYTES_READ_POST_FILTER_KEY = "numBytesReadPostFilter";
   String NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY = "numEntriesScannedInFilter";
   String NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY = "numEntriesScannedPostFilter";
   String NUM_SEGMENTS_QUERIED = "numSegmentsQueried";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
@@ -45,6 +45,8 @@ public class DataFetcher {
   private final Map<String, BlockMultiValIterator> _blockMultiValIteratorMap;
   private final int[] _reusableMVDictIds;
 
+  private long _bytesRead;
+
   /**
    * Constructor for DataFetcher.
    *
@@ -72,6 +74,11 @@ public class DataFetcher {
     }
 
     _reusableMVDictIds = new int[maxNumMultiValues];
+    _bytesRead = 0;
+  }
+
+  public long getBytesRead() {
+    return _bytesRead;
   }
 
   /**
@@ -107,6 +114,7 @@ public class DataFetcher {
     } else {
       _singleValueSetMap.get(column).getIntValues(inDocIds, 0, length, outValues, 0);
     }
+    _bytesRead += length * Integer.BYTES;
   }
 
   /**
@@ -126,6 +134,7 @@ public class DataFetcher {
     } else {
       _singleValueSetMap.get(column).getLongValues(inDocIds, 0, length, outValues, 0);
     }
+    _bytesRead += length * Long.BYTES;
   }
 
   /**
@@ -145,6 +154,7 @@ public class DataFetcher {
     } else {
       _singleValueSetMap.get(column).getFloatValues(inDocIds, 0, length, outValues, 0);
     }
+    _bytesRead += length * Float.BYTES;
   }
 
   /**
@@ -164,6 +174,7 @@ public class DataFetcher {
     } else {
       _singleValueSetMap.get(column).getDoubleValues(inDocIds, 0, length, outValues, 0);
     }
+    _bytesRead += length * Double.BYTES;
   }
 
   /**
@@ -183,6 +194,10 @@ public class DataFetcher {
     } else {
       _singleValueSetMap.get(column).getStringValues(inDocIds, 0, length, outValues, 0);
     }
+    // todo: optimize!
+    for( String val : outValues) {
+      _bytesRead += (val != null) ? val.length() : 0;
+    }
   }
 
   /**
@@ -201,6 +216,9 @@ public class DataFetcher {
       dictionary.readBytesValues(dictIds, 0, length, outValues, 0);
     } else {
       _singleValueSetMap.get(column).getBytesValues(inDocIds, 0, length, outValues, 0);
+    }
+    for( byte[] val : outValues) {
+      _bytesRead += (val != null) ? val.length : 0;
     }
   }
 
@@ -240,6 +258,7 @@ public class DataFetcher {
       int numMultiValues = blockMultiValIterator.nextIntVal(_reusableMVDictIds);
       outValues[i] = new int[numMultiValues];
       _dictionaryMap.get(column).readIntValues(_reusableMVDictIds, 0, numMultiValues, outValues[i], 0);
+      _bytesRead += numMultiValues * Integer.BYTES;
     }
   }
 
@@ -258,6 +277,7 @@ public class DataFetcher {
       int numMultiValues = blockMultiValIterator.nextIntVal(_reusableMVDictIds);
       outValues[i] = new long[numMultiValues];
       _dictionaryMap.get(column).readLongValues(_reusableMVDictIds, 0, numMultiValues, outValues[i], 0);
+      _bytesRead += numMultiValues * Long.BYTES;
     }
   }
 
@@ -276,6 +296,7 @@ public class DataFetcher {
       int numMultiValues = blockMultiValIterator.nextIntVal(_reusableMVDictIds);
       outValues[i] = new float[numMultiValues];
       _dictionaryMap.get(column).readFloatValues(_reusableMVDictIds, 0, numMultiValues, outValues[i], 0);
+      _bytesRead += numMultiValues * Float.BYTES;
     }
   }
 
@@ -294,6 +315,7 @@ public class DataFetcher {
       int numMultiValues = blockMultiValIterator.nextIntVal(_reusableMVDictIds);
       outValues[i] = new double[numMultiValues];
       _dictionaryMap.get(column).readDoubleValues(_reusableMVDictIds, 0, numMultiValues, outValues[i], 0);
+      _bytesRead += numMultiValues * Double.BYTES;
     }
   }
 
@@ -312,6 +334,9 @@ public class DataFetcher {
       int numMultiValues = blockMultiValIterator.nextIntVal(_reusableMVDictIds);
       outValues[i] = new String[numMultiValues];
       _dictionaryMap.get(column).readStringValues(_reusableMVDictIds, 0, numMultiValues, outValues[i], 0);
+      for(String val : outValues[i]) {
+        _bytesRead += val.length();
+      }
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
@@ -191,6 +191,8 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       }
       mergedBlock.setNumDocsScanned(executionStatistics.getNumDocsScanned());
       mergedBlock.setNumIndicesLoaded(executionStatistics.getNumIndicesLoaded());
+      mergedBlock.setNumBytesReadInFilter(executionStatistics.getNumBytesReadInFilter());
+      mergedBlock.setNumBytesReadPostFilter(executionStatistics.getNumBytesReadPostFilter());
       mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
       mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
       mergedBlock.setNumSegmentsProcessed(executionStatistics.getNumSegmentsProcessed());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
@@ -190,6 +190,7 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
         }
       }
       mergedBlock.setNumDocsScanned(executionStatistics.getNumDocsScanned());
+      mergedBlock.setNumIndicesLoaded(executionStatistics.getNumIndicesLoaded());
       mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
       mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
       mergedBlock.setNumSegmentsProcessed(executionStatistics.getNumSegmentsProcessed());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
@@ -185,6 +185,8 @@ public class CombineOperator extends BaseOperator<IntermediateResultsBlock> {
     }
     mergedBlock.setNumDocsScanned(executionStatistics.getNumDocsScanned());
     mergedBlock.setNumIndicesLoaded(executionStatistics.getNumIndicesLoaded());
+    mergedBlock.setNumBytesReadInFilter(executionStatistics.getNumBytesReadInFilter());
+    mergedBlock.setNumBytesReadPostFilter(executionStatistics.getNumBytesReadPostFilter());
     mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
     mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
     mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
@@ -184,6 +184,7 @@ public class CombineOperator extends BaseOperator<IntermediateResultsBlock> {
       }
     }
     mergedBlock.setNumDocsScanned(executionStatistics.getNumDocsScanned());
+    mergedBlock.setNumIndicesLoaded(executionStatistics.getNumIndicesLoaded());
     mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
     mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
     mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/DocIdSetOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/DocIdSetOperator.java
@@ -89,6 +89,7 @@ public class DocIdSetOperator extends BaseOperator<DocIdSetBlock> {
   @Override
   public ExecutionStatistics getExecutionStatistics() {
     return new ExecutionStatistics(0L, _filterBlockDocIdSet.getNumIndicesLoaded(),
+        _filterBlockDocIdSet.getTotalBytesRead(), 0L,
         _filterBlockDocIdSet.getNumEntriesScannedInFilter(), 0L, 0L);
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/DocIdSetOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/DocIdSetOperator.java
@@ -88,6 +88,7 @@ public class DocIdSetOperator extends BaseOperator<DocIdSetBlock> {
 
   @Override
   public ExecutionStatistics getExecutionStatistics() {
-    return new ExecutionStatistics(0L, _filterBlockDocIdSet.getNumEntriesScannedInFilter(), 0L, 0L);
+    return new ExecutionStatistics(0L, _filterBlockDocIdSet.getNumIndicesLoaded(),
+        _filterBlockDocIdSet.getNumEntriesScannedInFilter(), 0L, 0L);
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
@@ -20,6 +20,7 @@ package com.linkedin.pinot.core.operator;
  */
 public class ExecutionStatistics {
   private long _numDocsScanned;
+  private long _numIndicesLoaded;
   private long _numEntriesScannedInFilter;
   private long _numEntriesScannedPostFilter;
   private long _numTotalRawDocs;
@@ -29,9 +30,10 @@ public class ExecutionStatistics {
   public ExecutionStatistics() {
   }
 
-  public ExecutionStatistics(long numDocsScanned, long numEntriesScannedInFilter, long numEntriesScannedPostFilter,
-      long numTotalRawDocs) {
+  public ExecutionStatistics(long numDocsScanned, long numIndicesLoaded, long numEntriesScannedInFilter,
+      long numEntriesScannedPostFilter, long numTotalRawDocs) {
     _numDocsScanned = numDocsScanned;
+    _numIndicesLoaded = numIndicesLoaded;
     _numEntriesScannedInFilter = numEntriesScannedInFilter;
     _numEntriesScannedPostFilter = numEntriesScannedPostFilter;
     _numTotalRawDocs = numTotalRawDocs;
@@ -41,6 +43,10 @@ public class ExecutionStatistics {
 
   public long getNumDocsScanned() {
     return _numDocsScanned;
+  }
+
+  public long getNumIndicesLoaded() {
+    return _numIndicesLoaded;
   }
 
   public long getNumEntriesScannedInFilter() {
@@ -70,6 +76,7 @@ public class ExecutionStatistics {
    */
   public void merge(ExecutionStatistics executionStatisticsToMerge) {
     _numDocsScanned += executionStatisticsToMerge._numDocsScanned;
+    _numIndicesLoaded += executionStatisticsToMerge._numIndicesLoaded;
     _numEntriesScannedInFilter += executionStatisticsToMerge._numEntriesScannedInFilter;
     _numEntriesScannedPostFilter += executionStatisticsToMerge._numEntriesScannedPostFilter;
     _numTotalRawDocs += executionStatisticsToMerge._numTotalRawDocs;
@@ -81,6 +88,7 @@ public class ExecutionStatistics {
   public String toString() {
     return "Execution Statistics:"
         + "\n  numDocsScanned: " + _numDocsScanned
+        + "\n  numIndicesLoaded: " + _numIndicesLoaded
         + "\n  numEntriesScannedInFilter: " + _numEntriesScannedInFilter
         + "\n  numEntriesScannedPostFilter: " + _numEntriesScannedPostFilter
         + "\n  numTotalRawDocs: " + _numTotalRawDocs

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
@@ -21,19 +21,23 @@ package com.linkedin.pinot.core.operator;
 public class ExecutionStatistics {
   private long _numDocsScanned;
   private long _numIndicesLoaded;
+  private long _numBytesReadInFilter;
+  private long _numBytesReadPostFilter;
   private long _numEntriesScannedInFilter;
   private long _numEntriesScannedPostFilter;
   private long _numTotalRawDocs;
   private long _numSegmentsProcessed;
   private long _numSegmentsMatched;
-  
+
   public ExecutionStatistics() {
   }
 
-  public ExecutionStatistics(long numDocsScanned, long numIndicesLoaded, long numEntriesScannedInFilter,
-      long numEntriesScannedPostFilter, long numTotalRawDocs) {
+  public ExecutionStatistics(long numDocsScanned, long numIndicesLoaded, long numBytesReadInFilter,
+      long numBytesReadPostFilter, long numEntriesScannedInFilter, long numEntriesScannedPostFilter, long numTotalRawDocs) {
     _numDocsScanned = numDocsScanned;
     _numIndicesLoaded = numIndicesLoaded;
+    _numBytesReadInFilter = numBytesReadInFilter;
+    _numBytesReadPostFilter = numBytesReadPostFilter;
     _numEntriesScannedInFilter = numEntriesScannedInFilter;
     _numEntriesScannedPostFilter = numEntriesScannedPostFilter;
     _numTotalRawDocs = numTotalRawDocs;
@@ -47,6 +51,14 @@ public class ExecutionStatistics {
 
   public long getNumIndicesLoaded() {
     return _numIndicesLoaded;
+  }
+
+  public long getNumBytesReadInFilter() {
+    return _numBytesReadInFilter;
+  }
+
+  public long getNumBytesReadPostFilter() {
+    return _numBytesReadPostFilter;
   }
 
   public long getNumEntriesScannedInFilter() {
@@ -77,6 +89,8 @@ public class ExecutionStatistics {
   public void merge(ExecutionStatistics executionStatisticsToMerge) {
     _numDocsScanned += executionStatisticsToMerge._numDocsScanned;
     _numIndicesLoaded += executionStatisticsToMerge._numIndicesLoaded;
+    _numBytesReadInFilter += executionStatisticsToMerge._numBytesReadInFilter;
+    _numBytesReadPostFilter += executionStatisticsToMerge._numBytesReadPostFilter;
     _numEntriesScannedInFilter += executionStatisticsToMerge._numEntriesScannedInFilter;
     _numEntriesScannedPostFilter += executionStatisticsToMerge._numEntriesScannedPostFilter;
     _numTotalRawDocs += executionStatisticsToMerge._numTotalRawDocs;
@@ -89,6 +103,8 @@ public class ExecutionStatistics {
     return "Execution Statistics:"
         + "\n  numDocsScanned: " + _numDocsScanned
         + "\n  numIndicesLoaded: " + _numIndicesLoaded
+        + "\n  numBytesReadInFilter: " + _numBytesReadInFilter
+        + "\n  numBytesReadPostFilter: " + _numBytesReadPostFilter
         + "\n  numEntriesScannedInFilter: " + _numEntriesScannedInFilter
         + "\n  numEntriesScannedPostFilter: " + _numEntriesScannedPostFilter
         + "\n  numTotalRawDocs: " + _numTotalRawDocs

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ProjectionOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ProjectionOperator.java
@@ -32,6 +32,7 @@ public class ProjectionOperator extends BaseOperator<ProjectionBlock> {
   private final Map<String, DataSource> _dataSourceMap;
   private final Map<String, Block> _dataBlockMap;
   private final DocIdSetOperator _docIdSetOperator;
+  private final DataFetcher _dataFetcher;
   private final DataBlockCache _dataBlockCache;
 
   public ProjectionOperator(@Nonnull Map<String, DataSource> dataSourceMap,
@@ -42,7 +43,8 @@ public class ProjectionOperator extends BaseOperator<ProjectionBlock> {
       _dataBlockMap.put(entry.getKey(), entry.getValue().nextBlock());
     }
     _docIdSetOperator = docIdSetOperator;
-    _dataBlockCache = new DataBlockCache(new DataFetcher(dataSourceMap));
+    _dataFetcher = new DataFetcher(dataSourceMap);
+    _dataBlockCache = new DataBlockCache(_dataFetcher);
   }
 
   /**
@@ -52,6 +54,10 @@ public class ProjectionOperator extends BaseOperator<ProjectionBlock> {
    */
   public int getNumColumnsProjected() {
     return _dataSourceMap.size();
+  }
+
+  public long getNumBytesProjected() {
+    return _dataFetcher.getBytesRead();
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -50,6 +50,7 @@ public class IntermediateResultsBlock implements Block {
   private List<Map<String, Object>> _combinedAggregationGroupByResult;
   private List<ProcessingException> _processingExceptions;
   private long _numDocsScanned;
+  private long _numIndicesLoaded;
   private long _numEntriesScannedInFilter;
   private long _numEntriesScannedPostFilter;
   private long _numTotalRawDocs;
@@ -165,6 +166,10 @@ public class IntermediateResultsBlock implements Block {
 
   public void setNumDocsScanned(long numDocsScanned) {
     _numDocsScanned = numDocsScanned;
+  }
+
+  public void setNumIndicesLoaded(long numIndicesLoaded) {
+    _numIndicesLoaded = numIndicesLoaded;
   }
 
   public void setNumEntriesScannedInFilter(long numEntriesScannedInFilter) {
@@ -293,6 +298,7 @@ public class IntermediateResultsBlock implements Block {
 
   private DataTable attachMetadataToDataTable(DataTable dataTable) {
     dataTable.getMetadata().put(DataTable.NUM_DOCS_SCANNED_METADATA_KEY, String.valueOf(_numDocsScanned));
+    dataTable.getMetadata().put(DataTable.NUM_INDICES_LOADED_KEY, String.valueOf(_numIndicesLoaded));
     dataTable.getMetadata()
         .put(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedInFilter));
     dataTable.getMetadata()

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -51,6 +51,8 @@ public class IntermediateResultsBlock implements Block {
   private List<ProcessingException> _processingExceptions;
   private long _numDocsScanned;
   private long _numIndicesLoaded;
+  private long _numBytesReadInFilter;
+  private long _numBytesReadPostFilter;
   private long _numEntriesScannedInFilter;
   private long _numEntriesScannedPostFilter;
   private long _numTotalRawDocs;
@@ -172,6 +174,14 @@ public class IntermediateResultsBlock implements Block {
     _numIndicesLoaded = numIndicesLoaded;
   }
 
+  public void setNumBytesReadInFilter(long numBytesReadInFilter) {
+    _numBytesReadInFilter = numBytesReadInFilter;
+  }
+
+  public void setNumBytesReadPostFilter(long numBytesReadPostFilter) {
+    _numBytesReadPostFilter = numBytesReadPostFilter;
+  }
+
   public void setNumEntriesScannedInFilter(long numEntriesScannedInFilter) {
     _numEntriesScannedInFilter = numEntriesScannedInFilter;
   }
@@ -179,7 +189,7 @@ public class IntermediateResultsBlock implements Block {
   public void setNumEntriesScannedPostFilter(long numEntriesScannedPostFilter) {
     _numEntriesScannedPostFilter = numEntriesScannedPostFilter;
   }
-  
+
   public long getNumSegmentsProcessed() {
     return _numSegmentsProcessed;
   }
@@ -299,13 +309,15 @@ public class IntermediateResultsBlock implements Block {
   private DataTable attachMetadataToDataTable(DataTable dataTable) {
     dataTable.getMetadata().put(DataTable.NUM_DOCS_SCANNED_METADATA_KEY, String.valueOf(_numDocsScanned));
     dataTable.getMetadata().put(DataTable.NUM_INDICES_LOADED_KEY, String.valueOf(_numIndicesLoaded));
+    dataTable.getMetadata().put(DataTable.NUM_BYTES_READ_IN_FILTER_KEY, String.valueOf(_numBytesReadInFilter));
+    dataTable.getMetadata().put(DataTable.NUM_BYTES_READ_POST_FILTER_KEY, String.valueOf(_numBytesReadPostFilter));
     dataTable.getMetadata()
         .put(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedInFilter));
     dataTable.getMetadata()
         .put(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedPostFilter));
     dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_PROCESSED, String.valueOf(_numSegmentsProcessed));
     dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_MATCHED, String.valueOf(_numSegmentsMatched));
-    
+
     dataTable.getMetadata().put(DataTable.TOTAL_DOCS_METADATA_KEY, String.valueOf(_numTotalRawDocs));
     if (_numGroupsLimitReached) {
       dataTable.getMetadata().put(DataTable.NUM_GROUPS_LIMIT_REACHED_KEY, "true");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/AndBlockDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/AndBlockDocIdSet.java
@@ -268,4 +268,13 @@ public final class AndBlockDocIdSet implements FilterBlockDocIdSet {
     }
     return loaded;
   }
+
+  @Override
+  public long getTotalBytesRead() {
+    long bytes = 0;
+    for (FilterBlockDocIdSet docIdSet : blockDocIdSets) {
+      bytes += docIdSet.getTotalBytesRead();
+    }
+    return bytes;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/AndBlockDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/AndBlockDocIdSet.java
@@ -259,4 +259,13 @@ public final class AndBlockDocIdSet implements FilterBlockDocIdSet {
     }
     return numEntriesScannedInFilter;
   }
+
+  @Override
+  public long getNumIndicesLoaded() {
+    long loaded = 0;
+    for (FilterBlockDocIdSet docIdSet : blockDocIdSets) {
+      loaded += docIdSet.getNumIndicesLoaded();
+    }
+    return loaded;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/BitmapDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/BitmapDocIdSet.java
@@ -23,19 +23,20 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 public class BitmapDocIdSet implements FilterBlockDocIdSet {
   private final ImmutableRoaringBitmap _bitmap;
+  private final long _bitMapCount;
   private int _startDocId;
   // Inclusive
   private int _endDocId;
 
   public BitmapDocIdSet(ImmutableRoaringBitmap[] bitmaps, int startDocId, int endDocId, boolean exclusive) {
-    int numBitmaps = bitmaps.length;
-    if (numBitmaps > 1) {
+    _bitMapCount = bitmaps.length;
+    if (_bitMapCount > 1) {
       MutableRoaringBitmap orBitmap = MutableRoaringBitmap.or(bitmaps);
       if (exclusive) {
         orBitmap.flip(startDocId, endDocId + 1);
       }
       _bitmap = orBitmap;
-    } else if (numBitmaps == 1) {
+    } else if (_bitMapCount == 1) {
       if (exclusive) {
         // NOTE: cannot use ImmutableRoaringBitmap.flip() because the library has a bug in that method
         // TODO: the bug has been fixed in the latest version of ImmutableRoaringBitmap, update the version
@@ -80,6 +81,11 @@ public class BitmapDocIdSet implements FilterBlockDocIdSet {
   @Override
   public long getNumEntriesScannedInFilter() {
     return 0L;
+  }
+
+  @Override
+  public long getNumIndicesLoaded() {
+    return _bitMapCount;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/EmptyFilterBlockDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/EmptyFilterBlockDocIdSet.java
@@ -56,6 +56,11 @@ public final class EmptyFilterBlockDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getNumIndicesLoaded() {
+    return 0L;
+  }
+
+  @Override
   public BlockDocIdIterator iterator() {
     return EmptyBlockDocIdIterator.getInstance();
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/EmptyFilterBlockDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/EmptyFilterBlockDocIdSet.java
@@ -61,6 +61,11 @@ public final class EmptyFilterBlockDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getTotalBytesRead() {
+    return 0L;
+  }
+
+  @Override
   public BlockDocIdIterator iterator() {
     return EmptyBlockDocIdIterator.getInstance();
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/FilterBlockDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/FilterBlockDocIdSet.java
@@ -73,4 +73,9 @@ public interface FilterBlockDocIdSet extends BlockDocIdSet {
    * Returns the number of indices loaded in filtering phase.
    */
   long getNumIndicesLoaded();
+
+  /**
+   * Returns the number of bytes read in the filtering phase.
+   */
+  long getTotalBytesRead();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/FilterBlockDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/FilterBlockDocIdSet.java
@@ -68,4 +68,9 @@ public interface FilterBlockDocIdSet extends BlockDocIdSet {
    * Returns the number of entries scanned in filtering phase.
    */
   long getNumEntriesScannedInFilter();
+
+  /**
+   * Returns the number of indices loaded in filtering phase.
+   */
+  long getNumIndicesLoaded();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/OrBlockDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/OrBlockDocIdSet.java
@@ -81,6 +81,15 @@ public final class OrBlockDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getTotalBytesRead() {
+    long bytes = 0;
+    for (FilterBlockDocIdSet docIdSet : _docIdSets) {
+      bytes += docIdSet.getTotalBytesRead();
+    }
+    return bytes;
+  }
+
+  @Override
   public BlockDocIdIterator iterator() {
     boolean useBitmapOr = false;
     for (BlockDocIdSet docIdSet : _docIdSets) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/OrBlockDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/OrBlockDocIdSet.java
@@ -72,6 +72,15 @@ public final class OrBlockDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getNumIndicesLoaded() {
+    long loaded = 0;
+    for (FilterBlockDocIdSet docIdSet : _docIdSets) {
+      loaded += docIdSet.getNumIndicesLoaded();
+    }
+    return loaded;
+  }
+
+  @Override
   public BlockDocIdIterator iterator() {
     boolean useBitmapOr = false;
     for (BlockDocIdSet docIdSet : _docIdSets) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedMultiValueDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedMultiValueDocIdSet.java
@@ -27,12 +27,14 @@ public class ScanBasedMultiValueDocIdSet implements FilterBlockDocIdSet {
   private BlockMetadata blockMetadata;
   private MVScanDocIdIterator blockValSetBlockDocIdIterator;
   private String datasourceName;
+  private final int dataTypeSizeInBytes;
 
   public ScanBasedMultiValueDocIdSet(String datasourceName, BlockValSet blockValSet,
       BlockMetadata blockMetadata, PredicateEvaluator evaluator) {
     this.datasourceName = datasourceName;
     this.blockValSet = blockValSet;
     this.blockMetadata = blockMetadata;
+    this.dataTypeSizeInBytes = blockMetadata.getDataType().getSizeInBytes();
     blockValSetBlockDocIdIterator =
         new MVScanDocIdIterator(datasourceName, blockValSet, blockMetadata, evaluator);
   }
@@ -74,6 +76,11 @@ public class ScanBasedMultiValueDocIdSet implements FilterBlockDocIdSet {
   @Override
   public long getNumIndicesLoaded() {
     return 0L;
+  }
+
+  @Override
+  public long getTotalBytesRead() {
+    return getNumEntriesScannedInFilter() * dataTypeSizeInBytes;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedMultiValueDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedMultiValueDocIdSet.java
@@ -72,6 +72,11 @@ public class ScanBasedMultiValueDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getNumIndicesLoaded() {
+    return 0L;
+  }
+
+  @Override
   public ScanBasedDocIdIterator iterator() {
     return blockValSetBlockDocIdIterator;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedMultiValueDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedMultiValueDocIdSet.java
@@ -34,7 +34,7 @@ public class ScanBasedMultiValueDocIdSet implements FilterBlockDocIdSet {
     this.datasourceName = datasourceName;
     this.blockValSet = blockValSet;
     this.blockMetadata = blockMetadata;
-    this.dataTypeSizeInBytes = blockMetadata.getDataType().getSizeInBytes();
+    dataTypeSizeInBytes = evaluator.isDictionaryBased() ? Integer.BYTES : blockMetadata.getDataType().getSizeInBytes();
     blockValSetBlockDocIdIterator =
         new MVScanDocIdIterator(datasourceName, blockValSet, blockMetadata, evaluator);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedSingleValueDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedSingleValueDocIdSet.java
@@ -34,7 +34,7 @@ public class ScanBasedSingleValueDocIdSet implements FilterBlockDocIdSet {
     this.datasourceName = datasourceName;
     this.blockValSet = blockValSet;
     blockValSetBlockDocIdIterator = new SVScanDocIdIterator(datasourceName, blockValSet, blockMetadata, evaluator);
-    dataTypeSizeInBytes = blockMetadata.getDataType().getSizeInBytes();
+    dataTypeSizeInBytes = evaluator.isDictionaryBased() ? Integer.BYTES : blockMetadata.getDataType().getSizeInBytes();
     setStartDocId(blockMetadata.getStartDocId());
     setEndDocId(blockMetadata.getEndDocId());
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedSingleValueDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedSingleValueDocIdSet.java
@@ -26,6 +26,7 @@ public class ScanBasedSingleValueDocIdSet implements FilterBlockDocIdSet {
   private final BlockValSet blockValSet;
   private SVScanDocIdIterator blockValSetBlockDocIdIterator;
   private String datasourceName;
+  private long dataTypeSizeInBytes;
   int startDocId;
   int endDocId;
 
@@ -33,6 +34,7 @@ public class ScanBasedSingleValueDocIdSet implements FilterBlockDocIdSet {
     this.datasourceName = datasourceName;
     this.blockValSet = blockValSet;
     blockValSetBlockDocIdIterator = new SVScanDocIdIterator(datasourceName, blockValSet, blockMetadata, evaluator);
+    dataTypeSizeInBytes = blockMetadata.getDataType().getSizeInBytes();
     setStartDocId(blockMetadata.getStartDocId());
     setEndDocId(blockMetadata.getEndDocId());
   }
@@ -76,7 +78,12 @@ public class ScanBasedSingleValueDocIdSet implements FilterBlockDocIdSet {
   public long getNumIndicesLoaded() {
     return 0L;
   }
-  
+
+  @Override
+  public long getTotalBytesRead() {
+    return getNumEntriesScannedInFilter() * dataTypeSizeInBytes;
+  }
+
   @Override
   public ScanBasedDocIdIterator iterator() {
     return blockValSetBlockDocIdIterator;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedSingleValueDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/ScanBasedSingleValueDocIdSet.java
@@ -73,6 +73,11 @@ public class ScanBasedSingleValueDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getNumIndicesLoaded() {
+    return 0L;
+  }
+  
+  @Override
   public ScanBasedDocIdIterator iterator() {
     return blockValSetBlockDocIdIterator;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/SizeBasedDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/SizeBasedDocIdSet.java
@@ -55,6 +55,11 @@ public final class SizeBasedDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getTotalBytesRead() {
+    return 0L;
+  }
+
+  @Override
   public BlockDocIdIterator iterator() {
     return new SizeBasedDocIdIterator(_maxDocId);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/SizeBasedDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/SizeBasedDocIdSet.java
@@ -50,6 +50,11 @@ public final class SizeBasedDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getNumIndicesLoaded() {
+    return 0L;
+  }
+
+  @Override
   public BlockDocIdIterator iterator() {
     return new SizeBasedDocIdIterator(_maxDocId);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/SortedDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/SortedDocIdSet.java
@@ -78,6 +78,11 @@ public class SortedDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getNumIndicesLoaded() {
+    return 0L;
+  }
+
+  @Override
   public BlockDocIdIterator iterator() {
     if (pairs == null || pairs.isEmpty()) {
       return EmptyBlockDocIdIterator.getInstance();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/SortedDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/SortedDocIdSet.java
@@ -20,13 +20,11 @@ import com.linkedin.pinot.core.common.BlockDocIdIterator;
 import com.linkedin.pinot.core.operator.dociditerators.EmptyBlockDocIdIterator;
 import com.linkedin.pinot.core.operator.dociditerators.SortedDocIdIterator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 
 public class SortedDocIdSet implements FilterBlockDocIdSet {
 
   public final List<IntPair> pairs;
-  public final AtomicLong timeMeasure = new AtomicLong(0);
   int startDocId;
   int endDocId;
   private String datasourceName;
@@ -80,6 +78,12 @@ public class SortedDocIdSet implements FilterBlockDocIdSet {
   @Override
   public long getNumIndicesLoaded() {
     return 0L;
+  }
+
+  @Override
+  public long getTotalBytesRead() {
+    // TODO: verify if this is right
+    return pairs.size() * 2 * Integer.BYTES;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/StarTreeDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/StarTreeDocIdSet.java
@@ -89,6 +89,12 @@ public class StarTreeDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getNumIndicesLoaded() {
+    // TODO: this must be fixed
+    return 0L;
+  }
+
+  @Override
   public BlockDocIdIterator iterator() {
     return new RangeBasedDocIdIterator(minDocId, maxDocId);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/StarTreeDocIdSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docidsets/StarTreeDocIdSet.java
@@ -95,6 +95,12 @@ public class StarTreeDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
+  public long getTotalBytesRead() {
+    // TODO: this must be fixed
+    return 0L;
+  }
+
+  @Override
   public BlockDocIdIterator iterator() {
     return new RangeBasedDocIdIterator(minDocId, maxDocId);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
@@ -83,8 +83,8 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
     long numEntriesScannedInFilter = _transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
     long numEntriesScannedPostFilter = numDocsScanned * _transformOperator.getNumColumnsProjected();
     _executionStatistics =
-        new ExecutionStatistics(numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
-            _numTotalRawDocs);
+        new ExecutionStatistics(numDocsScanned,_transformOperator.getExecutionStatistics().getNumIndicesLoaded(),
+            numEntriesScannedInFilter, numEntriesScannedPostFilter, _numTotalRawDocs);
 
     // Build intermediate result block based on aggregation group-by result from the executor
     return new IntermediateResultsBlock(_functionContexts, groupByResult);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
@@ -80,11 +80,14 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
     AggregationGroupByResult groupByResult = groupByExecutor.getResult();
 
     // Gather execution statistics
-    long numEntriesScannedInFilter = _transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
+    ExecutionStatistics transformStats = _transformOperator.getExecutionStatistics();
+    long numEntriesScannedInFilter = transformStats.getNumEntriesScannedInFilter();
     long numEntriesScannedPostFilter = numDocsScanned * _transformOperator.getNumColumnsProjected();
+    long numBytesReadPostFilter = _transformOperator.getNumBytesProjected();
     _executionStatistics =
-        new ExecutionStatistics(numDocsScanned,_transformOperator.getExecutionStatistics().getNumIndicesLoaded(),
-            numEntriesScannedInFilter, numEntriesScannedPostFilter, _numTotalRawDocs);
+        new ExecutionStatistics(numDocsScanned, transformStats.getNumIndicesLoaded(),
+            transformStats.getNumBytesReadInFilter(), numBytesReadPostFilter, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+            _numTotalRawDocs);
 
     // Build intermediate result block based on aggregation group-by result from the executor
     return new IntermediateResultsBlock(_functionContexts, groupByResult);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationOperator.java
@@ -71,8 +71,8 @@ public class AggregationOperator extends BaseOperator<IntermediateResultsBlock> 
     long numEntriesScannedInFilter = _transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
     long numEntriesScannedPostFilter = numDocsScanned * _transformOperator.getNumColumnsProjected();
     _executionStatistics =
-        new ExecutionStatistics(numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
-            _numTotalRawDocs);
+        new ExecutionStatistics(numDocsScanned, _transformOperator.getExecutionStatistics().getNumIndicesLoaded(),
+            numEntriesScannedInFilter, numEntriesScannedPostFilter, _numTotalRawDocs);
 
     // Build intermediate result block based on aggregation result from the executor
     return new IntermediateResultsBlock(_functionContexts, aggregationResult, false);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationOperator.java
@@ -68,10 +68,13 @@ public class AggregationOperator extends BaseOperator<IntermediateResultsBlock> 
     List<Object> aggregationResult = aggregationExecutor.getResult();
 
     // Create execution statistics
-    long numEntriesScannedInFilter = _transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
+    ExecutionStatistics transformStats = _transformOperator.getExecutionStatistics();
+    long numEntriesScannedInFilter = transformStats.getNumEntriesScannedInFilter();
     long numEntriesScannedPostFilter = numDocsScanned * _transformOperator.getNumColumnsProjected();
+    long numBytesReadPostFilter = _transformOperator.getNumBytesProjected();
     _executionStatistics =
-        new ExecutionStatistics(numDocsScanned, _transformOperator.getExecutionStatistics().getNumIndicesLoaded(),
+        new ExecutionStatistics(numDocsScanned, transformStats.getNumIndicesLoaded(),
+            transformStats.getNumBytesReadInFilter(), numBytesReadPostFilter,
             numEntriesScannedInFilter, numEntriesScannedPostFilter, _numTotalRawDocs);
 
     // Build intermediate result block based on aggregation result from the executor

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -95,7 +95,8 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
 
     // Create execution statistics. Set numDocsScanned to totalRawDocs for backward compatibility.
     _executionStatistics =
-        new ExecutionStatistics(_totalRawDocs, 0/*numIndicesLoaded*/,
+        new ExecutionStatistics(_totalRawDocs, 0/*numIndicesLoaded*/, 0 /*numBytesReadInFilter*/,
+            0/*numBytesReadPostFilter*/,
             0/* numEntriesScannedInFilter */, 0/* numEntriesScannedPostFilter */,
             _totalRawDocs);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -95,7 +95,8 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
 
     // Create execution statistics. Set numDocsScanned to totalRawDocs for backward compatibility.
     _executionStatistics =
-        new ExecutionStatistics(_totalRawDocs, 0/* numEntriesScannedInFilter */, 0/* numEntriesScannedPostFilter */,
+        new ExecutionStatistics(_totalRawDocs, 0/*numIndicesLoaded*/,
+            0/* numEntriesScannedInFilter */, 0/* numEntriesScannedPostFilter */,
             _totalRawDocs);
 
     // Build intermediate result block based on aggregation result from the executor.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/EmptySelectionOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/EmptySelectionOperator.java
@@ -42,7 +42,7 @@ public class EmptySelectionOperator extends BaseOperator<IntermediateResultsBloc
     List<String> selectionColumns =
         SelectionOperatorUtils.getSelectionColumns(selection.getSelectionColumns(), indexSegment);
     _dataSchema = SelectionOperatorUtils.extractDataSchema(null, selectionColumns, indexSegment);
-    _executionStatistics = new ExecutionStatistics(0L, 0L, 0L, 0L, indexSegment.getSegmentMetadata().getTotalRawDocs());
+    _executionStatistics = new ExecutionStatistics(0L, 0L, 0L, 0L, 0L, 0L, indexSegment.getSegmentMetadata().getTotalRawDocs());
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/EmptySelectionOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/EmptySelectionOperator.java
@@ -42,7 +42,7 @@ public class EmptySelectionOperator extends BaseOperator<IntermediateResultsBloc
     List<String> selectionColumns =
         SelectionOperatorUtils.getSelectionColumns(selection.getSelectionColumns(), indexSegment);
     _dataSchema = SelectionOperatorUtils.extractDataSchema(null, selectionColumns, indexSegment);
-    _executionStatistics = new ExecutionStatistics(0L, 0L, 0L, indexSegment.getSegmentMetadata().getTotalRawDocs());
+    _executionStatistics = new ExecutionStatistics(0L, 0L, 0L, 0L, indexSegment.getSegmentMetadata().getTotalRawDocs());
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
@@ -70,7 +70,8 @@ public class MetadataBasedAggregationOperator extends BaseOperator<IntermediateR
 
     // Create execution statistics. Set numDocsScanned to totalRawDocs for backward compatibility.
     _executionStatistics =
-        new ExecutionStatistics(totalRawDocs, 0/*numEntriesScannedInFilter*/, 0/*numEntriesScannedPostFilter*/,
+        new ExecutionStatistics(totalRawDocs, 0/*numIndicesLoaded*/,
+            0/*numEntriesScannedInFilter*/, 0/*numEntriesScannedPostFilter*/,
             totalRawDocs);
 
     // Build intermediate result block based on aggregation result from the executor.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
@@ -70,7 +70,8 @@ public class MetadataBasedAggregationOperator extends BaseOperator<IntermediateR
 
     // Create execution statistics. Set numDocsScanned to totalRawDocs for backward compatibility.
     _executionStatistics =
-        new ExecutionStatistics(totalRawDocs, 0/*numIndicesLoaded*/,
+        new ExecutionStatistics(totalRawDocs, 0/*numIndicesLoaded*/, 0/*numBytesReadInFilter*/,
+            90/*numBytesReadPostFilter*/,
             0/*numEntriesScannedInFilter*/, 0/*numEntriesScannedPostFilter*/,
             totalRawDocs);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOnlyOperator.java
@@ -88,8 +88,8 @@ public class SelectionOnlyOperator extends BaseOperator<IntermediateResultsBlock
     long numEntriesScannedPostFilter = numDocsScanned * _projectionOperator.getNumColumnsProjected();
     long numTotalRawDocs = _indexSegment.getSegmentMetadata().getTotalRawDocs();
     _executionStatistics =
-        new ExecutionStatistics(numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
-            numTotalRawDocs);
+        new ExecutionStatistics(numDocsScanned, _projectionOperator.getExecutionStatistics().getNumIndicesLoaded(),
+            numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalRawDocs);
 
     return new IntermediateResultsBlock(_dataSchema, _rowEvents);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOnlyOperator.java
@@ -84,12 +84,16 @@ public class SelectionOnlyOperator extends BaseOperator<IntermediateResultsBlock
     }
 
     // Create execution statistics.
-    long numEntriesScannedInFilter = _projectionOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
+    ExecutionStatistics projectionStats = _projectionOperator.getExecutionStatistics();
+    long numEntriesScannedInFilter = projectionStats.getNumEntriesScannedInFilter();
     long numEntriesScannedPostFilter = numDocsScanned * _projectionOperator.getNumColumnsProjected();
+    long numBytesReadPostFilter = _projectionOperator.getNumBytesProjected();
     long numTotalRawDocs = _indexSegment.getSegmentMetadata().getTotalRawDocs();
     _executionStatistics =
-        new ExecutionStatistics(numDocsScanned, _projectionOperator.getExecutionStatistics().getNumIndicesLoaded(),
-            numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalRawDocs);
+        new ExecutionStatistics(numDocsScanned, projectionStats.getNumIndicesLoaded(),
+            projectionStats.getNumBytesReadInFilter(), numBytesReadPostFilter,
+            numEntriesScannedInFilter, numEntriesScannedPostFilter,
+            numTotalRawDocs);
 
     return new IntermediateResultsBlock(_dataSchema, _rowEvents);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -95,8 +95,8 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
     long numEntriesScannedPostFilter = numDocsScanned * _projectionOperator.getNumColumnsProjected();
     long numTotalRawDocs = _indexSegment.getSegmentMetadata().getTotalRawDocs();
     _executionStatistics =
-        new ExecutionStatistics(numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
-            numTotalRawDocs);
+        new ExecutionStatistics(numDocsScanned, _projectionOperator.getExecutionStatistics().getNumIndicesLoaded(),
+            numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalRawDocs);
 
     return new IntermediateResultsBlock(_selectionOperatorService.getDataSchema(), _selectionOperatorService.getRows());
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -90,13 +90,17 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
     }
 
     // Create execution statistics.
+    ExecutionStatistics projectionStats = _projectionOperator.getExecutionStatistics();
     numDocsScanned += _selectionOperatorService.getNumDocsScanned();
-    long numEntriesScannedInFilter = _projectionOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
+    long numEntriesScannedInFilter = projectionStats.getNumEntriesScannedInFilter();
     long numEntriesScannedPostFilter = numDocsScanned * _projectionOperator.getNumColumnsProjected();
+    long numBytesReadPostFilter = _projectionOperator.getNumBytesProjected();
     long numTotalRawDocs = _indexSegment.getSegmentMetadata().getTotalRawDocs();
     _executionStatistics =
-        new ExecutionStatistics(numDocsScanned, _projectionOperator.getExecutionStatistics().getNumIndicesLoaded(),
-            numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalRawDocs);
+        new ExecutionStatistics(numDocsScanned, projectionStats.getNumIndicesLoaded(),
+            projectionStats.getNumBytesReadInFilter(), numBytesReadPostFilter,
+            numEntriesScannedInFilter, numEntriesScannedPostFilter,
+            numTotalRawDocs);
 
     return new IntermediateResultsBlock(_selectionOperatorService.getDataSchema(), _selectionOperatorService.getRows());
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformOperator.java
@@ -66,6 +66,10 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
     return _dataSourceMap.size();
   }
 
+  public long getNumBytesProjected() {
+    return _projectionOperator.getNumBytesProjected();
+  }
+
   /**
    * Returns the transform result metadata associated with the given expression.
    *

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -47,7 +47,7 @@ public abstract class QueryScheduler {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryScheduler.class);
   private static final String INVALID_NUM_SCANNED = "-1";
   private static final String INVALID_SEGMENTS_COUNT = "-1";
-  
+
   protected final ServerMetrics serverMetrics;
   protected final QueryExecutor queryExecutor;
   protected final ResourceManager resourceManager;
@@ -144,6 +144,8 @@ public abstract class QueryScheduler {
     String tableNameWithType = queryRequest.getTableNameWithType();
     long numDocsScanned =
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_DOCS_SCANNED_METADATA_KEY, INVALID_NUM_SCANNED));
+    long numIndicesLoaded =
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_INDICES_LOADED_KEY, "0"));
     long numEntriesScannedInFilter = Long.parseLong(
         dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, INVALID_NUM_SCANNED));
     long numEntriesScannedPostFilter = Long.parseLong(
@@ -152,7 +154,7 @@ public abstract class QueryScheduler {
         dataTableMetadata.getOrDefault(DataTable.NUM_SEGMENTS_PROCESSED, INVALID_SEGMENTS_COUNT));
     long numSegmentsMatched = Long.parseLong(
         dataTableMetadata.getOrDefault(DataTable.NUM_SEGMENTS_MATCHED, INVALID_SEGMENTS_COUNT));
-    
+
     if (numDocsScanned > 0) {
       serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_DOCS_SCANNED, numDocsScanned);
     }
@@ -168,12 +170,12 @@ public abstract class QueryScheduler {
     TimerContext timerContext = queryRequest.getTimerContext();
     int numSegmentsQueried = queryRequest.getSegmentsToQuery().size();
     LOGGER.info(
-        "Processed requestId={},table={},Segments(Queried/processed/matched)={}/{}/{},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={}",
+        "Processed requestId={},table={},Segments(Queried/processed/matched)={}/{}/{},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},numIndicesLoaded={},scanInFilter={},scanPostFilter={},sched={}",
         requestId, tableNameWithType, numSegmentsQueried, numSegmentsProcessed, numSegmentsMatched,
         timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
         timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), queryRequest.getBrokerId(), numDocsScanned,
-        numEntriesScannedInFilter, numEntriesScannedPostFilter, name());
-    
+        numIndicesLoaded, numEntriesScannedInFilter, numEntriesScannedPostFilter, name());
+
     serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_QUERIED, numSegmentsQueried);
     serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_PROCESSED, numSegmentsProcessed);
     serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_MATCHED, numSegmentsMatched);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -146,6 +146,10 @@ public abstract class QueryScheduler {
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_DOCS_SCANNED_METADATA_KEY, INVALID_NUM_SCANNED));
     long numIndicesLoaded =
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_INDICES_LOADED_KEY, "0"));
+    long numBytesReadInFilter =
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_BYTES_READ_IN_FILTER_KEY, "0"));
+    long numBytesReadPostFilter =
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_BYTES_READ_POST_FILTER_KEY, "0"));
     long numEntriesScannedInFilter = Long.parseLong(
         dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, INVALID_NUM_SCANNED));
     long numEntriesScannedPostFilter = Long.parseLong(
@@ -170,11 +174,12 @@ public abstract class QueryScheduler {
     TimerContext timerContext = queryRequest.getTimerContext();
     int numSegmentsQueried = queryRequest.getSegmentsToQuery().size();
     LOGGER.info(
-        "Processed requestId={},table={},Segments(Queried/processed/matched)={}/{}/{},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},numIndicesLoaded={},scanInFilter={},scanPostFilter={},sched={}",
+        "Processed requestId={},table={},Segments(Queried/processed/matched)={}/{}/{},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},numIndicesLoaded={},numBytesReadInFilter={},numBytesReadPostFilter={},scanInFilter={},scanPostFilter={},sched={}",
         requestId, tableNameWithType, numSegmentsQueried, numSegmentsProcessed, numSegmentsMatched,
         timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
         timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), queryRequest.getBrokerId(), numDocsScanned,
-        numIndicesLoaded, numEntriesScannedInFilter, numEntriesScannedPostFilter, name());
+        numIndicesLoaded, numBytesReadInFilter, numBytesReadPostFilter,
+        numEntriesScannedInFilter, numEntriesScannedPostFilter, name());
 
     serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_QUERIED, numSegmentsQueried);
     serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_PROCESSED, numSegmentsProcessed);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BitmapInvertedIndexReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BitmapInvertedIndexReader.java
@@ -94,7 +94,7 @@ public class BitmapInvertedIndexReader implements InvertedIndexReader<ImmutableR
     ByteBuffer bb = buffer.toDirectByteBuffer(currentOffset, bufferLength);
     ImmutableRoaringBitmap immutableRoaringBitmap = null;
     try {
-      immutableRoaringBitmap = new ImmutableRoaringBitmap(bb);
+      immutableRoaringBitmap = new ImmutableRoaringBitmapWrapper(bb);
     } catch (Exception e) {
       LOGGER.error(
           "Error creating immutableRoaringBitmap for dictionary id:{} currentOffset:{} bufferLength:{} slice position{} limit:{} file:{}",

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableRoaringBitmapWrapper.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableRoaringBitmapWrapper.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.index.readers;
+
+import java.nio.ByteBuffer;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+public class ImmutableRoaringBitmapWrapper extends ImmutableRoaringBitmap {
+
+  private int sizeInBytes = -1;
+
+  public ImmutableRoaringBitmapWrapper(ByteBuffer bb) {
+    super(bb);
+  }
+
+  @Override
+  public int getSizeInBytes() {
+    if (sizeInBytes == -1) {
+      sizeInBytes = super.getSizeInBytes();
+    }
+    return sizeInBytes;
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/docidsets/BitmapDocIdSetTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/docidsets/BitmapDocIdSetTest.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.common.docidsets;
 import com.linkedin.pinot.core.common.BlockDocIdIterator;
 import com.linkedin.pinot.core.common.Constants;
 import com.linkedin.pinot.core.operator.docidsets.BitmapDocIdSet;
+import com.linkedin.pinot.core.segment.index.readers.ImmutableRoaringBitmapWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -57,7 +58,7 @@ public class BitmapDocIdSetTest {
       mutableRoaringBitmap.serialize(dos);
       dos.close();
       ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
-      ImmutableRoaringBitmap immutableRoaringBitmap = new ImmutableRoaringBitmap(bb);
+      ImmutableRoaringBitmap immutableRoaringBitmap = new ImmutableRoaringBitmapWrapper(bb);
       list.add(immutableRoaringBitmap);
     }
     ImmutableRoaringBitmap[] bitmaps = new ImmutableRoaringBitmap[list.size()];

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/operator/filter/TestFilterOperator.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/operator/filter/TestFilterOperator.java
@@ -60,6 +60,16 @@ public class TestFilterOperator extends BaseFilterOperator {
       }
 
       @Override
+      public long getNumIndicesLoaded() {
+        return 0;
+      }
+
+      @Override
+      public long getTotalBytesRead() {
+        return 0;
+      }
+
+      @Override
       public BlockDocIdIterator iterator() {
         return new ArrayBasedDocIdIterator(_docIds, _docIds.length);
       }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -16,10 +16,10 @@
 package com.linkedin.pinot.integration.tests;
 
 import com.google.common.base.Function;
-import com.linkedin.pinot.common.config.CombinedConfig;
-import com.linkedin.pinot.common.config.Serializer;
 import com.linkedin.pinot.client.ResultSet;
 import com.linkedin.pinot.client.ResultSetGroup;
+import com.linkedin.pinot.common.config.CombinedConfig;
+import com.linkedin.pinot.common.config.Serializer;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.util.TestUtils;
@@ -39,7 +39,6 @@ import org.apache.helix.model.InstanceConfig;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 
 
 /**
@@ -139,7 +138,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
   }
   /**
    * Test to ensure that broker response contains expected stats
-   * 
+   *
    * @throws Exception
    */
   public void testBrokerResponseMetadata() throws Exception {
@@ -149,12 +148,13 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
         "SELECT count(*) FROM mytable_foo" // query a non existing table
     };
     String[] statNames = new String[] { "totalDocs", "numServersQueried", "numServersResponded", "numSegmentsQueried", "numSegmentsProcessed",
-        "numSegmentsMatched", "numDocsScanned", "totalDocs", "timeUsedMs", "numEntriesScannedInFilter", "numEntriesScannedPostFilter" };
+        "numSegmentsMatched", "numDocsScanned", "totalDocs", "timeUsedMs", "numEntriesScannedInFilter", "numEntriesScannedPostFilter",
+        "numBytesReadInFilter", "numBytesReadPostFilter"};
 
     for (String query : pqlQueries) {
       JSONObject response = postQuery(query);
       for (String statName : statNames) {
-        Assert.assertTrue(response.has(statName));
+        Assert.assertTrue(response.has(statName), "Missing stat " + statName);
       }
     }
   }


### PR DESCRIPTION
WIP - Code is mostly done; need to validate with more tests and ensure all paths are covered.

This change introduces a few main changes:
- Ability to track the size of the inverted-index posting list size. This is achieved by adding a wrapper for ImmutableRoaringBitMap; the wrapper just caches the bitmap size (its immutable after all!).
- Tracks the bytes read in the scan-based filters. The current implementation is OK for dictionary based scans; For string/byte raw store, it might be off.
- Tracks byes projected via DataBlockCache/DataFetcher classes. 