### PR TITLE
Added a log message on pinot-server when controller leadership change…

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
@@ -94,6 +94,8 @@ public class ControllerLeaderLocator {
       int leaderPort = Integer.valueOf(leader.substring(index + 1));
       _controllerLeaderHostPort = new Pair<>(leaderHost, leaderPort);
       _cachedControllerLeaderInvalid = false;
+      LOGGER.info("Setting controller leader to be {}:{} as per znode version {}, mtime {}", leaderHost, leaderPort,
+          stat.getVersion(), stat.getMtime());
       return _controllerLeaderHostPort;
     } catch (Exception e) {
       LOGGER.warn("Could not locate controller leader, exception", e);


### PR DESCRIPTION
… is read from zookeeper.

Recently we saw a case where the server was repeatedly reporting that it received NOT_LEADER
responses from the controller. On further look at the logs, it turned out that the controller
did not get a helix notification that it became leader, so the server was logging what it saw
in zookeeper.

The behavior did lead us into looking at other things before we found the root cause.

This log will clearly identify how the server concludes who it thinks the leader is.