### PR TITLE
Disable realtime aggregate metrics if multi value columns present

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -447,7 +447,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
           canTakeMore = _realtimeSegment.index(transformedRow);
         } catch (Exception e) {
-          segmentLogger.debug("Caught exception while transforming the record: {}", decodedRow, e);
+          segmentLogger.error("Caught exception while transforming the record: {}", decodedRow, e);
           _numRowsErrored++;
         }
       } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -334,7 +334,7 @@ public class MutableSegmentImpl implements MutableSegment {
       Preconditions.checkState(_dictionaryMap.get(column) == null, "Updating metrics not supported with dictionary.");
       FieldSpec.DataType dataType = metricSpec.getDataType();
 
-      // TODO: this breaks for multi value metrics. https://github.com/apache/incubator-pinot/issues/3867
+      // FIXME: this breaks for multi value metrics. https://github.com/apache/incubator-pinot/issues/3867
       switch (dataType) {
         case INT:
           indexReaderWriter.setInt(docId, (Integer) value + indexReaderWriter.getInt(docId));
@@ -670,7 +670,7 @@ public class MutableSegmentImpl implements MutableSegment {
     int i = 0;
     int[] dictIds = new int[_numKeyColumns]; // dimensions + time column.
 
-    // TODO: this for loop breaks for multi value columns. https://github.com/apache/incubator-pinot/issues/3867
+    // FIXME: this for loop breaks for multi value dimensions. https://github.com/apache/incubator-pinot/issues/3867
     for (String column : _schema.getDimensionNames()) {
       dictIds[i++] = (Integer) dictIdMap.get(column);
     }


### PR DESCRIPTION
Consumption will stop in the case of aggregateMetrics=true in combination with multi-value dimensions or metrics. More details in https://github.com/apache/incubator-pinot/issues/3867

This will be fixed in a separate PR. Until then, disabling the realtime aggregation in this scenario