### PR TITLE
Add metric to capture max queries per 10s seen in the last minute

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerQPSMetricsHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerQPSMetricsHandler.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
+import org.apache.pinot.common.metrics.BrokerGauge;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Handles the setting of QPS related metrics to the metrics registry
+ *
+ * We want to get as close as possible to the true count of queries we received.
+ * Whenever a query is received, increment in _tableQueriesCount
+ * Two schedules will be running:
+ * 1) Every 10 seconds, for each table, report the queryCount in _tableQueriesCount to _tableMaxQueriesCount - which maintains the max value - and reset the queryCount
+ * 2) Every 1 minute, for each table, emit the maxQueryCount, and reset
+ */
+public class BrokerQPSMetricsHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerQPSMetricsHandler.class);
+
+  // the frequency at which we want to reset the collected query count
+  private static final int RESET_QUERY_COUNT_FREQ_SECONDS = 10;
+  private static final int RESET_QUERY_COUNT_INITIAL_DELAY_SECONDS = 10;
+
+  // the frequency at which {@link BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE} should be set
+  private static final int SET_MAX_QUERIES_PER_10_SEC_GAUGE_FREQ_SECONDS = 60;
+  private static final int SET_GAUGE_INITIAL_DELAY_SECONDS = 60;
+
+  private ConcurrentMap<String, LongAccumulator> _tableMaxQueriesCount = new ConcurrentHashMap<>();
+  private ConcurrentMap<String, LongAdder> _tableQueriesCount = new ConcurrentHashMap<>();
+  private BrokerMetrics _brokerMetrics;
+
+  private ScheduledExecutorService _scheduledExecutorService;
+
+  BrokerQPSMetricsHandler(BrokerMetrics brokerMetrics) {
+    _brokerMetrics = brokerMetrics;
+  }
+
+  /**
+   * Start the executor service and schedule the jobs
+   */
+  void start() {
+    try {
+      _scheduledExecutorService = Executors.newScheduledThreadPool(2);
+
+      // kick off 10 second freq schedule, to report query counts
+      _scheduledExecutorService.scheduleAtFixedRate(this::reportQueryCount, RESET_QUERY_COUNT_INITIAL_DELAY_SECONDS,
+          RESET_QUERY_COUNT_FREQ_SECONDS, TimeUnit.SECONDS);
+
+      // kick off 1 minute freq schedule to set gauge
+      _scheduledExecutorService.scheduleAtFixedRate(this::setMaxQueriesPer10SecGauge, SET_GAUGE_INITIAL_DELAY_SECONDS,
+          SET_MAX_QUERIES_PER_10_SEC_GAUGE_FREQ_SECONDS, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      LOGGER.error("Caught exception in starting BrokerQPSMetricsHandler", e);
+    }
+  }
+
+  /**
+   * Increments the query count for the given table
+   * @param rawTableName
+   */
+  void incrementQueryCount(String rawTableName) {
+    _tableQueriesCount.computeIfAbsent(rawTableName, k -> new LongAdder()).increment();
+  }
+
+  /**
+   * Report query count from _tableQueriesCount for each table to _tableMaxQueriesCount and then reset the query count
+   */
+  @VisibleForTesting
+  void reportQueryCount() {
+    _tableQueriesCount.forEach(
+        (table, queriesCount) -> _tableMaxQueriesCount.computeIfAbsent(table, k -> new LongAccumulator(Long::max, 0))
+            .accumulate(queriesCount.sumThenReset()));
+  }
+
+  /**
+   * Set max queries value to gauge {BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE} for each table in _tableMaxQueriesCount,
+   * and then reset max value
+   */
+  @VisibleForTesting
+  void setMaxQueriesPer10SecGauge() {
+    _tableMaxQueriesCount.forEach((table, maxQueriesCount) -> _brokerMetrics.setValueOfTableGauge(table,
+        BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE, maxQueriesCount.getThenReset()));
+  }
+
+  /**
+   * Stop the executor service
+   */
+  void stop() {
+    try {
+      if (_scheduledExecutorService != null) {
+        _scheduledExecutorService.shutdown();
+      }
+    } catch (Exception e) {
+      LOGGER.error("Caught exception in stopping BrokerQPSMetricsHandler", e);
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ConnectionPoolBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ConnectionPoolBrokerRequestHandler.java
@@ -119,12 +119,14 @@ public class ConnectionPoolBrokerRequestHandler extends BaseBrokerRequestHandler
 
   @Override
   public synchronized void start() {
+    super.start();
     _connPool.start();
     _liveInstanceChangeListener.init(_connPool, CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS);
   }
 
   @Override
   public synchronized void shutDown() {
+    super.shutDown();
     _connPool.shutdown();
     _requestSenderPool.shutdown();
     _poolTimeoutExecutor.shutdown();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -62,10 +62,12 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
   @Override
   public void start() {
+    super.start();
   }
 
   @Override
   public synchronized void shutDown() {
+    super.shutDown();
     _queryRouter.shutDown();
   }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerQPSMetricsHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerQPSMetricsHandlerTest.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.yammer.metrics.core.MetricsRegistry;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.metrics.BrokerGauge;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests the {@link BrokerQPSMetricsHandler} functionality
+ */
+public class BrokerQPSMetricsHandlerTest {
+
+  /**
+   * Tests the schedules in BrokerQPSMetricsHandler are emitting metrics
+   */
+    @Test
+    public void testBrokerMetricsHandlerSchedules() {
+      String table1 = "table1";
+      String table2 = "table2";
+      String table3 = "table3";
+      BrokerMetrics brokerMetrics = new BrokerMetrics(new MetricsRegistry());
+
+      BrokerQPSMetricsHandler _brokerMetricsHandler = new BrokerQPSMetricsHandler(brokerMetrics);
+      _brokerMetricsHandler.start();
+
+      // schedule to report query counts runs every 10s, with initial delay of 10s
+      long nowPlus20Seconds = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(20, TimeUnit.SECONDS);
+      while (System.currentTimeMillis() < nowPlus20Seconds) {
+        _brokerMetricsHandler.incrementQueryCount(table1);
+        _brokerMetricsHandler.incrementQueryCount(table2);
+        _brokerMetricsHandler.incrementQueryCount(table3);
+      }
+      Assert.assertTrue(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE) == 0);
+      Assert.assertTrue(brokerMetrics.getValueOfTableGauge(table2, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE) == 0);
+      Assert.assertTrue(brokerMetrics.getValueOfTableGauge(table3, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE) == 0);
+
+      // schedule to emit metric runs every 60s with initial delay of 60s
+      long nowPlus1Minute = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);
+      while (System.currentTimeMillis() < nowPlus1Minute) {
+        _brokerMetricsHandler.incrementQueryCount(table1);
+        _brokerMetricsHandler.incrementQueryCount(table2);
+        _brokerMetricsHandler.incrementQueryCount(table3);
+      }
+      Assert.assertTrue(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE) > 0);
+      Assert.assertTrue(brokerMetrics.getValueOfTableGauge(table2, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE) > 0);
+      Assert.assertTrue(brokerMetrics.getValueOfTableGauge(table3, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE) > 0);
+
+      _brokerMetricsHandler.stop();
+    }
+
+  /**
+   * Tests various scenarios of BrokerQPSMetricsHandler and gauge value
+   */
+  @Test
+    public void testSettingGaugeValues() {
+      String table1 = "table1";
+      BrokerMetrics brokerMetrics = new BrokerMetrics(new MetricsRegistry());
+
+      BrokerQPSMetricsHandler _brokerMetricsHandler = new BrokerQPSMetricsHandler(brokerMetrics);
+
+      // Initially gauge will be 0
+      Assert.assertEquals(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE), 0);
+
+      // no queries received, but gauge set by 1m schedule
+      _brokerMetricsHandler.setMaxQueriesPer10SecGauge();
+      Assert.assertEquals(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE), 0);
+
+      // received queries, but not reported before 1m schedule
+      for (int i = 0; i < 10; i ++) {
+        _brokerMetricsHandler.incrementQueryCount(table1);
+      }
+      _brokerMetricsHandler.setMaxQueriesPer10SecGauge();
+      Assert.assertEquals(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE), 0);
+
+      // queries reported by 10s schedule, but 1m gauge schedule yet to run
+      _brokerMetricsHandler.reportQueryCount();
+      Assert.assertEquals(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE), 0);
+
+      // 1m gauge schedule run and gauge set, value will finally increase
+      _brokerMetricsHandler.setMaxQueriesPer10SecGauge();
+      Assert.assertEquals(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE), 10);
+
+      // report that no queries received again, set gauge. gauge will retain old value until unset
+      _brokerMetricsHandler.reportQueryCount();
+      Assert.assertEquals(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE), 10);
+      _brokerMetricsHandler.setMaxQueriesPer10SecGauge();
+      Assert.assertEquals(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE), 0);
+
+      // received queries, and reported
+      for (int i = 0; i < 8; i ++) {
+        _brokerMetricsHandler.incrementQueryCount(table1);
+      }
+      _brokerMetricsHandler.reportQueryCount();
+      // received queries again and reported
+      for (int i = 0; i < 4; i ++) {
+        _brokerMetricsHandler.incrementQueryCount(table1);
+      }
+      _brokerMetricsHandler.reportQueryCount();
+      // set gauge, max value should be reported
+      _brokerMetricsHandler.setMaxQueriesPer10SecGauge();
+      Assert.assertEquals(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE), 8);
+
+      // gauge reset
+      _brokerMetricsHandler.setMaxQueriesPer10SecGauge();
+      Assert.assertEquals(brokerMetrics.getValueOfTableGauge(table1, BrokerGauge.MAX_QUERIES_PER_10_SEC_IN_MINUTE), 0);
+
+    }
+
+}
+

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -27,7 +27,8 @@ import org.apache.pinot.common.Utils;
 */
 public enum BrokerGauge implements AbstractMetrics.Gauge {
   QUERY_QUOTA_CAPACITY_UTILIZATION_RATE("tables", false),
-  NETTY_CONNECTION_CONNECT_TIME_MS("nettyConnection", true);
+  NETTY_CONNECTION_CONNECT_TIME_MS("nettyConnection", true),
+  MAX_QUERIES_PER_10_SEC_IN_MINUTE("maxQueriesPer10SecInMinute", false);
 
   private final String brokerGaugeName;
   private final String unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -121,6 +121,9 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_REFRESH_TIMEBOUNDARY_INFO_SLEEP_INTERVAL =
             "pinot.broker.refresh.timeBoundaryInfo.sleepInterval";
     public static final long DEFAULT_BROKER_REFRESH_TIMEBOUNDARY_INFO_SLEEP_INTERVAL_MS = 10000L;
+    public static final String CONFIG_OF_BROKER_EMIT_QPS_METRICS = "pinot.broker.emit.qps.metrics";
+    public static final boolean DEFAULT_BROKER_EMIT_QPS_METRICS = false;
+
     public static class Request {
       public static final String PQL = "pql";
       public static final String TRACE = "trace";


### PR DESCRIPTION
We don't have a very good way of knowing what was the QPS for a table at a given time. Currently, whenever we receive a query, we emit a "1" in the `QUERIES` BrokerMeter. This doesn't really give us the rate of queries over a smaller chunk of time, say QPS. This can be solved in metrics viewing applications, by showing average values over a period of time. However, we will lose spikes in queries if the chunk of time is even slightly big (say 1 minute).
Introducing a gauge to capture max qps in the last minute, to give us an accurate look into qps received by the broker. Starting with buckets of 10s (instead of 1s i.e. queries per 10 sec)