### PR TITLE
Let PinotDataBuffer.newIndexFor(...) takes long value

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -198,7 +198,7 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
   private void readCopyBuffers(SegmentDirectory.Reader reader, SegmentDirectory.Writer writer, String column,
       ColumnIndexType indexType) throws IOException {
     PinotDataBuffer oldBuffer = reader.getIndexFor(column, indexType);
-    PinotDataBuffer newDictBuffer = writer.newIndexFor(column, indexType, (int) oldBuffer.size());
+    PinotDataBuffer newDictBuffer = writer.newIndexFor(column, indexType, oldBuffer.size());
     oldBuffer.copyTo(0, newDictBuffer, 0, oldBuffer.size());
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/LoaderUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/LoaderUtils.java
@@ -48,7 +48,7 @@ public class LoaderUtils {
    */
   public static void writeIndexToV3Format(SegmentDirectory.Writer segmentWriter, String column, File indexFile,
       ColumnIndexType indexType) throws IOException {
-    int fileLength = (int) indexFile.length();
+    long fileLength = indexFile.length();
     try (PinotDataBuffer buffer = segmentWriter.newIndexFor(column, indexType, fileLength)) {
       buffer.readFrom(0, indexFile, 0, fileLength);
       FileUtils.forceDelete(indexFile);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/ColumnIndexDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/ColumnIndexDirectory.java
@@ -101,7 +101,7 @@ abstract class ColumnIndexDirectory implements Closeable {
    * @return in-memory ByteBuffer like buffer for data
    * @throws IOException
    */
-  public abstract PinotDataBuffer newDictionaryBuffer(String column, int sizeBytes)
+  public abstract PinotDataBuffer newDictionaryBuffer(String column, long sizeBytes)
       throws IOException;
   /**
    * Allocate a new data buffer of specified sizeBytes in the columnar index directory
@@ -110,7 +110,7 @@ abstract class ColumnIndexDirectory implements Closeable {
    * @return in-memory ByteBuffer like buffer for data
    * @throws IOException
    */
-  public abstract PinotDataBuffer newForwardIndexBuffer(String column, int sizeBytes)
+  public abstract PinotDataBuffer newForwardIndexBuffer(String column, long sizeBytes)
       throws IOException;
   /**
    * Allocate a new data buffer of specified sizeBytes in the columnar index directory
@@ -119,7 +119,7 @@ abstract class ColumnIndexDirectory implements Closeable {
    * @return in-memory ByteBuffer like buffer for data
    * @throws IOException
    */
-  public abstract PinotDataBuffer newInvertedIndexBuffer(String column, int sizeBytes)
+  public abstract PinotDataBuffer newInvertedIndexBuffer(String column, long sizeBytes)
       throws IOException;
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/FilePerIndexDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/FilePerIndexDirectory.java
@@ -46,7 +46,7 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
   }
 
   @Override
-  public PinotDataBuffer newDictionaryBuffer(String column, int sizeBytes)
+  public PinotDataBuffer newDictionaryBuffer(String column, long sizeBytes)
       throws IOException {
     IndexKey key = new IndexKey(column, ColumnIndexType.DICTIONARY);
     return getWriteBufferFor(key, sizeBytes);
@@ -60,7 +60,7 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
   }
 
   @Override
-  public PinotDataBuffer newForwardIndexBuffer(String column, int sizeBytes)
+  public PinotDataBuffer newForwardIndexBuffer(String column, long sizeBytes)
       throws IOException {
     IndexKey key = new IndexKey(column, ColumnIndexType.FORWARD_INDEX);
     return getWriteBufferFor(key, sizeBytes);
@@ -74,7 +74,7 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
   }
 
   @Override
-  public PinotDataBuffer newInvertedIndexBuffer(String column, int sizeBytes)
+  public PinotDataBuffer newInvertedIndexBuffer(String column, long sizeBytes)
       throws IOException {
     IndexKey key = new IndexKey(column, ColumnIndexType.INVERTED_INDEX);
     return getWriteBufferFor(key, sizeBytes);
@@ -116,7 +116,7 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
     return buffer;
   }
 
-  private PinotDataBuffer getWriteBufferFor(IndexKey key, int sizeBytes) throws IOException {
+  private PinotDataBuffer getWriteBufferFor(IndexKey key, long sizeBytes) throws IOException {
     if (indexBuffers.containsKey(key)) {
       return indexBuffers.get(key);
     }
@@ -146,7 +146,7 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
     return new File(segmentDirectory, filename);
   }
 
-  private PinotDataBuffer mapForWrites(File file, int sizeBytes, String context) throws IOException {
+  private PinotDataBuffer mapForWrites(File file, long sizeBytes, String context) throws IOException {
     Preconditions.checkNotNull(file);
     Preconditions.checkArgument(sizeBytes >= 0 && sizeBytes < Integer.MAX_VALUE,
         "File size must be less than 2GB, file: " + file);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectory.java
@@ -181,7 +181,7 @@ public abstract class SegmentDirectory implements Closeable {
     // NOTE: an interface like readFrom(File f, String column, ColumnIndexType, int sizeBytes) will be safe
     // but it can lead to potential endianness issues. Endianness used to create data may not be
     // same as PinotDataBufferOld
-    public abstract PinotDataBuffer newIndexFor(String columnName, ColumnIndexType indexType, int sizeBytes)
+    public abstract PinotDataBuffer newIndexFor(String columnName, ColumnIndexType indexType, long sizeBytes)
         throws IOException;
 
     /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
@@ -407,12 +407,11 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
       ColumnIndexType indexType = key.type;
       switch (indexType) {
         case DICTIONARY:
-          return columnIndexDirectory.newDictionaryBuffer(key.name, (int) sizeBytes);
-
+          return columnIndexDirectory.newDictionaryBuffer(key.name, sizeBytes);
         case FORWARD_INDEX:
-          return columnIndexDirectory.newForwardIndexBuffer(key.name, (int) sizeBytes);
+          return columnIndexDirectory.newForwardIndexBuffer(key.name, sizeBytes);
         case INVERTED_INDEX:
-          return columnIndexDirectory.newInvertedIndexBuffer(key.name, ((int) sizeBytes));
+          return columnIndexDirectory.newInvertedIndexBuffer(key.name, sizeBytes);
         default:
           throw new RuntimeException("Unknown index type: " + indexType.name() +
               " for directory: " + segmentDirectory);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
@@ -356,7 +356,7 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
     }
 
     @Override
-    public PinotDataBuffer newIndexFor(String columnName, ColumnIndexType indexType, int sizeBytes)
+    public PinotDataBuffer newIndexFor(String columnName, ColumnIndexType indexType, long sizeBytes)
         throws IOException {
       return getNewIndexBuffer(new IndexKey(columnName, indexType), sizeBytes);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SingleFileIndexDirectory.java
@@ -111,19 +111,19 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   }
 
   @Override
-  public PinotDataBuffer newDictionaryBuffer(String column, int sizeBytes)
+  public PinotDataBuffer newDictionaryBuffer(String column, long sizeBytes)
       throws IOException {
     return allocNewBufferInternal(column, ColumnIndexType.DICTIONARY, sizeBytes, "dictionary.create");
   }
 
   @Override
-  public PinotDataBuffer newForwardIndexBuffer(String column, int sizeBytes)
+  public PinotDataBuffer newForwardIndexBuffer(String column, long sizeBytes)
       throws IOException {
     return allocNewBufferInternal(column, ColumnIndexType.FORWARD_INDEX, sizeBytes, "forward_index.create");
   }
 
   @Override
-  public PinotDataBuffer newInvertedIndexBuffer(String column, int sizeBytes)
+  public PinotDataBuffer newInvertedIndexBuffer(String column, long sizeBytes)
       throws IOException {
     return  allocNewBufferInternal(column, ColumnIndexType.INVERTED_INDEX, sizeBytes, "inverted_index.create");
   }
@@ -139,7 +139,7 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   }
 
   // This is using extra resources right now which can be changed.
-  private PinotDataBuffer allocNewBufferInternal(String column, ColumnIndexType indexType, int size,
+  private PinotDataBuffer allocNewBufferInternal(String column, ColumnIndexType indexType, long size,
       String context)
       throws IOException {
 


### PR DESCRIPTION
Have got this exception during realtime segment persistence.

```
2018-11-17 02:31:28 INFO  SegmentV1V2ToV3FormatConverter:63 - Converting segment: /var/upinot/stream-pinot-server/dataDir/myTable_REALTIME/_tmp/tmp-myTable__0__4__20181117T0208Z-1542421858364/myTable__0__4__20181117T0208Z to v3 format
2018-11-17 02:31:28 ERROR PinotDataBuffer:194 - Caught exception while mapping file: /var/upinot/stream-pinot-server/dataDir/myTable_REALTIME/_tmp/tmp-myTable__0__4__20181117T0208Z-1542421858364/myTable__0__4__20181117T0208Z/myTable__0__4__20181117T0208Z.v3.tmp6929117218320816261/columns.psf from offset: 876008 of size: -1502500884 with description: SingleFileIndexDirectoryreason.dictionarydictionary.create
2018-11-17 02:31:28 ERROR LLRealtimeSegmentDataManager_myTable__0__4__20181117T0208Z:643 - Could not build segment
```