### PR TITLE
[TE] detection - last time stamp to handle data incompleteness

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionUtils.java
@@ -163,4 +163,16 @@ public class DetectionUtils {
 
     return anomaly;
   }
+
+  /**
+   * Helper for consolidate last time stamps in all nested detection pipelines
+   * @param nestedLastTimeStamps all nested last time stamps
+   * @return the last time stamp
+   */
+  public static long consolidateNestedLastTimeStamps(Collection<Long> nestedLastTimeStamps){
+    if(nestedLastTimeStamps.isEmpty() || nestedLastTimeStamps.contains(-1L)){
+      return -1L;
+    }
+    return Collections.min(nestedLastTimeStamps);
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/algorithm/MergeWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/algorithm/MergeWrapperTest.java
@@ -117,7 +117,7 @@ public class MergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 6);
-    Assert.assertEquals(output.getLastTimestamp(), 2800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
   }
 
   @Test
@@ -128,7 +128,7 @@ public class MergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 3);
-    Assert.assertEquals(output.getLastTimestamp(), 2800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(0, 1250)));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(1500, 2000)));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(2200, 2800)));
@@ -143,7 +143,7 @@ public class MergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 3);
-    Assert.assertEquals(output.getLastTimestamp(), 2800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(0, 1250)));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(1500, 2300)));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(2400, 2800)));
@@ -169,7 +169,7 @@ public class MergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 4);
-    Assert.assertEquals(output.getLastTimestamp(), 3800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(0, 1250)));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(1500, 2300)));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(2400, 3650)));
@@ -196,7 +196,7 @@ public class MergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 4);
-    Assert.assertEquals(output.getLastTimestamp(), 3800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(0, 1250)));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(1500, 2300)));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(2400, 3650)));

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleAnomalyFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleAnomalyFilterTest.java
@@ -141,7 +141,7 @@ public class ThresholdRuleAnomalyFilterTest {
 
     DetectionPipelineResult result = this.thresholdRuleFilter.run();
     List<MergedAnomalyResultDTO> anomalies = result.getAnomalies();
-    Assert.assertEquals(result.getLastTimestamp(), 8);
+    Assert.assertEquals(result.getLastTimestamp(), 10);
     Assert.assertEquals(anomalies.size(), 3);
     Assert.assertEquals(anomalies.get(0), this.anomalies.get(0));
     Assert.assertEquals(anomalies.get(1), this.anomalies.get(1));
@@ -156,7 +156,7 @@ public class ThresholdRuleAnomalyFilterTest {
 
     DetectionPipelineResult result = this.thresholdRuleFilter.run();
     List<MergedAnomalyResultDTO> anomalies = result.getAnomalies();
-    Assert.assertEquals(result.getLastTimestamp(), 8);
+    Assert.assertEquals(result.getLastTimestamp(), 10);
     Assert.assertEquals(anomalies.size(), 2);
     Assert.assertEquals(anomalies.get(0), this.anomalies.get(1));
     Assert.assertEquals(anomalies.get(1), this.anomalies.get(2));

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/integration/MergeDimensionThresholdIntegrationTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/integration/MergeDimensionThresholdIntegrationTest.java
@@ -130,7 +130,6 @@ public class MergeDimensionThresholdIntegrationTest {
     DetectionPipelineResult result = pipeline.run();
 
     Assert.assertEquals(result.getAnomalies().size(), 3);
-    Assert.assertEquals(result.getLastTimestamp(), 18000);
 
     Assert.assertTrue(result.getAnomalies().contains(makeAnomaly(9500, 18000, "thirdeye:metric:2")));
     Assert.assertTrue(result.getAnomalies().contains(makeAnomaly(0, 7200, "thirdeye:metric:2:a%3D1:b%3D2")));

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/ChildKeepingMergeWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/ChildKeepingMergeWrapperTest.java
@@ -112,7 +112,7 @@ public class ChildKeepingMergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 6);
-    Assert.assertEquals(output.getLastTimestamp(), 2800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
   }
 
   @Test
@@ -123,7 +123,7 @@ public class ChildKeepingMergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 3);
-    Assert.assertEquals(output.getLastTimestamp(), 2800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(0, 1250, ImmutableSet.of(makeAnomaly(1150, 1250), makeAnomaly(0, 1000), makeAnomaly(1100, 1200)))));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(1500, 2000)));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(2200, 2800, ImmutableSet.of(makeAnomaly(2200, 2300), makeAnomaly(2400, 2800)))));
@@ -138,7 +138,7 @@ public class ChildKeepingMergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 3);
-    Assert.assertEquals(output.getLastTimestamp(), 2800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(0, 1250, ImmutableSet.of(makeAnomaly(1150, 1250), makeAnomaly(0, 1000), makeAnomaly(1100, 1200)))));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(1500, 2300, ImmutableSet.of(makeAnomaly(2200, 2300), makeAnomaly(1500, 2000)))));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(2400, 2800)));
@@ -164,7 +164,7 @@ public class ChildKeepingMergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 4);
-    Assert.assertEquals(output.getLastTimestamp(), 3800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(0, 1250, ImmutableSet.of(makeAnomaly(1150, 1250), makeAnomaly(0, 1000), makeAnomaly(1100, 1200)))));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(1500, 2300, ImmutableSet.of(makeAnomaly(2200, 2300), makeAnomaly(1500, 2000)))));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(2400, 2800)));
@@ -191,7 +191,7 @@ public class ChildKeepingMergeWrapperTest {
     DetectionPipelineResult output = this.wrapper.run();
 
     Assert.assertEquals(output.getAnomalies().size(), 4);
-    Assert.assertEquals(output.getLastTimestamp(), 3800);
+    Assert.assertEquals(output.getLastTimestamp(), 2900);
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(0, 1250, ImmutableSet.of(makeAnomaly(1150, 1250), makeAnomaly(0, 1000), makeAnomaly(1100, 1200)))));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(1500, 2300, ImmutableSet.of(makeAnomaly(2200, 2300), makeAnomaly(1500, 2000)))));
     Assert.assertTrue(output.getAnomalies().contains(makeAnomaly(2400, 2800)));


### PR DESCRIPTION
This PR set the next detection timestamp based on the time series timestamps. If data is incomplete, next detection starts from the data's latest available timestamp plus the time granularity.