### PR TITLE
Adding execution stats for numSegmentsQueried/Processed/Matched

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -274,7 +274,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // Table name might have been changed (with suffix _OFFLINE/_REALTIME appended)
     LOGGER.info(
-        "RequestId:{}, table:{}, timeMs:{}, docs:{}/{}, entries:{}/{}, segments:{}/{}/{} servers:{}/{}, groupLimitReached:{}, exceptions:{}, serverStats:{}, query:{}",
+        "RequestId:{}, table:{}, timeMs:{}, docs:{}/{}, entries:{}/{}, segments(queried/processed/matched):{}/{}/{} servers:{}/{}, groupLimitReached:{}, exceptions:{}, serverStats:{}, query:{}",
         requestId, brokerRequest.getQuerySource().getTableName(), totalTimeMs, brokerResponse.getNumDocsScanned(),
         brokerResponse.getTotalDocs(), brokerResponse.getNumEntriesScannedInFilter(),
         brokerResponse.getNumSegmentsQueried(), brokerResponse.getNumSegmentsProcessed(), brokerResponse.getNumSegmentsMatched(),

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -274,9 +274,10 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // Table name might have been changed (with suffix _OFFLINE/_REALTIME appended)
     LOGGER.info(
-        "RequestId:{}, table:{}, timeMs:{}, docs:{}/{}, entries:{}/{}, servers:{}/{}, groupLimitReached:{}, exceptions:{}, serverStats:{}, query:{}",
+        "RequestId:{}, table:{}, timeMs:{}, docs:{}/{}, entries:{}/{}, segments:{}/{}/{} servers:{}/{}, groupLimitReached:{}, exceptions:{}, serverStats:{}, query:{}",
         requestId, brokerRequest.getQuerySource().getTableName(), totalTimeMs, brokerResponse.getNumDocsScanned(),
         brokerResponse.getTotalDocs(), brokerResponse.getNumEntriesScannedInFilter(),
+        brokerResponse.getNumSegmentsQueried(), brokerResponse.getNumSegmentsProcessed(), brokerResponse.getNumSegmentsMatched(),
         brokerResponse.getNumEntriesScannedPostFilter(), brokerResponse.getNumServersResponded(),
         brokerResponse.getNumServersQueried(), brokerResponse.isNumGroupsLimitReached(),
         brokerResponse.getExceptionsSize(), serverStats.getServerStats(),

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
@@ -51,7 +51,9 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NUM_DOCS_SCANNED("rows", false),
   NUM_ENTRIES_SCANNED_IN_FILTER("entries", false),
   NUM_ENTRIES_SCANNED_POST_FILTER("entries", false),
-  NUM_SEGMENTS_SEARCHED("numSegmentsSearched", false),
+  NUM_SEGMENTS_QUERIED("numSegmentsQueried", false),
+  NUM_SEGMENTS_PROCESSED("numSegmentsProcessed", false),
+  NUM_SEGMENTS_MATCHED("numSegmentsMatched", false),
   NUM_MISSING_SEGMENTS("segments", false);
 
   private final String meterName;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
@@ -87,17 +87,17 @@ public interface BrokerResponse {
   long getNumEntriesScannedPostFilter();
 
   /**
-   * Get number of entries scanned post filter phase while processing the query.
+   * Get the number of segments queried by the broker after broker side pruning
    */
   long getNumSegmentsQueried();
 
   /**
-   * Get number of entries scanned post filter phase while processing the query.
+   * Get the number of segments processed by server after server side pruning
    */
   long getNumSegmentsProcessed();
 
   /**
-   * Get number of entries scanned post filter phase while processing the query.
+   * Get number of segments that had at least one matching document
    */
   long getNumSegmentsMatched();
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
@@ -87,6 +87,21 @@ public interface BrokerResponse {
   long getNumEntriesScannedPostFilter();
 
   /**
+   * Get number of entries scanned post filter phase while processing the query.
+   */
+  long getNumSegmentsQueried();
+
+  /**
+   * Get number of entries scanned post filter phase while processing the query.
+   */
+  long getNumSegmentsProcessed();
+
+  /**
+   * Get number of entries scanned post filter phase while processing the query.
+   */
+  long getNumSegmentsMatched();
+
+  /**
    * Get total number of documents within the table hit.
    */
   long getTotalDocs();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
@@ -40,7 +40,7 @@ import org.json.JSONObject;
  * Supports serialization via JSON.
  */
 @JsonPropertyOrder({"selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded",
-    "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "totalDocs", "numGroupsLimitReached",
+    "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numSegmentsProcessed", "numSegmentsWithNoMatch", "totalDocs", "numGroupsLimitReached",
     "timeUsedMs", "segmentStatistics", "traceInfo"})
 public class BrokerResponseNative implements BrokerResponse {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -54,6 +54,9 @@ public class BrokerResponseNative implements BrokerResponse {
   private long _numDocsScanned = 0L;
   private long _numEntriesScannedInFilter = 0L;
   private long _numEntriesScannedPostFilter = 0L;
+  private long _numSegmentsProcessed = 0L;
+  private long _numSegmentsWithNoMatch = 0L;
+  
   private long _totalDocs = 0L;
   private boolean _numGroupsLimitReached = false;
   private long _timeUsedMs = 0L;
@@ -171,6 +174,26 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty("numEntriesScannedPostFilter")
   public void setNumEntriesScannedPostFilter(long numEntriesScannedPostFilter) {
     _numEntriesScannedPostFilter = numEntriesScannedPostFilter;
+  }
+
+  @JsonProperty("numSegmentsProcessed")
+  public long getNumSegmentsProcessed() {
+    return _numSegmentsProcessed;
+  }
+
+  @JsonProperty("numSegmentsProcessed")
+  public void setNumSegmentsProcessed(long numSegmentsProcessed) {
+    _numSegmentsProcessed = numSegmentsProcessed;
+  }
+
+  @JsonProperty("numSegmentsWithNoMatch")
+  public long getNumSegmentsWithNoMatch() {
+    return _numSegmentsWithNoMatch;
+  }
+  
+  @JsonProperty("numSegmentsWithNoMatch")
+  public void setNumSegmentsWithNoMatch(long numSegmentsWithNoMatch) {
+    _numSegmentsWithNoMatch = numSegmentsWithNoMatch;
   }
 
   @JsonProperty("totalDocs")

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
@@ -39,9 +39,9 @@ import org.json.JSONObject;
  *
  * Supports serialization via JSON.
  */
-@JsonPropertyOrder({"selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded",
-    "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numSegmentsProcessed", "numSegmentsQueried", "numSegmentsMatched", "totalDocs", "numGroupsLimitReached",
-    "timeUsedMs", "segmentStatistics", "traceInfo"})
+@JsonPropertyOrder({ "selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded", "numDocsScanned",
+    "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "totalDocs",
+    "numGroupsLimitReached", "timeUsedMs", "segmentStatistics", "traceInfo" })
 public class BrokerResponseNative implements BrokerResponse {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
@@ -39,9 +39,9 @@ import org.json.JSONObject;
  *
  * Supports serialization via JSON.
  */
-@JsonPropertyOrder({ "selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded", "numDocsScanned",
-    "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "totalDocs",
-    "numGroupsLimitReached", "timeUsedMs", "segmentStatistics", "traceInfo" })
+@JsonPropertyOrder({ "selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded", "numSegmentsQueried",
+    "numSegmentsProcessed", "numSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numGroupsLimitReached",
+    "totalDocs", "timeUsedMs", "segmentStatistics", "traceInfo" })
 public class BrokerResponseNative implements BrokerResponse {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
@@ -40,7 +40,7 @@ import org.json.JSONObject;
  * Supports serialization via JSON.
  */
 @JsonPropertyOrder({"selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded",
-    "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numSegmentsProcessed", "numSegmentsWithNoMatch", "totalDocs", "numGroupsLimitReached",
+    "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numSegmentsProcessed", "numSegmentsQueried", "numSegmentsMatched", "totalDocs", "numGroupsLimitReached",
     "timeUsedMs", "segmentStatistics", "traceInfo"})
 public class BrokerResponseNative implements BrokerResponse {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -54,8 +54,9 @@ public class BrokerResponseNative implements BrokerResponse {
   private long _numDocsScanned = 0L;
   private long _numEntriesScannedInFilter = 0L;
   private long _numEntriesScannedPostFilter = 0L;
+  private long _numSegmentsQueried = 0L;
   private long _numSegmentsProcessed = 0L;
-  private long _numSegmentsWithNoMatch = 0L;
+  private long _numSegmentsMatched = 0L;
   
   private long _totalDocs = 0L;
   private boolean _numGroupsLimitReached = false;
@@ -176,6 +177,16 @@ public class BrokerResponseNative implements BrokerResponse {
     _numEntriesScannedPostFilter = numEntriesScannedPostFilter;
   }
 
+  @JsonProperty("numSegmentsQueried")
+  public long getNumSegmentsQueried() {
+    return _numSegmentsQueried;
+  }
+
+  @JsonProperty("numSegmentsQueried")
+  public void setNumSegmentsQueried(long numSegmentsQueried) {
+    _numSegmentsQueried = numSegmentsQueried;
+  }
+
   @JsonProperty("numSegmentsProcessed")
   public long getNumSegmentsProcessed() {
     return _numSegmentsProcessed;
@@ -186,14 +197,14 @@ public class BrokerResponseNative implements BrokerResponse {
     _numSegmentsProcessed = numSegmentsProcessed;
   }
 
-  @JsonProperty("numSegmentsWithNoMatch")
-  public long getNumSegmentsWithNoMatch() {
-    return _numSegmentsWithNoMatch;
+  @JsonProperty("numSegmentsMatched")
+  public long getNumSegmentsMatched() {
+    return _numSegmentsMatched;
   }
-  
-  @JsonProperty("numSegmentsWithNoMatch")
-  public void setNumSegmentsWithNoMatch(long numSegmentsWithNoMatch) {
-    _numSegmentsWithNoMatch = numSegmentsWithNoMatch;
+
+  @JsonProperty("numSegmentsMatched")
+  public void setNumSegmentsMatched(long numSegmentsMatched) {
+    _numSegmentsMatched = numSegmentsMatched;
   }
 
   @JsonProperty("totalDocs")
@@ -285,4 +296,6 @@ public class BrokerResponseNative implements BrokerResponse {
   public int getExceptionsSize() {
     return _processingExceptions.size();
   }
+
+
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
@@ -29,6 +29,9 @@ public interface DataTable {
   String NUM_DOCS_SCANNED_METADATA_KEY = "numDocsScanned";
   String NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY = "numEntriesScannedInFilter";
   String NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY = "numEntriesScannedPostFilter";
+  String NUM_SEGMENTS_QUERIED = "numSegmentsQueried";
+  String NUM_SEGMENTS_PROCESSED = "numSegmentsProcessed";
+  String NUM_SEGMENTS_WITH_NO_MATCH = "numSegmentsWithNoMatch";
   String TOTAL_DOCS_METADATA_KEY = "totalDocs";
   String NUM_GROUPS_LIMIT_REACHED_KEY = "numGroupsLimitReached";
   String TIME_USED_MS_METADATA_KEY = "timeUsedMs";

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
@@ -31,7 +31,7 @@ public interface DataTable {
   String NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY = "numEntriesScannedPostFilter";
   String NUM_SEGMENTS_QUERIED = "numSegmentsQueried";
   String NUM_SEGMENTS_PROCESSED = "numSegmentsProcessed";
-  String NUM_SEGMENTS_WITH_NO_MATCH = "numSegmentsWithNoMatch";
+  String NUM_SEGMENTS_MATCHED = "numSegmentsMatched";
   String TOTAL_DOCS_METADATA_KEY = "totalDocs";
   String NUM_GROUPS_LIMIT_REACHED_KEY = "numGroupsLimitReached";
   String TIME_USED_MS_METADATA_KEY = "timeUsedMs";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
@@ -193,7 +193,7 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
       mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
       mergedBlock.setNumSegmentsProcessed(executionStatistics.getNumSegmentsProcessed());
-      mergedBlock.setNumSegmentsWithNoMatch(executionStatistics.getNumSegmentsWithNoMatch());
+      mergedBlock.setNumSegmentsMatched(executionStatistics.getNumSegmentsWithNoMatch());
       mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());
       // NOTE: numGroups might go slightly over numGroupsLimit because the comparison is not atomic
       if (numGroups.get() >= _numGroupsLimit) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
@@ -192,6 +192,8 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       mergedBlock.setNumDocsScanned(executionStatistics.getNumDocsScanned());
       mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
       mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
+      mergedBlock.setNumSegmentsProcessed(executionStatistics.getNumSegmentsProcessed());
+      mergedBlock.setNumSegmentsWithNoMatch(executionStatistics.getNumSegmentsWithNoMatch());
       mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());
       // NOTE: numGroups might go slightly over numGroupsLimit because the comparison is not atomic
       if (numGroups.get() >= _numGroupsLimit) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
@@ -193,7 +193,7 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
       mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
       mergedBlock.setNumSegmentsProcessed(executionStatistics.getNumSegmentsProcessed());
-      mergedBlock.setNumSegmentsMatched(executionStatistics.getNumSegmentsWithNoMatch());
+      mergedBlock.setNumSegmentsMatched(executionStatistics.getNumSegmentsMatched());
       mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());
       // NOTE: numGroups might go slightly over numGroupsLimit because the comparison is not atomic
       if (numGroups.get() >= _numGroupsLimit) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
@@ -187,6 +187,8 @@ public class CombineOperator extends BaseOperator<IntermediateResultsBlock> {
     mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
     mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
     mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());
+    mergedBlock.setNumSegmentsProcessed(executionStatistics.getNumSegmentsProcessed());
+    mergedBlock.setNumSegmentsWithNoMatch(executionStatistics.getNumSegmentsWithNoMatch());
 
     return mergedBlock;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
@@ -188,7 +188,7 @@ public class CombineOperator extends BaseOperator<IntermediateResultsBlock> {
     mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
     mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());
     mergedBlock.setNumSegmentsProcessed(executionStatistics.getNumSegmentsProcessed());
-    mergedBlock.setNumSegmentsMatched(executionStatistics.getNumSegmentsWithNoMatch());
+    mergedBlock.setNumSegmentsMatched(executionStatistics.getNumSegmentsMatched());
 
     return mergedBlock;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineOperator.java
@@ -188,7 +188,7 @@ public class CombineOperator extends BaseOperator<IntermediateResultsBlock> {
     mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
     mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());
     mergedBlock.setNumSegmentsProcessed(executionStatistics.getNumSegmentsProcessed());
-    mergedBlock.setNumSegmentsWithNoMatch(executionStatistics.getNumSegmentsWithNoMatch());
+    mergedBlock.setNumSegmentsMatched(executionStatistics.getNumSegmentsWithNoMatch());
 
     return mergedBlock;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
@@ -23,7 +23,9 @@ public class ExecutionStatistics {
   private long _numEntriesScannedInFilter;
   private long _numEntriesScannedPostFilter;
   private long _numTotalRawDocs;
-
+  private long _numSegmentsProcessed;
+  private long _numSegmentsWithNoMatch;
+  
   public ExecutionStatistics() {
   }
 
@@ -33,6 +35,8 @@ public class ExecutionStatistics {
     _numEntriesScannedInFilter = numEntriesScannedInFilter;
     _numEntriesScannedPostFilter = numEntriesScannedPostFilter;
     _numTotalRawDocs = numTotalRawDocs;
+    _numSegmentsProcessed = 1;
+    _numSegmentsWithNoMatch = (numDocsScanned == 0) ? 1 : 0;
   }
 
   public long getNumDocsScanned() {
@@ -51,6 +55,14 @@ public class ExecutionStatistics {
     return _numTotalRawDocs;
   }
 
+  public long getNumSegmentsProcessed() {
+    return _numSegmentsProcessed;
+  }
+
+  public long getNumSegmentsWithNoMatch() {
+    return _numSegmentsWithNoMatch;
+  }
+
   /**
    * Merge another execution statistics into the current one.
    *
@@ -61,6 +73,8 @@ public class ExecutionStatistics {
     _numEntriesScannedInFilter += executionStatisticsToMerge._numEntriesScannedInFilter;
     _numEntriesScannedPostFilter += executionStatisticsToMerge._numEntriesScannedPostFilter;
     _numTotalRawDocs += executionStatisticsToMerge._numTotalRawDocs;
+    _numSegmentsProcessed += executionStatisticsToMerge._numSegmentsProcessed;
+    _numSegmentsWithNoMatch += executionStatisticsToMerge._numSegmentsWithNoMatch;
   }
 
   @Override
@@ -69,6 +83,8 @@ public class ExecutionStatistics {
         + "\n  numDocsScanned: " + _numDocsScanned
         + "\n  numEntriesScannedInFilter: " + _numEntriesScannedInFilter
         + "\n  numEntriesScannedPostFilter: " + _numEntriesScannedPostFilter
-        + "\n  numTotalRawDocs: " + _numTotalRawDocs;
+        + "\n  numTotalRawDocs: " + _numTotalRawDocs
+        + "\n  numSegmentsProcessed: " + _numSegmentsProcessed
+        + "\n  numSegmentsWithNoMatch: " + _numSegmentsWithNoMatch;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
@@ -24,7 +24,7 @@ public class ExecutionStatistics {
   private long _numEntriesScannedPostFilter;
   private long _numTotalRawDocs;
   private long _numSegmentsProcessed;
-  private long _numSegmentsWithNoMatch;
+  private long _numSegmentsMatched;
   
   public ExecutionStatistics() {
   }
@@ -36,7 +36,7 @@ public class ExecutionStatistics {
     _numEntriesScannedPostFilter = numEntriesScannedPostFilter;
     _numTotalRawDocs = numTotalRawDocs;
     _numSegmentsProcessed = 1;
-    _numSegmentsWithNoMatch = (numDocsScanned == 0) ? 1 : 0;
+    _numSegmentsMatched = (numDocsScanned == 0) ? 0 : 1;
   }
 
   public long getNumDocsScanned() {
@@ -60,7 +60,7 @@ public class ExecutionStatistics {
   }
 
   public long getNumSegmentsWithNoMatch() {
-    return _numSegmentsWithNoMatch;
+    return _numSegmentsMatched;
   }
 
   /**
@@ -74,7 +74,7 @@ public class ExecutionStatistics {
     _numEntriesScannedPostFilter += executionStatisticsToMerge._numEntriesScannedPostFilter;
     _numTotalRawDocs += executionStatisticsToMerge._numTotalRawDocs;
     _numSegmentsProcessed += executionStatisticsToMerge._numSegmentsProcessed;
-    _numSegmentsWithNoMatch += executionStatisticsToMerge._numSegmentsWithNoMatch;
+    _numSegmentsMatched += executionStatisticsToMerge._numSegmentsMatched;
   }
 
   @Override
@@ -85,6 +85,6 @@ public class ExecutionStatistics {
         + "\n  numEntriesScannedPostFilter: " + _numEntriesScannedPostFilter
         + "\n  numTotalRawDocs: " + _numTotalRawDocs
         + "\n  numSegmentsProcessed: " + _numSegmentsProcessed
-        + "\n  numSegmentsWithNoMatch: " + _numSegmentsWithNoMatch;
+        + "\n  numSegmentsMatched: " + _numSegmentsMatched;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/ExecutionStatistics.java
@@ -59,7 +59,7 @@ public class ExecutionStatistics {
     return _numSegmentsProcessed;
   }
 
-  public long getNumSegmentsWithNoMatch() {
+  public long getNumSegmentsMatched() {
     return _numSegmentsMatched;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -53,6 +53,8 @@ public class IntermediateResultsBlock implements Block {
   private long _numEntriesScannedInFilter;
   private long _numEntriesScannedPostFilter;
   private long _numTotalRawDocs;
+  private long _numSegmentsProcessed;
+  private long _numSegmentsWithNoMatch;
   private boolean _numGroupsLimitReached;
 
   /**
@@ -172,6 +174,22 @@ public class IntermediateResultsBlock implements Block {
   public void setNumEntriesScannedPostFilter(long numEntriesScannedPostFilter) {
     _numEntriesScannedPostFilter = numEntriesScannedPostFilter;
   }
+  
+  public long getNumSegmentsProcessed() {
+    return _numSegmentsProcessed;
+  }
+
+  public void setNumSegmentsProcessed(long numSegmentsProcessed) {
+    _numSegmentsProcessed = numSegmentsProcessed;
+  }
+
+  public long getNumSegmentsWithNoMatch() {
+    return _numSegmentsWithNoMatch;
+  }
+
+  public void setNumSegmentsWithNoMatch(long numSegmentsWithNoMatch) {
+    _numSegmentsWithNoMatch = numSegmentsWithNoMatch;
+  }
 
   public void setNumTotalRawDocs(long numTotalRawDocs) {
     _numTotalRawDocs = numTotalRawDocs;
@@ -279,6 +297,9 @@ public class IntermediateResultsBlock implements Block {
         .put(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedInFilter));
     dataTable.getMetadata()
         .put(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedPostFilter));
+    dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_PROCESSED, String.valueOf(_numSegmentsProcessed));
+    dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_WITH_NO_MATCH, String.valueOf(_numSegmentsWithNoMatch));
+    
     dataTable.getMetadata().put(DataTable.TOTAL_DOCS_METADATA_KEY, String.valueOf(_numTotalRawDocs));
     if (_numGroupsLimitReached) {
       dataTable.getMetadata().put(DataTable.NUM_GROUPS_LIMIT_REACHED_KEY, "true");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -54,7 +54,7 @@ public class IntermediateResultsBlock implements Block {
   private long _numEntriesScannedPostFilter;
   private long _numTotalRawDocs;
   private long _numSegmentsProcessed;
-  private long _numSegmentsWithNoMatch;
+  private long _numSegmentsMatched;
   private boolean _numGroupsLimitReached;
 
   /**
@@ -183,12 +183,12 @@ public class IntermediateResultsBlock implements Block {
     _numSegmentsProcessed = numSegmentsProcessed;
   }
 
-  public long getNumSegmentsWithNoMatch() {
-    return _numSegmentsWithNoMatch;
+  public long getNumSegmentsMatched() {
+    return _numSegmentsMatched;
   }
 
-  public void setNumSegmentsWithNoMatch(long numSegmentsWithNoMatch) {
-    _numSegmentsWithNoMatch = numSegmentsWithNoMatch;
+  public void setNumSegmentsMatched(long numSegmentsWithNoMatch) {
+    _numSegmentsMatched = numSegmentsWithNoMatch;
   }
 
   public void setNumTotalRawDocs(long numTotalRawDocs) {
@@ -298,7 +298,7 @@ public class IntermediateResultsBlock implements Block {
     dataTable.getMetadata()
         .put(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedPostFilter));
     dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_PROCESSED, String.valueOf(_numSegmentsProcessed));
-    dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_WITH_NO_MATCH, String.valueOf(_numSegmentsWithNoMatch));
+    dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_MATCHED, String.valueOf(_numSegmentsMatched));
     
     dataTable.getMetadata().put(DataTable.TOTAL_DOCS_METADATA_KEY, String.valueOf(_numTotalRawDocs));
     if (_numGroupsLimitReached) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -187,8 +187,8 @@ public class IntermediateResultsBlock implements Block {
     return _numSegmentsMatched;
   }
 
-  public void setNumSegmentsMatched(long numSegmentsWithNoMatch) {
-    _numSegmentsMatched = numSegmentsWithNoMatch;
+  public void setNumSegmentsMatched(long numSegmentsMatched) {
+    _numSegmentsMatched = numSegmentsMatched;
   }
 
   public void setNumTotalRawDocs(long numTotalRawDocs) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
@@ -76,6 +76,8 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     long numDocsScanned = 0L;
     long numEntriesScannedInFilter = 0L;
     long numEntriesScannedPostFilter = 0L;
+    long numSegmentsProcessed = 0L;
+    long numSegmentsWithNoMatch = 0L;
     long numTotalRawDocs = 0L;
     boolean numGroupsLimitReached = false;
 
@@ -116,6 +118,15 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       if (numEntriesScannedPostFilterString != null) {
         numEntriesScannedPostFilter += Long.parseLong(numEntriesScannedPostFilterString);
       }
+      String numSegmentsProcessedString = metadata.get(DataTable.NUM_SEGMENTS_PROCESSED);
+      if (numSegmentsProcessedString != null) {
+        numSegmentsProcessed += Long.parseLong(numSegmentsProcessedString);
+      }
+      String numSegmentsWithNoMatchString = metadata.get(DataTable.NUM_SEGMENTS_WITH_NO_MATCH);
+      if (numSegmentsProcessedString != null) {
+        numSegmentsWithNoMatch += Long.parseLong(numSegmentsWithNoMatchString);
+      }
+      
       String numTotalRawDocsString = metadata.get(DataTable.TOTAL_DOCS_METADATA_KEY);
       if (numTotalRawDocsString != null) {
         numTotalRawDocs += Long.parseLong(numTotalRawDocsString);
@@ -143,6 +154,8 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     brokerResponseNative.setNumDocsScanned(numDocsScanned);
     brokerResponseNative.setNumEntriesScannedInFilter(numEntriesScannedInFilter);
     brokerResponseNative.setNumEntriesScannedPostFilter(numEntriesScannedPostFilter);
+    brokerResponseNative.setNumSegmentsProcessed(numSegmentsProcessed);
+    brokerResponseNative.setNumSegmentsWithNoMatch(numSegmentsWithNoMatch);
     brokerResponseNative.setTotalDocs(numTotalRawDocs);
     brokerResponseNative.setNumGroupsLimitReached(numGroupsLimitReached);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
@@ -76,8 +76,9 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     long numDocsScanned = 0L;
     long numEntriesScannedInFilter = 0L;
     long numEntriesScannedPostFilter = 0L;
+    long numSegmentsQueried = 0L;
     long numSegmentsProcessed = 0L;
-    long numSegmentsWithNoMatch = 0L;
+    long numSegmentsMatched = 0L;
     long numTotalRawDocs = 0L;
     boolean numGroupsLimitReached = false;
 
@@ -118,13 +119,18 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       if (numEntriesScannedPostFilterString != null) {
         numEntriesScannedPostFilter += Long.parseLong(numEntriesScannedPostFilterString);
       }
+      String numSegmentsQueriedString = metadata.get(DataTable.NUM_SEGMENTS_QUERIED);
+      if (numSegmentsQueriedString != null) {
+        numSegmentsQueried += Long.parseLong(numSegmentsQueriedString);
+      }
+
       String numSegmentsProcessedString = metadata.get(DataTable.NUM_SEGMENTS_PROCESSED);
       if (numSegmentsProcessedString != null) {
         numSegmentsProcessed += Long.parseLong(numSegmentsProcessedString);
       }
-      String numSegmentsWithNoMatchString = metadata.get(DataTable.NUM_SEGMENTS_WITH_NO_MATCH);
-      if (numSegmentsProcessedString != null) {
-        numSegmentsWithNoMatch += Long.parseLong(numSegmentsWithNoMatchString);
+      String numSegmentsMatchedString = metadata.get(DataTable.NUM_SEGMENTS_MATCHED);
+      if (numSegmentsMatchedString != null) {
+        numSegmentsMatched += Long.parseLong(numSegmentsMatchedString);
       }
       
       String numTotalRawDocsString = metadata.get(DataTable.TOTAL_DOCS_METADATA_KEY);
@@ -154,8 +160,9 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     brokerResponseNative.setNumDocsScanned(numDocsScanned);
     brokerResponseNative.setNumEntriesScannedInFilter(numEntriesScannedInFilter);
     brokerResponseNative.setNumEntriesScannedPostFilter(numEntriesScannedPostFilter);
+    brokerResponseNative.setNumSegmentsQueried(numSegmentsQueried);
     brokerResponseNative.setNumSegmentsProcessed(numSegmentsProcessed);
-    brokerResponseNative.setNumSegmentsWithNoMatch(numSegmentsWithNoMatch);
+    brokerResponseNative.setNumSegmentsMatched(numSegmentsMatched);
     brokerResponseNative.setTotalDocs(numTotalRawDocs);
     brokerResponseNative.setNumGroupsLimitReached(numGroupsLimitReached);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/request/ServerQueryRequest.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/request/ServerQueryRequest.java
@@ -191,12 +191,4 @@ public class ServerQueryRequest {
   public Set<String> getSelectionColumns() {
     return _selectionColumns;
   }
-
-  public int getSegmentCountAfterPruning() {
-    return _segmentCountAfterPruning;
-  }
-
-  public void setSegmentCountAfterPruning(int segmentCountAfterPruning) {
-    _segmentCountAfterPruning = segmentCountAfterPruning;
-  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -147,11 +147,11 @@ public abstract class QueryScheduler {
     long numEntriesScannedInFilter = Long.parseLong(
         dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, INVALID_NUM_SCANNED));
     long numEntriesScannedPostFilter = Long.parseLong(
-        dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, INVALID_NUM_SCANNED));
+        dataTableMetadata.getOrDefault(DataTable.NUM_SEGMENTS_QUERIED, INVALID_NUM_SCANNED));
     long numSegmentsProcessed = Long.parseLong(
-        dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, INVALID_SEGMENTS_COUNT));
+        dataTableMetadata.getOrDefault(DataTable.NUM_SEGMENTS_PROCESSED, INVALID_SEGMENTS_COUNT));
     long numSegmentsMatched = Long.parseLong(
-        dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, INVALID_SEGMENTS_COUNT));
+        dataTableMetadata.getOrDefault(DataTable.NUM_SEGMENTS_MATCHED, INVALID_SEGMENTS_COUNT));
     
     if (numDocsScanned > 0) {
       serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_DOCS_SCANNED, numDocsScanned);
@@ -168,7 +168,7 @@ public abstract class QueryScheduler {
     TimerContext timerContext = queryRequest.getTimerContext();
     int numSegmentsQueried = queryRequest.getSegmentsToQuery().size();
     LOGGER.info(
-        "Processed requestId={},table={},Segments={}/{}/{},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={}",
+        "Processed requestId={},table={},Segments(Queried/processed/matched)={}/{}/{},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={}",
         requestId, tableNameWithType, numSegmentsQueried, numSegmentsProcessed, numSegmentsMatched,
         timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
         timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), queryRequest.getBrokerId(), numDocsScanned,

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -46,7 +46,8 @@ import org.slf4j.LoggerFactory;
 public abstract class QueryScheduler {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryScheduler.class);
   private static final String INVALID_NUM_SCANNED = "-1";
-
+  private static final String INVALID_SEGMENTS_COUNT = "-1";
+  
   protected final ServerMetrics serverMetrics;
   protected final QueryExecutor queryExecutor;
   protected final ResourceManager resourceManager;
@@ -147,6 +148,11 @@ public abstract class QueryScheduler {
         dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, INVALID_NUM_SCANNED));
     long numEntriesScannedPostFilter = Long.parseLong(
         dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, INVALID_NUM_SCANNED));
+    long numSegmentsProcessed = Long.parseLong(
+        dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, INVALID_SEGMENTS_COUNT));
+    long numSegmentsMatched = Long.parseLong(
+        dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, INVALID_SEGMENTS_COUNT));
+    
     if (numDocsScanned > 0) {
       serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_DOCS_SCANNED, numDocsScanned);
     }
@@ -161,13 +167,13 @@ public abstract class QueryScheduler {
 
     TimerContext timerContext = queryRequest.getTimerContext();
     LOGGER.info(
-        "Processed requestId={},table={},reqSegments={},prunedToSegmentCount={},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={}",
-        requestId, tableNameWithType, queryRequest.getSegmentsToQuery().size(),
-        queryRequest.getSegmentCountAfterPruning(), timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
+        "Processed requestId={},table={},Segments={}/{}/{},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={}",
+        requestId, tableNameWithType, queryRequest.getSegmentsToQuery().size(), numSegmentsProcessed, numSegmentsMatched,
+        timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
         timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), queryRequest.getBrokerId(), numDocsScanned,
         numEntriesScannedInFilter, numEntriesScannedPostFilter, name());
-    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_SEARCHED,
-        queryRequest.getSegmentCountAfterPruning());
+    
+    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_QUERIED, numSegmentsProcessed);
 
     return responseData;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -166,14 +166,17 @@ public abstract class QueryScheduler {
     }
 
     TimerContext timerContext = queryRequest.getTimerContext();
+    int numSegmentsQueried = queryRequest.getSegmentsToQuery().size();
     LOGGER.info(
         "Processed requestId={},table={},Segments={}/{}/{},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={}",
-        requestId, tableNameWithType, queryRequest.getSegmentsToQuery().size(), numSegmentsProcessed, numSegmentsMatched,
+        requestId, tableNameWithType, numSegmentsQueried, numSegmentsProcessed, numSegmentsMatched,
         timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
         timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), queryRequest.getBrokerId(), numDocsScanned,
         numEntriesScannedInFilter, numEntriesScannedPostFilter, name());
     
-    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_QUERIED, numSegmentsProcessed);
+    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_QUERIED, numSegmentsQueried);
+    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_PROCESSED, numSegmentsProcessed);
+    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_MATCHED, numSegmentsMatched);
 
     return responseData;
   }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -251,6 +251,12 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
 
   @Test
   @Override
+  public void testBrokerResponseMetadata() throws Exception {
+    super.testBrokerResponseMetadata();
+  }
+
+  @Test
+  @Override
   public void testVirtualColumnQueries() {
     super.testVirtualColumnQueries();
   }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -358,6 +358,12 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   }
 
   @Test
+  @Override
+  public void testBrokerResponseMetadata() throws Exception {
+    super.testBrokerResponseMetadata();
+  }
+  
+  @Test
   public void testUDF() throws Exception {
     String pqlQuery = "SELECT COUNT(*) FROM mytable GROUP BY timeConvert(DaysSinceEpoch,'DAYS','SECONDS')";
     JSONObject response = postQuery(pqlQuery);


### PR DESCRIPTION
This PR allows us to know how effective is our pruning strategy. The flow is as follows
1. Total number of segments (NumSegments)
2. Broker side Pruning (NumSegmentsPrunedByBroker)
3. Broker queries all Servers after pruning(NumSegmentsQueried) 
4. Each server applies further pruning (NumSegmentsPrunedByServer)
5. Each server processes all segments after Pruning (NumSegmentsProcessed)
6. Some of the segments processed have no matching rows (NumSegmentsWithNoMatch)
 
If the pruning(broker + server) is effective, NumSegmentsWithNoMatch should be close to zero. Today, we don't have any metrics on numSegmentsProcessed. This PR allows us to identify use cases where Pruning is ineffective and we can add additional pruners e.g BloomFilter 

In the perf benchmarks, we have seen that the number of Segments can impact latency and max throughput.

Could not find any test case for BrokerNativeResponse class that validates the metadata fields in a response. Will add one and update the PR.

Sample response after this change

```
{
    "aggregationResults": [
    {
        "function": "count_star",
        "value": "9"
    }],
    "exceptions": [],
    "numServersQueried": 1,
    "numServersResponded": 1,
    "numSegmentsQueried": 136,
    "numSegmentsProcessed": 136,
    "numSegmentsMatched": 8,
    "numDocsScanned": 9,
    "numEntriesScannedInFilter": 0,
    "numEntriesScannedPostFilter": 0,
    "numGroupsLimitReached": false,
    "totalDocs": 66942316,
    "timeUsedMs": 314,
    "segmentStatistics": [],
    "traceInfo": {}
}
```

