### PR TITLE
[TE] detection - filter out child anomaly in anomaly fetching

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/DetectionMigrationResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/DetectionMigrationResource.java
@@ -97,7 +97,7 @@ public class DetectionMigrationResource {
     AnomalyFunctionDTO anomalyFunctionDTO = this.anomalyFunctionDAO.findById(anomalyFunctionId);
     Preconditions.checkArgument(anomalyFunctionDTO.getIsActive(), "try to migrate inactive anomaly function");
     Map<String, Object> yamlConfigs = new LinkedHashMap<>();
-    yamlConfigs.put("detectionName", anomalyFunctionDTO.getFunctionName());
+    yamlConfigs.put("detectionName", "new_pipeline_" + anomalyFunctionDTO.getFunctionName());
     yamlConfigs.put("metric", anomalyFunctionDTO.getMetric());
     yamlConfigs.put("dataset", anomalyFunctionDTO.getCollection());
     yamlConfigs.put("pipelineType", "Composite");

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/DetectionMigrationResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/DetectionMigrationResource.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.thirdeye.detection;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.thirdeye.anomaly.detection.AnomalyDetectionInputContextBuilder;
 import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
@@ -94,6 +95,7 @@ public class DetectionMigrationResource {
   @GET
   public String migrateToYaml(@QueryParam("id") long anomalyFunctionId) throws Exception {
     AnomalyFunctionDTO anomalyFunctionDTO = this.anomalyFunctionDAO.findById(anomalyFunctionId);
+    Preconditions.checkArgument(anomalyFunctionDTO.getIsActive(), "try to migrate inactive anomaly function");
     Map<String, Object> yamlConfigs = new LinkedHashMap<>();
     yamlConfigs.put("detectionName", anomalyFunctionDTO.getFunctionName());
     yamlConfigs.put("metric", anomalyFunctionDTO.getMetric());
@@ -192,8 +194,8 @@ public class DetectionMigrationResource {
     Map<String, Object> params = new HashMap<>();
     filterYamlParams.put("configuration", params);
     params.putAll(functionDTO.getAlertFilter());
-    params.put("variables.bucketPeriod", getBucketPeriod(functionDTO));
-    params.put("variables.timeZone", getTimezone(functionDTO));
+    params.put("bucketPeriod", getBucketPeriod(functionDTO));
+    params.put("timeZone", getTimezone(functionDTO));
     return filterYamlParams;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/wrapper/BaselineFillingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/wrapper/BaselineFillingMergeWrapper.java
@@ -110,7 +110,7 @@ public class BaselineFillingMergeWrapper extends MergeWrapper {
         }
       } catch (Exception e) {
         // ignore
-        LOG.warn("cannot get metric slice for anomaly {}", anomaly, e);
+        LOG.warn("cannot get current or baseline value for anomaly {}. ", anomaly, e);
       }
     }
     return mergedAnomalies;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/wrapper/ChildKeepingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/wrapper/ChildKeepingMergeWrapper.java
@@ -42,6 +42,7 @@ public class ChildKeepingMergeWrapper extends BaselineFillingMergeWrapper {
   }
 
   @Override
+  // does not fetch any anomalies from database
   protected List<MergedAnomalyResultDTO> retrieveAnomaliesFromDatabase(List<MergedAnomalyResultDTO> generated) {
     return Collections.emptyList();
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/wrapper/ChildKeepingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/wrapper/ChildKeepingMergeWrapper.java
@@ -20,6 +20,7 @@ import com.linkedin.thirdeye.datalayer.dto.DetectionConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.detection.DataProvider;
 import com.linkedin.thirdeye.detection.algorithm.MergeWrapper;
+import com.linkedin.thirdeye.detection.spi.model.AnomalySlice;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -41,6 +42,11 @@ public class ChildKeepingMergeWrapper extends BaselineFillingMergeWrapper {
   }
 
   @Override
+  protected List<MergedAnomalyResultDTO> retrieveAnomaliesFromDatabase(List<MergedAnomalyResultDTO> generated) {
+    return Collections.emptyList();
+  }
+
+  @Override
   protected List<MergedAnomalyResultDTO> merge(Collection<MergedAnomalyResultDTO> anomalies) {
     List<MergedAnomalyResultDTO> input = new ArrayList<>(anomalies);
     Collections.sort(input, MergeWrapper.COMPARATOR);
@@ -54,7 +60,7 @@ public class ChildKeepingMergeWrapper extends BaselineFillingMergeWrapper {
       }
 
       MergeWrapper.AnomalyKey
-          key = new MergeWrapper.AnomalyKey(anomaly.getMetric(), anomaly.getCollection(), anomaly.getDimensions(), "");
+          key = new MergeWrapper.AnomalyKey(anomaly.getMetric(), anomaly.getCollection(), anomaly.getDimensions(), "", "");
       MergedAnomalyResultDTO parent = parents.get(key);
 
       if (parent == null || anomaly.getStartTime() - parent.getEndTime() > this.maxGap) {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/wrapper/ChildKeepingMergeWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/wrapper/ChildKeepingMergeWrapperTest.java
@@ -18,7 +18,6 @@ package com.linkedin.thirdeye.detection.wrapper;
 
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.thirdeye.datalayer.dto.DetectionConfigDTO;
-import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.detection.DataProvider;
 import com.linkedin.thirdeye.detection.DetectionPipelineResult;
 import com.linkedin.thirdeye.detection.MockDataProvider;
@@ -85,26 +84,23 @@ public class ChildKeepingMergeWrapperTest {
     this.config.setName(PROP_NAME_VALUE);
     this.config.setProperties(this.properties);
 
-    List<MergedAnomalyResultDTO> existing = new ArrayList<>();
-    existing.add(makeAnomaly(0, 1000));
-    existing.add(makeAnomaly(1500, 2000));
-
     this.outputs = new ArrayList<>();
 
     this.outputs.add(new MockPipelineOutput(Arrays.asList(
         makeAnomaly(1100, 1200),
-        makeAnomaly(2200, 2300)
+        makeAnomaly(2200, 2300),
+        makeAnomaly(0, 1000)
     ), 2900));
 
     this.outputs.add(new MockPipelineOutput(Arrays.asList(
         makeAnomaly(1150, 1250),
-        makeAnomaly(2400, 2800)
+        makeAnomaly(2400, 2800),
+        makeAnomaly(1500, 2000)
     ), 3000));
 
     MockPipelineLoader mockLoader = new MockPipelineLoader(this.runs, this.outputs);
 
     this.provider = new MockDataProvider()
-        .setAnomalies(existing)
         .setLoader(mockLoader);
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/wrapper/ChildKeepingMergeWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/wrapper/ChildKeepingMergeWrapperTest.java
@@ -25,7 +25,6 @@ import com.linkedin.thirdeye.detection.MockDataProvider;
 import com.linkedin.thirdeye.detection.MockPipeline;
 import com.linkedin.thirdeye.detection.MockPipelineLoader;
 import com.linkedin.thirdeye.detection.MockPipelineOutput;
-import com.linkedin.thirdeye.detection.wrapper.ChildKeepingMergeWrapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
- Filter out child anomaly in data provider anomaly fetching
- Fill in timezone/bucket for anomaly filter
- The final child keeping merger does not fetch anomalies from the database.
- Replay remove anomaly flag.