### PR TITLE
Make delete table API async

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableDeletionRequest.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableDeletionRequest.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.utils.CommonConstants;
+
+
+public class TableDeletionRequest {
+  private String _rawTableName;
+  private String _tableType;
+  private Set<String> _instancesForRealtimeTable;
+  private List<String> _tablesDeleted;
+  private long _offlineTableDeletionStartTime;
+  private long _offlineTableIdealStateRemovalEndTime;
+  private long _realtimeTableDeletionStartTime;
+  private long _realtimeTableIdealStateRemovalEndTime;
+
+  public TableDeletionRequest(String tableName, String tableTypeStr) {
+    if (tableTypeStr == null) {
+      CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+      if (tableType != null) {
+        tableTypeStr = tableType.name();
+      }
+    }
+    _rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    _tableType = tableTypeStr;
+    _tablesDeleted = new LinkedList<>();
+    _offlineTableDeletionStartTime = 0L;
+    _realtimeTableDeletionStartTime = 0L;
+  }
+
+  public String getRawTableName() {
+    return _rawTableName;
+  }
+
+  public String getTableType() {
+    return _tableType;
+  }
+
+  public void setInstancesForRealtimeTable(Set<String> instancesForRealtimeTable) {
+    this._instancesForRealtimeTable = instancesForRealtimeTable;
+  }
+
+  public Set<String> getInstancesForRealtimeTable() {
+    return _instancesForRealtimeTable;
+  }
+
+  public List<String> getTablesDeleted() {
+    return _tablesDeleted;
+  }
+
+  public long getOfflineTableDeletionStartTime() {
+    return _offlineTableDeletionStartTime;
+  }
+
+  public void setOfflineTableDeletionStartTime(long offlineTableDeletionStartTime) {
+    _offlineTableDeletionStartTime = offlineTableDeletionStartTime;
+  }
+
+  public long getOfflineTableIdealStateRemovalEndTime() {
+    return _offlineTableIdealStateRemovalEndTime;
+  }
+
+  public void setOfflineTableIdealStateRemovalEndTime(long offlineTableIdealStateRemovalEndTime) {
+    _offlineTableIdealStateRemovalEndTime = offlineTableIdealStateRemovalEndTime;
+  }
+
+  public long getRealtimeTableDeletionStartTime() {
+    return _realtimeTableDeletionStartTime;
+  }
+
+  public void setRealtimeTableDeletionStartTime(long realtimeTableDeletionStartTime) {
+    _realtimeTableDeletionStartTime = realtimeTableDeletionStartTime;
+  }
+
+  public long getRealtimeTableIdealStateRemovalEndTime() {
+    return _realtimeTableIdealStateRemovalEndTime;
+  }
+
+  public void setRealtimeTableIdealStateRemovalEndTime(long realtimeTableIdealStateRemovalEndTime) {
+    _realtimeTableIdealStateRemovalEndTime = realtimeTableIdealStateRemovalEndTime;
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.TenantRole;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.resources.TableDeletionRequest;
 import org.apache.pinot.controller.helix.ControllerRequestBuilderUtil;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.testng.Assert;
@@ -220,7 +221,8 @@ public class PinotHelixResourceManagerTest extends ControllerTest {
     }
 
     // Delete the table
-    _helixResourceManager.deleteOfflineTable(TABLE_NAME);
+    TableDeletionRequest tableDeletionRequest = new TableDeletionRequest(OFFLINE_TABLE_NAME, null);
+    _helixResourceManager.deleteTable(tableDeletionRequest, null, null);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.common.partition.ReplicaGroupPartitionAssignment;
 import org.apache.pinot.common.partition.ReplicaGroupPartitionAssignmentGenerator;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.controller.api.resources.TableDeletionRequest;
 import org.apache.pinot.controller.helix.ControllerRequestBuilderUtil;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.util.HelixSetupUtils;
@@ -200,7 +201,8 @@ public class SegmentAssignmentStrategyTest {
 
   @Test
   public void testReplicaGroupPartitionAssignment() throws Exception {
-    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME_REPLICA_GROUP_PARTITION_ASSIGNMENT);
+    String rawTableName = TABLE_NAME_REPLICA_GROUP_PARTITION_ASSIGNMENT;
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
 
     // Adding a table without replica group
     TableConfig tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(
@@ -236,7 +238,7 @@ public class SegmentAssignmentStrategyTest {
     Assert.assertTrue(partitionAssignment != null);
 
     // After table deletion, check that the replica group partition assignment is deleted
-    _pinotHelixResourceManager.deleteOfflineTable(tableNameWithType);
+    _pinotHelixResourceManager.deleteTable(new TableDeletionRequest(tableNameWithType, null), null, null);
     partitionAssignment = _partitionAssignmentGenerator.getReplicaGroupPartitionAssignment(tableNameWithType);
     Assert.assertTrue(partitionAssignment == null);
 
@@ -246,7 +248,7 @@ public class SegmentAssignmentStrategyTest {
     Assert.assertTrue(partitionAssignment != null);
 
     // Check that the replica group partition assignment is deleted
-    _pinotHelixResourceManager.deleteOfflineTable(tableNameWithType);
+    _pinotHelixResourceManager.deleteTable(new TableDeletionRequest(tableNameWithType, null), null, null);
     partitionAssignment = _partitionAssignmentGenerator.getReplicaGroupPartitionAssignment(tableNameWithType);
     Assert.assertTrue(partitionAssignment == null);
   }


### PR DESCRIPTION
Currently the method deleteTable is a synchronized API. And there's no log to measure how long it takes to complete. This PR makes delete table API async so that the response can be returned fast. 

Modified the code as Subbu suggests:
Sync steps:
* Removing resource from broker idealstate
* Removing table resource from helix

Async steps:
* Removing segments
* Removing table config
* Removing replica group partition assigement

