### PR TITLE
exclude single char folders from check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1045,7 +1045,7 @@
             <exclude>thirdeye/**/*</exclude>
             <!-- Documentation files -->
             <exclude>**/docs/_build/**</exclude>
-            <exclude>**/?*</exclude>
+            <exclude>**/?/</exclude>
           </excludes>
           <mapping>
             <thrift>JAVADOC_STYLE</thrift>


### PR DESCRIPTION
this is a half-solution to ignore single-character directories - including the "?" directory