### PR TITLE
[PINOT-4] Hardern DateTimeFormatSpecTest with locale

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/data/DateTimeFormatPatternSpec.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/data/DateTimeFormatPatternSpec.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.data;
 
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,6 +37,7 @@ public class DateTimeFormatPatternSpec {
   private static final int SDF_PATTERN_GROUP = 1;
   private static final int TIMEZONE_GROUP = 3;
   public static final DateTimeZone DEFAULT_DATETIMEZONE = DateTimeZone.UTC;
+  public static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
 
   private TimeFormat _timeFormat;
   private String _sdfPattern = null;
@@ -52,7 +54,7 @@ public class DateTimeFormatPatternSpec {
         String timezoneString = m.group(TIMEZONE_GROUP).trim();
         _dateTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timezoneString));
       }
-      _dateTimeFormatter = DateTimeFormat.forPattern(_sdfPattern).withZone(_dateTimeZone);
+      _dateTimeFormatter = DateTimeFormat.forPattern(_sdfPattern).withZone(_dateTimeZone).withLocale(DEFAULT_LOCALE);
     }
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/DateTimeFormatSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/DateTimeFormatSpecTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.data;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.data.DateTimeFieldSpec.TimeFormat;
@@ -106,9 +107,9 @@ public class DateTimeFormatSpecTest {
             1498892400000L)});
     entries.add(
         new Object[]{"1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a", 1498892400000L, String.class, DateTimeFormat
-            .forPattern("M/d/yyyy h:mm:ss a").withZoneUTC().print(1498892400000L)});
+            .forPattern("M/d/yyyy h:mm:ss a").withZoneUTC().withLocale(Locale.ENGLISH).print(1498892400000L)});
     entries.add(new Object[]{"1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h a", 1502066750000L, String.class, DateTimeFormat
-        .forPattern("M/d/yyyy h a").withZoneUTC().print(1502066750000L)});
+        .forPattern("M/d/yyyy h a").withZoneUTC().withLocale(Locale.ENGLISH).print(1502066750000L)});
     return entries.toArray(new Object[entries.size()][]);
   }
 


### PR DESCRIPTION
In DateTimeFormatSpecTest, there are tests like '8/7/2017 12:45:50 AM" which may be fail on machines with non-English locale settings..so result in the exception like `Invalid format: "8/7/2017 12:45:50 AM" is malformed at "AM"`.

Maybe it need to set Locale.ENGLISH as default Locale in DateTimeFormatPatternSpec. The more flexible way might be allow users set local.