### PR TITLE
Better handle error messages in periodic tasks

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -240,7 +240,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
             nReplicasIdealMax);
       }
     } catch (Exception e) {
-      LOGGER.warn("Caught exception while updating segment status for table {}", e, tableNameWithType);
+      LOGGER.warn("Caught exception while updating segment status for table {}", tableNameWithType, e);
 
       // Remove the metric for this table
       resetTableMetrics(tableNameWithType);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
@@ -74,7 +74,7 @@ public class RetentionManager extends ControllerPeriodicTask {
       LOGGER.info("Start managing retention for table: {}", tableNameWithType);
       manageRetentionForTable(tableNameWithType);
     } catch (Exception e) {
-      LOGGER.error("Caught exception while managing retention for all tables", e);
+      LOGGER.error("Caught exception while managing retention for table: {}", tableNameWithType, e);
     }
   }
 


### PR DESCRIPTION
We've seen the following error messages:
```
2019/01/06 00:00:26.060 WARN [SegmentStatusChecker] [pool-11-thread-4] [pinot-controller] [] Caught exception while updating segment status for table java.lang.NullPointerException
2019/01/06 00:00:26.060 WARN [SegmentStatusChecker] [pool-11-thread-4] [pinot-controller] [] Caught exception while updating segment status for table java.lang.NullPointerException
```

This PR fixes the error messages.