### PR TITLE
Update pom files for preparing Apache release

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,12 +1,10 @@
-Apache Pinot (incubating) is an effort undergoing incubation at
-the Apache Software Foundation (ASF), sponsored by the Apache
-Incubator PMC.
+Apache Pinot (incubating) is an effort undergoing incubation at the Apache Software
+Foundation (ASF), sponsored by the Apache Incubator PMC.
 
-Incubation is required of all newly accepted projects until a
-further review indicates that the infrastructure, communications,
-and decision making process have stabilized in a manner consistent
-with other successful ASF projects.
+Incubation is required of all newly accepted projects until a further review
+indicates that the infrastructure, communications, and decision making process
+have stabilized in a manner consistent with other successful ASF projects.
 
-While incubation status is not necessarily a reflection of the
-completeness or stability of the code, it does indicate that the
-project has yet to be fully endorsed by the ASF.
+While incubation status is not necessarily a reflection of the completeness
+or stability of the code, it does indicate that the project has yet to be
+fully endorsed by the ASF.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Pinot (incubating)
-Copyright 2018 The Apache Software Foundation
+Copyright 2018-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/pinot-api/pom.xml
+++ b/pinot-api/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-api</artifactId>
-  <version>0.016</version>
   <name>Pinot API</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-azure-filesystem/pom.xml
+++ b/pinot-azure-filesystem/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-azure-filesystem</artifactId>
-  <version>0.016</version>
   <name>Pinot Azure Filesystem</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-broker</artifactId>
-  <version>0.016</version>
   <name>Pinot Broker</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-common</artifactId>
-  <version>0.016</version>
   <name>Pinot Common</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-controller</artifactId>
-  <version>0.016</version>
   <name>Pinot Controller</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-core</artifactId>
-  <version>0.016</version>
   <name>Pinot Core</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -24,7 +24,7 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>bin</id>
   <formats>
-    <format>zip</format>
+    <format>tar.gz</format>
     <format>dir</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
@@ -48,13 +48,28 @@
       </includes>
     </dependencySet>
   </dependencySets>
+
+  <files>
+    <!-- Rename LICENSE-binary, NOTICE-binary to LICENSE, NOTICE and include them to a distribution tarbell -->
+    <file>
+      <source>${pinot.root}/LICENSE-binary</source>
+      <destName>LICENSE</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/NOTICE-binary</source>
+      <destName>NOTICE</destName>
+    </file>
+    <!-- Include DISCLAIMER -->
+    <file>
+      <source>${pinot.root}/DISCLAIMER</source>
+    </file>
+  </files>
   <fileSets>
+    <!-- Rename liscenses-binary directory to licenses and include it to a distribution tarbell -->
     <fileSet>
-      <directory>${pinot.root}</directory>
-      <includes>
-        <include>LICENSE</include>
-      </includes>
-      <outputDirectory></outputDirectory>
+      <useDefaultExcludes>false</useDefaultExcludes>
+      <directory>${pinot.root}/licenses-binary</directory>
+      <outputDirectory>licenses</outputDirectory>
     </fileSet>
     <fileSet>
       <useDefaultExcludes>false</useDefaultExcludes>

--- a/pinot-distribution/pinot-source-assembly.xml
+++ b/pinot-distribution/pinot-source-assembly.xml
@@ -1,0 +1,47 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>source-release</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>${pinot.root}</directory>
+      <excludes>
+        <exclude>**/target/**</exclude>
+        <exclude>**/*.iml</exclude>
+        <exclude>**/*.ipr</exclude>
+        <exclude>**/*.iws</exclude>
+        <exclude>**/*.log</exclude>
+        <exclude>**/.idea/**</exclude>
+        <exclude>thirdeye/**</exclude>
+        <exclude>.travis*</exclude>
+        <exclude>.codecov*</exclude>
+        <exclude>.gitignore</exclude>
+        <exclude>contrib/**</exclude>
+      </excludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -22,13 +22,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-distribution</artifactId>
-  <version>0.016</version>
   <name>Pinot Distribution</name>
   <url>https://pinot.apache.org/</url>
   <properties>
@@ -89,66 +89,63 @@
       <artifactId>pinot-perf</artifactId>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <finalName>pinot-${project.version}-pkg</finalName>
-          <appendAssemblyId>false</appendAssemblyId>
-        </configuration>
-        <executions>
-          <execution>
-            <id>make-bundles</id>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <descriptors>
-                <descriptor>pinot-assembly.xml</descriptor>
-              </descriptors>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
   <profiles>
     <profile>
-      <id>github-release-profile</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <property>
-          <name>doGitHubRelease</name>
-          <value>true</value>
-        </property>
-      </activation>
+      <id>src-dist</id>
       <build>
         <plugins>
           <plugin>
-            <groupId>de.jutzig</groupId>
-            <artifactId>github-release-plugin</artifactId>
-            <version>1.1.1</version>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>source-release-assembly-pinot</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+                <configuration>
+                  <finalName>apache-pinot-incubating-${project.version}-src</finalName>
+                  <tarLongFileMode>posix</tarLongFileMode>
+                  <descriptors>
+                    <descriptor>${pinot.root}/pinot-distribution/pinot-source-assembly.xml</descriptor>
+                  </descriptors>
+                  <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>bin-dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
             <configuration>
-              <description></description>
-              <releaseName>SNAPSHOT ${maven.build.timestamp}</releaseName>
-              <tag>SNAPSHOT-${maven.build.timestamp}</tag>
-              <repositoryId>linkedin/pinot</repositoryId>
-              <artifact>${project.build.directory}/pinot-${project.version}-pkg.zip</artifact>
+              <finalName>apache-pinot-incubating-${project.version}-bin</finalName>
+              <appendAssemblyId>false</appendAssemblyId>
             </configuration>
             <executions>
               <execution>
-                <phase>install</phase>
+                <id>make-bundles</id>
                 <goals>
-                  <goal>release</goal>
+                  <goal>single</goal>
                 </goals>
+                <phase>package</phase>
+                <configuration>
+                  <descriptors>
+                    <descriptor>pinot-assembly.xml</descriptor>
+                  </descriptors>
+                </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
           </plugin>
         </plugins>
       </build>

--- a/pinot-filesystem/pom.xml
+++ b/pinot-filesystem/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-filesystem</artifactId>
-  <version>0.016</version>
   <name>Pinot Filesystem</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-hadoop-filesystem/pom.xml
+++ b/pinot-hadoop-filesystem/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-hadoop-filesystem</artifactId>
-  <version>0.016</version>
   <name>Pinot Hadoop Filesystem</name>
   <url>https://pinot.apache.org/</url>
   <properties>
@@ -75,7 +74,7 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-filesystem</artifactId>
-      <version>0.016</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pinot-hadoop/pom.xml
+++ b/pinot-hadoop/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-hadoop</artifactId>
-  <version>0.016</version>
   <name>Pinot Hadoop</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-integration-tests</artifactId>
-  <version>0.016</version>
   <name>Pinot Integration Tests</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-minion/pom.xml
+++ b/pinot-minion/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-minion</artifactId>
-  <version>0.016</version>
   <name>Pinot Minion</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-perf</artifactId>
-  <version>0.016</version>
   <name>Pinot Perf</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-server</artifactId>
-  <version>0.016</version>
   <name>Pinot Server</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-tools</artifactId>
-  <version>0.016</version>
   <name>Pinot Tools</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pinot-transport/pom.xml
+++ b/pinot-transport/pom.xml
@@ -25,10 +25,9 @@
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.016</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>pinot-transport</artifactId>
-  <version>0.016</version>
   <name>Pinot Transport</name>
   <url>https://pinot.apache.org/</url>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.pinot</groupId>
   <artifactId>pinot</artifactId>
-  <version>0.016</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Pinot</name>
   <description>A realtime distributed OLAP datastore</description>
@@ -89,7 +89,8 @@
     <developerConnection>scm:git:git://apache/incubator-pinot.git</developerConnection>
   </scm>
 
-  <inceptionYear>2014</inceptionYear>
+  <!-- Apache project inception year for generating correct NOTICE file for jar bundle. -->
+  <inceptionYear>2018</inceptionYear>
 
   <properties>
     <pinot.root>${basedir}</pinot.root>
@@ -433,7 +434,6 @@
         <artifactId>async-http-client</artifactId>
         <version>${async-http-client.version}</version>
       </dependency>
-
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
@@ -824,13 +824,15 @@
           <artifactId>maven-assembly-plugin</artifactId>
           <version>2.5.5</version>
         </plugin>
-
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.6</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.3</version>
+          <version>2.8</version>
         </plugin>
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
@@ -920,6 +922,13 @@
           <artifactId>license-maven-plugin</artifactId>
           <version>2.8</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <configuration>
+            <autoVersionSubmodules>true</autoVersionSubmodules>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -944,12 +953,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <!--
-      Configuration for unit/integration tests section 2 of 3 (plugins) STARTS HERE.
-      This is the core piece for being able to manage unit tests and
-      integration (='system') tests within Maven by using surefire.
-      See also: properties section and profiles section.
-     -->
+      <!--
+        Configuration for unit/integration tests section 2 of 3 (plugins) STARTS HERE.
+        This is the core piece for being able to manage unit tests and
+        integration (='system') tests within Maven by using surefire.
+        See also: properties section and profiles section.
+      -->
         <configuration>
           <testFailureIgnore>false</testFailureIgnore>
           <!-- Excludes integration tests when unit tests are run. -->
@@ -1058,8 +1067,9 @@
             <!-- Top level files -->
             <exclude>.codecov*</exclude>
             <exclude>HEADER</exclude>
-            <exclude>LICENSE</exclude>
-            <exclude>NOTICE</exclude>
+            <exclude>LICENSE*</exclude>
+            <exclude>NOTICE*</exclude>
+            <exclude>DISCLAIMER</exclude>
 
             <!-- js, css files that are exact copies of the third-party works. In this case, the original header has to
             be kept. Please refer to 'Treatment of Third-party works' in https://www.apache.org/legal/src-headers.html
@@ -1125,6 +1135,28 @@
             </filter>
           </filters>
         </configuration>
+      </plugin>
+      <!-- Include apache LICENSE, NOTICE, and DISCLAIMER files for jar resource bundle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-remote-resources-plugin</artifactId>
+        <version>1.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <projectName>Apache Pinot (incubating)</projectName>
+              </properties>
+              <resourceBundles>
+                <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
+                <resourceBundle>org.apache:apache-incubator-disclaimer-resource-bundle:1.1</resourceBundle>
+              </resourceBundles>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
1. Changed the version form "0.016" to "0.1.0-SNAPSHOT"
2. Added two profiles (-Psrc-dist, -Pbin-dist) for creating
   binary, source distribution tarbell. For bin-dist profile,
   LICENSE-binary, NOTICE-binary, and licenses-binary are
   included to a distribution tarbell after removing "-binary"
   from their names.
3. Added "maven-remote-resources-plugin" to include NOTICE,
   LICENSE, DISCLAIMER files in META-INF/ for jar bundle.

From now on, "mvn install -DskipTest" will only package the
projects into jars. In order to create a binary distribution
or source distribution, we will need to run the following
commands:

mvn install -Psrc-dist -DskipTests
mvn install -Pbin-dist -DskipTests
mvn install -Psrc-dist,bin-dist -DskipTests