### PR TITLE
Refactor ControllerPeriodicTask to iterate over tables 

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -90,7 +90,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
   }
 
   @Override
-  public void preprocess() {
+  protected void preprocess() {
     _realTimeTableCount = 0;
     _offlineTableCount = 0;
     _disabledTableCount = 0;
@@ -106,12 +106,12 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(String tableNameWithType) {
+  protected void process(String tableNameWithType) {
     updateSegmentMetrics(tableNameWithType);
   }
 
   @Override
-  public void postprocess() {
+  protected void postprocess() {
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.REALTIME_TABLE_COUNT, _realTimeTableCount);
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.OFFLINE_TABLE_COUNT, _offlineTableCount);
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT, _disabledTableCount);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -106,7 +106,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
   }
 
   @Override
-  protected void process(String tableNameWithType) {
+  protected void processTable(String tableNameWithType) {
     updateSegmentMetrics(tableNameWithType);
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -47,13 +47,19 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
   public static final String ERROR = "ERROR";
   public static final String CONSUMING = "CONSUMING";
   private final ControllerMetrics _metricsRegistry;
-  private final ControllerConf _config;
   private final HelixAdmin _helixAdmin;
+  private final String _helixClusterName;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private final int _waitForPushTimeSeconds;
 
   // log messages about disabled tables atmost once a day
   private static final long DISABLED_TABLE_LOG_INTERVAL_MS = TimeUnit.DAYS.toMillis(1);
   private long _lastDisabledTableLogTimestamp = 0;
+  private boolean _logDisabledTables;
+  private int _realTimeTableCount;
+  private int _offlineTableCount;
+  private int _disabledTableCount;
+
 
   /**
    * Constructs the segment status checker.
@@ -64,7 +70,9 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
       ControllerMetrics metricsRegistry) {
     super("SegmentStatusChecker", config.getStatusCheckerFrequencyInSeconds(), pinotHelixResourceManager);
     _helixAdmin = pinotHelixResourceManager.getHelixAdmin();
-    _config = config;
+    _helixClusterName = pinotHelixResourceManager.getHelixClusterName();
+    _propertyStore = _pinotHelixResourceManager.getPropertyStore();
+
     _waitForPushTimeSeconds = config.getStatusCheckerWaitForPushTimeInSeconds();
     _metricsRegistry = metricsRegistry;
   }
@@ -82,166 +90,167 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(List<String> tables) {
-    updateSegmentMetrics(tables);
+  public void preprocess() {
+    _realTimeTableCount = 0;
+    _offlineTableCount = 0;
+    _disabledTableCount = 0;
+
+    // check if we need to log disabled tables log messages
+    long now = System.currentTimeMillis();
+    if (now - _lastDisabledTableLogTimestamp >= DISABLED_TABLE_LOG_INTERVAL_MS) {
+      _logDisabledTables = true;
+      _lastDisabledTableLogTimestamp = now;
+    } else {
+      _logDisabledTables = false;
+    }
+  }
+
+  @Override
+  public void process(String tableNameWithType) {
+    updateSegmentMetrics(tableNameWithType);
+  }
+
+  @Override
+  public void postprocess() {
+    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.REALTIME_TABLE_COUNT, _realTimeTableCount);
+    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.OFFLINE_TABLE_COUNT, _offlineTableCount);
+    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT, _disabledTableCount);
   }
 
   /**
-   * Runs a segment status pass over the given tables.
+   * Runs a segment status pass over the given table.
    * TODO: revisit the logic and reduce the ZK access
    *
-   * @param tables List of table names
+   * @param tableNameWithType
    */
-  private void updateSegmentMetrics(List<String> tables) {
-    // Fetch the list of tables
-    String helixClusterName = _pinotHelixResourceManager.getHelixClusterName();
-    HelixAdmin helixAdmin = _pinotHelixResourceManager.getHelixAdmin();
-    int realTimeTableCount = 0;
-    int offlineTableCount = 0;
-    int disabledTableCount = 0;
-    ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
+  private void updateSegmentMetrics(String tableNameWithType) {
 
-    // check if we need to log disabled tables log messages
-    boolean logDisabledTables = false;
-    long now = System.currentTimeMillis();
-    if (now - _lastDisabledTableLogTimestamp >= DISABLED_TABLE_LOG_INTERVAL_MS) {
-      logDisabledTables = true;
-      _lastDisabledTableLogTimestamp = now;
-    } else {
-      logDisabledTables = false;
-    }
-
-    for (String tableName : tables) {
-      try {
-        if (TableNameBuilder.getTableTypeFromTableName(tableName) == TableType.OFFLINE) {
-          offlineTableCount++;
-        } else {
-          realTimeTableCount++;
-        }
-        IdealState idealState = helixAdmin.getResourceIdealState(helixClusterName, tableName);
-        if ((idealState == null) || (idealState.getPartitionSet().isEmpty())) {
-          int nReplicasFromIdealState = 1;
-          try {
-            if (idealState != null) {
-              nReplicasFromIdealState = Integer.valueOf(idealState.getReplicas());
-            }
-          } catch (NumberFormatException e) {
-            // Ignore
-          }
-          _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.NUMBER_OF_REPLICAS, nReplicasFromIdealState);
-          _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.PERCENT_OF_REPLICAS, 100);
-          _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE, 100);
-          continue;
-        }
-
-        if (!idealState.isEnabled()) {
-          if (logDisabledTables) {
-            LOGGER.warn("Table {} is disabled. Skipping segment status checks", tableName);
-          }
-          resetTableMetrics(tableName);
-          disabledTableCount++;
-          continue;
-        }
-
-        _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.IDEALSTATE_ZNODE_SIZE,
-            idealState.toString().length());
-        _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.SEGMENT_COUNT,
-            (long) (idealState.getPartitionSet().size()));
-        ExternalView externalView = helixAdmin.getResourceExternalView(helixClusterName, tableName);
-
-        int nReplicasIdealMax = 0; // Keeps track of maximum number of replicas in ideal state
-        int nReplicasExternal = -1; // Keeps track of minimum number of replicas in external view
-        int nErrors = 0; // Keeps track of number of segments in error state
-        int nOffline = 0; // Keeps track of number segments with no online replicas
-        int nSegments = 0; // Counts number of segments
-        for (String partitionName : idealState.getPartitionSet()) {
-          int nReplicas = 0;
-          int nIdeal = 0;
-          nSegments++;
-          // Skip segments not online in ideal state
-          for (Map.Entry<String, String> serverAndState : idealState.getInstanceStateMap(partitionName).entrySet()) {
-            if (serverAndState == null) {
-              break;
-            }
-            if (serverAndState.getValue().equals(ONLINE)) {
-              nIdeal++;
-              break;
-            }
-          }
-          if (nIdeal == 0) {
-            // No online segments in ideal state
-            continue;
-          }
-          nReplicasIdealMax = (idealState.getInstanceStateMap(partitionName).size() > nReplicasIdealMax)
-              ? idealState.getInstanceStateMap(partitionName).size() : nReplicasIdealMax;
-          if ((externalView == null) || (externalView.getStateMap(partitionName) == null)) {
-            // No replicas for this segment
-            TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
-            if ((tableType != null) && (tableType.equals(TableType.OFFLINE))) {
-              OfflineSegmentZKMetadata segmentZKMetadata =
-                  ZKMetadataProvider.getOfflineSegmentZKMetadata(propertyStore, tableName, partitionName);
-              if (segmentZKMetadata != null
-                  && segmentZKMetadata.getPushTime() > System.currentTimeMillis() - _waitForPushTimeSeconds * 1000) {
-                // push not yet finished, skip
-                continue;
-              }
-            }
-            nOffline++;
-            if (nOffline < MaxOfflineSegmentsToLog) {
-              LOGGER.warn("Segment {} of table {} has no replicas", partitionName, tableName);
-            }
-            nReplicasExternal = 0;
-            continue;
-          }
-          for (Map.Entry<String, String> serverAndState : externalView.getStateMap(partitionName).entrySet()) {
-            // Count number of online replicas. Ignore if state is CONSUMING.
-            // It is possible for a segment to be ONLINE in idealstate, and CONSUMING in EV for a short period of time.
-            // So, ignore this combination. If a segment exists in this combination for a long time, we will get
-            // low level-partition-not-consuming alert anyway.
-            if (serverAndState.getValue().equals(ONLINE) || serverAndState.getValue().equals(CONSUMING)) {
-              nReplicas++;
-            }
-            if (serverAndState.getValue().equals(ERROR)) {
-              nErrors++;
-            }
-          }
-          if (nReplicas == 0) {
-            if (nOffline < MaxOfflineSegmentsToLog) {
-              LOGGER.warn("Segment {} of table {} has no online replicas", partitionName, tableName);
-            }
-            nOffline++;
-          }
-          nReplicasExternal =
-              ((nReplicasExternal > nReplicas) || (nReplicasExternal == -1)) ? nReplicas : nReplicasExternal;
-        }
-        if (nReplicasExternal == -1) {
-          nReplicasExternal = (nReplicasIdealMax == 0) ? 1 : 0;
-        }
-        // Synchronization provided by Controller Gauge to make sure that only one thread updates the gauge
-        _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.NUMBER_OF_REPLICAS, nReplicasExternal);
-        _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.PERCENT_OF_REPLICAS,
-            (nReplicasIdealMax > 0) ? (nReplicasExternal * 100 / nReplicasIdealMax) : 100);
-        _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.SEGMENTS_IN_ERROR_STATE, nErrors);
-        _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE,
-            (nSegments > 0) ? (100 - (nOffline * 100 / nSegments)) : 100);
-        if (nOffline > 0) {
-          LOGGER.warn("Table {} has {} segments with no online replicas", tableName, nOffline);
-        }
-        if (nReplicasExternal < nReplicasIdealMax) {
-          LOGGER.warn("Table {} has {} replicas, below replication threshold :{}", tableName, nReplicasExternal,
-              nReplicasIdealMax);
-        }
-      } catch (Exception e) {
-        LOGGER.warn("Caught exception while updating segment status for table {}", e, tableName);
-
-        // Remove the metric for this table
-        resetTableMetrics(tableName);
+    try {
+      if (TableNameBuilder.getTableTypeFromTableName(tableNameWithType) == TableType.OFFLINE) {
+        _offlineTableCount++;
+      } else {
+        _realTimeTableCount++;
       }
-    }
+      IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableNameWithType);
+      if ((idealState == null) || (idealState.getPartitionSet().isEmpty())) {
+        int nReplicasFromIdealState = 1;
+        try {
+          if (idealState != null) {
+            nReplicasFromIdealState = Integer.valueOf(idealState.getReplicas());
+          }
+        } catch (NumberFormatException e) {
+          // Ignore
+        }
+        _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.NUMBER_OF_REPLICAS, nReplicasFromIdealState);
+        _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_OF_REPLICAS, 100);
+        _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE, 100);
+        return;
+      }
 
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.REALTIME_TABLE_COUNT, realTimeTableCount);
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.OFFLINE_TABLE_COUNT, offlineTableCount);
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT, disabledTableCount);
+      if (!idealState.isEnabled()) {
+        if (_logDisabledTables) {
+          LOGGER.warn("Table {} is disabled. Skipping segment status checks", tableNameWithType);
+        }
+        resetTableMetrics(tableNameWithType);
+        _disabledTableCount++;
+        return;
+      }
+
+      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_SIZE,
+          idealState.toString().length());
+      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENT_COUNT,
+          (long) (idealState.getPartitionSet().size()));
+      ExternalView externalView = _helixAdmin.getResourceExternalView(_helixClusterName, tableNameWithType);
+
+      int nReplicasIdealMax = 0; // Keeps track of maximum number of replicas in ideal state
+      int nReplicasExternal = -1; // Keeps track of minimum number of replicas in external view
+      int nErrors = 0; // Keeps track of number of segments in error state
+      int nOffline = 0; // Keeps track of number segments with no online replicas
+      int nSegments = 0; // Counts number of segments
+      for (String partitionName : idealState.getPartitionSet()) {
+        int nReplicas = 0;
+        int nIdeal = 0;
+        nSegments++;
+        // Skip segments not online in ideal state
+        for (Map.Entry<String, String> serverAndState : idealState.getInstanceStateMap(partitionName).entrySet()) {
+          if (serverAndState == null) {
+            break;
+          }
+          if (serverAndState.getValue().equals(ONLINE)) {
+            nIdeal++;
+            break;
+          }
+        }
+        if (nIdeal == 0) {
+          // No online segments in ideal state
+          continue;
+        }
+        nReplicasIdealMax =
+            (idealState.getInstanceStateMap(partitionName).size() > nReplicasIdealMax) ? idealState.getInstanceStateMap(
+                partitionName).size() : nReplicasIdealMax;
+        if ((externalView == null) || (externalView.getStateMap(partitionName) == null)) {
+          // No replicas for this segment
+          TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+          if ((tableType != null) && (tableType.equals(TableType.OFFLINE))) {
+            OfflineSegmentZKMetadata segmentZKMetadata =
+                ZKMetadataProvider.getOfflineSegmentZKMetadata(_propertyStore, tableNameWithType, partitionName);
+            if (segmentZKMetadata != null
+                && segmentZKMetadata.getPushTime() > System.currentTimeMillis() - _waitForPushTimeSeconds * 1000) {
+              // push not yet finished, skip
+              continue;
+            }
+          }
+          nOffline++;
+          if (nOffline < MaxOfflineSegmentsToLog) {
+            LOGGER.warn("Segment {} of table {} has no replicas", partitionName, tableNameWithType);
+          }
+          nReplicasExternal = 0;
+          continue;
+        }
+        for (Map.Entry<String, String> serverAndState : externalView.getStateMap(partitionName).entrySet()) {
+          // Count number of online replicas. Ignore if state is CONSUMING.
+          // It is possible for a segment to be ONLINE in idealstate, and CONSUMING in EV for a short period of time.
+          // So, ignore this combination. If a segment exists in this combination for a long time, we will get
+          // low level-partition-not-consuming alert anyway.
+          if (serverAndState.getValue().equals(ONLINE) || serverAndState.getValue().equals(CONSUMING)) {
+            nReplicas++;
+          }
+          if (serverAndState.getValue().equals(ERROR)) {
+            nErrors++;
+          }
+        }
+        if (nReplicas == 0) {
+          if (nOffline < MaxOfflineSegmentsToLog) {
+            LOGGER.warn("Segment {} of table {} has no online replicas", partitionName, tableNameWithType);
+          }
+          nOffline++;
+        }
+        nReplicasExternal =
+            ((nReplicasExternal > nReplicas) || (nReplicasExternal == -1)) ? nReplicas : nReplicasExternal;
+      }
+      if (nReplicasExternal == -1) {
+        nReplicasExternal = (nReplicasIdealMax == 0) ? 1 : 0;
+      }
+      // Synchronization provided by Controller Gauge to make sure that only one thread updates the gauge
+      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.NUMBER_OF_REPLICAS, nReplicasExternal);
+      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_OF_REPLICAS,
+          (nReplicasIdealMax > 0) ? (nReplicasExternal * 100 / nReplicasIdealMax) : 100);
+      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENTS_IN_ERROR_STATE, nErrors);
+      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE,
+          (nSegments > 0) ? (100 - (nOffline * 100 / nSegments)) : 100);
+      if (nOffline > 0) {
+        LOGGER.warn("Table {} has {} segments with no online replicas", tableNameWithType, nOffline);
+      }
+      if (nReplicasExternal < nReplicasIdealMax) {
+        LOGGER.warn("Table {} has {} replicas, below replication threshold :{}", tableNameWithType, nReplicasExternal,
+            nReplicasIdealMax);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while updating segment status for table {}", e, tableNameWithType);
+
+      // Remove the metric for this table
+      resetTableMetrics(tableNameWithType);
+    }
   }
 
   private void setStatusToDefault() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -160,7 +160,7 @@ public class PinotTaskManager extends ControllerPeriodicTask {
    * Returns the tasks that have been scheduled as part of the postprocess
    * @return
    */
-  public Map<String, String> getTasksScheduled() {
+  private Map<String, String> getTasksScheduled() {
     return _tasksScheduled;
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -123,7 +123,7 @@ public class PinotTaskManager extends ControllerPeriodicTask {
   }
 
   @Override
-  protected void process(String tableNameWithType) {
+  protected void processTable(String tableNameWithType) {
     TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
     if (tableConfig != null) {
       TableTaskConfig taskConfig = tableConfig.getTaskConfig();

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -124,7 +124,7 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
   protected abstract void preprocess();
 
   /**
-   * Process the controller periodic task for the given table
+   * Execute the controller periodic task for the given table
    * @param tableNameWithType
    */
   protected abstract void process(String tableNameWithType);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -110,7 +110,29 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
    *
    * @param tables List of table names
    */
-  public abstract void process(List<String> tables);
+  protected void process(List<String> tables) {
+    preprocess();
+    for (String table : tables) {
+      process(table);
+    }
+    postprocess();
+  }
+
+  /**
+   * This method runs before processing all tables
+   */
+  protected abstract void preprocess();
+
+  /**
+   * Process the controller periodic task for the given table
+   * @param tableNameWithType
+   */
+  protected abstract void process(String tableNameWithType);
+
+  /**
+   * This method runs after processing all tables
+   */
+  protected abstract void postprocess();
 
   @VisibleForTesting
   protected boolean isLeader() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -113,7 +113,7 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
   protected void process(List<String> tables) {
     preprocess();
     for (String table : tables) {
-      process(table);
+      processTable(table);
     }
     postprocess();
   }
@@ -127,7 +127,7 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
    * Execute the controller periodic task for the given table
    * @param tableNameWithType
    */
-  protected abstract void process(String tableNameWithType);
+  protected abstract void processTable(String tableNameWithType);
 
   /**
    * This method runs after processing all tables

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -58,51 +58,59 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(List<String> tables) {
-    runRelocation(tables);
+  protected void preprocess() {
+
+  }
+
+  @Override
+  protected void process(String tableNameWithType) {
+    runRelocation(tableNameWithType);
+  }
+
+  @Override
+  protected void postprocess() {
+
   }
 
   /**
-   * Check the given tables. Perform relocation of segments if table is realtime and relocation is required
+   * Check the given table. Perform relocation of segments if table is realtime and relocation is required
    * TODO: Model this to implement {@link com.linkedin.pinot.controller.helix.core.rebalance.RebalanceSegmentStrategy} interface
    * https://github.com/linkedin/pinot/issues/2609
    *
-   * @param tables List of table names
+   * @param tableNameWithType
    */
-  private void runRelocation(List<String> tables) {
-    for (String tableNameWithType : tables) {
-      // Only consider realtime tables.
-      if (!TableNameBuilder.REALTIME.tableHasTypeSuffix(tableNameWithType)) {
-        continue;
+  private void runRelocation(String tableNameWithType) {
+    // Only consider realtime tables.
+    if (!TableNameBuilder.REALTIME.tableHasTypeSuffix(tableNameWithType)) {
+      return;
+    }
+    try {
+      LOGGER.info("Starting relocation of segments for table: {}", tableNameWithType);
+
+      TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableNameWithType);
+      final RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(tableConfig);
+      if (!realtimeTagConfig.isRelocateCompletedSegments()) {
+        LOGGER.info("Skipping relocation of segments for {}", tableNameWithType);
+        return;
       }
-      try {
-        LOGGER.info("Starting relocation of segments for table: {}", tableNameWithType);
 
-        TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableNameWithType);
-        final RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(tableConfig);
-        if (!realtimeTagConfig.isRelocateCompletedSegments()) {
-          LOGGER.info("Skipping relocation of segments for {}", tableNameWithType);
-          continue;
-        }
-
-        Function<IdealState, IdealState> updater = new Function<IdealState, IdealState>() {
-          @Nullable
-          @Override
-          public IdealState apply(@Nullable IdealState idealState) {
-            if (!idealState.isEnabled()) {
-              LOGGER.info("Skipping relocation of segments for {} since ideal state is disabled", tableNameWithType);
-              return null;
-            }
-            relocateSegments(realtimeTagConfig, idealState);
-            return idealState;
+      Function<IdealState, IdealState> updater = new Function<IdealState, IdealState>() {
+        @Nullable
+        @Override
+        public IdealState apply(@Nullable IdealState idealState) {
+          if (!idealState.isEnabled()) {
+            LOGGER.info("Skipping relocation of segments for {} since ideal state is disabled", tableNameWithType);
+            return null;
           }
-        };
+          relocateSegments(realtimeTagConfig, idealState);
+          return idealState;
+        }
+      };
 
-        HelixHelper.updateIdealState(_pinotHelixResourceManager.getHelixZkManager(), tableNameWithType, updater,
-            RetryPolicies.exponentialBackoffRetryPolicy(5, 1000, 2.0f));
-      } catch (Exception e) {
-        LOGGER.error("Exception in relocating realtime segments of table {}", tableNameWithType, e);
-      }
+      HelixHelper.updateIdealState(_pinotHelixResourceManager.getHelixZkManager(), tableNameWithType, updater,
+          RetryPolicies.exponentialBackoffRetryPolicy(5, 1000, 2.0f));
+    } catch (Exception e) {
+      LOGGER.error("Exception in relocating realtime segments of table {}", tableNameWithType, e);
     }
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -63,7 +63,7 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
   }
 
   @Override
-  protected void process(String tableNameWithType) {
+  protected void processTable(String tableNameWithType) {
     runRelocation(tableNameWithType);
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
@@ -62,27 +62,24 @@ public class RetentionManager extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(List<String> tables) {
-    execute(tables);
+  protected void preprocess() {
+
   }
 
-  /**
-   * Manages retention for the given tables.
-   *
-   * @param tables List of table names
-   */
-  private void execute(List<String> tables) {
+  @Override
+  protected void process(String tableNameWithType) {
     try {
-      for (String tableNameWithType : tables) {
-        LOGGER.info("Start managing retention for table: {}", tableNameWithType);
-        manageRetentionForTable(tableNameWithType);
-      }
-
-      LOGGER.info("Removing aged (more than {} days) deleted segments for all tables", _deletedSegmentsRetentionInDays);
-      _pinotHelixResourceManager.getSegmentDeletionManager().removeAgedDeletedSegments(_deletedSegmentsRetentionInDays);
+      LOGGER.info("Start managing retention for table: {}", tableNameWithType);
+      manageRetentionForTable(tableNameWithType);
     } catch (Exception e) {
       LOGGER.error("Caught exception while managing retention for all tables", e);
     }
+  }
+
+  @Override
+  protected void postprocess() {
+    LOGGER.info("Removing aged (more than {} days) deleted segments for all tables", _deletedSegmentsRetentionInDays);
+    _pinotHelixResourceManager.getSegmentDeletionManager().removeAgedDeletedSegments(_deletedSegmentsRetentionInDays);
   }
 
   private void manageRetentionForTable(String tableNameWithType) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
@@ -67,7 +67,7 @@ public class RetentionManager extends ControllerPeriodicTask {
   }
 
   @Override
-  protected void process(String tableNameWithType) {
+  protected void processTable(String tableNameWithType) {
     try {
       LOGGER.info("Start managing retention for table: {}", tableNameWithType);
       manageRetentionForTable(tableNameWithType);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -76,7 +76,7 @@ public class ValidationManager extends ControllerPeriodicTask {
   }
 
   @Override
-  public void preprocess() {
+  protected void preprocess() {
     // Run segment level validation using a separate interval
     _runSegmentLevelValidation = false;
     long currentTimeMs = System.currentTimeMillis();
@@ -92,12 +92,12 @@ public class ValidationManager extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(String tableNameWithType) {
+  protected void process(String tableNameWithType) {
     runValidation(tableNameWithType);
   }
 
   @Override
-  public void postprocess() {
+  protected void postprocess() {
 
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -92,7 +92,7 @@ public class ValidationManager extends ControllerPeriodicTask {
   }
 
   @Override
-  protected void process(String tableNameWithType) {
+  protected void processTable(String tableNameWithType) {
     runValidation(tableNameWithType);
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -23,7 +23,7 @@ import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metrics.ValidationMetrics;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.HLCSegmentName;
 import com.linkedin.pinot.common.utils.SegmentName;
 import com.linkedin.pinot.common.utils.time.TimeUtils;
@@ -57,6 +57,8 @@ public class ValidationManager extends ControllerPeriodicTask {
   private final ValidationMetrics _validationMetrics;
 
   private long _lastSegmentLevelValidationTimeMs = 0L;
+  private boolean _runSegmentLevelValidation;
+  private List<InstanceConfig> _instanceConfigs;
 
   public ValidationManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
       PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager, ValidationMetrics validationMetrics) {
@@ -74,61 +76,62 @@ public class ValidationManager extends ControllerPeriodicTask {
   }
 
   @Override
-  public void process(List<String> tables) {
-    runValidation(tables);
-  }
-
-  /**
-   * Runs a validation pass over the given tables.
-   *
-   * @param tables List of table names
-   */
-  private void runValidation(List<String> tables) {
+  public void preprocess() {
     // Run segment level validation using a separate interval
-    boolean runSegmentLevelValidation = false;
+    _runSegmentLevelValidation = false;
     long currentTimeMs = System.currentTimeMillis();
     if (TimeUnit.MILLISECONDS.toSeconds(currentTimeMs - _lastSegmentLevelValidationTimeMs)
         >= _segmentLevelValidationIntervalInSeconds) {
       LOGGER.info("Run segment-level validation");
-      runSegmentLevelValidation = true;
+      _runSegmentLevelValidation = true;
       _lastSegmentLevelValidationTimeMs = currentTimeMs;
     }
 
     // Cache instance configs to reduce ZK access
-    List<InstanceConfig> instanceConfigs = _pinotHelixResourceManager.getAllHelixInstanceConfigs();
+    _instanceConfigs = _pinotHelixResourceManager.getAllHelixInstanceConfigs();
+  }
 
-    for (String tableNameWithType : tables) {
-      try {
-        TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-        if (tableConfig == null) {
-          LOGGER.warn("Failed to find table config for table: {}, skipping validation", tableNameWithType);
-          continue;
-        }
+  @Override
+  public void process(String tableNameWithType) {
+    runValidation(tableNameWithType);
+  }
 
-        // Rebuild broker resource
-        Set<String> brokerInstances = _pinotHelixResourceManager.getAllInstancesForBrokerTenant(instanceConfigs,
-            tableConfig.getTenantConfig().getBroker());
-        _pinotHelixResourceManager.rebuildBrokerResource(tableNameWithType, brokerInstances);
+  @Override
+  public void postprocess() {
 
-        // Perform validation based on the table type
-        TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-        if (tableType == TableType.OFFLINE) {
-          if (runSegmentLevelValidation) {
-            validateOfflineSegmentPush(tableConfig);
-          }
-        } else {
-          if (runSegmentLevelValidation) {
-            updateRealtimeDocumentCount(tableConfig);
-          }
-          Map<String, String> streamConfigMap = tableConfig.getIndexingConfig().getStreamConfigs();
-          StreamConfig streamConfig = new StreamConfig(streamConfigMap);
-          if (streamConfig.hasLowLevelConsumerType()) {
-            _llcRealtimeSegmentManager.validateLLCSegments(tableConfig);
-          }
-        }
-      } catch (Exception e) {
-        LOGGER.warn("Caught exception while validating table: {}", tableNameWithType, e);
+  }
+
+  private void runValidation(String tableNameWithType) {
+    try {
+      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+      if (tableConfig == null) {
+        LOGGER.warn("Failed to find table config for table: {}, skipping validation", tableNameWithType);
+        return;
       }
+
+      // Rebuild broker resource
+      Set<String> brokerInstances = _pinotHelixResourceManager.getAllInstancesForBrokerTenant(_instanceConfigs,
+          tableConfig.getTenantConfig().getBroker());
+      _pinotHelixResourceManager.rebuildBrokerResource(tableNameWithType, brokerInstances);
+
+      // Perform validation based on the table type
+      CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+      if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
+        if (_runSegmentLevelValidation) {
+          validateOfflineSegmentPush(tableConfig);
+        }
+      } else {
+        if (_runSegmentLevelValidation) {
+          updateRealtimeDocumentCount(tableConfig);
+        }
+        Map<String, String> streamConfigMap = tableConfig.getIndexingConfig().getStreamConfigs();
+        StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+        if (streamConfig.hasLowLevelConsumerType()) {
+          _llcRealtimeSegmentManager.validateLLCSegments(tableConfig);
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while validating table: {}", tableNameWithType, e);
     }
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
@@ -125,7 +125,7 @@ public class ControllerPeriodicTaskTest {
     }
 
     @Override
-    protected void process(String tableNameWithType) {
+    protected void processTable(String tableNameWithType) {
 
     }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
@@ -115,7 +115,22 @@ public class ControllerPeriodicTaskTest {
     }
 
     @Override
-    public void process(List<String> tables) {
+    protected void process(List<String> tables) {
+
+    }
+
+    @Override
+    protected void preprocess() {
+
+    }
+
+    @Override
+    protected void process(String tableNameWithType) {
+
+    }
+
+    @Override
+    public void postprocess() {
 
     }
 


### PR DESCRIPTION
Currently each periodic task is responsible for iterating over all tables. We plan to introduce checks for leadership before proceeding with the task for a table. In the current design, we would have to have a check in each periodic task. 
Refactoring this to pull up the iteration into ControllerPeriodicTask. This way we can have the checks just in the ControllerPeriodicTask, and each PeriodicTask is only responsible for executing the task on a given table.