### PR TITLE
Fix a bug in PinotSegmentRestletResource.getInstanceToSegmentsMap()

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -468,8 +468,15 @@ public class PinotSegmentRestletResource {
     for (String tableNameWithType : tableNamesWithType) {
       ObjectNode resultForTable = JsonUtils.newObjectNode();
       resultForTable.put(FileUploadPathProvider.TABLE_NAME, tableNameWithType);
-      resultForTable.set("segments",
-          JsonUtils.objectToJsonNode(_pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType)));
+      try {
+        // NOTE: for backward-compatibility, we put serialized map string as the value
+        resultForTable.put("segments",
+            JsonUtils.objectToString(_pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType)));
+      } catch (JsonProcessingException e) {
+        throw new ControllerApplicationException(LOGGER,
+            "Caught JSON exception while getting instance to segments map for table: " + tableNameWithType,
+            Response.Status.INTERNAL_SERVER_ERROR, e);
+      }
       result.add(resultForTable);
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/TraceContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/TraceContext.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.util.trace;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,9 +61,7 @@ public final class TraceContext {
       }
 
       JsonNode toJson() {
-        ObjectNode jsonLog = JsonUtils.newObjectNode();
-        jsonLog.set(_key, JsonUtils.objectToJsonNode(_value));
-        return jsonLog;
+        return JsonUtils.newObjectNode().set(_key, JsonUtils.objectToJsonNode(_value));
       }
     }
 
@@ -93,9 +90,7 @@ public final class TraceContext {
       for (LogEntry log : _logs) {
         jsonLogs.add(log.toJson());
       }
-      ObjectNode jsonTrace = JsonUtils.newObjectNode();
-      jsonTrace.set(_traceId, jsonLogs);
-      return jsonTrace;
+      return JsonUtils.newObjectNode().set(_traceId, jsonLogs);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/trace/TraceContextTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/trace/TraceContextTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.util.trace;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
@@ -117,8 +116,6 @@ public class TraceContextTest {
   }
 
   private static String getTraceString(String key, Object value) {
-    ObjectNode jsonTrace = JsonUtils.newObjectNode();
-    jsonTrace.set(key, JsonUtils.objectToJsonNode(value));
-    return jsonTrace.toString();
+    return JsonUtils.newObjectNode().set(key, JsonUtils.objectToJsonNode(value)).toString();
   }
 }


### PR DESCRIPTION
The value for key "segments" should be a serialized map string instead of a json object.
This is for backward-compatible.