### PR TITLE
[TE] yaml - subscribed detection names in notification yaml

### DIFF
--- a/thirdeye/thirdeye-frontend/app/utils/constants.js
+++ b/thirdeye/thirdeye-frontend/app/utils/constants.js
@@ -150,7 +150,7 @@ alertSchemes:
 - type: EMAIL
 recipients:
  to:
-  - "me@company.com"buildAlerterProperties
+  - "me@company.com"
  cc:
   - "cc_email@company.com"
 fromAddress: your_from@company.com

--- a/thirdeye/thirdeye-frontend/app/utils/constants.js
+++ b/thirdeye/thirdeye-frontend/app/utils/constants.js
@@ -150,11 +150,12 @@ alertSchemes:
 - type: EMAIL
 recipients:
  to:
-  - "me@company.com"
+  - "me@company.com"buildAlerterProperties
  cc:
   - "cc_email@company.com"
-fromAddress: thirdeye-dev@linkedin.com
+fromAddress: your_from@company.com
 
+cron: "0 0/5 * 1/1 * ? *"	
 active: true
 referenceLinks:
  "My Company FAQs": "http://www.company.com/faq"`;

--- a/thirdeye/thirdeye-frontend/app/utils/constants.js
+++ b/thirdeye/thirdeye-frontend/app/utils/constants.js
@@ -10,7 +10,8 @@ export default {
 };
 
 
-export const yamlAlertProps = `# give a name for this detection
+export const yamlAlertProps = `# Below are all dummy example. Please update accordingly.
+# give a name for this detection
 detectionName: name_of_the_detection
 # the metric to detect the anomalies
 metric: metric_name
@@ -75,7 +76,8 @@ rules:
 `;
 
 export const yamIt = function(metric, dataset){
-  return `# give a name for this detection
+  return `# Below are all dummy example. Please update accordingly.
+# give a name for this detection
 detectionName: name_of_the_detection
 # the metric to detect the anomalies
 metric: ${metric}
@@ -142,7 +144,7 @@ rules:
 
 export const yamlAlertSettings = `# Below are all dummy example. Please update accordingly.
 subscriptionGroupName: test_subscription_group
-application: "parity-check"
+application: your_application_name
 subscribedDetections: 
   - your_detection_name
 
@@ -153,9 +155,10 @@ recipients:
   - "me@company.com"
  cc:
   - "cc_email@company.com"
-fromAddress: your_from@company.com
+fromAddress: thirdeye-dev@linkedin.com
 
-cron: "0 0/5 * 1/1 * ? *"	
+cron: "0 0/5 * 1/1 * ? *"
+type: DEFAULT_ALERTER_PIPELINE
 active: true
 referenceLinks:
  "My Company FAQs": "http://www.company.com/faq"`;

--- a/thirdeye/thirdeye-frontend/app/utils/constants.js
+++ b/thirdeye/thirdeye-frontend/app/utils/constants.js
@@ -142,22 +142,19 @@ rules:
 
 export const yamlAlertSettings = `# Below are all dummy example. Please update accordingly.
 subscriptionGroupName: test_subscription_group
-cron: "0 0/5 * 1/1 * ? *"
 application: "parity-check"
-active: true
+subscribedDetections: 
+  - your_detection_name
 
-detectionConfigIds:
- - 5773069
-
-fromAddress: your_from@company.com
+alertSchemes:
+- type: EMAIL
 recipients:
  to:
   - "me@company.com"
  cc:
   - "cc_email@company.com"
+fromAddress: thirdeye-dev@linkedin.com
 
-alertSchemes:
-- type: EMAIL
-
+active: true
 referenceLinks:
  "My Company FAQs": "http://www.company.com/faq"`;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/DetectionAlertConfigValidator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/DetectionAlertConfigValidator.java
@@ -30,7 +30,8 @@ import static org.apache.pinot.thirdeye.detection.yaml.YamlDetectionAlertConfigT
 public class DetectionAlertConfigValidator extends ConfigValidator {
 
   private static final DetectionAlertConfigValidator INSTANCE = new DetectionAlertConfigValidator();
-
+  private static final String PROP_CLASS_NAME = "className";
+  
   public static DetectionAlertConfigValidator getInstance() {
     return INSTANCE;
   }
@@ -55,7 +56,11 @@ public class DetectionAlertConfigValidator extends ConfigValidator {
       responseMessage.put("message", "From address field cannot be left empty");
       return false;
     }
-
+    if (alertConfig.getProperties() == null || alertConfig.getProperties().get(PROP_CLASS_NAME) == null
+        || StringUtils.isEmpty(alertConfig.getProperties().get(PROP_CLASS_NAME).toString())) {
+      responseMessage.put("message", "'Type' field cannot be left empty.");
+      return false;
+    }
     // At least one alertScheme is required
     if (alertConfig.getAlertSchemes() == null || alertConfig.getAlertSchemes().size() == 0) {
       responseMessage.put("message", "Alert scheme cannot be left empty");

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/DetectionAlertConfigValidator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/DetectionAlertConfigValidator.java
@@ -30,7 +30,6 @@ import static org.apache.pinot.thirdeye.detection.yaml.YamlDetectionAlertConfigT
 public class DetectionAlertConfigValidator extends ConfigValidator {
 
   private static final DetectionAlertConfigValidator INSTANCE = new DetectionAlertConfigValidator();
-  private static final String PROP_CLASS_NAME = "className";
 
   public static DetectionAlertConfigValidator getInstance() {
     return INSTANCE;
@@ -56,11 +55,6 @@ public class DetectionAlertConfigValidator extends ConfigValidator {
       responseMessage.put("message", "From address field cannot be left empty");
       return false;
     }
-    if (alertConfig.getProperties() == null || alertConfig.getProperties().get(PROP_CLASS_NAME) == null
-        || StringUtils.isEmpty(alertConfig.getProperties().get(PROP_CLASS_NAME).toString())) {
-      responseMessage.put("message", "'Type' field cannot be left empty.");
-      return false;
-    }
 
     // At least one alertScheme is required
     if (alertConfig.getAlertSchemes() == null || alertConfig.getAlertSchemes().size() == 0) {
@@ -70,7 +64,7 @@ public class DetectionAlertConfigValidator extends ConfigValidator {
     // Properties cannot be empty
     if (alertConfig.getProperties() == null || alertConfig.getProperties().isEmpty()) {
       responseMessage.put("message", "Alert properties cannot be left empty. Please specify the recipients,"
-          + " detection ids, and type.");
+          + " subscribed detections, and type.");
       return false;
     }
     // detectionConfigIds cannot be empty

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslator.java
@@ -21,8 +21,14 @@ package org.apache.pinot.thirdeye.detection.yaml;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Preconditions;
+import java.util.stream.Collectors;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionAlertConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.pojo.AlertConfigBean;
+import org.apache.pinot.thirdeye.datalayer.util.Predicate;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionAlertRegistry;
 import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionRegistry;
@@ -49,59 +55,29 @@ public class YamlDetectionAlertConfigTranslator {
   public static final String PROP_ACTIVE = "active";
   public static final String PROP_APPLICATION = "application";
   public static final String PROP_FROM = "fromAddress";
-  public static final String PROP_ONLY_FETCH_LEGACY_ANOMALIES = "onlyFetchLegacyAnomalies";
   public static final String PROP_EMAIL_SUBJECT_TYPE = "emailSubjectStyle";
   public static final String PROP_ALERT_SCHEMES = "alertSchemes";
-  public static final String PROP_ALERT_SUPPRESSORS = "alertSuppressors";
-  public static final String PROP_REFERENCE_LINKS = "referenceLinks";
 
   public static final String PROP_TYPE = "type";
   public static final String PROP_CLASS_NAME = "className";
-  public static final String PROP_PARAM = "params";
+  static final String PROP_PARAM = "params";
+  static final String PROP_ALERT_SUPPRESSORS = "alertSuppressors";
+  static final String PROP_REFERENCE_LINKS = "referenceLinks";
+  static final String PROP_ONLY_FETCH_LEGACY_ANOMALIES = "onlyFetchLegacyAnomalies";
+  static final String PROP_DETECTION_NAMES = "subscribedDetections";
 
-  public static final String PROP_DIMENSION = "dimension";
-  public static final String PROP_DIMENSION_RECIPIENTS = "dimensionRecipients";
-  public static final String PROP_TIME_WINDOWS = "timeWindows";
-  public static final String CRON_SCHEDULE_DEFAULT = "0 0/5 * * * ? *"; // Every 5 min
+  static final String PROP_DIMENSION = "dimension";
+  static final String PROP_DIMENSION_RECIPIENTS = "dimensionRecipients";
+  static final String PROP_TIME_WINDOWS = "timeWindows";
+  static final String CRON_SCHEDULE_DEFAULT = "0 0/5 * * * ? *"; // Every 5 min
 
   private static final DetectionAlertRegistry DETECTION_ALERT_REGISTRY = DetectionAlertRegistry.getInstance();
   private static final Set<String> PROPERTY_KEYS = new HashSet<>(
-      Arrays.asList(PROP_DETECTION_CONFIG_IDS, PROP_RECIPIENTS, PROP_DIMENSION, PROP_DIMENSION_RECIPIENTS));
+      Arrays.asList(PROP_RECIPIENTS, PROP_DIMENSION, PROP_DIMENSION_RECIPIENTS));
+  private final DetectionConfigManager detectionConfigDAO;
 
-  private static final YamlDetectionAlertConfigTranslator INSTANCE = new YamlDetectionAlertConfigTranslator();
-
-  public static YamlDetectionAlertConfigTranslator getInstance() {
-    return INSTANCE;
-  }
-
-  /**
-   * generate detection alerter from YAML
-   * @param alertYamlConfigs yaml configuration of the alerter
-   * @param detectionConfigIds detection config ids that should be included in the detection alerter
-   * @param existingVectorClocks vector clocks that should be kept in the new alerter
-   * @return a detection alert config
-   */
-  public DetectionAlertConfigDTO generateDetectionAlertConfig(Map<String, Object> alertYamlConfigs,
-      Collection<Long> detectionConfigIds, Map<Long, Long> existingVectorClocks) {
-    DetectionAlertConfigDTO alertConfigDTO = new DetectionAlertConfigDTO();
-    Preconditions.checkArgument(alertYamlConfigs.containsKey(PROP_SUBS_GROUP_NAME), "Alert property missing: " + PROP_SUBS_GROUP_NAME);
-
-    if (existingVectorClocks == null) {
-      existingVectorClocks = new HashMap<>();
-    }
-    for (long detectionConfigId : detectionConfigIds) {
-      if (!existingVectorClocks.containsKey(detectionConfigId)){
-        existingVectorClocks.put(detectionConfigId, 0L);
-      }
-    }
-    alertConfigDTO.setVectorClocks(existingVectorClocks);
-
-    alertConfigDTO.setName(MapUtils.getString(alertYamlConfigs, PROP_SUBS_GROUP_NAME));
-    alertConfigDTO.setCronExpression(MapUtils.getString(alertYamlConfigs, PROP_CRON, CRON_SCHEDULE_DEFAULT));
-    alertConfigDTO.setActive(true);
-    alertConfigDTO.setApplication(MapUtils.getString(alertYamlConfigs, PROP_APPLICATION));
-    alertConfigDTO.setProperties(buildAlerterProperties(alertYamlConfigs, detectionConfigIds));
-    return alertConfigDTO;
+  public YamlDetectionAlertConfigTranslator(DetectionConfigManager detectionConfigDAO) {
+    this.detectionConfigDAO = detectionConfigDAO;
   }
 
   private Map<String, Object> buildAlerterProperties(Map<String, Object> alertYamlConfigs, Collection<Long> detectionConfigIds) {
@@ -209,15 +185,24 @@ public class YamlDetectionAlertConfigTranslator {
 
     alertConfigDTO.setAlertSchemes(buildAlertSchemes(yamlAlertConfig));
     alertConfigDTO.setAlertSuppressors(buildAlertSuppressors(yamlAlertConfig));
-    alertConfigDTO.setProperties(buildAlerterProperties(yamlAlertConfig));
+    alertConfigDTO.setHighWaterMark(0L);
 
     // NOTE: The below fields will/should be hidden from the YAML/UI. They will only be updated by the backend pipeline.
-    List<Integer> detectionConfigIds = ConfigUtils.getList(yamlAlertConfig.get(PROP_DETECTION_CONFIG_IDS));
-    Map<Long, Long> vectorClocks = new HashMap<>();
-    for (int detectionConfigId : detectionConfigIds) {
-      vectorClocks.put((long) detectionConfigId, 0L);
+    List<Long> detectionConfigIds = ConfigUtils.getLongs(yamlAlertConfig.get(PROP_DETECTION_CONFIG_IDS));
+    List<String> detectionNames = ConfigUtils.getList(yamlAlertConfig.get(PROP_DETECTION_NAMES));
+
+    try {
+      detectionConfigIds.addAll(detectionNames.stream().map(detectionName ->  this.detectionConfigDAO.findByPredicate(
+          Predicate.EQ("name", detectionName)).get(0).getId()).collect(Collectors.toList()));
+    } catch (Exception e){
+      throw new IllegalArgumentException("cannot find detection pipeline, please check the subscribed detections.");
     }
-    alertConfigDTO.setHighWaterMark(0L);
+
+    alertConfigDTO.setProperties(buildAlerterProperties(yamlAlertConfig, detectionConfigIds));
+    Map<Long, Long> vectorClocks = new HashMap<>();
+    for (long detectionConfigId : detectionConfigIds) {
+      vectorClocks.put(detectionConfigId, 0L);
+    }
     alertConfigDTO.setVectorClocks(vectorClocks);
 
     return alertConfigDTO;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslator.java
@@ -188,7 +188,7 @@ public class YamlDetectionAlertConfigTranslator {
     alertConfigDTO.setHighWaterMark(0L);
 
     // NOTE: The below fields will/should be hidden from the YAML/UI. They will only be updated by the backend pipeline.
-    List<Long> detectionConfigIds = ConfigUtils.getLongs(yamlAlertConfig.get(PROP_DETECTION_CONFIG_IDS));
+    List<Long> detectionConfigIds = new ArrayList<>();
     List<String> detectionNames = ConfigUtils.getList(yamlAlertConfig.get(PROP_DETECTION_NAMES));
 
     try {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
@@ -98,7 +98,7 @@ public class YamlResource {
     this.detectionAlertConfigDAO = DAORegistry.getInstance().getDetectionAlertConfigManager();
     this.translatorLoader = new YamlDetectionTranslatorLoader();
     this.alertValidator = DetectionAlertConfigValidator.getInstance();
-    this.alertConfigTranslator = YamlDetectionAlertConfigTranslator.getInstance();
+    this.alertConfigTranslator = new YamlDetectionAlertConfigTranslator(this.detectionConfigDAO);
     this.metricDAO = DAORegistry.getInstance().getMetricConfigDAO();
     this.datasetDAO = DAORegistry.getInstance().getDatasetConfigDAO();
     this.eventDAO = DAORegistry.getInstance().getEventDAO();
@@ -370,7 +370,13 @@ public class YamlResource {
     }
 
     // Translate config from YAML to detection alert config (JSON)
-    DetectionAlertConfigDTO alertConfig = this.alertConfigTranslator.translate(newAlertConfigMap);
+    DetectionAlertConfigDTO alertConfig;
+    try {
+      alertConfig = this.alertConfigTranslator.translate(newAlertConfigMap);
+    } catch (Exception e){
+      responseMessage.put("message", e.getMessage());
+      return null;
+    }
     alertConfig.setYaml(yamlAlertConfig);
 
     // Validate the config before saving it
@@ -434,7 +440,14 @@ public class YamlResource {
       responseMessage.put("message", "Subscription group name field cannot be left empty.");
       return null;
     }
-    DetectionAlertConfigDTO newAlertConfig = this.alertConfigTranslator.translate(newAlertConfigMap);
+
+    DetectionAlertConfigDTO newAlertConfig;
+    try {
+      newAlertConfig = this.alertConfigTranslator.translate(newAlertConfigMap);
+    } catch (Exception e){
+      responseMessage.put("message", e.getMessage());
+      return null;
+    }
 
     // Translate config from YAML to detection alert config (JSON)
     DetectionAlertConfigDTO updatedAlertConfig = updateDetectionAlertConfig(oldAlertConfig, newAlertConfig);

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslatorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslatorTest.java
@@ -1,13 +1,10 @@
 package org.apache.pinot.thirdeye.detection.yaml;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
@@ -46,9 +43,6 @@ public class YamlDetectionAlertConfigTranslatorTest {
     Map<String, String> refLinks = new HashMap<>();
     refLinks.put("Test Link", "test_url");
     alertYamlConfigs.put(PROP_REFERENCE_LINKS, refLinks);
-
-    Set<Integer> detectionIds = new HashSet<>(Arrays.asList(1234, 6789));
-    alertYamlConfigs.put(PROP_DETECTION_CONFIG_IDS, detectionIds);
 
     Map<String, Object> alertSchemes = new HashMap<>();
     alertSchemes.put(PROP_TYPE, "EMAIL");
@@ -95,7 +89,7 @@ public class YamlDetectionAlertConfigTranslatorTest {
     Assert.assertEquals(timeWindow.get("windowEndTime"), 1543215600000L);
 
     Assert.assertNotNull(alertConfig.getProperties());
-    Assert.assertEquals(ConfigUtils.getLongs(alertConfig.getProperties().get(PROP_DETECTION_CONFIG_IDS)).size(), 3);
+    Assert.assertEquals(ConfigUtils.getLongs(alertConfig.getProperties().get(PROP_DETECTION_CONFIG_IDS)).size(), 1);
 
     Map<String, Object> recipient = (Map<String, Object>) alertConfig.getProperties().get(PROP_RECIPIENTS);
     Assert.assertEquals(recipient.size(), 2);

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslatorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslatorTest.java
@@ -1,9 +1,5 @@
 package org.apache.pinot.thirdeye.detection.yaml;
 
-import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
-import org.apache.pinot.thirdeye.datalayer.pojo.AlertConfigBean;
-import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionAlertRegistry;
-import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -12,7 +8,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.pojo.AlertConfigBean;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
+import org.apache.pinot.thirdeye.detection.ConfigUtils;
+import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionAlertRegistry;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -20,43 +25,11 @@ import static org.apache.pinot.thirdeye.detection.yaml.YamlDetectionAlertConfigT
 
 
 public class YamlDetectionAlertConfigTranslatorTest {
-  private Map<String, Object> alertYamlConfigs;
-  private YamlDetectionAlertConfigTranslator translator;
 
-  @Test
-  public void testGenerateDetectionAlertConfig() {
-    List<Long> ids = Collections.singletonList(1234567L);
-    DetectionAlertConfigDTO
-        alertConfigDTO = this.translator.generateDetectionAlertConfig(this.alertYamlConfigs, ids, null);
-    Assert.assertEquals(alertConfigDTO.getName(), alertYamlConfigs.get(PROP_SUBS_GROUP_NAME));
-    Assert.assertEquals(alertConfigDTO.getApplication(), alertYamlConfigs.get("application"));
-    Assert.assertEquals(alertConfigDTO.getVectorClocks().get(ids.get(0)), new Long(0L));
-    Assert.assertEquals(alertConfigDTO.getCronExpression(), CRON_SCHEDULE_DEFAULT);
-    Map<String, Object> properties = alertConfigDTO.getProperties();
-    Assert.assertEquals(properties.get(PROP_DETECTION_CONFIG_IDS), ids);
-    Assert.assertEquals(properties.get("to"), alertYamlConfigs.get("to"));
-  }
+  private DAOTestBase testDAOProvider;
+  private DetectionConfigManager detectionConfigManager;
 
-  @Test
-  public void testGenerateDetectionAlertConfigWithExistingVectorClocks() {
-    List<Long> ids = Arrays.asList(1234567L, 7654321L);
-    Map<Long, Long> vectorClocks = new HashMap<>();
-    vectorClocks.put(ids.get(0), 1536173395000L);
-    vectorClocks.put(7654321L, 1536173395000L);
-    DetectionAlertConfigDTO
-        alertConfigDTO = this.translator.generateDetectionAlertConfig(this.alertYamlConfigs, ids, vectorClocks);
-    Assert.assertEquals(alertConfigDTO.getName(), alertYamlConfigs.get(PROP_SUBS_GROUP_NAME));
-    Assert.assertEquals(alertConfigDTO.getApplication(), alertYamlConfigs.get("application"));
-    Assert.assertEquals(alertConfigDTO.getVectorClocks().get(ids.get(0)), vectorClocks.get(ids.get(0)));
-    Assert.assertEquals(alertConfigDTO.getVectorClocks().get(7654321L), vectorClocks.get(7654321L));
-    Assert.assertEquals(alertConfigDTO.getCronExpression(), CRON_SCHEDULE_DEFAULT);
-
-    Map<String, Object> properties = alertConfigDTO.getProperties();
-    Assert.assertEquals(properties.get("detectionConfigIds"), ids);
-    Assert.assertEquals(properties.get("to"), alertYamlConfigs.get("to"));
-  }
-
-  @Test
+  @Test(priority=1)
   public void testTranslateAlert() {
     DetectionAlertRegistry.getInstance().registerAlertScheme("EMAIL", "EmailClass");
     DetectionAlertRegistry.getInstance().registerAlertSuppressor("TIME_WINDOW", "TimeWindowClass");
@@ -67,6 +40,8 @@ public class YamlDetectionAlertConfigTranslatorTest {
     alertYamlConfigs.put(PROP_FROM, "thirdeye@thirdeye");
     alertYamlConfigs.put(PROP_CRON, CRON_SCHEDULE_DEFAULT);
     alertYamlConfigs.put(PROP_ACTIVE, true);
+    alertYamlConfigs.put(PROP_DETECTION_NAMES, Collections.singletonList("test_pipeline_1"));
+
 
     Map<String, String> refLinks = new HashMap<>();
     refLinks.put("Test Link", "test_url");
@@ -96,7 +71,7 @@ public class YamlDetectionAlertConfigTranslatorTest {
     recipients.put("cc", new ArrayList<>(Collections.singleton("userCc@thirdeye.com")));
     alertYamlConfigs.put(PROP_RECIPIENTS, recipients);
 
-    DetectionAlertConfigDTO alertConfig = YamlDetectionAlertConfigTranslator.getInstance().translate(alertYamlConfigs);
+    DetectionAlertConfigDTO alertConfig = new YamlDetectionAlertConfigTranslator(this.detectionConfigManager).translate(alertYamlConfigs);
 
     Assert.assertTrue(alertConfig.isActive());
     Assert.assertFalse(alertConfig.isOnlyFetchLegacyAnomalies());
@@ -120,26 +95,30 @@ public class YamlDetectionAlertConfigTranslatorTest {
     Assert.assertEquals(timeWindow.get("windowEndTime"), 1543215600000L);
 
     Assert.assertNotNull(alertConfig.getProperties());
-    Assert.assertEquals(((Set<Long>) alertConfig.getProperties().get(PROP_DETECTION_CONFIG_IDS)).size(), 2);
+    Assert.assertEquals(ConfigUtils.getLongs(alertConfig.getProperties().get(PROP_DETECTION_CONFIG_IDS)).size(), 3);
 
     Map<String, Object> recipient = (Map<String, Object>) alertConfig.getProperties().get(PROP_RECIPIENTS);
     Assert.assertEquals(recipient.size(), 2);
     Assert.assertEquals(((List<String>) recipient.get("to")).get(0), "userTo@thirdeye.com");
     Assert.assertEquals(((List<String>) recipient.get("cc")).get(0), "userCc@thirdeye.com");
 
-    Assert.assertEquals(((Set<Long>) alertConfig.getProperties().get(PROP_DETECTION_CONFIG_IDS)).size(), 2);
   }
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() {
+    testDAOProvider = DAOTestBase.getInstance();
+    DAORegistry daoRegistry = DAORegistry.getInstance();
+    detectionConfigManager = daoRegistry.getDetectionConfigManager();
+    DetectionConfigDTO detectionConfigDTO = new DetectionConfigDTO();
+    detectionConfigDTO.setName("test_pipeline_1");
+    detectionConfigManager.save(detectionConfigDTO);
+
     DetectionAlertRegistry.getInstance().registerAlertFilter("DEFAULT_ALERTER_PIPELINE", "RECIPIENTClass");
-    this.alertYamlConfigs = new HashMap<>();
-    alertYamlConfigs.put(PROP_SUBS_GROUP_NAME, "test_alert");
-    alertYamlConfigs.put("type", "DEFAULT_ALerTeR_PipeLIne");
-    Map<String, Object> recipients = new HashMap<>();
-    recipients.put("to", Arrays.asList("test1", "test2"));
-    alertYamlConfigs.put("recipients", recipients);
-    alertYamlConfigs.put("application", "TestApplication");
-    this.translator = new YamlDetectionAlertConfigTranslator();
   }
+
+  @AfterMethod(alwaysRun = true)
+  void afterMethod() {
+    testDAOProvider.cleanup();
+  }
+
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslatorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlDetectionAlertConfigTranslatorTest.java
@@ -29,7 +29,7 @@ public class YamlDetectionAlertConfigTranslatorTest {
   private DAOTestBase testDAOProvider;
   private DetectionConfigManager detectionConfigManager;
 
-  @Test(priority=1)
+  @Test
   public void testTranslateAlert() {
     DetectionAlertRegistry.getInstance().registerAlertScheme("EMAIL", "EmailClass");
     DetectionAlertRegistry.getInstance().registerAlertSuppressor("TIME_WINDOW", "TimeWindowClass");

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlResourceTest.java
@@ -1,8 +1,10 @@
 package org.apache.pinot.thirdeye.detection.yaml;
 
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
 import org.apache.pinot.thirdeye.datalayer.dto.ApplicationDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionAlertRegistry;
 import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionRegistry;
@@ -27,6 +29,10 @@ public class YamlResourceTest {
     testDAOProvider = DAOTestBase.getInstance();
     this.yamlResource = new YamlResource();
     this.daoRegistry = DAORegistry.getInstance();
+    DetectionConfigManager detectionDAO = this.daoRegistry.getDetectionConfigManager();
+    DetectionConfigDTO config = new DetectionConfigDTO();
+    config.setName("test_detection_1");
+    detectionDAO.save(config);
 
     DetectionAlertRegistry.getInstance().registerAlertScheme("EMAIL", "EmailClass");
     DetectionAlertRegistry.getInstance().registerAlertScheme("IRIS", "IrisClass");

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/alertconfig/alert-config-2.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/alertconfig/alert-config-2.yaml
@@ -2,8 +2,8 @@ subscriptionGroupName: "Subscription Group Name"
 cron: "0 0/5 * 1/1 * ? *"
 application: "test_application"
 active: true
-fromAddress: thirdeye@thirdeye.com
-
+subscribedDetections:
+  - test_detection_1
 type: DIMENSIONAL_ALERTER_PIPELINE
 dimensionRecipients:
  "android":
@@ -12,8 +12,6 @@ dimensionRecipients:
   - "ios-thirdeye@thirdeye.com"
 dimension: app_name
 
-detectionConfigIds:
- - 5773069
 
 fromAddress: thirdeye-dev@linkedin.com
 

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/alertconfig/alert-config-3.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/alertconfig/alert-config-3.yaml
@@ -2,7 +2,8 @@ subscriptionGroupName: "test_group"
 cron: "0 0/5 * 1/1 * ? *"
 application: "test_application"
 active: true
-fromAddress: thirdeye@thirdeye.com
+subscribedDetections:
+  - test_detection_1
 
 type: DIMENSIONAL_ALERTER_PIPELINE
 dimensionRecipients:

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/alertconfig/alert-config-4.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/alertconfig/alert-config-4.yaml
@@ -2,7 +2,8 @@ subscriptionGroupName: "Subscription Group Name"
 cron: "0 0/5 * 1/1 * ? *"
 application: "test_application"
 active: true
-fromAddress: thirdeye@thirdeye.com
+subscribedDetections:
+  - test_detection_1
 
 type: DIMENSIONAL_ALERTER_PIPELINE
 dimensionRecipients:


### PR DESCRIPTION
This PR enables the ability to customize the subscribed detection pipelines by referring them by name in the notification yaml config.