### PR TITLE
Pick up official release of jersey 2.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.9.8</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
-    <jersey.version>2.28-RC4</jersey.version>
+    <jersey.version>2.28</jersey.version>
     <swagger.version>1.5.10</swagger.version>
     <hadoop.version>2.7.0</hadoop.version>
     <antlr.version>4.6</antlr.version>


### PR DESCRIPTION
We were using a release candidate to make progress; now that the official release is out, this change picks it up.