### PR TITLE
Unify move method in PinotFS

### DIFF
--- a/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
@@ -103,12 +103,8 @@ public class AzurePinotFS extends PinotFS {
    * then the call fails rather than overwrite the directory. Thus, it's best to specify
    * the full paths of both src and dst when using this method in AzurePinotFS.
    */
-  public boolean doMove(URI srcUri, URI dstUri)
+  protected boolean doMove(URI srcUri, URI dstUri)
       throws IOException {
-    // ensures the parent path of dst exists.
-    URI parentUri = Paths.get(dstUri).toUri();
-    _adlStoreClient.createDirectory(parentUri.getPath());
-    // renames the source file/directory to destination.
     return _adlStoreClient.rename(srcUri.getPath(), dstUri.getPath());
   }
 

--- a/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
@@ -98,24 +98,17 @@ public class AzurePinotFS extends PinotFS {
   }
 
   @Override
-  public boolean move(URI srcUri, URI dstUri, boolean overwrite)
+  /**
+   * Note: One corner scenario for this method in AzureFS is if the destination is a non-empty directory,
+   * then the call fails rather than overwrite the directory. Thus, it's best to specify
+   * the full paths of both src and dst when using this method in AzurePinotFS.
+   */
+  public boolean doMove(URI srcUri, URI dstUri)
       throws IOException {
-    if (exists(dstUri)) {
-      if (overwrite) {
-        delete(dstUri, true);
-      } else {
-        // dst file exists, returning
-        return false;
-      }
-    } else {
-      URI parentUri = Paths.get(dstUri).toUri();
-      // ensure the dst path exists
-      _adlStoreClient.createDirectory(parentUri.getPath());
-    }
-    if (exists(dstUri) && !overwrite) {
-      return false;
-    }
-    //rename the file
+    // ensures the parent path of dst exists.
+    URI parentUri = Paths.get(dstUri).toUri();
+    _adlStoreClient.createDirectory(parentUri.getPath());
+    // renames the source file/directory to destination.
     return _adlStoreClient.rename(srcUri.getPath(), dstUri.getPath());
   }
 

--- a/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
@@ -100,6 +100,18 @@ public class AzurePinotFS extends PinotFS {
   @Override
   public boolean move(URI srcUri, URI dstUri, boolean overwrite)
       throws IOException {
+    if (exists(dstUri)) {
+      if (overwrite) {
+        delete(dstUri, true);
+      } else {
+        // dst file exists, returning
+        return false;
+      }
+    } else {
+      URI parentUri = Paths.get(dstUri).toUri();
+      // ensure the dst path exists
+      _adlStoreClient.createDirectory(parentUri.getPath());
+    }
     if (exists(dstUri) && !overwrite) {
       return false;
     }

--- a/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
@@ -98,11 +98,6 @@ public class AzurePinotFS extends PinotFS {
   }
 
   @Override
-  /**
-   * Note: One corner scenario for this method in AzureFS is if the destination is a non-empty directory,
-   * then the call fails rather than overwrite the directory. Thus, it's best to specify
-   * the full paths of both src and dst when using this method in AzurePinotFS.
-   */
   protected boolean doMove(URI srcUri, URI dstUri)
       throws IOException {
     return _adlStoreClient.rename(srcUri.getPath(), dstUri.getPath());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -170,8 +170,8 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public static URI constructSegmentLocation(String baseDataDir, String tableName, String segmentName) {
     try {
-      return new URI(StringUtil.join(File.separator, baseDataDir, tableName, URLEncoder.encode(segmentName, "UTF-8")));
-    } catch (UnsupportedEncodingException | URISyntaxException e) {
+      return getUriFromPath(StringUtil.join(File.separator, baseDataDir, tableName, URLEncoder.encode(segmentName, "UTF-8")));
+    } catch (UnsupportedEncodingException e) {
       LOGGER
           .error("Could not construct segment location with baseDataDir {}, tableName {}, segmentName {}", baseDataDir,
               tableName, segmentName);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -188,12 +188,16 @@ public class SegmentDeletionManager {
       try {
         if (pinotFS.exists(fileToMoveURI)) {
           // Overwrites the file if it already exists in the target directory.
-          pinotFS.move(fileToMoveURI, deletedSegmentDestURI, true);
-          // Updates last modified.
-          // Touch is needed here so that removeAgedDeletedSegments() works correctly.
-          pinotFS.touch(deletedSegmentDestURI);
-          LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMoveURI.toString(),
-              deletedSegmentDestURI.toString());
+          if (pinotFS.move(fileToMoveURI, deletedSegmentDestURI, true)) {
+            // Updates last modified.
+            // Touch is needed here so that removeAgedDeletedSegments() works correctly.
+            pinotFS.touch(deletedSegmentDestURI);
+            LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMoveURI.toString(),
+                deletedSegmentDestURI.toString());
+          } else {
+            LOGGER.warn("Failed to move segment {} from {} to {}", segmentId, fileToMoveURI.toString(),
+                deletedSegmentDestURI.toString());
+          }
         } else {
           if (!SegmentName.isHighLevelConsumerSegmentName(segmentId)) {
             LOGGER.warn("Not found local segment file for segment {}" + fileToMoveURI.toString());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -385,7 +385,10 @@ public class PinotLLCRealtimeSegmentManager {
     }
 
     try {
-      pinotFS.move(segmentFileURI, uriToMoveTo, true);
+      if (!pinotFS.move(segmentFileURI, uriToMoveTo, true)) {
+        LOGGER.error("Could not move {} to {}", segmentLocation, segmentName);
+        return false;
+      }
     } catch (Exception e) {
       LOGGER.error("Could not move {} to {}", segmentLocation, segmentName, e);
       return false;

--- a/pinot-filesystem/src/main/java/org/apache/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/org/apache/pinot/filesystem/LocalPinotFS.java
@@ -75,24 +75,17 @@ public class LocalPinotFS extends PinotFS {
   }
 
   @Override
-  public boolean move(URI srcUri, URI dstUri, boolean overwrite)
+  public boolean doMove(URI srcUri, URI dstUri)
       throws IOException {
     File srcFile = new File(decodeURI(srcUri.getRawPath()));
     File dstFile = new File(decodeURI(dstUri.getRawPath()));
-    if (dstFile.exists()) {
-      if (overwrite) {
-        FileUtils.deleteQuietly(dstFile);
-      } else {
-        // dst file exists, returning
-        return false;
-      }
+    // ensures the parent path of dst exists.
+    FileUtils.forceMkdir(dstFile.getParentFile());
+    if (srcFile.isDirectory()) {
+      FileUtils.moveDirectoryToDirectory(srcFile, dstFile, true);
     } else {
-      // ensure the dst path exists
-      FileUtils.forceMkdir(dstFile.getParentFile());
+      FileUtils.moveFile(srcFile, dstFile);
     }
-
-    Files.move(srcFile.toPath(), dstFile.toPath());
-
     return true;
   }
 

--- a/pinot-filesystem/src/main/java/org/apache/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/org/apache/pinot/filesystem/LocalPinotFS.java
@@ -75,14 +75,12 @@ public class LocalPinotFS extends PinotFS {
   }
 
   @Override
-  public boolean doMove(URI srcUri, URI dstUri)
+  protected boolean doMove(URI srcUri, URI dstUri)
       throws IOException {
     File srcFile = new File(decodeURI(srcUri.getRawPath()));
     File dstFile = new File(decodeURI(dstUri.getRawPath()));
-    // ensures the parent path of dst exists.
-    FileUtils.forceMkdir(dstFile.getParentFile());
     if (srcFile.isDirectory()) {
-      FileUtils.moveDirectoryToDirectory(srcFile, dstFile, true);
+      FileUtils.moveDirectory(srcFile, dstFile);
     } else {
       FileUtils.moveFile(srcFile, dstFile);
     }

--- a/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/LocalPinotFSTest.java
@@ -117,10 +117,8 @@ public class LocalPinotFSTest {
     localPinotFS.move(newAbsoluteTempDirPath.toURI(), newAbsoluteTempDirPath3.toURI(), true);
     Assert.assertFalse(localPinotFS.exists(newAbsoluteTempDirPath.toURI()));
     Assert.assertTrue(localPinotFS.exists(newAbsoluteTempDirPath3.toURI()));
-    File testDirUnderNewAbsoluteTempDirPath3 = new File(newAbsoluteTempDirPath3, "absoluteTwo");
-    Assert.assertTrue(localPinotFS.exists(testDirUnderNewAbsoluteTempDirPath3.toURI()));
-    File testSubDirUnderNewAbsoluteTempDirPath3 = new File(testDirUnderNewAbsoluteTempDirPath3, "testDir");
-    Assert.assertTrue(localPinotFS.exists(new File(testSubDirUnderNewAbsoluteTempDirPath3, "testFile").toURI()));
+    Assert.assertTrue(localPinotFS.exists(new File(newAbsoluteTempDirPath3, "testDir").toURI()));
+    Assert.assertTrue(localPinotFS.exists(new File(new File(newAbsoluteTempDirPath3, "testDir"), "testFile").toURI()));
 
     // Check file copy to location where something already exists still works
     localPinotFS.copy(testFileUri, thirdTestFile.toURI());
@@ -135,18 +133,15 @@ public class LocalPinotFSTest {
     dstFile.createNewFile();
 
     // Expected that a move without overwrite will not succeed
-    Assert.assertFalse(localPinotFS.move(secondTestFileUri, thirdTestFile.toURI(), false));
-    Assert.assertTrue(localPinotFS.move(secondTestFileUri, thirdTestFile.toURI(), true));
+    Assert.assertFalse(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), false));
 
     int files = _absoluteTmpDirPath.listFiles().length;
-    String dirName  = _absoluteTmpDirPath.getName();
-    Assert.assertTrue(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), false));
-    Assert.assertFalse(_absoluteTmpDirPath.exists());
+    Assert.assertTrue(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), true));
     Assert.assertEquals(_absoluteTmpDirPath.length(), 0);
-    Assert.assertEquals(new File(_newTmpDir, dirName).listFiles().length, files);
-    Assert.assertTrue(dstFile.exists());
+    Assert.assertEquals(_newTmpDir.listFiles().length, files);
+    Assert.assertFalse(dstFile.exists());
 
-    // Check that a moving a file a non-existent destination folder will work
+    // Check that a moving a file to a non-existent destination folder will work
     FileUtils.deleteQuietly(_nonExistentTmpFolder);
     Assert.assertFalse(_nonExistentTmpFolder.exists());
     File srcFile = new File(_absoluteTmpDirPath, "srcFile");
@@ -158,13 +153,13 @@ public class LocalPinotFSTest {
     Assert.assertFalse(srcFile.exists());
     Assert.assertTrue(dstFile.exists());
 
-    //Check that moving a folder to a non-existent destination folder works
+    // Check that moving a folder to a non-existent destination folder works
     FileUtils.deleteQuietly(_nonExistentTmpFolder);
     Assert.assertFalse(_nonExistentTmpFolder.exists());
     srcFile = new File(_absoluteTmpDirPath, "srcFile");
     localPinotFS.mkdir(_absoluteTmpDirPath.toURI());
     Assert.assertTrue(srcFile.createNewFile());
-    dstFile = new File(_nonExistentTmpFolder.getPath() + "/" + dirName + "/srcFile");
+    dstFile = new File(_nonExistentTmpFolder.getPath() + "/srcFile");
     Assert.assertFalse(dstFile.exists());
     Assert.assertTrue(localPinotFS
         .move(_absoluteTmpDirPath.toURI(), _nonExistentTmpFolder.toURI(), true)); // overwrite flag has no impact

--- a/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/LocalPinotFSTest.java
@@ -210,6 +210,15 @@ public class LocalPinotFSTest {
     localPinotFS.copy(firstTempDir.toURI(), secondTempDir.toURI());
     Assert.assertEquals(localPinotFS.listFiles(secondTempDir.toURI(), true).length, 1);
 
+    // Copying directory with files under another directory.
+    File firstTempDirUnderSecondTempDir = new File(secondTempDir, firstTempDir.getName());
+    localPinotFS.copy(firstTempDir.toURI(), firstTempDirUnderSecondTempDir.toURI());
+    Assert.assertTrue(localPinotFS.exists(firstTempDirUnderSecondTempDir.toURI()));
+    // There're two files/directories under secondTempDir.
+    Assert.assertEquals(localPinotFS.listFiles(secondTempDir.toURI(), false).length, 2);
+    // The file under src directory also got copied under dst directory.
+    Assert.assertEquals(localPinotFS.listFiles(firstTempDirUnderSecondTempDir.toURI(), true).length, 1);
+
     // len of dir = exception
     try {
       localPinotFS.length(firstTempDir.toURI());

--- a/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/LocalPinotFSTest.java
@@ -117,8 +117,10 @@ public class LocalPinotFSTest {
     localPinotFS.move(newAbsoluteTempDirPath.toURI(), newAbsoluteTempDirPath3.toURI(), true);
     Assert.assertFalse(localPinotFS.exists(newAbsoluteTempDirPath.toURI()));
     Assert.assertTrue(localPinotFS.exists(newAbsoluteTempDirPath3.toURI()));
-    Assert.assertTrue(localPinotFS.exists(new File(newAbsoluteTempDirPath3, "testDir").toURI()));
-    Assert.assertTrue(localPinotFS.exists(new File(new File(newAbsoluteTempDirPath3, "testDir"), "testFile").toURI()));
+    File testDirUnderNewAbsoluteTempDirPath3 = new File(newAbsoluteTempDirPath3, "absoluteTwo");
+    Assert.assertTrue(localPinotFS.exists(testDirUnderNewAbsoluteTempDirPath3.toURI()));
+    File testSubDirUnderNewAbsoluteTempDirPath3 = new File(testDirUnderNewAbsoluteTempDirPath3, "testDir");
+    Assert.assertTrue(localPinotFS.exists(new File(testSubDirUnderNewAbsoluteTempDirPath3, "testFile").toURI()));
 
     // Check file copy to location where something already exists still works
     localPinotFS.copy(testFileUri, thirdTestFile.toURI());
@@ -133,13 +135,16 @@ public class LocalPinotFSTest {
     dstFile.createNewFile();
 
     // Expected that a move without overwrite will not succeed
-    Assert.assertFalse(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), false));
+    Assert.assertFalse(localPinotFS.move(secondTestFileUri, thirdTestFile.toURI(), false));
+    Assert.assertTrue(localPinotFS.move(secondTestFileUri, thirdTestFile.toURI(), true));
 
     int files = _absoluteTmpDirPath.listFiles().length;
-    Assert.assertTrue(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), true));
+    String dirName  = _absoluteTmpDirPath.getName();
+    Assert.assertTrue(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), false));
+    Assert.assertFalse(_absoluteTmpDirPath.exists());
     Assert.assertEquals(_absoluteTmpDirPath.length(), 0);
-    Assert.assertEquals(_newTmpDir.listFiles().length, files);
-    Assert.assertFalse(dstFile.exists());
+    Assert.assertEquals(new File(_newTmpDir, dirName).listFiles().length, files);
+    Assert.assertTrue(dstFile.exists());
 
     // Check that a moving a file a non-existent destination folder will work
     FileUtils.deleteQuietly(_nonExistentTmpFolder);
@@ -159,7 +164,7 @@ public class LocalPinotFSTest {
     srcFile = new File(_absoluteTmpDirPath, "srcFile");
     localPinotFS.mkdir(_absoluteTmpDirPath.toURI());
     Assert.assertTrue(srcFile.createNewFile());
-    dstFile = new File(_nonExistentTmpFolder.getPath() + "/srcFile");
+    dstFile = new File(_nonExistentTmpFolder.getPath() + "/" + dirName + "/srcFile");
     Assert.assertFalse(dstFile.exists());
     Assert.assertTrue(localPinotFS
         .move(_absoluteTmpDirPath.toURI(), _nonExistentTmpFolder.toURI(), true)); // overwrite flag has no impact

--- a/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/PinotFSFactoryTest.java
+++ b/pinot-filesystem/src/test/java/org/apache/pinot/filesystem/PinotFSFactoryTest.java
@@ -85,7 +85,7 @@ public class PinotFSFactoryTest {
     }
 
     @Override
-    public boolean move(URI srcUri, URI dstUri, boolean overwrite)
+    public boolean doMove(URI srcUri, URI dstUri)
         throws IOException {
       return true;
     }

--- a/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
@@ -90,7 +90,7 @@ public class HadoopPinotFS extends PinotFS {
   }
 
   @Override
-  public boolean doMove(URI srcUri, URI dstUri)
+  protected boolean doMove(URI srcUri, URI dstUri)
       throws IOException {
     return _hadoopFS.rename(new Path(srcUri), new Path(dstUri));
   }

--- a/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
@@ -90,19 +90,8 @@ public class HadoopPinotFS extends PinotFS {
   }
 
   @Override
-  public boolean move(URI srcUri, URI dstUri, boolean overwrite)
+  public boolean doMove(URI srcUri, URI dstUri)
       throws IOException {
-    if (exists(dstUri)) {
-      if (overwrite) {
-        delete(dstUri, true);
-      } else {
-        // dst file exists, returning
-        return false;
-      }
-    } else {
-      // ensure the dst path exists
-      _hadoopFS.mkdirs(new Path(dstUri).getParent());
-    }
     return _hadoopFS.rename(new Path(srcUri), new Path(dstUri));
   }
 

--- a/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
@@ -92,8 +92,16 @@ public class HadoopPinotFS extends PinotFS {
   @Override
   public boolean move(URI srcUri, URI dstUri, boolean overwrite)
       throws IOException {
-    if (exists(dstUri) && !overwrite) {
-      return false;
+    if (exists(dstUri)) {
+      if (overwrite) {
+        delete(dstUri, true);
+      } else {
+        // dst file exists, returning
+        return false;
+      }
+    } else {
+      // ensure the dst path exists
+      _hadoopFS.mkdirs(new Path(dstUri).getParent());
     }
     return _hadoopFS.rename(new Path(srcUri), new Path(dstUri));
   }


### PR DESCRIPTION
This PR unifies move method in different implementations of PinotFS.

In AzureFS, a file cannot move to a non-empty directory. Since the only usage of this API in Pinot is to move a file to a file, we add a note in PinotFS interface to suggest always specifying the names of both src and dst to make less confusion.