### PR TITLE
Update versions of packages to move to jersey 2.28

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -81,6 +81,10 @@
       <artifactId>jersey-container-grizzly2-http</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-transport</artifactId>
     </dependency>
@@ -110,10 +114,6 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jersey2-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.helix</groupId>

--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -112,6 +112,10 @@
       <artifactId>swagger-jersey2-jaxrs</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.helix</groupId>
       <artifactId>helix-core</artifactId>
       <exclusions>

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -108,6 +108,10 @@
       <artifactId>jersey-server</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
     </dependency>
@@ -138,10 +142,6 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-api</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -140,6 +140,10 @@
       <artifactId>swagger-jaxrs</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -177,6 +177,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -155,10 +155,6 @@
       <artifactId>javassist</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-common</artifactId>
     </dependency>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -155,8 +155,16 @@
       <artifactId>javassist</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
@@ -175,10 +183,6 @@
           <artifactId>javax.inject</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,11 +111,10 @@
     <!-- jfim: for Kafka 0.9.0.0, use zkclient 0.7 -->
     <kafka.version>0.9.0.1</kafka.version>
     <zkclient.version>0.7</zkclient.version>
-    <!-- TODO: bump up the jackson version once we update jersey version to 2.28 or later -->
-    <jackson.version>2.8.3</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
-    <jersey.version>2.23</jersey.version>
-    <swagger.version>1.5.10</swagger.version>
+    <jersey.version>2.28-RC4</jersey.version>
+    <swagger.version>1.5.21</swagger.version>
     <hadoop.version>2.7.0</hadoop.version>
     <antlr.version>4.6</antlr.version>
     <!-- commons-configuration, hadoop-common, hadoop-client use commons-lang -->
@@ -403,6 +402,16 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <version>1.7.7</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>2.0.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.hk2</groupId>
+        <artifactId>hk2-api</artifactId>
+        <version>2.1.58</version>
       </dependency>
       <dependency>
         <groupId>org.apache.helix</groupId>
@@ -774,7 +783,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>3.8.0</version>
           <configuration>
             <source>${jdk.version}</source>
             <target>${jdk.version}</target>
@@ -1098,7 +1107,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.2.1</version>
         <configuration>
           <shadedArtifactAttached>true</shadedArtifactAttached>
           <transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -411,7 +411,7 @@
       <dependency>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-api</artifactId>
-        <version>2.1.58</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.helix</groupId>
@@ -644,13 +644,13 @@
         <version>3.19.0-GA</version>
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jersey.inject</groupId>
-        <artifactId>jersey-hk2</artifactId>
+        <groupId>org.glassfish.jersey.core</groupId>
+        <artifactId>jersey-common</artifactId>
         <version>${jersey.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jersey.core</groupId>
-        <artifactId>jersey-common</artifactId>
+        <groupId>org.glassfish.jersey.inject</groupId>
+        <artifactId>jersey-hk2</artifactId>
         <version>${jersey.version}</version>
       </dependency>
       <dependency>
@@ -688,11 +688,6 @@
             <artifactId>javax.inject</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.hk2.external</groupId>
-        <artifactId>javax.inject</artifactId>
-        <version>2.4.0-b34</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -656,7 +656,7 @@
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
-        <version>2.24</version>
+        <version>${jersey.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <jackson.version>2.9.8</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
     <jersey.version>2.28-RC4</jersey.version>
-    <swagger.version>1.5.21</swagger.version>
+    <swagger.version>1.5.10</swagger.version>
     <hadoop.version>2.7.0</hadoop.version>
     <antlr.version>4.6</antlr.version>
     <!-- commons-configuration, hadoop-common, hadoop-client use commons-lang -->
@@ -642,6 +642,11 @@
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
         <version>3.19.0-GA</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.inject</groupId>
+        <artifactId>jersey-hk2</artifactId>
+        <version>${jersey.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -409,11 +409,6 @@
         <version>2.0.1.Final</version>
       </dependency>
       <dependency>
-        <groupId>org.glassfish.hk2</groupId>
-        <artifactId>hk2-api</artifactId>
-        <version>2.5.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.helix</groupId>
         <artifactId>helix-core</artifactId>
         <version>${helix.version}</version>


### PR DESCRIPTION
Pick up the latest version of Jersey so that we can move to latest version of Jackson.

Other changes were required (esp around javax.validation) as swagger and jersey required different versions - I've pinned the higher version in the top level pom and that seems to let the compilation go through.

maven-shade-plugin bump up was required as the MojoExecutor had IllegalArgumentException in pinot-common package that was failing the build.