### PR TITLE
[PINOT-7461] Fix segment deletion when folder under Deleted_Segment location does not exist

### DIFF
--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -80,6 +80,9 @@ public class LocalPinotFS extends PinotFS {
         // dst file exists, returning
         return false;
       }
+    } else {
+      // ensure the dst path exists
+      FileUtils.forceMkdir(dstFile.getParentFile());
     }
 
     Files.move(srcFile.toPath(), dstFile.toPath());


### PR DESCRIPTION
Segment deletion fails when the table-name folder does not exist in the deleted-segments directory (see exception at the end). 

This change fixes the code to ensure that the parent folders in the path always exist and adds tests that cover moving:
1. src-file to non-existent folder
2. src-folder to non-existent folder.
Existing test already cover moving src-folder to existing folder.

2018/12/06 23:49:14.795 WARN [SegmentDeletionManager] [PinotHelixResourceManagerExecutorService] [pinot-controller] [] Could not move segment <segmentname> from <srcpath> to <Deleted_Segments path>/tableName/<segmentname>
java.nio.file.NoSuchFileException: <srcpath>/<segmentname> -> <Deleted_Segments path>/tableName/<segmentname>
at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
at sun.nio.fs.UnixCopyFile.move(UnixCopyFile.java:457)
at sun.nio.fs.UnixFileSystemProvider.move(UnixFileSystemProvider.java:262)
at java.nio.file.Files.move(Files.java:1395)
at com.linkedin.pinot.filesystem.LocalPinotFS.move(LocalPinotFS.java:85)
at com.linkedin.pinot.controller.helix.core.SegmentDeletionManager.removeSegmentFromStore(SegmentDeletionManager.java:184)
at com.linkedin.pinot.controller.helix.core.SegmentDeletionManager.removeSegmentsFromStore(SegmentDeletionManager.java:166)
at com.linkedin.pinot.controller.helix.core.SegmentDeletionManager.deleteSegmentFromPropertyStoreAndLocal(SegmentDeletionManager.java:150)
at com.linkedin.pinot.controller.helix.core.SegmentDeletionManager$2.run(SegmentDeletionManager.java:91)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)