### PR TITLE
Fix segment merge command.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/MultiplePinotSegmentRecordReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/MultiplePinotSegmentRecordReader.java
@@ -147,15 +147,14 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
       return reuse;
     } else {
       // If there is no sorted column specified, simply concatenate the segments
-      PinotSegmentRecordReader currentReader = _pinotSegmentRecordReaders.get(_currentReaderId);
-      if (!currentReader.hasNext()) {
-        _currentReaderId++;
-        if (_currentReaderId >= _pinotSegmentRecordReaders.size()) {
-          throw new RuntimeException("next is called after reading all data");
+      for (int i = 0; i < _pinotSegmentRecordReaders.size();
+          i++, _currentReaderId = (_currentReaderId + 1) % _pinotSegmentRecordReaders.size()) {
+        PinotSegmentRecordReader currentReader = _pinotSegmentRecordReaders.get(_currentReaderId);
+        if (currentReader.hasNext()) {
+          return currentReader.next(reuse);
         }
-        currentReader = _pinotSegmentRecordReaders.get(_currentReaderId);
       }
-      return currentReader.next(reuse);
+      throw new RuntimeException("next is called after reading all data");
     }
   }
 


### PR DESCRIPTION
Some old pinot segments were allowed with 0 documents. Considering those documents for start/end time
causes minStartTime to become 0, an invalid value if auto-naming of segments is chosen.

Also, the multi-reader did not allow for the fact that some segments may be smaller than others, so
we need to iterate through all segments before throwing an exception.