### PR TITLE
Fix controller/server/broker admin console

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -77,7 +77,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
 
     HttpHandler httpHandler = new CLStaticHttpHandler(BrokerAdminApiApplication.class.getClassLoader(), "/api/");
     // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
-    _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api", "/help");
+    _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
 
     URL swaggerDistLocation =
         BrokerAdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -95,11 +95,11 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     // by a jersey handler
 
     httpServer.getServerConfiguration().addHttpHandler(
-        new CLStaticHttpHandler(classLoader,"/static/query/"), "/query");
+        new CLStaticHttpHandler(classLoader,"/static/query/"), "/query/");
     httpServer.getServerConfiguration().addHttpHandler(
-        new CLStaticHttpHandler(classLoader, "/static/css/"), "/css");
+        new CLStaticHttpHandler(classLoader, "/static/css/"), "/css/");
     httpServer.getServerConfiguration().addHttpHandler(
-        new CLStaticHttpHandler(classLoader, "/static/js/"), "/js");
+        new CLStaticHttpHandler(classLoader, "/static/js/"), "/js/");
     // without this explicit request to /index.html will not work
     httpServer.getServerConfiguration().addHttpHandler(
         new CLStaticHttpHandler(classLoader, "/static/"), "/index.html");
@@ -128,14 +128,14 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
 
-    CLStaticHttpHandler apiStaticHttpHandler = new CLStaticHttpHandler(ControllerAdminApiApplication.class.getClassLoader(),
+    ClassLoader loader = this.getClass().getClassLoader();
+    CLStaticHttpHandler apiStaticHttpHandler = new CLStaticHttpHandler(loader,
         "/api/");
     // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
-    httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/api");
-    httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/help");
+    httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/api/");
+    httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/help/");
 
-    URL swaggerDistLocation = ControllerAdminApiApplication.class.getClassLoader()
-        .getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");
+    URL swaggerDistLocation = loader.getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(
         new URLClassLoader(new URL[] {swaggerDistLocation}));
     httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AdminConsoleIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AdminConsoleIntegrationTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.File;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.pinot.broker.broker.BrokerAdminApiApplication;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.controller.api.ControllerAdminApiApplication;
+import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
+import org.apache.pinot.util.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests that the controller, broker and server admin consoles return the expected pages.
+ */
+public class AdminConsoleIntegrationTest extends BaseClusterIntegrationTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AdminConsoleIntegrationTest.class);
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    // Start an empty Pinot cluster
+    startZk();
+    startController();
+    startBroker();
+    startServer();
+  }
+
+  /**
+   * Tests resposnes to /api and /help.
+   */
+  @Test
+  public void testApiHelp() throws Exception {
+    // test controller
+    String response = sendGetRequest(_controllerBaseApiUrl + "/help");
+    String expected =
+        IOUtils.toString(ControllerAdminApiApplication.class.getClassLoader().getResourceAsStream("api/index.html"),
+            "UTF-8").replace("\n", "");
+    Assert.assertEquals(response, expected);
+    // help and api map to the same content
+    response = sendGetRequest(_controllerBaseApiUrl + "/api");
+    Assert.assertEquals(response, expected);
+
+
+    // test broker
+    response = sendGetRequest(_brokerBaseApiUrl + "/help");
+    expected =
+        IOUtils.toString(BrokerAdminApiApplication.class.getClassLoader().getResourceAsStream("api/index.html"),
+            "UTF-8").replace("\n", "");
+    Assert.assertEquals(response, expected);
+    // help and api map to the same content
+    response = sendGetRequest(_brokerBaseApiUrl + "/api");
+    Assert.assertEquals(response, expected);
+
+    String serverBaseApiUrl = "http://localhost:" + CommonConstants.Server.DEFAULT_ADMIN_API_PORT;
+    // test server
+    response = sendGetRequest( serverBaseApiUrl + "/help");
+    expected =
+        IOUtils.toString(BrokerAdminApiApplication.class.getClassLoader().getResourceAsStream("api/index.html"),
+            "UTF-8").replace("\n", "");
+    Assert.assertEquals(response, expected);
+
+    // help and api map to the same content
+    response = sendGetRequest(serverBaseApiUrl + "/api");
+    Assert.assertEquals(response, expected);
+  }
+
+  @Test
+  public void testQuery() throws Exception {
+    // test controller query console
+    String response = sendGetRequest(_controllerBaseApiUrl + "/query");
+    String expected =
+        IOUtils.toString(ControllerAdminApiApplication.class.getClassLoader().getResourceAsStream("static/query/index.html"),
+            "UTF-8").replace("\n", "");
+    Assert.assertEquals(response, expected);
+  }
+}
+
+

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AdminConsoleIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AdminConsoleIntegrationTest.java
@@ -18,36 +18,15 @@
  */
 package org.apache.pinot.integration.tests;
 
-import com.google.common.util.concurrent.MoreExecutors;
-import java.io.File;
-import java.util.Collections;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
-import org.apache.avro.Schema;
-import org.apache.avro.file.DataFileWriter;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.pinot.broker.broker.BrokerAdminApiApplication;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.controller.api.ControllerAdminApiApplication;
-import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
-import org.apache.pinot.util.TestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
 
 /**
  * Tests that the controller, broker and server admin consoles return the expected pages.

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
@@ -99,8 +99,8 @@ public class AdminApiApplication extends ResourceConfig {
 
     CLStaticHttpHandler staticHttpHandler = new CLStaticHttpHandler(AdminApiApplication.class.getClassLoader(), "/api/");
     // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
-    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/api");
-    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/help");
+    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/api/");
+    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/help/");
 
     URL swaggerDistLocation = AdminApiApplication.class.getClassLoader()
         .getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");


### PR DESCRIPTION
Recent upgrade to jersey-2.28-RC4 left the pinot admin consoles broken, with errors similar to: "Resource identified by path '/query', does not exist"

Traced this down to how the mappings for the different paths are setup - the newer grizzly handlers expect a trailing "/". 

Changes include:
- Fix the mappings in controller/broker/server to include the trailing slash.
- Added integration test to exercise the admin paths. Verified that the tests fail without the fix.

Also, tested the pages manually by launching controller/broker/server via pinot-tools/target/pinot-tools-pkg/start-{controller|broker|server}.sh