### PR TITLE
[PINOT-7] Add Remainder TransformFunction and test

### DIFF
--- a/docs/pql_examples.rst
+++ b/docs/pql_examples.rst
@@ -202,6 +202,9 @@ Supported transform functions
 ``DIV``
    Quotient of two values
 
+``MOD``
+   Remainder between two values
+
 ``TIMECONVERT``
    Takes 3 arguments, converts the value into another time unit. E.g. ``TIMECONVERT(time, 'MILLISECONDS', 'SECONDS')``
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RemainderTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RemainderTransformFunction.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.util.ArrayCopyUtils;
+
+
+public class RemainderTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "mod";
+
+  private double _firstLiteral;
+  private TransformFunction _firstTransformFunction;
+  private double _secondLiteral;
+  private TransformFunction _secondTransformFunction;
+  private double[] _remainders;
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+    // Check that there are exactly 2 arguments
+    if (arguments.size() != 2) {
+      throw new IllegalArgumentException("Exactly 2 arguments are required for MOD transform function");
+    }
+
+    TransformFunction firstArgument = arguments.get(0);
+    if (firstArgument instanceof LiteralTransformFunction) {
+      _firstLiteral = Double.parseDouble(((LiteralTransformFunction) firstArgument).getLiteral());
+    } else {
+      if (!firstArgument.getResultMetadata().isSingleValue()) {
+        throw new IllegalArgumentException("First argument of MOD transform function must be single-valued");
+      }
+      _firstTransformFunction = firstArgument;
+    }
+
+    TransformFunction secondArgument = arguments.get(1);
+    if (secondArgument instanceof LiteralTransformFunction) {
+      _secondLiteral = Double.parseDouble(((LiteralTransformFunction) secondArgument).getLiteral());
+    } else {
+      if (!secondArgument.getResultMetadata().isSingleValue()) {
+        throw new IllegalArgumentException("Second argument of MOD transform function must be single-valued");
+      }
+      _secondTransformFunction = secondArgument;
+    }
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return DOUBLE_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @SuppressWarnings("Duplicates")
+  @Override
+  public double[] transformToDoubleValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+    if (_remainders == null) {
+      _remainders = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+
+    int length = projectionBlock.getNumDocs();
+
+    if (_firstTransformFunction == null) {
+      Arrays.fill(_remainders, 0, length, _firstLiteral);
+    } else {
+      switch (_firstTransformFunction.getResultMetadata().getDataType()) {
+        case INT:
+          int[] intValues = _firstTransformFunction.transformToIntValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(intValues, _remainders, length);
+          break;
+        case LONG:
+          long[] longValues = _firstTransformFunction.transformToLongValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(longValues, _remainders, length);
+          break;
+        case FLOAT:
+          float[] floatValues = _firstTransformFunction.transformToFloatValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(floatValues, _remainders, length);
+          break;
+        case DOUBLE:
+          double[] doubleValues = _firstTransformFunction.transformToDoubleValuesSV(projectionBlock);
+          System.arraycopy(doubleValues, 0, _remainders, 0, length);
+          break;
+        case STRING:
+          String[] stringValues = _firstTransformFunction.transformToStringValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(stringValues, _remainders, length);
+          break;
+        default:
+          throw new UnsupportedOperationException();
+      }
+    }
+
+    if (_secondTransformFunction == null) {
+      for (int i = 0; i < length; i++) {
+        _remainders[i] %= _secondLiteral;
+      }
+    } else {
+      switch (_secondTransformFunction.getResultMetadata().getDataType()) {
+        case INT:
+          int[] intValues = _secondTransformFunction.transformToIntValuesSV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            _remainders[i] %= intValues[i];
+          }
+          break;
+        case LONG:
+          long[] longValues = _secondTransformFunction.transformToLongValuesSV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            _remainders[i] %= longValues[i];
+          }
+          break;
+        case FLOAT:
+          float[] floatValues = _secondTransformFunction.transformToFloatValuesSV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            _remainders[i] %= floatValues[i];
+          }
+          break;
+        case DOUBLE:
+          double[] doubleValues = _secondTransformFunction.transformToDoubleValuesSV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            _remainders[i] %= doubleValues[i];
+          }
+          break;
+        case STRING:
+          String[] stringValues = _secondTransformFunction.transformToStringValuesSV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            _remainders[i] %= Double.parseDouble(stringValues[i]);
+          }
+          break;
+        default:
+          throw new UnsupportedOperationException();
+      }
+    }
+
+    return _remainders;
+  }
+}
+

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RemainderTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RemainderTransformFunction.java
@@ -28,7 +28,11 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.util.ArrayCopyUtils;
 
-
+/**
+ * MOD(Remainder) transform function, takes exactly 2 arguments which could have types of
+ * INT, LONG, FLOAT, DOUBLE or STRING. For STRING type, it needs to be parsed as double,
+ * otherwise it will throw {@link NumberFormatException}
+ */
 public class RemainderTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "mod";
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -44,11 +44,11 @@ public class TransformFunctionFactory {
           put(SubtractionTransformFunction.FUNCTION_NAME.toLowerCase(), SubtractionTransformFunction.class);
           put(MultiplicationTransformFunction.FUNCTION_NAME.toLowerCase(), MultiplicationTransformFunction.class);
           put(DivisionTransformFunction.FUNCTION_NAME.toLowerCase(), DivisionTransformFunction.class);
+          put(RemainderTransformFunction.FUNCTION_NAME.toLowerCase(), RemainderTransformFunction.class);
           put(TimeConversionTransformFunction.FUNCTION_NAME.toLowerCase(), TimeConversionTransformFunction.class);
           put(DateTimeConversionTransformFunction.FUNCTION_NAME.toLowerCase(),
               DateTimeConversionTransformFunction.class);
           put(ValueInTransformFunction.FUNCTION_NAME.toLowerCase(), ValueInTransformFunction.class);
-          put(RemainderTransformFunction.FUNCTION_NAME.toLowerCase(), RemainderTransformFunction.class);
         }
       };
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -48,6 +48,7 @@ public class TransformFunctionFactory {
           put(DateTimeConversionTransformFunction.FUNCTION_NAME.toLowerCase(),
               DateTimeConversionTransformFunction.class);
           put(ValueInTransformFunction.FUNCTION_NAME.toLowerCase(), ValueInTransformFunction.class);
+          put(RemainderTransformFunction.FUNCTION_NAME.toLowerCase(), RemainderTransformFunction.class);
         }
       };
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RemainderTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RemainderTransformFunctionTest.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class RemainderTransformFunctionTest extends BaseTransformFunctionTest {
+
+  @Test
+  public void testRemainderTransformFunction() {
+    TransformExpressionTree expression =
+        TransformExpressionTree.compileToExpressionTree(String.format("mod(%s,%s)", LONG_SV_COLUMN, INT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RemainderTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), RemainderTransformFunction.FUNCTION_NAME);
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = (double) _longSVValues[i] % (double) _intSVValues[i];
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression =
+        TransformExpressionTree.compileToExpressionTree(String.format("mod(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RemainderTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = (double) _longSVValues[i] % (double) _floatSVValues[i];
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression =
+        TransformExpressionTree.compileToExpressionTree(String.format("mod(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RemainderTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = (double) _floatSVValues[i] % _doubleSVValues[i];
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = TransformExpressionTree
+        .compileToExpressionTree(String.format("mod(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RemainderTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _doubleSVValues[i] % Double.parseDouble(_stringSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression =
+        TransformExpressionTree.compileToExpressionTree(String.format("mod(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RemainderTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Double.parseDouble(_stringSVValues[i]) % (double) _intSVValues[i];
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = TransformExpressionTree.compileToExpressionTree(String
+        .format("mod(mod(mod(mod(mod(12,%s),%s),mod(mod(%s,%s),0.34)),%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
+            FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RemainderTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = (((((12d % Double.parseDouble(_stringSVValues[i])) % _doubleSVValues[i]) % (
+          ((double) _floatSVValues[i] % (double) _longSVValues[i]) % 0.34)) % (double) _intSVValues[i])
+          % _doubleSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
+  public void testIllegalArguments(String expressionStr) {
+    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    TransformFunctionFactory.get(expression, _dataSourceMap);
+  }
+
+  @DataProvider(name = "testIllegalArguments")
+  public Object[][] testIllegalArguments() {
+    return new Object[][]{new Object[]{String.format("mod(%s)", INT_SV_COLUMN)}, new Object[]{String.format(
+        "mod(%s, %s)", INT_MV_COLUMN, LONG_SV_COLUMN)}, new Object[]{String.format("mod(%s, %s)", LONG_SV_COLUMN,
+        INT_MV_COLUMN)}};
+  }
+}


### PR DESCRIPTION
Pinot has ADD, SUB, MULT, DIV binary transform functions right now, MOD(remainder) is another commonly used binary operators. It maybe an improvement to support mod operator. This PR adds RemainderTransformFunction and test.

The updates are:
* add `RemainderTransformFunction.java`
* add `RemainderTransformFunctionTest.java`
* add `MOD` doc in pql_examples.rst