### PR TITLE
Add maven-gpg-plugin and checksum-maven-plugin

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -85,6 +85,37 @@
       <artifactId>pinot-tools</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.nicoulaj.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>files</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <fileSets>
+            <fileSet>
+              <directory>${pinot.root}/pinot-distribution/target</directory>
+              <includes>
+                <include>*-src.tar.gz</include>
+                <include>*-bin.tar.gz</include>
+              </includes>
+            </fileSet>
+          </fileSets>
+          <failIfNoFiles>false</failIfNoFiles>
+          <algorithms>
+            <algorithm>SHA-512</algorithm>
+          </algorithms>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <profiles>
     <profile>
       <id>src-dist</id>
@@ -142,6 +173,27 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>sign</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
When we create an Apache release, we need to include
checksum file and the artifact has to be signed.
Running the following command will build source and
binary tarbells, sign them and generate checksums.

mvn install -Psrc-dist,bin-dist,sign -DskipTests

Output will be *.tar.gz, *.asc, *.sha512 files