### PR TITLE
Add metric gauge to track the number of llc simultaneous segment builds

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
@@ -350,7 +350,6 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * @param value The value to set the gauge to
    */
   public void setValueOfGlobalGauge(final G gauge, final long value) {
-    final String fullGaugeName;
     final String gaugeName = gauge.getGaugeName();
 
     if (!_gaugeValues.containsKey(gaugeName)) {
@@ -369,6 +368,34 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
       }
     } else {
       _gaugeValues.get(gaugeName).set(value);
+    }
+  }
+
+  /**
+   * Adds a value to a table gauge.
+   *
+   * @param gauge The gauge to use
+   * @param unitCount The number of units to add to the gauge
+   */
+  public void addValueToGlobalGauge(final G gauge, final long unitCount) {
+    String gaugeName = gauge.getGaugeName();
+
+    if (!_gaugeValues.containsKey(gaugeName)) {
+      synchronized (_gaugeValues) {
+        if(!_gaugeValues.containsKey(gaugeName)) {
+          _gaugeValues.put(gaugeName, new AtomicLong(unitCount));
+          addCallbackGauge(gaugeName, new Callable<Long>() {
+            @Override
+            public Long call() throws Exception {
+              return _gaugeValues.get(gaugeName).get();
+            }
+          });
+        } else {
+          _gaugeValues.get(gaugeName).addAndGet(unitCount);
+        }
+      }
+    } else {
+      _gaugeValues.get(gaugeName).addAndGet(unitCount);
     }
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
@@ -41,7 +41,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   STREAM_PARTITION_OFFSET_LAG("messages", false),
   REALTIME_OFFHEAP_MEMORY_USED("bytes", false),
   RUNNING_QUERIES("runningQueries", false),
-  REALTIME_SEGMENT_PARTITION_WIDTH("realtimeSegmentPartitionWidth", false);
+  REALTIME_SEGMENT_PARTITION_WIDTH("realtimeSegmentPartitionWidth", false),
+  LLC_SIMULTANEOUS_SEGMENT_BUILDS("llcSimultaneousSegmentBuilds", true);
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -626,6 +626,9 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         segmentLogger.info("Waiting to acquire semaphore for building segment");
         _segBuildSemaphore.acquire();
       }
+      // Increment llc simultaneous segment builds.
+      _serverMetrics.addValueToGlobalGauge(ServerGauge.LLC_SIMULTANEOUS_SEGMENT_BUILDS, 1L);
+
       final long lockAquireTimeMillis = now();
       // Build a segment from in-memory rows.If buildTgz is true, then build the tar.gz file as well
       // TODO Use an auto-closeable object to delete temp resources.
@@ -681,6 +684,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       if (_segBuildSemaphore != null) {
         _segBuildSemaphore.release();
       }
+      // Decrement llc simultaneous segment builds.
+      _serverMetrics.addValueToGlobalGauge(ServerGauge.LLC_SIMULTANEOUS_SEGMENT_BUILDS, -1L);
     }
   }
 


### PR DESCRIPTION
This PR adds a metric gauge to track the number of LLC simultaneous segment builds, which could help us debug what happened during the real-time segment completion.