### PR TITLE
[TE] rootcause - Round end time after adjusting with the maxDateTime

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
@@ -104,6 +104,9 @@ public class TimeSeriesResource {
         long delta = currentEnd - maxDataTime;
         currentEnd = currentEnd - delta;
         baselineEnd = baselineStart + (currentEnd - currentStart);
+        // round again after adjusting the end time since the maxDateTime may not round with the granularity
+        currentEnd = roundEndTimeByGranularity(currentEnd, datasetConfig);
+        baselineEnd = roundEndTimeByGranularity(baselineEnd, datasetConfig);
       }
 
       long analysisDuration = currentEnd - currentStart;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
@@ -98,16 +98,14 @@ public class TimeSeriesResource {
       DatasetConfigDTO datasetConfig = DAO_REGISTRY.getDatasetConfigDAO().findByDataset(dataset);
       long maxDataTime = datasetMaxDataTimeCache.get(dataset);
 
-      currentEnd = roundEndTimeByGranularity(currentEnd, datasetConfig);
-      baselineEnd = roundEndTimeByGranularity(baselineEnd, datasetConfig);
       if (currentEnd > maxDataTime) {
         long delta = currentEnd - maxDataTime;
         currentEnd = currentEnd - delta;
         baselineEnd = baselineStart + (currentEnd - currentStart);
-        // round again after adjusting the end time since the maxDateTime may not round with the granularity
-        currentEnd = roundEndTimeByGranularity(currentEnd, datasetConfig);
-        baselineEnd = roundEndTimeByGranularity(baselineEnd, datasetConfig);
       }
+
+      currentEnd = roundEndTimeByGranularity(currentEnd, datasetConfig);
+      baselineEnd = roundEndTimeByGranularity(baselineEnd, datasetConfig);
 
       long analysisDuration = currentEnd - currentStart;
       if (baselineEnd - baselineStart != analysisDuration) {


### PR DESCRIPTION
This is to fix the last zero data point in alert page.
After adjusting the data source maxDateTime the end time doesn't align with the boundary.
Still need a fix from frontend to set the default time to round to data granularity.