### PR TITLE
Remove unnecessary init from crypter

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -200,7 +200,6 @@ public class SegmentFetcherAndLoader {
       SegmentFetcherFactory.getInstance().getSegmentFetcherBasedOnURI(uri).fetchSegmentToLocal(uri, tempDownloadFile);
       if (crypter != null) {
         // TODO: We should not need to initialize crypter each time, instead Factory should have an initialized version ready.
-        crypter.init(_crypterConfig);
         crypter.decrypt(tempDownloadFile, tempTarFile);
       } else {
         tempTarFile = tempDownloadFile;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -199,7 +199,6 @@ public class SegmentFetcherAndLoader {
     try {
       SegmentFetcherFactory.getInstance().getSegmentFetcherBasedOnURI(uri).fetchSegmentToLocal(uri, tempDownloadFile);
       if (crypter != null) {
-        // TODO: We should not need to initialize crypter each time, instead Factory should have an initialized version ready.
         crypter.decrypt(tempDownloadFile, tempTarFile);
       } else {
         tempTarFile = tempDownloadFile;


### PR DESCRIPTION
* Crypter is initialized in controller/server starter, so we do not need to init it here. The problem with initing here is that there can be a possible race condition where we are trying to decrypt another segment but the keys will have disappeared since we have now introduced concurrent segment downloads