### PR TITLE
[TE] frontend - harleyjj/rootcause - warning value uses aggregate mul…

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
@@ -327,7 +327,6 @@ export default Component.extend({
           };
         }
       });
-
       return anomalyInfo;
     }
   ),
@@ -356,12 +355,16 @@ export default Component.extend({
    */
   isWarning: computed('anomalyInfo', 'isRangeChanged', function () {
     if(!get(this, 'isRangeChanged')) {
-      let oldCurrent = parseFloat(get(this, 'current'));
-      const newCurrent = this._getAggregate('current');
-      if (newCurrent && oldCurrent){
+      const oldCurrent = parseFloat(get(this, 'current'));
+      let newCurrent = this._getAggregate('current');
+      const aggregateMultiplier = parseFloat(get(this, 'aggregateMultiplier'));
+      if (newCurrent && oldCurrent && aggregateMultiplier){
+        newCurrent = newCurrent * aggregateMultiplier;
         const diffCurrent = Math.abs((newCurrent-oldCurrent)/newCurrent);
         if (diffCurrent > 0.01) {
           set(this, 'warningValue', true);
+        } else {
+          set(this, 'warningValue', false);
         }
       }
     }
@@ -373,7 +376,7 @@ export default Component.extend({
    * @type {string}
    */
   warningChangedTo: computed('warningValue', function() {
-    const newCurrent = this._getAggregate('current');
+    const newCurrent = this._getAggregate('current') * parseFloat(get(this, 'aggregateMultiplier'));
     return humanizeFloat(newCurrent);
   }),
 
@@ -392,7 +395,6 @@ export default Component.extend({
       if (value === 0.0) { return Number.NaN; }
       return value / (aggregateMultiplier || 1.0);
     }
-
     return aggregates[toOffsetUrn(metricUrn, offset)];
   },
 

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/rootcause-anomaly/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/rootcause-anomaly/component-test.js
@@ -74,7 +74,7 @@ module('Integration | Component | rootcause-anomaly', function(hooks) {
               score : [ '0.03195732831954956' ],
               functionId : [ '1' ],
               current : [ '93453.15844726562' ],
-              aggregateMultiplier : [ '0.041666666666666664' ],
+              aggregateMultiplier : [ '1' ],
               metricId : [ '1' ],
               metric : [ 'metric' ],
               function : [ 'function' ],


### PR DESCRIPTION
…tiplier and can be turned off if aggregates change without slider being adjusted

The warning uses the aggregate multiplier to ensure oldCurrent and newCurrent are being compared in the same timeframe.  Once the date picker has been adjusted, isWarning's return value won't be adjusted anymore.  If aggregates update without the date being adjusted, the warning can be turned on or off, as appropriate.  The displayed value only changes when the warningValue variable is changed.  