### PR TITLE
[TE] task - relax task retrieval to 5 per polling cycle

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
@@ -38,10 +38,10 @@ import com.linkedin.thirdeye.datalayer.util.Predicate;
 public class TaskManagerImpl extends AbstractManagerImpl<TaskDTO> implements TaskManager {
 
   private static final String FIND_BY_STATUS_ORDER_BY_CREATE_TIME_ASC =
-      " WHERE status = :status order by startTime asc limit 1";
+      " WHERE status = :status order by startTime asc limit 5";
 
   private static final String FIND_BY_STATUS_ORDER_BY_CREATE_TIME_DESC =
-      " WHERE status = :status order by startTime desc limit 1";
+      " WHERE status = :status order by startTime desc limit 5";
 
   public TaskManagerImpl() {
     super(TaskDTO.class, TaskBean.class);


### PR DESCRIPTION
After confirming database bottleneck in #3629, we can relax the task retrieval limit to 5 per cycle to increase throughput again