### PR TITLE
[TE] datasource - correction for maxtime offset in pinot datasource

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/TimeGranularity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/TimeGranularity.java
@@ -19,6 +19,8 @@ package com.linkedin.thirdeye.api;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.DurationFieldType;
 import org.joda.time.Period;
 import org.joda.time.PeriodType;
@@ -74,6 +76,29 @@ public class TimeGranularity {
    */
   public long toMillis(long number) {
     return unit.toMillis(number * size);
+  }
+
+  /**
+   * Returns the equivalent milliseconds of the specified number of this time granularity,
+   * given a time zone.
+   *
+   * @param number the specified number of this time granularity.
+   * @param timeZone the time zone to base the timestamp off of
+   * @return the timestamp in millis
+   */
+  public long toMillis(long number, DateTimeZone timeZone) {
+    if (number > Integer.MAX_VALUE) {
+      switch (this.getUnit()) {
+        case MILLISECONDS:
+          return number;
+        case SECONDS:
+          return number * 1000;
+        default:
+          throw new IllegalArgumentException("epoch offset too large");
+      }
+    }
+
+    return new DateTime(0, timeZone).plus(this.toPeriod((int) number)).getMillis();
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
@@ -71,7 +71,7 @@ public class PinotDataSourceDimensionFilters {
       // left blank
     }
 
-    DateTime endDateTime = new DateTime(maxTime);
+    DateTime endDateTime = new DateTime(maxTime).plusMillis(1);
     DateTime startDateTime = endDateTime.minusDays(7);
 
     Map<String, List<String>> filters = null;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceMaxTime.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceMaxTime.java
@@ -26,8 +26,10 @@ import com.linkedin.thirdeye.util.ThirdEyeUtils;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -41,7 +43,7 @@ public class PinotDataSourceMaxTime {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotDataSourceMaxTime.class);
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
-  private final static String COLLECTION_MAX_TIME_QUERY_TEMPLATE = "SELECT max(%s) FROM %s WHERE %s >= %s";
+  private final static String COLLECTION_MAX_TIME_QUERY_TEMPLATE = "SELECT max(%s) FROM %s WHERE %s";
 
   private final Map<String, Long> collectionToPrevMaxDataTimeMap = new ConcurrentHashMap<String, Long>();
   private final PinotThirdEyeDataSource pinotThirdEyeDataSource;
@@ -63,9 +65,11 @@ public class PinotDataSourceMaxTime {
       // By default, query only offline, unless dataset has been marked as realtime
       String tableName = ThirdEyeUtils.computeTableName(dataset);
       TimeSpec timeSpec = ThirdEyeUtils.getTimestampTimeSpecFromDatasetConfig(datasetConfig);
-      long prevMaxDataTime = getPrevMaxDataTime(dataset);
-      String maxTimePql = String.format(COLLECTION_MAX_TIME_QUERY_TEMPLATE, timeSpec.getColumnName(), tableName,
-          timeSpec.getColumnName(), prevMaxDataTime);
+
+      long cutoffTime = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);
+      String timeClause = PqlUtils.getBetweenClause(new DateTime(0, DateTimeZone.UTC), new DateTime(cutoffTime, DateTimeZone.UTC), timeSpec, dataset);
+
+      String maxTimePql = String.format(COLLECTION_MAX_TIME_QUERY_TEMPLATE, timeSpec.getColumnName(), tableName, timeClause);
       PinotQuery maxTimePinotQuery = new PinotQuery(maxTimePql, tableName);
 
       ThirdEyeResultSetGroup resultSetGroup;
@@ -83,15 +87,17 @@ public class PinotDataSourceMaxTime {
         LOGGER.error("Failed to get latest max time for dataset {} with PQL: {}", tableName, maxTimePinotQuery.getPql());
         this.collectionToPrevMaxDataTimeMap.remove(dataset);
       } else {
+        DateTimeZone timeZone = Utils.getDataTimeZone(dataset);
+
         long endTime = new Double(resultSetGroup.get(0).getDouble(0)).longValue();
         this.collectionToPrevMaxDataTimeMap.put(dataset, endTime);
         // endTime + 1 to make sure we cover the time range of that time value.
         String timeFormat = timeSpec.getFormat();
         if (StringUtils.isBlank(timeFormat) || TimeSpec.SINCE_EPOCH_FORMAT.equals(timeFormat)) {
-          maxTime = timeSpec.getDataGranularity().toMillis(endTime + 1) - 1;
+          maxTime = timeSpec.getDataGranularity().toMillis(endTime + 1, timeZone) - 1;
         } else {
           DateTimeFormatter inputDataDateTimeFormatter =
-              DateTimeFormat.forPattern(timeFormat).withZone(Utils.getDataTimeZone(dataset));
+              DateTimeFormat.forPattern(timeFormat).withZone(timeZone);
           DateTime endDateTime = DateTime.parse(String.valueOf(endTime), inputDataDateTimeFormatter);
           Period oneBucket = datasetConfig.bucketTimeGranularity().toPeriod();
           maxTime = endDateTime.plus(oneBucket).getMillis() - 1;
@@ -105,12 +111,5 @@ public class PinotDataSourceMaxTime {
       maxTime = System.currentTimeMillis();
     }
     return maxTime;
-  }
-
-  private long getPrevMaxDataTime(String collection) {
-    if (this.collectionToPrevMaxDataTimeMap.containsKey(collection)) {
-      return collectionToPrevMaxDataTimeMap.get(collection);
-    }
-    return 0;
   }
 }


### PR DESCRIPTION
This PR fixes the time offset as computed by the pinot data source max time fetcher. Previously, this method computed offsets from epoch without considering the time zone of the underlying data set. Additionally, the PR adds a sanity cutoff for the max time within 1 day in the future from the current timestamp. As a consequence this PR also fixes retrieval of dimension filter keys and values on data sets with a time granularity > 1 week.