### PR TITLE
Sslbranch

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -79,7 +79,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     if (_useHTTPS) {
       _baseUri = URI.create("https://0.0.0.0:" + httpPort + "/");
       SSLContextConfigurator sslContext = new SSLContextConfigurator();
-	  sslContext.setKeyStoreFile(_keyStoreFile);
+          sslContext.setKeyStoreFile(_keyStoreFile);
 	  sslContext.setKeyStorePass(_keyStorePass);
 	  sslContext.setTrustStoreFile(_trustStoreFile);
 	  sslContext.setTrustStorePass(_trustStorePass);

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -31,6 +31,8 @@ import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.ServiceStatus;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.yammer.metrics.core.MetricsRegistry;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -196,7 +198,7 @@ public class HelixBrokerStarter {
     }
   }
 
-  private BrokerServerBuilder startBroker(Configuration config) {
+  private BrokerServerBuilder startBroker(Configuration config) throws IOException {
     if (config == null) {
       config = DefaultHelixBrokerConfig.getDefaultBrokerConf();
     }

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -76,7 +76,7 @@ public class HelixBrokerStarterTest {
     _zkClient = new ZkClient(ZkStarter.DEFAULT_ZK_STR);
     final String instanceId = "localhost_helixController";
     _pinotResourceManager =
-        new PinotHelixResourceManager(ZkStarter.DEFAULT_ZK_STR, HELIX_CLUSTER_NAME, instanceId, null, 10000L, true, /*isUpdateStateModel=*/false, true);
+        new PinotHelixResourceManager(ZkStarter.DEFAULT_ZK_STR, HELIX_CLUSTER_NAME, instanceId, null, 10000L, true, /*isUpdateStateModel=*/false, true, null);
     _pinotResourceManager.start();
     _helixAdmin = _pinotResourceManager.getHelixAdmin();
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -44,11 +44,13 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
   private static final String CONTROLLER_HOST = "controller.host";
   private static final String CONTROLLER_PORT = "controller.port";
+  private static final String USE_HTTP_AND_SSL = "controller.ssl.enable.both";
   private static final String USE_SSL = "controller.ssl.enabled";
   private static final String KEYSTORE_FILE = "controller.ssl.keystore.file";
   private static final String KEYSTORE_PASSWORD = "controller.ssl.keystore.pass";
   private static final String TRUSTSTORE_FILE = "controller.ssl.truststore.file";
   private static final String TRUSTSTORE_PASSWORD = "controller.ssl.truststore.pass";
+  private static final String BROKER_SSL_LOADBALANCER_ADDRESS = "broker.ssl.loadbalancer";
   private static final String DATA_DIR = "controller.data.dir";
   // Potentially same as data dir if local
   private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
@@ -212,7 +214,11 @@ public class ControllerConf extends PropertiesConfiguration {
   public boolean getQueryConsoleUseHttps() {
     return containsKey(CONSOLE_WEBAPP_USE_HTTPS) && getBoolean(CONSOLE_WEBAPP_USE_HTTPS);
   }
-  
+
+  public boolean getUseHTTPAndSSL() {
+    return containsKey(USE_HTTP_AND_SSL) && getBoolean(USE_HTTP_AND_SSL);
+  }
+
   public void setUseSSL(boolean useSSL) {
 	setProperty(USE_SSL, useSSL);
   }
@@ -224,7 +230,15 @@ public class ControllerConf extends PropertiesConfiguration {
   public void setKeyStoreFile(String keyStoreFile) {
 	setProperty(KEYSTORE_FILE, keyStoreFile);
   }
-  
+
+  public String getBrokerSslLoadbalancerAddress() {
+    if(!containsKey(BROKER_SSL_LOADBALANCER_ADDRESS)){
+      return null;
+    } else {
+      return getString(BROKER_SSL_LOADBALANCER_ADDRESS);
+    }
+  }
+
   public String getKeyStoreFile() {
 	return getString(KEYSTORE_FILE, null);
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -47,11 +47,11 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String USE_HTTP = "controller.http.enabled";
   private static final String USE_HTTPS = "controller.https.enabled";
   private static final String CONTROLLER_HTTPS_PORT = "controller.https.port";
-  private static final String KEYSTORE_FILE = "controller.ssl.keystore.file";
-  private static final String KEYSTORE_PASSWORD = "controller.ssl.keystore.pass";
-  private static final String TRUSTSTORE_FILE = "controller.ssl.truststore.file";
-  private static final String TRUSTSTORE_PASSWORD = "controller.ssl.truststore.pass";
-  private static final String BROKER_SSL_LOADBALANCER_ADDRESS = "broker.ssl.loadbalancer";
+  private static final String KEYSTORE_FILE = "controller.https.keystore.file";
+  private static final String KEYSTORE_PASSWORD = "controller.https.keystore.pass";
+  private static final String TRUSTSTORE_FILE = "controller.https.truststore.file";
+  private static final String TRUSTSTORE_PASSWORD = "controller.https.truststore.pass";
+  private static final String BROKER_LOADBALANCER_ADDRESS = "broker.https.loadbalancer";
   private static final String DATA_DIR = "controller.data.dir";
   // Potentially same as data dir if local
   private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
@@ -60,7 +60,6 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String HELIX_CLUSTER_NAME = "controller.helix.cluster.name";
   private static final String CLUSTER_TENANT_ISOLATION_ENABLE = "cluster.tenant.isolation.enable";
   private static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
-  private static final String CONSOLE_WEBAPP_USE_HTTPS = "controller.query.console.useHttps";
   private static final String EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT = "controller.upload.onlineToOfflineTimeout";
 
   public static class ControllerPeriodicTasksConf {
@@ -208,15 +207,7 @@ public class ControllerConf extends PropertiesConfiguration {
     return ControllerConf.class.getClassLoader().getResource("webapp").toExternalForm();
   }
 
-  public void setQueryConsoleUseHttps(boolean useHttps) {
-    setProperty(CONSOLE_WEBAPP_USE_HTTPS, useHttps);
-  }
-
-  public boolean getQueryConsoleUseHttps() {
-    return containsKey(CONSOLE_WEBAPP_USE_HTTPS) && getBoolean(CONSOLE_WEBAPP_USE_HTTPS);
-  }
-
-  public void setUseHTTP(boolean useHTTP) {
+  public void setUseHttp(boolean useHTTP) {
     setProperty(USE_HTTP, useHTTP);
   }
 
@@ -227,12 +218,12 @@ public class ControllerConf extends PropertiesConfiguration {
       return (boolean) getBoolean(USE_HTTP);
     }
   }
-  
-  public void setUseSSL(boolean useSSL) {
-	setProperty(USE_HTTPS, useSSL);
+
+  public void setUseHttps(boolean useHttps) {
+	setProperty(USE_HTTPS, useHttps);
   }
   
-  public boolean getUseSSL() {
+  public boolean getUseHttps() {
 	return containsKey(USE_HTTPS) && getBoolean(USE_HTTPS);
   }
   
@@ -240,11 +231,11 @@ public class ControllerConf extends PropertiesConfiguration {
 	setProperty(KEYSTORE_FILE, keyStoreFile);
   }
 
-  public String getBrokerSslLoadbalancerAddress() {
-    if(!containsKey(BROKER_SSL_LOADBALANCER_ADDRESS)){
+  public String getBrokerLoadbalancerAddress() {
+    if(!containsKey(BROKER_LOADBALANCER_ADDRESS)){
       return null;
     } else {
-      return getString(BROKER_SSL_LOADBALANCER_ADDRESS);
+      return getString(BROKER_LOADBALANCER_ADDRESS);
     }
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -44,6 +44,11 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
   private static final String CONTROLLER_HOST = "controller.host";
   private static final String CONTROLLER_PORT = "controller.port";
+  private static final String USE_SSL = "controller.ssl.enabled";
+  private static final String KEYSTORE_FILE = "controller.ssl.keystore.file";
+  private static final String KEYSTORE_PASSWORD = "controller.ssl.keystore.pass";
+  private static final String TRUSTSTORE_FILE = "controller.ssl.truststore.file";
+  private static final String TRUSTSTORE_PASSWORD = "controller.ssl.truststore.pass";
   private static final String DATA_DIR = "controller.data.dir";
   // Potentially same as data dir if local
   private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
@@ -206,6 +211,46 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public boolean getQueryConsoleUseHttps() {
     return containsKey(CONSOLE_WEBAPP_USE_HTTPS) && getBoolean(CONSOLE_WEBAPP_USE_HTTPS);
+  }
+  
+  public void setUseSSL(boolean useSSL) {
+	setProperty(USE_SSL, useSSL);
+  }
+  
+  public boolean getUseSSL() {
+	return containsKey(USE_SSL) && getBoolean(USE_SSL);
+  }
+  
+  public void setKeyStoreFile(String keyStoreFile) {
+	setProperty(KEYSTORE_FILE, keyStoreFile);
+  }
+  
+  public String getKeyStoreFile() {
+	return getString(KEYSTORE_FILE, null);
+  }
+  
+  public void setKeyStorePassword(String keyStorePassword) {
+	setProperty(KEYSTORE_PASSWORD, keyStorePassword);
+  }
+	  
+  public String getKeyStorePassword() {
+	return getString(KEYSTORE_PASSWORD, null);
+  }
+  
+  public void setTrustStoreFile(String trustStoreFile) {
+    setProperty(TRUSTSTORE_FILE, trustStoreFile);
+  }
+  
+  public String getTrustStoreFile() {
+	return getString(TRUSTSTORE_FILE, null);
+  }
+  
+  public void setTrustStorePassword(String trustStorePassword) {
+	setProperty(TRUSTSTORE_PASSWORD, trustStorePassword);
+  }
+	  
+  public String getTrustStorePassword() {
+	return getString(TRUSTSTORE_PASSWORD, null);
   }
 
   public void setJerseyAdminPrimary(String jerseyAdminPrimary) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -44,8 +44,9 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
   private static final String CONTROLLER_HOST = "controller.host";
   private static final String CONTROLLER_PORT = "controller.port";
-  private static final String USE_HTTP_AND_SSL = "controller.ssl.enable.both";
-  private static final String USE_SSL = "controller.ssl.enabled";
+  private static final String USE_HTTP = "controller.http.enabled";
+  private static final String USE_HTTPS = "controller.https.enabled";
+  private static final String CONTROLLER_HTTPS_PORT = "controller.https.port";
   private static final String KEYSTORE_FILE = "controller.ssl.keystore.file";
   private static final String KEYSTORE_PASSWORD = "controller.ssl.keystore.pass";
   private static final String TRUSTSTORE_FILE = "controller.ssl.truststore.file";
@@ -215,16 +216,24 @@ public class ControllerConf extends PropertiesConfiguration {
     return containsKey(CONSOLE_WEBAPP_USE_HTTPS) && getBoolean(CONSOLE_WEBAPP_USE_HTTPS);
   }
 
-  public boolean getUseHTTPAndSSL() {
-    return containsKey(USE_HTTP_AND_SSL) && getBoolean(USE_HTTP_AND_SSL);
+  public void setUseHTTP(boolean useHTTP) {
+    setProperty(USE_HTTP, useHTTP);
   }
 
+  public boolean getUseHttp() {
+    if (!containsKey(USE_HTTP)) {
+      return true;
+    } else {
+      return (boolean) getBoolean(USE_HTTP);
+    }
+  }
+  
   public void setUseSSL(boolean useSSL) {
-	setProperty(USE_SSL, useSSL);
+	setProperty(USE_HTTPS, useSSL);
   }
   
   public boolean getUseSSL() {
-	return containsKey(USE_SSL) && getBoolean(USE_SSL);
+	return containsKey(USE_HTTPS) && getBoolean(USE_HTTPS);
   }
   
   public void setKeyStoreFile(String keyStoreFile) {
@@ -295,6 +304,10 @@ public class ControllerConf extends PropertiesConfiguration {
     setProperty(CONTROLLER_PORT, port);
   }
 
+  public void setControllerHttpsPort(String httpsPort) {
+    setProperty(CONTROLLER_HTTPS_PORT, httpsPort);
+  }
+
   public void setDataDir(String dataDir) {
     setProperty(DATA_DIR, dataDir);
   }
@@ -327,6 +340,14 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public String getControllerPort() {
     return (String) getProperty(CONTROLLER_PORT);
+  }
+
+  public String getControllerHttpsPort() {
+    if (!containsKey(CONTROLLER_HTTPS_PORT)) {
+      return "443";
+    } else {
+      return (String) getProperty(CONTROLLER_HTTPS_PORT);
+    }
   }
 
   public String getDataDir() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -57,10 +57,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import io.swagger.models.auth.In;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.io.FileUtils;
@@ -101,15 +98,17 @@ public class ControllerStarter {
 
   public ControllerStarter(ControllerConf conf) {
     _config = conf;
-    if (_config.getUseSSL()) {
+
+    if (_config.getUseHttps()) {
       LOGGER.info("Initializing https server");
-      _encryptedAdminApp = new ControllerAdminApiApplication(_config.getQueryConsoleWebappPath(), _config.getQueryConsoleUseHttps());
-      _encryptedAdminApp.setSSLConfigs(_config.getKeyStoreFile(), _config.getKeyStorePassword(),
+      _encryptedAdminApp = new ControllerAdminApiApplication(_config.getQueryConsoleWebappPath(), true);
+      _encryptedAdminApp.setHttpsConfigs(_config.getKeyStoreFile(), _config.getKeyStorePassword(),
               _config.getTrustStoreFile(), _config.getTrustStorePassword());
     }
     else {
       _encryptedAdminApp = null;
     }
+
     if (_config.getUseHttp()) {
       LOGGER.info("Initializing http server");
       _adminApp = new ControllerAdminApiApplication(_config.getQueryConsoleWebappPath(), false);
@@ -290,7 +289,7 @@ public class ControllerStarter {
       LOGGER.info("Started Jersey API for https server on port {}", httpsJerseyPort);
       LOGGER.info("Pinot controller ready and listening on port {} for API requests", httpsJerseyPort);
     }
-    if (_config.getUseSSL() && _config.getQueryConsoleUseHttps()) {
+    if (_config.getUseHttps()) {
       LOGGER.info("Controller services available at https://{}:{}/", _config.getControllerHost(),
     	_config.getControllerHttpsPort());
     }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.jackson.JacksonFeature;
@@ -93,6 +94,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     register(binder);
   }
 
+  // if both http and https protocols are enabled, will bind the https listener to default port 443
   public boolean start(int httpPort) {
     // ideally greater than reserved port but then port 80 is also valid
     Preconditions.checkArgument(httpPort > 0);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
@@ -82,7 +82,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     // property("jersey.config.server.tracing.threshold", "VERBOSE");
   }
   
-  public void setSSLConfigs(String keyStoreFile, String keyStorePass, String trustStoreFile, String trustStorePass) {
+  public void setHttpsConfigs(String keyStoreFile, String keyStorePass, String trustStoreFile, String trustStorePass) {
 	  _useSSL = true;
 	  _keyStoreFile = keyStoreFile;
 	  _keyStorePass = keyStorePass;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -143,7 +143,6 @@ public class PinotHelixResourceManager {
 
   public PinotHelixResourceManager(@Nonnull String zkURL, @Nonnull String helixClusterName,
       @Nonnull String controllerInstanceId, String dataDir, long externalViewOnlineToOfflineTimeoutMillis,
-      boolean isSingleTenantCluster, boolean isUpdateStateModel, boolean enableBatchMessageMode) {
       boolean isSingleTenantCluster, boolean isUpdateStateModel, boolean enableBatchMessageMode, String overloadBrokerWithLB) {
     _helixZkURL = HelixConfig.getAbsoluteZkPathForHelix(zkURL);
     _helixClusterName = helixClusterName;
@@ -156,10 +155,8 @@ public class PinotHelixResourceManager {
     _overloadBrokerWithLB = overloadBrokerWithLB;
   }
 
-  public PinotHelixResourceManager(@Nonnull String zkURL, @Nonnull String helixClusterName,
-      @Nonnull String controllerInstanceId, @Nonnull String dataDir) {
+  public PinotHelixResourceManager(@Nonnull String zkURL, @Nonnull String helixClusterName, @Nonnull String controllerInstanceId, @Nonnull String dataDir) {
     this(zkURL, helixClusterName, controllerInstanceId, dataDir, DEFAULT_EXTERNAL_VIEW_UPDATE_TIMEOUT_MILLIS,
-        false, false, true);
         false, false, true, null);
   }
 
@@ -167,7 +164,7 @@ public class PinotHelixResourceManager {
     this(controllerConf.getZkStr(), controllerConf.getHelixClusterName(),
         controllerConf.getControllerHost() + "_" + controllerConf.getControllerPort(), controllerConf.getDataDir(),
         controllerConf.getExternalViewOnlineToOfflineTimeout(), controllerConf.tenantIsolationEnabled(),
-        controllerConf.isUpdateSegmentStateModel(), controllerConf.getEnableBatchMessageMode(), controllerConf.getBrokerSslLoadbalancerAddress());
+        controllerConf.isUpdateSegmentStateModel(), controllerConf.getEnableBatchMessageMode(), controllerConf.getBrokerLoadbalancerAddress());
   }
 
   /**

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -130,6 +130,7 @@ public class PinotHelixResourceManager {
   private final boolean _isSingleTenantCluster;
   private final boolean _isUpdateStateModel;
   private final boolean _enableBatchMessageMode;
+  private final String _overloadBrokerWithLB;
 
   private HelixManager _helixZkManager;
   private HelixAdmin _helixAdmin;
@@ -143,6 +144,7 @@ public class PinotHelixResourceManager {
   public PinotHelixResourceManager(@Nonnull String zkURL, @Nonnull String helixClusterName,
       @Nonnull String controllerInstanceId, String dataDir, long externalViewOnlineToOfflineTimeoutMillis,
       boolean isSingleTenantCluster, boolean isUpdateStateModel, boolean enableBatchMessageMode) {
+      boolean isSingleTenantCluster, boolean isUpdateStateModel, boolean enableBatchMessageMode, String overloadBrokerWithLB) {
     _helixZkURL = HelixConfig.getAbsoluteZkPathForHelix(zkURL);
     _helixClusterName = helixClusterName;
     _instanceId = controllerInstanceId;
@@ -151,19 +153,21 @@ public class PinotHelixResourceManager {
     _isSingleTenantCluster = isSingleTenantCluster;
     _isUpdateStateModel = isUpdateStateModel;
     _enableBatchMessageMode = enableBatchMessageMode;
+    _overloadBrokerWithLB = overloadBrokerWithLB;
   }
 
   public PinotHelixResourceManager(@Nonnull String zkURL, @Nonnull String helixClusterName,
       @Nonnull String controllerInstanceId, @Nonnull String dataDir) {
     this(zkURL, helixClusterName, controllerInstanceId, dataDir, DEFAULT_EXTERNAL_VIEW_UPDATE_TIMEOUT_MILLIS,
         false, false, true);
+        false, false, true, null);
   }
 
   public PinotHelixResourceManager(@Nonnull ControllerConf controllerConf) {
     this(controllerConf.getZkStr(), controllerConf.getHelixClusterName(),
         controllerConf.getControllerHost() + "_" + controllerConf.getControllerPort(), controllerConf.getDataDir(),
         controllerConf.getExternalViewOnlineToOfflineTimeout(), controllerConf.tenantIsolationEnabled(),
-        controllerConf.isUpdateSegmentStateModel(), controllerConf.getEnableBatchMessageMode());
+        controllerConf.isUpdateSegmentStateModel(), controllerConf.getEnableBatchMessageMode(), controllerConf.getBrokerSslLoadbalancerAddress());
   }
 
   /**
@@ -298,6 +302,16 @@ public class PinotHelixResourceManager {
   @Nullable
   public InstanceZKMetadata getInstanceZKMetadata(@Nonnull String instanceId) {
     return ZKMetadataProvider.getInstanceZKMetadata(_propertyStore, instanceId);
+  }
+
+  /**
+   * Get the Broker Load Balancer address if it exists
+   * @param
+   * @return String of load balancer address, null if none defined
+   */
+  @Nullable
+  public String getBrokerLoadBalancerAddress() {
+    return _overloadBrokerWithLB;
   }
 
   /**

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/PinotResourceManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/PinotResourceManagerTest.java
@@ -55,7 +55,7 @@ public class PinotResourceManagerTest {
     final String instanceId = "localhost_helixController";
     _pinotHelixResourceManager =
         new PinotHelixResourceManager(ZkStarter.DEFAULT_ZK_STR, HELIX_CLUSTER_NAME, instanceId, null, 10000L, true,
-            /*isUpdateStateModel=*/ false, true);
+            /*isUpdateStateModel=*/ false, true, null);
     _pinotHelixResourceManager.start();
     _helixAdmin = _pinotHelixResourceManager.getHelixAdmin();
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyTest.java
@@ -79,7 +79,7 @@ public class SegmentAssignmentStrategyTest {
     final String instanceId = "localhost_helixController";
     _pinotHelixResourceManager =
         new PinotHelixResourceManager(ZK_SERVER, HELIX_CLUSTER_NAME, instanceId, null, 10000L, true, /*isUpdateStateModel=*/
-            false, true);
+            false, true, null);
     _pinotHelixResourceManager.start();
 
     final String helixZkURL = HelixConfig.getAbsoluteZkPathForHelix(ZK_SERVER);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -79,7 +79,7 @@ public class ValidationManagerTest {
     _pinotHelixResourceManager =
         new PinotHelixResourceManager(ZK_STR, HELIX_CLUSTER_NAME, CONTROLLER_INSTANCE_NAME, null, 1000L,
             true, /*isUpdateStateModel=*/
-            false, true);
+            false, true, null);
     _pinotHelixResourceManager.start();
 
     ControllerRequestBuilderUtil.addFakeDataInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME, ZK_STR, 2, true);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/PostQueryCommand.java
@@ -99,7 +99,8 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     final JSONObject json = new JSONObject();
     json.put("pql", _query);
 
-    String brokerUrl = "http://" + _brokerHost + ":" + _brokerPort;
+    //String brokerUrl = "http://" + _brokerHost + ":" + _brokerPort;
+    String brokerUrl = _brokerHost+":"+_brokerPort;
     final URLConnection conn = new URL(brokerUrl + "/query").openConnection();
     conn.setDoOutput(true);
 


### PR DESCRIPTION
I have been working on identifying components in the Pinot code base where data (aside from metadata e.g. segment name) can be transmitted over the network. This PR is to enable SSL configurations to be passed into controllers and brokers, and then to configure grizzly to support https. I can provide examples of the full configs of an example https controller/broker + a script to generate self-signed certs for testing if desired.

Please let me know if there is anything missing that needs to be added. I am still testing these changes (and others, see below). I wasn't sure how to perform in-code tests of whether the data is being properly encrypted but I am definitely open to suggestions.

Currently, this code does not allow a component to be configured with both http and https, which is a feature that has also been requested. Also, this does not include code I have written to configure Netty Servers, only Grizzly. Fortunately, when we URI push Azure data, that data is encrypted by default, so currently we have no plans to work on encryption during the segmentfetcher/upload process. I am putting this code up now to get a head start on review, and I do plan on adding Netty encryption and the ability to allow both http and https.