### PR TITLE
Add guava cache to cache table schema in pinot broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerServerBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerServerBuilder.java
@@ -27,6 +27,7 @@ import org.apache.pinot.broker.queryquota.TableQueryQuotaManager;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.requesthandler.ConnectionPoolBrokerRequestHandler;
 import org.apache.pinot.broker.requesthandler.SingleConnectionBrokerRequestHandler;
+import org.apache.pinot.broker.requesthandler.TableSchemaCache;
 import org.apache.pinot.broker.routing.RoutingTable;
 import org.apache.pinot.broker.routing.TimeBoundaryService;
 import org.apache.pinot.common.Utils;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerServerBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerServerBuilder.java
@@ -62,6 +62,7 @@ public class BrokerServerBuilder {
   private final TimeBoundaryService _timeBoundaryService;
   private final LiveInstancesChangeListenerImpl _liveInstanceChangeListener;
   private final TableQueryQuotaManager _tableQueryQuotaManager;
+  private final TableSchemaCache _tableSchemaCache;
   private final AccessControlFactory _accessControlFactory;
   private final MetricsRegistry _metricsRegistry;
   private final BrokerMetrics _brokerMetrics;
@@ -69,7 +70,8 @@ public class BrokerServerBuilder {
   private final BrokerAdminApiApplication _brokerAdminApplication;
 
   public BrokerServerBuilder(Configuration config, RoutingTable routingTable, TimeBoundaryService timeBoundaryService,
-      LiveInstancesChangeListenerImpl liveInstanceChangeListener, TableQueryQuotaManager tableQueryQuotaManager) {
+      LiveInstancesChangeListenerImpl liveInstanceChangeListener, TableQueryQuotaManager tableQueryQuotaManager,
+      TableSchemaCache tableSchemaCache) {
     _state.set(State.INIT);
     _config = config;
     _delayedShutdownTimeMs = config.getLong(DELAY_SHUTDOWN_TIME_MS_CONFIG, DEFAULT_DELAY_SHUTDOWN_TIME_MS);
@@ -77,6 +79,7 @@ public class BrokerServerBuilder {
     _timeBoundaryService = timeBoundaryService;
     _liveInstanceChangeListener = liveInstanceChangeListener;
     _tableQueryQuotaManager = tableQueryQuotaManager;
+    _tableSchemaCache = tableSchemaCache;
     _accessControlFactory = AccessControlFactory.loadFactory(_config.subset(ACCESS_CONTROL_PREFIX));
     _metricsRegistry = new MetricsRegistry();
     MetricsHelper.initializeMetrics(config.subset(METRICS_CONFIG_PREFIX));
@@ -92,11 +95,11 @@ public class BrokerServerBuilder {
     if (requestHandlerType.equalsIgnoreCase(SINGLE_CONNECTION_REQUEST_HANDLER_TYPE)) {
       LOGGER.info("Using SingleConnectionBrokerRequestHandler");
       return new SingleConnectionBrokerRequestHandler(_config, _routingTable, _timeBoundaryService,
-          _accessControlFactory, _tableQueryQuotaManager, _brokerMetrics);
+          _accessControlFactory, _tableQueryQuotaManager, _tableSchemaCache, _brokerMetrics);
     } else {
       LOGGER.info("Using ConnectionPoolBrokerRequestHandler");
       return new ConnectionPoolBrokerRequestHandler(_config, _routingTable, _timeBoundaryService, _accessControlFactory,
-          _tableQueryQuotaManager, _brokerMetrics, _liveInstanceChangeListener, _metricsRegistry);
+          _tableQueryQuotaManager, _tableSchemaCache, _brokerMetrics, _liveInstanceChangeListener, _metricsRegistry);
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BrokerResourceOnlineOfflineStateModelFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BrokerResourceOnlineOfflineStateModelFactory.java
@@ -33,6 +33,7 @@ import org.apache.helix.participant.statemachine.StateModelInfo;
 import org.apache.helix.participant.statemachine.Transition;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.broker.queryquota.TableQueryQuotaManager;
+import org.apache.pinot.broker.requesthandler.TableSchemaCache;
 import org.apache.pinot.broker.routing.HelixExternalViewBasedRouting;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.config.TableConfig;
@@ -57,17 +58,19 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
   private final HelixAdmin _helixAdmin;
   private final HelixExternalViewBasedRouting _helixExternalViewBasedRouting;
   private final TableQueryQuotaManager _tableQueryQuotaManager;
+  private final TableSchemaCache _tableSchemaCache;
 
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
   public BrokerResourceOnlineOfflineStateModelFactory(HelixManager helixManager,
       ZkHelixPropertyStore<ZNRecord> propertyStore, HelixExternalViewBasedRouting helixExternalViewBasedRouting,
-      TableQueryQuotaManager tableQueryQuotaManager) {
+      TableQueryQuotaManager tableQueryQuotaManager, TableSchemaCache tableSchemaCache) {
     _helixManager = helixManager;
     _propertyStore = propertyStore;
     _helixAdmin = helixManager.getClusterManagmentTool();
     _helixExternalViewBasedRouting = helixExternalViewBasedRouting;
     _tableQueryQuotaManager = tableQueryQuotaManager;
+    _tableSchemaCache = tableSchemaCache;
   }
 
   public static String getStateModelDef() {
@@ -97,6 +100,7 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
             instanceConfigList);
         _tableQueryQuotaManager.initTableQueryQuota(tableConfig, HelixHelper
             .getExternalViewForResource(_helixAdmin, _helixManager.getClusterName(), BROKER_RESOURCE_INSTANCE));
+        _tableSchemaCache.refreshTableSchema(tableName);
       } catch (Exception e) {
         LOGGER.error("Caught exception during OFFLINE -> ONLINE transition", e);
         Utils.rethrowException(e);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -40,6 +40,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.broker.broker.AccessControlFactory;
 import org.apache.pinot.broker.broker.BrokerServerBuilder;
 import org.apache.pinot.broker.queryquota.TableQueryQuotaManager;
+import org.apache.pinot.broker.requesthandler.TableSchemaCache;
 import org.apache.pinot.broker.routing.HelixExternalViewBasedRouting;
 import org.apache.pinot.common.config.TagNameUtils;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -208,8 +208,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // Validate the request
+    FilterQueryTree[] filterQueryTree = new FilterQueryTree[1];
     try {
-      validateRequest(brokerRequest, requestParams);
+      validateRequest(brokerRequest, requestParams, filterQueryTree);
     } catch (Exception e) {
       LOGGER.info("Caught exception while validating request {}: {}, {}", requestId, query, e.getMessage());
       requestStatistics.setErrorCode(QueryException.QUERY_VALIDATION_ERROR_CODE);
@@ -239,18 +240,18 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     BrokerRequest realtimeBrokerRequest = null;
     if ((offlineTableName != null) && (realtimeTableName != null)) {
       // Hybrid
-      offlineBrokerRequest = _brokerRequestOptimizer.optimize(getOfflineBrokerRequest(brokerRequest), timeColumn);
-      realtimeBrokerRequest = _brokerRequestOptimizer.optimize(getRealtimeBrokerRequest(brokerRequest), timeColumn);
+      offlineBrokerRequest = _brokerRequestOptimizer.optimize(getOfflineBrokerRequest(brokerRequest), timeColumn, filterQueryTree[0]);
+      realtimeBrokerRequest = _brokerRequestOptimizer.optimize(getRealtimeBrokerRequest(brokerRequest), timeColumn, filterQueryTree[0]);
       requestStatistics.setFanoutType(RequestStatistics.FanoutType.HYBRID);
     } else if (offlineTableName != null) {
       // OFFLINE only
       brokerRequest.getQuerySource().setTableName(offlineTableName);
-      offlineBrokerRequest = _brokerRequestOptimizer.optimize(brokerRequest, timeColumn);
+      offlineBrokerRequest = _brokerRequestOptimizer.optimize(brokerRequest, timeColumn, filterQueryTree[0]);
       requestStatistics.setFanoutType(RequestStatistics.FanoutType.OFFLINE);
     } else {
       // REALTIME only
       brokerRequest.getQuerySource().setTableName(realtimeTableName);
-      realtimeBrokerRequest = _brokerRequestOptimizer.optimize(brokerRequest, timeColumn);
+      realtimeBrokerRequest = _brokerRequestOptimizer.optimize(brokerRequest, timeColumn, filterQueryTree[0]);
       requestStatistics.setFanoutType(RequestStatistics.FanoutType.REALTIME);
     }
 
@@ -329,7 +330,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    *   <li>Value for 'LIMIT' for selection query <= configured value</li>
    * </ul>
    */
-  private void validateRequest(BrokerRequest brokerRequest, RequestParams requestParams) {
+  private void validateRequest(BrokerRequest brokerRequest, RequestParams requestParams, FilterQueryTree[] filterQueryTree) {
     if (brokerRequest.isSetAggregationsInfo()) {
       if (brokerRequest.isSetGroupBy()) {
         long topN = brokerRequest.getGroupBy().getTopN();
@@ -352,7 +353,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       String tableName = brokerRequest.getQuerySource().getTableName();
       Schema schema = _tableSchemaCache.getIfTableSchemaPresent(tableName);
       if (schema != null) {
-        Set<String> columnsFromBrokerRequest = getAllColumnsFromBrokerRequest(brokerRequest);
+        Set<String> columnsFromBrokerRequest = getAllColumnsFromBrokerRequest(brokerRequest, filterQueryTree);
         // Filters out virtual columns in the query.
         columnsFromBrokerRequest.removeIf(column -> column.startsWith("$"));
         columnsFromBrokerRequest.removeAll(schema.getColumnNames());
@@ -372,12 +373,12 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * Helper to get all the columns from broker request.
    * Returns the set of all the columns.
    */
-  private Set<String> getAllColumnsFromBrokerRequest(BrokerRequest brokerRequest) {
+  private Set<String> getAllColumnsFromBrokerRequest(BrokerRequest brokerRequest, FilterQueryTree[] filterQueryTree) {
     Set<String> allColumns = new HashSet<>();
     // Filter
-    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
-    if (filterQueryTree != null) {
-      allColumns.addAll(RequestUtils.extractFilterColumns(filterQueryTree));
+    filterQueryTree[0] = RequestUtils.generateFilterQueryTree(brokerRequest);
+    if (filterQueryTree[0] != null) {
+      allColumns.addAll(RequestUtils.extractFilterColumns(filterQueryTree[0]));
     }
 
     // Aggregation

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptimizer.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptimizer.java
@@ -38,9 +38,9 @@ public class BrokerRequestOptimizer {
    * @param timeColumn Time column for the table
    * @return An optimized request
    */
-  public BrokerRequest optimize(BrokerRequest brokerRequest, String timeColumn) {
+  public BrokerRequest optimize(BrokerRequest brokerRequest, String timeColumn, FilterQueryTree filterQueryTree) {
     OptimizationFlags optimizationFlags = OptimizationFlags.getOptimizationFlags(brokerRequest);
-    optimizeFilterQueryTree(brokerRequest, timeColumn, optimizationFlags);
+    optimizeFilterQueryTree(brokerRequest, timeColumn, optimizationFlags, filterQueryTree);
 
     return brokerRequest;
   }
@@ -51,16 +51,17 @@ public class BrokerRequestOptimizer {
    * @param timeColumn time column
    */
   private void optimizeFilterQueryTree(BrokerRequest brokerRequest, String timeColumn,
-      OptimizationFlags optimizationFlags) {
-    FilterQueryTree filterQueryTree = null;
+      OptimizationFlags optimizationFlags, FilterQueryTree filterQueryTree) {
     FilterQuery q = brokerRequest.getFilterQuery();
 
     if (q == null || brokerRequest.getFilterSubQueryMap() == null) {
       return;
     }
 
-    filterQueryTree =
-        RequestUtils.buildFilterQuery(q.getId(), brokerRequest.getFilterSubQueryMap().getFilterQueryMap());
+    if (filterQueryTree == null) {
+      filterQueryTree =
+          RequestUtils.buildFilterQuery(q.getId(), brokerRequest.getFilterSubQueryMap().getFilterQueryMap());
+    }
     FilterQueryOptimizerRequest.FilterQueryOptimizerRequestBuilder builder =
         new FilterQueryOptimizerRequest.FilterQueryOptimizerRequestBuilder();
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptimizer.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptimizer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.FilterQuery;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
+import org.apache.pinot.common.utils.request.RequestInfo;
 import org.apache.pinot.common.utils.request.RequestUtils;
 
 
@@ -38,9 +39,9 @@ public class BrokerRequestOptimizer {
    * @param timeColumn Time column for the table
    * @return An optimized request
    */
-  public BrokerRequest optimize(BrokerRequest brokerRequest, String timeColumn, FilterQueryTree filterQueryTree) {
+  public BrokerRequest optimize(BrokerRequest brokerRequest, String timeColumn, RequestInfo requestInfo) {
     OptimizationFlags optimizationFlags = OptimizationFlags.getOptimizationFlags(brokerRequest);
-    optimizeFilterQueryTree(brokerRequest, timeColumn, optimizationFlags, filterQueryTree);
+    optimizeFilterQueryTree(brokerRequest, timeColumn, optimizationFlags, requestInfo);
 
     return brokerRequest;
   }
@@ -51,17 +52,21 @@ public class BrokerRequestOptimizer {
    * @param timeColumn time column
    */
   private void optimizeFilterQueryTree(BrokerRequest brokerRequest, String timeColumn,
-      OptimizationFlags optimizationFlags, FilterQueryTree filterQueryTree) {
+      OptimizationFlags optimizationFlags, RequestInfo requestInfo) {
     FilterQuery q = brokerRequest.getFilterQuery();
 
     if (q == null || brokerRequest.getFilterSubQueryMap() == null) {
       return;
     }
 
-    if (filterQueryTree == null) {
+    FilterQueryTree filterQueryTree;
+    if (requestInfo != null && requestInfo.getFilterQueryTree() != null) {
+      filterQueryTree = requestInfo.getFilterQueryTree();
+    } else {
       filterQueryTree =
           RequestUtils.buildFilterQuery(q.getId(), brokerRequest.getFilterSubQueryMap().getFilterQueryMap());
     }
+
     FilterQueryOptimizerRequest.FilterQueryOptimizerRequestBuilder builder =
         new FilterQueryOptimizerRequest.FilterQueryOptimizerRequestBuilder();
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ConnectionPoolBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ConnectionPoolBrokerRequestHandler.java
@@ -89,9 +89,11 @@ public class ConnectionPoolBrokerRequestHandler extends BaseBrokerRequestHandler
 
   public ConnectionPoolBrokerRequestHandler(Configuration config, RoutingTable routingTable,
       TimeBoundaryService timeBoundaryService, AccessControlFactory accessControlFactory,
-      TableQueryQuotaManager tableQueryQuotaManager, BrokerMetrics brokerMetrics,
-      LiveInstancesChangeListenerImpl liveInstanceChangeListener, MetricsRegistry metricsRegistry) {
-    super(config, routingTable, timeBoundaryService, accessControlFactory, tableQueryQuotaManager, brokerMetrics);
+      TableQueryQuotaManager tableQueryQuotaManager, TableSchemaCache tableSchemaCache,
+      BrokerMetrics brokerMetrics, LiveInstancesChangeListenerImpl liveInstanceChangeListener,
+      MetricsRegistry metricsRegistry) {
+    super(config, routingTable, timeBoundaryService, accessControlFactory, tableQueryQuotaManager, tableSchemaCache,
+        brokerMetrics);
     _liveInstanceChangeListener = liveInstanceChangeListener;
 
     TransportClientConf transportClientConf = new TransportClientConf();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/RequestParams.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/RequestParams.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Splitter;
+import java.util.Map;
+
+import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.*;
+
+
+public class RequestParams {
+
+  private String _query;
+  private Map<String, String> _debugOptions = null;
+  private boolean _trace;
+  private boolean _validateQuery;
+
+  public RequestParams(JsonNode request) {
+    _query = request.get(PQL).asText();
+    _validateQuery = request.has(VALIDATE_QUERY) && request.get(VALIDATE_QUERY).asBoolean();
+    _trace = request.has(TRACE) && request.get(TRACE).asBoolean();
+    if (request.has(DEBUG_OPTIONS)) {
+      _debugOptions = Splitter.on(';')
+          .omitEmptyStrings()
+          .trimResults()
+          .withKeyValueSeparator('=')
+          .split(request.get(DEBUG_OPTIONS).asText());
+    }
+  }
+
+  public String getQuery() {
+    return _query;
+  }
+
+  public Map<String, String> getDebugOptions() {
+    return _debugOptions;
+  }
+
+  public boolean isTrace() {
+    return _trace;
+  }
+
+  public boolean isValidateQuery() {
+    return _validateQuery;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/RequestParams.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/RequestParams.java
@@ -57,7 +57,7 @@ public class RequestParams {
     return _trace;
   }
 
-  public boolean isValidateQuery() {
+  public boolean shouldValidateQuery() {
     return _validateQuery;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -55,8 +55,10 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
   public SingleConnectionBrokerRequestHandler(Configuration config, RoutingTable routingTable,
       TimeBoundaryService timeBoundaryService, AccessControlFactory accessControlFactory,
-      TableQueryQuotaManager tableQueryQuotaManager, BrokerMetrics brokerMetrics) {
-    super(config, routingTable, timeBoundaryService, accessControlFactory, tableQueryQuotaManager, brokerMetrics);
+      TableQueryQuotaManager tableQueryQuotaManager, TableSchemaCache tableSchemaCache,
+      BrokerMetrics brokerMetrics) {
+    super(config, routingTable, timeBoundaryService, accessControlFactory, tableQueryQuotaManager, tableSchemaCache,
+        brokerMetrics);
     _queryRouter = new QueryRouter(_brokerId, brokerMetrics);
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TableSchemaCache.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TableSchemaCache.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.data.Schema;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class TableSchemaCache {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableSchemaCache.class);
+
+  private final LoadingCache<String, Schema> _tableSchemaCache;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final ExecutorService _executorService;
+
+  public TableSchemaCache(ZkHelixPropertyStore<ZNRecord> propertyStore, int cacheTimeoutInMinute) {
+    LOGGER.info("Init table schema cache. cacheTimeoutInMinute: {}",
+        cacheTimeoutInMinute);
+    _executorService = Executors.newCachedThreadPool();
+    _propertyStore = propertyStore;
+    _tableSchemaCache = CacheBuilder.newBuilder()
+        .refreshAfterWrite(cacheTimeoutInMinute, TimeUnit.MINUTES)
+        .build(new CacheLoader<String, Schema>() {
+          @Override
+          public Schema load(@Nonnull String rawTableName) {
+            return ZKMetadataProvider.getTableSchema(_propertyStore, rawTableName);
+          }
+
+          @Override
+          public ListenableFuture<Schema> reload(String key, Schema oldValue) {
+            ListenableFutureTask<Schema> task =
+                ListenableFutureTask.create(() -> ZKMetadataProvider.getTableSchema(_propertyStore, key));
+            _executorService.execute(task);
+            return task;
+          }
+        });
+  }
+
+  /**
+   * Gets table schema if it's present.
+   * @param tableName Table name with or without type suffix.
+   */
+  public Schema getIfTableSchemaPresent(String tableName) {
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    return _tableSchemaCache.getIfPresent(rawTableName);
+  }
+
+  /**
+   * Refreshes table schema.
+   * @param tableName Table name with or without type suffix.
+   */
+  public void refreshTableSchema(String tableName) {
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    _tableSchemaCache.refresh(rawTableName);
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/FilterOptimizerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/FilterOptimizerTest.java
@@ -43,7 +43,7 @@ public class FilterOptimizerTest {
     int numOps;
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE (A = 4 AND B = 5) AND (C=7)");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn, null));
     Assert.assertEquals(tree.getChildren().size(), 3);
     Assert.assertEquals(tree.getOperator(), FilterOperator.AND);
     for (FilterQueryTree node : tree.getChildren()) {
@@ -52,7 +52,7 @@ public class FilterOptimizerTest {
     }
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 AND B = 5) AND (C=7)) AND D=8");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn, null));
     Assert.assertEquals(tree.getChildren().size(), 4);
     Assert.assertEquals(tree.getOperator(), FilterOperator.AND);
     for (FilterQueryTree node : tree.getChildren()) {
@@ -61,7 +61,7 @@ public class FilterOptimizerTest {
     }
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE (A = 4 OR B = 5) OR (C=7)");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn, null));
     Assert.assertEquals(tree.getChildren().size(), 3);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     for (FilterQueryTree node : tree.getChildren()) {
@@ -70,7 +70,7 @@ public class FilterOptimizerTest {
     }
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR B = 5) OR (C=7)) OR D=8");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn, null));
     Assert.assertEquals(tree.getChildren().size(), 4);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     for (FilterQueryTree node : tree.getChildren()) {
@@ -80,7 +80,7 @@ public class FilterOptimizerTest {
 
     // 3-level test case
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR (B = 5 OR D = 9)) OR (C=7)) OR E=8");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn, null));
     Assert.assertEquals(tree.getChildren().size(), 5);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     for (FilterQueryTree node : tree.getChildren()) {
@@ -90,7 +90,7 @@ public class FilterOptimizerTest {
 
     // Mixed case.
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR (B = 5 AND D = 9)) OR (C=7)) OR E=8");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn, null));
     Assert.assertEquals(tree.getChildren().size(), 4);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     numLeaves = 0;
@@ -111,7 +111,7 @@ public class FilterOptimizerTest {
     final int maxNodesAtTopLevel = FlattenNestedPredicatesFilterQueryTreeOptimizer.MAX_OPTIMIZING_DEPTH;
     String whereClause = constructWhereClause(FilterOperator.OR, maxNodesAtTopLevel + 50);
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE " + whereClause);
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn, null));
     Assert.assertEquals(tree.getChildren().size(), maxNodesAtTopLevel + 1);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     numLeaves = 0;
@@ -140,7 +140,7 @@ public class FilterOptimizerTest {
     int numOps;
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE (A = 4 AND (B = 5 OR D = 9))");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, null /* timeColumn */));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, null /* timeColumn */, null /* filterQueryTree */));
     Assert.assertEquals(tree.getChildren().size(), 2);
     Assert.assertEquals(tree.getOperator(), FilterOperator.AND);
     numOps = 0;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
@@ -98,7 +98,7 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
   }
 
   private String filterQueryTreeForQuery(String query) {
-    BrokerRequest brokerRequest = OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(query), null /* timeColumn */);
+    BrokerRequest brokerRequest = OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(query), null /* timeColumn */, null /* filterQueryTree */);
     return RequestUtils.generateFilterQueryTree(brokerRequest).toString();
   }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/TableSchemaCacheTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/TableSchemaCacheTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.concurrent.TimeUnit;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.Schema;
+import org.apache.pinot.common.data.TimeFieldSpec;
+import org.apache.pinot.common.utils.JsonUtils;
+import org.apache.pinot.common.utils.SchemaUtils;
+import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class TableSchemaCacheTest {
+  private static String TEST_TABLE = "testTableName";
+
+  @Test
+  public void testTableSchemaCache()
+      throws Exception {
+    ZNRecord znRecord = makeZNRecord();
+    Schema expectedSchema = SchemaUtils.fromZNRecord(znRecord);
+    ZkHelixPropertyStore<ZNRecord> fakePropertyStore = makePropertyStore(znRecord);
+    TableSchemaCache tableSchemaCache = new TableSchemaCache(fakePropertyStore, 1);
+
+    Schema schema = tableSchemaCache.getIfTableSchemaPresent(TEST_TABLE);
+    Assert.assertNull(schema);
+
+    long timeoutInMs = 500L;
+    String errorMsg = String.format("TableSchemaCache can't be updated within %d", timeoutInMs);
+    tableSchemaCache.refreshTableSchema(TEST_TABLE);
+    TestUtils.waitForCondition(aVoid -> {
+      Schema schema1 = tableSchemaCache.getIfTableSchemaPresent(TEST_TABLE);
+      return schema1 != null;
+    }, 100L, timeoutInMs, errorMsg);
+
+    schema = tableSchemaCache.getIfTableSchemaPresent(TEST_TABLE);
+    Assert.assertEquals(schema, expectedSchema);
+  }
+
+  private ZNRecord makeZNRecord() {
+    ObjectNode jsonSchema = JsonUtils.newObjectNode();
+    jsonSchema.put("schemaName", TEST_TABLE);
+
+    // dimension fields spec
+    ArrayNode dimensionJsonArray = JsonUtils.newArrayNode();
+    ObjectNode dimensionObjectNode = JsonUtils.newObjectNode();
+    dimensionObjectNode.put("name", "name");
+    dimensionObjectNode.put("dataType", "STRING");
+    dimensionObjectNode.put("isSingleValueField", true);
+    dimensionObjectNode.put("defaultNullValue", "null");
+    dimensionJsonArray.add(dimensionObjectNode);
+    jsonSchema.set("dimensionFieldSpecs", dimensionJsonArray);
+
+    // metric fields spec
+    ArrayNode metricJsonArray = JsonUtils.newArrayNode();
+    ObjectNode metricObjectNode = JsonUtils.newObjectNode();
+    metricObjectNode.put("name", "count");
+    metricObjectNode.put("dataType", "INT");
+    metricObjectNode.put("isSingleValueField", true);
+    metricObjectNode.put("defaultNullValue", 0);
+    metricJsonArray.add(metricObjectNode);
+    jsonSchema.set("metricFieldSpecs", metricJsonArray);
+
+    // time field spec
+    TimeFieldSpec timeFieldSpec = new TimeFieldSpec("incomingSec", FieldSpec.DataType.INT, TimeUnit.SECONDS);
+    jsonSchema.set("timeFieldSpec", timeFieldSpec.toJsonObject());
+
+    ZNRecord schemaZNRecord = new ZNRecord(TEST_TABLE);
+    schemaZNRecord.setSimpleField("schemaJSON", jsonSchema.toString());
+    return schemaZNRecord;
+  }
+
+  private ZkHelixPropertyStore<ZNRecord> makePropertyStore(ZNRecord znRecord) {
+    ZkHelixPropertyStore<ZNRecord> store = mock(ZkHelixPropertyStore.class);
+    when(store.get(anyString(), any(), anyInt())).thenReturn(znRecord);
+    return store;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -97,7 +97,9 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   // Netty connection metrics
   NETTY_CONNECTION_REQUESTS_SENT("nettyConnection", true),
   NETTY_CONNECTION_BYTES_SENT("nettyConnection", true),
-  NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true);
+  NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),
+
+  QUERY_NON_EXISTENT_COLUMNS("queries", false);
 
   private final String brokerMeterName;
   private final String unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -121,11 +121,14 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_REFRESH_TIMEBOUNDARY_INFO_SLEEP_INTERVAL =
         "pinot.broker.refresh.timeBoundaryInfo.sleepInterval";
     public static final long DEFAULT_BROKER_REFRESH_TIMEBOUNDARY_INFO_SLEEP_INTERVAL_MS = 10000L;
+    public static final String CONFIG_OF_TABLE_SCHEMA_CACHE_TIMEOUT_IN_MINUTE = "pinot.broker.table.schema.cache.timeoutInMinutes";
+    public static final int DEFAULT_TABLE_SCHEMA_CACHE_TIMEOUT_IN_MINUTE = 60;
 
     public static class Request {
       public static final String PQL = "pql";
       public static final String TRACE = "trace";
       public static final String DEBUG_OPTIONS = "debugOptions";
+      public static final String VALIDATE_QUERY = "validateQuery";
 
       public static class QueryOptionKey {
         public static final String PRESERVE_TYPE = "preserveType";

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestInfo.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.request;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
+
+
+public class RequestInfo {
+  // Pre-computed segment independent information
+  private final Set<String> _allColumns;
+  private final Set<String> _physicalColumns;
+  private final FilterQueryTree _filterQueryTree;
+  private final Set<String> _filterColumns;
+  private final Set<TransformExpressionTree> _aggregationExpressions;
+  private final Set<String> _aggregationColumns;
+  private final Set<TransformExpressionTree> _groupByExpressions;
+  private final Set<String> _groupByColumns;
+  private final Set<String> _selectionColumns;
+
+  public RequestInfo(Set<String> allColumns, FilterQueryTree filterQueryTree, Set<String> filterColumns,
+      Set<TransformExpressionTree> aggregationExpressions, Set<String> aggregationColumns,
+      Set<TransformExpressionTree> groupByExpressions, Set<String> groupByColumns, Set<String> selectionColumns) {
+    _allColumns = allColumns;
+    _physicalColumns = new HashSet<>(_allColumns);
+    // filters out virtual columns in the query.
+    _physicalColumns.removeIf(column -> column.startsWith("$"));
+    _filterQueryTree = filterQueryTree;
+    _filterColumns = filterColumns;
+    _aggregationExpressions = aggregationExpressions;
+    _aggregationColumns = aggregationColumns;
+    _groupByExpressions = groupByExpressions;
+    _groupByColumns = groupByColumns;
+    _selectionColumns = selectionColumns;
+  }
+
+  public Set<String> getAllColumns() {
+    return _allColumns;
+  }
+
+  public Set<String> getPhysicalColumns() {
+    return _physicalColumns;
+  }
+
+  public FilterQueryTree getFilterQueryTree() {
+    return _filterQueryTree;
+  }
+
+  public Set<String> getFilterColumns() {
+    return _filterColumns;
+  }
+
+  public Set<TransformExpressionTree> getAggregationExpressions() {
+    return _aggregationExpressions;
+  }
+
+  public Set<String> getAggregationColumns() {
+    return _aggregationColumns;
+  }
+
+  public Set<TransformExpressionTree> getGroupByExpressions() {
+    return _groupByExpressions;
+  }
+
+  public Set<String> getGroupByColumns() {
+    return _groupByColumns;
+  }
+
+  public Set<String> getSelectionColumns() {
+    return _selectionColumns;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -499,6 +499,7 @@ public abstract class ClusterTest extends ControllerTest {
     ObjectNode payload = JsonUtils.newObjectNode();
     payload.put("pql", query);
     payload.put("trace", enableTrace);
+    payload.put("validateQuery", true);
 
     return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/query", payload.toString()));
   }


### PR DESCRIPTION
This PR adds a guava cache to cache table schemas in broker so that non-existence column check can directly be done on broker side.

When the EV of broker resource got changed, the guava cache will make an async call to ZK once to fetch the schema for the table (referring to the code in `BrokerResourceOnlineOfflineStateModelFactory`).

The cached schema will be expired after certain amount of time. The reason of using **expire** instead of **refresh** is to reduce the number of times of ZK access. E.g. a single cluster is serving for thousands of tables. If we use `refreshAfterWrite`(lets say 30 mins), there'll be thousands of ZK read to update schema in the cache every 30 mins. The tables with less qps shouldn't be kept in the cache unless it's queried. And the ones with more qps should stay in the cache and keep updated.

When processing a query, if the cache contains the table schema, just simply returns the schema and compares against the columns appeared in the query.
Otherwise, the cache calls ZK **only once** to load the schema asynchronously. The following queries asking for the same new table will ignore the schema check until guava cache successfully gets the schema from ZK.

If there're columns in the query missing in the table schema, broker emits a broker metric and returns an exception back to the client.
