### PR TITLE
add support for parquet reader

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -313,6 +313,11 @@
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ParquetUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ParquetUtils.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.avro.AvroSchemaConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+
+public class ParquetUtils {
+  /**
+   * Get the parquet record iterator for the given file
+   */
+  public static Iterator<GenericRecord> getParquetReader(String fileName)
+      throws IOException {
+    Path dataFsPath = new Path(fileName);
+    Configuration conf = new Configuration();
+    ParquetReader<GenericRecord> parquet =
+        AvroParquetReader.<GenericRecord>builder(dataFsPath).disableCompatibility().withDataModel(GenericData.get())
+            .withConf(conf).build();
+
+    return new Iterator<GenericRecord>() {
+      private boolean hasNext = false;
+      private GenericRecord next = advance();
+
+      @Override
+      public boolean hasNext() {
+        return hasNext;
+      }
+
+      @Override
+      public GenericRecord next() {
+        if (!hasNext) {
+          throw new NoSuchElementException();
+        }
+
+        GenericRecord toReturn = next;
+        next = advance();
+        return toReturn;
+      }
+
+      private GenericRecord advance() {
+        try {
+          GenericRecord next = parquet.read();
+          hasNext = (next != null);
+
+          if (hasNext == false) {
+            parquet.close();
+          }
+
+          return next;
+        } catch (IOException e) {
+          throw new RuntimeException("Failed while reading parquet file: " + fileName, e);
+        }
+      }
+    };
+  }
+
+  /**
+   * Get parquet schema for the given file
+   */
+  public static Schema getParquetSchema(String fileName)
+      throws IOException {
+    Path dataFsPath = new Path(fileName);
+    FileSystem fs = dataFsPath.getFileSystem(new Configuration());
+    ParquetMetadata footer = ParquetFileReader.readFooter(fs.getConf(), dataFsPath);
+
+    String schemaString = footer.getFileMetaData().getKeyValueMetaData().get("parquet.avro.schema");
+    if (schemaString == null) {
+      // try the older property
+      schemaString = footer.getFileMetaData().getKeyValueMetaData().get("avro.schema");
+    }
+
+    if (schemaString != null) {
+      return new Schema.Parser().parse(schemaString);
+    } else {
+      return new AvroSchemaConverter().convert(footer.getFileMetaData().getSchema());
+    }
+  }
+
+  /**
+   * write records as parquet file
+   */
+  public static void writeParquetRecord(String fileName, Schema schema, List<GenericRecord> records)
+      throws IOException {
+    ParquetWriter<GenericRecord> writer =
+        AvroParquetWriter.<GenericRecord>builder(new Path(fileName)).withSchema(schema).build();
+
+    try {
+      for (GenericRecord r : records) {
+        writer.write(r);
+      }
+    } finally {
+      writer.close();
+    }
+  }
+}

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -208,6 +208,11 @@
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/FileFormat.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/FileFormat.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.core.data.readers;
 
 public enum FileFormat {
-  AVRO, GZIPPED_AVRO, CSV, JSON, PINOT, THRIFT, OTHER
+  AVRO, GZIPPED_AVRO, CSV, JSON, PINOT, THRIFT, PARQUET, OTHER
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/ParquetRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/ParquetRecordReader.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.data.readers;
 
 import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.utils.ParquetUtils;
 import org.apache.pinot.core.data.GenericRow;
@@ -27,7 +28,6 @@ import org.apache.pinot.core.util.AvroUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
 
 
 /**
@@ -37,13 +37,18 @@ public class ParquetRecordReader implements RecordReader {
   private final String _dataFilePath;
   private final Schema _schema;
 
-  private Iterator<GenericRecord> _reader;
+  private ParquetReader<GenericRecord> _reader;
+  private GenericRecord _next;
+  private boolean _hasNext;
 
   public ParquetRecordReader(File dataFile, Schema schema)
       throws IOException {
-    _dataFilePath = "file://" + dataFile.getAbsolutePath();
+    _dataFilePath = dataFile.getAbsolutePath();
     _schema = schema;
+
     _reader = ParquetUtils.getParquetReader(_dataFilePath);
+    advanceToNext();
+
     AvroUtils.validateSchema(_schema, ParquetUtils.getParquetSchema(_dataFilePath));
   }
 
@@ -54,7 +59,7 @@ public class ParquetRecordReader implements RecordReader {
 
   @Override
   public boolean hasNext() {
-    return _reader.hasNext();
+    return _hasNext;
   }
 
   @Override
@@ -66,8 +71,8 @@ public class ParquetRecordReader implements RecordReader {
   @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
-    GenericRecord next = _reader.next();
-    AvroUtils.fillGenericRow(next, reuse, _schema);
+    AvroUtils.fillGenericRow(_next, reuse, _schema);
+    advanceToNext();
     return reuse;
   }
 
@@ -75,6 +80,7 @@ public class ParquetRecordReader implements RecordReader {
   public void rewind()
       throws IOException {
     _reader = ParquetUtils.getParquetReader(_dataFilePath);
+    advanceToNext();
   }
 
   @Override
@@ -85,5 +91,15 @@ public class ParquetRecordReader implements RecordReader {
   @Override
   public void close()
       throws IOException {
+    _reader.close();
+  }
+
+  private void advanceToNext() {
+    try {
+      _next = _reader.read();
+      _hasNext = (_next != null);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed while reading parquet file: " + _dataFilePath, e);
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/ParquetRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/ParquetRecordReader.java
@@ -18,45 +18,33 @@
  */
 package org.apache.pinot.core.data.readers;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
+import org.apache.pinot.common.utils.ParquetUtils;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.util.AvroUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
 
 
 /**
- * Record reader for AVRO file.
+ * Record reader for Parquet file.
  */
-public class AvroRecordReader implements RecordReader {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AvroRecordReader.class);
-
-  private final File _dataFile;
+public class ParquetRecordReader implements RecordReader {
+  private final String _dataFilePath;
   private final Schema _schema;
-  private final List<FieldSpec> _fieldSpecs;
 
-  private DataFileStream<GenericRecord> _avroReader;
-  private GenericRecord _reusableAvroRecord = null;
+  private Iterator<GenericRecord> _reader;
 
-  public AvroRecordReader(File dataFile, Schema schema)
+  public ParquetRecordReader(File dataFile, Schema schema)
       throws IOException {
-    _dataFile = dataFile;
+    _dataFilePath = "file://" + dataFile.getAbsolutePath();
     _schema = schema;
-    _fieldSpecs = RecordReaderUtils.extractFieldSpecs(schema);
-    _avroReader = AvroUtils.getAvroReader(dataFile);
-    try {
-      AvroUtils.validateSchema(_schema, _avroReader.getSchema());
-    } catch (Exception e) {
-      _avroReader.close();
-      throw e;
-    }
+    _reader = ParquetUtils.getParquetReader(_dataFilePath);
+    AvroUtils.validateSchema(_schema, ParquetUtils.getParquetSchema(_dataFilePath));
   }
 
   @Override
@@ -66,7 +54,7 @@ public class AvroRecordReader implements RecordReader {
 
   @Override
   public boolean hasNext() {
-    return _avroReader.hasNext();
+    return _reader.hasNext();
   }
 
   @Override
@@ -75,28 +63,18 @@ public class AvroRecordReader implements RecordReader {
     return next(new GenericRow());
   }
 
-  // NOTE: hard to extract common code further
-  @SuppressWarnings("Duplicates")
   @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
-    _reusableAvroRecord = _avroReader.next(_reusableAvroRecord);
-    for (FieldSpec fieldSpec : _fieldSpecs) {
-      String fieldName = fieldSpec.getName();
-      Object value = _reusableAvroRecord.get(fieldName);
-      // Allow default value for non-time columns
-      if (value != null || fieldSpec.getFieldType() != FieldSpec.FieldType.TIME) {
-        reuse.putField(fieldName, RecordReaderUtils.convert(fieldSpec, value));
-      }
-    }
+    GenericRecord next = _reader.next();
+    AvroUtils.fillGenericRow(next, reuse, _schema);
     return reuse;
   }
 
   @Override
   public void rewind()
       throws IOException {
-    _avroReader.close();
-    _avroReader = AvroUtils.getAvroReader(_dataFile);
+    _reader = ParquetUtils.getParquetReader(_dataFilePath);
   }
 
   @Override
@@ -107,6 +85,5 @@ public class AvroRecordReader implements RecordReader {
   @Override
   public void close()
       throws IOException {
-    _avroReader.close();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReaderFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReaderFactory.java
@@ -70,6 +70,8 @@ public class RecordReaderFactory {
       // NOTE: PinotSegmentRecordReader does not support time conversion (field spec must match)
       case PINOT:
         return new PinotSegmentRecordReader(dataFile, schema, segmentGeneratorConfig.getColumnSortOrder());
+      case PARQUET:
+        return new ParquetRecordReader(dataFile, schema);
       default:
         throw new UnsupportedOperationException("Unsupported input file format: " + fileFormat);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/AvroUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/AvroUtils.java
@@ -277,60 +277,6 @@ public class AvroUtils {
   }
 
   /**
-   * Fill the data in a {@link GenericRecord} to a {@link GenericRow}.
-   */
-  public static void fillGenericRow(GenericRecord from, GenericRow to, Schema schema) {
-    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-      String fieldName = fieldSpec.getName();
-      Object avroValue = from.get(fieldName);
-      if (fieldSpec.isSingleValueField()) {
-        to.putField(fieldName, transformAvroValueToObject(avroValue, fieldSpec));
-      } else {
-        to.putField(fieldName, transformAvroArrayToObjectArray((GenericData.Array) avroValue, fieldSpec));
-      }
-    }
-  }
-
-  /**
-   * Transform a single-value Avro value into an object in Pinot format.
-   */
-  public static Object transformAvroValueToObject(Object avroValue, FieldSpec fieldSpec) {
-    if (avroValue == null) {
-      return fieldSpec.getDefaultNullValue();
-    }
-    if (avroValue instanceof GenericData.Record) {
-      return transformAvroValueToObject(((GenericData.Record) avroValue).get(0), fieldSpec);
-    }
-    if (fieldSpec.getDataType() == FieldSpec.DataType.STRING) {
-      return avroValue.toString();
-    } else if (fieldSpec.getDataType() == FieldSpec.DataType.BYTES && avroValue instanceof ByteBuffer) {
-      // Avro ByteBuffer maps to byte[].
-      ByteBuffer byteBuffer = (ByteBuffer) avroValue;
-
-      // Assumes byte-buffer is ready to read. Also, avoid getting underlying array, as it may be over-sized.
-      byte[] bytes = new byte[byteBuffer.remaining()];
-      byteBuffer.get(bytes);
-      return bytes;
-    }
-    return avroValue;
-  }
-
-  /**
-   * Transform an Avro array into an object array in Pinot format.
-   */
-  public static Object[] transformAvroArrayToObjectArray(GenericData.Array avroArray, FieldSpec fieldSpec) {
-    if (avroArray == null || avroArray.size() == 0) {
-      return new Object[]{fieldSpec.getDefaultNullValue()};
-    }
-    int numValues = avroArray.size();
-    Object[] objects = new Object[numValues];
-    for (int i = 0; i < numValues; i++) {
-      objects[i] = transformAvroValueToObject(avroArray.get(i), fieldSpec);
-    }
-    return objects;
-  }
-
-  /**
    * Valid table schema with avro schema
    */
   public static void validateSchema(Schema schema, org.apache.avro.Schema avroSchema) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/ParquetRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/ParquetRecordReaderTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
 public class ParquetRecordReaderTest extends RecordReaderTest {
   private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "ParquetRecordReaderTest");
   private static final File DATA_FILE = new File(TEMP_DIR, "data.parquet");
-  private static final String DATA_FILE_PATH = "file://" + DATA_FILE.getAbsolutePath();
+  private static final String DATA_FILE_PATH = DATA_FILE.getAbsolutePath();
 
   @BeforeClass
   public void setUp()

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/ParquetRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/ParquetRecordReaderTest.java
@@ -26,10 +26,12 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.io.FileUtils;
+import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.pinot.common.utils.ParquetUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
 
 public class ParquetRecordReaderTest extends RecordReaderTest {
   private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "ParquetRecordReaderTest");
@@ -68,7 +70,14 @@ public class ParquetRecordReaderTest extends RecordReaderTest {
       records.add(record);
     }
 
-    ParquetUtils.writeParquetRecord(DATA_FILE_PATH, schema, records);
+    ParquetWriter<GenericRecord> writer = ParquetUtils.getParquetWriter(DATA_FILE_PATH, schema);
+    try {
+      for (GenericRecord r : records) {
+        writer.write(r);
+      }
+    } finally {
+      writer.close();
+    }
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/ParquetRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/ParquetRecordReaderTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.readers;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.utils.ParquetUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ParquetRecordReaderTest extends RecordReaderTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "ParquetRecordReaderTest");
+  private static final File DATA_FILE = new File(TEMP_DIR, "data.parquet");
+  private static final String DATA_FILE_PATH = "file://" + DATA_FILE.getAbsolutePath();
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.forceMkdir(TEMP_DIR);
+
+    String strSchema =
+        "{\n" + "    \"name\": \"AvroParquetTest\",\n" + "    \"type\": \"record\",\n" + "    \"fields\": [\n"
+            + "        {\n" + "            \"name\": \"INT_SV\",\n" + "            \"type\": [ \"int\", \"null\"],\n"
+            + "            \"default\": 0 \n" + "        },\n" + "        {\n" + "            \"name\": \"INT_MV\",\n"
+            + "            \"type\": [{\n" + "                \"type\": \"array\",\n"
+            + "                \"items\": \"int\"\n" + "             }, \"null\"]\n" + "        }\n" + "    ]\n" + "}";
+
+    Schema schema = new Schema.Parser().parse(strSchema);
+    List<GenericRecord> records = new ArrayList<>();
+
+    for (Object[] r : RECORDS) {
+      GenericRecord record = new GenericData.Record(schema);
+      if (r[0] != null) {
+        record.put("INT_SV", r[0]);
+      } else {
+        record.put("INT_SV", 0);
+      }
+
+      if (r[1] != null) {
+        record.put("INT_MV", r[1]);
+      } else {
+        record.put("INT_MV", new int[]{-1});
+      }
+
+      records.add(record);
+    }
+
+    ParquetUtils.writeParquetRecord(DATA_FILE_PATH, schema, records);
+  }
+
+  @Test
+  public void testParquetRecordReader()
+      throws Exception {
+    try (ParquetRecordReader recordReader = new ParquetRecordReader(DATA_FILE, SCHEMA)) {
+      checkValue(recordReader);
+      recordReader.rewind();
+      checkValue(recordReader);
+    }
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    FileUtils.forceDelete(TEMP_DIR);
+  }
+}

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentCreationJob.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentCreationJob.java
@@ -109,7 +109,7 @@ public class SegmentCreationJob extends BaseSegmentJob {
       return true;
     }
     return fileName.endsWith(".avro") || fileName.endsWith(".csv") || fileName.endsWith(".json") || fileName
-        .endsWith(".thrift");
+        .endsWith(".thrift") || fileName.endsWith(".parquet");
   }
 
   public void run()

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mapper/SegmentCreationMapper.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mapper/SegmentCreationMapper.java
@@ -276,6 +276,9 @@ public class SegmentCreationMapper extends Mapper<LongWritable, Text, LongWritab
     if (fileName.endsWith(".thrift")) {
       return FileFormat.THRIFT;
     }
+    if (fileName.endsWith(".parquet")) {
+      return FileFormat.PARQUET;
+    }
     throw new IllegalArgumentException("Unsupported file format: {}" + fileName);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.7.6</avro.version>
+    <parquet.version>1.8.0</parquet.version>
     <helix.version>0.8.2</helix.version>
     <!-- jfim: for Kafka 0.9.0.0, use zkclient 0.7 -->
     <kafka.version>0.9.0.1</kafka.version>


### PR DESCRIPTION
Parquet is widely used in hadoop echo, such as spark, hive. Many companies use it as ETL result format. So I think it is necessary to support generating pinot segment from parquet.

This PR add a ParquetRecordReader, which supports parquet as datasource. 