### PR TITLE
Fixing jackson dependency issues with swagger

### DIFF
--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -216,6 +216,12 @@
     <dependency>
         <groupId>org.webjars</groupId>
         <artifactId>swagger-ui</artifactId>
+      <exclusions>
+      <exclusion>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+      </exclusion>
+      </exclusions>
     </dependency>
     <!-- test -->
     <dependency>


### PR DESCRIPTION
* Swagger UI pulls in an old version of Jackson, failing our current build. 
* Checked snapshot build to make sure dependencies work