### PR TITLE
[TE] - frontend harleyjj/yaml - reset and view documentation buttons

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/modals/yaml-documentation/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/modals/yaml-documentation/component.js
@@ -1,0 +1,36 @@
+import Component from '@ember/component';
+import { computed, set, get, getProperties } from '@ember/object';
+
+export default Component.extend({
+
+  showYAMLModal: computed(
+    'showAnomalyModal',
+    'showNotificationModal',
+    function() {
+      const {
+        showAnomalyModal,
+        showNotificationModal
+      } = getProperties(this, 'showAnomalyModal', 'showNotificationModal');
+      return showAnomalyModal || showNotificationModal;
+    }
+  ),
+
+  headerText: computed(
+    'YAMLField',
+    function() {
+      const YAMLField = get(this, 'YAMLField');
+      return `YAML ${YAMLField} Documentation`;
+    }
+  ),
+
+  actions: {
+    /**
+     * Handles the close event
+     * @return {undefined}
+     */
+    onExit() {
+      let YAMLField = get(this, 'YAMLField');
+      set(this, `show${YAMLField}Modal`, false);
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/modals/yaml-documentation/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/modals/yaml-documentation/template.hbs
@@ -1,0 +1,12 @@
+{{#te-modal
+  headerText=headerText
+  isShowingModal=showYAMLModal
+  cancelAction=(action "onExit")
+  hasFooter=false
+}}
+  <div class="row te-modal__settings">
+    <p class="col-md-2">
+      <span class="te-label te-label--bold te-label--dark">YAML Documentation Coming soon...</span>
+    </p>
+  </div>
+{{/te-modal}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/template.hbs
@@ -1,6 +1,25 @@
 <fieldset class="te-form__section te-form__section--first row">
   <div class="col-xs-12">
     <legend class="te-form__section-title">{{alertTitle}}</legend>
+    <label for="select-metric" class="control-label te-label te-label--taller required">Can't find your metric?
+      <a class="thirdeye-link-secondary" target="_blank">Import from InGraphs</a>
+    </label>
+    <div class="pull-right">
+      {{bs-button
+        defaultText="Reset"
+        type="outline-primary"
+        buttonType="reset"
+        onClick=(action "resetYAML" "anomaly")
+        class="te-button te-button--link"
+      }}
+      {{bs-button
+        defaultText="View Documentation"
+        type="outline-primary"
+        buttonType="modal"
+        onClick=(action "triggerDocModal" "Anomaly")
+        class="te-button te-button--cancel"
+      }}
+    </div>
     {{ember-ace
       lines=35
       value=currentYamlValues
@@ -24,6 +43,7 @@
       {{!--  subscription group --}}
       {{#power-select
         options=subscriptionGroupNames
+        placeholder="Create a subscription group"
         selected=groupName
         searchField="name"
         onchange=(action 'onYAMLGroupSelectionAction')
@@ -31,6 +51,30 @@
       }}
         {{groupName.name}} ({{groupName.id}})
       {{/power-select}}
+    </div>
+    <div class="col-xs-12">
+      <legend class="te-form__section-title">Configure new subscription group</legend>
+    </div>
+    <div class="col-xs-12">
+      <label for="select-metric" class="control-label te-label te-label--taller required">Can't find your team? Contact
+        <a class="thirdeye-link-secondary" target="_blank" href="mailto:ask_thirdeye@linkedin.com">ask_thirdeye@linkedin.com</a>
+      </label>
+      <div class="pull-right">
+        {{bs-button
+          defaultText="Reset"
+          type="outline-primary"
+          buttonType="reset"
+          onClick=(action "resetYAML" "notification")
+          class="te-button te-button--link"
+        }}
+        {{bs-button
+          defaultText="View Documentation"
+          type="outline-primary"
+          buttonType="modal"
+          onClick=(action "triggerDocModal" "Notification")
+          class="te-button te-button--cancel"
+        }}
+      </div>
     </div>
     <div class="col-xs-12">
       {{!-- notification settings editor --}}
@@ -80,3 +124,9 @@
     }}
   {{/if}}
 </fieldset>
+
+{{modals/yaml-documentation
+  showAnomalyModal=showAnomalyModal
+  showNotificationModal=showNotificationModal
+  YAMLField=YAMLField
+}}

--- a/thirdeye/thirdeye-frontend/app/styles/components/yaml-editor.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/yaml-editor.scss
@@ -14,3 +14,7 @@
     margin-bottom: 20px;
   }
 }
+
+.ace_editor.ace_autocomplete {
+  width: 650px;
+}


### PR DESCRIPTION
This commit includes:

1) Cleanup of some eslint warnings
2) Reset and View Documentation buttons for YAML fields in yaml-editor component
3) Installs a placeholder modal for the 'View Documentation' button to trigger
4) Updates some comments
5) Widens the yaml autocomplete box to accommodate long strings