### PR TITLE
Refactor periodic task

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -56,6 +56,8 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   // Introducing a new stream agnostic metric to replace LLC_KAFKA_DATA_LOSS.
   // We can phase out LLC_KAFKA_DATA_LOSS once we have collected sufficient metrics for the new one
   LLC_STREAM_DATA_LOSS("dataLoss", false),
+  CONTROLLER_PERIODIC_TASK_RUN("periodicTaskRun", false),
+  CONTROLLER_PERIODIC_TASK_ERROR("periodicTaskError", false),
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),
   NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.config.PinotTaskConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableTaskConfig;
@@ -44,21 +43,16 @@ import org.slf4j.LoggerFactory;
  * <p><code>PinotTaskManager</code> is also responsible for checking the health status on each type of tasks, detect and
  * fix issues accordingly.
  */
-public class PinotTaskManager extends ControllerPeriodicTask {
+public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotTaskManager.class);
 
   private final PinotHelixTaskResourceManager _helixTaskResourceManager;
   private final ClusterInfoProvider _clusterInfoProvider;
   private final TaskGeneratorRegistry _taskGeneratorRegistry;
 
-  private Map<String, List<TableConfig>> _enabledTableConfigMap;
-  private Set<String> _taskTypes;
-  private int _numTaskTypes;
-  private Map<String, String> _tasksScheduled;
-
-  public PinotTaskManager(@Nonnull PinotHelixTaskResourceManager helixTaskResourceManager,
-      @Nonnull PinotHelixResourceManager helixResourceManager, @Nonnull ControllerConf controllerConf,
-      @Nonnull ControllerMetrics controllerMetrics) {
+  public PinotTaskManager(PinotHelixTaskResourceManager helixTaskResourceManager,
+      PinotHelixResourceManager helixResourceManager, ControllerConf controllerConf,
+      ControllerMetrics controllerMetrics) {
     super("PinotTaskManager", controllerConf.getTaskManagerFrequencyInSeconds(),
         controllerConf.getPeriodicTaskInitialDelayInSeconds(), helixResourceManager, controllerMetrics);
     _helixTaskResourceManager = helixTaskResourceManager;
@@ -66,112 +60,109 @@ public class PinotTaskManager extends ControllerPeriodicTask {
     _taskGeneratorRegistry = new TaskGeneratorRegistry(_clusterInfoProvider);
   }
 
-  @Override
-  protected void initTask() {
-
-  }
-
   /**
-   * Get the cluster info provider.
-   * <p>Cluster info provider might be needed to initialize task generators.
+   * Returns the cluster info provider.
+   * <p>
+   * Cluster info provider might be useful when initializing task generators.
    *
    * @return Cluster info provider
    */
-  @Nonnull
   public ClusterInfoProvider getClusterInfoProvider() {
     return _clusterInfoProvider;
   }
 
   /**
-   * Register a task generator.
-   * <p>This is for pluggable task generators.
+   * Registers a task generator.
+   * <p>
+   * This method can be used to plug in custom task generators.
    *
    * @param pinotTaskGenerator Task generator to be registered
    */
-  public void registerTaskGenerator(@Nonnull PinotTaskGenerator pinotTaskGenerator) {
+  public void registerTaskGenerator(PinotTaskGenerator pinotTaskGenerator) {
     _taskGeneratorRegistry.registerTaskGenerator(pinotTaskGenerator);
   }
 
   /**
    * Public API to schedule tasks. It doesn't matter whether current pinot controller is leader.
    */
-  public Map<String, String> scheduleTasks() {
-    process(_pinotHelixResourceManager.getAllTables());
-    return getTasksScheduled();
+  public synchronized Map<String, String> scheduleTasks() {
+    Map<String, String> tasksScheduled = scheduleTasks(_pinotHelixResourceManager.getAllTables());
+
+    // For non-leader controller, perform non-leader cleanup
+    if (!isStarted()) {
+      nonLeaderCleanUp();
+    }
+    return tasksScheduled;
   }
 
-  @Override
-  protected void preprocess() {
-    _metricsRegistry.addMeteredGlobalValue(ControllerMeter.NUMBER_TIMES_SCHEDULE_TASKS_CALLED, 1L);
+  /**
+   * Check the Pinot cluster status and schedule new tasks for the given tables.
+   *
+   * @param tableNamesWithType List of table names with type suffix
+   * @return Map from task type to task scheduled
+   */
+  private Map<String, String> scheduleTasks(List<String> tableNamesWithType) {
+    _controllerMetrics.addMeteredGlobalValue(ControllerMeter.NUMBER_TIMES_SCHEDULE_TASKS_CALLED, 1L);
 
-    _taskTypes = _taskGeneratorRegistry.getAllTaskTypes();
-    _numTaskTypes = _taskTypes.size();
-    _enabledTableConfigMap = new HashMap<>(_numTaskTypes);
+    Set<String> taskTypes = _taskGeneratorRegistry.getAllTaskTypes();
+    int numTaskTypes = taskTypes.size();
+    Map<String, List<TableConfig>> enabledTableConfigMap = new HashMap<>(numTaskTypes);
 
-    for (String taskType : _taskTypes) {
-      _enabledTableConfigMap.put(taskType, new ArrayList<>());
+    for (String taskType : taskTypes) {
+      enabledTableConfigMap.put(taskType, new ArrayList<>());
 
       // Ensure all task queues exist
       _helixTaskResourceManager.ensureTaskQueueExists(taskType);
     }
-  }
 
-  @Override
-  protected void processTable(String tableNameWithType) {
-    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-    if (tableConfig != null) {
-      TableTaskConfig taskConfig = tableConfig.getTaskConfig();
-      if (taskConfig != null) {
-        for (String taskType : _taskTypes) {
-          if (taskConfig.isTaskTypeEnabled(taskType)) {
-            _enabledTableConfigMap.get(taskType).add(tableConfig);
+    // Scan all table configs to get the tables with tasks enabled
+    for (String tableNameWithType : tableNamesWithType) {
+      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+      if (tableConfig != null) {
+        TableTaskConfig taskConfig = tableConfig.getTaskConfig();
+        if (taskConfig != null) {
+          for (String taskType : taskTypes) {
+            if (taskConfig.isTaskTypeEnabled(taskType)) {
+              enabledTableConfigMap.get(taskType).add(tableConfig);
+            }
           }
         }
       }
     }
-  }
 
-  @Override
-  protected void exceptionHandler(String tableNameWithType, Exception e) {
-    LOGGER.error("Exception in PinotTaskManager for table {}", tableNameWithType, e);
-  }
-
-  @Override
-  protected void postprocess() {
     // Generate each type of tasks
-    _tasksScheduled = new HashMap<>(_numTaskTypes);
-    for (String taskType : _taskTypes) {
+    Map<String, String> tasksScheduled = new HashMap<>(numTaskTypes);
+    for (String taskType : taskTypes) {
       LOGGER.info("Generating tasks for task type: {}", taskType);
       PinotTaskGenerator pinotTaskGenerator = _taskGeneratorRegistry.getTaskGenerator(taskType);
-      List<PinotTaskConfig> pinotTaskConfigs = pinotTaskGenerator.generateTasks(_enabledTableConfigMap.get(taskType));
+      List<PinotTaskConfig> pinotTaskConfigs = pinotTaskGenerator.generateTasks(enabledTableConfigMap.get(taskType));
       int numTasks = pinotTaskConfigs.size();
       if (numTasks > 0) {
         LOGGER
             .info("Submitting {} tasks for task type: {} with task configs: {}", numTasks, taskType, pinotTaskConfigs);
-        _tasksScheduled.put(taskType, _helixTaskResourceManager
+        tasksScheduled.put(taskType, _helixTaskResourceManager
             .submitTask(pinotTaskConfigs, pinotTaskGenerator.getNumConcurrentTasksPerInstance()));
-        _metricsRegistry.addMeteredTableValue(taskType, ControllerMeter.NUMBER_TASKS_SUBMITTED, numTasks);
+        _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_TASKS_SUBMITTED, numTasks);
       }
     }
+
+    return tasksScheduled;
   }
 
-  /**
-   * Returns the tasks that have been scheduled as part of the postprocess
-   * @return
-   */
-  private Map<String, String> getTasksScheduled() {
-    return _tasksScheduled;
-  }
-
-  /**
-   * Performs necessary cleanups (e.g. remove metrics) when the controller leadership changes.
-   */
-  @Override
-  public void stopTask() {
-    LOGGER.info("Perform task cleanups.");
-    // Performs necessary cleanups for each task type.
+  private void nonLeaderCleanUp() {
+    LOGGER.info("Performing non-leader cleanups");
     for (String taskType : _taskGeneratorRegistry.getAllTaskTypes()) {
       _taskGeneratorRegistry.getTaskGenerator(taskType).nonLeaderCleanUp();
     }
+  }
+
+  @Override
+  protected void processTables(List<String> tableNamesWithType) {
+    scheduleTasks(tableNamesWithType);
+  }
+
+  @Override
+  public void cleanUpTask() {
+    nonLeaderCleanUp();
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -34,7 +34,6 @@ import org.apache.pinot.common.config.RealtimeTagConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metrics.ControllerMetrics;
-import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.common.utils.retry.RetryPolicies;
 import org.apache.pinot.common.utils.time.TimeUtils;
@@ -53,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * We only relocate segments for realtime tables, and only if tenant config indicates that relocation is required
  * A segment will be relocated, one replica at a time, once all of its replicas are in ONLINE state and all/some are on servers other than completed servers
  */
-public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
+public class RealtimeSegmentRelocator extends ControllerPeriodicTask<Void> {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentRelocator.class);
 
   public RealtimeSegmentRelocator(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf config,
@@ -63,29 +62,10 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
   }
 
   @Override
-  protected void initTask() {
-
-  }
-
-  @Override
-  protected void preprocess() {
-  }
-
-  @Override
   protected void processTable(String tableNameWithType) {
-    CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-    if (tableType == CommonConstants.Helix.TableType.REALTIME) {
+    if (TableNameBuilder.REALTIME.tableHasTypeSuffix(tableNameWithType)) {
       runRelocation(tableNameWithType);
     }
-  }
-
-  @Override
-  protected void postprocess() {
-  }
-
-  @Override
-  protected void exceptionHandler(String tableNameWithType, Exception e) {
-    LOGGER.error("Exception in relocating realtime segments of table {}", tableNameWithType, e);
   }
 
   /**
@@ -276,10 +256,5 @@ public class RealtimeSegmentRelocator extends ControllerPeriodicTask {
       throw new RuntimeException("Invalid time spec '" + timeStr + "' (Valid examples: '3h', '4h30m', '30m')", e);
     }
     return seconds;
-  }
-
-  @Override
-  public void stopTask() {
-
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * The <code>RetentionManager</code> class manages retention for all segments and delete expired segments.
  * <p>It is scheduled to run only on leader controller.
  */
-public class RetentionManager extends ControllerPeriodicTask {
+public class RetentionManager extends ControllerPeriodicTask<Void> {
   public static final long OLD_LLC_SEGMENTS_RETENTION_IN_MILLIS = TimeUnit.DAYS.toMillis(5L);
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RetentionManager.class);
@@ -65,15 +65,6 @@ public class RetentionManager extends ControllerPeriodicTask {
   }
 
   @Override
-  protected void initTask() {
-
-  }
-
-  @Override
-  protected void preprocess() {
-  }
-
-  @Override
   protected void processTable(String tableNameWithType) {
     LOGGER.info("Start managing retention for table: {}", tableNameWithType);
     manageRetentionForTable(tableNameWithType);
@@ -83,11 +74,6 @@ public class RetentionManager extends ControllerPeriodicTask {
   protected void postprocess() {
     LOGGER.info("Removing aged (more than {} days) deleted segments for all tables", _deletedSegmentsRetentionInDays);
     _pinotHelixResourceManager.getSegmentDeletionManager().removeAgedDeletedSegments(_deletedSegmentsRetentionInDays);
-  }
-
-  @Override
-  protected void exceptionHandler(String tableNameWithType, Exception e) {
-    LOGGER.error("Caught exception while managing retention for table: {}", tableNameWithType, e);
   }
 
   private void manageRetentionForTable(String tableNameWithType) {
@@ -189,10 +175,5 @@ public class RetentionManager extends ControllerPeriodicTask {
       return states.size() == 1 && states
           .contains(CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.OFFLINE);
     }
-  }
-
-  @Override
-  public void stopTask() {
-
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * Manages the segment validation metrics, to ensure that all offline segments are contiguous (no missing segments) and
  * that the offline push delay isn't too high.
  */
-public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask {
+public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask<Void> {
   private static final Logger LOGGER = LoggerFactory.getLogger(OfflineSegmentIntervalChecker.class);
 
   private final ValidationMetrics _validationMetrics;
@@ -53,10 +53,6 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask {
     super("OfflineSegmentIntervalChecker", config.getOfflineSegmentIntervalCheckerFrequencyInSeconds(),
         config.getPeriodicTaskInitialDelayInSeconds(), pinotHelixResourceManager, controllerMetrics);
     _validationMetrics = validationMetrics;
-  }
-
-  @Override
-  protected void preprocess() {
   }
 
   @Override
@@ -206,21 +202,7 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask {
   }
 
   @Override
-  protected void postprocess() {
-  }
-
-  @Override
-  protected void exceptionHandler(String tableNameWithType, Exception e) {
-    LOGGER.warn("Caught exception while checking offline segment intervals for table: {}", tableNameWithType, e);
-  }
-
-  @Override
-  protected void initTask() {
-
-  }
-
-  @Override
-  public void stopTask() {
+  public void cleanUpTask() {
     LOGGER.info("Unregister all the validation metrics.");
     _validationMetrics.unregisterAllMetrics();
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -87,7 +87,7 @@ public class SegmentStatusCheckerTest {
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(
         controllerMetrics.getValueOfTableGauge(externalView.getId(), ControllerGauge.SEGMENTS_IN_ERROR_STATE), 1);
@@ -149,7 +149,7 @@ public class SegmentStatusCheckerTest {
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(
         controllerMetrics.getValueOfTableGauge(externalView.getId(), ControllerGauge.SEGMENTS_IN_ERROR_STATE), 0);
@@ -225,7 +225,7 @@ public class SegmentStatusCheckerTest {
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(
         controllerMetrics.getValueOfTableGauge(externalView.getId(), ControllerGauge.SEGMENTS_IN_ERROR_STATE), 1);
@@ -267,7 +267,7 @@ public class SegmentStatusCheckerTest {
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName, ControllerGauge.SEGMENTS_IN_ERROR_STATE), 0);
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName, ControllerGauge.NUMBER_OF_REPLICAS), 0);
@@ -294,7 +294,7 @@ public class SegmentStatusCheckerTest {
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName, ControllerGauge.SEGMENTS_IN_ERROR_STATE),
         Long.MIN_VALUE);
@@ -352,7 +352,7 @@ public class SegmentStatusCheckerTest {
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(
         controllerMetrics.getValueOfTableGauge(externalView.getId(), ControllerGauge.SEGMENTS_IN_ERROR_STATE), 0);
@@ -393,7 +393,7 @@ public class SegmentStatusCheckerTest {
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName, ControllerGauge.SEGMENTS_IN_ERROR_STATE), 0);
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName, ControllerGauge.NUMBER_OF_REPLICAS), 1);
@@ -435,7 +435,7 @@ public class SegmentStatusCheckerTest {
     // verify state before test
     Assert.assertEquals(controllerMetrics.getValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT), 0);
     // update metrics
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT), 1);
   }
@@ -469,7 +469,7 @@ public class SegmentStatusCheckerTest {
     // verify state before test
     Assert.assertEquals(controllerMetrics.getValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT), 0);
     // update metrics
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT), 1);
   }
@@ -511,7 +511,7 @@ public class SegmentStatusCheckerTest {
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-    segmentStatusChecker.init();
+    segmentStatusChecker.start();
     segmentStatusChecker.run();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName, ControllerGauge.SEGMENTS_IN_ERROR_STATE),
         Long.MIN_VALUE);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -92,7 +92,7 @@ public class RetentionManagerTest {
     conf.setRetentionControllerFrequencyInSeconds(0);
     conf.setDeletedSegmentsRetentionInDays(0);
     RetentionManager retentionManager = new RetentionManager(pinotHelixResourceManager, conf, controllerMetrics);
-    retentionManager.init();
+    retentionManager.start();
     retentionManager.run();
 
     SegmentDeletionManager deletionManager = pinotHelixResourceManager.getSegmentDeletionManager();
@@ -215,7 +215,7 @@ public class RetentionManagerTest {
     conf.setRetentionControllerFrequencyInSeconds(0);
     conf.setDeletedSegmentsRetentionInDays(0);
     RetentionManager retentionManager = new RetentionManager(pinotHelixResourceManager, conf, controllerMetrics);
-    retentionManager.init();
+    retentionManager.start();
     retentionManager.run();
 
     SegmentDeletionManager deletionManager = pinotHelixResourceManager.getSegmentDeletionManager();

--- a/pinot-core/src/main/java/org/apache/pinot/core/periodictask/BasePeriodicTask.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/periodictask/BasePeriodicTask.java
@@ -18,18 +18,37 @@
  */
 package org.apache.pinot.core.periodictask;
 
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 /**
  * A base class to implement periodic task interface.
  */
+@ThreadSafe
 public abstract class BasePeriodicTask implements PeriodicTask {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BasePeriodicTask.class);
+
+  // Wait for at most 5 minutes while calling stop() for task to terminate
+  private static final long MAX_PERIODIC_TASK_STOP_TIME_MILLIS = 30_000L;
+
   protected final String _taskName;
   protected final long _intervalInSeconds;
   protected final long _initialDelayInSeconds;
+
+  private volatile boolean _started;
+  private volatile boolean _running;
 
   public BasePeriodicTask(String taskName, long runFrequencyInSeconds, long initialDelayInSeconds) {
     _taskName = taskName;
     _intervalInSeconds = runFrequencyInSeconds;
     _initialDelayInSeconds = initialDelayInSeconds;
+  }
+
+  @Override
+  public String getTaskName() {
+    return _taskName;
   }
 
   @Override
@@ -42,9 +61,126 @@ public abstract class BasePeriodicTask implements PeriodicTask {
     return _initialDelayInSeconds;
   }
 
+  /**
+   * Returns the status of the {@code started} flag. This flag will be set after calling {@link #start()}, and reset
+   * after calling {@link #stop()}.
+   */
+  public final boolean isStarted() {
+    return _started;
+  }
+
+  /**
+   * Returns the status of the {@code running} flag. This flag will be set during the task execution.
+   */
+  public final boolean isRunning() {
+    return _running;
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * This method sets {@code started} flag to true.
+   */
   @Override
-  public String getTaskName() {
-    return _taskName;
+  public final synchronized void start() {
+    if (_started) {
+      LOGGER.warn("Task: {} is already started", _taskName);
+      return;
+    }
+    _started = true;
+
+    try {
+      setUpTask();
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while setting up task: {}", _taskName, e);
+    }
+  }
+
+  /**
+   * Can be override for extra task setups.
+   */
+  protected void setUpTask() {
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * During the task execution, the {@code running} flag will be set.
+   */
+  @Override
+  public final void run() {
+    _running = true;
+
+    if (_started) {
+      long startTime = System.currentTimeMillis();
+      LOGGER.info("Start running task: {}", _taskName);
+      try {
+        runTask();
+      } catch (Exception e) {
+        LOGGER.error("Caught exception while running task: {}", _taskName, e);
+      }
+      LOGGER.info("Finish running task: {} in {}ms", _taskName, System.currentTimeMillis() - startTime);
+    } else {
+      LOGGER.warn("Task: {} is skipped because it is not started or already stopped", _taskName);
+    }
+
+    _running = false;
+  }
+
+  /**
+   * Executes the task. This method should early terminate if {@code started} flag is set to false by {@link #stop()}
+   * during execution.
+   */
+  protected abstract void runTask();
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * This method sets {@code started} flag to false. If the task is running, this method will block for at most 5
+   * minutes until the task finishes.
+   */
+  @Override
+  public final synchronized void stop() {
+    if (!_started) {
+      LOGGER.warn("Task: {} is not started", _taskName);
+      return;
+    }
+    _started = false;
+
+    if (_running) {
+      long startTimeMs = System.currentTimeMillis();
+      long remainingTimeMs = MAX_PERIODIC_TASK_STOP_TIME_MILLIS;
+      LOGGER.info("Task: {} is running, wait for at most {}ms for it to finish", _taskName, remainingTimeMs);
+      while (_running && remainingTimeMs > 0L) {
+        long sleepTimeMs = Long.min(remainingTimeMs, 1000L);
+        remainingTimeMs -= sleepTimeMs;
+        try {
+          Thread.sleep(sleepTimeMs);
+        } catch (InterruptedException e) {
+          LOGGER.error("Caught InterruptedException while waiting for task: {} to finish", _taskName);
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+      long waitTimeMs = System.currentTimeMillis() - startTimeMs;
+      if (_running) {
+        LOGGER.info("Task: {} is finished in {}ms", waitTimeMs);
+      } else {
+        LOGGER.warn("Task: {} is not finished in {}ms", waitTimeMs);
+      }
+    }
+
+    try {
+      cleanUpTask();
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while cleaning up task: {}", _taskName, e);
+    }
+  }
+
+  /**
+   * Can be override for extra task cleanups.
+   */
+  protected void cleanUpTask() {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/periodictask/BasePeriodicTask.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/periodictask/BasePeriodicTask.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public abstract class BasePeriodicTask implements PeriodicTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(BasePeriodicTask.class);
 
-  // Wait for at most 5 minutes while calling stop() for task to terminate
+  // Wait for at most 30 seconds while calling stop() for task to terminate
   private static final long MAX_PERIODIC_TASK_STOP_TIME_MILLIS = 30_000L;
 
   protected final String _taskName;
@@ -97,7 +97,9 @@ public abstract class BasePeriodicTask implements PeriodicTask {
   }
 
   /**
-   * Can be override for extra task setups.
+   * Can be overridden for extra task setups. This method will be called when the periodic task starts.
+   * <p>
+   * Possible setups include adding or resetting the metric values.
    */
   protected void setUpTask() {
   }
@@ -136,8 +138,8 @@ public abstract class BasePeriodicTask implements PeriodicTask {
   /**
    * {@inheritDoc}
    * <p>
-   * This method sets {@code started} flag to false. If the task is running, this method will block for at most 5
-   * minutes until the task finishes.
+   * This method sets {@code started} flag to false. If the task is running, this method will block for at most 30
+   * seconds until the task finishes.
    */
   @Override
   public final synchronized void stop() {
@@ -164,9 +166,9 @@ public abstract class BasePeriodicTask implements PeriodicTask {
       }
       long waitTimeMs = System.currentTimeMillis() - startTimeMs;
       if (_running) {
-        LOGGER.info("Task: {} is finished in {}ms", waitTimeMs);
-      } else {
         LOGGER.warn("Task: {} is not finished in {}ms", waitTimeMs);
+      } else {
+        LOGGER.info("Task: {} is finished in {}ms", waitTimeMs);
       }
     }
 
@@ -178,7 +180,9 @@ public abstract class BasePeriodicTask implements PeriodicTask {
   }
 
   /**
-   * Can be override for extra task cleanups.
+   * Can be overridden for extra task cleanups. This method will be called when the periodic task stops.
+   * <p>
+   * Possible cleanups include removing or resetting the metric values.
    */
   protected void cleanUpTask() {
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/periodictask/PeriodicTask.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/periodictask/PeriodicTask.java
@@ -18,37 +18,50 @@
  */
 package org.apache.pinot.core.periodictask;
 
+import javax.annotation.concurrent.ThreadSafe;
+
+
 /**
  * An interface to describe the functionality of periodic task. Periodic tasks will be added to a list, scheduled
  * and run in the periodic task scheduler with the fixed interval time.
  */
+@ThreadSafe
 public interface PeriodicTask extends Runnable {
 
   /**
-   * Initialize the task before running the task.
-   */
-  void init();
-
-  /**
-   * Get the interval time of running the same task.
-   * @return the interval time in seconds.
-   */
-  long getIntervalInSeconds();
-
-  /**
-   * Get the initial delay of the fist run.
-   * @return initial delay in seconds.
-   */
-  long getInitialDelayInSeconds();
-
-  /**
-   * Get the periodic task name.
+   * Returns the periodic task name.
    * @return task name.
    */
   String getTaskName();
 
   /**
-   * Stop the periodic task
+   * Returns the interval time of running the same task.
+   * @return the interval time in seconds.
+   */
+  long getIntervalInSeconds();
+
+  /**
+   * Returns the initial delay of the fist run.
+   * @return initial delay in seconds.
+   */
+  long getInitialDelayInSeconds();
+
+  /**
+   * Performs necessary setups and starts the periodic task. Should be called before scheduling the periodic task. Can
+   * be called after calling {@link #stop()} to restart the periodic task.
+   */
+  void start();
+
+  /**
+   * Executes the task. This method should be called only after {@link #start()} getting called but before
+   * {@link #stop()} getting called.
+   */
+  @Override
+  void run();
+
+  /**
+   * Stops the periodic task and performs necessary cleanups. Should be called after removing the periodic task from the
+   * scheduler. Should be called after {@link #start()} getting called.
    */
   void stop();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/periodictask/PeriodicTaskScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/periodictask/PeriodicTaskScheduler.java
@@ -37,8 +37,7 @@ public class PeriodicTaskScheduler {
   private List<PeriodicTask> _tasksWithValidInterval;
 
   /**
-   * Initialize the PeriodicTaskScheduler with list of PeriodicTasks
-   * @param periodicTasks
+   * Initializes the periodic task scheduler with a list of periodic tasks.
    */
   public void init(List<PeriodicTask> periodicTasks) {
     _tasksWithValidInterval = new ArrayList<>();
@@ -46,7 +45,6 @@ public class PeriodicTaskScheduler {
       if (periodicTask.getIntervalInSeconds() > 0) {
         LOGGER.info("Adding periodic task: {}", periodicTask);
         _tasksWithValidInterval.add(periodicTask);
-        periodicTask.init();
       } else {
         LOGGER.info("Skipping periodic task: {}", periodicTask);
       }
@@ -54,7 +52,7 @@ public class PeriodicTaskScheduler {
   }
 
   /**
-   * Start scheduling periodic tasks.
+   * Starts scheduling periodic tasks.
    */
   public synchronized void start() {
     if (_executorService != null) {
@@ -67,6 +65,7 @@ public class PeriodicTaskScheduler {
       LOGGER.info("Starting periodic task scheduler with tasks: {}", _tasksWithValidInterval);
       _executorService = Executors.newScheduledThreadPool(_tasksWithValidInterval.size());
       for (PeriodicTask periodicTask : _tasksWithValidInterval) {
+        periodicTask.start();
         _executorService.scheduleWithFixedDelay(() -> {
           try {
             LOGGER.info("Starting {} with running frequency of {} seconds.", periodicTask.getTaskName(),
@@ -83,7 +82,7 @@ public class PeriodicTaskScheduler {
   }
 
   /**
-   * Shutdown executor service and stop the periodic tasks
+   * Shuts down the executor service and stops the periodic tasks.
    */
   public synchronized void stop() {
     if (_executorService != null) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/periodictask/PeriodicTaskSchedulerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/periodictask/PeriodicTaskSchedulerTest.java
@@ -34,24 +34,24 @@ public class PeriodicTaskSchedulerTest {
   @Test
   public void testTaskWithInvalidInterval()
       throws Exception {
-    AtomicBoolean initCalled = new AtomicBoolean();
+    AtomicBoolean startCalled = new AtomicBoolean();
     AtomicBoolean runCalled = new AtomicBoolean();
     AtomicBoolean stopCalled = new AtomicBoolean();
 
     List<PeriodicTask> periodicTasks = Collections.singletonList(new BasePeriodicTask("TestTask", 0L/*Invalid*/, 0L) {
       @Override
-      public void init() {
-        initCalled.set(true);
+      protected void setUpTask() {
+        startCalled.set(true);
       }
 
       @Override
-      public void stop() {
-        stopCalled.set(true);
-      }
-
-      @Override
-      public void run() {
+      protected void runTask() {
         runCalled.set(true);
+      }
+
+      @Override
+      protected void cleanUpTask() {
+        stopCalled.set(true);
       }
     });
 
@@ -61,7 +61,7 @@ public class PeriodicTaskSchedulerTest {
     Thread.sleep(100L);
     taskScheduler.stop();
 
-    assertFalse(initCalled.get());
+    assertFalse(startCalled.get());
     assertFalse(runCalled.get());
     assertFalse(stopCalled.get());
   }
@@ -70,26 +70,26 @@ public class PeriodicTaskSchedulerTest {
   public void testScheduleMultipleTasks()
       throws Exception {
     int numTasks = 3;
-    AtomicInteger numTimesInitCalled = new AtomicInteger();
+    AtomicInteger numTimesStartCalled = new AtomicInteger();
     AtomicInteger numTimesRunCalled = new AtomicInteger();
     AtomicInteger numTimesStopCalled = new AtomicInteger();
 
     List<PeriodicTask> periodicTasks = new ArrayList<>(numTasks);
     for (int i = 0; i < numTasks; i++) {
-      periodicTasks.add(new BasePeriodicTask("Task", 1L, 0L) {
+      periodicTasks.add(new BasePeriodicTask("TestTask", 1L, 0L) {
         @Override
-        public void init() {
-          numTimesInitCalled.getAndIncrement();
+        protected void setUpTask() {
+          numTimesStartCalled.getAndIncrement();
         }
 
         @Override
-        public void stop() {
-          numTimesStopCalled.getAndIncrement();
-        }
-
-        @Override
-        public void run() {
+        protected void runTask() {
           numTimesRunCalled.getAndIncrement();
+        }
+
+        @Override
+        protected void cleanUpTask() {
+          numTimesStopCalled.getAndIncrement();
         }
       });
     }
@@ -100,7 +100,7 @@ public class PeriodicTaskSchedulerTest {
     Thread.sleep(1100L);
     taskScheduler.stop();
 
-    assertEquals(numTimesInitCalled.get(), numTasks);
+    assertEquals(numTimesStartCalled.get(), numTasks);
     assertEquals(numTimesRunCalled.get(), numTasks * 2);
     assertEquals(numTimesStopCalled.get(), numTasks);
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTests.java
@@ -160,7 +160,7 @@ public class SegmentCompletionIntegrationTests extends LLCRealtimeClusterIntegra
 
     // Now call the validation manager, and the segment should fix itself
     RealtimeSegmentValidationManager validationManager = _controllerStarter.getRealtimeSegmentValidationManager();
-    validationManager.init();
+    validationManager.start();
     validationManager.run();
 
     // Check if a new segment get into CONSUMING state


### PR DESCRIPTION
Refactor periodic task to fix the following issues：
- PinotTaskManager.scheduleTasks() has no effect on non-leader controller, but returns result from previous run
  The reason for this is that, we store states for each run as member variables in the periodic task, which mixed the concept of task and run
- After calling stop() (lose leadership), when re-gaining leadership, no start() method is called to set up the environment
- Potential race condition

Replace init() with start() and call it whenever the leadership is gained
Move the basic control methods for periodic task (start(), run(), stop()) into BasePeriodicTask
Keep table level methods in ControllerPeriodicTask
For per-run states, add context generic type to pass them between processing multiple tables