### PR TITLE
Add headers for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 # Apache Pinot (incubating)
 
 [![Build Status](https://api.travis-ci.org/apache/incubator-pinot.svg?branch=master)](https://travis-ci.org/apache/incubator-pinot) [![codecov.io](https://codecov.io/github/linkedin/pinot/branch/master/graph/badge.svg)](https://codecov.io/github/linkedin/pinot) [![Join the chat at https://gitter.im/linkedin/pinot](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/linkedin/pinot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![license](https://img.shields.io/github/license/linkedin/pinot.svg)](LICENSE)

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Architecture
 ============
 
@@ -23,7 +42,7 @@ Pinot Components
 *Pinot Broker*
     Accepts queries from clients and routes them to one or more servers, and returns consolidated response to the client.
 
-Pinot leverages `Apache Helix <http://helix.apache.org>`_ for cluster management. 
+Pinot leverages `Apache Helix <http://helix.apache.org>`_ for cluster management.
 Helix is a cluster management framework to manage replicated, partitioned resources in a distributed system.
 Helix uses Zookeeper to store cluster state and metadata.
 
@@ -68,7 +87,7 @@ Table Schema defines column names and their metadata. Table configuration and sc
 Offline tables ingest pre-built pinot-segments from external data stores, whereas Reatime tables
 ingest data from streams (such as Kafka) and build segments.
 
-A hybrid Pinot table essentially has both realtime as well as offline tables. 
+A hybrid Pinot table essentially has both realtime as well as offline tables.
 In such a table, offline segments may be pushed periodically (say, once a day). The retention on the offline table
 can be set to a high value (say, a few years) since segments are coming in on a periodic basis, whereas the retention
 on the realtime part can be small (say, a few days). Once an offline segment is pushed to cover a recent time period,
@@ -87,7 +106,7 @@ Pinot provides libraries to create Pinot segments out of input files in AVRO, JS
 the constructed segments to the controlers via REST APIs.
 
 When an Offline segment is ingested, the controller looks up the table's configuration and assigns the segment
-to the servers that host the table. It may assign multiple servers for each servers depending on the number of replicas 
+to the servers that host the table. It may assign multiple servers for each servers depending on the number of replicas
 configured for that table.
 
 Pinot supports different segment assignment strategies that are optimized for various use cases.
@@ -96,7 +115,7 @@ Once segments are assigned, Pinot servers get notified via Helix to "host" the s
 (as a cached local copy to serve queries) and load them into local memory. All segment data is maintained in memory as long
 as the server hosts that segment.
 
-Once the server has loaded the segment, Helix notifies brokers of the availability of these segments. The brokers 
+Once the server has loaded the segment, Helix notifies brokers of the availability of these segments. The brokers
 start include the new
 segments for queries. Brokers support different routing strategies depending on the type of table, the segment assignment
 strategy and the use case.

--- a/docs/client_api.rst
+++ b/docs/client_api.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Executing queries via REST API on the Broker
 ============================================
 
@@ -13,11 +32,11 @@ Aggregation
   curl -X POST -d '{"pql":"select count(*) from flights"}' http://localhost:8099/query
 
 
-  {  
+  {
    "traceInfo":{},
    "numDocsScanned":17,
-   "aggregationResults":[  
-      {  
+   "aggregationResults":[
+      {
          "function":"count_star",
          "value":"17"
       }

--- a/docs/in_production.rst
+++ b/docs/in_production.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Running Pinot in production
 ===========================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 .. Pinot documentation master file, created by
    sphinx-quickstart on Fri Feb  9 14:54:43 2018.
    You can adapt this file completely to your liking, but it should at least

--- a/docs/index_techniques.rst
+++ b/docs/index_techniques.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 .. TODO: add more details
 
 Index Techniques

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 About Pinot
 ===========
 
@@ -8,24 +27,24 @@ so that it can scale to larger data sets and higher query rates as needed.
 What is it for (and not)?
 -------------------------
 
-Pinot is well suited for analytical use cases on immutable append-only data that require low latency between an event being ingested and it being available to be queried. 
+Pinot is well suited for analytical use cases on immutable append-only data that require low latency between an event being ingested and it being available to be queried.
 
 Key Features
 ------------
 
 * A column-oriented database with various compression schemes such as Run Length, Fixed Bit Length
 * Pluggable indexing technologies - Sorted Index, Bitmap Index, Inverted Index
-* Ability to optimize query/execution plan based on query and segment metadata . 
+* Ability to optimize query/execution plan based on query and segment metadata .
 * Near real time ingestion from streams and batch ingestion from Hadoop
 * SQL like language that supports selection, aggregation, filtering, group by, order by, distinct queries on data.
 * Support for multivalued fields
-* Horizontally scalable and fault tolerant 
+* Horizontally scalable and fault tolerant
 
 Because of the design choices we made to achieve these goals, there are certain limitations in Pinot:
 
-* Pinot is not a replacement for database i.e it cannot be used as source of truth store, cannot mutate data 
+* Pinot is not a replacement for database i.e it cannot be used as source of truth store, cannot mutate data
 * Not a replacement for search engine i.e Full text search, relevance not supported
-* Query cannot span across multiple tables. 
+* Query cannot span across multiple tables.
 
 Pinot works very well for querying time series data with lots of Dimensions and Metrics. For example:
 

--- a/docs/management_api.rst
+++ b/docs/management_api.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Managing Pinot via REST API on the Controller
 =============================================
 

--- a/docs/multitenancy.rst
+++ b/docs/multitenancy.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Multitenancy
 ============
 

--- a/docs/pinot_hadoop.rst
+++ b/docs/pinot_hadoop.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Creating Pinot segments
 =======================
 
@@ -41,7 +60,7 @@ Create a job properties configuration file, such as one below:
   segment.table.name=flights
 
   # === Segment tar push job config ===
-  
+
   # push.to.hosts: Comma separated list of controllers host names to which to push
   push.to.hosts=controller_host_0,controller_host_1
 
@@ -77,8 +96,8 @@ Here is how you can create Pinot segments from standard formats like CSV/JSON.
 #.  The file name extensions are expected to be the same as the format name (*i.e* ``.csv``, or ``.json``), and are case insensitive.
     Note that the converter expects the ``.csv`` extension even if the data is delimited using tabs or spaces instead.
 #.  Prepare a schema file describing the schema of the input data. The schema needs to be in JSON format. See example later in this section.
-#.  Specifically for CSV format, an optional csv config file can be provided (also in JSON format). This is used to configure parameters like the delimiter/header for the CSV file etc.  
-        A detailed description of this follows below.  
+#.  Specifically for CSV format, an optional csv config file can be provided (also in JSON format). This is used to configure parameters like the delimiter/header for the CSV file etc.
+        A detailed description of this follows below.
 
 Run the pinot-admin command to generate the segments. The command can be invoked as follows. Options within "[ ]" are optional. For -format, the default value is AVRO.
 
@@ -89,7 +108,7 @@ Run the pinot-admin command to generate the segments. The command can be invoked
 
 To configure various parameters for CSV a config file in JSON format can be provided. This file is optional, as are each of its parameters. When not provided, default values used for these parameters are described below:
 
-#.  fileFormat: Specify one of the following. Default is EXCEL.  
+#.  fileFormat: Specify one of the following. Default is EXCEL.
 
  ##.  EXCEL
  ##.  MYSQL
@@ -119,7 +138,7 @@ Sample Schema:
 
   {
     "dimensionFieldSpecs" : [
-      {			   
+      {
         "dataType" : "STRING",
         "delimiter" : null,
         "singleValueField" : true,
@@ -172,6 +191,6 @@ Alternatively you can use the pinot-admin.sh utility to upload one or more segme
 
   pinot-tools/target/pinot-tools-pkg/bin//pinot-admin.sh UploadSegment -controllerHost <hostname> -controllerPort <port> -segmentDir <segmentDirectoryPath>
 
-The command uploads all the segments found in ``segmentDirectoryPath``. 
+The command uploads all the segments found in ``segmentDirectoryPath``.
 The segments could be either tar-compressed (in which case it is a file under ``segmentDirectoryPath``)
 or uncompressed (in which case it is a directory under ``segmentDirectoryPath``).

--- a/docs/pluggable_storage.rst
+++ b/docs/pluggable_storage.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Pluggable Storage
 =================
 

--- a/docs/pluggable_streams.rst
+++ b/docs/pluggable_streams.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Pluggable Streams
 =================
 

--- a/docs/pql_examples.rst
+++ b/docs/pql_examples.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 .. _pql:
 
 PQL

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 .. _reference:
 
 .. toctree::

--- a/docs/segment_fetcher.rst
+++ b/docs/segment_fetcher.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Segment Fetchers
 ================
 
@@ -28,7 +47,7 @@ or
     pinot.server.segment.fetcher.hdfs.hadoop.conf.path=`<file path to hadoop conf folder>
 
 
-This path should point the local folder containing ``core-site.xml`` and ``hdfs-site.xml`` files from your Hadoop installation 
+This path should point the local folder containing ``core-site.xml`` and ``hdfs-site.xml`` files from your Hadoop installation
 
 .. code-block:: none
 
@@ -43,7 +62,7 @@ or
     pinot.server.segment.fetcher.hdfs.hadoop.kerberos.keytab=`<your kerberos keytab>
 
 
-These two configs should be the corresponding Kerberos configuration if your Hadoop installation is secured with Kerberos. Please check Hadoop Kerberos guide on how to generate Kerberos security identification. 
+These two configs should be the corresponding Kerberos configuration if your Hadoop installation is secured with Kerberos. Please check Hadoop Kerberos guide on how to generate Kerberos security identification.
 
 You will also need to provide proper Hadoop dependencies jars from your Hadoop installation to your Pinot startup scripts.
 
@@ -55,7 +74,7 @@ To push HDFS segment files to Pinot controller, you just need to ensure you have
 For example, the following curl requests to Controller will notify it to download segment files to the proper table:
 
 .. code-block:: none
- 
+
   curl -X POST -H "UPLOAD_TYPE:URI" -H "DOWNLOAD_URI:hdfs://nameservice1/hadoop/path/to/segment/file.gz" -H "content-type:application/json" -d '' localhost:9000/segments
 
 Implement your own segment fetcher for other systems
@@ -73,5 +92,5 @@ or
 
     pinot.server.segment.fetcher.`<protocol>`.class =`<class path to your implementation>
 
-You can also provide other configs to your fetcher under config-root ``pinot.server.segment.fetcher.<protocol>`` 
+You can also provide other configs to your fetcher under config-root ``pinot.server.segment.fetcher.<protocol>``
 

--- a/docs/trying_pinot.rst
+++ b/docs/trying_pinot.rst
@@ -1,3 +1,22 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
 Quick Demo
 ==========
 

--- a/pinot-hadoop/README.md
+++ b/pinot-hadoop/README.md
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 # Pinot Hadoop
 
 Introduction

--- a/pinot-perf/README.md
+++ b/pinot-perf/README.md
@@ -1,3 +1,24 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
 Pint Perf Package
 ===
 Pinot perf package contains a set of performance benchmark for Pinot components.

--- a/pom.xml
+++ b/pom.xml
@@ -1085,7 +1085,7 @@
 
             <!-- Top level directories -->
             <exclude>thirdeye/**</exclude>
-            <exclude>docs/**</exclude>
+
             <!-- Note: this will exclude all single character directories under the root directory.
             We use this to exclude the temporary files generated during build -->
             <exclude>?/**</exclude>
@@ -1137,9 +1137,8 @@
         </executions>
         <configuration>
           <excludes>
-            <!-- Documentation -->
-            <exclude>**/*.md</exclude>
-            <exclude>docs/**</exclude>
+            <!-- Sphynx auto generated makefile -->
+            <exclude>docs/Makefile</exclude>
 
             <!-- Exclude license copies -->
             <exclude>licenses/**</exclude>


### PR DESCRIPTION
According to the apache header policy, documentation files (md, rst)
also needs the headers just like source codes. This pr addresses
the issue.