### PR TITLE
Add stop method in PinotLLCRealtimeSegmentManager

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -293,6 +293,9 @@ public class ControllerStarter {
       LOGGER.info("Stopping Jersey admin API");
       _adminApp.stop();
 
+      LOGGER.info("Stopping PinotLLCRealtimeSegmentManager");
+      PinotLLCRealtimeSegmentManager.getInstance().stop();
+
       LOGGER.info("Stopping realtime segment manager");
       _realtimeSegmentsManager.stop();
 


### PR DESCRIPTION
Commit segment metadata happens in 3 zk updates 1) consuming segment metadata update 2) new segment metadata creation 3) ideal state update. If the controller shuts down after 1 and before 3, we will end up in a state where the partition will not consume. The validation manager will fix this when it runs (currently runs every 1 hour), but this delay might not be acceptable for certain scenarios. 
Adding a stop method to the PinotLLCRealtimeSegmentManager, which will wait 30 seconds before stopping. This time will allow any segment metadata commits which were in progress, to complete. We will also prevent any new segment metadata commits once the shutdown has been invoked.