### PR TITLE
Check assigned instances for uploading new segment

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -57,6 +57,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -72,6 +73,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.upload.SegmentValidator;
+import org.apache.pinot.controller.api.upload.SegmentValidatorResponse;
 import org.apache.pinot.controller.api.upload.ZKOperator;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineStateModelGenerator;
@@ -315,12 +317,13 @@ public class PinotSegmentUploadRestletResource {
               clientAddress);
 
       // Validate segment
-      new SegmentValidator(_pinotHelixResourceManager, _controllerConf, _executor, _connectionManager,
-          _controllerMetrics).validateSegment(segmentMetadata, tempSegmentDir);
+      SegmentValidatorResponse segmentValidatorResponse =
+          new SegmentValidator(_pinotHelixResourceManager, _controllerConf, _executor, _connectionManager,
+              _controllerMetrics).validateSegment(segmentMetadata, tempSegmentDir);
 
       // Zk operations
       completeZkOperations(enableParallelPushProtection, headers, tempEncryptedFile, provider, segmentMetadata,
-          segmentName, zkDownloadUri, moveSegmentToFinalLocation);
+          segmentName, zkDownloadUri, moveSegmentToFinalLocation, segmentValidatorResponse);
 
       return new SuccessResponse(
           "Successfully uploaded segment: " + segmentMetadata.getName() + " of table: " + segmentMetadata
@@ -380,7 +383,7 @@ public class PinotSegmentUploadRestletResource {
 
   private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File tempDecryptedFile,
       FileUploadPathProvider provider, SegmentMetadata segmentMetadata, String segmentName, String zkDownloadURI,
-      boolean moveSegmentToFinalLocation)
+      boolean moveSegmentToFinalLocation, SegmentValidatorResponse segmentValidatorResponse)
       throws Exception {
     String finalSegmentPath = StringUtil
         .join("/", provider.getBaseDataDirURI().toString(), segmentMetadata.getTableName(),
@@ -388,7 +391,7 @@ public class PinotSegmentUploadRestletResource {
     URI finalSegmentLocationURI = new URI(finalSegmentPath);
     ZKOperator zkOperator = new ZKOperator(_pinotHelixResourceManager, _controllerConf, _controllerMetrics);
     zkOperator.completeSegmentOperations(segmentMetadata, finalSegmentLocationURI, tempDecryptedFile,
-        enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation);
+        enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation, segmentValidatorResponse);
   }
 
   private void decryptFile(String crypterClassHeader, File tempEncryptedFile, File tempDecryptedFile) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidatorResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidatorResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.upload;
+
+import java.util.List;
+import org.apache.helix.ZNRecord;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.controller.validation.StorageQuotaChecker;
+
+
+public class SegmentValidatorResponse {
+  private TableConfig _offlineTableConfig;
+  private ZNRecord _segmentMetadataZnRecord;
+  private List<String> _assignedInstances;
+  private StorageQuotaChecker.QuotaCheckerResponse _quotaCheckerResponse;
+
+  public SegmentValidatorResponse(TableConfig offlineTableConfig, ZNRecord segmentMetadataZnRecord, List<String> assignedInstances, StorageQuotaChecker.QuotaCheckerResponse quotaCheckerResponse) {
+    _offlineTableConfig = offlineTableConfig;
+    _segmentMetadataZnRecord = segmentMetadataZnRecord;
+    _assignedInstances = assignedInstances;
+    _quotaCheckerResponse = quotaCheckerResponse;
+  }
+
+  public TableConfig getOfflineTableConfig() {
+    return _offlineTableConfig;
+  }
+
+  public ZNRecord getSegmentMetadataZnRecord() {
+    return _segmentMetadataZnRecord;
+  }
+
+  public List<String> getAssignedInstances() {
+    return _assignedInstances;
+  }
+
+  public StorageQuotaChecker.QuotaCheckerResponse getQuotaCheckerResponse() {
+    return _quotaCheckerResponse;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidatorResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidatorResponse.java
@@ -25,10 +25,10 @@ import org.apache.pinot.controller.validation.StorageQuotaChecker;
 
 
 public class SegmentValidatorResponse {
-  private TableConfig _offlineTableConfig;
-  private ZNRecord _segmentMetadataZnRecord;
-  private List<String> _assignedInstances;
-  private StorageQuotaChecker.QuotaCheckerResponse _quotaCheckerResponse;
+  private final TableConfig _offlineTableConfig;
+  private final ZNRecord _segmentMetadataZnRecord;
+  private final List<String> _assignedInstances;
+  private final StorageQuotaChecker.QuotaCheckerResponse _quotaCheckerResponse;
 
   public SegmentValidatorResponse(TableConfig offlineTableConfig, ZNRecord segmentMetadataZnRecord, List<String> assignedInstances, StorageQuotaChecker.QuotaCheckerResponse quotaCheckerResponse) {
     _offlineTableConfig = offlineTableConfig;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1461,11 +1461,12 @@ public class PinotHelixResourceManager {
   }
 
   public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl) {
-    addNewSegment(segmentMetadata, downloadUrl, null, null);
+    List<String> assignedInstances = getAssignedInstancesForSegment(segmentMetadata);
+    addNewSegment(segmentMetadata, downloadUrl, null, assignedInstances);
   }
 
   public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl, String crypter,
-      List<String> assignedInstances) {
+      @Nonnull List<String> assignedInstances) {
     String segmentName = segmentMetadata.getName();
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
 
@@ -1688,8 +1689,7 @@ public class PinotHelixResourceManager {
   }
 
   /**
-   * Gets assigned instances for uploading new segment. This method can be used to detect
-   * whether table config is misconfigured when validating segment.
+   * Gets assigned instances for uploading new segment.
    * @param segmentMetadata segment metadata
    * @return a list of assigned instances.
    */
@@ -1722,9 +1722,6 @@ public class PinotHelixResourceManager {
     String segmentName = segmentMetadata.getName();
 
     // Assign new segment to instances
-    if (assignedInstances == null) {
-      assignedInstances = getAssignedInstancesForSegment(segmentMetadata);
-    }
     HelixHelper.addSegmentToIdealState(_helixZkManager, offlineTableName, segmentName, assignedInstances);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1467,6 +1467,7 @@ public class PinotHelixResourceManager {
 
   public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl, String crypter,
       @Nonnull List<String> assignedInstances) {
+    Preconditions.checkNotNull(assignedInstances, "Assigned Instances should not be null!");
     String segmentName = segmentMetadata.getName();
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1461,10 +1461,11 @@ public class PinotHelixResourceManager {
   }
 
   public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl) {
-    addNewSegment(segmentMetadata, downloadUrl, null);
+    addNewSegment(segmentMetadata, downloadUrl, null, null);
   }
 
-  public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl, String crypter) {
+  public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl, String crypter,
+      List<String> assignedInstances) {
     String segmentName = segmentMetadata.getName();
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
 
@@ -1481,7 +1482,7 @@ public class PinotHelixResourceManager {
     }
     LOGGER.info("Added segment: {} of table: {} to property store", segmentName, offlineTableName);
 
-    addNewOfflineSegment(segmentMetadata);
+    addNewOfflineSegment(segmentMetadata, assignedInstances);
     LOGGER.info("Added segment: {} of table: {} to ideal state", segmentName, offlineTableName);
   }
 
@@ -1687,6 +1688,25 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Gets assigned instances for uploading new segment. This method can be used to detect
+   * whether table config is misconfigured when validating segment.
+   * @param segmentMetadata segment metadata
+   * @return a list of assigned instances.
+   */
+  public List<String> getAssignedInstancesForSegment(SegmentMetadata segmentMetadata) {
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
+    TableConfig offlineTableConfig = ZKMetadataProvider.getOfflineTableConfig(_propertyStore, offlineTableName);
+    Preconditions.checkNotNull(offlineTableConfig);
+    int numReplicas = Integer.parseInt(offlineTableConfig.getValidationConfig().getReplication());
+    String serverTenant = TagNameUtils.getOfflineTagForTenant(offlineTableConfig.getTenantConfig().getServer());
+    SegmentAssignmentStrategy segmentAssignmentStrategy = SegmentAssignmentStrategyFactory
+        .getSegmentAssignmentStrategy(offlineTableConfig.getValidationConfig().getSegmentAssignmentStrategy());
+    return segmentAssignmentStrategy
+        .getAssignedInstances(_helixZkManager, _helixAdmin, _propertyStore, _helixClusterName, segmentMetadata,
+            numReplicas, serverTenant);
+  }
+
+  /**
    * Helper method to add the passed in offline segment to the helix cluster.
    * - Gets the segment name and the table name from the passed in segment meta-data.
    * - Identifies the instance set onto which the segment needs to be added, based on
@@ -1697,21 +1717,14 @@ public class PinotHelixResourceManager {
    * @param segmentMetadata Meta-data for the segment, used to access segmentName and tableName.
    */
   // NOTE: method should be thread-safe
-  private void addNewOfflineSegment(SegmentMetadata segmentMetadata) {
+  private void addNewOfflineSegment(SegmentMetadata segmentMetadata, List<String> assignedInstances) {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
     String segmentName = segmentMetadata.getName();
 
     // Assign new segment to instances
-    TableConfig offlineTableConfig = ZKMetadataProvider.getOfflineTableConfig(_propertyStore, offlineTableName);
-    Preconditions.checkNotNull(offlineTableConfig);
-    int numReplicas = Integer.parseInt(offlineTableConfig.getValidationConfig().getReplication());
-    String serverTenant = TagNameUtils.getOfflineTagForTenant(offlineTableConfig.getTenantConfig().getServer());
-    SegmentAssignmentStrategy segmentAssignmentStrategy = SegmentAssignmentStrategyFactory
-        .getSegmentAssignmentStrategy(offlineTableConfig.getValidationConfig().getSegmentAssignmentStrategy());
-    List<String> assignedInstances = segmentAssignmentStrategy
-        .getAssignedInstances(_helixZkManager, _helixAdmin, _propertyStore, _helixClusterName, segmentMetadata,
-            numReplicas, serverTenant);
-
+    if (assignedInstances == null) {
+      assignedInstances = getAssignedInstancesForSegment(segmentMetadata);
+    }
     HelixHelper.addSegmentToIdealState(_helixZkManager, offlineTableName, segmentName, assignedInstances);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PinotURIUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PinotURIUploadIntegrationTest.java
@@ -202,8 +202,7 @@ public class PinotURIUploadIntegrationTest extends BaseClusterIntegrationTestSet
       uploadSegmentsDirectly(segmentTarDir);
       Assert.fail("Uploading segments should fail.");
     } catch (Exception e) {
-      Assert.assertNotNull(e);
-      Assert.assertTrue(e.getMessage().contains("No assigned Instances for Segment"));
+      //
     }
 
     // Re-enable the server instance.


### PR DESCRIPTION
This PR improves segment validator to check assigned instances for uploading new segment.

Refactor the code in `SegmentValidator` so that the results of validation can be re-used.