### PR TITLE
Modify Makefile for docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -51,7 +51,7 @@ help:
 
 .PHONY: clean
 clean:
-	rm -rf $(BUILDDIR)/*
+	rm -rf $(BUILDDIR)
 
 .PHONY: html
 html:


### PR DESCRIPTION
In order to avoid including "_build" directory for source code bundle,
this pr modifies the behavior of "make clean" to remove build directory.