### PR TITLE
Fixing AzurePinotFS Move API

### DIFF
--- a/pinot-azure-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-azure-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
@@ -99,8 +99,7 @@ public class AzurePinotFS extends PinotFS {
     if (exists(dstUri) && !overwrite) {
       return false;
     }
-    //rename the file
-    return _adlStoreClient.rename(srcUri.getPath(), dstUri.getPath());
+    return copy(srcUri, dstUri) && delete(srcUri, true);
   }
 
   @Override


### PR DESCRIPTION
* Previously, we called a rename in the move method in AzurePinotFS. PinotFS assumes that the move command takes in the srcUri and that the file gets moved to dstUri. However, rename doesn't behave that way. I have changed move to be a copy and delete instead. 