### PR TITLE
[TE] frontend - harleyjj/rootcause-visual - componentize rootcause gr…

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-visual/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-visual/component.js
@@ -1,0 +1,106 @@
+import { get } from '@ember/object';
+import Component from '@ember/component';
+
+export default Component.extend({
+  showLegend: false, // boolean
+
+  showToolbar: false, // boolean
+
+  showSlider: false, // boolean
+  
+  entities: null, // {}
+
+  selectedUrns: null, // Set
+
+  invisibleUrns: null, // Set
+
+  context: null, // {}
+
+  timeseriesMode: null, // 'absolute', 'relative', 'log', 'split'
+
+  chartSelectedUrns: null, // Set
+
+  timeseries: null, // {}
+
+  /**
+   * urns of the entities to be focused on the chart
+   * @type {Set}
+   */
+  focusedUrns: new Set(),
+
+  onVisibility: null, // function (updates)
+
+  onSelection: null, // function (data)
+
+  onLegendHover: null, // function (urns)
+
+  onPrimaryChange: null, // function (data)
+
+  onContext: null, // func (context)
+
+  onChart: null, // func (timeseriesMode)
+
+  chartOnHover: null, // function (outputUrns, d)
+
+  onComparisonChange: null, // function (start, end, compareMode)
+
+  actions: {
+    onVisibility(updates) {
+      const onVisibility = get(this, 'onVisibility');
+      if (onVisibility) {
+        onVisibility(updates);
+      }
+    },
+
+    onSelection(data) {
+      const onSelection = get(this, 'onSelection');
+      if (onSelection) {
+        onSelection(data);
+      }
+    },
+
+    onLegendHover(urns) {
+      const onLegendHover = get(this, 'onLegendHover');
+      if (onLegendHover) {
+        onLegendHover(urns);
+      }
+    },
+
+    onPrimaryChange(data) {
+      const onPrimaryChange = get(this, 'onPrimaryChange');
+      if (onPrimaryChange) {
+        onPrimaryChange(data);
+      }
+    },
+
+    onContext(context) {
+      const onContext = get(this, 'onContext');
+      if (onContext) {
+        onContext(context);
+      }
+    },
+
+    onChart(timeSeriesMode) {
+      const onChart = get(this, 'onChart');
+      if (onChart) {
+        onChart(timeSeriesMode);
+      }
+    },
+
+    chartOnHover(outputUrns, d) {
+      const chartOnHover = get(this, 'chartOnHover');
+      if (chartOnHover) {
+        chartOnHover(outputUrns, d);
+      }
+    },
+
+    onComparisonChange(start, end, compareMode) {
+      const onComparisonChange = get(this, 'onComparisonChange');
+      if (onComparisonChange) {
+        onComparisonChange(start, end, compareMode);
+      }
+    }
+
+  }
+
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-visual/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-visual/template.hbs
@@ -1,0 +1,63 @@
+<div class="card-container__body--padding-md card-container__body--flush-bottom">
+  {{#if selectedUrns.size}}
+    <div class="rootcause-wrapper">
+      {{#if showLegend}}
+        {{rootcause-legend
+          entities=entities
+          selectedUrns=selectedUrns
+          invisibleUrns=invisibleUrns
+          onVisibility=(action "onVisibility")
+          onSelection=(action "onSelection")
+          onMouseEnter=(action "onLegendHover")
+          onMouseLeave=(action "onLegendHover")
+          onPrimaryChange=(action "onPrimaryChange")
+        }}
+      {{/if}}
+      <div class="rootcause-wrapper__chart">
+        {{#if showToolbar}}
+          <div class="row rootcause-wrapper__toolbar">
+            {{rootcause-chart-toolbar
+              context=context
+              timeseriesMode=timeseriesMode
+              onContext=(action "onContext")
+              onChart=(action "onChart")
+            }}
+          </div>
+        {{/if}}
+        {{#if isLoadingTimeseries}}
+          <div class="spinner-wrapper spinner-wrapper--card">
+            {{ember-spinner}}
+          </div>
+        {{/if}}
+        {{rootcause-chart
+          entities=entities
+          selectedUrns=chartSelectedUrns
+          timeseries=timeseries
+          timeseriesMode=timeseriesMode
+          focusedUrns=focusedUrns
+          context=context
+          onHover=(action "chartOnHover")
+          onSelection=(action "onSelection")
+          onPrimaryChange=(action "onPrimaryChange")
+        }}
+      </div>
+    </div>
+    {{#if showSlider}}
+      <div class="row rootcause-compare">
+        {{rootcause-select-comparison-range
+          granularity=context.granularity
+          anomalyRange=context.anomalyRange
+          displayRange=context.analysisRange
+          compareMode=context.compareMode
+          onChange=(action "onComparisonChange")
+        }}
+      </div>
+    {{/if}}
+  {{else}}
+    <div class="card-container card-container--md card-container--flush-top">
+      {{rootcause-placeholder
+        message="Please select a metric and click on '+ add to chart' below. The root cause graph will load here."
+        iconClass="glyphicon glyphicon-equalizer"}}
+    </div>
+  {{/if}}
+</div>

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -39,63 +39,27 @@
   {{/if}}
 
   <div class="row card-container card-container--md card-container--box-shadow">
-    <div class="card-container__body--padding-md card-container__body--flush-bottom">
-      {{#if selectedUrns.size}}
-        <div class="rootcause-wrapper">
-          {{rootcause-legend
-            entities=entities
-            selectedUrns=selectedUrns
-            invisibleUrns=invisibleUrns
-            onVisibility=(action "onVisibility")
-            onSelection=(action "onSelection")
-            onMouseEnter=(action "onLegendHover")
-            onMouseLeave=(action "onLegendHover")
-            onPrimaryChange=(action "onPrimaryChange")
-          }}
-          <div class="rootcause-wrapper__chart">
-            <div class="row rootcause-wrapper__toolbar">
-              {{rootcause-chart-toolbar
-                context=context
-                timeseriesMode=timeseriesMode
-                onContext=(action "onContext")
-                onChart=(action "onChart")
-              }}
-            </div>
-            {{#if isLoadingTimeseries}}
-              <div class="spinner-wrapper spinner-wrapper--card">
-                {{ember-spinner}}
-              </div>
-            {{/if}}
-            {{rootcause-chart
-              entities=entities
-              selectedUrns=chartSelectedUrns
-              timeseries=timeseries
-              timeseriesMode=timeseriesMode
-              focusedUrns=focusedUrns
-              context=context
-              onHover=(action "chartOnHover")
-              onSelection=(action "onSelection")
-              onPrimaryChange=(action "onPrimaryChange")
-            }}
-          </div>
-        </div>
-        <div class="row rootcause-compare">
-          {{rootcause-select-comparison-range
-            granularity=context.granularity
-            anomalyRange=context.anomalyRange
-            displayRange=context.analysisRange
-            compareMode=context.compareMode
-            onChange=(action "onComparisonChange")
-          }}
-        </div>
-      {{else}}
-        <div class="card-container card-container--md card-container--flush-top">
-          {{rootcause-placeholder
-            message="Please select a metric and click on '+ add to chart' below. The root cause graph will load here."
-            iconClass="glyphicon glyphicon-equalizer"}}
-        </div>
-      {{/if}}
-    </div>
+    {{rootcause-visual
+      showLegend=true
+      showToolbar=true
+      showSlider=true
+      entities=entities
+      selectedUrns=selectedUrns
+      invisibleUrns=invisibleUrns
+      context=context
+      timeseriesMode=timeseriesMode
+      chartSelectedUrns=chartSelectedUrns
+      timeseries=timeseries
+      focusedUrns=focusedUrns
+      onVisibility=(action "onVisibility")
+      onSelection=(action "onSelection")
+      onLegendHover=(action "onLegendHover")
+      onPrimaryChange=(action "onPrimaryChange")
+      onContext=(action "onContext")
+      onChart=(action "onChart")
+      chartOnHover=(action "chartOnHover")
+      onComparisonChange=(action "onComparisonChange")
+    }}
 
     {{#if hasServiceErrors}}
       <div class="rootcause-alert alert alert-danger alert-dismissable fade in">


### PR DESCRIPTION
…aph for reusability in other routes

This wraps the rootcause chart, legend, toolbar, and sliding date picker into a component called rootcause-visual for future usage in other routes, such as manage/alert.  Adds booleans for legend, toolbar, and slider so that they can be rendered or not depending on needs.  