### PR TITLE
[PINOT-5] make BitmapInvertedIndexTest Windows compatible

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -119,8 +119,11 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
         .of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
             PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_EXECUTE,
             PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE);
-
-    Files.setPosixFilePermissions(v3Directory.toPath(), permissions);
+    try {
+      Files.setPosixFilePermissions(v3Directory.toPath(), permissions);
+    } catch(UnsupportedOperationException ex) {
+      LOGGER.error("unsupported non-posix filesystem permissions setting");
+    }
   }
 
   private void copyIndexData(File v2Directory, SegmentMetadataImpl v2Metadata, File v3Directory)

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/BitmapInvertedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/BitmapInvertedIndexTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segments.v1.creator;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.net.URI;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
@@ -67,7 +68,8 @@ public class BitmapInvertedIndexTest {
     FileUtils.deleteQuietly(INDEX_DIR);
     URL resourceUrl = getClass().getClassLoader().getResource(AVRO_FILE_PATH);
     Assert.assertNotNull(resourceUrl);
-    _avroFile = new File(resourceUrl.getFile());
+    URI resourceUri = new URI(resourceUrl.toString());
+    _avroFile = new File(resourceUri);
 
     SegmentGeneratorConfig segmentGeneratorConfig =
         SegmentTestUtils.getSegmentGeneratorConfigWithoutTimeColumn(_avroFile, INDEX_DIR, "myTable");


### PR DESCRIPTION
BitmapInvertedIndexTest failed on windows caused by two places, one is that `resourceUrl` of `AVRO_FILE_PATH` contains '%5c' which was '\\' originally, the other is `Files.setPosixFilePermissions` which throws exception on windows