### PR TITLE
Minor fix for star-tree v2 metadata

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/BaseSingleTreeBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/BaseSingleTreeBuilder.java
@@ -498,11 +498,11 @@ abstract class BaseSingleTreeBuilder implements SingleTreeBuilder {
   }
 
   private void writeMetadata() {
-    _metadataProperties.addProperty(MetadataKey.TOTAL_DOCS, _numDocs);
-    _metadataProperties.addProperty(MetadataKey.DIMENSIONS_SPLIT_ORDER, _dimensionsSplitOrder);
-    _metadataProperties.addProperty(MetadataKey.FUNCTION_COLUMN_PAIRS, _metrics);
-    _metadataProperties.addProperty(MetadataKey.MAX_LEAF_RECORDS, _maxLeafRecords);
-    _metadataProperties.addProperty(MetadataKey.SKIP_STAR_NODE_CREATION_FOR_DIMENSIONS,
+    _metadataProperties.setProperty(MetadataKey.TOTAL_DOCS, _numDocs);
+    _metadataProperties.setProperty(MetadataKey.DIMENSIONS_SPLIT_ORDER, _dimensionsSplitOrder);
+    _metadataProperties.setProperty(MetadataKey.FUNCTION_COLUMN_PAIRS, _metrics);
+    _metadataProperties.setProperty(MetadataKey.MAX_LEAF_RECORDS, _maxLeafRecords);
+    _metadataProperties.setProperty(MetadataKey.SKIP_STAR_NODE_CREATION_FOR_DIMENSIONS,
         _builderConfig.getSkipStarNodeCreationForDimensions());
   }
 }


### PR DESCRIPTION
Use setProperty() instead of addProperty() for sub-config.
Calling addProperty() for sub-config will cause list of properties
written in multiple lines. Changing it to setProperty() can wrap
the list into one single line, thus enhance readability. Also, it
can prevent writing the same property multiple times.

E.g.
Result after addProperty("a", [1, 2]):
a = 1
a = 2
Result after setProperty("a", [1, 2]):
a = 1,2