### PR TITLE
Move instantiation of objects which depend on _helixResourceManager to after invocation of PinotHelixResourceManager::start

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix;
+
+import java.util.List;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.ControllerStarter;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.core.periodictask.PeriodicTask;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class ControllerPeriodicTaskStarterTest extends ControllerTest {
+  private MockControllerStarter _mockControllerStarter;
+
+  @BeforeClass
+  public void setup() {
+    startZk();
+  }
+
+  /**
+   * Test that controller starts up and helixResourceManager is non null before initiating periodic tasks
+   */
+  @Test
+  public void testHelixResourceManagerDuringControllerStart() {
+    startController();
+  }
+
+  @AfterClass
+  public void teardown() {
+    stopController();
+  }
+
+  @Override
+  protected void startControllerStarter(ControllerConf config) {
+    _mockControllerStarter = new MockControllerStarter(config);
+    _mockControllerStarter.start();
+    _helixResourceManager = _mockControllerStarter.getHelixResourceManager();
+  }
+
+  @Override
+  protected void stopControllerStarter() {
+    Assert.assertNotNull(_mockControllerStarter);
+
+    _mockControllerStarter.stop();
+    _mockControllerStarter = null;
+  }
+
+  private class MockControllerStarter extends ControllerStarter {
+
+    private static final int NUM_PERIODIC_TASKS = 7;
+
+    private List<PeriodicTask> _controllerPeriodicTasks;
+
+    public MockControllerStarter(ControllerConf conf) {
+      super(conf);
+    }
+
+    @Override
+    protected List<PeriodicTask> setupControllerPeriodicTasks() {
+      PinotHelixResourceManager helixResourceManager = getHelixResourceManager();
+      Assert.assertNotNull(helixResourceManager);
+      Assert.assertNotNull(helixResourceManager.getHelixAdmin());
+      Assert.assertNotNull(helixResourceManager.getHelixZkManager());
+      Assert.assertNotNull(helixResourceManager.getHelixClusterName());
+      Assert.assertNotNull(helixResourceManager.getPropertyStore());
+
+      _controllerPeriodicTasks = super.setupControllerPeriodicTasks();
+      Assert.assertNotNull(_controllerPeriodicTasks);
+      Assert.assertEquals(_controllerPeriodicTasks.size(), NUM_PERIODIC_TASKS);
+      return _controllerPeriodicTasks;
+    }
+
+    List<PeriodicTask> getControllerPeriodicTasks() {
+      return _controllerPeriodicTasks;
+    }
+   }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -127,22 +127,30 @@ public abstract class ControllerTest {
       _zkClient.deleteRecursive("/" + helixClusterName);
     }
 
-    _controllerStarter = new ControllerStarter(config);
-    _controllerStarter.start();
+    startControllerStarter(config);
 
-    _helixResourceManager = _controllerStarter.getHelixResourceManager();
     _helixManager = _helixResourceManager.getHelixZkManager();
     _helixAdmin = _helixResourceManager.getHelixAdmin();
     _propertyStore = _helixResourceManager.getPropertyStore();
   }
 
+  protected void startControllerStarter(ControllerConf config) {
+    _controllerStarter = new ControllerStarter(config);
+    _controllerStarter.start();
+    _helixResourceManager = _controllerStarter.getHelixResourceManager();
+  }
+
   protected void stopController() {
+    stopControllerStarter();
+    FileUtils.deleteQuietly(new File(_controllerDataDir));
+    _zkClient.close();
+  }
+
+  protected void stopControllerStarter() {
     Assert.assertNotNull(_controllerStarter);
 
     _controllerStarter.stop();
     _controllerStarter = null;
-    FileUtils.deleteQuietly(new File(_controllerDataDir));
-    _zkClient.close();
   }
 
   protected Schema createDummySchema(String tableName) {


### PR DESCRIPTION
Certain objects which are instantiated in the `ControllerStarter` need an instance of `PinotHelixResourceManager`. Even though `PinotHelixResourceManager` is instantiated in the `ControllerStarter` constructor right at the beginning, it cannot be used until `PinotHelixResourceManager::start` is invoked. The start is invoked in `ControllerStarter::start()`. Every object that depends on `PinotHelixResourceManage`r should be created **after** this invocation of start. These include 
1) ControllerLeadershipManager
2) PinotHelixTaskResourceManager
3) PeriodicTasks - RetentionManager, SegmentStatusChecker, RealtimeSegmentValidationManager, OfflineSegmentValidationManager, BrokerResourcevalidationManager, RealtimeSegmentRelocator and PinotTaskManager
4) PinotLLCRealtimeSegmentManager, PinotRealtimeSegmentManager

Of this list, some of 3 and 4 were being created before `PinotHelixResourceManager::start`.

This PR moves all the dependents to after `PinotHelixResourceManager` being ready
