### PR TITLE
Fix SegmentStatusCheckerIntegrationTest setup timings

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -38,6 +38,14 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   OFFLINE_TABLE_COUNT("TableCount", true),
   DISABLED_TABLE_COUNT("TableCount", true),
 
+  SEGMENT_STATUS_CHECKER_NUM_TABLES_PROCESSED("SegmentStatusCheckerNumTablesProcessed", true),
+  REALTIME_SEGMENTS_VALIDATION_NUM_TABLES_PROCESSED("RealtimeSegmentsValidationNumTablesProcessed", true),
+  OFFLINE_SEGMENT_INTERVAL_CHECKER_NUM_TABLES_PROCESSED("OfflineSegmentIntervalCheckerNumTablesProcessed", true),
+  BROKER_RESOURCE_VALIDATION_NUM_TABLES_PROCESSED("BrokerResourceValidationNumTablesProcessed", true),
+  SEGMENT_RELOCATOR_NUM_TABLES_PROCESSED("SegmentRelocatorNumTablesProcessed", true),
+  RETENTION_NUM_TABLES_PROCESSED("RetentionNumTablesProcessed", true),
+  PINOT_TASK_MANAGER_NUM_TABLES_PROCESSED("PinotTaskManagerNumTablesProcessed", true),
+
   SHORT_OF_LIVE_INSTANCES("ShortOfLiveInstances", false), // Number of extra live instances needed.
 
   REALTIME_TABLE_ESTIMATED_SIZE("RealtimeTableEstimatedSize", false), // Estimated size of realtime table.

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -38,13 +38,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   OFFLINE_TABLE_COUNT("TableCount", true),
   DISABLED_TABLE_COUNT("TableCount", true),
 
-  SEGMENT_STATUS_CHECKER_NUM_TABLES_PROCESSED("SegmentStatusCheckerNumTablesProcessed", true),
-  REALTIME_SEGMENTS_VALIDATION_NUM_TABLES_PROCESSED("RealtimeSegmentsValidationNumTablesProcessed", true),
-  OFFLINE_SEGMENT_INTERVAL_CHECKER_NUM_TABLES_PROCESSED("OfflineSegmentIntervalCheckerNumTablesProcessed", true),
-  BROKER_RESOURCE_VALIDATION_NUM_TABLES_PROCESSED("BrokerResourceValidationNumTablesProcessed", true),
-  SEGMENT_RELOCATOR_NUM_TABLES_PROCESSED("SegmentRelocatorNumTablesProcessed", true),
-  RETENTION_NUM_TABLES_PROCESSED("RetentionNumTablesProcessed", true),
-  PINOT_TASK_MANAGER_NUM_TABLES_PROCESSED("PinotTaskManagerNumTablesProcessed", true),
+  PERIODIC_TASK_NUM_TABLES_PROCESSED("PeriodicTaskNumTablesProcessed", true),
 
   SHORT_OF_LIVE_INSTANCES("ShortOfLiveInstances", false), // Number of extra live instances needed.
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -300,21 +300,21 @@ public class ControllerStarter {
     List<PeriodicTask> periodicTasks = new ArrayList<>();
     _taskManager = new PinotTaskManager(_helixTaskResourceManager, _helixResourceManager, _config, _controllerMetrics);
     periodicTasks.add(_taskManager);
-    _retentionManager = new RetentionManager(_helixResourceManager, _config);
+    _retentionManager = new RetentionManager(_helixResourceManager, _config, _controllerMetrics);
     periodicTasks.add(_retentionManager);
     _offlineSegmentIntervalChecker =
-        new OfflineSegmentIntervalChecker(_config, _helixResourceManager, new ValidationMetrics(_metricsRegistry));
+        new OfflineSegmentIntervalChecker(_config, _helixResourceManager, new ValidationMetrics(_metricsRegistry),
+            _controllerMetrics);
     periodicTasks.add(_offlineSegmentIntervalChecker);
-    _realtimeSegmentValidationManager =
-        new RealtimeSegmentValidationManager(_config, _helixResourceManager, PinotLLCRealtimeSegmentManager.getInstance(),
-            new ValidationMetrics(_metricsRegistry));
+    _realtimeSegmentValidationManager = new RealtimeSegmentValidationManager(_config, _helixResourceManager,
+        PinotLLCRealtimeSegmentManager.getInstance(), new ValidationMetrics(_metricsRegistry), _controllerMetrics);
     periodicTasks.add(_realtimeSegmentValidationManager);
     _brokerResourceValidationManager =
-        new BrokerResourceValidationManager(_config, _helixResourceManager);
+        new BrokerResourceValidationManager(_config, _helixResourceManager, _controllerMetrics);
     periodicTasks.add(_brokerResourceValidationManager);
     _segmentStatusChecker = new SegmentStatusChecker(_helixResourceManager, _config, _controllerMetrics);
     periodicTasks.add(_segmentStatusChecker);
-    _realtimeSegmentRelocator = new RealtimeSegmentRelocator(_helixResourceManager, _config);
+    _realtimeSegmentRelocator = new RealtimeSegmentRelocator(_helixResourceManager, _config, _controllerMetrics);
     periodicTasks.add(_realtimeSegmentRelocator);
 
     return periodicTasks;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -45,7 +45,6 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
   public static final String ONLINE = "ONLINE";
   public static final String ERROR = "ERROR";
   public static final String CONSUMING = "CONSUMING";
-  private final ControllerMetrics _metricsRegistry;
   private final int _waitForPushTimeSeconds;
 
   // log messages about disabled tables atmost once a day
@@ -63,12 +62,11 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
    * @param config The controller configuration object
    */
   public SegmentStatusChecker(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf config,
-      ControllerMetrics metricsRegistry) {
+      ControllerMetrics controllerMetrics) {
     super("SegmentStatusChecker", config.getStatusCheckerFrequencyInSeconds(),
-        config.getStatusCheckerInitialDelayInSeconds(), pinotHelixResourceManager);
+        config.getStatusCheckerInitialDelayInSeconds(), pinotHelixResourceManager, controllerMetrics);
 
     _waitForPushTimeSeconds = config.getStatusCheckerWaitForPushTimeInSeconds();
-    _metricsRegistry = metricsRegistry;
   }
 
   @Override
@@ -79,6 +77,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
+    _numTablesProcessed = 0;
     _realTimeTableCount = 0;
     _offlineTableCount = 0;
     _disabledTableCount = 0;
@@ -95,11 +94,21 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
 
   @Override
   protected void processTable(String tableNameWithType) {
-    updateSegmentMetrics(tableNameWithType);
+    try {
+      updateSegmentMetrics(tableNameWithType);
+      _numTablesProcessed ++;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while updating segment status for table {}", tableNameWithType, e);
+
+      // Remove the metric for this table
+      resetTableMetrics(tableNameWithType);
+    }
   }
 
   @Override
   protected void postprocess() {
+    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.SEGMENT_STATUS_CHECKER_NUM_TABLES_PROCESSED,
+        _numTablesProcessed);
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.REALTIME_TABLE_COUNT, _realTimeTableCount);
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.OFFLINE_TABLE_COUNT, _offlineTableCount);
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT, _disabledTableCount);
@@ -113,138 +122,132 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
    */
   private void updateSegmentMetrics(String tableNameWithType) {
 
-    try {
-      if (TableNameBuilder.getTableTypeFromTableName(tableNameWithType) == TableType.OFFLINE) {
-        _offlineTableCount++;
-      } else {
-        _realTimeTableCount++;
-      }
+    if (TableNameBuilder.getTableTypeFromTableName(tableNameWithType) == TableType.OFFLINE) {
+      _offlineTableCount++;
+    } else {
+      _realTimeTableCount++;
+    }
 
-      IdealState idealState = _pinotHelixResourceManager.getTableIdealState(tableNameWithType);
+    IdealState idealState = _pinotHelixResourceManager.getTableIdealState(tableNameWithType);
 
-      if (idealState == null) {
-        LOGGER.warn("Table {} has null ideal state. Skipping segment status checks", tableNameWithType);
-        resetTableMetrics(tableNameWithType);
-        return;
-      }
-
-      if (!idealState.isEnabled()) {
-        if (_logDisabledTables) {
-          LOGGER.warn("Table {} is disabled. Skipping segment status checks", tableNameWithType);
-        }
-        resetTableMetrics(tableNameWithType);
-        _disabledTableCount++;
-        return;
-      }
-
-      if (idealState.getPartitionSet().isEmpty()) {
-        int nReplicasFromIdealState = 1;
-        try {
-          nReplicasFromIdealState = Integer.valueOf(idealState.getReplicas());
-        } catch (NumberFormatException e) {
-          // Ignore
-        }
-        _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.NUMBER_OF_REPLICAS, nReplicasFromIdealState);
-        _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_OF_REPLICAS, 100);
-        _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE, 100);
-        return;
-      }
-
-      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_SIZE,
-          idealState.toString().length());
-      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENT_COUNT,
-          (long) (idealState.getPartitionSet().size()));
-      ExternalView externalView = _pinotHelixResourceManager.getTableExternalView(tableNameWithType);
-
-      int nReplicasIdealMax = 0; // Keeps track of maximum number of replicas in ideal state
-      int nReplicasExternal = -1; // Keeps track of minimum number of replicas in external view
-      int nErrors = 0; // Keeps track of number of segments in error state
-      int nOffline = 0; // Keeps track of number segments with no online replicas
-      int nSegments = 0; // Counts number of segments
-      for (String partitionName : idealState.getPartitionSet()) {
-        int nReplicas = 0;
-        int nIdeal = 0;
-        nSegments++;
-        // Skip segments not online in ideal state
-        for (Map.Entry<String, String> serverAndState : idealState.getInstanceStateMap(partitionName).entrySet()) {
-          if (serverAndState == null) {
-            break;
-          }
-          if (serverAndState.getValue().equals(ONLINE)) {
-            nIdeal++;
-            break;
-          }
-        }
-        if (nIdeal == 0) {
-          // No online segments in ideal state
-          continue;
-        }
-        nReplicasIdealMax =
-            (idealState.getInstanceStateMap(partitionName).size() > nReplicasIdealMax) ? idealState.getInstanceStateMap(
-                partitionName).size() : nReplicasIdealMax;
-        if ((externalView == null) || (externalView.getStateMap(partitionName) == null)) {
-          // No replicas for this segment
-          TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-          if ((tableType != null) && (tableType.equals(TableType.OFFLINE))) {
-            OfflineSegmentZKMetadata segmentZKMetadata =
-                _pinotHelixResourceManager.getOfflineSegmentZKMetadata(tableNameWithType, partitionName);
-
-            if (segmentZKMetadata != null
-                && segmentZKMetadata.getPushTime() > System.currentTimeMillis() - _waitForPushTimeSeconds * 1000) {
-              // push not yet finished, skip
-              continue;
-            }
-          }
-          nOffline++;
-          if (nOffline < MaxOfflineSegmentsToLog) {
-            LOGGER.warn("Segment {} of table {} has no replicas", partitionName, tableNameWithType);
-          }
-          nReplicasExternal = 0;
-          continue;
-        }
-        for (Map.Entry<String, String> serverAndState : externalView.getStateMap(partitionName).entrySet()) {
-          // Count number of online replicas. Ignore if state is CONSUMING.
-          // It is possible for a segment to be ONLINE in idealstate, and CONSUMING in EV for a short period of time.
-          // So, ignore this combination. If a segment exists in this combination for a long time, we will get
-          // low level-partition-not-consuming alert anyway.
-          if (serverAndState.getValue().equals(ONLINE) || serverAndState.getValue().equals(CONSUMING)) {
-            nReplicas++;
-          }
-          if (serverAndState.getValue().equals(ERROR)) {
-            nErrors++;
-          }
-        }
-        if (nReplicas == 0) {
-          if (nOffline < MaxOfflineSegmentsToLog) {
-            LOGGER.warn("Segment {} of table {} has no online replicas", partitionName, tableNameWithType);
-          }
-          nOffline++;
-        }
-        nReplicasExternal =
-            ((nReplicasExternal > nReplicas) || (nReplicasExternal == -1)) ? nReplicas : nReplicasExternal;
-      }
-      if (nReplicasExternal == -1) {
-        nReplicasExternal = (nReplicasIdealMax == 0) ? 1 : 0;
-      }
-      // Synchronization provided by Controller Gauge to make sure that only one thread updates the gauge
-      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.NUMBER_OF_REPLICAS, nReplicasExternal);
-      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_OF_REPLICAS,
-          (nReplicasIdealMax > 0) ? (nReplicasExternal * 100 / nReplicasIdealMax) : 100);
-      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENTS_IN_ERROR_STATE, nErrors);
-      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE,
-          (nSegments > 0) ? (100 - (nOffline * 100 / nSegments)) : 100);
-      if (nOffline > 0) {
-        LOGGER.warn("Table {} has {} segments with no online replicas", tableNameWithType, nOffline);
-      }
-      if (nReplicasExternal < nReplicasIdealMax) {
-        LOGGER.warn("Table {} has {} replicas, below replication threshold :{}", tableNameWithType, nReplicasExternal,
-            nReplicasIdealMax);
-      }
-    } catch (Exception e) {
-      LOGGER.error("Caught exception while updating segment status for table {}", tableNameWithType, e);
-
-      // Remove the metric for this table
+    if (idealState == null) {
+      LOGGER.warn("Table {} has null ideal state. Skipping segment status checks", tableNameWithType);
       resetTableMetrics(tableNameWithType);
+      return;
+    }
+
+    if (!idealState.isEnabled()) {
+      if (_logDisabledTables) {
+        LOGGER.warn("Table {} is disabled. Skipping segment status checks", tableNameWithType);
+      }
+      resetTableMetrics(tableNameWithType);
+      _disabledTableCount++;
+      return;
+    }
+
+    if (idealState.getPartitionSet().isEmpty()) {
+      int nReplicasFromIdealState = 1;
+      try {
+        nReplicasFromIdealState = Integer.valueOf(idealState.getReplicas());
+      } catch (NumberFormatException e) {
+        // Ignore
+      }
+      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.NUMBER_OF_REPLICAS,
+          nReplicasFromIdealState);
+      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_OF_REPLICAS, 100);
+      _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE, 100);
+      return;
+    }
+
+    _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_SIZE,
+        idealState.toString().length());
+    _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENT_COUNT,
+        (long) (idealState.getPartitionSet().size()));
+    ExternalView externalView = _pinotHelixResourceManager.getTableExternalView(tableNameWithType);
+
+    int nReplicasIdealMax = 0; // Keeps track of maximum number of replicas in ideal state
+    int nReplicasExternal = -1; // Keeps track of minimum number of replicas in external view
+    int nErrors = 0; // Keeps track of number of segments in error state
+    int nOffline = 0; // Keeps track of number segments with no online replicas
+    int nSegments = 0; // Counts number of segments
+    for (String partitionName : idealState.getPartitionSet()) {
+      int nReplicas = 0;
+      int nIdeal = 0;
+      nSegments++;
+      // Skip segments not online in ideal state
+      for (Map.Entry<String, String> serverAndState : idealState.getInstanceStateMap(partitionName).entrySet()) {
+        if (serverAndState == null) {
+          break;
+        }
+        if (serverAndState.getValue().equals(ONLINE)) {
+          nIdeal++;
+          break;
+        }
+      }
+      if (nIdeal == 0) {
+        // No online segments in ideal state
+        continue;
+      }
+      nReplicasIdealMax =
+          (idealState.getInstanceStateMap(partitionName).size() > nReplicasIdealMax) ? idealState.getInstanceStateMap(
+              partitionName).size() : nReplicasIdealMax;
+      if ((externalView == null) || (externalView.getStateMap(partitionName) == null)) {
+        // No replicas for this segment
+        TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+        if ((tableType != null) && (tableType.equals(TableType.OFFLINE))) {
+          OfflineSegmentZKMetadata segmentZKMetadata =
+              _pinotHelixResourceManager.getOfflineSegmentZKMetadata(tableNameWithType, partitionName);
+
+          if (segmentZKMetadata != null
+              && segmentZKMetadata.getPushTime() > System.currentTimeMillis() - _waitForPushTimeSeconds * 1000) {
+            // push not yet finished, skip
+            continue;
+          }
+        }
+        nOffline++;
+        if (nOffline < MaxOfflineSegmentsToLog) {
+          LOGGER.warn("Segment {} of table {} has no replicas", partitionName, tableNameWithType);
+        }
+        nReplicasExternal = 0;
+        continue;
+      }
+      for (Map.Entry<String, String> serverAndState : externalView.getStateMap(partitionName).entrySet()) {
+        // Count number of online replicas. Ignore if state is CONSUMING.
+        // It is possible for a segment to be ONLINE in idealstate, and CONSUMING in EV for a short period of time.
+        // So, ignore this combination. If a segment exists in this combination for a long time, we will get
+        // low level-partition-not-consuming alert anyway.
+        if (serverAndState.getValue().equals(ONLINE) || serverAndState.getValue().equals(CONSUMING)) {
+          nReplicas++;
+        }
+        if (serverAndState.getValue().equals(ERROR)) {
+          nErrors++;
+        }
+      }
+      if (nReplicas == 0) {
+        if (nOffline < MaxOfflineSegmentsToLog) {
+          LOGGER.warn("Segment {} of table {} has no online replicas", partitionName, tableNameWithType);
+        }
+        nOffline++;
+      }
+      nReplicasExternal =
+          ((nReplicasExternal > nReplicas) || (nReplicasExternal == -1)) ? nReplicas : nReplicasExternal;
+    }
+    if (nReplicasExternal == -1) {
+      nReplicasExternal = (nReplicasIdealMax == 0) ? 1 : 0;
+    }
+    // Synchronization provided by Controller Gauge to make sure that only one thread updates the gauge
+    _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.NUMBER_OF_REPLICAS, nReplicasExternal);
+    _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_OF_REPLICAS,
+        (nReplicasIdealMax > 0) ? (nReplicasExternal * 100 / nReplicasIdealMax) : 100);
+    _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENTS_IN_ERROR_STATE, nErrors);
+    _metricsRegistry.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE,
+        (nSegments > 0) ? (100 - (nOffline * 100 / nSegments)) : 100);
+    if (nOffline > 0) {
+      LOGGER.warn("Table {} has {} segments with no online replicas", tableNameWithType, nOffline);
+    }
+    if (nReplicasExternal < nReplicasIdealMax) {
+      LOGGER.warn("Table {} has {} replicas, below replication threshold :{}", tableNameWithType, nReplicasExternal,
+          nReplicasIdealMax);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -77,7 +77,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    _numTablesProcessed = 0;
+    super.preprocess();
     _realTimeTableCount = 0;
     _offlineTableCount = 0;
     _disabledTableCount = 0;
@@ -107,8 +107,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
 
   @Override
   protected void postprocess() {
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.SEGMENT_STATUS_CHECKER_NUM_TABLES_PROCESSED,
-        _numTablesProcessed);
+    super.postprocess();
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.REALTIME_TABLE_COUNT, _realTimeTableCount);
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.OFFLINE_TABLE_COUNT, _offlineTableCount);
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT, _disabledTableCount);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -77,7 +77,6 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    super.preprocess();
     _realTimeTableCount = 0;
     _offlineTableCount = 0;
     _disabledTableCount = 0;
@@ -94,20 +93,18 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
 
   @Override
   protected void processTable(String tableNameWithType) {
-    try {
-      updateSegmentMetrics(tableNameWithType);
-      _numTablesProcessed ++;
-    } catch (Exception e) {
-      LOGGER.error("Caught exception while updating segment status for table {}", tableNameWithType, e);
+    updateSegmentMetrics(tableNameWithType);
+  }
 
-      // Remove the metric for this table
-      resetTableMetrics(tableNameWithType);
-    }
+  @Override
+  protected void exceptionHandler(String tableNameWithType, Exception e) {
+    LOGGER.error("Caught exception while updating segment status for table {}", tableNameWithType, e);
+    // Remove the metric for this table
+    resetTableMetrics(tableNameWithType);
   }
 
   @Override
   protected void postprocess() {
-    super.postprocess();
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.REALTIME_TABLE_COUNT, _realTimeTableCount);
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.OFFLINE_TABLE_COUNT, _offlineTableCount);
     _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT, _disabledTableCount);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -102,7 +102,6 @@ public class PinotTaskManager extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    super.preprocess();
     _metricsRegistry.addMeteredGlobalValue(ControllerMeter.NUMBER_TIMES_SCHEDULE_TASKS_CALLED, 1L);
 
     _taskTypes = _taskGeneratorRegistry.getAllTaskTypes();
@@ -130,7 +129,11 @@ public class PinotTaskManager extends ControllerPeriodicTask {
         }
       }
     }
-    _numTablesProcessed ++;
+  }
+
+  @Override
+  protected void exceptionHandler(String tableNameWithType, Exception e) {
+    LOGGER.error("Exception in PinotTaskManager for table {}", tableNameWithType, e);
   }
 
   @Override
@@ -150,7 +153,6 @@ public class PinotTaskManager extends ControllerPeriodicTask {
         _metricsRegistry.addMeteredTableValue(taskType, ControllerMeter.NUMBER_TASKS_SUBMITTED, numTasks);
       }
     }
-    super.postprocess();
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -27,7 +27,6 @@ import javax.annotation.Nonnull;
 import org.apache.pinot.common.config.PinotTaskConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableTaskConfig;
-import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
@@ -103,7 +102,7 @@ public class PinotTaskManager extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    _numTablesProcessed = 0;
+    super.preprocess();
     _metricsRegistry.addMeteredGlobalValue(ControllerMeter.NUMBER_TIMES_SCHEDULE_TASKS_CALLED, 1L);
 
     _taskTypes = _taskGeneratorRegistry.getAllTaskTypes();
@@ -151,8 +150,7 @@ public class PinotTaskManager extends ControllerPeriodicTask {
         _metricsRegistry.addMeteredTableValue(taskType, ControllerMeter.NUMBER_TASKS_SUBMITTED, numTasks);
       }
     }
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.PINOT_TASK_MANAGER_NUM_TABLES_PROCESSED,
-        _numTablesProcessed);
+    super.postprocess();
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.helix.core.periodictask;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.periodictask.BasePeriodicTask;
@@ -140,7 +141,9 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
   /**
    * This method runs before processing all tables
    */
-  protected abstract void preprocess();
+  protected void preprocess() {
+    _numTablesProcessed = 0;
+  }
 
   /**
    * Execute the controller periodic task for the given table
@@ -151,7 +154,10 @@ public abstract class ControllerPeriodicTask extends BasePeriodicTask {
   /**
    * This method runs after processing all tables
    */
-  protected abstract void postprocess();
+  protected void postprocess() {
+    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED, getTaskName(),
+        _numTablesProcessed);
+  }
 
   @VisibleForTesting
   protected boolean shouldStopPeriodicTask() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.helix.core.periodictask;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.periodictask.BasePeriodicTask;
 import org.slf4j.Logger;
@@ -33,18 +34,21 @@ import org.slf4j.LoggerFactory;
 public abstract class ControllerPeriodicTask extends BasePeriodicTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(ControllerPeriodicTask.class);
 
-
   private static final long MAX_CONTROLLER_PERIODIC_TASK_STOP_TIME_MILLIS = 30_000L;
 
   protected final PinotHelixResourceManager _pinotHelixResourceManager;
+  protected final ControllerMetrics _metricsRegistry;
 
   private volatile boolean _stopPeriodicTask;
   private volatile boolean _periodicTaskInProgress;
 
+  protected int _numTablesProcessed;
+
   public ControllerPeriodicTask(String taskName, long runFrequencyInSeconds, long initialDelayInSeconds,
-      PinotHelixResourceManager pinotHelixResourceManager) {
+      PinotHelixResourceManager pinotHelixResourceManager, ControllerMetrics controllerMetrics) {
     super(taskName, runFrequencyInSeconds, initialDelayInSeconds);
     _pinotHelixResourceManager = pinotHelixResourceManager;
+    _metricsRegistry = controllerMetrics;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -33,7 +33,6 @@ import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.config.RealtimeTagConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
-import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.helix.HelixHelper;
@@ -70,7 +69,7 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    _numTablesProcessed = 0;
+    super.preprocess();
   }
 
   @Override
@@ -88,7 +87,7 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
 
   @Override
   protected void postprocess() {
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.SEGMENT_RELOCATOR_NUM_TABLES_PROCESSED, _numTablesProcessed);
+    super.postprocess();
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -69,25 +69,23 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    super.preprocess();
   }
 
   @Override
   protected void processTable(String tableNameWithType) {
-    try {
-      CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-      if (tableType == CommonConstants.Helix.TableType.REALTIME) {
-        runRelocation(tableNameWithType);
-        _numTablesProcessed ++;
-      }
-    } catch (Exception e) {
-      LOGGER.error("Exception in relocating realtime segments of table {}", tableNameWithType, e);
+    CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+    if (tableType == CommonConstants.Helix.TableType.REALTIME) {
+      runRelocation(tableNameWithType);
     }
   }
 
   @Override
   protected void postprocess() {
-    super.postprocess();
+  }
+
+  @Override
+  protected void exceptionHandler(String tableNameWithType, Exception e) {
+    LOGGER.error("Exception in relocating realtime segments of table {}", tableNameWithType, e);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -33,6 +33,9 @@ import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.config.RealtimeTagConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.common.utils.retry.RetryPolicies;
 import org.apache.pinot.common.utils.time.TimeUtils;
@@ -54,9 +57,10 @@ import org.slf4j.LoggerFactory;
 public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentRelocator.class);
 
-  public RealtimeSegmentRelocator(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf config) {
+  public RealtimeSegmentRelocator(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf config,
+      ControllerMetrics controllerMetrics) {
     super("RealtimeSegmentRelocator", getRunFrequencySeconds(config.getRealtimeSegmentRelocatorFrequency()),
-        config.getPeriodicTaskInitialDelayInSeconds(), pinotHelixResourceManager);
+        config.getPeriodicTaskInitialDelayInSeconds(), pinotHelixResourceManager, controllerMetrics);
   }
 
   @Override
@@ -66,17 +70,25 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-
+    _numTablesProcessed = 0;
   }
 
   @Override
   protected void processTable(String tableNameWithType) {
-    runRelocation(tableNameWithType);
+    try {
+      CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+      if (tableType == CommonConstants.Helix.TableType.REALTIME) {
+        runRelocation(tableNameWithType);
+        _numTablesProcessed ++;
+      }
+    } catch (Exception e) {
+      LOGGER.error("Exception in relocating realtime segments of table {}", tableNameWithType, e);
+    }
   }
 
   @Override
   protected void postprocess() {
-
+    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.SEGMENT_RELOCATOR_NUM_TABLES_PROCESSED, _numTablesProcessed);
   }
 
   /**
@@ -87,38 +99,30 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
    * @param tableNameWithType
    */
   private void runRelocation(String tableNameWithType) {
-    // Only consider realtime tables.
-    if (!TableNameBuilder.REALTIME.tableHasTypeSuffix(tableNameWithType)) {
+    LOGGER.info("Starting relocation of segments for table: {}", tableNameWithType);
+
+    TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableNameWithType);
+    final RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(tableConfig);
+    if (!realtimeTagConfig.isRelocateCompletedSegments()) {
+      LOGGER.info("Skipping relocation of segments for {}", tableNameWithType);
       return;
     }
-    try {
-      LOGGER.info("Starting relocation of segments for table: {}", tableNameWithType);
 
-      TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableNameWithType);
-      final RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(tableConfig);
-      if (!realtimeTagConfig.isRelocateCompletedSegments()) {
-        LOGGER.info("Skipping relocation of segments for {}", tableNameWithType);
-        return;
-      }
-
-      Function<IdealState, IdealState> updater = new Function<IdealState, IdealState>() {
-        @Nullable
-        @Override
-        public IdealState apply(@Nullable IdealState idealState) {
-          if (!idealState.isEnabled()) {
-            LOGGER.info("Skipping relocation of segments for {} since ideal state is disabled", tableNameWithType);
-            return null;
-          }
-          relocateSegments(realtimeTagConfig, idealState);
-          return idealState;
+    Function<IdealState, IdealState> updater = new Function<IdealState, IdealState>() {
+      @Nullable
+      @Override
+      public IdealState apply(@Nullable IdealState idealState) {
+        if (!idealState.isEnabled()) {
+          LOGGER.info("Skipping relocation of segments for {} since ideal state is disabled", tableNameWithType);
+          return null;
         }
-      };
+        relocateSegments(realtimeTagConfig, idealState);
+        return idealState;
+      }
+    };
 
-      HelixHelper.updateIdealState(_pinotHelixResourceManager.getHelixZkManager(), tableNameWithType, updater,
-          RetryPolicies.exponentialBackoffRetryPolicy(5, 1000, 2.0f));
-    } catch (Exception e) {
-      LOGGER.error("Exception in relocating realtime segments of table {}", tableNameWithType, e);
-    }
+    HelixHelper.updateIdealState(_pinotHelixResourceManager.getHelixZkManager(), tableNameWithType, updater,
+        RetryPolicies.exponentialBackoffRetryPolicy(5, 1000, 2.0f));
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -30,7 +30,6 @@ import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
-import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Segment.Realtime.Status;
@@ -72,7 +71,7 @@ public class RetentionManager extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    _numTablesProcessed = 0;
+    super.preprocess();
   }
 
   @Override
@@ -90,7 +89,7 @@ public class RetentionManager extends ControllerPeriodicTask {
   protected void postprocess() {
     LOGGER.info("Removing aged (more than {} days) deleted segments for all tables", _deletedSegmentsRetentionInDays);
     _pinotHelixResourceManager.getSegmentDeletionManager().removeAgedDeletedSegments(_deletedSegmentsRetentionInDays);
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.RETENTION_NUM_TABLES_PROCESSED, _numTablesProcessed);
+    super.postprocess();
   }
 
   private void manageRetentionForTable(String tableNameWithType) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/BrokerResourceValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/BrokerResourceValidationManager.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Set;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.config.TableConfig;
-import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -47,7 +46,7 @@ public class BrokerResourceValidationManager extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    _numTablesProcessed = 0;
+    super.preprocess();
     _instanceConfigs = _pinotHelixResourceManager.getAllHelixInstanceConfigs();
   }
 
@@ -73,8 +72,7 @@ public class BrokerResourceValidationManager extends ControllerPeriodicTask {
 
   @Override
   protected void postprocess() {
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.BROKER_RESOURCE_VALIDATION_NUM_TABLES_PROCESSED,
-        _numTablesProcessed);
+    super.postprocess();
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/BrokerResourceValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/BrokerResourceValidationManager.java
@@ -46,33 +46,31 @@ public class BrokerResourceValidationManager extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    super.preprocess();
     _instanceConfigs = _pinotHelixResourceManager.getAllHelixInstanceConfigs();
   }
 
   @Override
   protected void processTable(String tableNameWithType) {
-    try {
-      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-      if (tableConfig == null) {
-        LOGGER.warn("Failed to find table config for table: {}, skipping broker resource validation", tableNameWithType);
-        return;
-      }
-
-      // Rebuild broker resource
-      Set<String> brokerInstances = _pinotHelixResourceManager.getAllInstancesForBrokerTenant(_instanceConfigs,
-          tableConfig.getTenantConfig().getBroker());
-      _pinotHelixResourceManager.rebuildBrokerResource(tableNameWithType, brokerInstances);
-      _numTablesProcessed ++;
-    } catch (Exception e) {
-      LOGGER.warn("Caught exception while validating broker resource for table: {}", tableNameWithType, e);
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (tableConfig == null) {
+      LOGGER.warn("Failed to find table config for table: {}, skipping broker resource validation", tableNameWithType);
+      return;
     }
+
+    // Rebuild broker resource
+    Set<String> brokerInstances = _pinotHelixResourceManager.getAllInstancesForBrokerTenant(_instanceConfigs,
+        tableConfig.getTenantConfig().getBroker());
+    _pinotHelixResourceManager.rebuildBrokerResource(tableNameWithType, brokerInstances);
   }
 
 
   @Override
   protected void postprocess() {
-    super.postprocess();
+  }
+
+  @Override
+  protected void exceptionHandler(String tableNameWithType, Exception e) {
+    LOGGER.error("Caught exception while validating broker resource for table: {}", tableNameWithType, e);
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
@@ -26,7 +26,6 @@ import org.apache.pinot.common.config.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
-import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ValidationMetrics;
 import org.apache.pinot.common.utils.CommonConstants;
@@ -58,7 +57,7 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    _numTablesProcessed = 0;
+    super.preprocess();
   }
 
   @Override
@@ -216,8 +215,7 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask {
 
   @Override
   protected void postprocess() {
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.OFFLINE_SEGMENT_INTERVAL_CHECKER_NUM_TABLES_PROCESSED,
-        _numTablesProcessed);
+    super.postprocess();
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
@@ -57,27 +57,19 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    super.preprocess();
   }
 
   @Override
   protected void processTable(String tableNameWithType) {
-    try {
+    CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+    if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
 
-      CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-      if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
-
-        TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-        if (tableConfig == null) {
-          LOGGER.warn("Failed to find table config for table: {}, skipping validation", tableNameWithType);
-          return;
-        }
-
-        validateOfflineSegmentPush(tableConfig);
-        _numTablesProcessed ++;
+      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+      if (tableConfig == null) {
+        LOGGER.warn("Failed to find table config for table: {}, skipping validation", tableNameWithType);
+        return;
       }
-    } catch (Exception e) {
-      LOGGER.warn("Caught exception while checking offline segment intervals for table: {}", tableNameWithType, e);
+      validateOfflineSegmentPush(tableConfig);
     }
   }
 
@@ -215,7 +207,11 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask {
 
   @Override
   protected void postprocess() {
-    super.postprocess();
+  }
+
+  @Override
+  protected void exceptionHandler(String tableNameWithType, Exception e) {
+    LOGGER.warn("Caught exception while checking offline segment intervals for table: {}", tableNameWithType, e);
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
-import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ValidationMetrics;
 import org.apache.pinot.common.utils.CommonConstants;
@@ -68,7 +67,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask {
 
   @Override
   protected void preprocess() {
-    _numTablesProcessed = 0;
+    super.preprocess();
     // Update realtime document counts only if certain time has passed after previous run
     _updateRealtimeDocumentCount = false;
     long currentTimeMs = System.currentTimeMillis();
@@ -156,8 +155,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask {
 
   @Override
   protected void postprocess() {
-    _metricsRegistry.setValueOfGlobalGauge(ControllerGauge.REALTIME_SEGMENTS_VALIDATION_NUM_TABLES_PROCESSED,
-        _numTablesProcessed);
+    super.postprocess();
   }
 
   @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
@@ -73,7 +73,6 @@ public class ControllerPeriodicTaskTest {
     @Override
     public void processTable(String tableNameWithType) {
       _tablesProcessed.getAndIncrement();
-      _numTablesProcessed ++;
     }
   };
 
@@ -164,7 +163,6 @@ public class ControllerPeriodicTaskTest {
 
     @Override
     protected void preprocess() {
-      super.preprocess();
     }
 
     @Override
@@ -174,9 +172,12 @@ public class ControllerPeriodicTaskTest {
 
     @Override
     public void postprocess() {
-      super.postprocess();
     }
 
+    @Override
+    public void exceptionHandler(String tableNameWithType, Exception e) {
+
+    }
 
     @Override
     public void stopTask() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.helix.core.relocation;
 
 import com.google.common.collect.Lists;
+import com.yammer.metrics.core.MetricsRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -31,6 +32,7 @@ import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.builder.CustomModeISBuilder;
 import org.apache.pinot.common.config.RealtimeTagConfig;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineStateModelGenerator;
@@ -68,7 +70,9 @@ public class RealtimeSegmentRelocatorTest {
     _mockHelixManager = mock(HelixManager.class);
     when(mockPinotHelixResourceManager.getHelixZkManager()).thenReturn(_mockHelixManager);
     ControllerConf controllerConfig = new ControllerConf();
-    _realtimeSegmentRelocator = new TestRealtimeSegmentRelocator(mockPinotHelixResourceManager, controllerConfig);
+    ControllerMetrics controllerMetrics = new ControllerMetrics(new MetricsRegistry());
+    _realtimeSegmentRelocator =
+        new TestRealtimeSegmentRelocator(mockPinotHelixResourceManager, controllerConfig, controllerMetrics);
 
     final int maxInstances = 20;
     serverNames = new String[maxInstances];
@@ -261,8 +265,9 @@ public class RealtimeSegmentRelocatorTest {
 
     private Map<String, List<String>> tagToInstances;
 
-    public TestRealtimeSegmentRelocator(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf config) {
-      super(pinotHelixResourceManager, config);
+    public TestRealtimeSegmentRelocator(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf config,
+        ControllerMetrics controllerMetrics) {
+      super(pinotHelixResourceManager, config, controllerMetrics);
       tagToInstances = new HashedMap();
     }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix.core.retention;
 
+import com.yammer.metrics.core.MetricsRegistry;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.segment.SegmentMetadata;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -86,9 +88,10 @@ public class RetentionManagerTest {
     when(pinotHelixResourceManager.getOfflineSegmentMetadata(OFFLINE_TABLE_NAME)).thenReturn(metadataList);
 
     ControllerConf conf = new ControllerConf();
+    ControllerMetrics controllerMetrics = new ControllerMetrics(new MetricsRegistry());
     conf.setRetentionControllerFrequencyInSeconds(0);
     conf.setDeletedSegmentsRetentionInDays(0);
-    RetentionManager retentionManager = new RetentionManager(pinotHelixResourceManager, conf);
+    RetentionManager retentionManager = new RetentionManager(pinotHelixResourceManager, conf, controllerMetrics);
     retentionManager.init();
     retentionManager.run();
 
@@ -206,9 +209,10 @@ public class RetentionManagerTest {
     setupPinotHelixResourceManager(tableConfig, removedSegments, pinotHelixResourceManager);
 
     ControllerConf conf = new ControllerConf();
+    ControllerMetrics controllerMetrics = new ControllerMetrics(new MetricsRegistry());
     conf.setRetentionControllerFrequencyInSeconds(0);
     conf.setDeletedSegmentsRetentionInDays(0);
-    RetentionManager retentionManager = new RetentionManager(pinotHelixResourceManager, conf);
+    RetentionManager retentionManager = new RetentionManager(pinotHelixResourceManager, conf, controllerMetrics);
     retentionManager.init();
     retentionManager.run();
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/controller/periodic/tasks/SegmentStatusCheckerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/controller/periodic/tasks/SegmentStatusCheckerIntegrationTest.java
@@ -175,8 +175,8 @@ public class SegmentStatusCheckerIntegrationTest extends BaseClusterIntegrationT
     ControllerMetrics controllerMetrics = _controllerStarter.getControllerMetrics();
 
     long millisToWait = TimeUnit.MILLISECONDS.convert(2, TimeUnit.MINUTES);
-    while (controllerMetrics.getValueOfGlobalGauge(ControllerGauge.SEGMENT_STATUS_CHECKER_NUM_TABLES_PROCESSED)
-        < NUM_TABLES && millisToWait > 0) {
+    while (controllerMetrics.getValueOfGlobalGauge(ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED,
+        "SegmentStatusChecker") < NUM_TABLES && millisToWait > 0) {
       try {
         Thread.sleep(1000);
         millisToWait -= 1000;
@@ -185,9 +185,8 @@ public class SegmentStatusCheckerIntegrationTest extends BaseClusterIntegrationT
       }
     }
 
-    Assert.assertEquals(
-        controllerMetrics.getValueOfGlobalGauge(ControllerGauge.SEGMENT_STATUS_CHECKER_NUM_TABLES_PROCESSED),
-        NUM_TABLES);
+    Assert.assertEquals(controllerMetrics.getValueOfGlobalGauge(ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED,
+        "SegmentStatusChecker"), NUM_TABLES);
 
     // empty table - table1_OFFLINE
     // num replicas set from ideal state

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/controller/periodic/tasks/SegmentStatusCheckerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/controller/periodic/tasks/SegmentStatusCheckerIntegrationTest.java
@@ -40,6 +40,8 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.integration.tests.BaseClusterIntegrationTestSet;
 import org.apache.pinot.integration.tests.ClusterIntegrationTestUtils;
 import org.apache.pinot.util.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -52,13 +54,18 @@ import org.testng.annotations.Test;
  */
 public class SegmentStatusCheckerIntegrationTest extends BaseClusterIntegrationTestSet {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentStatusCheckerIntegrationTest.class);
+
   private String emptyTable = "table1_OFFLINE";
   private String disabledOfflineTable = "table2_OFFLINE";
   private String basicOfflineTable = "table3_OFFLINE";
   private String errorOfflineTable = "table4_OFFLINE";
   private String realtimeTableErrorState = "table5_REALTIME";
+  private String _currentTableName;
+  private static final int NUM_TABLES = 5;
 
   private static final int SEGMENT_STATUS_CHECKER_INITIAL_DELAY_SECONDS = 60;
+  private static final int SEGMENT_STATUS_CHECKER_FREQ_SECONDS = 5;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -67,14 +74,13 @@ public class SegmentStatusCheckerIntegrationTest extends BaseClusterIntegrationT
     startZk();
 
     // Set initial delay of 60 seconds for the segment status checker, to allow time for tables setup.
-    // By default, it will pick a random delay between 120s and 300s
+    // Run at 5 seconds freq in order to keep it running, in case first run happens before table setup
     ControllerConf controllerConf = getDefaultControllerConfiguration();
     controllerConf.setStatusCheckerInitialDelayInSeconds(SEGMENT_STATUS_CHECKER_INITIAL_DELAY_SECONDS);
+    controllerConf.setStatusCheckerFrequencyInSeconds(SEGMENT_STATUS_CHECKER_FREQ_SECONDS);
 
     startController(controllerConf);
-
     startBroker();
-
     startServers(3);
 
     // empty table
@@ -107,9 +113,6 @@ public class SegmentStatusCheckerIntegrationTest extends BaseClusterIntegrationT
 
     // realtime table with segments in error state
     setupRealtimeTable(realtimeTableErrorState);
-
-    // we need to wait for SegmentStatusChecker to finish at least 1 run
-    Thread.sleep(TimeUnit.MILLISECONDS.convert(SEGMENT_STATUS_CHECKER_INITIAL_DELAY_SECONDS + 10, TimeUnit.SECONDS));
   }
 
   private void setupOfflineTable(String table) throws Exception {
@@ -119,6 +122,8 @@ public class SegmentStatusCheckerIntegrationTest extends BaseClusterIntegrationT
   }
 
   private void setupOfflineTableAndSegments(String table) throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+    setTableName(table);
     _realtimeTableConfig = null;
     addOfflineTable(table);
     completeTableConfiguration();
@@ -129,6 +134,8 @@ public class SegmentStatusCheckerIntegrationTest extends BaseClusterIntegrationT
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);
     uploadSegments(_tarDir);
+
+    waitForAllDocsLoaded(600_000L);
   }
 
   private void setupRealtimeTable(String table) throws Exception {
@@ -151,6 +158,14 @@ public class SegmentStatusCheckerIntegrationTest extends BaseClusterIntegrationT
     completeTableConfiguration();
   }
 
+  @Override
+  public String getTableName() {
+    return _currentTableName;
+  }
+
+  private void setTableName(String tableName) {
+    _currentTableName = tableName;
+  }
   /**
    * After 1 run of SegmentStatusChecker the controllerMetrics will be set for each table
    * Validate that we are seeing the expected numbers
@@ -158,6 +173,21 @@ public class SegmentStatusCheckerIntegrationTest extends BaseClusterIntegrationT
   @Test
   public void testSegmentStatusChecker() {
     ControllerMetrics controllerMetrics = _controllerStarter.getControllerMetrics();
+
+    long millisToWait = TimeUnit.MILLISECONDS.convert(2, TimeUnit.MINUTES);
+    while (controllerMetrics.getValueOfGlobalGauge(ControllerGauge.SEGMENT_STATUS_CHECKER_NUM_TABLES_PROCESSED)
+        < NUM_TABLES && millisToWait > 0) {
+      try {
+        Thread.sleep(1000);
+        millisToWait -= 1000;
+      } catch (InterruptedException e) {
+        LOGGER.info("Interrupted while waiting for SegmentStatusChecker");
+      }
+    }
+
+    Assert.assertEquals(
+        controllerMetrics.getValueOfGlobalGauge(ControllerGauge.SEGMENT_STATUS_CHECKER_NUM_TABLES_PROCESSED),
+        NUM_TABLES);
 
     // empty table - table1_OFFLINE
     // num replicas set from ideal state


### PR DESCRIPTION
SegmentStatusCheckerIntegrationTest fails unpredictably, depending on if the table creation and segment pushes take too long, resulting in SegmentStatusChecker running before the  table is setup.
Adding a ControllerGauge to track number of tables processed in each ControllerPeriodicTask (reset in preprocess, set to gauge in postprocess). Checking this metric in the integration test before beginning to test.