### PR TITLE
 Make different PinotFS concrete classes have the same behaviors

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -218,13 +218,12 @@ public class SegmentDeletionManager {
       URI deletedDirURI = ControllerConf.getUriFromPath(StringUtil.join(File.separator, _dataDir, DELETED_SEGMENTS));
       PinotFS pinotFS = PinotFSFactory.create(dataDirURI.getScheme());
 
-      // Check that the directory for deleted segments exists
-      if (!pinotFS.isDirectory(deletedDirURI)) {
-        LOGGER.warn("Deleted segment directory {} does not exist or it is not directory.", deletedDirURI.toString());
-        return;
-      }
-
       try {
+        // Check that the directory for deleted segments exists
+        if (!pinotFS.isDirectory(deletedDirURI)) {
+          LOGGER.warn("Deleted segment directory {} does not exist or it is not directory.", deletedDirURI.toString());
+          return;
+        }
         String[] tableNameDirs = pinotFS.listFiles(deletedDirURI, false);
         if (tableNameDirs == null) {
           LOGGER.warn("Deleted segment directory {} does not exist.", deletedDirURI.toString());

--- a/pinot-filesystem/src/main/java/org/apache/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/org/apache/pinot/filesystem/PinotFS.java
@@ -56,13 +56,13 @@ public abstract class PinotFS implements Closeable {
 
   /**
    * Moves the file from the src to dst. Does not keep the original file. If the dst has parent directories
-   * that haven't been created, this method will create all the necessary parent directories. If dst already exists,
-   * it will overwrite. Will work either for moving a directory or a file. Currently assumes that both the srcUri
-   * and the dstUri are of the same type (both files or both directories). If srcUri is a file, it will move the file to
-   * dstUri's location. If srcUri is a directory, it will move the directory to dstUri. Does not support moving a file under a
-   * directory.
-   *
-   * For example, if a/b/c is moved to x/y/z, in the case of overwrite, a/b/c will be renamed to x/y/z.
+   * that haven't been created, this method will create all the necessary parent directories.
+   * If both src and dst are files, dst will be overwritten.
+   * If src is a file and dst is a directory, src file will get copied under dst directory.
+   * If both src and dst are directories, src folder will get copied under dst directory.
+   * If src is a directory and dst is a file, operation will fail.
+   * For example, if a file a/b/c is moved to x/y/z, in the case of overwrite, a/b/c will be renamed to x/y/z;
+   * if a file x is copied to x/y, all the original files under x/y will be kept.
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @param overwrite true if we want to overwrite the dstURI, false otherwise
@@ -74,8 +74,8 @@ public abstract class PinotFS implements Closeable {
       throws IOException;
 
   /**
-   * Same as move except the srcUri is retained. For example, if x/y/z is copied to a/b/c, x/y/z will be retained
-   * and x/y/z will also be present as a/b/c; if x is copied to x/y, all the original files under x/y will be kept.
+   * Same as move except the srcUri is retained. For example, if a file x/y/z is copied to a/b/c, x/y/z will be retained
+   * and x/y/z will also be present as a/b/c; if a file x is copied to x/y, all the original files under x/y will be kept.
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @return true if copy is successful
@@ -95,7 +95,7 @@ public abstract class PinotFS implements Closeable {
       throws IOException;
 
   /**
-   * Returns the length of the file at the provided location. Will throw exception if a directory
+   * Returns the length of the file at the provided location. Will throw exception if a directory.
    * @param fileUri location of file
    * @return the number of bytes
    * @throws IOException on IO Failure

--- a/pinot-filesystem/src/main/java/org/apache/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/org/apache/pinot/filesystem/PinotFS.java
@@ -74,8 +74,8 @@ public abstract class PinotFS implements Closeable {
       throws IOException;
 
   /**
-   * Same as move except the srcUri is not retained. For example, if x/y/z is copied to a/b/c, x/y/z will be retained
-   * and x/y/z will also be present as a/b/c
+   * Same as move except the srcUri is retained. For example, if x/y/z is copied to a/b/c, x/y/z will be retained
+   * and x/y/z will also be present as a/b/c; if x is copied to x/y, all the original files under x/y will be kept.
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @return true if copy is successful
@@ -105,7 +105,7 @@ public abstract class PinotFS implements Closeable {
       throws IOException;
 
   /**
-   * Lists all the files at the location provided. Lists recursively.
+   * Lists all the files and directories at the location provided. Lists recursively.
    * Throws exception if this abstract pathname is not valid, or if
    * an I/O error occurs.
    * @param fileUri location of file
@@ -143,7 +143,7 @@ public abstract class PinotFS implements Closeable {
    * @return true if uri is a directory, false otherwise.
    * @throws Exception if uri is not valid or present
    */
-  public abstract boolean isDirectory(URI uri);
+  public abstract boolean isDirectory(URI uri) throws IOException;
 
   /**
    * Returns the age of the file

--- a/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/LocalPinotFSTest.java
@@ -141,13 +141,36 @@ public class LocalPinotFSTest {
     Assert.assertEquals(_newTmpDir.listFiles().length, files);
     Assert.assertFalse(dstFile.exists());
 
-    // Check that a moving a file a non-existent destination folder will work
+    // Check that copying a file to a non-existent destination folder will work
     FileUtils.deleteQuietly(_nonExistentTmpFolder);
     Assert.assertFalse(_nonExistentTmpFolder.exists());
     File srcFile = new File(_absoluteTmpDirPath, "srcFile");
     localPinotFS.mkdir(_absoluteTmpDirPath.toURI());
     Assert.assertTrue(srcFile.createNewFile());
     dstFile = new File(_nonExistentTmpFolder.getPath() + "/newFile");
+    Assert.assertFalse(dstFile.exists());
+    Assert.assertTrue(localPinotFS.copy(srcFile.toURI(), dstFile.toURI()));
+    Assert.assertTrue(srcFile.exists());
+    Assert.assertTrue(dstFile.exists());
+
+    //Check that copying a folder to a non-existent destination folder works
+    FileUtils.deleteQuietly(_nonExistentTmpFolder);
+    Assert.assertFalse(_nonExistentTmpFolder.exists());
+    localPinotFS.mkdir(_absoluteTmpDirPath.toURI());
+    dstFile = new File(_nonExistentTmpFolder.getPath() + "/srcFile" );
+    Assert.assertFalse(dstFile.exists());
+    Assert.assertTrue(localPinotFS.copy(_absoluteTmpDirPath.toURI(), _nonExistentTmpFolder.toURI()));
+    Assert.assertTrue(dstFile.exists());
+    FileUtils.deleteQuietly(srcFile);
+    Assert.assertFalse(srcFile.exists());
+
+    // Check that moving a file to a non-existent destination folder will work
+    FileUtils.deleteQuietly(_nonExistentTmpFolder);
+    Assert.assertFalse(_nonExistentTmpFolder.exists());
+    srcFile = new File(_absoluteTmpDirPath, "srcFile");
+    localPinotFS.mkdir(_absoluteTmpDirPath.toURI());
+    Assert.assertTrue(srcFile.createNewFile());
+    dstFile = new File(_nonExistentTmpFolder.getPath() + "/newFile" );
     Assert.assertFalse(dstFile.exists());
     Assert.assertTrue(localPinotFS.move(srcFile.toURI(), dstFile.toURI(), true)); // overwrite flag has no impact
     Assert.assertFalse(srcFile.exists());

--- a/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
@@ -23,13 +23,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.configuration.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.pinot.common.utils.retry.RetryPolicies;
 import org.apache.pinot.common.utils.retry.RetryPolicy;
@@ -82,6 +83,9 @@ public class HadoopPinotFS extends PinotFS {
   @Override
   public boolean delete(URI segmentUri, boolean forceDelete)
       throws IOException {
+    if (!exists(segmentUri)) {
+      return true;
+    }
     // Returns false if we are moving a directory and that directory is not empty
     if (isDirectory(segmentUri) && listFiles(segmentUri, false).length > 0 && !forceDelete) {
       return false;
@@ -92,8 +96,17 @@ public class HadoopPinotFS extends PinotFS {
   @Override
   public boolean move(URI srcUri, URI dstUri, boolean overwrite)
       throws IOException {
-    if (exists(dstUri) && !overwrite) {
+    if (!exists(srcUri)) {
+      LOGGER.warn("Source {} does not exist", srcUri);
       return false;
+    }
+    if (exists(dstUri)) {
+      if (!overwrite) {
+        return false;
+      } else {
+        delete(dstUri, true);
+        mkdir(dstUri);
+      }
     }
     return _hadoopFS.rename(new Path(srcUri), new Path(dstUri));
   }
@@ -105,31 +118,87 @@ public class HadoopPinotFS extends PinotFS {
   @Override
   public boolean copy(URI srcUri, URI dstUri)
       throws IOException {
-    Path source = new Path(srcUri);
-    Path target = new Path(dstUri);
-    RemoteIterator<LocatedFileStatus> sourceFiles = _hadoopFS.listFiles(source, true);
-    if (sourceFiles != null) {
-      while (sourceFiles.hasNext()) {
-        boolean succeeded =
-            FileUtil.copy(_hadoopFS, sourceFiles.next().getPath(), _hadoopFS, target, true, _hadoopConf);
-        if (!succeeded) {
-          return false;
+    if (!exists(srcUri)) {
+      String errorMsg = String.format("Source %s does not exist", srcUri);
+      LOGGER.warn(errorMsg);
+      throw new IOException(errorMsg);
+    }
+    if (srcUri.equals(dstUri)) {
+      LOGGER.info("Source {} and destination {} are the same.", srcUri, dstUri);
+      return true;
+    }
+    if (exists(dstUri) && !isDirectory(dstUri)) {
+      if (isDirectory(srcUri)) {
+        String errorMsg = String.format("Source %s is a directory while destination %s is a file", srcUri, dstUri);
+        LOGGER.warn(errorMsg);
+        throw new IOException(errorMsg);
+      } else {
+        delete(dstUri, true);
+      }
+    }
+    if (isDirectory(srcUri)) {
+      mkdir(dstUri);
+      List<String> exclusionList = null;
+      // Cater for destination being directory within the source directory
+      if (dstUri.getRawPath().startsWith(srcUri.getRawPath())) {
+        FileStatus[] srcFiles = listStatus(new Path(srcUri), false);
+        exclusionList = new ArrayList<>(srcFiles.length);
+        for (FileStatus srcFile : srcFiles) {
+          Path dstPath = new Path(dstUri.getRawPath(), srcFile.getPath().getName());
+          exclusionList.add(dstPath.toString());
+        }
+      }
+      doCopyDirectory(srcUri, dstUri, exclusionList);
+    } else {
+      doCopyFile(srcUri, dstUri);
+    }
+    return true;
+  }
+
+  /**
+   * Does the actual copy behavior on directory.
+   */
+  private void doCopyDirectory(URI srcUri, URI dstUri, List<String> exclusionList) throws IOException {
+    FileStatus[] srcFiles = listStatus(new Path(srcUri), true);
+    for (FileStatus srcFile : srcFiles) {
+      Path srcPath = srcFile.getPath();
+      Path dstPath = new Path(dstUri.getPath(), srcFile.getPath().getName());
+      if (exclusionList == null || !exclusionList.contains(srcPath.toUri().getRawPath())) {
+        if (isDirectory(srcPath.toUri())) {
+          doCopyDirectory(srcPath.toUri(), dstPath.toUri(), exclusionList);
+        } else {
+          doCopyFile(srcPath.toUri(), dstPath.toUri());
         }
       }
     }
-    return true;
+  }
+
+  /**
+   * Does the actual copy behavior on file.
+   */
+  private boolean doCopyFile(URI srcUri, URI dstUri) throws IOException {
+    Path source = new Path(srcUri);
+    Path target = new Path(dstUri);
+    URI parentUri = target.getParent().toUri();
+    if (!exists(parentUri)) {
+      mkdir(parentUri);
+    }
+    return FileUtil.copy(_hadoopFS, source, _hadoopFS, target, false, _hadoopConf);
   }
 
   @Override
   public boolean exists(URI fileUri)
       throws IOException {
-    return _hadoopFS.exists(new Path(fileUri));
+    return fileUri != null && _hadoopFS.exists(new Path(fileUri));
   }
 
   @Override
   public long length(URI fileUri)
       throws IOException {
-    return _hadoopFS.getLength(new Path(fileUri));
+    if (isDirectory(fileUri)) {
+      throw new IllegalArgumentException("File is directory");
+    }
+    return _hadoopFS.getFileStatus(new Path(fileUri)).getLen();
   }
 
   @Override
@@ -138,10 +207,10 @@ public class HadoopPinotFS extends PinotFS {
     ArrayList<String> filePathStrings = new ArrayList<>();
     Path path = new Path(fileUri);
     if (_hadoopFS.exists(path)) {
-      RemoteIterator<LocatedFileStatus> fileListItr = _hadoopFS.listFiles(path, recursive);
-      while (fileListItr != null && fileListItr.hasNext()) {
-        LocatedFileStatus file = fileListItr.next();
-        filePathStrings.add(file.getPath().toUri().toString());
+      // _hadoopFS.listFiles(path, false) will not return directories as files, thus use listStatus(path) here.
+      FileStatus[] files = listStatus(path, recursive);
+      for (FileStatus file : files) {
+        filePathStrings.add(file.getPath().toUri().getRawPath());
       }
     } else {
       throw new IllegalArgumentException("segmentUri is not valid");
@@ -149,6 +218,20 @@ public class HadoopPinotFS extends PinotFS {
     String[] retArray = new String[filePathStrings.size()];
     filePathStrings.toArray(retArray);
     return retArray;
+  }
+
+  private FileStatus[] listStatus(Path path, boolean recursive) throws IOException {
+    List<FileStatus> fileStatuses = new ArrayList<>();
+    FileStatus[] files = _hadoopFS.listStatus(path);
+    for (FileStatus file : files) {
+      fileStatuses.add(file);
+      if (file.isDirectory() && recursive) {
+        List<FileStatus> subFiles = Arrays.asList(listStatus(file.getPath(), true));
+        fileStatuses.addAll(subFiles);
+      }
+    }
+    FileStatus[] fileStatusesArr = new FileStatus[fileStatuses.size()];
+    return fileStatuses.toArray(fileStatusesArr);
   }
 
   @Override
@@ -189,9 +272,8 @@ public class HadoopPinotFS extends PinotFS {
   }
 
   @Override
-  public boolean isDirectory(URI uri) {
-    FileStatus fileStatus = new FileStatus();
-    fileStatus.setPath(new Path(uri));
+  public boolean isDirectory(URI uri) throws IOException {
+    FileStatus fileStatus = _hadoopFS.getFileStatus(new Path(uri));
     return fileStatus.isDirectory();
   }
 


### PR DESCRIPTION
Currently different PinotFS behaves differently. 
E.g., as for `listFile(URI, true)` LocalPinotFS lists all the files and directories, while HadoopPinotFS only list non-dir files.
This PR:
* makes sure that these two `FS` have the same behaviors.
* follows up from https://github.com/apache/incubator-pinot/pull/3589
* unit tests added.