### PR TITLE
Fix the build failure when installing inside the sub-module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1034,7 +1034,7 @@
         <artifactId>license-maven-plugin</artifactId>
         <version>2.8</version>
         <configuration>
-          <header>license.header</header>
+          <header>${basedir}/../license.header</header>
           <excludes>
             <!-- Text and log files -->
             <exclude>**/*.txt</exclude>


### PR DESCRIPTION
Make license.header always point to the root directory