### PR TITLE
Update ControllerConf.java

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -156,7 +156,7 @@ public class ControllerConf extends PropertiesConfiguration {
    */
   public static URI getUriFromPath(String path) {
     try {
-      URI uri = new URI(path);
+      URI uri = Paths.get(path).toUri();
       if (uri.getScheme() != null) {
         return uri;
       } else {


### PR DESCRIPTION
Quick start fails on windows because of malformed conf data dir path. Corrected it by making it using Paths.get