### PR TITLE
Fix listFiles method in HadoopPinotFS

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -304,6 +304,8 @@ public class LLCSegmentCompletionHandlers {
           ControllerConf.getUriFromPath(StringUtil.join("/", provider.getBaseDataDirURI().toString(), rawTableName));
       java.net.URI segmentFileURI;
       if (isSplitCommit) {
+        // We only clean up tmp segment file under table dir, so don't create any sub-dir under table dir.
+        // See PinotLLCRealtimeSegmentManager.commitSegmentFile().
         String uniqueSegmentFileName = SegmentCompletionUtils.generateSegmentFileName(segmentName);
         segmentFileURI =
             ControllerConf.getUriFromPath(StringUtil.join("/", tableDirURI.toString(), uniqueSegmentFileName));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -306,6 +306,7 @@ public class LLCSegmentCompletionHandlers {
       if (isSplitCommit) {
         // We only clean up tmp segment file under table dir, so don't create any sub-dir under table dir.
         // See PinotLLCRealtimeSegmentManager.commitSegmentFile().
+        // TODO: move tmp file logic into SegmentCompletionUtils.
         String uniqueSegmentFileName = SegmentCompletionUtils.generateSegmentFileName(segmentName);
         segmentFileURI =
             ControllerConf.getUriFromPath(StringUtil.join("/", tableDirURI.toString(), uniqueSegmentFileName));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -394,7 +394,7 @@ public class PinotLLCRealtimeSegmentManager {
     // Cleans up tmp segment files under table dir.
     // We only clean up tmp segment files in table level dir, so there's no need to list recursively.
     // See LLCSegmentCompletionHandlers.uploadSegment().
-    // See LLCSegmentCompletionHandlers.uploadSegment().
+    // TODO: move tmp file logic into SegmentCompletionUtils.
     try {
       for (String uri : pinotFS.listFiles(tableDirURI, false)) {
         if (uri.contains(SegmentCompletionUtils.getSegmentNamePrefix(segmentName))) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -391,8 +391,12 @@ public class PinotLLCRealtimeSegmentManager {
       return false;
     }
 
+    // Cleans up tmp segment files under table dir.
+    // We only clean up tmp segment files in table level dir, so there's no need to list recursively.
+    // See LLCSegmentCompletionHandlers.uploadSegment().
+    // See LLCSegmentCompletionHandlers.uploadSegment().
     try {
-      for (String uri : pinotFS.listFiles(tableDirURI, true)) {
+      for (String uri : pinotFS.listFiles(tableDirURI, false)) {
         if (uri.contains(SegmentCompletionUtils.getSegmentNamePrefix(segmentName))) {
           LOGGER.warn("Deleting " + uri);
           pinotFS.delete(new URI(uri), true);

--- a/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.List;
 import org.apache.commons.configuration.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -138,10 +139,10 @@ public class HadoopPinotFS extends PinotFS {
     ArrayList<String> filePathStrings = new ArrayList<>();
     Path path = new Path(fileUri);
     if (_hadoopFS.exists(path)) {
-      RemoteIterator<LocatedFileStatus> fileListItr = _hadoopFS.listFiles(path, recursive);
-      while (fileListItr != null && fileListItr.hasNext()) {
-        LocatedFileStatus file = fileListItr.next();
-        filePathStrings.add(file.getPath().toUri().toString());
+      // _hadoopFS.listFiles(path, false) will not return directories as files, thus use listStatus(path) here.
+      List<FileStatus> files = listStatus(path, recursive);
+      for (FileStatus file : files) {
+        filePathStrings.add(file.getPath().toUri().getRawPath());
       }
     } else {
       throw new IllegalArgumentException("segmentUri is not valid");
@@ -149,6 +150,19 @@ public class HadoopPinotFS extends PinotFS {
     String[] retArray = new String[filePathStrings.size()];
     filePathStrings.toArray(retArray);
     return retArray;
+  }
+
+  private List<FileStatus> listStatus(Path path, boolean recursive) throws IOException {
+    List<FileStatus> fileStatuses = new ArrayList<>();
+    FileStatus[] files = _hadoopFS.listStatus(path);
+    for (FileStatus file : files) {
+      fileStatuses.add(file);
+      if (file.isDirectory() && recursive) {
+        List<FileStatus> subFiles =listStatus(file.getPath(), true);
+        fileStatuses.addAll(subFiles);
+      }
+    }
+    return fileStatuses;
   }
 
   @Override


### PR DESCRIPTION
Currently the existing behavior of `listFiles()` in HadoopPinotFS only returns pure files instead of both files and directories, which makes SegmentDeletionManager doesn't work in HDFS.

This PR changes the behavior so that both files and directories can be returned by calling `listFiles()`.