### PR TITLE
Start and stop ControllerPeriodicTasks based on leadership changes

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -310,9 +310,6 @@ public class ControllerStarter {
       LOGGER.info("Stopping resource manager");
       _helixResourceManager.stop();
 
-      LOGGER.info("Stopping periodic task scheduler");
-      _periodicTaskScheduler.stop();
-
       _executorService.shutdownNow();
 
     } catch (final Exception e) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -32,6 +32,7 @@ import com.linkedin.pinot.controller.helix.SegmentStatusChecker;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import com.linkedin.pinot.controller.helix.core.minion.PinotTaskManager;
+import com.linkedin.pinot.controller.helix.core.periodictask.ControllerPeriodicTaskScheduler;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotRealtimeSegmentManager;
 import com.linkedin.pinot.controller.helix.core.rebalance.RebalanceSegmentStrategyFactory;
@@ -40,7 +41,6 @@ import com.linkedin.pinot.controller.helix.core.retention.RetentionManager;
 import com.linkedin.pinot.controller.validation.ValidationManager;
 import com.linkedin.pinot.core.crypt.PinotCrypterFactory;
 import com.linkedin.pinot.core.periodictask.PeriodicTask;
-import com.linkedin.pinot.core.periodictask.PeriodicTaskScheduler;
 import com.linkedin.pinot.filesystem.PinotFSFactory;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
@@ -80,7 +80,7 @@ public class ControllerStarter {
   private final PinotRealtimeSegmentManager _realtimeSegmentsManager;
   private final SegmentStatusChecker _segmentStatusChecker;
   private final ExecutorService _executorService;
-  private final PeriodicTaskScheduler _periodicTaskScheduler;
+  private final ControllerPeriodicTaskScheduler _periodicTaskScheduler;
 
   // Can only be constructed after resource manager getting started
   private ValidationManager _validationManager;
@@ -101,7 +101,7 @@ public class ControllerStarter {
         Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("restapi-multiget-thread-%d").build());
     _segmentStatusChecker = new SegmentStatusChecker(_helixResourceManager, _config, _controllerMetrics);
     _realtimeSegmentRelocator = new RealtimeSegmentRelocator(_helixResourceManager, _config);
-    _periodicTaskScheduler = new PeriodicTaskScheduler();
+    _periodicTaskScheduler = new ControllerPeriodicTaskScheduler();
   }
 
   public PinotHelixResourceManager getHelixResourceManager() {
@@ -183,7 +183,8 @@ public class ControllerStarter {
     periodicTasks.add(_validationManager);
     periodicTasks.add(_segmentStatusChecker);
     periodicTasks.add(_realtimeSegmentRelocator);
-    _periodicTaskScheduler.start(periodicTasks);
+    _periodicTaskScheduler.init(periodicTasks);
+
 
     LOGGER.info("Creating rebalance segments factory");
     RebalanceSegmentStrategyFactory.createInstance(helixManager);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -173,6 +173,7 @@ public class ControllerStarter {
     _realtimeSegmentsManager.start(_controllerMetrics);
 
     // Setting up periodic tasks
+    LOGGER.info("Setting up periodic tasks");
     List<PeriodicTask> periodicTasks = new ArrayList<>();
     _taskManager = new PinotTaskManager(_helixTaskResourceManager, _helixResourceManager, _config, _controllerMetrics);
     periodicTasks.add(_taskManager);
@@ -183,6 +184,8 @@ public class ControllerStarter {
     periodicTasks.add(_validationManager);
     periodicTasks.add(_segmentStatusChecker);
     periodicTasks.add(_realtimeSegmentRelocator);
+
+    LOGGER.info("Init controller periodic tasks scheduler");
     _controllerPeriodicTaskScheduler.init(periodicTasks);
 
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -80,7 +80,7 @@ public class ControllerStarter {
   private final PinotRealtimeSegmentManager _realtimeSegmentsManager;
   private final SegmentStatusChecker _segmentStatusChecker;
   private final ExecutorService _executorService;
-  private final ControllerPeriodicTaskScheduler _periodicTaskScheduler;
+  private final ControllerPeriodicTaskScheduler _controllerPeriodicTaskScheduler;
 
   // Can only be constructed after resource manager getting started
   private ValidationManager _validationManager;
@@ -101,7 +101,7 @@ public class ControllerStarter {
         Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("restapi-multiget-thread-%d").build());
     _segmentStatusChecker = new SegmentStatusChecker(_helixResourceManager, _config, _controllerMetrics);
     _realtimeSegmentRelocator = new RealtimeSegmentRelocator(_helixResourceManager, _config);
-    _periodicTaskScheduler = new ControllerPeriodicTaskScheduler();
+    _controllerPeriodicTaskScheduler = new ControllerPeriodicTaskScheduler();
   }
 
   public PinotHelixResourceManager getHelixResourceManager() {
@@ -183,7 +183,7 @@ public class ControllerStarter {
     periodicTasks.add(_validationManager);
     periodicTasks.add(_segmentStatusChecker);
     periodicTasks.add(_realtimeSegmentRelocator);
-    _periodicTaskScheduler.init(periodicTasks);
+    _controllerPeriodicTaskScheduler.init(periodicTasks);
 
 
     LOGGER.info("Creating rebalance segments factory");

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -78,7 +78,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
   }
 
   @Override
-  public void init() {
+  public void initTask() {
     LOGGER.info("Initializing table metrics for all the tables.");
     setStatusToDefault();
   }
@@ -263,7 +263,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
   }
 
   @Override
-  public void cleanup() {
+  public void stopTask() {
     LOGGER.info("Resetting table metrics for all the tables.");
     setStatusToDefault();
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -84,12 +84,6 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
   }
 
   @Override
-  public void onBecomeNotLeader() {
-    LOGGER.info("Resetting table metrics for all the tables.");
-    setStatusToDefault();
-  }
-
-  @Override
   protected void preprocess() {
     _realTimeTableCount = 0;
     _offlineTableCount = 0;
@@ -266,5 +260,11 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
     _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.PERCENT_OF_REPLICAS, Long.MIN_VALUE);
     _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.SEGMENTS_IN_ERROR_STATE, Long.MIN_VALUE);
     _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE, Long.MIN_VALUE);
+  }
+
+  @Override
+  public void cleanup() {
+    LOGGER.info("Resetting table metrics for all the tables.");
+    setStatusToDefault();
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -64,6 +64,11 @@ public class PinotTaskManager extends ControllerPeriodicTask {
     _controllerMetrics = controllerMetrics;
   }
 
+  @Override
+  protected void initTask() {
+
+  }
+
   /**
    * Get the cluster info provider.
    * <p>Cluster info provider might be needed to initialize task generators.
@@ -155,7 +160,7 @@ public class PinotTaskManager extends ControllerPeriodicTask {
    * Performs necessary cleanups (e.g. remove metrics) when the controller leadership changes.
    */
   @Override
-  public void cleanup() {
+  public void stopTask() {
     LOGGER.info("Perform task cleanups.");
     // Performs necessary cleanups for each task type.
     for (String taskType : _taskGeneratorRegistry.getAllTaskTypes()) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -93,19 +93,6 @@ public class PinotTaskManager extends ControllerPeriodicTask {
     return getTasksScheduled();
   }
 
-  /**
-   * Performs necessary cleanups (e.g. remove metrics) when the controller leadership changes.
-   */
-  @Override
-  public void onBecomeNotLeader() {
-    LOGGER.info("Perform task cleanups.");
-    // Performs necessary cleanups for each task type.
-    for (String taskType : _taskGeneratorRegistry.getAllTaskTypes()) {
-      _taskGeneratorRegistry.getTaskGenerator(taskType).nonLeaderCleanUp();
-    }
-  }
-
-
   @Override
   protected void preprocess() {
     _controllerMetrics.addMeteredGlobalValue(ControllerMeter.NUMBER_TIMES_SCHEDULE_TASKS_CALLED, 1L);
@@ -162,5 +149,17 @@ public class PinotTaskManager extends ControllerPeriodicTask {
    */
   private Map<String, String> getTasksScheduled() {
     return _tasksScheduled;
+  }
+
+  /**
+   * Performs necessary cleanups (e.g. remove metrics) when the controller leadership changes.
+   */
+  @Override
+  public void cleanup() {
+    LOGGER.info("Perform task cleanups.");
+    // Performs necessary cleanups for each task type.
+    for (String taskType : _taskGeneratorRegistry.getAllTaskTypes()) {
+      _taskGeneratorRegistry.getTaskGenerator(taskType).nonLeaderCleanUp();
+    }
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -59,17 +59,17 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
 
   /**
    * Reset flags, and call initTask which initializes each individual task
-   * Synchronizing init() and stop() to handle the scenario where the controller loses leadership, and gains it back before the stop method can finish
    */
   @Override
-  public final synchronized void init() {
+  public final void init() {
     _stopPeriodicTask = false;
     _periodicTaskInProgress = false;
     initTask();
   }
 
   /**
-   * Execute the ControllerPeriodicTask. The _periodicTaskInProgress is enabled at the beginning and disabled before exiting,
+   * Execute the ControllerPeriodicTask.
+   * The _periodicTaskInProgress is enabled at the beginning and disabled before exiting,
    * to ensure that we can wait for a task in progress to finish when stop has been invoked
    */
   @Override
@@ -94,7 +94,7 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
    * Finally, it invokes the stopTask for any specific cleanup at the individual task level
    */
   @Override
-  public final synchronized void stop() {
+  public final void stop() {
     _stopPeriodicTask = true;
 
     LOGGER.info("Waiting for periodic task {} to finish, maxWaitTimeMillis = {}", _taskName,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -109,12 +109,13 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
         Thread.sleep(thisWait);
         millisToWait -= thisWait;
       } catch (InterruptedException e) {
-        LOGGER.info("Interrupted: Remaining wait time {} (out of {})", millisToWait,
-            MAX_CONTROLLER_PERIODIC_TASK_STOP_TIME_MILLIS);
+        LOGGER.info("Interrupted: Remaining wait time {} (out of {}) for task {}", millisToWait,
+            MAX_CONTROLLER_PERIODIC_TASK_STOP_TIME_MILLIS, _taskName);
         break;
       }
     }
-    LOGGER.info("Wait completed. _periodicTaskInProgress = {}", _periodicTaskInProgress);
+    LOGGER.info("Wait completed for task {}. Waited for {} ms. _periodicTaskInProgress = {}", _taskName,
+        MAX_CONTROLLER_PERIODIC_TASK_STOP_TIME_MILLIS - millisToWait, _periodicTaskInProgress);
 
     stopTask();
   }
@@ -128,13 +129,17 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
   protected void process(List<String> tableNamesWithType) {
     if (!shouldStopPeriodicTask()) {
       preprocess();
-      for (String table : tableNamesWithType) {
+      for (String tableNameWithType : tableNamesWithType) {
         if (shouldStopPeriodicTask()) {
+          LOGGER.info("_stopPeriodicTask={}. Skip processing table {} and all the remaining tables for task {}.",
+              shouldStopPeriodicTask(), tableNameWithType, _taskName);
           break;
         }
-        processTable(table);
+        processTable(tableNameWithType);
       }
       postprocess();
+    } else {
+      LOGGER.info("_stopPeriodicTask={}. Skip processing all tables for task {}", shouldStopPeriodicTask(), _taskName);
     }
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -121,7 +121,6 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
     stopTask();
   }
 
-
   /**
    * Processes the task on the given tables.
    *
@@ -132,15 +131,15 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
       preprocess();
       for (String tableNameWithType : tableNamesWithType) {
         if (shouldStopPeriodicTask()) {
-          LOGGER.info("Skip processing table {} and all the remaining tables for task {}.",
-              shouldStopPeriodicTask(), tableNameWithType, getTaskName());
+          LOGGER.info("Skip processing table {} and all the remaining tables for task {}.", tableNameWithType,
+              getTaskName());
           break;
         }
         processTable(tableNameWithType);
       }
       postprocess();
     } else {
-      LOGGER.info("Skip processing all tables for task {}", shouldStopPeriodicTask(), getTaskName());
+      LOGGER.info("Skip processing all tables for task {}", getTaskName());
     }
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
@@ -31,6 +31,7 @@ public class ControllerPeriodicTaskScheduler extends PeriodicTaskScheduler imple
 
   /**
    * Initialize the {@link ControllerPeriodicTaskScheduler} with the list of {@link ControllerPeriodicTask} created at startup
+   * This is called only once during controller startup
    * @param controllerPeriodicTasks
    */
   public void init(List<PeriodicTask> controllerPeriodicTasks) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
@@ -29,20 +29,18 @@ import java.util.List;
  */
 public class ControllerPeriodicTaskScheduler extends PeriodicTaskScheduler implements LeadershipChangeSubscriber {
 
-  private List<PeriodicTask> _controllerPeriodicTasks;
-
   /**
-   * Initialize the {@link ControllerPeriodicTaskScheduler} with the {@link ControllerPeriodicTask} created at startup
+   * Initialize the {@link ControllerPeriodicTaskScheduler} with the list of {@link ControllerPeriodicTask} created at startup
    * @param controllerPeriodicTasks
    */
   public void init(List<PeriodicTask> controllerPeriodicTasks) {
-    _controllerPeriodicTasks = controllerPeriodicTasks;
+    super.init(controllerPeriodicTasks);
     ControllerLeadershipManager.getInstance().subscribe(ControllerPeriodicTaskScheduler.class.getName(), this);
   }
 
   @Override
   public void onBecomingLeader() {
-    start(_controllerPeriodicTasks);
+    start();
   }
 
   @Override

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
@@ -1,0 +1,36 @@
+package com.linkedin.pinot.controller.helix.core.periodictask;
+
+import com.linkedin.pinot.controller.ControllerLeadershipManager;
+import com.linkedin.pinot.controller.LeadershipChangeSubscriber;
+import com.linkedin.pinot.core.periodictask.PeriodicTask;
+import com.linkedin.pinot.core.periodictask.PeriodicTaskScheduler;
+import java.util.List;
+
+
+/**
+ * A {@link PeriodicTaskScheduler} for scheduling {@link ControllerPeriodicTask} which are created on controller startup
+ * and started/stopped on controller leadership changes
+ */
+public class ControllerPeriodicTaskScheduler extends PeriodicTaskScheduler implements LeadershipChangeSubscriber {
+
+  private List<PeriodicTask> _controllerPeriodicTasks;
+
+  /**
+   * Initialize the {@link ControllerPeriodicTaskScheduler} with the {@link ControllerPeriodicTask} created at startup
+   * @param controllerPeriodicTasks
+   */
+  public void init(List<PeriodicTask> controllerPeriodicTasks) {
+    _controllerPeriodicTasks = controllerPeriodicTasks;
+    ControllerLeadershipManager.getInstance().subscribe(ControllerPeriodicTaskScheduler.class.getName(), this);
+  }
+
+  @Override
+  public void onBecomingLeader() {
+    start(_controllerPeriodicTasks);
+  }
+
+  @Override
+  public void onBecomingNonLeader() {
+    stop();
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
@@ -21,6 +21,8 @@ import com.linkedin.pinot.controller.LeadershipChangeSubscriber;
 import com.linkedin.pinot.core.periodictask.PeriodicTask;
 import com.linkedin.pinot.core.periodictask.PeriodicTaskScheduler;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -28,6 +30,8 @@ import java.util.List;
  * Any controllerPeriodicTasks provided during initialization, will run only on leadership, and stop when leadership lost
  */
 public class ControllerPeriodicTaskScheduler extends PeriodicTaskScheduler implements LeadershipChangeSubscriber {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ControllerPeriodicTaskScheduler.class);
 
   /**
    * Initialize the {@link ControllerPeriodicTaskScheduler} with the list of {@link ControllerPeriodicTask} created at startup
@@ -41,11 +45,13 @@ public class ControllerPeriodicTaskScheduler extends PeriodicTaskScheduler imple
 
   @Override
   public void onBecomingLeader() {
+    LOGGER.info("Received callback for controller leadership gain. Starting PeriodicTaskScheduler.");
     start();
   }
 
   @Override
   public void onBecomingNonLeader() {
+    LOGGER.info("Received callback for controller leadership loss. Stopping PeriodicTaskScheduler.");
     stop();
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.linkedin.pinot.controller.helix.core.periodictask;
 
 import com.linkedin.pinot.controller.ControllerLeadershipManager;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskScheduler.java
@@ -24,8 +24,8 @@ import java.util.List;
 
 
 /**
- * A {@link PeriodicTaskScheduler} for scheduling {@link ControllerPeriodicTask} which are created on controller startup
- * and started/stopped on controller leadership changes
+ * A {@link PeriodicTaskScheduler} for scheduling {@link ControllerPeriodicTask} according to controller leadership changes.
+ * Any controllerPeriodicTasks provided during initialization, will run only on leadership, and stop when leadership lost
  */
 public class ControllerPeriodicTaskScheduler extends PeriodicTaskScheduler implements LeadershipChangeSubscriber {
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -269,4 +269,9 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
     }
     return seconds;
   }
+
+  @Override
+  public void cleanup() {
+
+  }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -58,6 +58,11 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
   }
 
   @Override
+  protected void initTask() {
+
+  }
+
+  @Override
   protected void preprocess() {
 
   }
@@ -271,7 +276,7 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
   }
 
   @Override
-  public void cleanup() {
+  public void stopTask() {
 
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
@@ -59,6 +59,11 @@ public class RetentionManager extends ControllerPeriodicTask {
   }
 
   @Override
+  protected void initTask() {
+
+  }
+
+  @Override
   protected void preprocess() {
 
   }
@@ -185,7 +190,7 @@ public class RetentionManager extends ControllerPeriodicTask {
 
 
   @Override
-  public void cleanup() {
+  public void stopTask() {
 
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
@@ -53,10 +53,7 @@ public class RetentionManager extends ControllerPeriodicTask {
       int deletedSegmentsRetentionInDays) {
     super("RetentionManager", runFrequencyInSeconds, pinotHelixResourceManager);
     _deletedSegmentsRetentionInDays = deletedSegmentsRetentionInDays;
-  }
 
-  @Override
-  public void onBecomeLeader() {
     LOGGER.info("Starting RetentionManager with runFrequencyInSeconds: {}, deletedSegmentsRetentionInDays: {}",
         getIntervalInSeconds(), _deletedSegmentsRetentionInDays);
   }
@@ -184,5 +181,11 @@ public class RetentionManager extends ControllerPeriodicTask {
       return states.size() == 1 && states.contains(
           CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.OFFLINE);
     }
+  }
+
+
+  @Override
+  public void cleanup() {
+
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -308,7 +308,12 @@ public class ValidationManager extends ControllerPeriodicTask {
   }
 
   @Override
-  public void cleanup() {
+  protected void initTask() {
+
+  }
+
+  @Override
+  public void stopTask() {
     LOGGER.info("Unregister all the validation metrics.");
     _validationMetrics.unregisterAllMetrics();
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -70,12 +70,6 @@ public class ValidationManager extends ControllerPeriodicTask {
   }
 
   @Override
-  public void onBecomeNotLeader() {
-    LOGGER.info("Unregister all the validation metrics.");
-    _validationMetrics.unregisterAllMetrics();
-  }
-
-  @Override
   protected void preprocess() {
     // Run segment level validation using a separate interval
     _runSegmentLevelValidation = false;
@@ -311,5 +305,11 @@ public class ValidationManager extends ControllerPeriodicTask {
     }
 
     return numTotalDocs;
+  }
+
+  @Override
+  public void cleanup() {
+    LOGGER.info("Unregister all the validation metrics.");
+    _validationMetrics.unregisterAllMetrics();
   }
 }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -86,7 +86,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     segmentStatusChecker.init();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
@@ -151,7 +151,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     segmentStatusChecker.init();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
@@ -228,7 +228,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     segmentStatusChecker.init();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
@@ -274,7 +274,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     segmentStatusChecker.init();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
@@ -308,7 +308,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     segmentStatusChecker.init();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
@@ -376,7 +376,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     segmentStatusChecker.init();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
@@ -420,7 +420,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     segmentStatusChecker.init();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
@@ -458,7 +458,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     segmentStatusChecker.init();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
@@ -504,7 +504,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     // verify state before test
     Assert.assertEquals(controllerMetrics.getValueOfGlobalGauge(
         ControllerGauge.DISABLED_TABLE_COUNT), 0);
@@ -555,7 +555,7 @@ public class SegmentStatusCheckerTest {
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
-    segmentStatusChecker = new MockSegmentStatusChecker(helixResourceManager, config, controllerMetrics);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
     segmentStatusChecker.init();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
@@ -566,18 +566,5 @@ public class SegmentStatusCheckerTest {
         ControllerGauge.PERCENT_OF_REPLICAS), 100);
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
         ControllerGauge.PERCENT_SEGMENTS_AVAILABLE), 100);
-  }
-
-  private class MockSegmentStatusChecker extends SegmentStatusChecker {
-
-    public MockSegmentStatusChecker(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf config,
-        ControllerMetrics metricsRegistry) {
-      super(pinotHelixResourceManager, config, metricsRegistry);
-    }
-
-    @Override
-    protected boolean isLeader() {
-      return true;
-    }
   }
 }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
@@ -36,7 +36,11 @@ public class ControllerPeriodicTaskTest {
       new MockControllerPeriodicTask("TestTask", RUN_FREQUENCY_IN_SECONDS, _resourceManager) {
 
         @Override
-        public void cleanup() {
+        protected void initTask() {
+        }
+
+        @Override
+        public void stopTask() {
           _cleanupCalled.set(true);
         }
 
@@ -106,6 +110,11 @@ public class ControllerPeriodicTaskTest {
     }
 
     @Override
+    protected void initTask() {
+
+    }
+
+    @Override
     protected void process(List<String> tableNamesWithType) {
 
     }
@@ -126,7 +135,7 @@ public class ControllerPeriodicTaskTest {
     }
 
     @Override
-    protected boolean isStopPeriodicTask() {
+    protected boolean shouldStopPeriodicTask() {
       return _isStopPeriodicTask;
     }
 
@@ -135,7 +144,7 @@ public class ControllerPeriodicTaskTest {
     }
 
     @Override
-    public void cleanup() {
+    public void stopTask() {
 
     }
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -84,7 +84,7 @@ public class RetentionManagerTest {
     when(pinotHelixResourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(tableConfig);
     when(pinotHelixResourceManager.getOfflineSegmentMetadata(OFFLINE_TABLE_NAME)).thenReturn(metadataList);
 
-    RetentionManager retentionManager = new MockRetentionManager(pinotHelixResourceManager, 0, 0);
+    RetentionManager retentionManager = new RetentionManager(pinotHelixResourceManager, 0, 0);
     retentionManager.init();
     retentionManager.run();
 
@@ -201,7 +201,7 @@ public class RetentionManagerTest {
         setupSegmentMetadata(tableConfig, now, initialNumSegments, removedSegments);
     setupPinotHelixResourceManager(tableConfig, removedSegments, pinotHelixResourceManager);
 
-    RetentionManager retentionManager = new MockRetentionManager(pinotHelixResourceManager, 0, 0);
+    RetentionManager retentionManager = new RetentionManager(pinotHelixResourceManager, 0, 0);
     retentionManager.init();
     retentionManager.run();
 
@@ -306,16 +306,4 @@ public class RetentionManagerTest {
     return segmentMetadata;
   }
 
-  private class MockRetentionManager extends RetentionManager {
-
-    public MockRetentionManager(PinotHelixResourceManager pinotHelixResourceManager, int runFrequencyInSeconds,
-        int deletedSegmentsRetentionInDays) {
-      super(pinotHelixResourceManager, runFrequencyInSeconds, deletedSegmentsRetentionInDays);
-    }
-
-    @Override
-    protected boolean isLeader() {
-      return true;
-    }
-  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/PeriodicTask.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/PeriodicTask.java
@@ -43,4 +43,9 @@ public interface PeriodicTask extends Runnable {
    * @return task name.
    */
   String getTaskName();
+
+  /**
+   * Stop the periodic task
+   */
+  void stop();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/PeriodicTaskScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/PeriodicTaskScheduler.java
@@ -34,13 +34,10 @@ public class PeriodicTaskScheduler {
   private List<PeriodicTask> _tasksWithValidInterval;
 
   /**
-   * Start scheduling periodic tasks.
+   * Initialize the PeriodicTaskScheduler with list of PeriodicTasks
+   * @param periodicTasks
    */
-  public void start(List<PeriodicTask> periodicTasks) {
-    if (_executorService != null) {
-      LOGGER.warn("Periodic task scheduler already started");
-    }
-
+  public void init(List<PeriodicTask> periodicTasks) {
     _tasksWithValidInterval = new ArrayList<>();
     for (PeriodicTask periodicTask : periodicTasks) {
       if (periodicTask.getIntervalInSeconds() > 0) {
@@ -49,6 +46,15 @@ public class PeriodicTaskScheduler {
       } else {
         LOGGER.info("Skipping periodic task: {}", periodicTask);
       }
+    }
+  }
+
+  /**
+   * Start scheduling periodic tasks.
+   */
+  public void start() {
+    if (_executorService != null) {
+      LOGGER.warn("Periodic task scheduler already started");
     }
 
     if (_tasksWithValidInterval.isEmpty()) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/PeriodicTaskScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/PeriodicTaskScheduler.java
@@ -52,7 +52,7 @@ public class PeriodicTaskScheduler {
   /**
    * Start scheduling periodic tasks.
    */
-  public void start() {
+  public synchronized void start() {
     if (_executorService != null) {
       LOGGER.warn("Periodic task scheduler already started");
     }
@@ -82,7 +82,7 @@ public class PeriodicTaskScheduler {
   /**
    * Shutdown executor service and stop the periodic tasks
    */
-  public void stop() {
+  public synchronized void stop() {
     if (_executorService != null) {
       LOGGER.info("Stopping periodic task scheduler");
       _executorService.shutdown();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/PeriodicTaskScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/periodictask/PeriodicTaskScheduler.java
@@ -43,6 +43,7 @@ public class PeriodicTaskScheduler {
       if (periodicTask.getIntervalInSeconds() > 0) {
         LOGGER.info("Adding periodic task: {}", periodicTask);
         _tasksWithValidInterval.add(periodicTask);
+        periodicTask.init();
       } else {
         LOGGER.info("Skipping periodic task: {}", periodicTask);
       }
@@ -63,7 +64,6 @@ public class PeriodicTaskScheduler {
       LOGGER.info("Starting periodic task scheduler with tasks: {}", _tasksWithValidInterval);
       _executorService = Executors.newScheduledThreadPool(_tasksWithValidInterval.size());
       for (PeriodicTask periodicTask : _tasksWithValidInterval) {
-        periodicTask.init();
         _executorService.scheduleWithFixedDelay(() -> {
           try {
             LOGGER.info("Starting {} with running frequency of {} seconds.", periodicTask.getTaskName(),

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/periodictask/PeriodicTaskSchedulerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/periodictask/PeriodicTaskSchedulerTest.java
@@ -51,7 +51,8 @@ public class PeriodicTaskSchedulerTest {
     });
 
     PeriodicTaskScheduler taskScheduler = new PeriodicTaskScheduler();
-    taskScheduler.start(periodicTasks);
+    taskScheduler.init(periodicTasks);
+    taskScheduler.start();
     Thread.sleep(100L);
     taskScheduler.stop();
 
@@ -88,7 +89,8 @@ public class PeriodicTaskSchedulerTest {
     }
 
     PeriodicTaskScheduler taskScheduler = new PeriodicTaskScheduler();
-    taskScheduler.start(periodicTasks);
+    taskScheduler.init(periodicTasks);
+    taskScheduler.start();
     Thread.sleep(1100L);
     taskScheduler.stop();
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/periodictask/PeriodicTaskSchedulerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/periodictask/PeriodicTaskSchedulerTest.java
@@ -31,11 +31,17 @@ public class PeriodicTaskSchedulerTest {
   public void testTaskWithInvalidInterval() throws Exception {
     AtomicBoolean initCalled = new AtomicBoolean();
     AtomicBoolean runCalled = new AtomicBoolean();
+    AtomicBoolean stopCalled = new AtomicBoolean();
 
     List<PeriodicTask> periodicTasks = Collections.singletonList(new BasePeriodicTask("TestTask", 0L/*Invalid*/, 0L) {
       @Override
       public void init() {
         initCalled.set(true);
+      }
+
+      @Override
+      public void stop() {
+        stopCalled.set(true);
       }
 
       @Override
@@ -51,6 +57,7 @@ public class PeriodicTaskSchedulerTest {
 
     assertFalse(initCalled.get());
     assertFalse(runCalled.get());
+    assertFalse(stopCalled.get());
   }
 
   @Test
@@ -58,6 +65,7 @@ public class PeriodicTaskSchedulerTest {
     int numTasks = 3;
     AtomicInteger numTimesInitCalled = new AtomicInteger();
     AtomicInteger numTimesRunCalled = new AtomicInteger();
+    AtomicInteger numTimesStopCalled = new AtomicInteger();
 
     List<PeriodicTask> periodicTasks = new ArrayList<>(numTasks);
     for (int i = 0; i < numTasks; i++) {
@@ -65,6 +73,11 @@ public class PeriodicTaskSchedulerTest {
         @Override
         public void init() {
           numTimesInitCalled.getAndIncrement();
+        }
+
+        @Override
+        public void stop() {
+          numTimesStopCalled.getAndIncrement();
         }
 
         @Override
@@ -81,5 +94,6 @@ public class PeriodicTaskSchedulerTest {
 
     assertEquals(numTimesInitCalled.get(), numTasks);
     assertEquals(numTimesRunCalled.get(), numTasks * 2);
+    assertEquals(numTimesStopCalled.get(), numTasks);
   }
 }


### PR DESCRIPTION
Currently the ControllerPeriodicTasks are scheduled on all controllers , everytime checking for leadership, and executing on their schedule if on a leader controller. This makes it difficult for us to control when the periodic tasks can start and stop. When lead controller changes, it is desirable that the services restart on the new leader, and gracefully shutdown immediately on the old leader.
Introducing a ControllerPeriodicTasksScheduler and making it a subscriber of LeadershipChangeSubscriber. This will enable the scheduler to start the periodic tasks on a controller whenever it becomes leader, as well as stop the tasks on a controller who lost leadership.