### PR TITLE
add kafka simple consumer buffer and timeout to stream config

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -72,6 +73,11 @@ public class KafkaConnectionHandler {
   final Random _random = new Random();
 
   boolean isPartitionProvided;
+
+  @VisibleForTesting
+  public SimpleConsumer getSimpleConsumer() {
+    return _simpleConsumer;
+  }
 
   /**
    * A Kafka protocol error that indicates a situation that is not likely to clear up by retrying the request (for

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -42,8 +42,6 @@ import org.slf4j.LoggerFactory;
  */
 public class KafkaConnectionHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConnectionHandler.class);
-  private static final int SOCKET_TIMEOUT_MILLIS = 10000;
-  private static final int SOCKET_BUFFER_SIZE = 512000;
 
   enum ConsumerState {
     CONNECTING_TO_BOOTSTRAP_NODE,
@@ -65,6 +63,8 @@ public class KafkaConnectionHandler {
   KafkaBrokerWrapper _leader;
   String _currentHost;
   int _currentPort;
+  int _bufferSize;
+  int _socketTimeout;
 
   final KafkaSimpleConsumerFactory _simpleConsumerFactory;
   SimpleConsumer _simpleConsumer;
@@ -110,6 +110,8 @@ public class KafkaConnectionHandler {
     isPartitionProvided = false;
     _partition = Integer.MIN_VALUE;
 
+    _bufferSize = kafkaLowLevelStreamConfig.getKafkaBufferSize();
+    _socketTimeout = kafkaLowLevelStreamConfig.getKafkaSocketTimeout();
     initializeBootstrapNodeList(kafkaLowLevelStreamConfig.getBootstrapHosts());
     setCurrentState(new ConnectingToBootstrapNode());
   }
@@ -133,6 +135,8 @@ public class KafkaConnectionHandler {
     isPartitionProvided = true;
     _partition = partition;
 
+    _bufferSize = kafkaLowLevelStreamConfig.getKafkaBufferSize();
+    _socketTimeout = kafkaLowLevelStreamConfig.getKafkaSocketTimeout();
     initializeBootstrapNodeList(kafkaLowLevelStreamConfig.getBootstrapHosts());
     setCurrentState(new ConnectingToBootstrapNode());
   }
@@ -216,8 +220,8 @@ public class KafkaConnectionHandler {
 
       try {
         LOGGER.info("Connecting to bootstrap host {}:{} for topic {}", _currentHost, _currentPort, _topic);
-        _simpleConsumer = _simpleConsumerFactory.buildSimpleConsumer(_currentHost, _currentPort, SOCKET_TIMEOUT_MILLIS,
-            SOCKET_BUFFER_SIZE, _clientId);
+        _simpleConsumer = _simpleConsumerFactory.buildSimpleConsumer(_currentHost, _currentPort, _socketTimeout,
+            _bufferSize, _clientId);
         setCurrentState(new ConnectedToBootstrapNode());
       } catch (Exception e) {
         handleConsumerException(e);
@@ -326,8 +330,8 @@ public class KafkaConnectionHandler {
       // Connect to the partition leader
       try {
         _simpleConsumer =
-            _simpleConsumerFactory.buildSimpleConsumer(_leader.host(), _leader.port(), SOCKET_TIMEOUT_MILLIS,
-                SOCKET_BUFFER_SIZE, _clientId);
+            _simpleConsumerFactory.buildSimpleConsumer(_leader.host(), _leader.port(), _socketTimeout,
+                _bufferSize, _clientId);
 
         setCurrentState(new ConnectedToPartitionLeader());
       } catch (Exception e) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfig.java
@@ -49,9 +49,9 @@ public class KafkaLowLevelStreamConfig {
     String llcTimeoutKey =
         KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT);
     _bootstrapHosts = streamConfigMap.get(llcBrokerListKey);
-    _kafkaBufferSize = getConfigWithDefault(streamConfigMap, llcBufferKey,
+    _kafkaBufferSize = getIntConfigWithDefault(streamConfigMap, llcBufferKey,
         KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT);
-    _kafkaSocketTimeout = getConfigWithDefault(streamConfigMap, llcTimeoutKey,
+    _kafkaSocketTimeout = getIntConfigWithDefault(streamConfigMap, llcTimeoutKey,
         KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT_DEFAULT);
     Preconditions.checkNotNull(_bootstrapHosts,
         "Must specify kafka brokers list " + llcBrokerListKey + " in case of low level kafka consumer");
@@ -73,7 +73,7 @@ public class KafkaLowLevelStreamConfig {
     return _kafkaSocketTimeout;
   }
 
-  private int getConfigWithDefault(Map<String, String> configMap, String key, int defaultValue) {
+  private int getIntConfigWithDefault(Map<String, String> configMap, String key, int defaultValue) {
     String stringValue = configMap.get(key);
     try {
       if (StringUtils.isNotEmpty(stringValue)) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfig.java
@@ -18,6 +18,8 @@ package com.linkedin.pinot.core.realtime.impl.kafka;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import com.linkedin.pinot.core.realtime.stream.StreamConfig;
+import org.apache.commons.lang.StringUtils;
+
 import java.util.Map;
 
 
@@ -28,6 +30,8 @@ public class KafkaLowLevelStreamConfig {
 
   private String _kafkaTopicName;
   private String _bootstrapHosts;
+  private int _kafkaBufferSize;
+  private int _kafkaSocketTimeout;
 
   /**
    * Builds a wrapper around {@link StreamConfig} to fetch kafka partition level consumer related configs
@@ -40,7 +44,15 @@ public class KafkaLowLevelStreamConfig {
 
     String llcBrokerListKey =
         KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BROKER_LIST);
+    String llcBufferKey =
+        KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE);
+    String llcTimeoutKey =
+        KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT);
     _bootstrapHosts = streamConfigMap.get(llcBrokerListKey);
+    _kafkaBufferSize = getConfigWithDefault(streamConfigMap, llcBufferKey,
+        KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT);
+    _kafkaSocketTimeout = getConfigWithDefault(streamConfigMap, llcTimeoutKey,
+        KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT_DEFAULT);
     Preconditions.checkNotNull(_bootstrapHosts,
         "Must specify kafka brokers list " + llcBrokerListKey + " in case of low level kafka consumer");
   }
@@ -53,11 +65,35 @@ public class KafkaLowLevelStreamConfig {
     return _bootstrapHosts;
   }
 
+  public int getKafkaBufferSize() {
+    return _kafkaBufferSize;
+  }
+
+  public int getKafkaSocketTimeout() {
+    return _kafkaSocketTimeout;
+  }
+
+  private int getConfigWithDefault(Map<String, String> configMap, String key, int defaultValue) {
+    String stringValue = configMap.get(key);
+    try {
+      if (StringUtils.isNotEmpty(stringValue)) {
+        return Integer.parseInt(stringValue);
+      }
+      return defaultValue;
+    } catch (NumberFormatException ex) {
+      return defaultValue;
+    }
+  }
+
   @Override
   public String toString() {
-    return "KafkaLowLevelStreamConfig{" + "_kafkaTopicName='" + _kafkaTopicName + '\'' + ", _bootstrapHosts='"
-        + _bootstrapHosts + '\'' + '}';
+    return "KafkaLowLevelStreamConfig{" + "_kafkaTopicName='" + _kafkaTopicName + '\''
+        + ", _bootstrapHosts='" + _bootstrapHosts + '\''
+        + ", _kafkaBufferSize='" + _kafkaBufferSize + '\''
+        + ", _kafkaSocketTimeout='" + _kafkaSocketTimeout + '\''
+        + '}';
   }
+
 
   @Override
   public boolean equals(Object o) {
@@ -71,14 +107,18 @@ public class KafkaLowLevelStreamConfig {
 
     KafkaLowLevelStreamConfig that = (KafkaLowLevelStreamConfig) o;
 
-    return EqualityUtils.isEqual(_kafkaTopicName, that._kafkaTopicName) && EqualityUtils.isEqual(_bootstrapHosts,
-        that._bootstrapHosts);
+    return EqualityUtils.isEqual(_kafkaTopicName, that._kafkaTopicName)
+        && EqualityUtils.isEqual(_bootstrapHosts, that._bootstrapHosts)
+        && EqualityUtils.isEqual(_kafkaBufferSize, that._kafkaBufferSize)
+        && EqualityUtils.isEqual(_kafkaSocketTimeout, that._kafkaSocketTimeout);
   }
 
   @Override
   public int hashCode() {
     int result = EqualityUtils.hashCodeOf(_kafkaTopicName);
     result = EqualityUtils.hashCodeOf(result, _bootstrapHosts);
+    result = EqualityUtils.hashCodeOf(result, _kafkaBufferSize);
+    result = EqualityUtils.hashCodeOf(result, _kafkaSocketTimeout);
     return result;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
@@ -23,7 +23,6 @@ import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.io.IOException;
 import kafka.api.FetchRequestBuilder;
 import kafka.javaapi.FetchResponse;
-import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.MessageAndOffset;
 import org.slf4j.Logger;
@@ -44,11 +43,6 @@ public class KafkaPartitionLevelConsumer extends KafkaConnectionHandler implemen
   public KafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition,
       KafkaSimpleConsumerFactory kafkaSimpleConsumerFactory) {
     super(clientId, streamConfig, partition, kafkaSimpleConsumerFactory);
-  }
-
-  @VisibleForTesting
-  public SimpleConsumer getSimpleConsumer() {
-    return _simpleConsumer;
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
@@ -23,6 +23,7 @@ import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.io.IOException;
 import kafka.api.FetchRequestBuilder;
 import kafka.javaapi.FetchResponse;
+import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.MessageAndOffset;
 import org.slf4j.Logger;
@@ -43,6 +44,11 @@ public class KafkaPartitionLevelConsumer extends KafkaConnectionHandler implemen
   public KafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition,
       KafkaSimpleConsumerFactory kafkaSimpleConsumerFactory) {
     super(clientId, streamConfig, partition, kafkaSimpleConsumerFactory);
+  }
+
+  @VisibleForTesting
+  public SimpleConsumer getSimpleConsumer() {
+    return _simpleConsumer;
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
@@ -39,6 +39,10 @@ public class KafkaStreamConfigProperties {
 
   public static class LowLevelConsumer {
     public static final String KAFKA_BROKER_LIST = "kafka.broker.list";
+    public static final String KAFKA_BUFFER_SIZE = "kafka.buffer.size";
+    public static final int KAFKA_BUFFER_SIZE_DEFAULT = 512000;
+    public static final String KAFKA_SOCKET_TIMEOUT = "kafka.socket.timeout";
+    public static final int KAFKA_SOCKET_TIMEOUT_DEFAULT = 10000;
   }
 
   public static final String KAFKA_CONSUMER_PROP_PREFIX = "kafka.consumer.prop";

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfigTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfigTest.java
@@ -1,6 +1,20 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
-import com.google.common.collect.ImmutableMap;
 import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
 import org.testng.Assert;
@@ -8,9 +22,6 @@ import org.testng.annotations.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.testng.Assert.*;
-import static com.linkedin.pinot.core.realtime.impl.kafka.KafkaStreamConfigProperties.LowLevelConsumer.*;
 
 public class KafkaLowLevelStreamConfigTest {
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfigTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfigTest.java
@@ -1,0 +1,89 @@
+package com.linkedin.pinot.core.realtime.impl.kafka;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+import static com.linkedin.pinot.core.realtime.impl.kafka.KafkaStreamConfigProperties.LowLevelConsumer.*;
+
+public class KafkaLowLevelStreamConfigTest {
+
+  private KafkaLowLevelStreamConfig getStreamConfig(String topic, String bootstrapHosts, String buffer, String socketTimeout) {
+    Map<String, String> streamConfigMap = new HashMap<>();
+    String streamType = "kafka";
+    String consumerType = StreamConfig.ConsumerType.LOWLEVEL.toString();
+    String consumerFactoryClassName = KafkaConsumerFactory.class.getName();
+    String decoderClass = KafkaAvroMessageDecoder.class.getName();
+    streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), topic);
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
+        consumerType);
+    streamConfigMap.put(StreamConfigProperties.constructStreamProperty(streamType,
+        StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS), consumerFactoryClassName);
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
+        decoderClass);
+    streamConfigMap.put("stream.kafka.broker.list", bootstrapHosts);
+    if (buffer != null) {
+      streamConfigMap.put("stream.kafka.buffer.size", buffer);
+    }
+    if (socketTimeout != null) {
+      streamConfigMap.put("stream.kafka.socket.timeout", String.valueOf(socketTimeout));
+    }
+    return new KafkaLowLevelStreamConfig(new StreamConfig(streamConfigMap));
+  }
+
+  @Test
+  public void testGetKafkaTopicName() {
+    KafkaLowLevelStreamConfig config = getStreamConfig("topic", "", "", "");
+    Assert.assertEquals("topic", config.getKafkaTopicName());
+  }
+
+  @Test
+  public void testGetBootstrapHosts() {
+    KafkaLowLevelStreamConfig config = getStreamConfig("topic", "host1", "", "");
+    Assert.assertEquals("host1", config.getBootstrapHosts());
+  }
+
+  @Test
+  public void testGetKafkaBufferSize() {
+    // test default
+    KafkaLowLevelStreamConfig config = getStreamConfig("topic", "host1", null, "");
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT, config.getKafkaBufferSize());
+
+    config = getStreamConfig("topic", "host1", "", "");
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT, config.getKafkaBufferSize());
+
+    config = getStreamConfig("topic", "host1", "bad value", "");
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT, config.getKafkaBufferSize());
+
+    // correct config
+    config = getStreamConfig("topic", "host1", "100", "");
+    Assert.assertEquals(100, config.getKafkaBufferSize());
+  }
+
+  @Test
+  public void testGetKafkaSocketTimeout() {
+    // test default
+    KafkaLowLevelStreamConfig config = getStreamConfig("topic", "host1", "",null);
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT_DEFAULT, config.getKafkaSocketTimeout());
+
+    config = getStreamConfig("topic", "host1", "","");
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT_DEFAULT, config.getKafkaSocketTimeout());
+
+    config = getStreamConfig("topic", "host1", "","bad value");
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT_DEFAULT, config.getKafkaSocketTimeout());
+
+    // correct config
+    config = getStreamConfig("topic", "host1", "", "100");
+    Assert.assertEquals(100, config.getKafkaSocketTimeout());
+  }
+}


### PR DESCRIPTION
When the kafka broker cluster has max message size config bigger than our current hard-coded value of low-level consumer buffer size (512K), pinot kafka consumer could encounter messages from kafka that are bigger than our buffer size. When this happens, kafka low-level consumer will fail silently and returns an empty message result list to low-level message ingester. From pinot users' point of view, pinot kafka low-level consumer stuck at the large message offset. This change aims to allow users to define their kafka ingestor buffer size so it can handle the failure scenarios above.