### PR TITLE
[TE] - frontend harleyjj/yaml - reset and view documentation buttons

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/RoutingTableBuilderTestUtil.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/RoutingTableBuilderTestUtil.java
@@ -18,29 +18,27 @@
  */
 package org.apache.pinot.broker.routing.builder;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.config.RoutingConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
-import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 
 
 /**
  * Util class for routing table builder tests
  */
 public class RoutingTableBuilderTestUtil {
-
   private RoutingTableBuilderTestUtil() {
   }
 
-  public static TableConfig getDynamicComputingTableConfig(String tableName) throws IOException {
-    CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
-    TableConfig tableConfig = new TableConfig.Builder(tableType).setTableName(tableName).build();
-    Map<String, String> option = new HashMap<>();
-    option.put(RoutingConfig.ENABLE_DYNAMIC_COMPUTING_KEY, "true");
-    tableConfig.getRoutingConfig().setRoutingTableBuilderOptions(option);
-    return tableConfig;
+  public static TableConfig getDynamicComputingTableConfig(String tableName) {
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+    RoutingConfig routingConfig = new RoutingConfig();
+    Map<String, String> routingTableBuilderOptions = new HashMap<>();
+    routingTableBuilderOptions.put(RoutingConfig.ENABLE_DYNAMIC_COMPUTING_KEY, "true");
+    routingConfig.setRoutingTableBuilderOptions(routingTableBuilderOptions);
+    return new TableConfig.Builder(tableType).setTableName(tableName).setRoutingConfig(routingConfig).build();
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TableConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TableConfig.java
@@ -41,15 +41,15 @@ import org.apache.pinot.startree.hll.HllConfig;
 @ConfigDoc(value = "Configuration for a table", mandatory = true)
 @ConfigKey("table")
 public class TableConfig {
-  private static final String TABLE_NAME_KEY = "tableName";
-  private static final String TABLE_TYPE_KEY = "tableType";
-  private static final String VALIDATION_CONFIG_KEY = "segmentsConfig";
-  private static final String TENANT_CONFIG_KEY = "tenants";
-  private static final String INDEXING_CONFIG_KEY = "tableIndexConfig";
-  private static final String CUSTOM_CONFIG_KEY = "metadata";
-  private static final String QUOTA_CONFIG_KEY = "quota";
-  private static final String TASK_CONFIG_KEY = "task";
-  private static final String ROUTING_CONFIG_KEY = "routing";
+  public static final String TABLE_NAME_KEY = "tableName";
+  public static final String TABLE_TYPE_KEY = "tableType";
+  public static final String VALIDATION_CONFIG_KEY = "segmentsConfig";
+  public static final String TENANT_CONFIG_KEY = "tenants";
+  public static final String INDEXING_CONFIG_KEY = "tableIndexConfig";
+  public static final String CUSTOM_CONFIG_KEY = "metadata";
+  public static final String QUOTA_CONFIG_KEY = "quota";
+  public static final String TASK_CONFIG_KEY = "task";
+  public static final String ROUTING_CONFIG_KEY = "routing";
 
   @ConfigKey("name")
   @ConfigDoc(value = "The name for the table.", mandatory = true, exampleValue = "myTable")
@@ -158,22 +158,22 @@ public class TableConfig {
   }
 
   @Nonnull
-  public static JsonNode toJSONConfig(@Nonnull TableConfig tableConfig) throws JsonProcessingException {
+  public static JsonNode toJSONConfig(@Nonnull TableConfig tableConfig) {
     ObjectNode jsonConfig = JsonUtils.newObjectNode();
     jsonConfig.put(TABLE_NAME_KEY, tableConfig._tableName);
     jsonConfig.put(TABLE_TYPE_KEY, tableConfig._tableType.toString());
-    jsonConfig.put(VALIDATION_CONFIG_KEY, JsonUtils.objectToString(tableConfig._validationConfig));
-    jsonConfig.put(TENANT_CONFIG_KEY, JsonUtils.objectToString(tableConfig._tenantConfig));
-    jsonConfig.put(INDEXING_CONFIG_KEY, JsonUtils.objectToString(tableConfig._indexingConfig));
-    jsonConfig.put(CUSTOM_CONFIG_KEY, JsonUtils.objectToString(tableConfig._customConfig));
+    jsonConfig.set(VALIDATION_CONFIG_KEY, JsonUtils.objectToJsonNode(tableConfig._validationConfig));
+    jsonConfig.set(TENANT_CONFIG_KEY, JsonUtils.objectToJsonNode(tableConfig._tenantConfig));
+    jsonConfig.set(INDEXING_CONFIG_KEY, JsonUtils.objectToJsonNode(tableConfig._indexingConfig));
+    jsonConfig.set(CUSTOM_CONFIG_KEY, JsonUtils.objectToJsonNode(tableConfig._customConfig));
     if (tableConfig._quotaConfig != null) {
-      jsonConfig.put(QUOTA_CONFIG_KEY, JsonUtils.objectToString(tableConfig._quotaConfig));
+      jsonConfig.set(QUOTA_CONFIG_KEY, JsonUtils.objectToJsonNode(tableConfig._quotaConfig));
     }
     if (tableConfig._taskConfig != null) {
-      jsonConfig.put(TASK_CONFIG_KEY, JsonUtils.objectToString(tableConfig._taskConfig));
+      jsonConfig.set(TASK_CONFIG_KEY, JsonUtils.objectToJsonNode(tableConfig._taskConfig));
     }
     if (tableConfig._routingConfig != null) {
-      jsonConfig.put(ROUTING_CONFIG_KEY, JsonUtils.objectToString(tableConfig._routingConfig));
+      jsonConfig.set(ROUTING_CONFIG_KEY, JsonUtils.objectToJsonNode(tableConfig._routingConfig));
     }
     return jsonConfig;
   }
@@ -311,6 +311,7 @@ public class TableConfig {
     _taskConfig = taskConfig;
   }
 
+  @Nullable
   public RoutingConfig getRoutingConfig() {
     return _routingConfig;
   }
@@ -606,10 +607,6 @@ public class TableConfig {
       if (_customConfig == null) {
         _customConfig = new TableCustomConfig();
         _customConfig.setCustomConfigs(new HashMap<>());
-      }
-
-      if (_routingConfig == null) {
-        _routingConfig = new RoutingConfig();
       }
 
       return new TableConfig(_tableName, _tableType, validationConfig, tenantConfig, indexingConfig, _customConfig,

--- a/pinot-common/src/test/java/org/apache/pinot/common/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/config/TableConfigTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.common.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -43,8 +45,16 @@ public class TableConfigTest {
       Assert.assertEquals(tableConfig.getIndexingConfig().getLoadMode(), "HEAP");
       Assert.assertNull(tableConfig.getQuotaConfig());
 
-      // Serialize then de-serialize
-      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(TableConfig.toJSONConfig(tableConfig));
+      // Serialize
+      JsonNode jsonTableConfig = TableConfig.toJSONConfig(tableConfig);
+      // All nested configs should be json objects instead of serialized strings
+      Assert.assertTrue(jsonTableConfig.get(TableConfig.VALIDATION_CONFIG_KEY) instanceof ObjectNode);
+      Assert.assertTrue(jsonTableConfig.get(TableConfig.TENANT_CONFIG_KEY) instanceof ObjectNode);
+      Assert.assertTrue(jsonTableConfig.get(TableConfig.INDEXING_CONFIG_KEY) instanceof ObjectNode);
+      Assert.assertTrue(jsonTableConfig.get(TableConfig.CUSTOM_CONFIG_KEY) instanceof ObjectNode);
+
+      // De-serialize
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonTableConfig);
       Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
       Assert.assertNull(tableConfigToCompare.getQuotaConfig());
       Assert.assertNull(tableConfigToCompare.getValidationConfig().getReplicaGroupStrategyConfig());

--- a/thirdeye/thirdeye-frontend/app/pods/components/modals/yaml-documentation/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/modals/yaml-documentation/component.js
@@ -1,0 +1,36 @@
+import Component from '@ember/component';
+import { computed, set, get, getProperties } from '@ember/object';
+
+export default Component.extend({
+
+  showYAMLModal: computed(
+    'showAnomalyModal',
+    'showNotificationModal',
+    function() {
+      const {
+        showAnomalyModal,
+        showNotificationModal
+      } = getProperties(this, 'showAnomalyModal', 'showNotificationModal');
+      return showAnomalyModal || showNotificationModal;
+    }
+  ),
+
+  headerText: computed(
+    'YAMLField',
+    function() {
+      const YAMLField = get(this, 'YAMLField');
+      return `YAML ${YAMLField} Documentation`;
+    }
+  ),
+
+  actions: {
+    /**
+     * Handles the close event
+     * @return {undefined}
+     */
+    onExit() {
+      let YAMLField = get(this, 'YAMLField');
+      set(this, `show${YAMLField}Modal`, false);
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/modals/yaml-documentation/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/modals/yaml-documentation/template.hbs
@@ -1,0 +1,12 @@
+{{#te-modal
+  headerText=headerText
+  isShowingModal=showYAMLModal
+  cancelAction=(action "onExit")
+  hasFooter=false
+}}
+  <div class="row te-modal__settings">
+    <p class="col-md-2">
+      <span class="te-label te-label--bold te-label--dark">YAML Documentation Coming soon...</span>
+    </p>
+  </div>
+{{/te-modal}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/template.hbs
@@ -1,6 +1,25 @@
 <fieldset class="te-form__section te-form__section--first row">
   <div class="col-xs-12">
     <legend class="te-form__section-title">{{alertTitle}}</legend>
+    <label for="select-metric" class="control-label te-label te-label--taller required">Can't find your metric?
+      <a class="thirdeye-link-secondary" target="_blank">Import from InGraphs</a>
+    </label>
+    <div class="pull-right">
+      {{bs-button
+        defaultText="Reset"
+        type="outline-primary"
+        buttonType="reset"
+        onClick=(action "resetYAML" "anomaly")
+        class="te-button te-button--link"
+      }}
+      {{bs-button
+        defaultText="View Documentation"
+        type="outline-primary"
+        buttonType="modal"
+        onClick=(action "triggerDocModal" "Anomaly")
+        class="te-button te-button--cancel"
+      }}
+    </div>
     {{ember-ace
       lines=35
       value=currentYamlValues
@@ -24,6 +43,7 @@
       {{!--  subscription group --}}
       {{#power-select
         options=subscriptionGroupNames
+        placeholder="Create a subscription group"
         selected=groupName
         searchField="name"
         onchange=(action 'onYAMLGroupSelectionAction')
@@ -31,6 +51,30 @@
       }}
         {{groupName.name}} ({{groupName.id}})
       {{/power-select}}
+    </div>
+    <div class="col-xs-12">
+      <legend class="te-form__section-title">Configure new subscription group</legend>
+    </div>
+    <div class="col-xs-12">
+      <label for="select-metric" class="control-label te-label te-label--taller required">Can't find your team? Contact
+        <a class="thirdeye-link-secondary" target="_blank" href="mailto:ask_thirdeye@linkedin.com">ask_thirdeye@linkedin.com</a>
+      </label>
+      <div class="pull-right">
+        {{bs-button
+          defaultText="Reset"
+          type="outline-primary"
+          buttonType="reset"
+          onClick=(action "resetYAML" "notification")
+          class="te-button te-button--link"
+        }}
+        {{bs-button
+          defaultText="View Documentation"
+          type="outline-primary"
+          buttonType="modal"
+          onClick=(action "triggerDocModal" "Notification")
+          class="te-button te-button--cancel"
+        }}
+      </div>
     </div>
     <div class="col-xs-12">
       {{!-- notification settings editor --}}
@@ -80,3 +124,9 @@
     }}
   {{/if}}
 </fieldset>
+
+{{modals/yaml-documentation
+  showAnomalyModal=showAnomalyModal
+  showNotificationModal=showNotificationModal
+  YAMLField=YAMLField
+}}

--- a/thirdeye/thirdeye-frontend/app/styles/components/yaml-editor.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/yaml-editor.scss
@@ -14,3 +14,7 @@
     margin-bottom: 20px;
   }
 }
+
+.ace_editor.ace_autocomplete {
+  width: 650px;
+}


### PR DESCRIPTION
This commit includes

1) Cleanup of some eslint warnings
2) Reset and View Documentation buttons for YAML fields in yaml-editor component
3) Installs a placeholder modal for the 'View Documentation' button to trigger
4) Updates some comments
5) Widens the yaml autocomplete box to accommodate long strings