### PR TITLE
Adding pluggable storage support for realtime upload

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -304,10 +304,10 @@ public class LLCSegmentCompletionHandlers {
 
       FileUploadPathProvider provider = new FileUploadPathProvider(_controllerConf);
 
-      String tmpFilePath = StringUtil.join("/", provider.getFileUploadTmpDirURI().toString(), name + "." + UUID.randomUUID().toString());
-      java.net.URI tmpFileURI = ControllerConf.getUriFromPath(tmpFilePath);
+      String remoteTmpFilePath = StringUtil.join("/", provider.getFileUploadTmpDirURI().toString(), name + "." + UUID.randomUUID().toString());
+      java.net.URI remoteTmpFileURI = ControllerConf.getUriFromPath(remoteTmpFilePath);
 
-      PinotFS pinotFS = PinotFSFactory.create(tmpFileURI.getScheme());
+      PinotFS pinotFS = PinotFSFactory.create(remoteTmpFileURI.getScheme());
 
       File localTmpFile = new File(provider.getFileUploadTmpDir(), name + "." + UUID.randomUUID().toString());
       localTmpFile.deleteOnExit();
@@ -321,10 +321,11 @@ public class LLCSegmentCompletionHandlers {
       // If remote, will need to copy tmp file to remote storage
       try {
         if ((!(pinotFS instanceof LocalPinotFS))) {
-          pinotFS.copyFromLocalFile(localTmpFile, tmpFileURI);
+          pinotFS.copyFromLocalFile(localTmpFile, remoteTmpFileURI);
+          pinotFS.delete(localTmpFile.toURI(), true)
         }
       } catch (Exception e) {
-        pinotFS.delete(tmpFileURI, true);
+        pinotFS.delete(remoteTmpFileURI, true);
         LOGGER.error("Could not copy from local to remote storage");
       }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -18,9 +18,13 @@ package com.linkedin.pinot.controller.api.resources;
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.core.realtime.SegmentCompletionManager;
 import com.linkedin.pinot.controller.util.SegmentCompletionUtils;
+import com.linkedin.pinot.filesystem.LocalPinotFS;
+import com.linkedin.pinot.filesystem.PinotFS;
+import com.linkedin.pinot.filesystem.PinotFSFactory;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -39,7 +43,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.httpclient.URI;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -300,27 +303,48 @@ public class LLCSegmentCompletionHandlers {
       FormDataBodyPart bodyPart = map.get(name).get(0);
 
       FileUploadPathProvider provider = new FileUploadPathProvider(_controllerConf);
-      File tmpFile = new File(provider.getFileUploadTmpDir(), name + "." + UUID.randomUUID().toString());
-      tmpFile.deleteOnExit();
 
+      String tmpFilePath = StringUtil.join("/", provider.getFileUploadTmpDirURI().toString(), name + "." + UUID.randomUUID().toString());
+      java.net.URI tmpFileURI = ControllerConf.getUriFromPath(tmpFilePath);
+
+      PinotFS pinotFS = PinotFSFactory.create(tmpFileURI.getScheme());
+
+      File localTmpFile = new File(provider.getFileUploadTmpDir(), name + "." + UUID.randomUUID().toString());
+      localTmpFile.deleteOnExit();
+
+      // Copy multipart to local
       try (InputStream inputStream = bodyPart.getValueAs(InputStream.class);
-          OutputStream outputStream = new FileOutputStream(tmpFile)) {
+          OutputStream outputStream = new FileOutputStream(localTmpFile)) {
         IOUtils.copyLarge(inputStream, outputStream);
+      }
+
+      // If remote, will need to copy tmp file to remote storage
+      try {
+        if ((!(pinotFS instanceof LocalPinotFS))) {
+          pinotFS.copyFromLocalFile(localTmpFile, tmpFileURI);
+        }
+      } catch (Exception e) {
+        pinotFS.delete(tmpFileURI, true);
+        LOGGER.error("Could not copy from local to remote storage");
       }
 
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
       final String rawTableName = llcSegmentName.getTableName();
-      final File tableDir = new File(provider.getBaseDataDir(), rawTableName);
-      File segmentFile;
+      final java.net.URI tableDirURI = ControllerConf.getUriFromPath(StringUtil.join("/", provider.getBaseDataDirURI().toString(), rawTableName));
+      java.net.URI segmentFileURI;
       if (isSplitCommit) {
         String uniqueSegmentFileName = SegmentCompletionUtils.generateSegmentFileName(segmentName);
-        segmentFile = new File(tableDir, uniqueSegmentFileName);
+        segmentFileURI = ControllerConf.getUriFromPath(StringUtil.join("/", tableDirURI.toString(), uniqueSegmentFileName));
       } else {
-        segmentFile = new File(tableDir, segmentName);
+        segmentFileURI = ControllerConf.getUriFromPath(StringUtil.join("/", tableDirURI.toString(), segmentName));
       }
 
       if (isSplitCommit) {
-        FileUtils.moveFile(tmpFile, segmentFile);
+        try {
+          pinotFS.copyFromLocalFile(localTmpFile, segmentFileURI);
+        } catch (Exception e) {
+          LOGGER.error("Could not copy from {} to {}", localTmpFile.getAbsolutePath(), segmentFileURI.toString());
+        }
       } else {
         // Multiple threads can reach this point at the same time, if the following scenario happens
         // The server that was asked to commit did so very slowly (due to network speeds). Meanwhile the FSM in
@@ -337,16 +361,20 @@ public class LLCSegmentCompletionHandlers {
         // For now, we live with these corner cases. Once we have split-commit enabled and working, this code will no longer
         // be used.
         synchronized (SegmentCompletionManager.getInstance()) {
-          if (segmentFile.exists()) {
-            LOGGER.warn("Segment file {} exists. Replacing with upload from {}", segmentFile.getAbsolutePath(),
+          if (pinotFS.exists(segmentFileURI)) {
+            LOGGER.warn("Segment file {} exists. Replacing with upload from {}", segmentFileURI.toString(),
                 instanceId);
-            FileUtils.deleteQuietly(segmentFile);
+            pinotFS.delete(segmentFileURI, true);
           }
-          FileUtils.moveFile(tmpFile, segmentFile);
+          try {
+            pinotFS.copyFromLocalFile(localTmpFile, segmentFileURI);
+          } catch (Exception e) {
+            LOGGER.error("Could not copy from {} to {}", localTmpFile.getAbsolutePath(), segmentFileURI.toString());
+          }
         }
       }
-      LOGGER.info("Moved file {} to {}", tmpFile.getAbsolutePath(), segmentFile.getAbsolutePath());
-      return new URI(SCHEME + segmentFile.getAbsolutePath(), /* boolean escaped */ false).toString();
+      LOGGER.info("Moved file {} to {}", localTmpFile.getAbsolutePath(), segmentFileURI.toString());
+      return new URI(SCHEME + segmentFileURI.toString(), /* boolean escaped */ false).toString();
     } catch (InvalidControllerConfigException e) {
       LOGGER.error("Invalid controller config exception from instance {} for segment {}", instanceId, segmentName, e);
       return null;

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -40,7 +40,7 @@ public abstract class PinotFS implements Closeable {
   /**
    * Deletes the file at the location provided. If the segmentUri is a directory, it will delete the entire directory.
    * @param segmentUri URI of the segment
-   * @param forceDelete true if we want the uri and any suburis to always be deleted, true if we want delete to fail
+   * @param forceDelete true if we want the uri and any suburis to always be deleted, false if we want delete to fail
    *                    when we want to delete a directory and that directory is not empty
    * @return true if delete is successful else false
    * @throws IOException IO failure


### PR DESCRIPTION
* First phase of pluggable storage support for realtime includes replacing filesystem-level calls with pinotFS calls.
* See #3420 for more details