### PR TITLE
In SegmentCreationJob, fix the issue where ControllerRestApi is used when _pushLocations is not set

### DIFF
--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentCreationJob.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentCreationJob.java
@@ -211,24 +211,20 @@ public class SegmentCreationJob extends BaseSegmentJob {
   @Nullable
   protected TableConfig getTableConfig()
       throws IOException {
-    if (_pushLocations != null) {
-      try (ControllerRestApi controllerRestApi = getControllerRestApi()) {
-        return controllerRestApi.getTableConfig();
-      }
-    } else {
-      return null;
+    try (ControllerRestApi controllerRestApi = getControllerRestApi()) {
+      return controllerRestApi != null ? controllerRestApi.getTableConfig() : null;
     }
   }
 
   protected Schema getSchema()
       throws IOException {
-    if (_pushLocations != null) {
-      try (ControllerRestApi controllerRestApi = getControllerRestApi()) {
+    try (ControllerRestApi controllerRestApi = getControllerRestApi()) {
+      if (controllerRestApi != null) {
         return controllerRestApi.getSchema();
-      }
-    } else {
-      try (InputStream inputStream = _fileSystem.open(_schemaFile)) {
-        return Schema.fromInputSteam(inputStream);
+      } else {
+        try (InputStream inputStream = _fileSystem.open(_schemaFile)) {
+          return Schema.fromInputSteam(inputStream);
+        }
       }
     }
   }
@@ -236,8 +232,9 @@ public class SegmentCreationJob extends BaseSegmentJob {
   /**
    * Can be overridden to provide custom controller Rest API.
    */
+  @Nullable
   protected ControllerRestApi getControllerRestApi() {
-    return new DefaultControllerRestApi(_pushLocations, _rawTableName);
+    return _pushLocations != null ? new DefaultControllerRestApi(_pushLocations, _rawTableName) : null;
   }
 
   protected void validateTableConfig(TableConfig tableConfig) {


### PR DESCRIPTION
When extending SegmentCreationJob class, the ControllerRestApi can be constructed without _pushLocations
Change getTableConfig() and getSchema() so that they work without setting _pushLocations