### PR TITLE
[PINOT-6] Fix Windows compatibility of a batch of pinot-core tests

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -85,7 +85,10 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
 
     File newLocation = SegmentDirectoryPaths.segmentDirectoryFor(v2SegmentDirectory, SegmentVersion.v3);
     LOGGER.info("v3 segment location for segment: {} is {}", v2Metadata.getName(), newLocation);
-    v3TempDirectory.renameTo(newLocation);
+
+    if (!v3TempDirectory.renameTo(newLocation)) {
+      LOGGER.error("cannot rename {} to {}", v3TempDirectory.getName(), newLocation.getName());
+    }
     deleteV2Files(v2SegmentDirectory);
   }
 
@@ -177,6 +180,9 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
     OutputStream v3StarTreeStream = v3DataWriter.starTreeOutputStream();
 
     IOUtils.copy(v2StarTreeStream, v3StarTreeStream);
+
+    v2StarTreeStream.close();
+    v3StarTreeStream.close();
   }
 
   private void copyDictionary(SegmentDirectory.Reader reader, SegmentDirectory.Writer writer, String column)

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -86,9 +86,7 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
     File newLocation = SegmentDirectoryPaths.segmentDirectoryFor(v2SegmentDirectory, SegmentVersion.v3);
     LOGGER.info("v3 segment location for segment: {} is {}", v2Metadata.getName(), newLocation);
 
-    if (!v3TempDirectory.renameTo(newLocation)) {
-      LOGGER.error("cannot rename {} to {}", v3TempDirectory.getName(), newLocation.getName());
-    }
+    v3TempDirectory.renameTo(newLocation);
     deleteV2Files(v2SegmentDirectory);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/MultipleTreesBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/MultipleTreesBuilder.java
@@ -135,6 +135,6 @@ public class MultipleTreesBuilder {
   }
 
   public void close() {
-	  _segment.destroy();
+    _segment.destroy();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/MultipleTreesBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/MultipleTreesBuilder.java
@@ -133,4 +133,8 @@ public class MultipleTreesBuilder {
       return new OffHeapSingleTreeBuilder(builderConfig, outputDir, segment, metadataProperties);
     }
   }
+
+  public void close() {
+	  _segment.destroy();
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/io/writer/impl/MmapMemoryManagerFileCleanupTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/io/writer/impl/MmapMemoryManagerFileCleanupTest.java
@@ -54,13 +54,14 @@ public class MmapMemoryManagerFileCleanupTest {
     final long allocAfterRestart = 200;
     try (PinotDataBufferMemoryManager memoryManager1 = new MmapMemoryManager(_tmpDir, segmentName)) {
       memoryManager1.allocate(firstAlloc, someColumn);
-      // Now, if the host restarts, we will have a file left behind for the same consuming segment.
-      // and we should not see any exception.
-      try (PinotDataBufferMemoryManager memoryManager2 = new MmapMemoryManager(_tmpDir, segmentName)) {
-        memoryManager2.allocate(allocAfterRestart, someColumn);
-        // We should not see the first allocation in the total.
-        Assert.assertEquals(memoryManager2.getTotalAllocatedBytes(), allocAfterRestart);
-      }
+    }
+
+    // Now, if the host restarts, we will have a file left behind for the same consuming segment.
+    // and we should not see any exception.
+    try (PinotDataBufferMemoryManager memoryManager2 = new MmapMemoryManager(_tmpDir, segmentName)) {
+      memoryManager2.allocate(allocAfterRestart, someColumn);
+      // We should not see the first allocation in the total.
+      Assert.assertEquals(memoryManager2.getTotalAllocatedBytes(), allocAfterRestart);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.plan.maker;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,7 +76,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     // Get resource file path.
     URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
     Assert.assertNotNull(resource);
-    String filePath = resource.getFile();
+    URI resourceUri = new URI(resource.toString());
 
     // Build the segment schema.
     Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable").addMetric("column1", FieldSpec.DataType.INT)
@@ -90,7 +91,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
 
     // Create the segment generator config.
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
-    segmentGeneratorConfig.setInputFilePath(filePath);
+    segmentGeneratorConfig.setInputFilePath(resourceUri.getPath());
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
@@ -116,7 +117,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
 
     // Create the segment generator config.
     segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
-    segmentGeneratorConfig.setInputFilePath(filePath);
+    segmentGeneratorConfig.setInputFilePath(resourceUri.getPath());
     segmentGeneratorConfig.setTableName("testTableStarTree");
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME_STARTREE);
     segmentGeneratorConfig.setOutDir(INDEX_DIR_STARTREE.getAbsolutePath());

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/ColumnMetadataTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/ColumnMetadataTest.java
@@ -159,6 +159,7 @@ public class ColumnMetadataTest {
 
     // Make sure we got the creator name as well.
     String creatorName = metadata.getCreatorName();
+    segment.destroy();
     Assert.assertEquals(creatorName, CREATOR_VERSION);
   }
 
@@ -178,6 +179,7 @@ public class ColumnMetadataTest {
 
     // Make sure we get null for creator name.
     String creatorName = metadata.getCreatorName();
+    segment.destroy();
     Assert.assertEquals(creatorName, null);
   }
 
@@ -197,6 +199,7 @@ public class ColumnMetadataTest {
 
     // Make sure we get null for creator name.
     char paddingCharacter = metadata.getPaddingCharacter();
+    segment.destroy();
     Assert.assertEquals(paddingCharacter, '\0');
   }
 
@@ -220,6 +223,7 @@ public class ColumnMetadataTest {
       StarTreeMetadata starTreeMetadata = metadata.getStarTreeMetadata();
       Assert.assertNotNull(starTreeMetadata);
       ColumnMetadata column = metadata.getColumnMetadataFor("column7_hllSuffix");
+      segment.destroy();
       Assert.assertEquals(column.getDerivedMetricType(), MetricFieldSpec.DerivedMetricType.HLL);
       Assert.assertEquals(column.getOriginColumnName(), "column7");
     } finally {

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/OffHeapStarTreeBuilderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/OffHeapStarTreeBuilderTest.java
@@ -101,6 +101,7 @@ public class OffHeapStarTreeBuilderTest {
       }
     }
 
+    builder.close();
     FileUtils.deleteDirectory(TEMP_DIR);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/OffHeapStarTreeBuilderWithHllFieldTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/OffHeapStarTreeBuilderWithHllFieldTest.java
@@ -150,6 +150,7 @@ public class OffHeapStarTreeBuilderWithHllFieldTest {
     assertApproximation(HllUtil.convertStringToHll((String) lastRow.getValue(hllMetricName)).cardinality(),
         preciseCardinality, 0.1);
 
+    builder.close();
     FileUtils.deleteDirectory(TEMP_DIR);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -141,7 +141,9 @@ abstract class BaseStarTreeV2Test<R, A> {
 
     // Randomly build star-tree using on-heap or off-heap mode
     BuildMode buildMode = RANDOM.nextBoolean() ? BuildMode.ON_HEAP : BuildMode.OFF_HEAP;
-    new MultipleTreesBuilder(Collections.singletonList(starTreeV2BuilderConfig), indexDir, buildMode).build();
+    MultipleTreesBuilder builder = new MultipleTreesBuilder(Collections.singletonList(starTreeV2BuilderConfig), indexDir, buildMode);
+    builder.build();
+    builder.close();
 
     _indexSegment = ImmutableSegmentLoader.load(indexDir, ReadMode.mmap);
     _starTreeV2 = _indexSegment.getStarTrees().get(0);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.queries;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -82,7 +83,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
     // Get resource file path.
     URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
     Assert.assertNotNull(resource);
-    String filePath = resource.getFile();
+    URI resourceUri = new URI(resource.toString());
 
     // Build the segment schema.
     Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable").addMetric("column1", FieldSpec.DataType.INT)
@@ -96,7 +97,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
 
     // Create the segment generator config.
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
-    segmentGeneratorConfig.setInputFilePath(filePath);
+    segmentGeneratorConfig.setInputFilePath(resourceUri.getPath());
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
     segmentGeneratorConfig.setInvertedIndexCreationColumns(Arrays.asList("column3", "column7", "column8", "column9"));

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.queries;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -83,7 +84,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
     // Get resource file path.
     URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
     Assert.assertNotNull(resource);
-    String filePath = resource.getFile();
+    URI resourceUri = new URI(resource.toString());
 
     // Build the segment schema.
     Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable").addMetric("column1", FieldSpec.DataType.INT)
@@ -98,7 +99,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
 
     // Create the segment generator config.
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
-    segmentGeneratorConfig.setInputFilePath(filePath);
+    segmentGeneratorConfig.setInputFilePath(resourceUri.getPath());
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
     segmentGeneratorConfig

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.queries;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -212,7 +213,7 @@ public class FastHllQueriesTest extends BaseQueriesTest {
       resource = getClass().getClassLoader().getResource(AVRO_DATA_WITHOUT_PRE_GENERATED_HLL_COLUMNS);
     }
     Assert.assertNotNull(resource);
-    String filePath = resource.getFile();
+    URI resourceUri = new URI(resource.toString());
 
     // Build the segment schema
     Schema.SchemaBuilder schemaBuilder =
@@ -232,7 +233,7 @@ public class FastHllQueriesTest extends BaseQueriesTest {
 
     // Create the segment generator config
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schemaBuilder.build());
-    segmentGeneratorConfig.setInputFilePath(filePath);
+    segmentGeneratorConfig.setInputFilePath(resourceUri.getPath());
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
     segmentGeneratorConfig

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/OnHeapDictionariesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/OnHeapDictionariesTest.java
@@ -91,6 +91,8 @@ public class OnHeapDictionariesTest {
   @AfterClass
   public void tearDown()
       throws IOException {
+    _offHeapSegment.destroy();
+    _onHeapSegment.destroy();
     FileUtils.deleteDirectory(new File(SEGMENT_DIR_NAME));
   }
 


### PR DESCRIPTION
This PR fixes Windows compatibility of a batch of pinot-core tests. These batch of tests are generally about that file stream etc resources do not close or file path compatible.
There are still several tests need to be investigated more deeply such as `PinotDataBufferTest(maybe related with xerial mmap)`, `CountStarTreeV2Test(Windows '*' filename)`, `FixedByteWidthRowColDataFileWriterTest(special chars)` etc...
