### PR TITLE
Unify all JSON usage to fasterxml.jackson package

### DIFF
--- a/pinot-api/pom.xml
+++ b/pinot-api/pom.xml
@@ -57,8 +57,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ning</groupId>

--- a/pinot-api/src/main/java/com/linkedin/pinot/client/AggregationResultSet.java
+++ b/pinot-api/src/main/java/com/linkedin/pinot/client/AggregationResultSet.java
@@ -18,8 +18,8 @@
  */
 package com.linkedin.pinot.client;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
+
 
 /**
  * A Pinot query result set for aggregation results without group by clauses, of which there is one
@@ -27,9 +27,9 @@ import org.json.JSONObject;
  * function in the query.
  */
 class AggregationResultSet extends AbstractResultSet {
-  private final JSONObject _jsonObject;
+  private final JsonNode _jsonObject;
 
-  public AggregationResultSet(JSONObject jsonObject) {
+  public AggregationResultSet(JsonNode jsonObject) {
     _jsonObject = jsonObject;
   }
 
@@ -45,29 +45,20 @@ class AggregationResultSet extends AbstractResultSet {
 
   @Override
   public String getColumnName(int columnIndex) {
-    try {
-      return _jsonObject.getString("function");
-    } catch (JSONException e) {
-      throw new PinotClientException(e);
-    }
+    return _jsonObject.get("function").asText();
   }
 
   @Override
   public String getString(int rowIndex, int columnIndex) {
     if (columnIndex != 0) {
-      throw new IllegalArgumentException(
-          "Column index must always be 0 for aggregation result sets");
+      throw new IllegalArgumentException("Column index must always be 0 for aggregation result sets");
     }
 
     if (rowIndex != 0) {
       throw new IllegalArgumentException("Row index must always be 0 for aggregation result sets");
     }
 
-    try {
-      return _jsonObject.get("value").toString();
-    } catch (Exception e) {
-      throw new PinotClientException(e);
-    }
+    return _jsonObject.get("value").asText();
   }
 
   @Override

--- a/pinot-api/src/main/java/com/linkedin/pinot/client/BrokerResponse.java
+++ b/pinot-api/src/main/java/com/linkedin/pinot/client/BrokerResponse.java
@@ -18,52 +18,39 @@
  */
 package com.linkedin.pinot.client;
 
-import java.util.List;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
 
 
 /**
  * Reimplementation of BrokerResponse from pinot-common, so that pinot-api does not depend on pinot-common.
  */
 class BrokerResponse {
-  private JSONArray _aggregationResults;
-  private JSONObject _selectionResults;
-  private JSONArray _exceptions;
+  private JsonNode _aggregationResults;
+  private JsonNode _selectionResults;
+  private JsonNode _exceptions;
 
   private BrokerResponse() {
   }
 
-  private BrokerResponse(JSONObject brokerResponse) {
-    try {
-      if (brokerResponse.has("aggregationResults")) {
-        _aggregationResults = brokerResponse.getJSONArray("aggregationResults");
-      }
-      if (brokerResponse.has("exceptions")) {
-        _exceptions = brokerResponse.getJSONArray("exceptions");
-      }
-      if (brokerResponse.has("selectionResults")) {
-        _selectionResults = brokerResponse.getJSONObject("selectionResults");
-      }
-    } catch (JSONException e) {
-      throw new PinotClientException(e);
-    }
+  private BrokerResponse(JsonNode brokerResponse) {
+    _aggregationResults = brokerResponse.get("aggregationResults");
+    _exceptions = brokerResponse.get("exceptions");
+    _selectionResults = brokerResponse.get("selectionResults");
   }
 
   boolean hasExceptions() {
-    return _exceptions != null && _exceptions.length() != 0;
+    return _exceptions != null && _exceptions.size() != 0;
   }
 
-  JSONArray getExceptions() {
+  JsonNode getExceptions() {
     return _exceptions;
   }
 
-  JSONArray getAggregationResults() {
+  JsonNode getAggregationResults() {
     return _aggregationResults;
   }
 
-  JSONObject getSelectionResults() {
+  JsonNode getSelectionResults() {
     return _selectionResults;
   }
 
@@ -71,11 +58,11 @@ class BrokerResponse {
     if (_aggregationResults == null) {
       return 0;
     } else {
-      return _aggregationResults.length();
+      return _aggregationResults.size();
     }
   }
 
-  static BrokerResponse fromJson(JSONObject json) {
+  static BrokerResponse fromJson(JsonNode json) {
     return new BrokerResponse(json);
   }
 

--- a/pinot-api/src/main/java/com/linkedin/pinot/client/GroupByResultSet.java
+++ b/pinot-api/src/main/java/com/linkedin/pinot/client/GroupByResultSet.java
@@ -18,27 +18,22 @@
  */
 package com.linkedin.pinot.client;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
+
 
 /**
  * A Pinot query result set for group by results, of which there is one of per aggregation function
  * in the query.
  */
 class GroupByResultSet extends AbstractResultSet {
-  private final JSONArray _groupByResults;
-  private final JSONArray _groupByColumns;
+  private final JsonNode _groupByResults;
+  private final JsonNode _groupByColumns;
   private final String _functionName;
 
-  public GroupByResultSet(JSONObject jsonObject) {
-    try {
-      _groupByResults = jsonObject.getJSONArray("groupByResult");
-      _groupByColumns = jsonObject.getJSONArray("groupByColumns");
-      _functionName = jsonObject.getString("function");
-    } catch (JSONException e) {
-      throw new PinotClientException(e);
-    }
+  public GroupByResultSet(JsonNode jsonObject) {
+    _groupByResults = jsonObject.get("groupByResult");
+    _groupByColumns = jsonObject.get("groupByColumns");
+    _functionName = jsonObject.get("function").asText();
   }
 
   /**
@@ -47,7 +42,7 @@ class GroupByResultSet extends AbstractResultSet {
    */
   @Override
   public int getRowCount() {
-    return _groupByResults.length();
+    return _groupByResults.size();
   }
 
   @Override
@@ -63,38 +58,24 @@ class GroupByResultSet extends AbstractResultSet {
   @Override
   public String getString(int rowIndex, int columnIndex) {
     if (columnIndex != 0) {
-      throw new IllegalArgumentException(
-          "Column index must always be 0 for aggregation result sets");
+      throw new IllegalArgumentException("Column index must always be 0 for aggregation result sets");
     }
-
-    try {
-      return _groupByResults.getJSONObject(rowIndex).get("value").toString();
-    } catch (Exception e) {
-      throw new PinotClientException(e);
-    }
+    return _groupByResults.get(rowIndex).get("value").asText();
   }
 
   @Override
   public int getGroupKeyLength() {
-    return _groupByColumns.length();
+    return _groupByColumns.size();
   }
 
   @Override
   public String getGroupKeyString(int rowIndex, int groupKeyColumnIndex) {
-    try {
-      return _groupByResults.getJSONObject(rowIndex).getJSONArray("group").getString(groupKeyColumnIndex);
-    } catch (Exception e) {
-      throw new PinotClientException(e);
-    }
+    return _groupByResults.get(rowIndex).get("group").get(groupKeyColumnIndex).asText();
   }
 
   @Override
   public String getGroupKeyColumnName(int groupKeyColumnIndex) {
-    try {
-      return _groupByColumns.getString(groupKeyColumnIndex);
-    } catch (Exception e) {
-      throw new PinotClientException(e);
-    }
+    return _groupByColumns.get(groupKeyColumnIndex).asText();
   }
 
   @Override

--- a/pinot-api/src/main/java/com/linkedin/pinot/client/ResultSetGroup.java
+++ b/pinot-api/src/main/java/com/linkedin/pinot/client/ResultSetGroup.java
@@ -18,10 +18,9 @@
  */
 package com.linkedin.pinot.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.List;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 
 /**
@@ -31,7 +30,7 @@ public class ResultSetGroup {
   private final List<ResultSet> _resultSets;
 
   ResultSetGroup(BrokerResponse brokerResponse) {
-    _resultSets = new ArrayList<ResultSet>();
+    _resultSets = new ArrayList<>();
 
     if (brokerResponse.getSelectionResults() != null) {
       _resultSets.add(new SelectionResultSet(brokerResponse.getSelectionResults()));
@@ -39,12 +38,7 @@ public class ResultSetGroup {
 
     int aggregationResultCount = brokerResponse.getAggregationResultsSize();
     for (int i = 0; i < aggregationResultCount; i++) {
-      JSONObject aggregationResult;
-      try {
-        aggregationResult = brokerResponse.getAggregationResults().getJSONObject(i);
-      } catch (JSONException e) {
-        throw new PinotClientException(e);
-      }
+      JsonNode aggregationResult = brokerResponse.getAggregationResults().get(i);
       if (aggregationResult.has("value")) {
         _resultSets.add(new AggregationResultSet(aggregationResult));
       } else if (aggregationResult.has("groupByResult")) {
@@ -74,11 +68,11 @@ public class ResultSetGroup {
   public ResultSet getResultSet(int index) {
     return _resultSets.get(index);
   }
-  
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    for(ResultSet resultSet:_resultSets){
+    for (ResultSet resultSet : _resultSets) {
       sb.append(resultSet);
       sb.append("\n");
     }

--- a/pinot-api/src/test/java/com/linkedin/pinot/client/ResultSetGroupTest.java
+++ b/pinot-api/src/test/java/com/linkedin/pinot/client/ResultSetGroupTest.java
@@ -18,9 +18,9 @@
  */
 package com.linkedin.pinot.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.util.concurrent.Future;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -133,7 +133,7 @@ public class ResultSetGroupTest {
           lastByte = stream.read();
         }
         String jsonText = builder.toString();
-        return BrokerResponse.fromJson(new JSONObject(jsonText));
+        return BrokerResponse.fromJson(new ObjectMapper().readTree(jsonText));
       } catch (Exception e) {
         Assert.fail("Unexpected exception", e);
         return null;

--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -113,18 +113,6 @@
       <artifactId>swagger-jersey2-jaxrs</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.alibaba</groupId>
-      <artifactId>fastjson</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.helix</groupId>
       <artifactId>helix-core</artifactId>
       <exclusions>

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/api/resources/PinotClientRequest.java
@@ -18,11 +18,14 @@
  */
 package com.linkedin.pinot.broker.api.resources;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.pinot.broker.api.RequestStatistics;
 import com.linkedin.pinot.broker.requesthandler.BrokerRequestHandler;
 import com.linkedin.pinot.common.metrics.BrokerMeter;
 import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import com.linkedin.pinot.common.response.BrokerResponse;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -37,7 +40,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,10 +69,9 @@ public class PinotClientRequest {
       // Query param "bql" is for backward compatibility
       @ApiParam(value = "Query", required = true) @QueryParam("bql") String query,
       @ApiParam(value = "Trace enabled") @QueryParam(TRACE) String traceEnabled,
-      @ApiParam(value = "Debug options") @QueryParam(DEBUG_OPTIONS) String debugOptions
-  ) {
+      @ApiParam(value = "Debug options") @QueryParam(DEBUG_OPTIONS) String debugOptions) {
     try {
-      JSONObject requestJson = new JSONObject();
+      ObjectNode requestJson = JsonUtils.newObjectNode();
       requestJson.put(PQL, query);
       if (traceEnabled != null) {
         requestJson.put(TRACE, traceEnabled);
@@ -97,7 +98,7 @@ public class PinotClientRequest {
   })
   public String processQueryPost(String query) {
     try {
-      JSONObject requestJson = new JSONObject(query);
+      JsonNode requestJson = JsonUtils.stringToJsonNode(query);
       BrokerResponse brokerResponse = requestHandler.handleRequest(requestJson, null, new RequestStatistics());
       return brokerResponse.toJsonString();
     } catch (Exception e) {

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -18,12 +18,12 @@
  */
 package com.linkedin.pinot.broker.requesthandler;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.pinot.broker.api.RequestStatistics;
 import com.linkedin.pinot.broker.api.RequesterIdentity;
 import com.linkedin.pinot.common.response.BrokerResponse;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.json.JSONObject;
 
 
 @ThreadSafe
@@ -33,10 +33,6 @@ public interface BrokerRequestHandler {
 
   void shutDown();
 
-  @Deprecated
-  BrokerResponse handleRequest(JSONObject request, @Nullable RequesterIdentity requesterIdentity)
-      throws Exception;
-
-  BrokerResponse handleRequest(JSONObject request, @Nullable RequesterIdentity requesterIdentity,
+  BrokerResponse handleRequest(JsonNode request, @Nullable RequesterIdentity requesterIdentity,
       RequestStatistics requestStatistics) throws Exception;
 }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/TimeBoundaryService.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/TimeBoundaryService.java
@@ -18,7 +18,8 @@
  */
 package com.linkedin.pinot.broker.routing;
 
-import org.json.JSONObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.linkedin.pinot.common.utils.JsonUtils;
 
 
 public interface TimeBoundaryService {
@@ -37,7 +38,7 @@ public interface TimeBoundaryService {
    */
   void remove(String tableName);
 
-  public class TimeBoundaryInfo {
+  class TimeBoundaryInfo {
     private String _timeColumn;
     private String _timeValue;
 
@@ -57,11 +58,8 @@ public interface TimeBoundaryService {
       _timeValue = timeValue;
     }
 
-    public String toJsonString() throws Exception {
-      JSONObject obj = new JSONObject();
-      obj.put("timeColumnName", _timeColumn);
-      obj.put("timeColumnValue",_timeValue);
-      return obj.toString(2);
+    public String toJsonString() throws JsonProcessingException {
+      return JsonUtils.objectToPrettyString(this);
     }
   }
 }

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/queryquota/TableQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/queryquota/TableQueryQuotaManagerTest.java
@@ -24,7 +24,6 @@ import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.ZkStarter;
-import java.io.IOException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
@@ -35,7 +34,6 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
@@ -358,7 +356,7 @@ public class TableQueryQuotaManagerTest {
     Assert.assertEquals(_tableQueryQuotaManager.getRateLimiterMapSize(), 1);
   }
 
-  private TableConfig generateDefaultTableConfig(String tableName) throws IOException, JSONException {
+  private TableConfig generateDefaultTableConfig(String tableName) {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
     TableConfig.Builder builder = new TableConfig.Builder(tableType);
     builder.setTableName(tableName);

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RoutingTableTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RoutingTableTest.java
@@ -31,7 +31,6 @@ import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
 import com.linkedin.pinot.common.utils.HLCSegmentName;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.yammer.metrics.core.MetricsRegistry;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,7 +41,6 @@ import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.lang.mutable.MutableBoolean;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
-import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -288,7 +286,7 @@ public class RoutingTableTest {
     return configs;
   }
 
-  private TableConfig generateTableConfig(String tableName) throws IOException, JSONException {
+  private TableConfig generateTableConfig(String tableName) {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
     Builder builder = new TableConfig.Builder(tableType);
     builder.setTableName(tableName);

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -99,10 +99,6 @@
       <artifactId>antlr4-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.alibaba</groupId>
-      <artifactId>fastjson</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>
@@ -140,10 +136,6 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-configuration</groupId>
@@ -227,16 +219,16 @@
       <artifactId>swagger-ui</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/ColumnPartitionConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/ColumnPartitionConfig.java
@@ -18,14 +18,14 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang.math.IntRange;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 
 @SuppressWarnings("unused") // Suppress incorrect warnings as methods used for ser/de.

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.lang.reflect.Field;
@@ -25,7 +26,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,7 +172,7 @@ public class IndexingConfig {
     return _noDictionaryColumns;
   }
 
-  public Map<String, String> getnoDictionaryConfig() {
+  public Map<String, String> getNoDictionaryConfig() {
     return _noDictionaryConfig;
   }
 
@@ -220,7 +220,7 @@ public class IndexingConfig {
     return _segmentPartitionConfig;
   }
 
-  public boolean getAggregateMetrics() {
+  public boolean isAggregateMetrics() {
     return _aggregateMetrics;
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/QuotaConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/QuotaConfig.java
@@ -18,13 +18,12 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.utils.DataSize;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.ConfigurationRuntimeException;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,8 +34,6 @@ import org.slf4j.LoggerFactory;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class QuotaConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(QuotaConfig.class);
-  private static final String STORAGE_FIELD_NAME = "storage";
-  private static final String MAX_QUERIES_PER_SECOND_FIELD_NAME = "maxQueriesPerSecond";
 
   @ConfigKey("storage")
   @ConfigDoc(value = "Storage allocated for this table", exampleValue = "10 GiB")
@@ -70,21 +67,6 @@ public class QuotaConfig {
     return DataSize.toBytes(_storage);
   }
 
-  public JSONObject toJson() {
-    JSONObject quotaObject = new JSONObject();
-    try {
-      quotaObject.put(STORAGE_FIELD_NAME, _storage);
-      quotaObject.put(MAX_QUERIES_PER_SECOND_FIELD_NAME, _maxQueriesPerSecond);
-    } catch (JSONException e) {
-      LOGGER.error("Failed to convert to json", e);
-    }
-    return quotaObject;
-  }
-
-  public String toString() {
-    return toJson().toString();
-  }
-
   public void validate() {
     if (!isStorageValid()) {
       LOGGER.error("Failed to convert storage quota config: {} to bytes", _storage);
@@ -96,10 +78,12 @@ public class QuotaConfig {
     }
   }
 
+  @JsonIgnore
   public boolean isStorageValid() {
     return _storage == null || DataSize.toBytes(_storage) >= 0;
   }
 
+  @JsonIgnore
   public boolean isMaxQueriesPerSecondValid() {
     Double qps = null;
     if (_maxQueriesPerSecond != null) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/ReplicaGroupStrategyConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/ReplicaGroupStrategyConfig.java
@@ -18,9 +18,9 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import javax.annotation.Nullable;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 /**
  * Class representing configurations related to segment assignment strategy.

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/RoutingConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/RoutingConfig.java
@@ -18,28 +18,20 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.utils.EqualityUtils;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RoutingConfig {
-  private static final Logger LOGGER = LoggerFactory.getLogger(RoutingConfig.class);
-
   public static final String ENABLE_DYNAMIC_COMPUTING_KEY = "enableDynamicComputing";
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @ConfigKey("routingTableBuilderName")
   private String _routingTableBuilderName;
 
-  private Map<String,String> _routingTableBuilderOptions = new HashMap<>();
+  private Map<String, String> _routingTableBuilderOptions = new HashMap<>();
 
   public String getRoutingTableBuilderName() {
     return _routingTableBuilderName;
@@ -55,15 +47,6 @@ public class RoutingConfig {
 
   public void setRoutingTableBuilderOptions(Map<String, String> routingTableBuilderOptions) {
     _routingTableBuilderOptions = routingTableBuilderOptions;
-  }
-
-  public String toString() {
-    try {
-      return OBJECT_MAPPER.writeValueAsString(this);
-    } catch (IOException e) {
-      //ignore
-    }
-    return "";
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentPartitionConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentPartitionConfig.java
@@ -18,22 +18,21 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.utils.EqualityUtils;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.IOException;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
 
 
 @SuppressWarnings("unused") // Suppress incorrect warning, as methods are used for json ser/de.
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SegmentPartitionConfig {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   public static final int INVALID_NUM_PARTITIONS = -1;
 
   @ConfigKey("columnPartitionMap")
@@ -96,9 +95,8 @@ public class SegmentPartitionConfig {
    * @return Instance of {@link SegmentPartitionConfig} built from the input string.
    * @throws IOException
    */
-  public static SegmentPartitionConfig fromJsonString(String jsonString)
-      throws IOException {
-    return OBJECT_MAPPER.readValue(jsonString, SegmentPartitionConfig.class);
+  public static SegmentPartitionConfig fromJsonString(String jsonString) throws IOException {
+    return JsonUtils.stringToObject(jsonString, SegmentPartitionConfig.class);
   }
 
   /**
@@ -107,9 +105,8 @@ public class SegmentPartitionConfig {
    * @return JSON string equivalent of the object.
    * @throws IOException
    */
-  public String toJsonString()
-      throws IOException {
-    return OBJECT_MAPPER.writeValueAsString(this);
+  public String toJsonString() throws IOException {
+    return JsonUtils.objectToString(this);
   }
 
   /**
@@ -143,10 +140,5 @@ public class SegmentPartitionConfig {
   public int hashCode() {
     int result = EqualityUtils.hashCodeOf(_columnPartitionMap);
     return result;
-  }
-
-  @Override
-  public String toString() {
-    return "SegmentPartitionConfig{" + "_columnPartitionMap=" + _columnPartitionMap + '}';
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentsValidationAndRetentionConfig.java
@@ -18,11 +18,11 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import com.linkedin.pinot.startree.hll.HllConfig;
 import java.lang.reflect.Field;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/StarTreeIndexConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/StarTreeIndexConfig.java
@@ -18,8 +18,8 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 
 @SuppressWarnings("unused")

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/StreamConsumptionConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/StreamConsumptionConfig.java
@@ -18,20 +18,11 @@
  */
 package com.linkedin.pinot.common.config;
 
-import java.io.IOException;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamConsumptionConfig {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(StreamConsumptionConfig.class);
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
   private String _streamPartitionAssignmentStrategy;
 
   public String getStreamPartitionAssignmentStrategy() {
@@ -41,14 +32,4 @@ public class StreamConsumptionConfig {
   public void setStreamPartitionAssignmentStrategy(String streamPartitionAssignmentStrategy) {
     _streamPartitionAssignmentStrategy = streamPartitionAssignmentStrategy;
   }
-
-  @Override
-  public String toString() {
-    try {
-      return OBJECT_MAPPER.writeValueAsString(this);
-    } catch (IOException e) {
-      return e.toString();
-    }
-  }
-
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableCustomConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableCustomConfig.java
@@ -18,10 +18,10 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.lang.reflect.Field;
 import java.util.Map;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableTaskConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableTaskConfig.java
@@ -18,18 +18,15 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.util.Map;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 
 @SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TableTaskConfig {
-  private static final String TASK_TYPE_CONFIGS_MAP_KEY = "taskTypeConfigsMap";
 
   @ConfigKey("taskConfig")
   @UseChildKeyHandler(TaskConfigMapChildKeyHandler.class)
@@ -51,17 +48,6 @@ public class TableTaskConfig {
   @JsonIgnore
   public Map<String, String> getConfigsForTaskType(String taskType) {
     return _taskTypeConfigsMap.get(taskType);
-  }
-
-  @Override
-  public String toString() {
-    JSONObject jsonTaskConfigsMap = new JSONObject();
-    try {
-      jsonTaskConfigsMap.put(TASK_TYPE_CONFIGS_MAP_KEY, _taskTypeConfigsMap);
-      return jsonTaskConfigsMap.toString(2);
-    } catch (JSONException e) {
-      return e.toString();
-    }
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TagOverrideConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TagOverrideConfig.java
@@ -18,10 +18,8 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.utils.EqualityUtils;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -44,7 +42,6 @@ import org.slf4j.LoggerFactory;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TagOverrideConfig {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TagOverrideConfig.class);
 
   @ConfigKey("realtimeConsuming")
   @ConfigDoc("Tag override for realtime consuming segments")

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/Tenant.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/Tenant.java
@@ -18,118 +18,89 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.utils.EqualityUtils;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Objects;
 import com.linkedin.pinot.common.utils.TenantRole;
+
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Tenant {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(Tenant.class);
-
-  private String tenantRole;
-  private String tenantName;
-  private int numberOfInstances = 0;
-  private int offlineInstances = 0;
-  private int realtimeInstances = 0;
-
-  // private boolean colocated = false;
-
-  public void setTenantRole(String tenantRole) {
-    this.tenantRole = tenantRole;
-  }
-
-  public void setTenantName(String tenantName) {
-    this.tenantName = tenantName;
-  }
-
-  public void setNumberOfInstances(int numberOfInstances) {
-    this.numberOfInstances = numberOfInstances;
-  }
-
-  public void setOfflineInstances(int offlineInstances) {
-    this.offlineInstances = offlineInstances;
-  }
-
-  public void setRealtimeInstances(int realtimeInstances) {
-    this.realtimeInstances = realtimeInstances;
-  }
+  private TenantRole _tenantRole;
+  private String _tenantName;
+  private int _numberOfInstances = 0;
+  private int _offlineInstances = 0;
+  private int _realtimeInstances = 0;
 
   public TenantRole getTenantRole() {
-    return TenantRole.valueOf(tenantRole.toUpperCase());
+    return _tenantRole;
+  }
+
+  public void setTenantRole(TenantRole tenantRole) {
+    _tenantRole = tenantRole;
   }
 
   public String getTenantName() {
-    return tenantName;
+    return _tenantName;
+  }
+
+  public void setTenantName(String tenantName) {
+    _tenantName = tenantName;
   }
 
   public int getNumberOfInstances() {
-    return numberOfInstances;
+    return _numberOfInstances;
+  }
+
+  public void setNumberOfInstances(int numberOfInstances) {
+    _numberOfInstances = numberOfInstances;
   }
 
   public int getOfflineInstances() {
-    return offlineInstances;
+    return _offlineInstances;
+  }
+
+  public void setOfflineInstances(int offlineInstances) {
+    _offlineInstances = offlineInstances;
   }
 
   public int getRealtimeInstances() {
-    return realtimeInstances;
+    return _realtimeInstances;
+  }
+
+  public void setRealtimeInstances(int realtimeInstances) {
+    _realtimeInstances = realtimeInstances;
   }
 
   @JsonIgnore
   public boolean isCoLocated() {
-    return (realtimeInstances + offlineInstances > numberOfInstances);
+    return _realtimeInstances + _offlineInstances > _numberOfInstances;
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (EqualityUtils.isSameReference(this, o)) {
+  public boolean equals(Object obj) {
+    if (this == obj) {
       return true;
     }
-
-    if (EqualityUtils.isNullOrNotSameClass(this, o)) {
-      return false;
+    if (obj instanceof Tenant) {
+      Tenant that = (Tenant) obj;
+      return EqualityUtils.isEqual(_numberOfInstances, that._numberOfInstances)
+          && EqualityUtils.isEqual(_offlineInstances, that._offlineInstances)
+          && EqualityUtils.isEqual(_realtimeInstances, that._realtimeInstances)
+          && EqualityUtils.isEqual(_tenantRole, that._tenantRole)
+          && EqualityUtils.isEqual(_tenantName, that._tenantName);
     }
-
-    Tenant tenant = (Tenant) o;
-
-    return EqualityUtils.isEqual(numberOfInstances, tenant.numberOfInstances) &&
-        EqualityUtils.isEqual(offlineInstances, tenant.offlineInstances) &&
-        EqualityUtils.isEqual(realtimeInstances, tenant.realtimeInstances) &&
-        EqualityUtils.isEqual(tenantRole, tenant.tenantRole) &&
-        EqualityUtils.isEqual(tenantName, tenant.tenantName);
+    return false;
   }
 
   @Override
   public int hashCode() {
-    int result = EqualityUtils.hashCodeOf(tenantRole);
-    result = EqualityUtils.hashCodeOf(result, tenantName);
-    result = EqualityUtils.hashCodeOf(result, numberOfInstances);
-    result = EqualityUtils.hashCodeOf(result, offlineInstances);
-    result = EqualityUtils.hashCodeOf(result, realtimeInstances);
+    int result = EqualityUtils.hashCodeOf(_tenantRole);
+    result = EqualityUtils.hashCodeOf(result, _tenantName);
+    result = EqualityUtils.hashCodeOf(result, _numberOfInstances);
+    result = EqualityUtils.hashCodeOf(result, _offlineInstances);
+    result = EqualityUtils.hashCodeOf(result, _realtimeInstances);
     return result;
-  }
-
-  @Override
-  public String toString() {
-    String ret = null;
-    try {
-      ret = new ObjectMapper().writeValueAsString(this);
-    } catch (Exception e) {
-      LOGGER.error("error toString for tenant ", e);
-    }
-    return ret;
-  }
-
-  public JSONObject toJSON() throws JSONException {
-    return new JSONObject(toString());
   }
 
   public static class TenantBuilder {
@@ -141,7 +112,7 @@ public class Tenant {
     }
 
     public TenantBuilder setRole(TenantRole role) {
-      tenant.setTenantRole(role.toString());
+      tenant.setTenantRole(role);
       return this;
     }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TenantConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TenantConfig.java
@@ -18,10 +18,9 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.lang.reflect.Field;
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
@@ -18,13 +18,13 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import com.google.gson.JsonObject;
 import com.linkedin.pinot.common.config.ConfigKey;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import javax.annotation.Nonnull;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 
 @SuppressWarnings("unused")
@@ -121,10 +121,10 @@ public final class DateTimeFieldSpec extends FieldSpec {
 
   @Nonnull
   @Override
-  public JsonObject toJsonObject() {
-    JsonObject jsonObject = super.toJsonObject();
-    jsonObject.addProperty("format", _format);
-    jsonObject.addProperty("granularity", _granularity);
+  public ObjectNode toJsonObject() {
+    ObjectNode jsonObject = super.toJsonObject();
+    jsonObject.put("format", _format);
+    jsonObject.put("granularity", _granularity);
     return jsonObject;
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DimensionFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DimensionFieldSpec.java
@@ -18,9 +18,9 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import javax.annotation.Nonnull;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -18,13 +18,13 @@
  */
 package com.linkedin.pinot.common.data;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.config.ConfigKey;
 import com.linkedin.pinot.common.config.ConfigNodeLifecycleAware;
 import com.linkedin.pinot.common.utils.EqualityUtils;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import javax.annotation.Nullable;
 import org.apache.avro.Schema.Type;
 import org.apache.commons.codec.DecoderException;
@@ -267,63 +267,63 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
   }
 
   /**
-   * Returns the {@link JsonObject} representing the field spec.
+   * Returns the {@link ObjectNode} representing the field spec.
    * <p>Only contains fields with non-default value.
-   * <p>NOTE: here we use {@link JsonObject} to preserve the insertion order.
+   * <p>NOTE: here we use {@link ObjectNode} to preserve the insertion order.
    */
-  public JsonObject toJsonObject() {
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("name", _name);
-    jsonObject.addProperty("dataType", _dataType.name());
+  public ObjectNode toJsonObject() {
+    ObjectNode jsonObject = JsonUtils.newObjectNode();
+    jsonObject.put("name", _name);
+    jsonObject.put("dataType", _dataType.name());
     if (!_isSingleValueField) {
-      jsonObject.addProperty("singleValueField", false);
+      jsonObject.put("singleValueField", false);
     }
     if (_maxLength != DEFAULT_MAX_LENGTH) {
-      jsonObject.addProperty("maxLength", _maxLength);
+      jsonObject.put("maxLength", _maxLength);
     }
     appendDefaultNullValue(jsonObject);
     return jsonObject;
   }
 
-  protected void appendDefaultNullValue(JsonObject jsonObject) {
+  protected void appendDefaultNullValue(ObjectNode jsonNode) {
     assert _defaultNullValue != null;
     if (!_defaultNullValue.equals(getDefaultNullValue(getFieldType(), _dataType, null))) {
       if (_defaultNullValue instanceof Number) {
-        jsonObject.add("defaultNullValue", new JsonPrimitive((Number) _defaultNullValue));
+        jsonNode.set("defaultNullValue", JsonUtils.objectToJsonNode(_defaultNullValue));
       } else {
-        jsonObject.addProperty("defaultNullValue", getStringValue(_defaultNullValue));
+        jsonNode.put("defaultNullValue", getStringValue(_defaultNullValue));
       }
     }
   }
 
-  public JsonObject toAvroSchemaJsonObject() {
-    JsonObject jsonSchema = new JsonObject();
-    jsonSchema.addProperty("name", _name);
+  public ObjectNode toAvroSchemaJsonObject() {
+    ObjectNode jsonSchema = JsonUtils.newObjectNode();
+    jsonSchema.put("name", _name);
     switch (_dataType) {
       case INT:
-        jsonSchema.add("type", convertStringsToJsonArray("null", "int"));
+        jsonSchema.set("type", convertStringsToJsonArray("null", "int"));
         return jsonSchema;
       case LONG:
-        jsonSchema.add("type", convertStringsToJsonArray("null", "long"));
+        jsonSchema.set("type", convertStringsToJsonArray("null", "long"));
         return jsonSchema;
       case FLOAT:
-        jsonSchema.add("type", convertStringsToJsonArray("null", "float"));
+        jsonSchema.set("type", convertStringsToJsonArray("null", "float"));
         return jsonSchema;
       case DOUBLE:
-        jsonSchema.add("type", convertStringsToJsonArray("null", "double"));
+        jsonSchema.set("type", convertStringsToJsonArray("null", "double"));
         return jsonSchema;
       case STRING:
-        jsonSchema.add("type", convertStringsToJsonArray("null", "string"));
+        jsonSchema.set("type", convertStringsToJsonArray("null", "string"));
         return jsonSchema;
       default:
         throw new UnsupportedOperationException();
     }
   }
 
-  private static JsonArray convertStringsToJsonArray(String... strings) {
-    JsonArray jsonArray = new JsonArray();
+  private static ArrayNode convertStringsToJsonArray(String... strings) {
+    ArrayNode jsonArray = JsonUtils.newArrayNode();
     for (String string : strings) {
-      jsonArray.add(new JsonPrimitive(string));
+      jsonArray.add(string);
     }
     return jsonArray;
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
@@ -18,13 +18,13 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import com.google.gson.JsonObject;
 import com.linkedin.pinot.common.config.ConfigKey;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import javax.annotation.Nonnull;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 
 /**
@@ -141,13 +141,13 @@ public final class MetricFieldSpec extends FieldSpec {
 
   @Nonnull
   @Override
-  public JsonObject toJsonObject() {
-    JsonObject jsonObject = super.toJsonObject();
+  public ObjectNode toJsonObject() {
+    ObjectNode jsonObject = super.toJsonObject();
     if (_dataType == DataType.STRING && _fieldSize != UNDEFINED_METRIC_SIZE) {
-      jsonObject.addProperty("fieldSize", _fieldSize);
+      jsonObject.put("fieldSize", _fieldSize);
     }
     if (_derivedMetricType != null) {
-      jsonObject.addProperty("derivedMetricType", _derivedMetricType.name());
+      jsonObject.put("derivedMetricType", _derivedMetricType.name());
     }
     return jsonObject;
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
@@ -18,18 +18,19 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Sets;
+import com.linkedin.pinot.common.config.ConfigKey;
 import com.linkedin.pinot.common.segment.StarTreeMetadata;
 import com.linkedin.pinot.common.utils.EqualityUtils;
-import com.linkedin.pinot.common.config.ConfigKey;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
 
 
 @SuppressWarnings("unused")
@@ -37,8 +38,6 @@ import org.codehaus.jackson.map.ObjectMapper;
 public class StarTreeIndexSpec {
   public static final int DEFAULT_MAX_LEAF_RECORDS = 100000; // TODO: determine a good number via experiment
   public static final int DEFAULT_SKIP_MATERIALIZATION_CARDINALITY_THRESHOLD = 10000;
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   /** The upper bound on the number of leaf records to be scanned for any query */
   @ConfigKey("maxLeafRecords")
@@ -115,8 +114,8 @@ public class StarTreeIndexSpec {
     return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
   }
 
-  public String toJsonString() throws Exception {
-    return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+  public String toJsonString() throws JsonProcessingException {
+    return JsonUtils.objectToString(this);
   }
 
   /**
@@ -127,11 +126,11 @@ public class StarTreeIndexSpec {
    * @throws IOException
    */
   public static StarTreeIndexSpec fromFile(File starTreeIndexSpecFile) throws IOException {
-    return OBJECT_MAPPER.readValue(starTreeIndexSpecFile, StarTreeIndexSpec.class);
+    return JsonUtils.fileToObject(starTreeIndexSpecFile, StarTreeIndexSpec.class);
   }
 
   public static StarTreeIndexSpec fromJsonString(String jsonString) throws IOException {
-    return OBJECT_MAPPER.readValue(jsonString, StarTreeIndexSpec.class);
+    return JsonUtils.stringToObject(jsonString, StarTreeIndexSpec.class);
   }
 
   public static StarTreeIndexSpec fromStarTreeMetadata(StarTreeMetadata starTreeMetadata) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
@@ -18,14 +18,15 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import com.google.gson.JsonObject;
 import com.linkedin.pinot.common.config.ConfigKey;
 import com.linkedin.pinot.common.utils.EqualityUtils;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 
 @SuppressWarnings("unused")
@@ -205,11 +206,11 @@ public final class TimeFieldSpec extends FieldSpec {
 
   @Nonnull
   @Override
-  public JsonObject toJsonObject() {
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.add("incomingGranularitySpec", _incomingGranularitySpec.toJsonObject());
+  public ObjectNode toJsonObject() {
+    ObjectNode jsonObject = JsonUtils.newObjectNode();
+    jsonObject.set("incomingGranularitySpec", _incomingGranularitySpec.toJsonObject());
     if (!getOutgoingGranularitySpec().equals(_incomingGranularitySpec)) {
-      jsonObject.add("outgoingGranularitySpec", _outgoingGranularitySpec.toJsonObject());
+      jsonObject.set("outgoingGranularitySpec", _outgoingGranularitySpec.toJsonObject());
     }
     appendDefaultNullValue(jsonObject);
     return jsonObject;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeGranularitySpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeGranularitySpec.java
@@ -18,14 +18,15 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import com.google.gson.JsonObject;
 import com.linkedin.pinot.common.config.ConfigKey;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.utils.EqualityUtils;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 
@@ -249,20 +250,20 @@ public class TimeGranularitySpec {
   }
 
   /**
-   * Returns the {@link JsonObject} representing the time granularity spec.
+   * Returns the {@link ObjectNode} representing the time granularity spec.
    * <p>Only contains fields with non-default value.
-   * <p>NOTE: here we use {@link JsonObject} to preserve the insertion order.
+   * <p>NOTE: here we use {@link ObjectNode} to preserve the insertion order.
    */
-  public JsonObject toJsonObject() {
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("name", _name);
-    jsonObject.addProperty("dataType", _dataType.name());
-    jsonObject.addProperty("timeType", _timeType.name());
+  public ObjectNode toJsonObject() {
+    ObjectNode jsonObject = JsonUtils.newObjectNode();
+    jsonObject.put("name", _name);
+    jsonObject.put("dataType", _dataType.name());
+    jsonObject.put("timeType", _timeType.name());
     if (_timeUnitSize != DEFAULT_TIME_UNIT_SIZE) {
-      jsonObject.addProperty("timeUnitSize", _timeUnitSize);
+      jsonObject.put("timeUnitSize", _timeUnitSize);
     }
     if (!_timeFormat.equals(DEFAULT_TIME_FORMAT)) {
-      jsonObject.addProperty("timeFormat", _timeFormat);
+      jsonObject.put("timeFormat", _timeFormat);
     }
     return jsonObject;
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/ColumnPartitionMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/ColumnPartitionMetadata.java
@@ -18,22 +18,22 @@
  */
 package com.linkedin.pinot.common.metadata.segment;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.linkedin.pinot.common.config.ColumnPartitionConfig;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang.math.IntRange;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 
 /**
@@ -43,7 +43,6 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
  *   <li> Number of partitions. </li>
  *   <li> List of partition ranges. </li>
  * </ul>
-
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ColumnPartitionMetadata extends ColumnPartitionConfig {
@@ -113,8 +112,7 @@ public class ColumnPartitionMetadata extends ColumnPartitionConfig {
   public static class PartitionRangesDeserializer extends JsonDeserializer<List<IntRange>> {
 
     @Override
-    public List<IntRange> deserialize(JsonParser jsonParser, DeserializationContext context)
-        throws IOException {
+    public List<IntRange> deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
       return ColumnPartitionConfig.rangesFromString(jsonParser.getText());
     }
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentPartitionMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentPartitionMetadata.java
@@ -34,17 +34,17 @@ package com.linkedin.pinot.common.metadata.segment;
  * limitations under the License.
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.math.IntRange;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
 
 
 /**
@@ -53,8 +53,6 @@ import org.codehaus.jackson.map.ObjectMapper;
 @SuppressWarnings("unused") // Suppress incorrect warning, as methods are used for json ser/de.
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SegmentPartitionMetadata {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
   public static final int INVALID_NUM_PARTITIONS = -1;
   private final Map<String, ColumnPartitionMetadata> _columnPartitionMap;
 
@@ -109,9 +107,8 @@ public class SegmentPartitionMetadata {
    * @return Instance of {@link SegmentPartitionMetadata} built from the input string.
    * @throws IOException
    */
-  public static SegmentPartitionMetadata fromJsonString(String jsonString)
-      throws IOException {
-    return OBJECT_MAPPER.readValue(jsonString, SegmentPartitionMetadata.class);
+  public static SegmentPartitionMetadata fromJsonString(String jsonString) throws IOException {
+    return JsonUtils.stringToObject(jsonString, SegmentPartitionMetadata.class);
   }
 
   /**
@@ -120,9 +117,8 @@ public class SegmentPartitionMetadata {
    * @return JSON string equivalent of the object.
    * @throws IOException
    */
-  public String toJsonString()
-      throws IOException {
-    return OBJECT_MAPPER.writeValueAsString(this);
+  public String toJsonString() throws IOException {
+    return JsonUtils.objectToString(this);
   }
 
   /**

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -18,9 +18,11 @@
  */
 package com.linkedin.pinot.common.metadata.segment;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.pinot.common.metadata.ZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Segment.SegmentType;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +31,6 @@ import javax.annotation.Nonnull;
 import org.apache.helix.ZNRecord;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -336,8 +337,11 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     if (_customMap == null) {
       configMap.put(CommonConstants.Segment.CUSTOM_MAP, null);
     } else {
-      JSONObject jsonObject = new JSONObject(_customMap);
-      configMap.put(CommonConstants.Segment.CUSTOM_MAP, jsonObject.toString());
+      try {
+        configMap.put(CommonConstants.Segment.CUSTOM_MAP, JsonUtils.objectToString(_customMap));
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     return configMap;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
@@ -20,7 +20,6 @@ package com.linkedin.pinot.common.response;
 
 import com.linkedin.pinot.common.response.broker.QueryProcessingException;
 import java.util.List;
-import org.json.JSONObject;
 
 
 /**
@@ -53,16 +52,9 @@ public interface BrokerResponse {
   void setTimeUsedMs(long timeUsedMs);
 
   /**
-   * Convert the broker response to JSONObject.
-   */
-  JSONObject toJson()
-      throws Exception;
-
-  /**
    * Convert the broker response to JSON String.
    */
-  String toJsonString()
-      throws Exception;
+  String toJsonString() throws Exception;
 
   /**
    * Returns the number of servers queried.

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/AggregationResult.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/AggregationResult.java
@@ -18,11 +18,11 @@
  */
 package com.linkedin.pinot.common.response.broker;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 
 /**
@@ -72,7 +72,7 @@ public class AggregationResult {
    * @return
    */
   @JsonProperty("function")
-  @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public String getFunction() {
     return _function;
   }
@@ -91,7 +91,7 @@ public class AggregationResult {
    * @return
    */
   @JsonProperty("value")
-  @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public Serializable getValue() {
     return _value;
   }
@@ -110,7 +110,7 @@ public class AggregationResult {
    * @return
    */
   @JsonProperty("groupByResult")
-  @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public List<GroupByResult> getGroupByResult() {
     return _groupByResults;
   }
@@ -129,7 +129,7 @@ public class AggregationResult {
    * @return
    */
   @JsonProperty("groupByColumns")
-  @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public List<String> getGroupByColumns() {
     return _groupByColumns;
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
@@ -18,22 +18,19 @@
  */
 package com.linkedin.pinot.common.response.broker;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.response.BrokerResponse;
 import com.linkedin.pinot.common.response.ProcessingException;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.type.TypeReference;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 
 /**
@@ -42,12 +39,11 @@ import org.json.JSONObject;
  *
  * Supports serialization via JSON.
  */
-@JsonPropertyOrder({ "selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded", "numSegmentsQueried",
-    "numSegmentsProcessed", "numSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numGroupsLimitReached",
-    "totalDocs", "timeUsedMs", "segmentStatistics", "traceInfo" })
+@JsonPropertyOrder({"selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded",
+    "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter",
+    "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "segmentStatistics",
+    "traceInfo"})
 public class BrokerResponseNative implements BrokerResponse {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
   public static final BrokerResponseNative EMPTY_RESULT = BrokerResponseNative.empty();
   public static final BrokerResponseNative NO_TABLE_RESULT =
       new BrokerResponseNative(QueryException.BROKER_RESOURCE_MISSING_ERROR);
@@ -60,7 +56,7 @@ public class BrokerResponseNative implements BrokerResponse {
   private long _numSegmentsQueried = 0L;
   private long _numSegmentsProcessed = 0L;
   private long _numSegmentsMatched = 0L;
-  
+
   private long _totalDocs = 0L;
   private boolean _numGroupsLimitReached = false;
   private long _timeUsedMs = 0L;
@@ -93,7 +89,7 @@ public class BrokerResponseNative implements BrokerResponse {
   }
 
   @JsonProperty("selectionResults")
-  @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public SelectionResults getSelectionResults() {
     return _selectionResults;
   }
@@ -104,7 +100,7 @@ public class BrokerResponseNative implements BrokerResponse {
   }
 
   @JsonProperty("aggregationResults")
-  @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public List<AggregationResult> getAggregationResults() {
     return _aggregationResults;
   }
@@ -265,21 +261,11 @@ public class BrokerResponseNative implements BrokerResponse {
 
   @Override
   public String toJsonString() throws IOException {
-    return OBJECT_MAPPER.writeValueAsString(this);
-  }
-
-  @Override
-  public JSONObject toJson() throws IOException, JSONException {
-    return new JSONObject(toJsonString());
+    return JsonUtils.objectToString(this);
   }
 
   public static BrokerResponseNative fromJsonString(String jsonString) throws IOException {
-    return OBJECT_MAPPER.readValue(jsonString, new TypeReference<BrokerResponseNative>() {
-    });
-  }
-
-  public static BrokerResponseNative fromJsonObject(JSONObject jsonObject) throws IOException {
-    return fromJsonString(jsonObject.toString());
+    return JsonUtils.stringToObject(jsonString, BrokerResponseNative.class);
   }
 
   @JsonIgnore
@@ -299,6 +285,4 @@ public class BrokerResponseNative implements BrokerResponse {
   public int getExceptionsSize() {
     return _processingExceptions.size();
   }
-
-
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/GroupByResult.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/GroupByResult.java
@@ -18,10 +18,10 @@
  */
 package com.linkedin.pinot.common.response.broker;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 
 @JsonPropertyOrder({"value", "group"})

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/QueryProcessingException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/QueryProcessingException.java
@@ -18,7 +18,7 @@
  */
 package com.linkedin.pinot.common.response.broker;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 /**

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/SelectionResults.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/SelectionResults.java
@@ -18,11 +18,11 @@
  */
 package com.linkedin.pinot.common.response.broker;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 
 @JsonPropertyOrder({"columns", "results"})

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/RebalanceResult.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/RebalanceResult.java
@@ -19,9 +19,9 @@
 package com.linkedin.pinot.common.restlet.resources;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.linkedin.pinot.common.partition.PartitionAssignment;
 import java.util.Map;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RebalanceResult {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/ResourceUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/ResourceUtils.java
@@ -18,10 +18,10 @@
  */
 package com.linkedin.pinot.common.restlet.resources;
 
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.IOException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,9 +36,8 @@ public class ResourceUtils {
   }
 
   public static String convertToJsonString(Object object) {
-    ObjectMapper mapper = new ObjectMapper();
     try {
-      return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+      return JsonUtils.objectToPrettyString(object);
     } catch (IOException e) {
       LOGGER.error("Failed to convert json into string: ", e);
       throw new WebApplicationException("Failed to convert json into string.", Response.Status.INTERNAL_SERVER_ERROR);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/SegmentSizeInfo.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/SegmentSizeInfo.java
@@ -18,7 +18,7 @@
  */
 package com.linkedin.pinot.common.restlet.resources;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/TableSizeInfo.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/TableSizeInfo.java
@@ -18,9 +18,9 @@
  */
 package com.linkedin.pinot.common.restlet.resources;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.ArrayList;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/TablesList.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/TablesList.java
@@ -18,21 +18,18 @@
  */
 package com.linkedin.pinot.common.restlet.resources;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class TablesList {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TablesList.class);
-  List<String> tables;
+  private List<String> _tables;
 
   public TablesList(@JsonProperty("tables") List<String> tables) {
-    this.tables = tables;
+    _tables = tables;
   }
 
   public List<String> getTables() {
-    return tables;
+    return _tables;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
@@ -55,7 +55,6 @@ import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,7 +156,7 @@ public class FileUploadDownloadClient implements Closeable {
   public static URI getOldUploadSegmentHttpsURI(String host, int port) throws URISyntaxException {
     return getURI(HTTPS, host, port, OLD_SEGMENT_PATH);
   }
-  
+
   public static URI getUploadSegmentHttpURI(String host, int port) throws URISyntaxException {
     return getURI(HTTP, host, port, SEGMENT_PATH);
   }
@@ -316,7 +315,7 @@ public class FileUploadDownloadClient implements Closeable {
     StatusLine statusLine = response.getStatusLine();
     String reason;
     try {
-      reason = new JSONObject(EntityUtils.toString(response.getEntity())).getString("error");
+      reason = JsonUtils.stringToJsonNode(EntityUtils.toString(response.getEntity())).get("error").asText();
     } catch (Exception e) {
       reason = "Failed to get reason";
     }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/JsonUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/JsonUtils.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.data.FieldSpec;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.annotation.Nullable;
+
+
+public class JsonUtils {
+  private JsonUtils() {
+  }
+
+  public static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
+  public static final ObjectReader DEFAULT_READER = DEFAULT_MAPPER.reader();
+  public static final ObjectWriter DEFAULT_WRITER = DEFAULT_MAPPER.writer();
+  public static final ObjectWriter DEFAULT_PRETTY_WRITER = DEFAULT_MAPPER.writerWithDefaultPrettyPrinter();
+
+  public static <T> T stringToObject(String jsonString, Class<T> valueType) throws IOException {
+    return DEFAULT_MAPPER.readValue(jsonString, valueType);
+  }
+
+  public static JsonNode stringToJsonNode(String jsonString) throws IOException {
+    return DEFAULT_READER.readTree(jsonString);
+  }
+
+  public static <T> T fileToObject(File jsonFile, Class<T> valueType) throws IOException {
+    return DEFAULT_MAPPER.readValue(jsonFile, valueType);
+  }
+
+  public static JsonNode fileToJsonNode(File jsonFile) throws IOException {
+    try (InputStream inputStream = new FileInputStream(jsonFile)) {
+      return inputStreamToJsonNode(inputStream);
+    }
+  }
+
+  public static <T> T inputStreamToObject(InputStream jsonInputStream, Class<T> valueType) throws IOException {
+    return DEFAULT_MAPPER.readValue(jsonInputStream, valueType);
+  }
+
+  public static JsonNode inputStreamToJsonNode(InputStream jsonInputStream) throws IOException {
+    return DEFAULT_READER.readTree(jsonInputStream);
+  }
+
+  public static <T> T bytesToObject(byte[] jsonBytes, Class<T> valueType) throws IOException {
+    return DEFAULT_MAPPER.readValue(jsonBytes, valueType);
+  }
+
+  public static JsonNode bytesToJsonNode(byte[] jsonBytes) throws IOException {
+    return inputStreamToJsonNode(new ByteArrayInputStream(jsonBytes));
+  }
+
+  public static <T> T jsonNodeToObject(JsonNode jsonNode, Class<T> valueType) throws JsonProcessingException {
+    return DEFAULT_READER.treeToValue(jsonNode, valueType);
+  }
+
+  public static String objectToString(Object object) throws JsonProcessingException {
+    return DEFAULT_WRITER.writeValueAsString(object);
+  }
+
+  public static String objectToPrettyString(Object object) throws JsonProcessingException {
+    return DEFAULT_PRETTY_WRITER.writeValueAsString(object);
+  }
+
+  public static byte[] objectToBytes(Object object) throws JsonProcessingException {
+    return DEFAULT_WRITER.writeValueAsBytes(object);
+  }
+
+  public static JsonNode objectToJsonNode(Object object) {
+    return DEFAULT_MAPPER.valueToTree(object);
+  }
+
+  public static ObjectNode newObjectNode() {
+    return JsonNodeFactory.instance.objectNode();
+  }
+
+  public static ArrayNode newArrayNode() {
+    return JsonNodeFactory.instance.arrayNode();
+  }
+
+  public static Object extractValue(@Nullable JsonNode jsonValue, FieldSpec fieldSpec) {
+    if (fieldSpec.isSingleValueField()) {
+      if (jsonValue != null && !jsonValue.isNull()) {
+        return extractSingleValue(jsonValue, fieldSpec.getDataType());
+      } else {
+        return fieldSpec.getDefaultNullValue();
+      }
+    } else {
+      if (jsonValue != null && !jsonValue.isNull()) {
+        if (jsonValue.isArray()) {
+          int numValues = jsonValue.size();
+          if (numValues != 0) {
+            Object[] values = new Object[numValues];
+            for (int i = 0; i < numValues; i++) {
+              values[i] = extractSingleValue(jsonValue.get(i), fieldSpec.getDataType());
+            }
+            return values;
+          } else {
+            return new Object[]{fieldSpec.getDefaultNullValue()};
+          }
+        } else {
+          return new Object[]{extractSingleValue(jsonValue, fieldSpec.getDataType())};
+        }
+      } else {
+        return new Object[]{fieldSpec.getDefaultNullValue()};
+      }
+    }
+  }
+
+  private static Object extractSingleValue(JsonNode jsonValue, FieldSpec.DataType dataType) {
+    Preconditions.checkArgument(jsonValue.isValueNode());
+    switch (dataType) {
+      case INT:
+        return jsonValue.asInt();
+      case LONG:
+        return jsonValue.asLong();
+      case FLOAT:
+        return (float) jsonValue.asDouble();
+      case DOUBLE:
+        return jsonValue.asDouble();
+      case STRING:
+        return jsonValue.asText();
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/startree/hll/HllConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/startree/hll/HllConfig.java
@@ -18,9 +18,11 @@
  */
 package com.linkedin.pinot.startree.hll;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.config.ConfigKey;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,13 +30,8 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.map.ObjectMapper;
 
-import static com.linkedin.pinot.common.utils.EqualityUtils.hashCodeOf;
-import static com.linkedin.pinot.common.utils.EqualityUtils.isEqual;
-import static com.linkedin.pinot.common.utils.EqualityUtils.isNullOrNotSameClass;
-import static com.linkedin.pinot.common.utils.EqualityUtils.isSameReference;
+import static com.linkedin.pinot.common.utils.EqualityUtils.*;
 
 
 /**
@@ -57,8 +54,6 @@ public class HllConfig {
   private Set<String> columnsToDeriveHllFields = new HashSet<>();
 
   private transient Map<String, String> derivedHllFieldToOriginMap;
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   /**
    * HllConfig with default hll log2m. No Hll derived field is generated.
@@ -149,11 +144,11 @@ public class HllConfig {
   }
 
   public String toJsonString() throws Exception {
-    return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+    return JsonUtils.objectToPrettyString(this);
   }
 
   public static HllConfig fromJsonString(String jsonString) throws IOException {
-    return OBJECT_MAPPER.readValue(jsonString, HllConfig.class);
+    return JsonUtils.stringToObject(jsonString, HllConfig.class);
   }
 
   @Override

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/QuotaConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/QuotaConfigTest.java
@@ -18,11 +18,12 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.IOException;
 import org.apache.commons.configuration.ConfigurationRuntimeException;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
 
 public class QuotaConfigTest {
 
@@ -30,14 +31,14 @@ public class QuotaConfigTest {
   public void testQuotaConfig() throws IOException {
     {
       String quotaConfigStr = "{\"storage\" : \"100g\"}";
-      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+      QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
 
       Assert.assertEquals(quotaConfig.getStorage(), "100g");
       Assert.assertEquals(quotaConfig.storageSizeBytes(), 100 * 1024 * 1024 * 1024L);
     }
     {
       String quotaConfigStr = "{}";
-      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+      QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
       Assert.assertNull(quotaConfig.getStorage());
       Assert.assertEquals(quotaConfig.storageSizeBytes(), -1);
     }
@@ -47,7 +48,7 @@ public class QuotaConfigTest {
   public void testBadQuotaConfig() throws IOException {
     {
       String quotaConfigStr = "{\"storage\" : \"124GB3GB\"}";
-      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+      QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
       Assert.assertNotNull(quotaConfig.getStorage());
       Assert.assertEquals(quotaConfig.storageSizeBytes(), -1);
     }
@@ -56,7 +57,7 @@ public class QuotaConfigTest {
   @Test(expectedExceptions = ConfigurationRuntimeException.class)
   public void testBadConfig() throws IOException {
     String quotaConfigStr = "{\"storage\":\"-1M\"}";
-    QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+    QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
     quotaConfig.validate();
   }
 
@@ -64,7 +65,7 @@ public class QuotaConfigTest {
   public void testQpsQuota() throws IOException {
     {
       String quotaConfigStr = "{\"maxQueriesPerSecond\" : \"100.00\"}";
-      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+      QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
 
       Assert.assertNotNull(quotaConfig.getMaxQueriesPerSecond());
       Assert.assertEquals(quotaConfig.getMaxQueriesPerSecond(), "100.00");
@@ -72,7 +73,7 @@ public class QuotaConfigTest {
     }
     {
       String quotaConfigStr = "{\"maxQueriesPerSecond\" : \"0.5\"}";
-      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+      QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
 
       Assert.assertNotNull(quotaConfig.getMaxQueriesPerSecond());
       Assert.assertEquals(quotaConfig.getMaxQueriesPerSecond(), "0.5");
@@ -80,7 +81,7 @@ public class QuotaConfigTest {
     }
     {
       String quotaConfigStr = "{}";
-      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+      QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
       Assert.assertNull(quotaConfig.getMaxQueriesPerSecond());
       Assert.assertTrue(quotaConfig.isMaxQueriesPerSecondValid());
     }
@@ -89,7 +90,7 @@ public class QuotaConfigTest {
   @Test(expectedExceptions = ConfigurationRuntimeException.class)
   public void testInvalidQpsQuota() throws IOException {
     String quotaConfigStr = "{\"maxQueriesPerSecond\" : \"InvalidQpsQuota\"}";
-    QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+    QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
     Assert.assertNotNull(quotaConfig.getMaxQueriesPerSecond());
     quotaConfig.validate();
   }
@@ -97,7 +98,7 @@ public class QuotaConfigTest {
   @Test(expectedExceptions = ConfigurationRuntimeException.class)
   public void testNegativeQpsQuota() throws IOException {
     String quotaConfigStr = "{\"maxQueriesPerSecond\" : \"-1.0\"}";
-    QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+    QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
     Assert.assertNotNull(quotaConfig.getMaxQueriesPerSecond());
     quotaConfig.validate();
   }
@@ -105,7 +106,7 @@ public class QuotaConfigTest {
   @Test(expectedExceptions = ConfigurationRuntimeException.class)
   public void testBadQpsQuota() throws IOException {
     String quotaConfigStr = "{\"maxQueriesPerSecond\" : \"1.0Test\"}";
-    QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+    QuotaConfig quotaConfig = JsonUtils.stringToObject(quotaConfigStr, QuotaConfig.class);
     Assert.assertNotNull(quotaConfig.getMaxQueriesPerSecond());
     quotaConfig.validate();
   }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/TableConfigTest.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.helix.ZNRecord;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -45,8 +44,7 @@ public class TableConfigTest {
       Assert.assertNull(tableConfig.getQuotaConfig());
 
       // Serialize then de-serialize
-      JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
-      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(TableConfig.toJSONConfig(tableConfig));
       Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
       Assert.assertNull(tableConfigToCompare.getQuotaConfig());
       Assert.assertNull(tableConfigToCompare.getValidationConfig().getReplicaGroupStrategyConfig());
@@ -75,12 +73,12 @@ public class TableConfigTest {
       // With qps quota
       quotaConfig.setMaxQueriesPerSecond("100.00");
       tableConfig = tableConfigBuilder.setQuotaConfig(quotaConfig).build();
+      Assert.assertNotNull(tableConfig.getQuotaConfig());
       Assert.assertNotNull(tableConfig.getQuotaConfig().getMaxQueriesPerSecond());
       Assert.assertEquals(tableConfig.getQuotaConfig().getMaxQueriesPerSecond(), "100.00");
 
       // Serialize then de-serialize
-      JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
-      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(TableConfig.toJSONConfig(tableConfig));
       Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
       Assert.assertNotNull(tableConfigToCompare.getQuotaConfig());
       Assert.assertEquals(tableConfigToCompare.getQuotaConfig().getStorage(),
@@ -106,8 +104,7 @@ public class TableConfigTest {
       Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig());
 
       // Serialize then de-serialize
-      JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
-      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(TableConfig.toJSONConfig(tableConfig));
       Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
       Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
       Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
@@ -140,8 +137,7 @@ public class TableConfigTest {
       Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig().getRealtimeCompleted());
 
       // Serialize then de-serialize
-      jsonConfig = TableConfig.toJSONConfig(tableConfig);
-      tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      tableConfigToCompare = TableConfig.fromJSONConfig(TableConfig.toJSONConfig(tableConfig));
       Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
       Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
       Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
@@ -176,8 +172,7 @@ public class TableConfigTest {
       tableConfig.getValidationConfig().setReplicaGroupStrategyConfig(replicaGroupConfig);
 
       // Serialize then de-serialize
-      JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
-      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(TableConfig.toJSONConfig(tableConfig));
       checkTableConfigWithAssignmentConfig(tableConfig, tableConfigToCompare);
 
       ZNRecord znRecord = TableConfig.toZnRecord(tableConfig);
@@ -199,8 +194,7 @@ public class TableConfigTest {
               .getStreamPartitionAssignmentStrategy(), "BalancedStreamPartitionAssignment");
 
       // Serialize then de-serialize
-      JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
-      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(TableConfig.toJSONConfig(tableConfig));
       Assert.assertEquals(
           tableConfigToCompare.getIndexingConfig().getStreamConsumptionConfig()
               .getStreamPartitionAssignmentStrategy(), "BalancedStreamPartitionAssignment");
@@ -226,8 +220,7 @@ public class TableConfigTest {
       tableConfig.getIndexingConfig().setStarTreeIndexSpec(starTreeIndexSpec);
 
       // Serialize then de-serialize
-      JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
-      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(TableConfig.toJSONConfig(tableConfig));
       checkTableConfigWithStarTreeConfig(tableConfig, tableConfigToCompare);
 
       ZNRecord znRecord = TableConfig.toZnRecord(tableConfig);
@@ -255,8 +248,7 @@ public class TableConfigTest {
       tableConfig.getValidationConfig().setHllConfig(hllConfig);
 
       // Serialize then de-serialize
-      JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
-      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(TableConfig.toJSONConfig(tableConfig));
       checkTableConfigWithHllConfig(tableConfig, tableConfigToCompare);
 
       ZNRecord znRecord = TableConfig.toZnRecord(tableConfig);
@@ -275,7 +267,7 @@ public class TableConfigTest {
     // Check that the configurations are correct.
     ReplicaGroupStrategyConfig strategyConfig =
         tableConfigToCompare.getValidationConfig().getReplicaGroupStrategyConfig();
-    Assert.assertEquals(strategyConfig.getMirrorAssignmentAcrossReplicaGroups(), true);
+    Assert.assertTrue(strategyConfig.getMirrorAssignmentAcrossReplicaGroups());
     Assert.assertEquals(strategyConfig.getNumInstancesPerPartition(), 5);
     Assert.assertEquals(strategyConfig.getPartitionColumn(), "memberId");
   }
@@ -318,7 +310,7 @@ public class TableConfigTest {
     columns.add("column");
     columns.add("column2");
 
-    Assert.assertTrue(hllConfig.getColumnsToDeriveHllFields().equals(columns));
+    Assert.assertEquals(hllConfig.getColumnsToDeriveHllFields(), columns);
     Assert.assertEquals(hllConfig.getHllLog2m(), 9);
     Assert.assertEquals(hllConfig.getHllDeriveColumnSuffix(), "suffix");
   }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/TagOverrideConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/TagOverrideConfigTest.java
@@ -19,10 +19,8 @@
 package com.linkedin.pinot.common.config;
 
 import com.linkedin.pinot.common.utils.CommonConstants;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,7 +29,7 @@ import org.testng.annotations.Test;
 public class TagOverrideConfigTest {
 
   @DataProvider(name = "realtimeTagConfigTestDataProvider")
-  public Object[][] realtimeTagConfigTestDataProvider() throws IOException, JSONException {
+  public Object[][] realtimeTagConfigTestDataProvider() {
     TableConfig.Builder tableConfigBuilder = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE);
     tableConfigBuilder.setTableName("testRealtimeTable")
         .setTimeColumnName("timeColumn")
@@ -85,7 +83,7 @@ public class TagOverrideConfigTest {
   }
 
   @DataProvider(name = "offlineTagConfigTestDataProvider")
-  public Object[][] offlineTagConfigTestDataProvider() throws IOException, JSONException {
+  public Object[][] offlineTagConfigTestDataProvider() {
     TableConfig.Builder tableConfigBuilder = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE);
     tableConfigBuilder.setTableName("testOfflineTable")
         .setTimeColumnName("timeColumn")

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/TenantTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/TenantTest.java
@@ -18,35 +18,31 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.TenantRole;
 import java.io.IOException;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
 
 public class TenantTest {
 
   @Test
-  public void testDeserializeFromJson()
-      throws JSONException, IOException {
-    JSONObject json = new JSONObject();
-    json.put("tenantRole", "SERVER");
-    json.put("tenantName", "newTenant");
-    json.put("numberOfInstances", 10);
-    json.put("offlineInstances", 5);
-    json.put("realtimeInstances", 5);
-    json.put("keyIDontKnow", "blahblahblah");
+  public void testDeserializeFromJson() throws IOException {
+    Tenant tenant = new Tenant();
+    tenant.setTenantRole(TenantRole.SERVER);
+    tenant.setTenantName("newTenant");
+    tenant.setNumberOfInstances(10);
+    tenant.setOfflineInstances(5);
+    tenant.setRealtimeInstances(5);
 
-    ObjectMapper mapper = new ObjectMapper();
-    JsonNode jsonNode = mapper.readTree(json.toString());
-    Tenant tenant = mapper.readValue(jsonNode, Tenant.class);
-    Assert.assertEquals(5, tenant.getOfflineInstances());
-    Assert.assertEquals(10, tenant.getNumberOfInstances());
-    Assert.assertEquals("newTenant", tenant.getTenantName());
-    Assert.assertEquals(TenantRole.SERVER, tenant.getTenantRole());
+    tenant = JsonUtils.stringToObject(JsonUtils.objectToString(tenant), Tenant.class);
+
+    assertEquals(tenant.getTenantRole(), TenantRole.SERVER);
+    assertEquals(tenant.getTenantName(), "newTenant");
+    assertEquals(tenant.getNumberOfInstances(), 10);
+    assertEquals(tenant.getOfflineInstances(), 5);
+    assertEquals(tenant.getRealtimeInstances(), 5);
   }
-
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/data/FieldSpecTest.java
@@ -18,13 +18,13 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -39,7 +39,6 @@ public class FieldSpecTest {
   private static final long RANDOM_SEED = System.currentTimeMillis();
   private static final Random RANDOM = new Random(RANDOM_SEED);
   private static final String ERROR_MESSAGE = "Random seed is: " + RANDOM_SEED;
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * Test all {@link FieldSpec.DataType}.
@@ -134,7 +133,7 @@ public class FieldSpecTest {
 
     // Test serialize deserialize.
     MetricFieldSpec derivedMetricField2 =
-        MAPPER.readValue(derivedMetricField.toJsonObject().toString(), MetricFieldSpec.class);
+        JsonUtils.stringToObject(derivedMetricField.toJsonObject().toString(), MetricFieldSpec.class);
     Assert.assertEquals(derivedMetricField2, derivedMetricField);
   }
 
@@ -278,7 +277,8 @@ public class FieldSpecTest {
   public void testOrderOfFields() throws Exception {
     // Metric field with default null value.
     String[] metricFields = {"\"name\":\"metric\"", "\"dataType\":\"INT\"", "\"defaultNullValue\":-1"};
-    MetricFieldSpec metricFieldSpec1 = MAPPER.readValue(getRandomOrderJsonString(metricFields), MetricFieldSpec.class);
+    MetricFieldSpec metricFieldSpec1 =
+        JsonUtils.stringToObject(getRandomOrderJsonString(metricFields), MetricFieldSpec.class);
     MetricFieldSpec metricFieldSpec2 = new MetricFieldSpec("metric", INT, -1);
     Assert.assertEquals(metricFieldSpec1, metricFieldSpec2, ERROR_MESSAGE);
     Assert.assertEquals(metricFieldSpec1.getDefaultNullValue(), -1, ERROR_MESSAGE);
@@ -286,7 +286,7 @@ public class FieldSpecTest {
     // Single-value boolean type dimension field with default null value.
     String[] dimensionFields = {"\"name\":\"dimension\"", "\"dataType\":\"BOOLEAN\"", "\"defaultNullValue\":false"};
     DimensionFieldSpec dimensionFieldSpec1 =
-        MAPPER.readValue(getRandomOrderJsonString(dimensionFields), DimensionFieldSpec.class);
+        JsonUtils.stringToObject(getRandomOrderJsonString(dimensionFields), DimensionFieldSpec.class);
     DimensionFieldSpec dimensionFieldSpec2 = new DimensionFieldSpec("dimension", BOOLEAN, true, false);
     Assert.assertEquals(dimensionFieldSpec1, dimensionFieldSpec2, ERROR_MESSAGE);
     Assert.assertEquals(dimensionFieldSpec1.getDefaultNullValue(), "false", ERROR_MESSAGE);
@@ -294,7 +294,7 @@ public class FieldSpecTest {
     // Multi-value dimension field with default null value.
     dimensionFields =
         new String[]{"\"name\":\"dimension\"", "\"dataType\":\"STRING\"", "\"singleValueField\":false", "\"defaultNullValue\":\"default\""};
-    dimensionFieldSpec1 = MAPPER.readValue(getRandomOrderJsonString(dimensionFields), DimensionFieldSpec.class);
+    dimensionFieldSpec1 = JsonUtils.stringToObject(getRandomOrderJsonString(dimensionFields), DimensionFieldSpec.class);
     dimensionFieldSpec2 = new DimensionFieldSpec("dimension", STRING, false, "default");
     Assert.assertEquals(dimensionFieldSpec1, dimensionFieldSpec2, ERROR_MESSAGE);
     Assert.assertEquals(dimensionFieldSpec1.getDefaultNullValue(), "default", ERROR_MESSAGE);
@@ -302,7 +302,7 @@ public class FieldSpecTest {
     // Time field with default null value.
     String[] timeFields =
         {"\"incomingGranularitySpec\":{\"timeType\":\"MILLISECONDS\",\"dataType\":\"LONG\",\"name\":\"incomingTime\"}", "\"outgoingGranularitySpec\":{\"timeType\":\"SECONDS\",\"dataType\":\"INT\",\"name\":\"outgoingTime\"}", "\"defaultNullValue\":-1"};
-    TimeFieldSpec timeFieldSpec1 = MAPPER.readValue(getRandomOrderJsonString(timeFields), TimeFieldSpec.class);
+    TimeFieldSpec timeFieldSpec1 = JsonUtils.stringToObject(getRandomOrderJsonString(timeFields), TimeFieldSpec.class);
     TimeFieldSpec timeFieldSpec2 =
         new TimeFieldSpec("incomingTime", LONG, TimeUnit.MILLISECONDS, "outgoingTime", INT, TimeUnit.SECONDS, -1);
     Assert.assertEquals(timeFieldSpec1, timeFieldSpec2, ERROR_MESSAGE);
@@ -312,7 +312,7 @@ public class FieldSpecTest {
     String[] dateTimeFields =
         {"\"name\":\"Date\"", "\"dataType\":\"LONG\"", "\"format\":\"1:MILLISECONDS:EPOCH\"", "\"granularity\":\"5:MINUTES\"", "\"dateTimeType\":\"PRIMARY\""};
     DateTimeFieldSpec dateTimeFieldSpec1 =
-        MAPPER.readValue(getRandomOrderJsonString(dateTimeFields), DateTimeFieldSpec.class);
+        JsonUtils.stringToObject(getRandomOrderJsonString(dateTimeFields), DateTimeFieldSpec.class);
     DateTimeFieldSpec dateTimeFieldSpec2 = new DateTimeFieldSpec("Date", LONG, "1:MILLISECONDS:EPOCH", "5:MINUTES");
     Assert.assertEquals(dateTimeFieldSpec1, dateTimeFieldSpec2, ERROR_MESSAGE);
   }
@@ -327,29 +327,29 @@ public class FieldSpecTest {
 
     // Single-value boolean type dimension field with default null value.
     String[] dimensionFields = {"\"name\":\"dimension\"", "\"dataType\":\"BOOLEAN\"", "\"defaultNullValue\":false"};
-    first = MAPPER.readValue(getRandomOrderJsonString(dimensionFields), DimensionFieldSpec.class);
-    second = MAPPER.readValue(first.toJsonObject().toString(), DimensionFieldSpec.class);
+    first = JsonUtils.stringToObject(getRandomOrderJsonString(dimensionFields), DimensionFieldSpec.class);
+    second = JsonUtils.stringToObject(first.toJsonObject().toString(), DimensionFieldSpec.class);
     Assert.assertEquals(first, second, ERROR_MESSAGE);
 
     // Multi-value dimension field with default null value.
     dimensionFields =
         new String[]{"\"name\":\"dimension\"", "\"dataType\":\"STRING\"", "\"singleValueField\":false", "\"defaultNullValue\":\"default\""};
-    first = MAPPER.readValue(getRandomOrderJsonString(dimensionFields), DimensionFieldSpec.class);
-    second = MAPPER.readValue(first.toJsonObject().toString(), DimensionFieldSpec.class);
+    first = JsonUtils.stringToObject(getRandomOrderJsonString(dimensionFields), DimensionFieldSpec.class);
+    second = JsonUtils.stringToObject(first.toJsonObject().toString(), DimensionFieldSpec.class);
     Assert.assertEquals(first, second, ERROR_MESSAGE);
 
     // Time field with default value.
     String[] timeFields =
         {"\"incomingGranularitySpec\":{\"timeUnitSize\":1, \"timeType\":\"MILLISECONDS\",\"dataType\":\"LONG\",\"name\":\"incomingTime\"}", "\"outgoingGranularitySpec\":{\"timeType\":\"SECONDS\",\"dataType\":\"INT\",\"name\":\"outgoingTime\"}", "\"defaultNullValue\":-1"};
-    first = MAPPER.readValue(getRandomOrderJsonString(timeFields), TimeFieldSpec.class);
-    second = MAPPER.readValue(first.toJsonObject().toString(), TimeFieldSpec.class);
+    first = JsonUtils.stringToObject(getRandomOrderJsonString(timeFields), TimeFieldSpec.class);
+    second = JsonUtils.stringToObject(first.toJsonObject().toString(), TimeFieldSpec.class);
     Assert.assertEquals(first, second, ERROR_MESSAGE);
 
     // DateTime field
     String[] dateTimeFields =
         {"\"name\":\"Date\"", "\"dataType\":\"LONG\"", "\"format\":\"1:MILLISECONDS:EPOCH\"", "\"granularity\":\"5:MINUTES\"", "\"dateTimeType\":\"PRIMARY\""};
-    first = MAPPER.readValue(getRandomOrderJsonString(dateTimeFields), DateTimeFieldSpec.class);
-    second = MAPPER.readValue(first.toJsonObject().toString(), DateTimeFieldSpec.class);
+    first = JsonUtils.stringToObject(getRandomOrderJsonString(dateTimeFields), DateTimeFieldSpec.class);
+    second = JsonUtils.stringToObject(first.toJsonObject().toString(), DateTimeFieldSpec.class);
     Assert.assertEquals(first, second, ERROR_MESSAGE);
   }
 

--- a/pinot-common/src/test/java/com/linkedin/pinot/request/BrokerResponseNativeTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/request/BrokerResponseNativeTest.java
@@ -22,7 +22,6 @@ import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.response.broker.BrokerResponseNative;
 import com.linkedin.pinot.common.response.broker.QueryProcessingException;
 import java.io.IOException;
-import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -30,8 +29,7 @@ import org.testng.annotations.Test;
 public class BrokerResponseNativeTest {
 
   @Test
-  public void testEmptyResponse()
-      throws JSONException, IOException {
+  public void testEmptyResponse() throws IOException {
     BrokerResponseNative expected = BrokerResponseNative.EMPTY_RESULT;
     String brokerString = expected.toJsonString();
     BrokerResponseNative actual = BrokerResponseNative.fromJsonString(brokerString);
@@ -42,8 +40,7 @@ public class BrokerResponseNativeTest {
   }
 
   @Test
-  public void testNullResponse()
-      throws JSONException, IOException {
+  public void testNullResponse() throws IOException {
     BrokerResponseNative expected = BrokerResponseNative.NO_TABLE_RESULT;
     String brokerString = expected.toJsonString();
     BrokerResponseNative actual = BrokerResponseNative.fromJsonString(brokerString);
@@ -54,8 +51,7 @@ public class BrokerResponseNativeTest {
   }
 
   @Test
-  public void testMultipleExceptionsResponse()
-      throws JSONException, IOException {
+  public void testMultipleExceptionsResponse() throws IOException {
     BrokerResponseNative expected = BrokerResponseNative.NO_TABLE_RESULT;
     String errorMsgStr = "Some random string!";
     QueryProcessingException processingException = new QueryProcessingException(400, errorMsgStr);

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -98,10 +98,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>
@@ -131,11 +127,11 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/pojos/Instance.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/pojos/Instance.java
@@ -22,8 +22,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import org.apache.helix.model.InstanceConfig;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 
 /**
@@ -109,15 +107,6 @@ public class Instance {
       bld.append("tag : " + _tag + "\n");
     }
     return bld.toString();
-  }
-
-  public JSONObject toJSON() throws JSONException {
-    final JSONObject ret = new JSONObject();
-    ret.put("host", _host);
-    ret.put("port", _port);
-    ret.put("type", _type);
-    ret.put("tag", getTagOrDefaultTag());
-    return ret;
   }
 
   public InstanceConfig toInstanceConfig() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -19,6 +19,8 @@
 package com.linkedin.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.controller.api.pojos.Instance;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.PinotResourceManagerResponse;
@@ -39,9 +41,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.helix.model.InstanceConfig;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,16 +99,12 @@ public class PinotInstanceRestletResource {
           Response.Status.NOT_FOUND);
     }
     InstanceConfig instanceConfig = pinotHelixResourceManager.getHelixInstanceConfig(instanceName);
-    JSONObject response = new JSONObject();
-    try {
-      response.put("instanceName", instanceConfig.getInstanceName());
-      response.put("hostName", instanceConfig.getHostName());
-      response.put("enabled", instanceConfig.getInstanceEnabled());
-      response.put("port", instanceConfig.getPort());
-      response.put("tags", new JSONArray(instanceConfig.getTags()));
-    } catch (JSONException e) {
-      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
-    }
+    ObjectNode response = JsonUtils.newObjectNode();
+    response.put("instanceName", instanceConfig.getInstanceName());
+    response.put("hostName", instanceConfig.getHostName());
+    response.put("enabled", instanceConfig.getInstanceEnabled());
+    response.put("port", instanceConfig.getPort());
+    response.set("tags", JsonUtils.objectToJsonNode(instanceConfig.getTags()));
     return response.toString();
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -18,10 +18,12 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metrics.ControllerMeter;
 import com.linkedin.pinot.common.metrics.ControllerMetrics;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.controller.api.events.MetadataEventNotifierFactory;
 import com.linkedin.pinot.controller.api.events.SchemaEventType;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -47,7 +49,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.json.JSONArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,11 +73,11 @@ public class PinotSchemaRestletResource {
   @ApiOperation(value = "List all schema names", notes = "Lists all schema names")
   public String listSchemaNames() {
     List<String> schemaNames = _pinotHelixResourceManager.getSchemaNames();
-    JSONArray ret = new JSONArray();
+    ArrayNode ret = JsonUtils.newArrayNode();
 
     if (schemaNames != null) {
       for (String schema : schemaNames) {
-        ret.put(schema);
+        ret.add(schema);
       }
     }
     return ret.toString();

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableIndexingConfigs.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableIndexingConfigs.java
@@ -33,8 +33,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,13 +58,12 @@ public class PinotTableIndexingConfigs {
       @ApiParam(value = "Table name (without type)", required = true) @PathParam("tableName") String tableName,
       String body
   ) {
-    TableConfig tableConfig = null;
     try {
-      tableConfig = TableConfig.fromJSONConfig(new JSONObject(body));
+      TableConfig tableConfig = TableConfig.fromJsonString(body);
       pinotHelixResourceManager.updateIndexingConfigFor(tableConfig.getTableName(), tableConfig.getTableType(),
           tableConfig.getIndexingConfig());
       return new SuccessResponse("Updated indexing config for table " + tableName);
-    } catch (JSONException | IOException e) {
+    } catch (IOException e) {
       String errStr = "Error converting request to table config for table: " + tableName;
       throw new ControllerApplicationException(LOGGER, errStr, Response.Status.BAD_REQUEST, e);
     } catch (Exception e) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableMetadataConfigs.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableMetadataConfigs.java
@@ -31,7 +31,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +53,7 @@ public class PinotTableMetadataConfigs {
   public SuccessResponse updateTableMetadata(@PathParam("tableName")String tableName, String requestBody
   ) {
     try {
-      TableConfig tableConfig = TableConfig.fromJSONConfig(new JSONObject(requestBody));
+      TableConfig tableConfig = TableConfig.fromJsonString(requestBody);
       pinotHelixResourceManager.updateMetadataConfigFor(tableConfig.getTableName(), tableConfig.getTableType(),
         tableConfig.getCustomConfig());
       return new SuccessResponse("Successfully updated " + tableName + " configuration");

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableSegmentConfigs.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableSegmentConfigs.java
@@ -27,6 +27,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.io.IOException;
 import javax.inject.Inject;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -34,8 +35,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,11 +63,11 @@ public class PinotTableSegmentConfigs {
       String requestBody
   ) {
     try {
-      TableConfig tableConfig = TableConfig.fromJSONConfig(new JSONObject(requestBody));
+      TableConfig tableConfig = TableConfig.fromJsonString(requestBody);
       pinotHelixResourceManager.updateSegmentsValidationAndRetentionConfigFor(tableConfig.getTableName(),
           tableConfig.getTableType(), tableConfig.getValidationConfig());
       return new SuccessResponse("Update segmentsConfig for table: " + tableName);
-    } catch (JSONException e) {
+    } catch (IOException e) {
       metrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_SCHEMA_UPDATE_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER,
           String.format("Invalid json while updating segments config for table: %s", tableName),

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotVersionRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotVersionRestletResource.java
@@ -18,7 +18,9 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.pinot.common.Utils;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -27,7 +29,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.json.JSONObject;
 
 
 /**
@@ -42,7 +43,10 @@ public class PinotVersionRestletResource {
   @ApiOperation(value = "Get version number of Pinot components")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success")})
   public String getVersionNumber() {
-    JSONObject jsonObject = new JSONObject(Utils.getComponentVersions());
-    return jsonObject.toString();
+    try {
+      return JsonUtils.objectToString(Utils.getComponentVersions());
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PqlQueryResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PqlQueryResource.java
@@ -18,10 +18,13 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.controller.api.access.AccessControl;
 import com.linkedin.pinot.controller.api.access.AccessControlFactory;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -47,7 +50,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.helix.model.InstanceConfig;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,8 +70,8 @@ public class PqlQueryResource {
   @Path("pql")
   public String post(String requestJsonStr, @Context HttpHeaders httpHeaders) {
     try {
-      JSONObject requestJson = new JSONObject(requestJsonStr);
-      String pqlQuery = requestJson.getString("pql");
+      JsonNode requestJson = JsonUtils.stringToJsonNode(requestJsonStr);
+      String pqlQuery = requestJson.get("pql").asText();
       String traceEnabled = "false";
       if (requestJson.has("trace")) {
         traceEnabled = requestJson.get("trace").toString();
@@ -216,7 +218,7 @@ public class PqlQueryResource {
   public String sendPQLRaw(String url, String pqlRequest, String traceEnabled) {
     try {
       final long startTime = System.currentTimeMillis();
-      final JSONObject bqlJson = new JSONObject().put("pql", pqlRequest);
+      ObjectNode bqlJson = JsonUtils.newObjectNode().put("pql", pqlRequest);
       if (traceEnabled != null && !traceEnabled.isEmpty()) {
         bqlJson.put("trace", traceEnabled);
       }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
@@ -22,6 +22,7 @@ import com.google.common.collect.BiMap;
 import com.linkedin.pinot.common.http.MultiGetRequest;
 import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
 import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,7 +32,6 @@ import java.util.concurrent.Executor;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.methods.GetMethod;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
  */
 public class ServerTableSizeReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerTableSizeReader.class);
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final Executor _executor;
   private final HttpConnectionManager _connectionManager;
@@ -80,7 +79,8 @@ public class ServerTableSizeReader {
           LOGGER.error("Server: {} returned error: {}", instance, getMethod.getStatusCode());
           continue;
         }
-        TableSizeInfo tableSizeInfo = OBJECT_MAPPER.readValue(getMethod.getResponseBodyAsStream(), TableSizeInfo.class);
+        TableSizeInfo tableSizeInfo =
+            JsonUtils.inputStreamToObject(getMethod.getResponseBodyAsStream(), TableSizeInfo.class);
         serverToSegmentSizeInfoListMap.put(instance, tableSizeInfo.segments);
       } catch (Exception e) {
         // Ignore individual exceptions because the exception has been logged in MultiGetRequest

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/WebApplicationExceptionMapper.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/WebApplicationExceptionMapper.java
@@ -21,7 +21,7 @@ package com.linkedin.pinot.controller.api.resources;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 @Provider
 public class WebApplicationExceptionMapper implements ExceptionMapper<Throwable> {
   private static final Logger LOGGER = LoggerFactory.getLogger(WebApplicationExceptionMapper.class);
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   @Override
   public Response toResponse(Throwable t) {
@@ -46,14 +45,10 @@ public class WebApplicationExceptionMapper implements ExceptionMapper<Throwable>
 
     ErrorInfo einfo = new ErrorInfo(status, t.getMessage());
     try {
-      return Response.status(status).entity(JSON_MAPPER.writeValueAsString(einfo))
-          .type(MediaType.APPLICATION_JSON)
-          .build();
+      return Response.status(status).entity(JsonUtils.objectToString(einfo)).type(MediaType.APPLICATION_JSON).build();
     } catch (JsonProcessingException e) {
       String err = String.format("{\"status\":%d, \"error\":%s}", einfo.code, einfo.error);
-      return Response.status(status).entity(err)
-          .type(MediaType.APPLICATION_JSON)
-          .build();
+      return Response.status(status).entity(err).type(MediaType.APPLICATION_JSON).build();
     }
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
@@ -18,11 +18,13 @@
  */
 package com.linkedin.pinot.controller.helix;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.config.TagNameUtils;
 import com.linkedin.pinot.common.config.Tenant;
 import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.TenantRole;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,11 +35,8 @@ import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModelFactory;
-import org.json.JSONException;
-import org.json.JSONObject;
 
-import static com.linkedin.pinot.common.utils.CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE;
-import static com.linkedin.pinot.common.utils.CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE;
+import static com.linkedin.pinot.common.utils.CommonConstants.Helix.*;
 
 
 public class ControllerRequestBuilderUtil {
@@ -130,23 +129,23 @@ public class ControllerRequestBuilderUtil {
     helixZkManager.getClusterManagmentTool().setConfig(scope, props);
   }
 
-  public static JSONObject buildBrokerTenantCreateRequestJSON(String tenantName, int numberOfInstances)
-      throws JSONException {
+  public static String buildBrokerTenantCreateRequestJSON(String tenantName, int numberOfInstances)
+      throws JsonProcessingException {
     Tenant tenant = new TenantBuilder(tenantName).setRole(TenantRole.BROKER)
         .setTotalInstances(numberOfInstances)
         .setOfflineInstances(0)
         .setRealtimeInstances(0)
         .build();
-    return tenant.toJSON();
+    return JsonUtils.objectToString(tenant);
   }
 
-  public static JSONObject buildServerTenantCreateRequestJSON(String tenantName, int numberOfInstances,
-      int offlineInstances, int realtimeInstances) throws JSONException {
+  public static String buildServerTenantCreateRequestJSON(String tenantName, int numberOfInstances,
+      int offlineInstances, int realtimeInstances) throws JsonProcessingException {
     Tenant tenant = new TenantBuilder(tenantName).setRole(TenantRole.SERVER)
         .setTotalInstances(numberOfInstances)
         .setOfflineInstances(offlineInstances)
         .setRealtimeInstances(realtimeInstances)
         .build();
-    return tenant.toJSON();
+    return JsonUtils.objectToString(tenant);
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -35,13 +35,12 @@ import com.linkedin.pinot.common.utils.HLCSegmentName;
 import com.linkedin.pinot.common.utils.SegmentName;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
-import com.linkedin.pinot.controller.LeadershipChangeSubscriber;
 import com.linkedin.pinot.controller.ControllerLeadershipManager;
+import com.linkedin.pinot.controller.LeadershipChangeSubscriber;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.core.query.utils.Pair;
 import com.linkedin.pinot.core.realtime.stream.StreamConfig;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -60,7 +59,6 @@ import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.HelixPropertyListener;
 import org.apache.zookeeper.data.Stat;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,8 +113,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
     _pinotHelixResourceManager.getPropertyStore().stop();
   }
 
-  private synchronized void assignRealtimeSegmentsToServerInstancesIfNecessary()
-      throws JSONException, IOException {
+  private synchronized void assignRealtimeSegmentsToServerInstancesIfNecessary() {
     // Fetch current ideal state snapshot
     Map<String, IdealState> idealStateMap = new HashMap<>();
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotSchemaRestletResourceTest.java
@@ -18,27 +18,20 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.controller.helix.ControllerTest;
 import java.io.IOException;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.linkedin.pinot.common.data.DimensionFieldSpec;
-import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.common.data.MetricFieldSpec;
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.controller.helix.ControllerTest;
 
 
 public class PinotSchemaRestletResourceTest extends ControllerTest {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @BeforeClass
   public void setUp() {
@@ -46,29 +39,8 @@ public class PinotSchemaRestletResourceTest extends ControllerTest {
     startController();
   }
 
-  public JSONObject createDefaultSchema() throws JSONException, JsonProcessingException {
-    JSONObject schemaJson = new JSONObject();
-    schemaJson.put("schemaName", "testSchema");
-    JSONArray dimFieldSpec = new JSONArray();
-    schemaJson.put("dimensionFieldSpecs", dimFieldSpec);
-    JSONArray metricFieldSpec = new JSONArray();
-    schemaJson.put("metricFieldSpecs", metricFieldSpec);
-
-    DimensionFieldSpec df = new DimensionFieldSpec("dimA", FieldSpec.DataType.STRING, true, "");
-    dimFieldSpec.put(new JSONObject(OBJECT_MAPPER.writeValueAsString(df)));
-    df = new DimensionFieldSpec("dimB", FieldSpec.DataType.LONG, true, 0);
-    dimFieldSpec.put(new JSONObject(OBJECT_MAPPER.writeValueAsString(df)));
-
-    MetricFieldSpec mf = new MetricFieldSpec("metricA", FieldSpec.DataType.INT, 0);
-    metricFieldSpec.put(new JSONObject(OBJECT_MAPPER.writeValueAsString(mf)));
-
-    mf = new MetricFieldSpec("metricB", FieldSpec.DataType.DOUBLE, -1);
-    metricFieldSpec.put(new JSONObject(OBJECT_MAPPER.writeValueAsString(mf)));
-    return schemaJson;
-  }
-
   @Test
-  public void testBadContentType() throws JSONException, JsonProcessingException {
+  public void testBadContentType() {
     Schema schema = createDummySchema("testSchema");
     try {
       sendPostRequest(_controllerRequestURLBuilder.forSchemaCreate(), schema.getJSONSchema());
@@ -82,7 +54,7 @@ public class PinotSchemaRestletResourceTest extends ControllerTest {
   }
 
   @Test
-  public void testCreateUpdateSchema() throws JSONException, IOException {
+  public void testCreateUpdateSchema() throws IOException {
     String schemaName = "testSchema";
     Schema schema = createDummySchema(schemaName);
     String url = _controllerRequestURLBuilder.forSchemaCreate();

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
@@ -18,12 +18,11 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
 import com.linkedin.pinot.controller.helix.ControllerTest;
@@ -39,7 +38,6 @@ import org.testng.annotations.Test;
 public class PinotSegmentRestletResourceTest extends ControllerTest {
   private final static String ZK_SERVER = ZkStarter.DEFAULT_ZK_STR;
   private final static String TABLE_NAME = "testTable";
-  private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -113,8 +111,7 @@ public class PinotSegmentRestletResourceTest extends ControllerTest {
 
   private void checkCrcRequest(Map<String, SegmentMetadata> metadataTable, int expectedSize) throws Exception {
     String crcMapStr = sendGetRequest(_controllerRequestURLBuilder.forListAllCrcInformationForTable(TABLE_NAME));
-    Map<String, String> crcMap = OBJECT_MAPPER.readValue(crcMapStr, new TypeReference<Map<String, Object>>() {
-    });
+    Map<String, String> crcMap = JsonUtils.stringToObject(crcMapStr, Map.class);
     for (String segmentName : crcMap.keySet()) {
       SegmentMetadata metadata = metadataTable.get(segmentName);
       Assert.assertTrue(metadata != null);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/SegmentCompletionProtocolDeserTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/SegmentCompletionProtocolDeserTest.java
@@ -18,11 +18,12 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
-import com.alibaba.fastjson.JSON;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
-import org.json.JSONException;
-import org.testng.Assert;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 
 public class SegmentCompletionProtocolDeserTest {
@@ -34,134 +35,131 @@ public class SegmentCompletionProtocolDeserTest {
   @Test
   public void testCompleteResponseParams() {
     // Test with all params
-    SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params()
-        .withBuildTimeSeconds(BUILD_TIME_MILLIS)
-        .withOffset(OFFSET)
-        .withSegmentLocation(SEGMENT_LOCATION)
-        .withSplitCommit(true)
-        .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+    SegmentCompletionProtocol.Response.Params params =
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withOffset(OFFSET)
+            .withSegmentLocation(SEGMENT_LOCATION)
+            .withSplitCommit(true)
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
-    Assert.assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
-    Assert.assertEquals(response.getOffset(), OFFSET);
-    Assert.assertEquals(response.getSegmentLocation(), SEGMENT_LOCATION);
-    Assert.assertEquals(response.getIsSplitCommit(), true);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+    assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
+    assertEquals(response.getOffset(), OFFSET);
+    assertEquals(response.getSegmentLocation(), SEGMENT_LOCATION);
+    assertTrue(response.isSplitCommit());
+    assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
   }
 
   @Test
   public void testIncompleteResponseParams() {
     // Test with reduced params
-    SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params()
-        .withBuildTimeSeconds(BUILD_TIME_MILLIS)
-        .withOffset(OFFSET)
-        .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+    SegmentCompletionProtocol.Response.Params params =
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withOffset(OFFSET)
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
-    Assert.assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
-    Assert.assertEquals(response.getOffset(), OFFSET);
-    Assert.assertEquals(response.getSegmentLocation(), null);
-    Assert.assertEquals(response.getIsSplitCommit(), false);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+    assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
+    assertEquals(response.getOffset(), OFFSET);
+    assertNull(response.getSegmentLocation());
+    assertFalse(response.isSplitCommit());
+    assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
   }
 
   @Test
-  public void testJsonResponseWithAllParams() throws JSONException {
+  public void testJsonResponseWithAllParams() {
     // Test with all params
-    SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params()
-        .withBuildTimeSeconds(BUILD_TIME_MILLIS)
-        .withOffset(OFFSET)
-        .withSegmentLocation(SEGMENT_LOCATION)
-        .withSplitCommit(true)
-        .withControllerVipUrl(CONTROLLER_VIP_URL).withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+    SegmentCompletionProtocol.Response.Params params =
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withOffset(OFFSET)
+            .withSegmentLocation(SEGMENT_LOCATION)
+            .withSplitCommit(true)
+            .withControllerVipUrl(CONTROLLER_VIP_URL)
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
+    JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    com.alibaba.fastjson.JSONObject jsonObject = JSON.parseObject(response.toJsonString());
-
-    Assert.assertEquals(jsonObject.get("offset"), OFFSET);
-    Assert.assertEquals(jsonObject.get("segmentLocation"), SEGMENT_LOCATION);
-    Assert.assertEquals(jsonObject.get("isSplitCommitType"), true);
-    Assert.assertEquals(jsonObject.get("status"), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
-    Assert.assertEquals(jsonObject.get("controllerVipUrl"), CONTROLLER_VIP_URL);
+    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertEquals(jsonNode.get("segmentLocation").asText(), SEGMENT_LOCATION);
+    assertTrue(jsonNode.get("isSplitCommitType").asBoolean());
+    assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
+    assertEquals(jsonNode.get("controllerVipUrl").asText(), CONTROLLER_VIP_URL);
   }
 
   @Test
-  public void testJsonNullSegmentLocationAndVip() throws JSONException {
-    SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params()
-        .withBuildTimeSeconds(BUILD_TIME_MILLIS)
-        .withOffset(OFFSET)
-        .withSplitCommit(false)
-        .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+  public void testJsonNullSegmentLocationAndVip() {
+    SegmentCompletionProtocol.Response.Params params =
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withOffset(OFFSET)
+            .withSplitCommit(false)
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
+    JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    com.alibaba.fastjson.JSONObject jsonObject = JSON.parseObject(response.toJsonString());
-
-    Assert.assertEquals(jsonObject.get("offset"), OFFSET);
-    Assert.assertEquals(jsonObject.get("segmentLocation"), null);
-    Assert.assertEquals(jsonObject.get("isSplitCommitType"), false);
-    Assert.assertEquals(jsonObject.get("status"), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
-    Assert.assertEquals(jsonObject.get("controllerVipUrl"), null);
+    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertNull(jsonNode.get("segmentLocation"));
+    assertFalse(jsonNode.get("isSplitCommitType").asBoolean());
+    assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
+    assertNull(jsonNode.get("controllerVipUrl"));
   }
 
   @Test
-  public void testJsonResponseWithoutSplitCommit() throws JSONException {
-    SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params()
-        .withBuildTimeSeconds(BUILD_TIME_MILLIS)
-        .withOffset(OFFSET)
-        .withSplitCommit(false)
-        .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+  public void testJsonResponseWithoutSplitCommit() {
+    SegmentCompletionProtocol.Response.Params params =
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withOffset(OFFSET)
+            .withSplitCommit(false)
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
+    JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    com.alibaba.fastjson.JSONObject jsonObject = JSON.parseObject(response.toJsonString());
-
-    Assert.assertEquals(jsonObject.get("offset"), OFFSET);
-    Assert.assertEquals(jsonObject.get("isSplitCommitType"), false);
-    Assert.assertEquals(jsonObject.get("status"), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
-    Assert.assertEquals(jsonObject.get("controllerVipUrl"), null);
+    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertNull(jsonNode.get("segmentLocation"));
+    assertFalse(jsonNode.get("isSplitCommitType").asBoolean());
+    assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
+    assertNull(jsonNode.get("controllerVipUrl"));
   }
 
   @Test
-  public void testJsonResponseWithSegmentLocationNullVip() throws JSONException {
+  public void testJsonResponseWithSegmentLocationNullVip() {
     // Should never happen because if split commit, should have both location and VIP, but testing deserialization regardless
-    SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params()
-        .withBuildTimeSeconds(BUILD_TIME_MILLIS)
-        .withOffset(OFFSET)
-        .withSegmentLocation(SEGMENT_LOCATION)
-        .withSplitCommit(false)
-        .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+    SegmentCompletionProtocol.Response.Params params =
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withOffset(OFFSET)
+            .withSegmentLocation(SEGMENT_LOCATION)
+            .withSplitCommit(false)
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
+    JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    com.alibaba.fastjson.JSONObject jsonObject = JSON.parseObject(response.toJsonString());
-
-    Assert.assertEquals(jsonObject.get("offset"), OFFSET);
-    Assert.assertEquals(jsonObject.get("isSplitCommitType"), false);
-    Assert.assertEquals(jsonObject.get("segmentLocation"), SEGMENT_LOCATION);
-    Assert.assertEquals(jsonObject.get("status"), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
-    Assert.assertEquals(jsonObject.get("controllerVipUrl"), null);
+    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertEquals(jsonNode.get("segmentLocation").asText(), SEGMENT_LOCATION);
+    assertFalse(jsonNode.get("isSplitCommitType").asBoolean());
+    assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
+    assertNull(jsonNode.get("controllerVipUrl"));
   }
 
   @Test
-  public void testJsonResponseWithVipAndNullSegmentLocation() throws JSONException {
+  public void testJsonResponseWithVipAndNullSegmentLocation() {
     // Should never happen because if split commit, should have both location and VIP, but testing deserialization regardless
-    SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params()
-        .withBuildTimeSeconds(BUILD_TIME_MILLIS)
-        .withOffset(OFFSET)
-        .withControllerVipUrl(CONTROLLER_VIP_URL)
-        .withSplitCommit(false)
-        .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+    SegmentCompletionProtocol.Response.Params params =
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withOffset(OFFSET)
+            .withControllerVipUrl(CONTROLLER_VIP_URL)
+            .withSplitCommit(false)
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
+    JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    com.alibaba.fastjson.JSONObject jsonObject = JSON.parseObject(response.toJsonString());
-
-    Assert.assertEquals(jsonObject.get("offset"), OFFSET);
-    Assert.assertEquals(jsonObject.get("isSplitCommitType"), false);
-    Assert.assertEquals(jsonObject.get("segmentLocation"), null);
-    Assert.assertEquals(jsonObject.get("status"), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
-    Assert.assertEquals(jsonObject.get("controllerVipUrl"), CONTROLLER_VIP_URL);
+    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertNull(jsonNode.get("segmentLocation"));
+    assertFalse(jsonNode.get("isSplitCommitType").asBoolean());
+    assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
+    assertEquals(jsonNode.get("controllerVipUrl").asText(), CONTROLLER_VIP_URL);
   }
 }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReaderTest.java
@@ -18,11 +18,11 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
 import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -123,7 +123,7 @@ public class ServerTableSizeReaderTest {
             LOGGER.info("Handler interrupted during sleep");
           }
         }
-        String json = new ObjectMapper().writeValueAsString(tableSize);
+        String json = JsonUtils.objectToString(tableSize);
         httpExchange.sendResponseHeaders(status, json.length());
         OutputStream responseBody = httpExchange.getResponseBody();
         responseBody.write(json.getBytes());

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
@@ -18,7 +18,6 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.linkedin.pinot.common.config.TableNameBuilder;
@@ -27,6 +26,7 @@ import com.linkedin.pinot.common.metrics.ControllerGauge;
 import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
 import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.util.TableSizeReader;
 import com.sun.net.httpserver.HttpExchange;
@@ -156,7 +156,7 @@ public class TableSizeReaderTest {
           tableInfo.diskSizeInBytes += segmentSize.diskSizeInBytes;
         }
 
-        String json = new ObjectMapper().writeValueAsString(tableInfo);
+        String json = JsonUtils.objectToString(tableInfo);
         httpExchange.sendResponseHeaders(status, json.length());
         OutputStream responseBody = httpExchange.getResponseBody();
         responseBody.write(json.getBytes());

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableViewsTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableViewsTest.java
@@ -18,10 +18,10 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
 import com.linkedin.pinot.controller.helix.ControllerTest;
@@ -42,7 +42,6 @@ import org.testng.annotations.Test;
 
 
 public class TableViewsTest extends ControllerTest {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String OFFLINE_TABLE_NAME = "offlineTable";
   private static final String OFFLINE_SEGMENT_NAME = "offlineSegment";
   private static final String HYBRID_TABLE_NAME = "hybridTable";
@@ -183,7 +182,7 @@ public class TableViewsTest extends ControllerTest {
   }
 
   private TableViews.TableView getTableView(String tableName, String view, String tableType) throws Exception {
-    return OBJECT_MAPPER.readValue(
+    return JsonUtils.stringToObject(
         sendGetRequest(_controllerRequestURLBuilder.forTableView(tableName, view, tableType)),
         TableViews.TableView.class);
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerSentinelTestV2.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerSentinelTestV2.java
@@ -24,7 +24,6 @@ import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.utils.SegmentMetadataMockUtils;
 import java.io.IOException;
-import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -51,7 +50,7 @@ public class ControllerSentinelTestV2 extends ControllerTest {
   }
 
   @Test
-  public void testOfflineTableLifeCycle() throws IOException, JSONException {
+  public void testOfflineTableLifeCycle() throws IOException {
     // Create offline table creation request
     String tableName = "testTable";
     String tableJSONConfigString =

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
@@ -18,7 +18,6 @@
  */
 package com.linkedin.pinot.controller.helix;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
@@ -49,7 +48,6 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.json.JSONException;
 import org.testng.Assert;
 
 
@@ -58,7 +56,6 @@ import org.testng.Assert;
  */
 public abstract class ControllerTest {
   public static final String LOCAL_HOST = "localhost";
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private static final int DEFAULT_CONTROLLER_PORT = 8998;
   private static final String DEFAULT_DATA_DIR =
@@ -148,7 +145,7 @@ public abstract class ControllerTest {
     _zkClient.close();
   }
 
-  protected Schema createDummySchema(String tableName) throws JSONException {
+  protected Schema createDummySchema(String tableName) {
     Schema schema = new Schema();
     schema.setSchemaName(tableName);
     schema.addField(new DimensionFieldSpec("dimA", FieldSpec.DataType.STRING, true, ""));
@@ -160,7 +157,7 @@ public abstract class ControllerTest {
     return schema;
   }
 
-  protected void addDummySchema(String tableName) throws JSONException, IOException {
+  protected void addDummySchema(String tableName) throws IOException {
     addSchema(createDummySchema(tableName).getJSONSchema());
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -27,13 +27,11 @@ import com.linkedin.pinot.core.realtime.impl.kafka.KafkaAvroMessageDecoder;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -272,11 +270,9 @@ public class FlushThresholdUpdaterTest {
 
   /**
    * Tests that the flush threshold manager returns the right updater given various scenarios of flush threshold setting in the table config
-   * @throws IOException
-   * @throws JSONException
    */
   @Test
-  public void testFlushThresholdUpdater() throws IOException, JSONException {
+  public void testFlushThresholdUpdater() {
     FlushThresholdUpdateManager manager = new FlushThresholdUpdateManager();
     TableConfig.Builder tableConfigBuilder = new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME);
     tableConfigBuilder.setTableName("tableName_REALTIME");

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceStrategyTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceStrategyTest.java
@@ -33,7 +33,6 @@ import com.linkedin.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineSt
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaAvroMessageDecoder;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,7 +44,6 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.builder.CustomModeISBuilder;
-import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -281,8 +279,7 @@ public class DefaultRebalanceStrategyTest {
   }
 
   @Test
-  public void testGetRebalancedIdealStateOffline() throws IOException, JSONException {
-
+  public void testGetRebalancedIdealStateOffline() {
     String offlineTableName = "letsRebalanceThisTable_OFFLINE";
     TableConfig tableConfig;
 
@@ -380,8 +377,7 @@ public class DefaultRebalanceStrategyTest {
   }
 
   @Test
-  public void testGetRebalancedIdealStateRealtime() throws IOException, JSONException {
-
+  public void testGetRebalancedIdealStateRealtime() {
     String realtimeTableName = "letsRebalanceThisTable_REALTIME";
     TableConfig tableConfig;
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -31,7 +31,6 @@ import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.controller.helix.core.SegmentDeletionManager;
 import com.linkedin.pinot.controller.helix.core.util.ZKMetadataUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,7 +39,6 @@ import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.IdealState;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.json.JSONException;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -151,7 +149,7 @@ public class RetentionManagerTest {
         .build();
   }
 
-  private TableConfig createRealtimeTableConfig1(int replicaCount) throws IOException, JSONException {
+  private TableConfig createRealtimeTableConfig1(int replicaCount) {
     return new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME).setTableName(TEST_TABLE_NAME)
         .setLLC(true)
         .setRetentionTimeUnit("DAYS")

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -119,10 +119,6 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
@@ -19,15 +19,12 @@
 package com.linkedin.pinot.core.data;
 
 import com.linkedin.pinot.common.data.RowEvent;
-import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 
 /**
@@ -35,8 +32,7 @@ import org.codehaus.jackson.type.TypeReference;
  * {@link GenericRow#createOrReuseRow(GenericRow)}
  */
 public class GenericRow implements RowEvent {
-  private Map<String, Object> _fieldMap = new HashMap<String, Object>();
-  private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private Map<String, Object> _fieldMap = new HashMap<>();
 
   @Override
   public void init(Map<String, Object> field) {
@@ -101,19 +97,15 @@ public class GenericRow implements RowEvent {
     }
   }
 
-  static TypeReference typeReference = new TypeReference<Map<String, Object>>() {};
-
   public static GenericRow fromBytes(byte[] buffer) throws IOException {
-    Map<String, Object> fieldMap = (Map<String, Object>) OBJECT_MAPPER.readValue(buffer, typeReference);
+    Map<String, Object> fieldMap = JsonUtils.bytesToObject(buffer, Map.class);
     GenericRow genericRow = new GenericRow();
     genericRow.init(fieldMap);
     return genericRow;
   }
 
   public byte[] toBytes() throws IOException {
-    StringWriter writer = new StringWriter();
-    OBJECT_MAPPER.writeValue(writer, _fieldMap);
-    return StringUtil.encodeUtf8(writer.toString());
+    return JsonUtils.objectToBytes(_fieldMap);
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -169,7 +169,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     tableStreamName = tableName + "_" + _streamConfig.getTopicName();
 
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
-    if (indexingConfig != null && indexingConfig.getAggregateMetrics()) {
+    if (indexingConfig != null && indexingConfig.isAggregateMetrics()) {
       LOGGER.warn("Updating of metrics only supported for LLC consumer, ignoring.");
     }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -744,7 +744,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       throw new RuntimeException("Segment file does not exist:" + segTarFileName);
     }
     SegmentCompletionProtocol.Response returnedResponse;
-    if (response.getIsSplitCommit() && _indexLoadingConfig.isEnableSplitCommit()) {
+    if (response.isSplitCommit() && _indexLoadingConfig.isEnableSplitCommit()) {
       // Send segmentStart, segmentUpload, & segmentCommitEnd to the controller
       // if that succeeds, swap in-memory segment with the one built.
       returnedResponse = doSplitCommit(response);
@@ -1062,7 +1062,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             .setOffHeap(_isOffHeap)
             .setMemoryManager(_memoryManager)
             .setStatsHistory(realtimeTableDataManager.getStatsHistory())
-            .setAggregateMetrics(indexingConfig.getAggregateMetrics());
+            .setAggregateMetrics(indexingConfig.isAggregateMetrics());
 
     // Create message decoder
     _messageDecoder = StreamDecoderProvider.create(_partitionLevelStreamConfig, _schema);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/JSONRecordReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/JSONRecordReader.java
@@ -18,14 +18,12 @@
  */
 package com.linkedin.pinot.core.data.readers;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.core.data.GenericRow;
-
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.ObjectMapper;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,8 +35,6 @@ import java.util.Map;
  * Record reader for JSON file.
  */
 public class JSONRecordReader implements RecordReader {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
   private final JsonFactory _factory = new JsonFactory();
   private final File _dataFile;
   private final Schema _schema;
@@ -54,9 +50,9 @@ public class JSONRecordReader implements RecordReader {
   }
 
   private void init() throws IOException {
-    _parser = _factory.createJsonParser(RecordReaderUtils.getFileReader(_dataFile));
+    _parser = _factory.createParser(RecordReaderUtils.getFileReader(_dataFile));
     try {
-      _iterator = OBJECT_MAPPER.readValues(_parser, Map.class);
+      _iterator = JsonUtils.DEFAULT_MAPPER.readValues(_parser, Map.class);
     } catch (Exception e) {
       _parser.close();
       throw e;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -18,6 +18,8 @@
  */
 package com.linkedin.pinot.core.indexsegment.generator;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.config.SegmentPartitionConfig;
@@ -29,6 +31,7 @@ import com.linkedin.pinot.common.data.FieldSpec.FieldType;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.core.data.readers.CSVRecordReaderConfig;
 import com.linkedin.pinot.core.data.readers.FileFormat;
 import com.linkedin.pinot.core.data.readers.RecordReaderConfig;
@@ -53,9 +56,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.joda.time.format.DateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,7 +172,7 @@ public class SegmentGeneratorConfig {
 
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
-    Map<String, String> noDictionaryColumnMap = indexingConfig.getnoDictionaryConfig();
+    Map<String, String> noDictionaryColumnMap = indexingConfig.getNoDictionaryConfig();
 
     if (noDictionaryColumns != null) {
       this.setRawIndexCreationColumns(noDictionaryColumns);
@@ -584,8 +584,6 @@ public class SegmentGeneratorConfig {
    */
   @Deprecated
   public void loadConfigFiles() throws IOException {
-    ObjectMapper objectMapper = new ObjectMapper();
-
     Schema schema;
     if (_schemaFile != null) {
       schema = Schema.fromFile(new File(_schemaFile));
@@ -605,7 +603,7 @@ public class SegmentGeneratorConfig {
     }
 
     if (_readerConfigFile != null) {
-      setReaderConfig(objectMapper.readValue(new File(_readerConfigFile), CSVRecordReaderConfig.class));
+      setReaderConfig(JsonUtils.fileToObject(new File(_readerConfigFile), CSVRecordReaderConfig.class));
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/ColumnMetadata.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/ColumnMetadata.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.core.segment.index;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.linkedin.pinot.common.config.ColumnPartitionConfig;
 import com.linkedin.pinot.common.data.DateTimeFieldSpec;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
@@ -37,13 +38,11 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.math.IntRange;
-import org.codehaus.jackson.annotate.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Column.*;
-import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_PADDING_CHARACTER;
-import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.TIME_UNIT;
+import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.*;
 
 
 public class ColumnMetadata {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -91,7 +91,7 @@ public class IndexLoadingConfig {
       _noDictionaryColumns.addAll(noDictionaryColumns);
     }
 
-    Map<String, String> noDictionaryConfig = indexingConfig.getnoDictionaryConfig();
+    Map<String, String> noDictionaryConfig = indexingConfig.getNoDictionaryConfig();
     if (noDictionaryConfig != null) {
       _noDictionaryConfig.putAll(noDictionaryConfig);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -165,7 +165,7 @@ public class ServerSegmentCompletionProtocolHandler {
       String responseStr =
           _fileUploadDownloadClient.sendSegmentCompletionProtocolRequest(new URI(url), OTHER_REQUESTS_TIMEOUT)
               .getResponse();
-      response = new SegmentCompletionProtocol.Response(responseStr);
+      response = SegmentCompletionProtocol.Response.fromJsonString(responseStr);
       LOGGER.info("Controller response {} for {}", response.toJsonString(), url);
       if (response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER)) {
         ControllerLeaderLocator.getInstance().invalidateCachedControllerLeader();
@@ -189,7 +189,7 @@ public class ServerSegmentCompletionProtocolHandler {
       String responseStr =
           _fileUploadDownloadClient.uploadSegment(new URI(url), segmentName, segmentTarFile, null, null,
               SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS).getResponse();
-      response = new SegmentCompletionProtocol.Response(responseStr);
+      response = SegmentCompletionProtocol.Response.fromJsonString(responseStr);
       LOGGER.info("Controller response {} for {}", response.toJsonString(), url);
       if (response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER)) {
         ControllerLeaderLocator.getInstance().invalidateCachedControllerLeader();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -25,6 +25,7 @@ import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.manager.config.InstanceDataManagerConfig;
@@ -42,10 +43,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.Map;
-import junit.framework.Assert;
 import org.apache.commons.io.FileUtils;
 import org.apache.kafka.common.protocol.Errors;
-import org.json.JSONObject;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -115,7 +115,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
   private TableConfig createTableConfig()
       throws Exception {
-    return TableConfig.fromJSONConfig(new JSONObject(_tableConfigJson));
+    return TableConfig.fromJsonString(_tableConfigJson);
   }
 
   private RealtimeTableDataManager createTableDataManager() {
@@ -684,7 +684,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     public boolean invokeCommit(String segTarFileName) {
       SegmentCompletionProtocol.Response response = mock(SegmentCompletionProtocol.Response.class);
-      when(response.getIsSplitCommit()).thenReturn(false);
+      when(response.isSplitCommit()).thenReturn(false);
       return super.commitSegment(response);
     }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/readers/JSONRecordReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/readers/JSONRecordReaderTest.java
@@ -18,11 +18,11 @@
  */
 package com.linkedin.pinot.core.data.readers;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.File;
 import java.io.FileWriter;
 import org.apache.commons.io.FileUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -38,12 +38,12 @@ public class JSONRecordReaderTest extends RecordReaderTest {
 
     try (FileWriter fileWriter = new FileWriter(DATA_FILE)) {
       for (Object[] record : RECORDS) {
-        JSONObject jsonRecord = new JSONObject();
+        ObjectNode jsonRecord = JsonUtils.newObjectNode();
         if (record[0] != null) {
-          jsonRecord.put(COLUMNS[0], record[0]);
+          jsonRecord.set(COLUMNS[0], JsonUtils.objectToJsonNode(record[0]));
         }
         if (record[1] != null) {
-          jsonRecord.put(COLUMNS[1], new JSONArray(record[1]));
+          jsonRecord.set(COLUMNS[1], JsonUtils.objectToJsonNode(record[1]));
         }
         fileWriter.write(jsonRecord.toString());
       }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/util/trace/TraceContextTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/util/trace/TraceContextTest.java
@@ -18,7 +18,8 @@
  */
 package com.linkedin.pinot.core.util.trace;
 
-import java.util.Collections;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
@@ -27,7 +28,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -117,6 +117,8 @@ public class TraceContextTest {
   }
 
   private static String getTraceString(String key, Object value) {
-    return new JSONObject(Collections.singletonMap(key, value)).toString();
+    ObjectNode jsonTrace = JsonUtils.newObjectNode();
+    jsonTrace.set(key, JsonUtils.objectToJsonNode(value));
+    return jsonTrace.toString();
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/persist/AvroDataPublisherTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/persist/AvroDataPublisherTest.java
@@ -18,8 +18,10 @@
  */
 package com.linkedin.pinot.index.persist;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.readers.AvroRecordReader;
 import com.linkedin.pinot.core.data.readers.FileFormat;
@@ -32,7 +34,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -63,13 +64,12 @@ public class AvroDataPublisherTest {
 
     int cnt = 0;
     for (String line : FileUtils.readLines(new File(jsonPath))) {
-
-      JSONObject obj = new JSONObject(line);
+      JsonNode jsonNode = JsonUtils.stringToJsonNode(line);
       if (avroDataPublisher.hasNext()) {
         GenericRow recordRow = avroDataPublisher.next();
 
         for (String column : recordRow.getFieldNames()) {
-          String valueFromJson = obj.get(column).toString();
+          String valueFromJson = jsonNode.get(column).asText();
           String valueFromAvro = recordRow.getValue(column).toString();
           if (cnt > 1) {
             Assert.assertEquals(valueFromJson, valueFromAvro);
@@ -104,14 +104,13 @@ public class AvroDataPublisherTest {
 
     int cnt = 0;
     for (final String line : FileUtils.readLines(new File(jsonPath))) {
-
-      final JSONObject obj = new JSONObject(line);
+      JsonNode jsonNode = JsonUtils.stringToJsonNode(line);
       if (avroDataPublisher.hasNext()) {
         final GenericRow recordRow = avroDataPublisher.next();
         // System.out.println(recordRow);
         Assert.assertEquals(recordRow.getFieldNames().length, 2);
         for (final String column : recordRow.getFieldNames()) {
-          final String valueFromJson = obj.get(column).toString();
+          final String valueFromJson = jsonNode.get(column).asText();
           final String valueFromAvro = recordRow.getValue(column).toString();
           if (cnt > 1) {
             Assert.assertEquals(valueFromAvro, valueFromJson);

--- a/pinot-core/src/test/java/com/linkedin/pinot/util/TestUtils.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/util/TestUtils.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
-import org.json.JSONArray;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -118,40 +116,6 @@ public class TestUtils {
       }
     }
     LOGGER.info("group overlap rate: " + (cnt+0.0)/mapEstimate.keySet().size());
-  }
-
-  public static void assertJSONArrayApproximation(JSONArray jsonArrayEstimate, JSONArray jsonArrayActual, double precision) {
-    LOGGER.info("====== assertJSONArrayApproximation ======");
-    try {
-      HashMap<String, Double> mapEstimate = genMapFromJSONArray(jsonArrayEstimate);
-      HashMap<String, Double> mapActual = genMapFromJSONArray(jsonArrayActual);
-
-      // estimation should not affect number of groups formed
-      Assert.assertEquals(mapEstimate.keySet().size(), mapActual.keySet().size());
-      LOGGER.info("estimate: " + mapEstimate.keySet());
-      LOGGER.info("actual: " + mapActual.keySet());
-      int cnt = 0;
-      for (String key: mapEstimate.keySet()) {
-        // Not strictly enforced, since in quantile, top 100 groups from accurate maybe not be top 100 from estimate
-        // Assert.assertEquals(mapActual.keySet().contains(key), true);
-        if (mapActual.keySet().contains(key)) {
-          assertApproximation(mapEstimate.get(key), mapActual.get(key), precision);
-          cnt += 1;
-        }
-      }
-      LOGGER.info("group overlap rate: " + (cnt+0.0)/mapEstimate.keySet().size());
-    } catch (JSONException e) {
-      e.printStackTrace();
-    }
-  }
-
-  private static HashMap<String, Double> genMapFromJSONArray(JSONArray array) throws JSONException {
-    HashMap<String, Double> map = new HashMap<String, Double>();
-    for (int i = 0; i < array.length(); ++i) {
-      map.put(array.getJSONObject(i).getJSONArray("group").getString(0),
-          array.getJSONObject(i).getDouble("value"));
-    }
-    return map;
   }
 
   /**

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/io/JsonPinotOutputFormat.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/io/JsonPinotOutputFormat.java
@@ -18,113 +18,81 @@
  */
 package com.linkedin.pinot.hadoop.io;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.JobContext;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.IOException;
 import java.io.Serializable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+
 
 /**
  * OutputFormat implementation for Json source
  */
 public class JsonPinotOutputFormat<K, V extends Serializable> extends PinotOutputFormat<K, V> {
+  private static final String JSON_READER_CLASS = "json.reader.class";
 
-    private static final String JSON_READER_CLASS = "json.reader.class";
+  @Override
+  public void configure(Configuration conf) {
+    conf.set(PinotOutputFormat.PINOT_RECORD_SERIALIZATION_CLASS, JsonPinotRecordSerialization.class.getName());
+  }
+
+  public static void setJsonReaderClass(JobContext context, Class<?> clazz) {
+    context.getConfiguration().set(JSON_READER_CLASS, clazz.getName());
+  }
+
+  public static String getJsonReaderClass(Configuration conf) {
+    if (conf.get(JSON_READER_CLASS) == null) {
+      throw new RuntimeException("Json reader class not set");
+    }
+    return conf.get(JSON_READER_CLASS);
+  }
+
+  public static class JsonPinotRecordSerialization<T> implements PinotRecordSerialization<T> {
+    private Schema _schema;
+    private Configuration _conf;
+    private PinotRecord _record;
 
     @Override
-    public void configure(Configuration conf) {
-        conf.set(PinotOutputFormat.PINOT_RECORD_SERIALIZATION_CLASS, JsonPinotRecordSerialization.class.getName());
+    public void init(Configuration conf, Schema schema) {
+      _schema = schema;
+      _conf = conf;
+      _record = new PinotRecord(_schema);
     }
 
-    public static void setJsonReaderClass(JobContext context, Class<?> clazz) {
-        context.getConfiguration().set(JSON_READER_CLASS, clazz.getName());
+    @Override
+    public PinotRecord serialize(T t) {
+      _record.clear();
+      JsonNode jsonRecord = JsonUtils.objectToJsonNode(t);
+      for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+        String column = fieldSpec.getName();
+        _record.putField(column, JsonUtils.extractValue(jsonRecord.get(column), fieldSpec));
+      }
+      return _record;
     }
 
-    public static String getJsonReaderClass(Configuration conf) {
-        if (conf.get(JSON_READER_CLASS) == null) {
-            throw new RuntimeException("Json reader class not set");
-        }
-        return conf.get(JSON_READER_CLASS);
+    @Override
+    public T deserialize(PinotRecord record) throws IOException {
+      ObjectNode jsonRecord = JsonUtils.newObjectNode();
+      for (String column : _schema.getColumnNames()) {
+        jsonRecord.set(column, JsonUtils.objectToJsonNode(record.getValue(column)));
+      }
+      return JsonUtils.jsonNodeToObject(jsonRecord, getJsonReaderClass(_conf));
     }
 
-    public static class JsonPinotRecordSerialization<T> implements PinotRecordSerialization<T> {
-
-        private PinotRecord _record;
-        private Schema _schema;
-        private ObjectMapper _mapper;
-        private Configuration _conf;
-
-        @Override
-        public void init(Configuration conf, Schema schema) {
-            _schema = schema;
-            _mapper = new ObjectMapper();
-            _conf = conf;
-        }
-
-        @Override
-        public PinotRecord serialize(T t) throws IOException {
-            _record = PinotRecord.createOrReuseRecord(_record, _schema);
-            try {
-                JSONObject obj = new JSONObject(_mapper.writeValueAsString(t));
-                for (FieldSpec fieldSpec : _record.getSchema().getAllFieldSpecs()) {
-                    Object fieldValue = getFieldValue(obj, fieldSpec);
-                    _record.putField(fieldSpec.getName(), fieldValue);
-                }
-            } catch (JSONException e) {
-                throw new RuntimeException("Serialization exception", e);
-            }
-            return _record;
-        }
-
-        @Override
-        public T deserialize(PinotRecord record) throws IOException {
-            JSONObject obj = new JSONObject();
-            for (FieldSpec fieldSpec : _record.getSchema().getAllFieldSpecs()) {
-                Object value = record.getValue(fieldSpec.getName());
-                addJsonField(obj, fieldSpec, value);
-            }
-            return _mapper.readValue(obj.toString().getBytes("UTF-8"), getJsonReaderClass(_conf));
-        }
-
-        private void addJsonField(JSONObject obj, FieldSpec fieldSpec, Object value) {
-            try {
-                if (value instanceof Object[]) {
-                    obj.put(fieldSpec.getName(), new JSONArray(value));
-                } else {
-                    obj.put(fieldSpec.getName(), value);
-                }
-            } catch (JSONException e) {
-                throw new RuntimeException("Error initialize json reader class", e);
-            }
-        }
-
-        @Override
-        public void close() {
-
-        }
-
-        private Class<T> getJsonReaderClass(Configuration conf) {
-            try {
-                return (Class<T>) Class.forName(JsonPinotOutputFormat.getJsonReaderClass(conf));
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException("Error initialize json reader class", e);
-            }
-        }
-
-        private Object getFieldValue(JSONObject obj, FieldSpec fieldSpec) {
-            Object fieldValue = obj.opt(fieldSpec.getName());
-            if (fieldValue != null) {
-                return fieldValue;
-            }
-            return fieldSpec.getDefaultNullValue();
-        }
+    @Override
+    public void close() {
     }
 
+    private Class<T> getJsonReaderClass(Configuration conf) {
+      try {
+        return (Class<T>) Class.forName(JsonPinotOutputFormat.getJsonReaderClass(conf));
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException("Error initialize json reader class", e);
+      }
+    }
+  }
 }

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/ControllerRestApi.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/ControllerRestApi.java
@@ -18,15 +18,16 @@
  */
 package com.linkedin.pinot.hadoop.job;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.SimpleHttpResponse;
 import com.linkedin.pinot.hadoop.utils.PushLocation;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,10 +61,9 @@ public class ControllerRestApi {
     for (URI uri : tableConfigURIs) {
       try {
         SimpleHttpResponse response = fileUploadDownloadClient.getTableConfig(uri);
-        JSONObject queryResponse = new JSONObject(response.getResponse());
-        JSONObject offlineTableConfig = queryResponse.getJSONObject(OFFLINE);
-        LOGGER.info("Got table config {}", offlineTableConfig);
-        if (!queryResponse.isNull(OFFLINE)) {
+        JsonNode offlineTableConfig = JsonUtils.stringToJsonNode(response.getResponse()).get(OFFLINE);
+        if (offlineTableConfig != null) {
+          LOGGER.info("Got table config {}", offlineTableConfig);
           return TableConfig.fromJSONConfig(offlineTableConfig);
         }
       } catch (Exception e) {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BalanceNumSegmentAssignmentStrategyIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BalanceNumSegmentAssignmentStrategyIntegrationTest.java
@@ -18,13 +18,14 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.helix.model.IdealState;
-import org.json.JSONObject;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -47,7 +48,7 @@ public class BalanceNumSegmentAssignmentStrategyIntegrationTest extends UploadRe
 
     // Create eight dummy server instances
     for(int i = 0; i < 8; ++i) {
-      JSONObject serverInstance = new JSONObject();
+      ObjectNode serverInstance = JsonUtils.newObjectNode();
       serverInstance.put("host", hostName);
       serverInstance.put("port", Integer.toString(basePort + i));
       serverInstance.put("tag", serverTenant);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -18,6 +18,8 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.pinot.broker.broker.BrokerServerBuilder;
 import com.linkedin.pinot.broker.broker.BrokerTestUtils;
 import com.linkedin.pinot.broker.broker.helix.HelixBrokerStarter;
@@ -30,6 +32,7 @@ import com.linkedin.pinot.common.utils.CommonConstants.Helix;
 import com.linkedin.pinot.common.utils.CommonConstants.Minion;
 import com.linkedin.pinot.common.utils.CommonConstants.Server;
 import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
 import com.linkedin.pinot.controller.helix.ControllerTest;
@@ -69,7 +72,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -463,34 +465,34 @@ public abstract class ClusterTest extends ControllerTest {
   }
 
   protected void createBrokerTenant(String tenantName, int brokerCount) throws Exception {
-    JSONObject request = ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(tenantName, brokerCount);
-    sendPostRequest(_controllerRequestURLBuilder.forBrokerTenantCreate(), request.toString());
+    String request = ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(tenantName, brokerCount);
+    sendPostRequest(_controllerRequestURLBuilder.forBrokerTenantCreate(), request);
   }
 
   protected void createServerTenant(String tenantName, int offlineServerCount, int realtimeServerCount)
       throws Exception {
-    JSONObject request = ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(tenantName,
+    String request = ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(tenantName,
         offlineServerCount + realtimeServerCount, offlineServerCount, realtimeServerCount);
-    sendPostRequest(_controllerRequestURLBuilder.forServerTenantCreate(), request.toString());
+    sendPostRequest(_controllerRequestURLBuilder.forServerTenantCreate(), request);
   }
 
-  protected JSONObject getDebugInfo(final String uri) throws Exception {
-    return new JSONObject(sendGetRequest(_brokerBaseApiUrl + "/" + uri));
+  protected JsonNode getDebugInfo(final String uri) throws Exception {
+    return JsonUtils.stringToJsonNode(sendGetRequest(_brokerBaseApiUrl + "/" + uri));
   }
 
-  protected JSONObject postQuery(String query) throws Exception {
+  protected JsonNode postQuery(String query) throws Exception {
     return postQuery(query, _brokerBaseApiUrl);
   }
 
-  public static JSONObject postQuery(String query, String brokerBaseApiUrl) throws Exception {
+  public static JsonNode postQuery(String query, String brokerBaseApiUrl) throws Exception {
     return postQuery(query, brokerBaseApiUrl, false);
   }
 
-  public static JSONObject postQuery(String query, String brokerBaseApiUrl, boolean enableTrace) throws Exception {
-    JSONObject payload = new JSONObject();
+  public static JsonNode postQuery(String query, String brokerBaseApiUrl, boolean enableTrace) throws Exception {
+    ObjectNode payload = JsonUtils.newObjectNode();
     payload.put("pql", query);
     payload.put("trace", enableTrace);
 
-    return new JSONObject(sendPostRequest(brokerBaseApiUrl + "/query", payload.toString()));
+    return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/query", payload.toString()));
   }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -18,10 +18,12 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Function;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.util.TestUtils;
@@ -34,8 +36,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import kafka.server.KafkaServerStartable;
 import org.apache.commons.io.FileUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -180,40 +180,40 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
     {
       String jsonOutputStr = sendGetRequest(_controllerRequestURLBuilder.
           forSegmentListAPIWithTableType(getTableName(), CommonConstants.Helix.TableType.OFFLINE.toString()));
-      JSONArray array = new JSONArray(jsonOutputStr);
+      JsonNode array = JsonUtils.stringToJsonNode(jsonOutputStr);
       // There should be one element in the array
-      JSONObject element = (JSONObject) array.get(0);
-      JSONArray segments = (JSONArray) element.get("OFFLINE");
-      Assert.assertEquals(segments.length(), 8);
+      JsonNode element = array.get(0);
+      JsonNode segments = element.get("OFFLINE");
+      Assert.assertEquals(segments.size(), 8);
     }
     {
       String jsonOutputStr = sendGetRequest(_controllerRequestURLBuilder.
           forSegmentListAPIWithTableType(getTableName(), CommonConstants.Helix.TableType.REALTIME.toString()));
-      JSONArray array = new JSONArray(jsonOutputStr);
+      JsonNode array = JsonUtils.stringToJsonNode(jsonOutputStr);
       // There should be one element in the array
-      JSONObject element = (JSONObject) array.get(0);
-      JSONArray segments = (JSONArray) element.get("REALTIME");
-      Assert.assertEquals(segments.length(), 3);
+      JsonNode element = array.get(0);
+      JsonNode segments = element.get("REALTIME");
+      Assert.assertEquals(segments.size(), 3);
     }
     {
       String jsonOutputStr = sendGetRequest(_controllerRequestURLBuilder. forSegmentListAPI(getTableName()));
-      JSONArray array = new JSONArray(jsonOutputStr);
+      JsonNode array = JsonUtils.stringToJsonNode(jsonOutputStr);
       // there should be 2 elements in the array now.
       int realtimeIndex = 0;
       int offlineIndex = 1;
-      JSONObject element = (JSONObject) array.get(realtimeIndex);
+      JsonNode element = array.get(realtimeIndex);
       if (!element.has("REALTIME")) {
         realtimeIndex = 1;
         offlineIndex = 0;
       }
-      JSONObject offlineElement = (JSONObject)array.get(offlineIndex);
-      JSONObject realtimeElement = (JSONObject)array.get(realtimeIndex);
+      JsonNode offlineElement = array.get(offlineIndex);
+      JsonNode realtimeElement = array.get(realtimeIndex);
 
-      JSONArray realtimeSegments = (JSONArray) realtimeElement.get("REALTIME");
-      Assert.assertEquals(realtimeSegments.length(), 3);
+      JsonNode realtimeSegments = realtimeElement.get("REALTIME");
+      Assert.assertEquals(realtimeSegments.size(), 3);
 
-      JSONArray offlineSegments = (JSONArray) offlineElement.get("OFFLINE");
-      Assert.assertEquals(offlineSegments.length(), 8);
+      JsonNode offlineSegments = offlineElement.get("OFFLINE");
+      Assert.assertEquals(offlineSegments.size(), 8);
     }
   }
 
@@ -277,9 +277,8 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
       @Override
       public Boolean apply(@Nullable Void aVoid) {
         try {
-          JSONArray routingTableSnapshot =
-              getDebugInfo("debug/routingTable/" + tableName).getJSONArray("routingTableSnapshot");
-          return routingTableSnapshot.length() == 0;
+          JsonNode routingTableSnapshot = getDebugInfo("debug/routingTable/" + tableName).get("routingTableSnapshot");
+          return routingTableSnapshot.size() == 0;
         } catch (Exception e) {
           return null;
         }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -18,10 +18,10 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Function;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
 import java.util.Arrays;
@@ -31,7 +31,6 @@ import org.apache.avro.reflect.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.ZNRecord;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -113,10 +112,10 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
 
     final long numTotalDocs = getCountStarResult();
 
-    JSONObject queryResponse = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
-    Assert.assertEquals(queryResponse.getLong("totalDocs"), numTotalDocs);
+    JsonNode queryResponse = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
+    Assert.assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
     // TODO: investigate why assert for a specific value fails intermittently
-    Assert.assertNotSame(queryResponse.getLong("numEntriesScannedInFilter"), 0);
+    Assert.assertNotSame(queryResponse.get("numEntriesScannedInFilter").asLong(), 0);
 
     updateRealtimeTableConfig(getTableName(), UPDATED_INVERTED_INDEX_COLUMNS, null);
 
@@ -126,10 +125,10 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
       @Override
       public Boolean apply(@javax.annotation.Nullable Void aVoid) {
         try {
-          JSONObject queryResponse = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
+          JsonNode queryResponse = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
           // Total docs should not change during reload
-          Assert.assertEquals(queryResponse.getLong("totalDocs"), numTotalDocs);
-          return queryResponse.getLong("numEntriesScannedInFilter") == 0;
+          Assert.assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
+          return queryResponse.get("numEntriesScannedInFilter").asLong() == 0;
         } catch (Exception e) {
           throw new RuntimeException(e);
         }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/MetadataAndDictionaryAggregationPlanClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/MetadataAndDictionaryAggregationPlanClusterIntegrationTest.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.util.TestUtils;
@@ -29,11 +30,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
-import org.json.JSONObject;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 
 /**
@@ -81,7 +82,6 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
   protected String getTableName() {
     return _currentTable;
   }
-
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -155,31 +155,31 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
     pqlQuery = "SELECT MIN(ArrTime) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MIN(ArrTime) FROM " + STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MIN(ArrTime) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery = "SELECT MIN(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
     pqlQuery = "SELECT MINMAXRANGE(ArrTime) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MINMAXRANGE(ArrTime) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MINMAXRANGE(ArrTime) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery = "SELECT MAX(ArrTime)-MIN(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
     pqlQuery = "SELECT MIN(ArrTime), MAX(ArrTime), MINMAXRANGE(ArrTime) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MIN(ArrTime), MAX(ArrTime), MINMAXRANGE(ArrTime) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MIN(ArrTime), MAX(ArrTime), MINMAXRANGE(ArrTime) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery1 = "SELECT MIN(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery2 = "SELECT MAX(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery3 = "SELECT MAX(ArrTime)-MIN(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Lists.newArrayList(sqlQuery1, sqlQuery2, sqlQuery3));
     testQuery(pqlStarTreeQuery, Lists.newArrayList(sqlQuery1, sqlQuery2, sqlQuery3));
     pqlQuery = "SELECT MIN(ArrTime), COUNT(*) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MIN(ArrTime), COUNT(*) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MIN(ArrTime), COUNT(*) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery1 = "SELECT MIN(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery2 = "SELECT COUNT(*) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Lists.newArrayList(sqlQuery1, sqlQuery2));
     testQuery(pqlStarTreeQuery, Lists.newArrayList(sqlQuery1, sqlQuery2));
     // float
     pqlQuery = "SELECT MAX(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MAX(DepDelayMinutes) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MAX(DepDelayMinutes) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery = "SELECT MAX(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
@@ -189,19 +189,21 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
     pqlQuery = "SELECT MINMAXRANGE(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MINMAXRANGE(DepDelayMinutes) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MINMAXRANGE(DepDelayMinutes) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery = "SELECT MAX(DepDelayMinutes)-MIN(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
-    pqlQuery = "SELECT MIN(DepDelayMinutes), MAX(DepDelayMinutes), MINMAXRANGE(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MIN(DepDelayMinutes), MAX(DepDelayMinutes), MINMAXRANGE(DepDelayMinutes) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlQuery =
+        "SELECT MIN(DepDelayMinutes), MAX(DepDelayMinutes), MINMAXRANGE(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
+    pqlStarTreeQuery =
+        "SELECT MIN(DepDelayMinutes), MAX(DepDelayMinutes), MINMAXRANGE(DepDelayMinutes) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery1 = "SELECT MIN(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery2 = "SELECT MAX(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery3 = "SELECT MAX(DepDelayMinutes)-MIN(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Lists.newArrayList(sqlQuery1, sqlQuery2, sqlQuery3));
     testQuery(pqlStarTreeQuery, Lists.newArrayList(sqlQuery1, sqlQuery2, sqlQuery3));
     pqlQuery = "SELECT MIN(DepDelayMinutes), COUNT(*) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MIN(DepDelayMinutes), COUNT(*) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MIN(DepDelayMinutes), COUNT(*) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery1 = "SELECT MIN(DepDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery2 = "SELECT COUNT(*) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Lists.newArrayList(sqlQuery1, sqlQuery2));
@@ -209,22 +211,24 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
 
     // double
     pqlQuery = "SELECT MAX(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MAX(ArrDelayMinutes) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MAX(ArrDelayMinutes) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery = "SELECT MAX(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
     pqlQuery = "SELECT MIN(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MIN(ArrDelayMinutes) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MIN(ArrDelayMinutes) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery = "SELECT MIN(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
     pqlQuery = "SELECT MINMAXRANGE(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MINMAXRANGE(ArrDelayMinutes) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MINMAXRANGE(ArrDelayMinutes) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery = "SELECT MAX(ArrDelayMinutes)-MIN(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
-    pqlQuery = "SELECT MIN(ArrDelayMinutes), MAX(ArrDelayMinutes), MINMAXRANGE(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery = "SELECT MIN(ArrDelayMinutes), MAX(ArrDelayMinutes), MINMAXRANGE(ArrDelayMinutes) FROM " + STAR_TREE_TABLE_NAME;
+    pqlQuery =
+        "SELECT MIN(ArrDelayMinutes), MAX(ArrDelayMinutes), MINMAXRANGE(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
+    pqlStarTreeQuery =
+        "SELECT MIN(ArrDelayMinutes), MAX(ArrDelayMinutes), MINMAXRANGE(ArrDelayMinutes) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery1 = "SELECT MIN(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery2 = "SELECT MAX(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery3 = "SELECT MAX(ArrDelayMinutes)-MIN(ArrDelayMinutes) FROM " + DEFAULT_TABLE_NAME;
@@ -239,7 +243,7 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
 
     // long
     pqlQuery = "SELECT MAX(AirlineID) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery =  "SELECT MAX(AirlineID) FROM "+ STAR_TREE_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MAX(AirlineID) FROM " + STAR_TREE_TABLE_NAME;
     sqlQuery = "SELECT MAX(AirlineID) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
@@ -287,8 +291,10 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
     sqlQuery = "SELECT MAX(ActualElapsedTime)-MIN(ActualElapsedTime) FROM " + DEFAULT_TABLE_NAME;
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
-    pqlQuery = "SELECT MIN(ActualElapsedTime), MAX(ActualElapsedTime), MINMAXRANGE(ActualElapsedTime) FROM " + DEFAULT_TABLE_NAME;
-    pqlStarTreeQuery = "SELECT MIN(ActualElapsedTime), MAX(ActualElapsedTime), MINMAXRANGE(ActualElapsedTime) FROM " + STAR_TREE_TABLE_NAME;
+    pqlQuery = "SELECT MIN(ActualElapsedTime), MAX(ActualElapsedTime), MINMAXRANGE(ActualElapsedTime) FROM "
+        + DEFAULT_TABLE_NAME;
+    pqlStarTreeQuery = "SELECT MIN(ActualElapsedTime), MAX(ActualElapsedTime), MINMAXRANGE(ActualElapsedTime) FROM "
+        + STAR_TREE_TABLE_NAME;
     sqlQuery1 = "SELECT MIN(ActualElapsedTime) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery2 = "SELECT MAX(ActualElapsedTime) FROM " + DEFAULT_TABLE_NAME;
     sqlQuery3 = "SELECT MAX(ActualElapsedTime)-MIN(ActualElapsedTime) FROM " + DEFAULT_TABLE_NAME;
@@ -365,50 +371,49 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
     // TODO: add test cases for string column when we add support for min and max on string datatype columns
 
     // Check execution stats
-    JSONObject response;
+    JsonNode response;
 
     // Dictionary column: answered by DictionaryBasedAggregationOperator
     pqlQuery = "SELECT MAX(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter"), 0);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
+    assertEquals(response.get("numEntriesScannedPostFilter").asLong(), 0);
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
 
     // Non dictionary column: not answered by DictionaryBasedAggregationOperator
     pqlQuery = "SELECT MAX(DepDelay) FROM " + DEFAULT_TABLE_NAME;
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter"), response.getLong("numDocsScanned"));
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
+    assertEquals(response.get("numEntriesScannedPostFilter").asLong(), response.get("numDocsScanned").asLong());
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
 
     // multiple dictionary based aggregation functions, dictionary columns: answered by DictionaryBasedAggregationOperator
     pqlQuery = "SELECT MAX(ArrTime),MIN(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter"), 0);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
+    assertEquals(response.get("numEntriesScannedPostFilter").asLong(), 0);
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
 
     // multiple aggregation functions, mix of dictionary based and non dictionary based: not answered by DictionaryBasedAggregationOperator
     pqlQuery = "SELECT MAX(ArrTime),COUNT(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter"), response.getLong("numDocsScanned"));
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
+    assertEquals(response.get("numEntriesScannedPostFilter").asLong(), response.get("numDocsScanned").asLong());
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
 
     // group by in query : not answered by DictionaryBasedAggregationOperator
     pqlQuery = "SELECT MAX(ArrTime) FROM " + DEFAULT_TABLE_NAME + "  group by DaysSinceEpoch";
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter") > 0, true);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
+    assertTrue(response.get("numEntriesScannedPostFilter").asLong() > 0);
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
 
     // filter in query: not answered by DictionaryBasedAggregationOperator
     pqlQuery = "SELECT MAX(ArrTime) FROM " + DEFAULT_TABLE_NAME + " where DaysSinceEpoch > 16100";
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter") > 0, true);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter") > 0, true);
+    assertTrue(response.get("numEntriesScannedPostFilter").asLong() > 0);
+    assertTrue(response.get("numEntriesScannedInFilter").asLong() > 0);
   }
-
 
   @Test
   public void testMetadataBasedQueries() throws Exception {
@@ -432,50 +437,47 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
     testQuery(pqlStarTreeQuery, Collections.singletonList(sqlQuery));
 
     // Check execution stats
-    JSONObject response;
+    JsonNode response;
 
     pqlQuery = "SELECT COUNT(*) FROM " + DEFAULT_TABLE_NAME;
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter"), 0);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
+    assertEquals(response.get("numEntriesScannedPostFilter").asLong(), 0);
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
 
     pqlStarTreeQuery = "SELECT COUNT(*) FROM " + STAR_TREE_TABLE_NAME;
     response = postQuery(pqlStarTreeQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter"), 0);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
-
+    assertEquals(response.get("numEntriesScannedPostFilter").asLong(), 0);
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
 
     // group by present in query: not answered by MetadataBasedAggregationOperator
     pqlQuery = "SELECT COUNT(*) FROM " + DEFAULT_TABLE_NAME + " GROUP BY DaysSinceEpoch";
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter") > 0, true);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
+    assertTrue(response.get("numEntriesScannedPostFilter").asLong() > 0);
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
 
     // filter present in query: not answered by MetadataBasedAggregationOperator
     pqlQuery = "SELECT COUNT(*) FROM " + DEFAULT_TABLE_NAME + " WHERE DaysSinceEpoch > 16100";
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter"), 0);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter") > 0, true);
+    assertEquals(response.get("numEntriesScannedPostFilter").asLong(), 0);
+    assertTrue(response.get("numEntriesScannedInFilter").asLong() > 0);
 
     // mixed aggregation functions in query: not answered by MetadataBasedAggregationOperator
     pqlQuery = "SELECT COUNT(*),MAX(ArrTime) FROM " + DEFAULT_TABLE_NAME;
     response = postQuery(pqlQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter") > 0, true);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
+    assertTrue(response.get("numEntriesScannedPostFilter").asLong() > 0);
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
 
     // mixed aggregation functions in star tree query: not answered by MetadataBasedAggregationOperator
     pqlStarTreeQuery = "SELECT COUNT(*),MAX(DaysSinceEpoch) FROM " + STAR_TREE_TABLE_NAME;
     response = postQuery(pqlStarTreeQuery);
-    Assert.assertEquals(response.getLong("numEntriesScannedPostFilter") > 0, true);
-    Assert.assertEquals(response.getLong("numEntriesScannedInFilter"), 0);
-    Assert.assertEquals(response.getLong("totalDocs"), response.getLong("numDocsScanned"));
+    assertTrue(response.get("numEntriesScannedPostFilter").asLong() > 0);
+    assertEquals(response.get("numEntriesScannedInFilter").asLong(), 0);
+    assertEquals(response.get("totalDocs").asLong(), response.get("numDocsScanned").asLong());
   }
-
-
 
   @AfterClass
   public void tearDown() throws Exception {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/PinotURIUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/PinotURIUploadIntegrationTest.java
@@ -18,8 +18,10 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.util.TestUtils;
@@ -44,8 +46,6 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.io.FileUtils;
-import org.apache.htrace.fasterxml.jackson.databind.JsonNode;
-import org.apache.htrace.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -244,7 +244,7 @@ public class PinotURIUploadIntegrationTest extends BaseClusterIntegrationTest {
         throw new IllegalStateException(res.getStatusLine().toString());
       }
       InputStream content = res.getEntity().getContent();
-      JsonNode segmentsData = new ObjectMapper().readTree(content);
+      JsonNode segmentsData = JsonUtils.inputStreamToJsonNode(content);
 
       if (segmentsData != null) {
         JsonNode offlineSegments = segmentsData.get(0).get("OFFLINE");

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/QueryGenerator.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/QueryGenerator.java
@@ -18,6 +18,8 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -37,8 +39,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang.StringUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 
 /**
@@ -220,9 +220,9 @@ public class QueryGenerator {
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputFile))) {
       for (int i = 0; i < 10000; i++) {
         Query query = queryGenerator.generateQuery();
-        JSONObject queryJson = new JSONObject();
+        ObjectNode queryJson = JsonUtils.newObjectNode();
         queryJson.put("pql", query.generatePql());
-        queryJson.put("hsqls", new JSONArray(query.generateH2Sql()));
+        queryJson.set("hsqls", JsonUtils.objectToJsonNode(query.generateH2Sql()));
         writer.write(queryJson.toString());
         writer.newLine();
       }
@@ -357,7 +357,6 @@ public class QueryGenerator {
       return new PredicateQueryFragment(predicates, operators);
     }
   }
-
 
   /**
    * Query interface with capability of generating PQL and H2 SQL query.
@@ -830,12 +829,11 @@ public class QueryGenerator {
       }
       //Generate a HAVING predicate
       ArrayList<String> arrayOfAggregationColumnsAndFunctions = new ArrayList<>(aggregationColumnsAndFunctions);
-      HavingQueryFragment havingPredicate= generateHavingPredicate(arrayOfAggregationColumnsAndFunctions);
+      HavingQueryFragment havingPredicate = generateHavingPredicate(arrayOfAggregationColumnsAndFunctions);
       // Generate a result limit of at most MAX_RESULT_LIMIT.
       TopQueryFragment top = new TopQueryFragment(RANDOM.nextInt(MAX_RESULT_LIMIT + 1));
       return new AggregationQuery(arrayOfAggregationColumnsAndFunctions, predicate, groupColumns, top, havingPredicate);
     }
-
 
     /**
      * Helper method to generate a having predicate query fragment.
@@ -849,9 +847,9 @@ public class QueryGenerator {
       List<String> havingClauseBooleanOperators = new ArrayList<String>();
       createHavingClause(arrayOfAggregationColumnsAndFunctions, havingClauseAggregationFunctions,
           havingClauseOperatorsAndValues, havingClauseBooleanOperators);
-      return new HavingQueryFragment(havingClauseAggregationFunctions,havingClauseOperatorsAndValues,havingClauseBooleanOperators);
+      return new HavingQueryFragment(havingClauseAggregationFunctions, havingClauseOperatorsAndValues,
+          havingClauseBooleanOperators);
     }
-
 
     private void createHavingClause(ArrayList<String> arrayOfAggregationColumnsAndFunctions,
         List<String> havingClauseAggregationFunctions, List<String> havingClauseOperatorsAndValues,

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.tools.query.comparison.QueryComparison;
 import com.linkedin.pinot.tools.query.comparison.SegmentInfoProvider;
@@ -33,7 +34,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -182,14 +182,13 @@ public class StarTreeClusterIntegrationTest extends BaseClusterIntegrationTest {
 
   private void testStarQuery(String starQuery) throws Exception {
     String referenceQuery = starQuery.replace(STAR_TREE_TABLE_NAME, DEFAULT_TABLE_NAME) + " TOP 10000";
-    JSONObject starResponse = postQuery(starQuery);
-    JSONObject referenceResponse = postQuery(referenceQuery);
+    JsonNode starResponse = postQuery(starQuery);
+    JsonNode referenceResponse = postQuery(referenceQuery);
 
     // Skip comparison if not all results returned in reference response
     if (referenceResponse.has("aggregationResults")) {
-      JSONObject aggregationResults = referenceResponse.getJSONArray("aggregationResults").getJSONObject(0);
-      if (aggregationResults.has("groupByResult")
-          && aggregationResults.getJSONArray("groupByResult").length() == 10000) {
+      JsonNode aggregationResults = referenceResponse.get("aggregationResults").get(0);
+      if (aggregationResults.has("groupByResult") && aggregationResults.get("groupByResult").size() == 10000) {
         return;
       }
     }

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkQueryEngine.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkQueryEngine.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
-import org.json.JSONObject;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -53,9 +52,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 @Fork(value = 1, jvmArgs = {"-server", "-Xmx8G", "-XX:MaxDirectMemorySize=16G"})
 public class BenchmarkQueryEngine {
   /** List of query patterns used in the benchmark */
-  private static final String[] QUERY_PATTERNS = new String[] {
-      "SELECT count(*) from myTable"
-  };
+  private static final String[] QUERY_PATTERNS = new String[]{"SELECT count(*) from myTable"};
 
   /** List of optimization flags to test,
    * see {@link OptimizationFlags#getOptimizationFlags(BrokerRequest)} for the syntax
@@ -144,22 +141,18 @@ public class BenchmarkQueryEngine {
 
     ranOnce = false;
 
-    System.out.println(
-        _perfBenchmarkDriver.postQuery(QUERY_PATTERNS[queryPattern], optimizationFlags).toString(2)
-    );
+    System.out.println(_perfBenchmarkDriver.postQuery(QUERY_PATTERNS[queryPattern], optimizationFlags).toString());
   }
 
   @Benchmark
   @BenchmarkMode({Mode.SampleTime})
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int sendQueryToPinot() throws Exception {
-    JSONObject returnValue = _perfBenchmarkDriver.postQuery(QUERY_PATTERNS[queryPattern], optimizationFlags);
-    return returnValue.getInt("totalDocs");
+    return _perfBenchmarkDriver.postQuery(QUERY_PATTERNS[queryPattern], optimizationFlags).get("totalDocs").asInt();
   }
 
   public static void main(String[] args) throws Exception {
-    ChainedOptionsBuilder opt = new OptionsBuilder()
-        .include(BenchmarkQueryEngine.class.getSimpleName())
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkQueryEngine.class.getSimpleName())
         .warmupTime(TimeValue.seconds(30))
         .warmupIterations(4)
         .measurementTime(TimeValue.seconds(30))

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkRealtimeConsumptionSpeed.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkRealtimeConsumptionSpeed.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.perf;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
@@ -30,8 +31,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import kafka.server.KafkaServerStartable;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 
 /**
@@ -110,11 +109,8 @@ public class BenchmarkRealtimeConsumptionSpeed extends RealtimeClusterIntegratio
 
       // Run the query
       try {
-        JSONObject response = postQuery("select count(*) from mytable");
-        JSONArray aggregationResultsArray = response.getJSONArray("aggregationResults");
-        JSONObject firstAggregationResult = aggregationResultsArray.getJSONObject(0);
-        String pinotValue = firstAggregationResult.get("value").toString();
-        pinotRecordCount = Integer.parseInt(pinotValue);
+        JsonNode response = postQuery("select count(*) from mytable");
+        pinotRecordCount = response.get("aggregationResults").get(0).get("value").asInt();
       } catch (Exception e) {
         // Ignore
         continue;

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/RealtimeStressTest.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/RealtimeStressTest.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.perf;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
@@ -31,8 +32,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import kafka.server.KafkaServerStartable;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 
 /**
@@ -105,11 +104,8 @@ public class RealtimeStressTest extends RealtimeClusterIntegrationTest {
 
       // Run the query
       try {
-        JSONObject response = postQuery("select count(*) from mytable");
-        JSONArray aggregationResultsArray = response.getJSONArray("aggregationResults");
-        JSONObject firstAggregationResult = aggregationResultsArray.getJSONObject(0);
-        String pinotValue = firstAggregationResult.get("value").toString();
-        pinotRecordCount = Long.parseLong(pinotValue);
+        JsonNode response = postQuery("select count(*) from mytable");
+        pinotRecordCount = response.get("aggregationResults").get(0).get("value").asLong();
       } catch (Exception e) {
         // Ignore
         continue;

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -112,14 +112,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.alibaba</groupId>
-      <artifactId>fastjson</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.helix</groupId>
       <artifactId>helix-core</artifactId>
       <exclusions>
@@ -191,15 +183,15 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/DefaultExceptionMapper.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/DefaultExceptionMapper.java
@@ -19,39 +19,32 @@
 package com.linkedin.pinot.server.api.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+
 @Provider
-public class DefaultExceptionMapper implements ExceptionMapper<WebApplicationException>
-{
-  private static final transient ObjectMapper MAPPER = new ObjectMapper();
+public class DefaultExceptionMapper implements ExceptionMapper<WebApplicationException> {
 
   @Override
-  public Response toResponse(final WebApplicationException exception)
-  {
-    Response.ResponseBuilder builder = Response.status(exception.getResponse().getStatus())
-                                      .entity(toJson(exception))
-                                      .type(MediaType.APPLICATION_JSON);
+  public Response toResponse(final WebApplicationException exception) {
+    Response.ResponseBuilder builder =
+        Response.status(exception.getResponse().getStatus()).entity(toJson(exception)).type(MediaType.APPLICATION_JSON);
     return builder.build();
   }
 
-  private String toJson(final WebApplicationException exception)
-  {
+  private String toJson(final WebApplicationException exception) {
     ErrorInfo errorInfo = new ErrorInfo(exception);
 
     // difference between try and catch block is that
     // ErrorInfo can contain more information that just message
-    try
-    {
-      return MAPPER.writeValueAsString(errorInfo);
-    }
-    catch (JsonProcessingException e)
-    {
+    try {
+      return JsonUtils.objectToString(errorInfo);
+    } catch (JsonProcessingException e) {
       return "{\"message\":\"Error converting error message: " + e.getMessage() + " to string\"}";
     }
   }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/TablesResource.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.server.api.resources;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.pinot.common.restlet.resources.ResourceUtils;
 import com.linkedin.pinot.common.restlet.resources.TableSegments;
 import com.linkedin.pinot.common.restlet.resources.TablesList;
@@ -47,7 +48,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,7 +150,7 @@ public class TablesResource {
       }
       try {
         return segmentMetadata.toJson(columnSet).toString();
-      } catch (JSONException e) {
+      } catch (JsonProcessingException e) {
         LOGGER.error("Failed to convert table {} segment {} to json", tableName, segmentMetadata);
         throw new WebApplicationException("Failed to convert segment metadata to json",
             Response.Status.INTERNAL_SERVER_ERROR);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotZKChanger.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotZKChanger.java
@@ -18,7 +18,7 @@
  */
 package com.linkedin.pinot.tools;
 
-import java.io.StringWriter;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +37,6 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 /**
@@ -50,7 +49,6 @@ public class PinotZKChanger {
   protected HelixManager helixManager;
   protected String clusterName;
   protected ZkHelixPropertyStore<ZNRecord> propertyStore;
-  protected ObjectMapper objectMapper;
 
   public PinotZKChanger(String zkAddress, String clusterName) {
     this.clusterName = clusterName;
@@ -66,7 +64,6 @@ public class PinotZKChanger {
     ZNRecordSerializer serializer = new ZNRecordSerializer();
     String path = PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, clusterName);
     propertyStore = new ZkHelixPropertyStore<>(zkAddress, serializer, path);
-    objectMapper = new ObjectMapper();
   }
 
   public ZKHelixAdmin getHelixAdmin() {
@@ -121,15 +118,13 @@ public class PinotZKChanger {
   }
 
   protected void printSegmentAssignment(Map<String, Map<String, String>> mapping) throws Exception {
-    StringWriter sw = new StringWriter();
-    objectMapper.writerWithDefaultPrettyPrinter().writeValue(sw, mapping);
-    LOGGER.info(sw.toString());
+    LOGGER.info(JsonUtils.objectToPrettyString(mapping));
     Map<String, List<String>> serverToSegmentMapping = new TreeMap<>();
     for (String segment : mapping.keySet()) {
       Map<String, String> serverToStateMap = mapping.get(segment);
       for (String server : serverToStateMap.keySet()) {
         if (!serverToSegmentMapping.containsKey(server)) {
-          serverToSegmentMapping.put(server, new ArrayList<String>());
+          serverToSegmentMapping.put(server, new ArrayList<>());
         }
         serverToSegmentMapping.get(server).add(segment);
       }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/Quickstart.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.tools;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.linkedin.pinot.core.data.readers.FileFormat;
@@ -29,9 +30,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Category;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 
 public class Quickstart {
@@ -58,24 +56,23 @@ public class Quickstart {
     System.out.println(color._code + message + Color.RESET._code);
   }
 
-  public static String prettyPrintResponse(JSONObject response)
-      throws JSONException {
+  public static String prettyPrintResponse(JsonNode response) {
     StringBuilder responseBuilder = new StringBuilder();
 
     // Selection query
     if (response.has("selectionResults")) {
-      JSONArray columns = response.getJSONObject("selectionResults").getJSONArray("columns");
-      int numColumns = columns.length();
+      JsonNode columns = response.get("selectionResults").get("columns");
+      int numColumns = columns.size();
       for (int i = 0; i < numColumns; i++) {
-        responseBuilder.append(columns.getString(i)).append(TAB);
+        responseBuilder.append(columns.get(i).asText()).append(TAB);
       }
       responseBuilder.append(NEW_LINE);
-      JSONArray rows = response.getJSONObject("selectionResults").getJSONArray("results");
-      int numRows = rows.length();
+      JsonNode rows = response.get("selectionResults").get("results");
+      int numRows = rows.size();
       for (int i = 0; i < numRows; i++) {
-        JSONArray row = rows.getJSONArray(i);
+        JsonNode row = rows.get(i);
         for (int j = 0; j < numColumns; j++) {
-          responseBuilder.append(row.getString(j)).append(TAB);
+          responseBuilder.append(row.get(j).asText()).append(TAB);
         }
         responseBuilder.append(NEW_LINE);
       }
@@ -83,40 +80,40 @@ public class Quickstart {
     }
 
     // Aggregation only query
-    if (!response.getJSONArray("aggregationResults").getJSONObject(0).has("groupByResult")) {
-      JSONArray aggregationResults = response.getJSONArray("aggregationResults");
-      int numAggregations = aggregationResults.length();
+    if (!response.get("aggregationResults").get(0).has("groupByResult")) {
+      JsonNode aggregationResults = response.get("aggregationResults");
+      int numAggregations = aggregationResults.size();
       for (int i = 0; i < numAggregations; i++) {
-        responseBuilder.append(aggregationResults.getJSONObject(i).getString("function")).append(TAB);
+        responseBuilder.append(aggregationResults.get(i).get("function").asText()).append(TAB);
       }
       responseBuilder.append(NEW_LINE);
       for (int i = 0; i < numAggregations; i++) {
-        responseBuilder.append(aggregationResults.getJSONObject(i).getString("value")).append(TAB);
+        responseBuilder.append(aggregationResults.get(i).get("value").asText()).append(TAB);
       }
       responseBuilder.append(NEW_LINE);
       return responseBuilder.toString();
     }
 
     // Aggregation group-by query
-    JSONArray groupByResults = response.getJSONArray("aggregationResults");
-    int numGroupBys = groupByResults.length();
+    JsonNode groupByResults = response.get("aggregationResults");
+    int numGroupBys = groupByResults.size();
     for (int i = 0; i < numGroupBys; i++) {
-      JSONObject groupByResult = groupByResults.getJSONObject(i);
-      responseBuilder.append(groupByResult.getString("function")).append(TAB);
-      JSONArray columns = groupByResult.getJSONArray("groupByColumns");
-      int numColumns = columns.length();
+      JsonNode groupByResult = groupByResults.get(i);
+      responseBuilder.append(groupByResult.get("function").asText()).append(TAB);
+      JsonNode columns = groupByResult.get("groupByColumns");
+      int numColumns = columns.size();
       for (int j = 0; j < numColumns; j++) {
-        responseBuilder.append(columns.getString(j)).append(TAB);
+        responseBuilder.append(columns.get(j).asText()).append(TAB);
       }
       responseBuilder.append(NEW_LINE);
-      JSONArray rows = groupByResult.getJSONArray("groupByResult");
-      int numRows = rows.length();
+      JsonNode rows = groupByResult.get("groupByResult");
+      int numRows = rows.size();
       for (int j = 0; j < numRows; j++) {
-        JSONObject row = rows.getJSONObject(j);
-        responseBuilder.append(row.getString("value")).append(TAB);
-        JSONArray columnValues = row.getJSONArray("group");
+        JsonNode row = rows.get(j);
+        responseBuilder.append(row.get("value").asText()).append(TAB);
+        JsonNode columnValues = row.get("group");
         for (int k = 0; k < numColumns; k++) {
-          responseBuilder.append(columnValues.getString(k)).append(TAB);
+          responseBuilder.append(columnValues.get(k).asText()).append(TAB);
         }
         responseBuilder.append(NEW_LINE);
       }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
@@ -18,8 +18,10 @@
  */
 package com.linkedin.pinot.tools;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.MinMaxPriorityQueue;
 import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.BlockSingleValIterator;
 import com.linkedin.pinot.core.common.BlockValSet;
@@ -48,8 +50,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -77,6 +77,7 @@ public class StarTreeIndexViewer {
       return _name;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public List<StarTreeJsonNode> getChildren() {
       return _children;
     }
@@ -113,9 +114,7 @@ public class StarTreeIndexViewer {
     build(tree.getRoot(), jsonRoot);
     indexSegment.destroy();
 
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.getSerializationConfig().withSerializationInclusion(Inclusion.NON_NULL);
-    String writeValueAsString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonRoot);
+    String writeValueAsString = JsonUtils.objectToPrettyString(jsonRoot);
     LOGGER.info(writeValueAsString);
     startServer(segmentDir, writeValueAsString);
   }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -26,13 +26,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLConnection;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 
 /**
@@ -65,8 +62,7 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     pidFile.close();
   }
 
-  public static String sendPostRequest(String urlString, String payload) throws UnsupportedEncodingException,
-      IOException, JSONException {
+  public static String sendPostRequest(String urlString, String payload) throws IOException {
     final URL url = new URL(urlString);
     final URLConnection conn = url.openConnection();
 
@@ -85,37 +81,6 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     }
 
     return sb.toString();
-  }
-
-  public static JSONObject postQuery(String query, String brokerBaseApiUrl) throws Exception {
-    final JSONObject json = new JSONObject();
-    json.put("pql", query);
-
-    final long start = System.currentTimeMillis();
-    final URLConnection conn = new URL(brokerBaseApiUrl + "/query").openConnection();
-    conn.setDoOutput(true);
-    final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream(), "UTF-8"));
-    final String reqStr = json.toString();
-    System.out.println("reqStr = " + reqStr);
-
-    writer.write(reqStr, 0, reqStr.length());
-    writer.flush();
-    final BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
-
-    final StringBuilder sb = new StringBuilder();
-    String line = null;
-    while ((line = reader.readLine()) != null) {
-      sb.append(line);
-    }
-
-    final long stop = System.currentTimeMillis();
-
-    final String res = sb.toString();
-    System.out.println("res = " + res);
-    final JSONObject ret = new JSONObject(res);
-    ret.put("totalTime", (stop - start));
-
-    return ret;
   }
 
   PropertiesConfiguration readConfigFromFile(String configFileName) throws ConfigurationException {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AddTableCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AddTableCommand.java
@@ -18,20 +18,16 @@
  */
 package com.linkedin.pinot.tools.admin.command;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.linkedin.pinot.common.utils.JsonUtils;
+import com.linkedin.pinot.common.utils.NetUtil;
+import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
 import com.linkedin.pinot.tools.Command;
-import java.io.FileInputStream;
+import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.json.JSONException;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.linkedin.pinot.common.utils.NetUtil;
-import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
 
 
 /**
@@ -103,7 +99,7 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
     return this;
   }
 
-  public boolean execute(JsonNode node) throws UnsupportedEncodingException, IOException, JSONException {
+  public boolean execute(JsonNode node) throws IOException {
     if (_controllerHost == null) {
       _controllerHost = NetUtil.getHostAddress();
     }
@@ -126,7 +122,6 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
 
   @Override
   public boolean execute() throws Exception {
-    JsonNode node = new ObjectMapper().readTree(new FileInputStream(_filePath));
-    return execute(node);
+    return execute(JsonUtils.fileToJsonNode(new File(_filePath)));
   }
 }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/BackfillDateTimeColumnCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/BackfillDateTimeColumnCommand.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.tools.admin.command;
 
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +41,6 @@ import com.linkedin.pinot.tools.backfill.BackfillSegmentUtils;
  *
  */
 public class BackfillDateTimeColumnCommand extends AbstractBaseAdminCommand implements Command {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String OUTPUT_FOLDER = "output";
   private static final String DOWNLOAD_FOLDER = "download";
   private static final String BACKUP_FOLDER = "backup";
@@ -160,8 +160,9 @@ public class BackfillDateTimeColumnCommand extends AbstractBaseAdminCommand impl
     if (_srcTimeFieldSpec == null || _destDateTimeFieldSpec == null) {
       throw new RuntimeException("Must specify srcTimeFieldSpec and destTimeFieldSpec.");
     }
-    TimeFieldSpec timeFieldSpec = OBJECT_MAPPER.readValue(new File(_srcTimeFieldSpec), TimeFieldSpec.class);
-    DateTimeFieldSpec dateTimeFieldSpec = OBJECT_MAPPER.readValue(new File(_destDateTimeFieldSpec), DateTimeFieldSpec.class);
+    TimeFieldSpec timeFieldSpec = JsonUtils.fileToObject(new File(_srcTimeFieldSpec), TimeFieldSpec.class);
+    DateTimeFieldSpec dateTimeFieldSpec =
+        JsonUtils.fileToObject(new File(_destDateTimeFieldSpec), DateTimeFieldSpec.class);
 
     if (_tableName == null) {
       throw new RuntimeException("Must specify tableName.");

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -19,6 +19,7 @@
 package com.linkedin.pinot.tools.admin.command;
 
 import com.linkedin.pinot.common.data.StarTreeIndexSpec;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.core.data.readers.FileFormat;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -35,7 +36,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +47,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(CreateSegmentCommand.class);
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Option(name = "-generatorConfigFile", metaVar = "<string>", usage = "Config file for segment generator.")
   private String _generatorConfigFile;
@@ -211,7 +210,7 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
     // Load generator config if exist.
     final SegmentGeneratorConfig segmentGeneratorConfig;
     if (_generatorConfigFile != null) {
-      segmentGeneratorConfig = OBJECT_MAPPER.readValue(new File(_generatorConfigFile), SegmentGeneratorConfig.class);
+      segmentGeneratorConfig = JsonUtils.fileToObject(new File(_generatorConfigFile), SegmentGeneratorConfig.class);
     } else {
       segmentGeneratorConfig = new SegmentGeneratorConfig();
     }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/GenerateDataCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/GenerateDataCommand.java
@@ -18,34 +18,28 @@
  */
 package com.linkedin.pinot.tools.admin.command;
 
-import com.linkedin.pinot.tools.Command;
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.commons.lang.math.IntRange;
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
-import org.kohsuke.args4j.Option;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.FieldSpec.FieldType;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.Schema.SchemaBuilder;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.core.data.readers.FileFormat;
+import com.linkedin.pinot.tools.Command;
 import com.linkedin.pinot.tools.data.generator.DataGenerator;
 import com.linkedin.pinot.tools.data.generator.DataGeneratorSpec;
 import com.linkedin.pinot.tools.data.generator.SchemaAnnotation;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang.math.IntRange;
+import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -141,16 +135,12 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
   }
 
   private void buildCardinalityRangeMaps(String file, HashMap<String, Integer> cardinality,
-      HashMap<String, IntRange> range) throws JsonParseException, JsonMappingException, IOException {
-    List<SchemaAnnotation> saList;
-
+      HashMap<String, IntRange> range) throws IOException {
     if (file == null) {
       return; // Nothing to do here.
     }
 
-    ObjectMapper objectMapper = new ObjectMapper();
-    saList = objectMapper.readValue(new File(file), new TypeReference<List<SchemaAnnotation>>() {
-    });
+    List<SchemaAnnotation> saList = JsonUtils.fileToObject(new File(file), List.class);
 
     for (SchemaAnnotation sa : saList) {
       String column = sa.getColumn();
@@ -204,7 +194,7 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
         timeUnits, FileFormat.AVRO, _outDir, _overwrite);
   }
 
-  public static void main(String[] args) throws JsonGenerationException, JsonMappingException, IOException {
+  public static void main(String[] args) throws IOException {
     SchemaBuilder schemaBuilder = new SchemaBuilder();
 
     schemaBuilder.addSingleValueDimension("name", DataType.STRING);
@@ -213,7 +203,6 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
     schemaBuilder.addTime("days", TimeUnit.DAYS, DataType.LONG);
 
     Schema schema = schemaBuilder.build();
-    ObjectMapper objectMapper = new ObjectMapper();
-    System.out.println(objectMapper.writeValueAsString(schema));
+    System.out.println(JsonUtils.objectToPrettyString(schema));
   }
 }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/MoveReplicaGroup.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/MoveReplicaGroup.java
@@ -19,12 +19,12 @@
 package com.linkedin.pinot.tools.admin.command;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
 import com.linkedin.pinot.tools.Command;
@@ -49,7 +49,6 @@ import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.json.JSONException;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
@@ -122,8 +121,7 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
 
   }
 
-  public boolean execute()
-      throws IOException, JSONException, InterruptedException {
+  public boolean execute() throws IOException, InterruptedException {
     validateParams();
 
     zkChanger = new PinotZKChanger(zkHost, zkPath);
@@ -200,8 +198,7 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
 
   private void printIdealState(Map<String, Map<String, String>> idealState)
       throws JsonProcessingException {
-    String output = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(idealState);
-    System.out.println(output);
+    System.out.println(JsonUtils.objectToPrettyString(idealState));
   }
 
   private void applyIdealState(final Map<String, Map<String, String>> proposedIdealState) {
@@ -417,13 +414,11 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
     LOGGER.info("Using zkHost: {}, zkPath: {}", zkHost, zkPath);
   }
 
-  private String getServerTenantName(String tableName)
-      throws IOException, JSONException {
+  private String getServerTenantName(String tableName) throws IOException {
     return getTableConfig(tableName).getTenantConfig().getServer();
   }
 
-  private TableConfig getTableConfig(String tableName)
-      throws IOException, JSONException {
+  private TableConfig getTableConfig(String tableName) throws IOException {
     ZNRecordSerializer serializer = new ZNRecordSerializer();
     String path = PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, zkPath);
     ZkHelixPropertyStore<ZNRecord> propertyStore = new ZkHelixPropertyStore<>(zkHost, serializer, path);
@@ -437,8 +432,7 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
     return helix.getResourcesInCluster(zkPath).contains(tableName);
   }
 
-  private List<String> readDestinationServers()
-      throws IOException, JSONException {
+  private List<String> readDestinationServers() throws IOException {
     if (destHostsFile.isEmpty()) {
       String serverTenant = getServerTenantName(tableName) + "_OFFLINE";
       LOGGER.debug("Using server tenant: {}", serverTenant);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/PostQueryCommand.java
@@ -18,21 +18,14 @@
  */
 package com.linkedin.pinot.tools.admin.command;
 
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.JsonUtils;
+import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.tools.Command;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.net.URL;
-import java.net.URLConnection;
-
-import org.json.JSONObject;
+import java.util.Collections;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.NetUtil;
 
 
 public class PostQueryCommand extends AbstractBaseAdminCommand implements Command {
@@ -47,8 +40,8 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
   @Option(name = "-query", required = true, metaVar = "<string>", usage = "Query string to perform.")
   private String _query;
 
-  @Option(name = "-help", required = false, help = true, aliases = { "-h", "--h", "--help" },
-      usage = "Print this message.")
+  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h",
+      "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
   @Override
@@ -80,7 +73,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     _brokerHost = host;
     return this;
   }
-  
+
   public PostQueryCommand setBrokerPort(String port) {
     _brokerPort = port;
     return this;
@@ -96,28 +89,9 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
       _brokerHost = NetUtil.getHostAddress();
     }
     LOGGER.info("Executing command: " + toString());
-    final JSONObject json = new JSONObject();
-    json.put("pql", _query);
 
-    String brokerUrl = "http://" + _brokerHost + ":" + _brokerPort;
-    final URLConnection conn = new URL(brokerUrl + "/query").openConnection();
-    conn.setDoOutput(true);
-
-    final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream(), "UTF-8"));
-    String request = json.toString();
-
-    writer.write(request, 0, request.length());
-    writer.flush();
-
-    final BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
-    final StringBuilder sb = new StringBuilder();
-
-    String line = null;
-    while ((line = reader.readLine()) != null) {
-      sb.append(line);
-    }
-
-    return sb.toString();
+    String request = JsonUtils.objectToString(Collections.singletonMap("pql", _query));
+    return sendPostRequest("http://" + _brokerHost + ":" + _brokerPort + "/query", request);
   }
 
   @Override

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/QuickstartRunner.java
@@ -18,7 +18,9 @@
  */
 package com.linkedin.pinot.tools.admin.command;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.TenantRole;
 import com.linkedin.pinot.tools.QuickstartTableRequest;
 import java.io.File;
@@ -27,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
-import org.json.JSONObject;
 
 
 public class QuickstartRunner {
@@ -211,9 +212,9 @@ public class QuickstartRunner {
     }
   }
 
-  public JSONObject runQuery(String query)
+  public JsonNode runQuery(String query)
       throws Exception {
     int brokerPort = _brokerPorts.get(RANDOM.nextInt(_brokerPorts.size()));
-    return new JSONObject(new PostQueryCommand().setBrokerPort(String.valueOf(brokerPort)).setQuery(query).run());
+    return JsonUtils.stringToJsonNode(new PostQueryCommand().setBrokerPort(String.valueOf(brokerPort)).setQuery(query).run());
   }
 }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONObject;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,7 +141,7 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
     TableConfig tableConfig;
     try (FileInputStream fis = new FileInputStream(new File(_tableConfigFile))) {
       String tableConfigString = IOUtils.toString(fis);
-      tableConfig = TableConfig.fromJSONConfig(new JSONObject(tableConfigString));
+      tableConfig = TableConfig.fromJsonString(tableConfigString);
     } catch (IOException e) {
       throw new RuntimeException("Exception in reading table config from file " + _tableConfigFile, e);
     }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/backfill/BackfillSegmentUtils.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/backfill/BackfillSegmentUtils.java
@@ -19,9 +19,9 @@
 package com.linkedin.pinot.tools.backfill;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.pinot.common.utils.CommonConstants.Segment.SegmentType;
 import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.SimpleHttpResponse;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import java.io.File;
@@ -73,10 +73,11 @@ public class BackfillSegmentUtils {
     List<String> allSegments = new ArrayList<>();
     String urlString = String.format(SEGMENTS_ENDPOINT, _controllerHttpHost.toURI(), tableName);
     URL url = new URL(urlString);
-    InputStream is = url.openConnection().getInputStream();
 
-    String response = IOUtils.toString(is);
-    JsonNode segmentsData = new ObjectMapper().readTree(response);
+    JsonNode segmentsData;
+    try (InputStream inputStream = url.openConnection().getInputStream()) {
+      segmentsData = JsonUtils.inputStreamToJsonNode(inputStream);
+    }
 
     if (segmentsData != null) {
       if (segmentType == null || SegmentType.OFFLINE.equals(segmentType)) {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/data/generator/AvroWriter.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/data/generator/AvroWriter.java
@@ -18,10 +18,12 @@
  */
 package com.linkedin.pinot.tools.data.generator;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -44,16 +46,16 @@ public class AvroWriter implements Closeable {
   }
 
   public static org.apache.avro.Schema getAvroSchema(Schema schema) {
-    JsonObject avroSchema = new JsonObject();
-    avroSchema.addProperty("name", "data_gen_record");
-    avroSchema.addProperty("type", "record");
+    ObjectNode avroSchema = JsonUtils.newObjectNode();
+    avroSchema.put("name", "data_gen_record");
+    avroSchema.put("type", "record");
 
-    JsonArray fields = new JsonArray();
+    ArrayNode fields = JsonUtils.newArrayNode();
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-      JsonObject jsonObject = fieldSpec.toAvroSchemaJsonObject();
+      JsonNode jsonObject = fieldSpec.toAvroSchemaJsonObject();
       fields.add(jsonObject);
     }
-    avroSchema.add("fields", fields);
+    avroSchema.set("fields", fields);
 
     return new org.apache.avro.Schema.Parser().parse(avroSchema.toString());
   }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/data/generator/DataGenerator.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/data/generator/DataGenerator.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.math.IntRange;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +88,7 @@ public class DataGenerator {
     }
   }
 
-  public void generate(long totalDocs, int numFiles) throws IOException, JSONException {
+  public void generate(long totalDocs, int numFiles) throws IOException {
     final int numPerFiles = (int) (totalDocs / numFiles);
     for (int i = 0; i < numFiles; i++) {
       try (AvroWriter writer = new AvroWriter(outDir, i, generators, fetchSchema())) {
@@ -138,7 +137,7 @@ public class DataGenerator {
     return spec;
   }
 
-  public static void main(String[] args) throws IOException, JSONException {
+  public static void main(String[] args) throws IOException {
     final String[] columns = { "column1", "column2", "column3", "column4", "column5" };
     final Map<String, DataType> dataTypes = new HashMap<String, DataType>();
     final Map<String, FieldType> fieldTypes = new HashMap<String, FieldType>();

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -18,8 +18,9 @@
  */
 package com.linkedin.pinot.tools.perf;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.linkedin.pinot.broker.broker.helix.HelixBrokerStarter;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
@@ -28,6 +29,7 @@ import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.common.utils.TenantRole;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.ControllerStarter;
@@ -51,7 +53,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -354,14 +355,14 @@ public class PerfBenchmarkDriver {
     }
   }
 
-  public JSONObject postQuery(String query)
+  public JsonNode postQuery(String query)
       throws Exception {
     return postQuery(query, null);
   }
 
-  public JSONObject postQuery(String query, String optimizationFlags)
+  public JsonNode postQuery(String query, String optimizationFlags)
       throws Exception {
-    JSONObject requestJson = new JSONObject();
+    ObjectNode requestJson = JsonUtils.newObjectNode();
     requestJson.put("pql", query);
 
     if (optimizationFlags != null && !optimizationFlags.isEmpty()) {
@@ -387,10 +388,10 @@ public class PerfBenchmarkDriver {
 
       long totalTime = System.currentTimeMillis() - start;
       String responseString = stringBuilder.toString();
-      JSONObject responseJson = new JSONObject(responseString);
+      ObjectNode responseJson = (ObjectNode) JsonUtils.stringToJsonNode(responseString);
       responseJson.put("totalTime", totalTime);
 
-      if (_verbose && (responseJson.getLong("numDocsScanned") > 0)) {
+      if (_verbose && (responseJson.get("numDocsScanned").asLong() > 0)) {
         LOGGER.info("requestString: {}", requestString);
         LOGGER.info("responseString: {}", responseString);
       }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/QueryRunner.java
@@ -18,6 +18,7 @@
  */
 package com.linkedin.pinot.tools.perf;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.pinot.tools.AbstractBaseCommand;
 import com.linkedin.pinot.tools.Command;
 import java.io.File;
@@ -32,7 +33,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.math.stat.descriptive.DescriptiveStatistics;
-import org.json.JSONObject;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -240,11 +240,11 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
     int numTimesExecuted = 0;
     while (numTimesToRunQueries == 0 || numTimesExecuted < numTimesToRunQueries) {
       for (String query : queries) {
-        JSONObject response = driver.postQuery(query);
+        JsonNode response = driver.postQuery(query);
         numQueriesExecuted++;
-        long brokerTime = response.getLong("timeUsedMs");
+        long brokerTime = response.get("timeUsedMs").asLong();
         totalBrokerTime += brokerTime;
-        long clientTime = response.getLong("totalTime");
+        long clientTime = response.get("totalTime").asLong();
         totalClientTime += clientTime;
         statisticsList.get(0).addValue(clientTime);
 
@@ -645,11 +645,11 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
       AtomicInteger numQueriesExecuted, AtomicLong totalBrokerTime, AtomicLong totalClientTime,
       List<Statistics> statisticsList)
       throws Exception {
-    JSONObject response = driver.postQuery(query);
+    JsonNode response = driver.postQuery(query);
     numQueriesExecuted.getAndIncrement();
-    long brokerTime = response.getLong("timeUsedMs");
+    long brokerTime = response.get("timeUsedMs").asLong();
     totalBrokerTime.getAndAdd(brokerTime);
-    long clientTime = response.getLong("totalTime");
+    long clientTime = response.get("totalTime").asLong();
     totalClientTime.getAndAdd(clientTime);
     statisticsList.get(0).addValue(clientTime);
   }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/query/comparison/StarQueryComparison.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/query/comparison/StarQueryComparison.java
@@ -18,8 +18,9 @@
  */
 package com.linkedin.pinot.tools.query.comparison;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import java.io.File;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,8 +87,8 @@ public class StarQueryComparison {
       String query = queryGenerator.nextQuery();
       LOGGER.info("QUERY: {}", query);
 
-      JSONObject refResponse = new JSONObject(_refCluster.query(query));
-      JSONObject starTreeResponse = new JSONObject((_startTreeCluster.query(query)));
+      JsonNode refResponse = JsonUtils.stringToJsonNode(_refCluster.query(query));
+      JsonNode starTreeResponse = JsonUtils.stringToJsonNode((_startTreeCluster.query(query)));
 
       if (QueryComparison.compare(refResponse, starTreeResponse, false)) {
         LOGGER.error("Comparison PASSED: {}", query);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/QueryResponse.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/QueryResponse.java
@@ -18,13 +18,13 @@
  */
 package com.linkedin.pinot.tools.scan.query;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.core.query.utils.Pair;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 
 public class QueryResponse {
@@ -165,13 +165,13 @@ public class QueryResponse {
   }
 
   @JsonProperty("selectionResults")
-  @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   SelectionResults getSelectionResults() {
     return _selectionResults;
   }
 
   @JsonProperty("aggregationResults")
-  @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   List<AggregationResult> getAggregationResults() {
     return _aggregationResults;
   }
@@ -219,19 +219,19 @@ public class QueryResponse {
     }
 
     @JsonProperty("function")
-    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getFunction() {
       return _function;
     }
 
     @JsonProperty("value")
-    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getValue() {
       return _value;
     }
 
     @JsonProperty("groupByResult")
-    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public List<GroupValue> getGroupValues() {
       return _groupValues;
     }
@@ -265,7 +265,7 @@ public class QueryResponse {
   @Override
   public String toString() {
     try {
-      return new ObjectMapper().writeValueAsString(this);
+      return JsonUtils.objectToString(this);
     } catch (IOException e) {
       return null;
     }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/ScanBasedQueryProcessor.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/ScanBasedQueryProcessor.java
@@ -21,6 +21,7 @@ package com.linkedin.pinot.tools.scan.query;
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.GroupBy;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.pql.parsers.Pql2Compiler;
 import java.io.BufferedReader;
 import java.io.File;
@@ -35,7 +36,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -170,15 +170,13 @@ public class ScanBasedQueryProcessor implements Cloneable {
       QueryResponse queryResponse = scanBasedQueryProcessor.processQuery(query);
       printResult(queryResponse);
       printWriter.println("Query: " + query);
-      printWriter.println("Result: " + new ObjectMapper().writeValueAsString(queryResponse));
+      printWriter.println("Result: " + JsonUtils.objectToString(queryResponse));
     }
     bufferedReader.close();
     printWriter.close();
   }
 
-  public static void printResult(QueryResponse queryResponse)
-      throws IOException {
-    ObjectMapper objectMapper = new ObjectMapper();
-    LOGGER.info(objectMapper.writeValueAsString(queryResponse));
+  public static void printResult(QueryResponse queryResponse) throws IOException {
+    LOGGER.info(JsonUtils.objectToString(queryResponse));
   }
 }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/ColumnarToStarTreeConverter.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/ColumnarToStarTreeConverter.java
@@ -24,15 +24,14 @@ import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.data.readers.FileFormat;
 import com.linkedin.pinot.core.data.readers.PinotSegmentRecordReader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
-import com.linkedin.pinot.core.segment.name.DefaultSegmentNameGenerator;
-import com.linkedin.pinot.core.segment.name.SegmentNameGenerator;
 import com.linkedin.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.core.segment.name.DefaultSegmentNameGenerator;
+import com.linkedin.pinot.core.segment.name.SegmentNameGenerator;
 import java.io.File;
 import java.lang.reflect.Field;
 import org.apache.commons.io.FileUtils;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
@@ -42,7 +41,6 @@ import org.kohsuke.args4j.Option;
  */
 public class ColumnarToStarTreeConverter {
   private static final String TMP_DIR_PREFIX = "_tmp_";
-  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Option(name = "-inputDir", required = true, usage = "Path to input directory containing Pinot segments")
   private String _inputDirName = null;

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/PinotSegmentToJsonConverter.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/PinotSegmentToJsonConverter.java
@@ -18,13 +18,13 @@
  */
 package com.linkedin.pinot.tools.segment.converter;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.pinot.common.utils.JsonUtils;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.readers.PinotSegmentRecordReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 
 /**
@@ -46,17 +46,10 @@ public class PinotSegmentToJsonConverter implements PinotSegmentConverter {
       GenericRow row = new GenericRow();
       while (recordReader.hasNext()) {
         row = recordReader.next(row);
-        JSONObject record = new JSONObject();
-
-        for (String field : row.getFieldNames()) {
-          Object value = row.getValue(field);
-          if (value instanceof Object[]) {
-            record.put(field, new JSONArray(value));
-          } else {
-            record.put(field, value);
-          }
+        ObjectNode record = JsonUtils.newObjectNode();
+        for (String column : row.getFieldNames()) {
+          record.set(column, JsonUtils.objectToJsonNode(row.getValue(column)));
         }
-
         recordWriter.write(record.toString());
         recordWriter.newLine();
       }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/SegmentMergeCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/SegmentMergeCommand.java
@@ -18,22 +18,7 @@
  */
 package com.linkedin.pinot.tools.segment.converter;
 
-import com.linkedin.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import com.google.common.base.Preconditions;
-import org.apache.commons.io.FileUtils;
-import org.json.JSONObject;
-import org.kohsuke.args4j.Option;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.data.Schema;
@@ -43,8 +28,20 @@ import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.minion.rollup.MergeRollupSegmentConverter;
 import com.linkedin.pinot.core.minion.rollup.MergeType;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
 import com.linkedin.pinot.tools.Command;
 import com.linkedin.pinot.tools.admin.command.AbstractBaseAdminCommand;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -146,8 +143,7 @@ public class SegmentMergeCommand extends AbstractBaseAdminCommand implements Com
       // Read table config
       String tableConfigString =
           new String(Files.readAllBytes(Paths.get(_tableConfigFilePath)), StandardCharsets.UTF_8);
-      JSONObject tableConfigJson = new JSONObject(tableConfigString);
-      TableConfig tableConfig = TableConfig.fromJSONConfig(tableConfigJson);
+      TableConfig tableConfig = TableConfig.fromJsonString(tableConfigString);
 
       // Read schema
       Schema schema = Schema.fromFile(new File(_schemaFilePath));

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/streams/MeetupRsvpStream.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/streams/MeetupRsvpStream.java
@@ -18,28 +18,26 @@
  */
 package com.linkedin.pinot.tools.streams;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.JsonUtils;
+import com.linkedin.pinot.common.utils.KafkaStarterUtils;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaJSONMessageDecoder;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Properties;
-
 import javax.websocket.ClientEndpointConfig;
 import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 import javax.websocket.MessageHandler;
 import javax.websocket.Session;
-
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
 import kafka.producer.ProducerConfig;
-
 import org.glassfish.tyrus.client.ClientManager;
-import org.json.JSONObject;
-
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.utils.KafkaStarterUtils;
-import com.linkedin.pinot.core.realtime.impl.kafka.KafkaJSONMessageDecoder;
 
 
 public class MeetupRsvpStream {
@@ -82,31 +80,30 @@ public class MeetupRsvpStream {
               @Override
               public void onMessage(String message) {
                 try {
+                  JsonNode messageJSON = JsonUtils.stringToJsonNode(message);
+                  ObjectNode extracted = JsonUtils.newObjectNode();
 
-                  JSONObject messageJSON = new JSONObject(message);
-                  JSONObject extracted = new JSONObject();
-
-                  if (messageJSON.has("venue")) {
-                    JSONObject venue = messageJSON.getJSONObject("venue");
-                    extracted.put("venue_name", venue.getString("venue_name"));
+                  JsonNode venue = messageJSON.get("venue");
+                  if (venue != null) {
+                    extracted.set("venue_name", venue.get("venue_name"));
                   }
 
-                  if (messageJSON.has("event")) {
-                    JSONObject event = messageJSON.getJSONObject("event");
-                    extracted.put("event_name", event.getString("event_name"));
-                    extracted.put("event_id", event.getString("event_id"));
-                    extracted.put("event_time", event.getLong("time"));
+                  JsonNode event = messageJSON.get("event");
+                  if (event != null) {
+                    extracted.set("event_name", event.get("event_name"));
+                    extracted.set("event_id", event.get("event_id"));
+                    extracted.set("event_time", event.get("time"));
                   }
 
-                  if (messageJSON.has("group")) {
-                    JSONObject group = messageJSON.getJSONObject("group");
-                    extracted.put("group_city", group.getString("group_city"));
-                    extracted.put("group_country", group.getString("group_country"));
-                    extracted.put("group_id", group.getLong("group_id"));
-                    extracted.put("group_name", group.getString("group_name"));
+                  JsonNode group = messageJSON.get("group");
+                  if (group != null) {
+                    extracted.set("group_city", group.get("group_city"));
+                    extracted.set("group_country", group.get("group_country"));
+                    extracted.set("group_id", group.get("group_id"));
+                    extracted.set("group_name", group.get("group_name"));
                   }
 
-                  extracted.put("mtime", messageJSON.getLong("mtime"));
+                  extracted.set("mtime", messageJSON.get("mtime"));
                   extracted.put("rsvp_count", 1);
 
                   if (keepPublishing) {

--- a/pinot-transport/pom.xml
+++ b/pinot-transport/pom.xml
@@ -53,10 +53,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/perf/ScatterGatherPerfClient.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/perf/ScatterGatherPerfClient.java
@@ -42,7 +42,6 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +60,6 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.configuration.PropertiesConfiguration;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -276,11 +274,8 @@ public class ScatterGatherPerfClient implements Runnable {
 
   /**
    * Build a request from the JSON query and partition passed
-   * @return
-   * @throws IOException
-   * @throws JSONException
    */
-  public SimpleScatterGatherRequest getRequest() throws IOException, JSONException {
+  public SimpleScatterGatherRequest getRequest() {
 
     PerTableRoutingConfig cfg = _routingConfig.getPerTableRoutingCfg().get(_resourceName);
     if (null == cfg) {

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,8 @@
     under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.linkedin.pinot</groupId>
   <artifactId>pinot</artifactId>
@@ -67,7 +68,7 @@
     </developer>
     <developer>
       <id>Jackie-Jiang</id>
-      <name>Jackie Jiang </name>
+      <name>Jackie Jiang</name>
     </developer>
     <developer>
       <id>jfim</id>
@@ -118,7 +119,7 @@
     <!-- jfim: for Kafka 0.9.0.0, use zkclient 0.7 -->
     <kafka.version>0.9.0.1</kafka.version>
     <zkclient.version>0.7</zkclient.version>
-    <jackson.version>2.8.0</jackson.version>
+    <jackson.version>2.9.6</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
     <jersey.version>2.23</jersey.version>
     <swagger.version>1.5.10</swagger.version>
@@ -131,7 +132,7 @@
     <snappy-java.version>1.1.1.7</snappy-java.version>
 
     <!-- Sets the VM argument line used when unit tests are run. -->
-    <argLine> -Xms4g -Xmx4g -XX:MaxPermSize=512m -XX:MaxDirectMemorySize=10g </argLine>
+    <argLine>-Xms4g -Xmx4g -XX:MaxPermSize=512m -XX:MaxDirectMemorySize=10g</argLine>
   </properties>
 
   <profiles>
@@ -187,8 +188,7 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-     </repository>
-
+    </repository>
   </repositories>
 
   <dependencyManagement>
@@ -305,11 +305,6 @@
         <version>0.5.10</version>
       </dependency>
       <dependency>
-        <groupId>com.alibaba</groupId>
-        <artifactId>fastjson</artifactId>
-        <version>1.1.24</version>
-      </dependency>
-      <dependency>
         <groupId>com.101tec</groupId>
         <artifactId>zkclient</artifactId>
         <version>${zkclient.version}</version>
@@ -417,11 +412,6 @@
         <version>2.0.1</version>
       </dependency>
       <dependency>
-        <groupId>org.json</groupId>
-        <artifactId>json</artifactId>
-        <version>20170516</version>
-      </dependency>
-      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>1.7.7</version>
@@ -444,7 +434,7 @@
             <groupId>org.jboss.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
-      </exclusions>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -457,21 +447,6 @@
         <version>${async-http-client.version}</version>
       </dependency>
 
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
@@ -499,6 +474,52 @@
         <version>1.6</version>
       </dependency>
 
+      <!-- Jackson -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-xml</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-joda</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-base</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
 
       <!-- Kafka  -->
       <dependency>
@@ -535,46 +556,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-minicluster</artifactId>
         <version>${hadoop.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-xc</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-xc</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
@@ -591,28 +578,29 @@
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-json</artifactId>
           </exclusion>
-      </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>1.9.6</version>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-core-asl</artifactId>
-        <version>1.9.6</version>
+        <version>1.9.13</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-mapper-asl</artifactId>
+        <version>1.9.13</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-jaxrs</artifactId>
-        <version>1.9.6</version>
+        <version>1.9.13</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-xc</artifactId>
-        <version>1.9.6</version>
+        <version>1.9.13</version>
       </dependency>
+
       <dependency>
         <groupId>org.twitter4j</groupId>
         <artifactId>twitter4j-core</artifactId>
@@ -654,24 +642,9 @@
         <version>3.0.0</version>
       </dependency>
       <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.7</version>
-      </dependency>
-      <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>jersey-container-grizzly2-http</artifactId>
         <version>${jersey.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
@@ -703,31 +676,12 @@
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
         <version>2.24</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-client</artifactId>
         <version>1.9</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-jaxb-annotations</artifactId>
-        <version>2.5.4</version>
       </dependency>
       <dependency>
         <groupId>io.swagger</groupId>
@@ -740,39 +694,14 @@
         <version>${swagger.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>javax.inject</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>ackson-module-jaxb-annotations</artifactId>
-          </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>2.5.4</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2.external</groupId>


### PR DESCRIPTION
Remove the usage of json package from org.json, org.codehaus.jackson, com.google.code.gson, com.alibaba
Add JsonUtils class to reuse ObjectMapper and provide util methods