### PR TITLE
[TE] rootcause - callgraph gui

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-callgraph-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-callgraph-table/component.js
@@ -71,9 +71,17 @@ export default Component.extend({
     if (_.isEmpty(metricUrn)) { return []; }
 
     const pageKeys = toFilters(metricUrn).filter(t => t[0] === 'page_key').map(t => t[2]);
-    if (_.isEmpty(pageKeys)) { return ['none']; }
 
     return pageKeys;
+  }),
+
+  /**
+   * Tracks presence of page keys
+   * @type {boolean}
+   */
+  hasPageKeys: computed('pageKeys', function () {
+    const { pageKeys } = getProperties(this, 'pageKeys');
+    return !_.isEmpty(pageKeys);
   }),
 
   /**
@@ -108,7 +116,12 @@ export default Component.extend({
    */
   _parse(value) {
     const f = parseFloat(value);
-    if (!Number.isNaN(f)) { return (f / 1000.0).toFixed(3); }
+    if (!Number.isNaN(f)) {
+      if (f >= 100) {
+        return Math.round(f);
+      }
+      return (f / 1000.0).toFixed(3);
+    }
     return value;
   },
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-callgraph-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-callgraph-table/component.js
@@ -1,0 +1,124 @@
+import { computed, getProperties, set } from '@ember/object';
+import Component from '@ember/component';
+import {
+  toFilters
+} from 'thirdeye-frontend/utils/rca-utils';
+import {
+  humanizeChange,
+  humanizeFloat
+} from 'thirdeye-frontend/utils/utils';
+import CALLGRAPH_TABLE_COLUMNS from 'thirdeye-frontend/shared/callgraphTableColumns';
+import _ from 'lodash';
+
+export default Component.extend({
+  classNames: ['rootcause-metrics'],
+
+  /**
+   * Columns for dimensions table
+   * @type {Array}
+   */
+  callgraphTableColumns: CALLGRAPH_TABLE_COLUMNS,
+
+  //
+  // external properties
+  //
+
+  /**
+   * Primary metric
+   * @type {string}
+   */
+  metricUrn: null,
+
+  /**
+   * Edges cache
+   * @type {object}
+   */
+  edges: null,
+
+  //
+  // internal properties
+  //
+
+  /**
+   * Tracks presence of callgraph edges
+   * @type {boolean}
+   */
+  hasEdges: computed('edges', function () {
+    const { edges } = getProperties(this, 'edges');
+    return !_.isEmpty(edges);
+  }),
+
+  /**
+   * Fabrics analyzed
+   * @type {array}
+   */
+  fabrics: computed('metricUrn', function () {
+    const { metricUrn } = getProperties(this, 'metricUrn');
+    if (_.isEmpty(metricUrn)) { return []; }
+
+    const fabrics = toFilters(metricUrn).filter(t => t[0] === 'data_center').map(t => t[2]);
+    if (_.isEmpty(fabrics)) { return ['all']; }
+
+    return fabrics;
+  }),
+
+  /**
+   * Page keys analyzed
+   * @type {array}
+   */
+  pageKeys: computed('metricUrn', function () {
+    const { metricUrn } = getProperties(this, 'metricUrn');
+    if (_.isEmpty(metricUrn)) { return []; }
+
+    const pageKeys = toFilters(metricUrn).filter(t => t[0] === 'page_key').map(t => t[2]);
+    if (_.isEmpty(pageKeys)) { return ['none']; }
+
+    return pageKeys;
+  }),
+
+  /**
+   * Data for metrics table
+   * @type {Array}
+   */
+  callgraphTableData: computed('edges', function() {
+    const { edges } = getProperties(this, 'edges');
+
+    if (_.isEmpty(edges)) { return []; }
+
+    return Object.keys(edges).map(edge =>
+      toFilters(edge).reduce((agg, t) => { agg[t[0]] = this._parse(t[2]); return agg; }, {}));
+  }),
+
+  /**
+   * Keeps track of items that are selected in the table
+   * @type {Array}
+   */
+  preselectedItems: computed({
+    get () {
+      return [];
+    },
+    set () {
+      // ignore
+    }
+  }),
+
+  /**
+   * Parse values heuristically as string or float
+   * @private
+   */
+  _parse(value) {
+    const f = parseFloat(value);
+    if (!Number.isNaN(f)) { return (f / 1000.0).toFixed(3); }
+    return value;
+  },
+
+  actions: {
+    /**
+     * Triggered on cell selection, ignored.
+     * @param {Object} e
+     */
+    displayDataChanged (e) {
+      // ignore
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-callgraph-table/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-callgraph-table/template.hbs
@@ -1,17 +1,33 @@
-<div class="col-xs-6">
-  <span class="rootcause-callgraph-label">Page Keys: </span>{{pageKeys}}
-</div>
 
-<div class="col-xs-6">
-  <span class="rootcause-callgraph-label">Fabrics: </span>{{fabrics}}
-</div>
+{{#if hasPageKeys}}
+  <ul class="list-unstyled">
+    <li><span class="rootcause-callgraph-label">Page Keys: </span>{{pageKeys}}</li>
+    <li><span class="rootcause-callgraph-label">Fabrics: </span>{{fabrics}}</li>
+  </ul>
 
-<div>
-  {{update-table
-    data=callgraphTableData
-    columns=callgraphTableColumns
-    preselectedItems=preselectedItems
-    showColumnsDropdown=false
-    showGlobalFilter=false
-  }}
-</div>
+  {{#if hasEdges}}
+    <div class="rootcause-callgraph-table">
+      {{update-table
+        data=callgraphTableData
+        columns=callgraphTableColumns
+        preselectedItems=preselectedItems
+        showColumnsDropdown=false
+        showGlobalFilter=false
+      }}
+    </div>
+
+  {{else}}
+    <div class="rootcause-alert alert alert-warning fade in">
+      No call graph data available for the selected page keys and time range.
+      You may need to expand the investigation period.
+    </div>
+    
+  {{/if}}
+
+{{else}}
+  <div class="rootcause-alert alert alert-warning fade in">
+    Call Graph analysis requires at least one active page key filter.
+    Please select a metric with a page key support, and select a page key filter to generate the report.
+  </div>
+
+{{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-callgraph-table/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-callgraph-table/template.hbs
@@ -1,0 +1,17 @@
+<div class="col-xs-6">
+  <span class="rootcause-callgraph-label">Page Keys: </span>{{pageKeys}}
+</div>
+
+<div class="col-xs-6">
+  <span class="rootcause-callgraph-label">Fabrics: </span>{{fabrics}}
+</div>
+
+<div>
+  {{update-table
+    data=callgraphTableData
+    columns=callgraphTableColumns
+    preselectedItems=preselectedItems
+    showColumnsDropdown=false
+    showGlobalFilter=false
+  }}
+</div>

--- a/thirdeye/thirdeye-frontend/app/pods/partials/rootcause/callgraph/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/partials/rootcause/callgraph/template.hbs
@@ -1,0 +1,10 @@
+{{#if isLoadingCallgraph}}
+  <div class="spinner-wrapper spinner-wrapper--card">
+    {{ember-spinner}}
+  </div>
+{{/if}}
+
+{{rootcause-callgraph-table
+  edges=edges
+  metricUrn=metricUrn
+}}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -174,6 +174,7 @@
                 {{#tablist.tab name="dimensions"}}Dimensions{{/tablist.tab}}
                 {{#tablist.tab name="events"}}Events{{/tablist.tab}}
                 {{#tablist.tab name="trend"}}Trend{{/tablist.tab}}
+                {{#tablist.tab name="callgraph"}}CallGraph{{/tablist.tab}}
               {{/tabs.tablist}}
               {{!-- metrics --}}
               {{#tabs.tabpanel name="metrics"}}
@@ -190,6 +191,10 @@
               {{!-- trend --}}
               {{#tabs.tabpanel name="trend"}}
                 {{partial 'partials/rootcause/trend'}}
+              {{/tabs.tabpanel}}
+              {{!-- callgraph --}}
+              {{#tabs.tabpanel name="callgraph"}}
+                {{partial 'partials/rootcause/callgraph'}}
               {{/tabs.tabpanel}}
             {{/shared/common-tabs}}
           </div>

--- a/thirdeye/thirdeye-frontend/app/pods/services/rootcause-callgraph-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/rootcause-callgraph-cache/service.js
@@ -1,0 +1,106 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import {
+  trimTimeRanges,
+  filterPrefix,
+  toBaselineRange,
+  toDimensionsUrn
+} from 'thirdeye-frontend/utils/rca-utils';
+import { checkStatus } from 'thirdeye-frontend/utils/utils';
+import _ from 'lodash';
+
+const ROOTCAUSE_CALLGRAPH_ENDPOINT = '/rootcause/query';
+const ROOTCAUSE_CALLGRAPH_PRIORITY = 15;
+
+export default Service.extend({
+  edges: null, // {}
+
+  context: null, // {}
+
+  pending: null, // Set
+
+  errors: null, // Set({ urn, error })
+
+  fetcher: service('services/rootcause-fetcher'),
+
+  init() {
+    this._super(...arguments);
+    this.setProperties({ edges: {}, context: {}, pending: new Set(), errors: new Set() });
+  },
+
+  clearErrors() {
+    this.setProperties({ errors: new Set() });
+  },
+
+  request(requestContext, urns) {
+    const { context } = this.getProperties('context');
+
+    const metrics = [...urns].filter(urn => urn.startsWith('thirdeye:metric:'));
+
+    if(_.isEqual(context, requestContext)) {
+      return;
+    }
+
+    // new analysis range: evict all, reload
+    this.get('fetcher').resetPrefix(ROOTCAUSE_CALLGRAPH_ENDPOINT);
+    this.setProperties({ context: _.cloneDeep(requestContext), edges: {}, pending: new Set(metrics) });
+
+    if (_.isEmpty(metrics)) {
+      return;
+    }
+
+    // call graph properties
+    const fetcher = this.get('fetcher');
+
+    const dimensionsUrns = [...metrics].map(toDimensionsUrn);
+
+    // TODO generalize replacement
+    const dimensionsUrnsModified = dimensionsUrns
+      .map(urn => urn.replace(/:data_center/, ':callee_fabric'))
+      .map(urn => urn.replace(/:fabric/, ':callee_fabric'))
+      .map(urn => urn.replace(/:service/, ':callee_container'))
+      .map(urn => urn.replace(/:data_center/, ':callee_fabric'));
+
+    const url = this._makeUrl('callgraph', requestContext, dimensionsUrnsModified);
+    fetcher.fetch(url, ROOTCAUSE_CALLGRAPH_PRIORITY)
+      .then(checkStatus)
+      .then(res => this._complete(requestContext, res))
+      .catch(error => this._handleError(urns, error));
+  },
+
+  _complete(requestContext, incoming) {
+    const { context } = this.getProperties('context');
+
+    if (!_.isEqual(context, requestContext)) {
+      return;
+    }
+
+    const edges = incoming.reduce((agg, e) => { agg[e.urn] = e; return agg; }, {});
+
+    this.setProperties({ edges, pending: new Set() });
+  },
+
+  _makeUrl(framework, context, urns) {
+    const urnString = filterPrefix(urns, 'thirdeye:dimensions:').join(',');
+    const ranges = trimTimeRanges(context.anomalyRange, context.analysisRange);
+
+    const baselineRange = toBaselineRange(ranges.anomalyRange, context.compareMode);
+    return `${ROOTCAUSE_CALLGRAPH_ENDPOINT}?framework=${framework}` +
+      `&anomalyStart=${ranges.anomalyRange[0]}&anomalyEnd=${ranges.anomalyRange[1]}` +
+      `&baselineStart=${baselineRange[0]}&baselineEnd=${baselineRange[1]}` +
+      `&analysisStart=${ranges.analysisRange[0]}&analysisEnd=${ranges.analysisRange[1]}` +
+      `&urns=${urnString}`;
+  },
+
+  _handleError(urns, error) {
+    const { errors, pending } = this.getProperties('errors', 'pending');
+
+    const newError = urns;
+    const newErrors = new Set([...errors, newError]);
+
+    const newPending = new Set(pending);
+    [...urns].forEach(urn => newPending.delete(urn));
+
+    this.setProperties({ errors: newErrors, pending: newPending });
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/shared/callgraphTableColumns.js
+++ b/thirdeye/thirdeye-frontend/app/shared/callgraphTableColumns.js
@@ -1,0 +1,23 @@
+// rootcause dimensions table columns
+export default [
+  {
+    propertyName: 'callee_container',
+    title: 'Container',
+    className: 'metrics-table__column metrics-table__column--text'
+  }, {
+    propertyName: 'callee_fabric',
+    title: 'Fabric',
+    className: 'metrics-table__column metrics-table__column--text'
+  }, {
+    propertyName: 'callee_api',
+    title: 'API',
+    className: 'metrics-table__column metrics-table__column--text'
+  }, {
+    propertyName: 'diffAverage',
+    title: 'Change in Avg. Latency',
+    disableFiltering: true,
+    className: 'metrics-table__column metrics-table__column--small',
+    sortDirection: 'desc',
+    sortPrecedence: 0
+  }
+];

--- a/thirdeye/thirdeye-frontend/app/shared/callgraphTableColumns.js
+++ b/thirdeye/thirdeye-frontend/app/shared/callgraphTableColumns.js
@@ -13,6 +13,11 @@ export default [
     title: 'API',
     className: 'metrics-table__column metrics-table__column--text'
   }, {
+    propertyName: 'currCount',
+    title: 'Traffic',
+    disableFiltering: true,
+    className: 'metrics-table__column metrics-table__column--small'
+  }, {
     propertyName: 'diffAverage',
     title: 'Change in Avg. Latency',
     disableFiltering: true,

--- a/thirdeye/thirdeye-frontend/app/styles/app.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/app.scss
@@ -56,6 +56,7 @@ body {
 @import 'components/rootcause-chart';
 @import 'components/rootcause-trend';
 @import 'components/rootcause-dimensions';
+@import 'components/rootcause-callgraph';
 @import 'components/alert-report-modal';
 @import 'components/te-radio';
 @import 'components/metrics-table';

--- a/thirdeye/thirdeye-frontend/app/styles/components/metrics-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/metrics-table.scss
@@ -1,6 +1,7 @@
 .metrics-table {
   &__column {
     vertical-align: middle !important; // override ember-models-table
+
     &--checkbox {
       width: 24px;
     }
@@ -10,8 +11,14 @@
       text-align: right;
     }
 
+    &--text {
+      width: 80px;
+      text-align: left;
+    }
+
     &--large {
       min-width: 200px;
+      text-align: left;
     }
   }
 

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-callgraph.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-callgraph.scss
@@ -1,3 +1,7 @@
 .rootcause-callgraph-label {
   font-weight: bold;
 }
+
+.rootcause-callgraph-table {
+  margin-top: 16px;
+}

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-callgraph.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-callgraph.scss
@@ -1,0 +1,3 @@
+.rootcause-callgraph-label {
+  font-weight: bold;
+}


### PR DESCRIPTION
Adds an additional **CallGraph** tab to the RCA UI that provides bare-bones visualization of call graph analysis results. This call graph UI integrates directly with data sets and metrics that support **page_key** and **fabric**/**datacenter** filters. The UI does not support time series visualization and selection toggling yet.