### PR TITLE
[TE] rootcause - rich metric selector

### DIFF
--- a/thirdeye/thirdeye-frontend/app/mirage/endpoints/rootcause.js
+++ b/thirdeye/thirdeye-frontend/app/mirage/endpoints/rootcause.js
@@ -185,7 +185,8 @@ export default function(server) {
   server.get('/rootcause/metric/aggregate', () => {});
   server.get('/rootcause/metric/aggregate/cache', () => {});
   server.get('/rootcause/metric/breakdown', () => {});
-  server.get('rootcause/metric/aggregate/batch', () => {});
+  server.get('/rootcause/metric/aggregate/batch', () => {});
+  server.get('/rootcause/metric/aggregate/chunk', () => {});
   server.get('/rootcause/metric/timeseries', () => {
     return {
       timestamp: [moment().valueOf()],

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-select/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-select/component.js
@@ -152,15 +152,13 @@ export default Component.extend({
   // Selected Filters Serializer
   selectedFilters: computed('selected', {
     get() {
-      const filters = JSON.parse(this.get('selected'));
+      const selected = this.get('selected') || '{}';
+      const filters = JSON.parse(selected);
 
       return convertHashToFilters(filters);
     },
     set(key, value) {
-      const filters = convertFiltersToHash(value);
-      this.set('selected', filters);
-
-      return value;
+      this.set('selected', value);
     }
   }),
 
@@ -201,10 +199,12 @@ export default Component.extend({
     // Action handler for filter Selection/Deselection
     onFilterChange(filters) {
       const onChangeHandler = this.get('onChange');
-      this.set('selectedFilters', filters);
+
+      const newSelected = convertFiltersToHash(filters);
+      this.set('selected', newSelected);
 
       if (onChangeHandler) {
-        onChangeHandler(this.get('selected'));
+        onChangeHandler(newSelected);
       }
     }
   }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric-dimension/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric-dimension/component.js
@@ -208,11 +208,14 @@ export default Component.extend({
       const baseUrn = metricUrns[0];
 
       const { selectedUrn, baseUrnCache } = getProperties(this, 'selectedUrn', 'baseUrnCache');
-      const filterMap = toFilterMap(toFilters(selectedUrn));
 
-      if (!_.isEqual(baseUrn, baseUrnCache)) {
+      const previousFilterMap = toFilterMap(toFilters(selectedUrn));
+      const incomingFilterMap = toFilterMap(toFilters(baseUrn));
+      const newFilterMap = _.isEmpty(incomingFilterMap) ? previousFilterMap : incomingFilterMap;
+
+      if (!_.isEqual(baseUrn, baseUrnCache) || !_.isEqual(previousFilterMap, newFilterMap)) {
         setProperties(this, { baseUrn, baseUrnCache: baseUrn });
-        this._fetchFilters(baseUrn, filterMap);
+        this._fetchFilters(baseUrn, newFilterMap);
       }
     },
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric-dimension/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric-dimension/template.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-xs-6">
     <label class="te-label te-label--small" for="select-metric">
-      Metrics to Investigate
+      Metric under Investigation
       <span>
         <i class="glyphicon glyphicon-question-sign"></i>
         {{#tooltip-on-element class="te-tooltip"}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/template.hbs
@@ -10,9 +10,5 @@
   matchTriggerWidth=false
 as |metric|
 }}
-{{#if (eq selectedMetric.alias metric.alias)}}
-  <span class="bluelink">{{metric.alias}}</span>
-{{else}}
-  {{metric.alias}}
-{{/if}}
+  {{partial 'partials/rootcause/select-metric-label'}}
 {{/power-select}}

--- a/thirdeye/thirdeye-frontend/app/pods/custom/metrics-table-metric/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/metrics-table-metric/template.hbs
@@ -5,5 +5,5 @@
   {{/if}}
 </p>
 <p class="metrics-table__value--small">
-  ({{get record 'dataset'}})
+  {{get record 'dataset'}}
 </p>

--- a/thirdeye/thirdeye-frontend/app/pods/partials/rootcause/select-metric-label/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/partials/rootcause/select-metric-label/template.hbs
@@ -1,0 +1,6 @@
+<p class="rootcause-select-metric__value {{if (get-safe metric "isSelected") "rootcause-select-metric__value--bluelink"}}">
+  {{get-safe metric "name"}}
+</p>
+<p class="rootcause-select-metric__value--small">
+  {{get-safe metric "dataset"}}
+</p>

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-select-metric.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-select-metric.scss
@@ -3,8 +3,30 @@
 }
 
 .ember-power-select-option {
-  .bluelink {
-    font-weight: bold;
-    color: $te-blue;
+
+}
+
+#select-metric .ember-power-select-selected-item {
+  margin-left: 0;
+}
+
+.rootcause-select-metric {
+  &__value {
+    margin: 0;
+    padding: 0;
+    height: 21px;
+
+    &--small {
+      margin: 0;
+      padding: 0;
+      height: 18px;
+      font-size: 10px;
+      color: app-shade(black, 0.60);
+    }
+
+    &--bluelink {
+      font-weight: bold;
+      color: $te-blue;
+    }
   }
 }

--- a/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
@@ -17,7 +17,7 @@ module('Acceptance | rootcause', async function(hooks) {
 
   test(`visiting /rootcause on anomalyId shows correct header title`, async assert => {
     await visit('/rootcause?anomalyId=1');
-    
+
     assert.ok(
       $('.rootcause-header__major').get(0).value.includes('Investigation on pageViews'),
       'title is correct');
@@ -52,11 +52,6 @@ module('Acceptance | rootcause', async function(hooks) {
         $(rcEl.LABEL).get(0).innerText.trim(),
         'pageViews',
         'metric label is correct'
-      );
-      assert.equal(
-        $(rcEl.SELECTED_METRIC).get(0).innerText.trim(),
-        'pageViews',
-        'selected metric is correct'
       );
     });
 


### PR DESCRIPTION
Improve visualization of metrics selector on root cause page. Displays metric names similar to metrics table, with dataset subscript and dimension values. Also enables quick-selection of metrics with pre-existing dimensions.

![image](https://user-images.githubusercontent.com/25439965/49256925-74f3df80-f3e5-11e8-9eec-c8a48b0e2e2d.png)
