### PR TITLE
Update maven config files for preparing release

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderUtilsTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 
 
 public class LoaderUtilsTest {
-  private static final File TEST_DIR = new File("tmp", LoaderUtils.class.getName());
+  private static final File TEST_DIR = new File(FileUtils.getTempDirectory(), LoaderUtils.class.getName());
 
   @BeforeClass
   public void setUp()

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -27,7 +27,7 @@
     <format>tar.gz</format>
     <format>dir</format>
   </formats>
-  <includeBaseDirectory>false</includeBaseDirectory>
+  <includeBaseDirectory>true</includeBaseDirectory>
   <dependencySets>
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>

--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -118,7 +118,7 @@
   </build>
   <profiles>
     <profile>
-      <id>src-dist</id>
+      <id>apache-release</id>
       <build>
         <plugins>
           <plugin>
@@ -151,18 +151,16 @@
         <plugins>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <configuration>
-              <finalName>apache-pinot-incubating-${project.version}-bin</finalName>
-              <appendAssemblyId>false</appendAssemblyId>
-            </configuration>
             <executions>
               <execution>
-                <id>make-bundles</id>
+                <id>binary-release-assembly-pinot</id>
                 <goals>
                   <goal>single</goal>
                 </goals>
                 <phase>package</phase>
                 <configuration>
+                  <finalName>apache-pinot-incubating-${project.version}-bin</finalName>
+                  <appendAssemblyId>false</appendAssemblyId>
                   <descriptors>
                     <descriptor>pinot-assembly.xml</descriptor>
                   </descriptors>
@@ -173,27 +171,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>sign</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>21</version>
+  </parent>
+
   <groupId>org.apache.pinot</groupId>
   <artifactId>pinot</artifactId>
   <version>0.1.0-SNAPSHOT</version>
@@ -86,7 +93,7 @@
   </mailingLists>
 
   <scm>
-    <developerConnection>scm:git:git://apache/incubator-pinot.git</developerConnection>
+    <developerConnection>scm:git:git@github.com:apache/incubator-pinot.git</developerConnection>
   </scm>
 
   <!-- Apache project inception year for generating correct NOTICE file for jar bundle. -->
@@ -155,6 +162,23 @@
             <configuration>
               <skipTests>true</skipTests>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- Disable source release assembly for 'apache-release' profile. -->
+    <profile>
+      <id>apache-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>source-release-assembly</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>
@@ -812,7 +836,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.5.5</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
@@ -827,6 +851,10 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.1</version>
+          <configuration>
+            <!-- Remove this after fixing all javadoc warnings -->
+            <additionalparam>-Xdoclint:none</additionalparam>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -915,6 +943,14 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.scm</groupId>
+              <artifactId>maven-scm-provider-gitexe</artifactId>
+              <version>1.9.4</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
           </configuration>
@@ -1086,6 +1122,66 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>0.13</version>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <excludes>
+            <!-- Documentation -->
+            <exclude>**/*.md</exclude>
+            <exclude>docs/**</exclude>
+
+            <!-- Exclude license copies -->
+            <exclude>licenses/**</exclude>
+            <exclude>licenses-binary/**</exclude>
+
+            <!-- js, css files that are exact copies of the third-party works. In this case, the original header has to
+            be kept. Please refer to 'Treatment of Third-party works' in https://www.apache.org/legal/src-headers.html
+            -->
+            <exclude>**/codemirror/**</exclude>
+            <exclude>**/codemirror*</exclude>
+            <exclude>**/foundation*</exclude>
+            <exclude>**/angular*</exclude>
+            <exclude>**/underscore*</exclude>
+            <exclude>**/jquery*</exclude>
+            <exclude>**/normalize*</exclude>
+            <exclude>**/handlebars*</exclude>
+            <exclude>**/beautify*</exclude>
+
+            <!-- Binary files -->
+            <exclude>**/*.json</exclude>
+            <exclude>**/*.pql</exclude>
+            <exclude>**/*.log</exclude>
+            <exclude>**/*.csv</exclude>
+            <exclude>**/*.avro</exclude>
+            <exclude>**/*.conf</exclude>
+            <exclude>**/*.yml</exclude>
+            <exclude>**/*.yaml</exclude>
+            <exclude>**/*.properties</exclude>
+
+            <!-- Top level -->
+            <exclude>.codecov*</exclude>
+
+            <!-- Test Resources -->
+            <exclude>**/test/resources/**</exclude>
+
+            <!-- Pinot-Druid Benchmark (not part of the distribution) -->
+            <exclude>contrib/**</exclude>
+
+            <!-- Third eye (not part of the distribution) -->
+            <exclude>thirdeye/**</exclude>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
1. Added apache parent pom
2. Make 'apache-release' profile to build source tarbells,
   sha512 hash, and sign
3. Override configs for Apache rat to make the check pass
4. Turning off doclint for javadoc
5. Fix "LoaderUtilsTest" to use randomly generated tmp directory
   instead of using "tmp" dir within a project
6. Fix bin-dist to include base directory for its tarbell
7. Add Apache RAT exclude configs