### PR TITLE
Fix SegmentConverter to handle virtual column

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReader.java
@@ -35,6 +35,7 @@ import org.apache.pinot.core.data.readers.sort.PinotSegmentSorter;
 import org.apache.pinot.core.data.readers.sort.SegmentSorter;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
 
 
 /**
@@ -72,7 +73,9 @@ public class PinotSegmentRecordReader implements RecordReader {
       SegmentMetadata segmentMetadata = _immutableSegment.getSegmentMetadata();
       _numDocs = segmentMetadata.getTotalRawDocs();
       if (schema == null) {
-        _schema = segmentMetadata.getSchema();
+        // In order not to expose virtual columns to client, schema shouldn't be fetched from segmentMetadata;
+        // otherwise the original metadata will be modified. Hence, initialize a new schema.
+        _schema = new SegmentMetadataImpl(indexDir).getSchema();
         Collection<String> columnNames = _schema.getColumnNames();
         _columnReaderMap = new HashMap<>(columnNames.size());
         for (String columnName : columnNames) {


### PR DESCRIPTION
Currently the `ConvertPinotSegment` command didn't work properly with virtual column.
This PR fixes this issue by removing virtual columns before writing to avro file.
Error messages we found:
```
$ ./pinot-distribution/target/pinot-0.016-pkg/bin/pinot-admin.sh ConvertPinotSegment -dataDir /input/test -outputDir /output/test -outputFormat avro -overwrite
Exception caught: 
org.apache.avro.SchemaParseException: Illegal initial character: $hostName
        at org.apache.avro.Schema.validateName(Schema.java:1064)
        at org.apache.avro.Schema.access$200(Schema.java:79)
        at org.apache.avro.Schema$Field.<init>(Schema.java:372)
        at org.apache.avro.SchemaBuilder$FieldBuilder.completeField(SchemaBuilder.java:2124)
        at org.apache.avro.SchemaBuilder$FieldBuilder.completeField(SchemaBuilder.java:2120)
        at org.apache.avro.SchemaBuilder$FieldBuilder.access$5200(SchemaBuilder.java:2034)
        at org.apache.avro.SchemaBuilder$FieldDefault.noDefault(SchemaBuilder.java:2146)
        at org.apache.pinot.core.util.AvroUtils.getAvroSchemaFromPinotSchema(AvroUtils.java:165)
        at org.apache.pinot.tools.segment.converter.PinotSegmentToAvroConverter.convert(PinotSegmentToAvroConverter.java:47)
        at org.apache.pinot.tools.segment.converter.PinotSegmentConvertCommand.execute(PinotSegmentConvertCommand.java:133)
        at org.apache.pinot.tools.admin.PinotAdministrator.execute(PinotAdministrator.java:126)
        at org.apache.pinot.tools.admin.PinotAdministrator.main(PinotAdministrator.java:138)
```

We move the removal of virtual column part on to record reader side. The reason is virtual column shouldn't be exposed to client side. E.g. client side doesn't need to know about $hostname.