### PR TITLE
[TE] Make new alerter tag old anomalies as notified

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/MultipleAnomaliesEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/MultipleAnomaliesEmailContentFormatter.java
@@ -160,7 +160,9 @@ public class MultipleAnomaliesEmailContentFormatter extends BaseEmailContentForm
     final DateTime eventStart = windowStart.minus(preEventCrawlOffset);
     final DateTime eventEnd = windowEnd.plus(postEventCrawlOffset);
     Map<String, List<String>> targetDimensions = new HashMap<>();
-    targetDimensions.put(EVENT_FILTER_COUNTRY, emailContentFormatterConfiguration.getHolidayCountriesWhitelist());
+    if (emailContentFormatterConfiguration.getHolidayCountriesWhitelist() != null) {
+      targetDimensions.put(EVENT_FILTER_COUNTRY, emailContentFormatterConfiguration.getHolidayCountriesWhitelist());
+    }
     List<EventDTO> holidays = getHolidayEvents(eventStart, eventEnd, targetDimensions);
     Collections.sort(holidays, new Comparator<EventDTO>() {
       @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/events/EventFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/events/EventFilter.java
@@ -27,8 +27,13 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 
 import com.linkedin.thirdeye.datalayer.dto.EventDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class EventFilter {
+  private static final Logger LOG = LoggerFactory.getLogger(EventFilter.class);
+
   String eventType;
   String serviceName;
   String metricName;
@@ -152,6 +157,8 @@ public class EventFilter {
         filteredEvents.addAll(allEvents);
       }
     }
+
+    LOG.info("Whitelisting complete. Returning {} fetched events after whitelist", filteredEvents.size());
     return filteredEvents;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/events/HolidayEventProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/events/HolidayEventProvider.java
@@ -32,12 +32,13 @@ public class HolidayEventProvider implements EventDataProvider<EventDTO> {
 
   @Override
   public List<EventDTO> getEvents(EventFilter eventFilter) {
-    LOG.info("Fetching all {} events between {} and {}", eventFilter.getEventType(), eventFilter.getStartTime(), eventFilter.getEndTime());
     List<EventDTO> allEventsBetweenTimeRange = eventDAO.findEventsBetweenTimeRange(
         eventFilter.getEventType(),
         eventFilter.getStartTime(),
         eventFilter.getEndTime());
 
+    LOG.info("Fetched {} {} events between {} and {}", allEventsBetweenTimeRange.size(),
+        eventFilter.getEventType(), eventFilter.getStartTime(), eventFilter.getEndTime());
     return EventFilter.applyDimensionFilter(allEventsBetweenTimeRange, eventFilter.getTargetDimensionMap());
   }
 


### PR DESCRIPTION
The current UI relies on notified tag to fetch and display the anomalies.Due to this behavior, when an old pipeline anomaly is alerted using the new alerter it doesn't show up on the UI. The notified tag needs to be cleaned up after the migration.