### PR TITLE
[PINOT-7370] Return number of bytes read from the reader interfaces/implementations

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BaseBlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BaseBlockValSet.java
@@ -39,32 +39,32 @@ public abstract class BaseBlockValSet implements BlockValSet {
   }
 
   @Override
-  public void getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos) {
+  public long getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos) {
+  public long getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos) {
+  public long getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos) {
+  public long getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos) {
+  public long getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void getBytesValues(int[] inDocIds, int inStartPos, int inDocIdsSize, byte[][] outValues, int outStartPos) {
+  public long getBytesValues(int[] inDocIds, int inStartPos, int inDocIdsSize, byte[][] outValues, int outStartPos) {
     throw new UnsupportedOperationException();
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
@@ -35,7 +35,6 @@ public interface BlockValSet {
    * @param inDocIdsSize Number of input doc ids
    * @param outDictionaryIds Output array
    * @param outStartPos Start position in outDictionaryIds
-   * @return total number of bytes read
    */
   void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
@@ -30,7 +30,6 @@ public interface BlockValSet {
 
   /**
    * Get dictionary Ids for the given docIds.
-   *
    * @param inDocIds Input docIds
    * @param inStartPos Start index in inDocIds
    * @param inDocIdsSize Number of input doc ids
@@ -41,68 +40,62 @@ public interface BlockValSet {
 
   /**
    * Get Integer values for the given docIds.
-   *
    * @param inDocIds Input docIds
    * @param inStartPos Start index in inDocIds
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
    */
-  void getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos);
+  long getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos);
 
   /**
    * Get long values for the given docIds.
-   *
    * @param inDocIds Input docIds
    * @param inStartPos Start index in inDocIds
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
    */
-  void getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos);
+  long getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos);
 
   /**
    * Get float values for the given docIds.
-   *
    * @param inDocIds Input docIds
    * @param inStartPos Start index in inDocIds
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
    */
-  void getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos);
+  long getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos);
 
   /**
-   *
    * @param inDocIds Input docIds
    * @param inStartPos Start index in inDocIds
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
    */
-  void getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos);
+  long getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos);
 
   /**
    * Get string values for the given docIds.
-   *
    * @param inDocIds Input docIds
    * @param inStartPos Start index in inDocIds
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
    */
-  void getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos);
+  long getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos);
 
   /**
    * Get byte[] values for the given docIds.
-   *
    * @param inDocIds Input docIds
    * @param inStartPos Start index in inDocIds
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
    */
-  void getBytesValues(int[] inDocIds, int inStartPos, int inDocIdsSize, byte[][] outValues, int outStartPos);
+  long getBytesValues(int[] inDocIds, int inStartPos, int inDocIdsSize, byte[][] outValues, int outStartPos);
 
   /**
    * SINGLE-VALUED COLUMN APIs

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
@@ -35,6 +35,7 @@ public interface BlockValSet {
    * @param inDocIdsSize Number of input doc ids
    * @param outDictionaryIds Output array
    * @param outStartPos Start position in outDictionaryIds
+   * @return total number of bytes read
    */
   void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos);
 
@@ -45,6 +46,7 @@ public interface BlockValSet {
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
+   * @return total number of bytes read
    */
   long getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos);
 
@@ -55,6 +57,7 @@ public interface BlockValSet {
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
+   * @return total number of bytes read
    */
   long getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos);
 
@@ -65,6 +68,7 @@ public interface BlockValSet {
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
+   * @return total number of bytes read
    */
   long getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos);
 
@@ -74,6 +78,7 @@ public interface BlockValSet {
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
+   * @return total number of bytes read
    */
   long getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos);
 
@@ -84,6 +89,7 @@ public interface BlockValSet {
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
+   * @return total number of bytes read
    */
   long getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos);
 
@@ -94,6 +100,7 @@ public interface BlockValSet {
    * @param inDocIdsSize Number of input doc ids
    * @param outValues Output array
    * @param outStartPos Start position in outValues
+   * @return total number of bytes read
    */
   long getBytesValues(int[] inDocIds, int inStartPos, int inDocIdsSize, byte[][] outValues, int outStartPos);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/DictionaryDelegatingValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/DictionaryDelegatingValueReader.java
@@ -60,6 +60,11 @@ public class DictionaryDelegatingValueReader implements ValueReader {
   }
 
   @Override
+  public int getUnpaddedStringBytes(int index, int numBytesPerValue, byte paddingByte, byte[] buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public String getPaddedString(int index, int numBytesPerValue, byte[] buffer) {
     throw new UnsupportedOperationException();
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
@@ -51,17 +51,31 @@ public final class FixedByteValueReaderWriter implements Closeable, ValueReader 
 
   @Override
   public String getUnpaddedString(int index, int numBytesPerValue, byte paddingByte, byte[] buffer) {
+    int len = getUnpaddedStringBytes(index, numBytesPerValue, paddingByte, buffer);
+    return StringUtil.decodeUtf8(buffer, 0, len);
+  }
+
+  /**
+   * Read the bytes of a string and return the number of bytes in the buffer that represent the unpadded string.
+   * @param index the index of the string value being read
+   * @param numBytesPerValue number of bytes used to store each string
+   * @param paddingByte the value of the padding byte
+   * @param buffer the buffer used to read the value (in and out param)
+   * @return the number of bytes in the buffer representing the string
+   */
+  @Override
+  public int getUnpaddedStringBytes(int index, int numBytesPerValue, byte paddingByte, byte[] buffer) {
     assert buffer.length >= numBytesPerValue;
 
     long startOffset = (long) index * numBytesPerValue;
     for (int i = 0; i < numBytesPerValue; i++) {
       byte currentByte = _dataBuffer.getByte(startOffset + i);
       if (currentByte == paddingByte) {
-        return StringUtil.decodeUtf8(buffer, 0, i);
+        return i;
       }
       buffer[i] = currentByte;
     }
-    return StringUtil.decodeUtf8(buffer, 0, numBytesPerValue);
+    return numBytesPerValue;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/ValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/ValueReader.java
@@ -32,6 +32,8 @@ public interface ValueReader {
 
   String getUnpaddedString(int index, int numBytesPerValue, byte paddingByte, byte[] buffer);
 
+  int getUnpaddedStringBytes(int index, int numBytesPerValue, byte paddingByte, byte[] buffer);
+
   String getPaddedString(int index, int numBytesPerValue, byte[] buffer);
 
   byte[] getBytes(int index, int numBytesPerValue, byte[] buffer);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SingleValueSet.java
@@ -46,7 +46,7 @@ public final class SingleValueSet extends BaseBlockValSet {
   }
 
   @Override
-  public void getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos) {
+  public long getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos) {
     int inEndPos = inStartPos + inDocIdsSize;
     ReaderContext context = _reader.createContext();
     if (_dataType == DataType.INT) {
@@ -56,10 +56,11 @@ public final class SingleValueSet extends BaseBlockValSet {
     } else {
       throw new UnsupportedOperationException();
     }
+    return inDocIdsSize * Integer.BYTES;
   }
 
   @Override
-  public void getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos) {
+  public long getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos) {
     int inEndPos = inStartPos + inDocIdsSize;
     ReaderContext context = _reader.createContext();
     switch (_dataType) {
@@ -67,19 +68,19 @@ public final class SingleValueSet extends BaseBlockValSet {
         for (int i = inStartPos; i < inEndPos; i++) {
           outValues[outStartPos++] = _reader.getInt(inDocIds[i], context);
         }
-        break;
+        return inDocIdsSize * Integer.BYTES;
       case LONG:
         for (int i = inStartPos; i < inEndPos; i++) {
           outValues[outStartPos++] = _reader.getLong(inDocIds[i], context);
         }
-        break;
+        return inDocIdsSize * Long.BYTES;
       default:
         throw new UnsupportedOperationException();
     }
   }
 
   @Override
-  public void getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos) {
+  public long getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos) {
     int inEndPos = inStartPos + inDocIdsSize;
     ReaderContext context = _reader.createContext();
     switch (_dataType) {
@@ -87,24 +88,24 @@ public final class SingleValueSet extends BaseBlockValSet {
         for (int i = inStartPos; i < inEndPos; i++) {
           outValues[outStartPos++] = _reader.getInt(inDocIds[i], context);
         }
-        break;
+        return inDocIdsSize * Integer.BYTES;
       case LONG:
         for (int i = inStartPos; i < inEndPos; i++) {
           outValues[outStartPos++] = _reader.getLong(inDocIds[i], context);
         }
-        break;
+        return inDocIdsSize * Long.BYTES;
       case FLOAT:
         for (int i = inStartPos; i < inEndPos; i++) {
           outValues[outStartPos++] = _reader.getFloat(inDocIds[i], context);
         }
-        break;
+        return inDocIdsSize * Float.BYTES;
       default:
         throw new UnsupportedOperationException();
     }
   }
 
   @Override
-  public void getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos) {
+  public long getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos) {
     int inEndPos = inStartPos + inDocIdsSize;
     ReaderContext context = _reader.createContext();
     switch (_dataType) {
@@ -112,48 +113,57 @@ public final class SingleValueSet extends BaseBlockValSet {
         for (int i = inStartPos; i < inEndPos; i++) {
           outValues[outStartPos++] = _reader.getInt(inDocIds[i], context);
         }
-        break;
+        return inDocIdsSize * Integer.BYTES;
       case LONG:
         for (int i = inStartPos; i < inEndPos; i++) {
           outValues[outStartPos++] = _reader.getLong(inDocIds[i], context);
         }
-        break;
+        return inDocIdsSize * Long.BYTES;
       case FLOAT:
         for (int i = inStartPos; i < inEndPos; i++) {
           outValues[outStartPos++] = _reader.getFloat(inDocIds[i], context);
         }
-        break;
+        return inDocIdsSize * Float.BYTES;
       case DOUBLE:
         for (int i = inStartPos; i < inEndPos; i++) {
           outValues[outStartPos++] = _reader.getDouble(inDocIds[i], context);
         }
-        break;
+        return inDocIdsSize * Double.BYTES;
       default:
         throw new UnsupportedOperationException();
     }
   }
 
   @Override
-  public void getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos) {
+  public long getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos) {
+
+    long bytesRead = 0;
     int inEndPos = inStartPos + inDocIdsSize;
     ReaderContext context = _reader.createContext();
     if (_dataType == DataType.STRING) {
       for (int i = inStartPos; i < inEndPos; i++) {
-        outValues[outStartPos++] = _reader.getString(inDocIds[i], context);
+        String val =  _reader.getString(inDocIds[i], context);
+        outValues[outStartPos++] = val;
+        bytesRead += val.length();
       }
+      return bytesRead;
     } else {
       throw new UnsupportedOperationException();
     }
   }
 
   @Override
-  public void getBytesValues(int[] inDocIds, int inStartPos, int inDocIdsSize, byte[][] outValues, int outStartPos) {
+  public long getBytesValues(int[] inDocIds, int inStartPos, int inDocIdsSize, byte[][] outValues, int outStartPos) {
     int inEndPos = inStartPos + inDocIdsSize;
+    long bytesRead = 0;
     ReaderContext context = _reader.createContext();
     if (_dataType.equals(DataType.BYTES)) {
       for (int i = inStartPos; i < inEndPos; i++) {
-        outValues[outStartPos++] = _reader.getBytes(inDocIds[i], context);
+        byte[] val = _reader.getBytes(inDocIds[i], context);
+        outValues[outStartPos++] = val;
+        bytesRead += val.length;
       }
+      return bytesRead;
     } else {
       throw new UnsupportedOperationException();
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SingleValueSet.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.operator.docvalsets;
 
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.common.BaseBlockValSet;
 import com.linkedin.pinot.core.common.BlockValIterator;
 import com.linkedin.pinot.core.io.reader.ReaderContext;
@@ -142,9 +143,11 @@ public final class SingleValueSet extends BaseBlockValSet {
     ReaderContext context = _reader.createContext();
     if (_dataType == DataType.STRING) {
       for (int i = inStartPos; i < inEndPos; i++) {
-        String val =  _reader.getString(inDocIds[i], context);
+        // read as bytes and then decode to string - allows correct estimation of bytes-read
+        byte[] bytes = _reader.getBytes(inDocIds[i], context);
+        String val = StringUtil.decodeUtf8(bytes, 0, bytes.length);
         outValues[outStartPos++] = val;
-        bytesRead += val.length();
+        bytesRead += bytes.length;
       }
       return bytesRead;
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BaseDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BaseDictionary.java
@@ -95,6 +95,12 @@ public abstract class BaseDictionary implements Dictionary {
     for (int i = inStartPos; i < inEndPos; i++) {
       String str = getStringValue(dictIds[i]);
       outValues[outStartPos++] = str;
+      // NOTE: we use string length as an approximation for bytes-read here
+      // In some cases (OnHeap dictionary for example), the strings are not
+      // stored as corresponding bytes - hence we rely on an approximation
+      // based on string length instead of paying a decode penalty to get
+      // actual bytes read Where applicable, derived-classes can override
+      // and return the right values.
       bytesRead += str.length();
     }
     return bytesRead;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BaseDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BaseDictionary.java
@@ -54,50 +54,62 @@ public abstract class BaseDictionary implements Dictionary {
   }
 
   @Override
-  public void readIntValues(int[] dictIds, int inStartPos, int length, int[] outValues, int outStartPos) {
+  public long readIntValues(int[] dictIds, int inStartPos, int length, int[] outValues, int outStartPos) {
     int inEndPos = inStartPos + length;
     for (int i = inStartPos; i < inEndPos; i++) {
       outValues[outStartPos++] = getIntValue(dictIds[i]);
     }
+    return length * Integer.BYTES;
   }
 
   @Override
-  public void readLongValues(int[] dictIds, int inStartPos, int length, long[] outValues, int outStartPos) {
+  public long readLongValues(int[] dictIds, int inStartPos, int length, long[] outValues, int outStartPos) {
     int inEndPos = inStartPos + length;
     for (int i = inStartPos; i < inEndPos; i++) {
       outValues[outStartPos++] = getLongValue(dictIds[i]);
     }
+    return length * Long.BYTES;
   }
 
   @Override
-  public void readFloatValues(int[] dictIds, int inStartPos, int length, float[] outValues, int outStartPos) {
+  public long readFloatValues(int[] dictIds, int inStartPos, int length, float[] outValues, int outStartPos) {
     int inEndPos = inStartPos + length;
     for (int i = inStartPos; i < inEndPos; i++) {
       outValues[outStartPos++] = getFloatValue(dictIds[i]);
     }
+    return length * Float.BYTES;
   }
 
   @Override
-  public void readDoubleValues(int[] dictIds, int inStartPos, int length, double[] outValues, int outStartPos) {
+  public long readDoubleValues(int[] dictIds, int inStartPos, int length, double[] outValues, int outStartPos) {
     int inEndPos = inStartPos + length;
     for (int i = inStartPos; i < inEndPos; i++) {
       outValues[outStartPos++] = getDoubleValue(dictIds[i]);
     }
+    return length * Double.BYTES;
   }
 
   @Override
-  public void readStringValues(int[] dictIds, int inStartPos, int length, String[] outValues, int outStartPos) {
+  public long readStringValues(int[] dictIds, int inStartPos, int length, String[] outValues, int outStartPos) {
+    long bytesRead = 0;
     int inEndPos = inStartPos + length;
     for (int i = inStartPos; i < inEndPos; i++) {
-      outValues[outStartPos++] = getStringValue(dictIds[i]);
+      String str = getStringValue(dictIds[i]);
+      outValues[outStartPos++] = str;
+      bytesRead += str.length();
     }
+    return bytesRead;
   }
 
   @Override
-  public void readBytesValues(int[] dictIds, int inStartPos, int length, byte[][] outValues, int outStartPos) {
+  public long readBytesValues(int[] dictIds, int inStartPos, int length, byte[][] outValues, int outStartPos) {
+    long bytesRead = 0;
     int inEndPos = inStartPos + length;
     for (int i = inStartPos; i < inEndPos; i++) {
-      outValues[outStartPos++] = getBytesValue(dictIds[i]);
+      byte[] val = getBytesValue(dictIds[i]);
+      outValues[outStartPos++] = val;
+      bytesRead += val.length;
     }
+    return bytesRead;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BaseDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BaseDictionary.java
@@ -48,7 +48,6 @@ public abstract class BaseDictionary implements Dictionary {
   }
 
   @Override
-
   public byte[] getBytesValue(int dictId) {
     throw new UnsupportedOperationException();
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BytesDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BytesDictionary.java
@@ -49,10 +49,14 @@ public class BytesDictionary extends ImmutableDictionaryReader {
   }
 
   @Override
-  public void readBytesValues(int[] dictIds, int inStartPos, int length, byte[][] outValues, int outStartPos) {
+  public long readBytesValues(int[] dictIds, int inStartPos, int length, byte[][] outValues, int outStartPos) {
+    long bytesRead = 0;
     int inEndPos = inStartPos + length;
     for (int i = inStartPos; i < inEndPos; i++) {
-      outValues[outStartPos++] = getBytes(dictIds[i], getBuffer());
+      byte[] val = getBytes(dictIds[i], getBuffer());
+      outValues[outStartPos++] = val;
+      bytesRead += val.length;
     }
+    return bytesRead;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/Dictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/Dictionary.java
@@ -50,16 +50,16 @@ public interface Dictionary extends Closeable {
 
   // Batch read APIs
 
-  void readIntValues(int[] dictIds, int inStartPos, int length, int[] outValues, int outStartPos);
+  long readIntValues(int[] dictIds, int inStartPos, int length, int[] outValues, int outStartPos);
 
-  void readLongValues(int[] dictIds, int inStartPos, int length, long[] outValues, int outStartPos);
+  long readLongValues(int[] dictIds, int inStartPos, int length, long[] outValues, int outStartPos);
 
-  void readFloatValues(int[] dictIds, int inStartPos, int length, float[] outValues, int outStartPos);
+  long readFloatValues(int[] dictIds, int inStartPos, int length, float[] outValues, int outStartPos);
 
-  void readDoubleValues(int[] dictIds, int inStartPos, int length, double[] outValues, int outStartPos);
+  long readDoubleValues(int[] dictIds, int inStartPos, int length, double[] outValues, int outStartPos);
 
-  void readStringValues(int[] dictIds, int inStartPos, int length, String[] outValues, int outStartPos);
+  long readStringValues(int[] dictIds, int inStartPos, int length, String[] outValues, int outStartPos);
 
-  void readBytesValues(int[] dictIds, int inStartPos, int length, byte[][] outValues, int outStartPos);
+  long readBytesValues(int[] dictIds, int inStartPos, int length, byte[][] outValues, int outStartPos);
 
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
@@ -227,6 +227,10 @@ public abstract class ImmutableDictionaryReader extends BaseDictionary {
     return _valueReader.getDouble(dictId);
   }
 
+  protected int getUnpaddedStringBytes(int dictId, byte[] buffer) {
+    return _valueReader.getUnpaddedStringBytes(dictId, _numBytesPerValue, _paddingByte, buffer);
+  }
+
   protected String getUnpaddedString(int dictId, byte[] buffer) {
     return _valueReader.getUnpaddedString(dictId, _numBytesPerValue, _paddingByte, buffer);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
@@ -51,11 +51,15 @@ public class StringDictionary extends ImmutableDictionaryReader {
   }
 
   @Override
-  public void readStringValues(int[] dictIds, int inStartPos, int length, String[] outValues, int outStartPos) {
+  public long readStringValues(int[] dictIds, int inStartPos, int length, String[] outValues, int outStartPos) {
+    long bytesRead = 0;
     byte[] buffer = getBuffer();
     int inEndPos = inStartPos + length;
     for (int i = inStartPos; i < inEndPos; i++) {
-      outValues[outStartPos++] = getUnpaddedString(dictIds[i], buffer);
+      String val = getUnpaddedString(dictIds[i], buffer);
+      outValues[outStartPos++] = val;
+      bytesRead += val.length();
     }
+    return bytesRead;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.segment.index.readers;
 
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.io.util.ValueReader;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 
@@ -56,9 +57,9 @@ public class StringDictionary extends ImmutableDictionaryReader {
     byte[] buffer = getBuffer();
     int inEndPos = inStartPos + length;
     for (int i = inStartPos; i < inEndPos; i++) {
-      String val = getUnpaddedString(dictIds[i], buffer);
-      outValues[outStartPos++] = val;
-      bytesRead += val.length();
+      int len = getUnpaddedStringBytes(dictIds[i], buffer);
+      outValues[outStartPos++] = StringUtil.decodeUtf8(buffer, 0, len);
+      bytesRead += buffer.length;
     }
     return bytesRead;
   }


### PR DESCRIPTION
This change stems from feedback in https://github.com/apache/incubator-pinot/pull/3511. We would like to track the number of bytes read with minimal overhead. For most data-types the overhead is minimal, but for strings/byte types there is a linear time penalty. With this change, we update all batch read APIs to return the number of bytes read so its easier for higher layers to work with the data across both dictionary based and no-dictionary based readers.