### PR TITLE
add config to control kafka fetcher size and increase default

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -77,6 +77,8 @@ public class KafkaConnectionHandler {
 
   boolean isPartitionProvided;
 
+  private final KafkaLowLevelStreamConfig _kafkaLowLevelStreamConfig;
+
   @VisibleForTesting
   public SimpleConsumer getSimpleConsumer() {
     return _simpleConsumer;
@@ -109,19 +111,19 @@ public class KafkaConnectionHandler {
    */
   public KafkaConnectionHandler(String clientId, StreamConfig streamConfig,
       KafkaSimpleConsumerFactory simpleConsumerFactory) {
-    KafkaLowLevelStreamConfig kafkaLowLevelStreamConfig = new KafkaLowLevelStreamConfig(streamConfig);
+    _kafkaLowLevelStreamConfig = new KafkaLowLevelStreamConfig(streamConfig);
     _simpleConsumerFactory = simpleConsumerFactory;
     _clientId = clientId;
-    _topic = kafkaLowLevelStreamConfig.getKafkaTopicName();
+    _topic = _kafkaLowLevelStreamConfig.getKafkaTopicName();
     _connectTimeoutMillis = streamConfig.getConnectionTimeoutMillis();
     _simpleConsumer = null;
 
     isPartitionProvided = false;
     _partition = Integer.MIN_VALUE;
 
-    _bufferSize = kafkaLowLevelStreamConfig.getKafkaBufferSize();
-    _socketTimeout = kafkaLowLevelStreamConfig.getKafkaSocketTimeout();
-    initializeBootstrapNodeList(kafkaLowLevelStreamConfig.getBootstrapHosts());
+    _bufferSize = _kafkaLowLevelStreamConfig.getKafkaBufferSize();
+    _socketTimeout = _kafkaLowLevelStreamConfig.getKafkaSocketTimeout();
+    initializeBootstrapNodeList(_kafkaLowLevelStreamConfig.getBootstrapHosts());
     setCurrentState(new ConnectingToBootstrapNode());
   }
 
@@ -134,19 +136,19 @@ public class KafkaConnectionHandler {
   public KafkaConnectionHandler(String clientId, StreamConfig streamConfig, int partition,
       KafkaSimpleConsumerFactory simpleConsumerFactory) {
 
-    KafkaLowLevelStreamConfig kafkaLowLevelStreamConfig = new KafkaLowLevelStreamConfig(streamConfig);
+    _kafkaLowLevelStreamConfig = new KafkaLowLevelStreamConfig(streamConfig);
     _simpleConsumerFactory = simpleConsumerFactory;
     _clientId = clientId;
-    _topic = kafkaLowLevelStreamConfig.getKafkaTopicName();
+    _topic = _kafkaLowLevelStreamConfig.getKafkaTopicName();
     _connectTimeoutMillis = streamConfig.getConnectionTimeoutMillis();
     _simpleConsumer = null;
 
     isPartitionProvided = true;
     _partition = partition;
 
-    _bufferSize = kafkaLowLevelStreamConfig.getKafkaBufferSize();
-    _socketTimeout = kafkaLowLevelStreamConfig.getKafkaSocketTimeout();
-    initializeBootstrapNodeList(kafkaLowLevelStreamConfig.getBootstrapHosts());
+    _bufferSize = _kafkaLowLevelStreamConfig.getKafkaBufferSize();
+    _socketTimeout = _kafkaLowLevelStreamConfig.getKafkaSocketTimeout();
+    initializeBootstrapNodeList(_kafkaLowLevelStreamConfig.getBootstrapHosts());
     setCurrentState(new ConnectingToBootstrapNode());
   }
 
@@ -178,6 +180,10 @@ public class KafkaConnectionHandler {
             "Could not parse port number " + splitHostAndPort[1] + " for host:port combination " + hostAndPort);
       }
     }
+  }
+
+  protected KafkaLowLevelStreamConfig getkafkaLowLevelStreamConfig() {
+    return _kafkaLowLevelStreamConfig;
   }
 
   abstract class State {

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfig.java
@@ -30,10 +30,12 @@ import org.apache.pinot.core.realtime.stream.StreamConfig;
  */
 public class KafkaLowLevelStreamConfig {
 
-  private String _kafkaTopicName;
-  private String _bootstrapHosts;
-  private int _kafkaBufferSize;
-  private int _kafkaSocketTimeout;
+  private final String _kafkaTopicName;
+  private final String _bootstrapHosts;
+  private final int _kafkaBufferSize;
+  private final int _kafkaSocketTimeout;
+  private final int _kafkaFetcherSizeBytes;
+  private final int _kafkaFetcherMinBytes;
 
   /**
    * Builds a wrapper around {@link StreamConfig} to fetch kafka partition level consumer related configs
@@ -50,11 +52,18 @@ public class KafkaLowLevelStreamConfig {
         .constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE);
     String llcTimeoutKey = KafkaStreamConfigProperties
         .constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT);
+    String fetcherSizeKey = KafkaStreamConfigProperties
+        .constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_FETCHER_SIZE_BYTES);
+    String fetcherMinBytesKey = KafkaStreamConfigProperties
+        .constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_FETCHER_MIN_BYTES);
     _bootstrapHosts = streamConfigMap.get(llcBrokerListKey);
     _kafkaBufferSize = getIntConfigWithDefault(streamConfigMap, llcBufferKey,
         KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT);
     _kafkaSocketTimeout = getIntConfigWithDefault(streamConfigMap, llcTimeoutKey,
         KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT_DEFAULT);
+    _kafkaFetcherSizeBytes = getIntConfigWithDefault(streamConfigMap, fetcherSizeKey, _kafkaBufferSize);
+    _kafkaFetcherMinBytes = getIntConfigWithDefault(streamConfigMap, fetcherMinBytesKey,
+        KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_FETCHER_MIN_BYTES_DEFAULT);
     Preconditions.checkNotNull(_bootstrapHosts,
         "Must specify kafka brokers list " + llcBrokerListKey + " in case of low level kafka consumer");
   }
@@ -75,6 +84,14 @@ public class KafkaLowLevelStreamConfig {
     return _kafkaSocketTimeout;
   }
 
+  public int getKafkaFetcherSizeBytes() {
+    return _kafkaFetcherSizeBytes;
+  }
+
+  public int getKafkaFetcherMinBytes() {
+    return _kafkaFetcherMinBytes;
+  }
+
   private int getIntConfigWithDefault(Map<String, String> configMap, String key, int defaultValue) {
     String stringValue = configMap.get(key);
     try {
@@ -91,7 +108,8 @@ public class KafkaLowLevelStreamConfig {
   public String toString() {
     return "KafkaLowLevelStreamConfig{" + "_kafkaTopicName='" + _kafkaTopicName + '\'' + ", _bootstrapHosts='"
         + _bootstrapHosts + '\'' + ", _kafkaBufferSize='" + _kafkaBufferSize + '\'' + ", _kafkaSocketTimeout='"
-        + _kafkaSocketTimeout + '\'' + '}';
+        + _kafkaSocketTimeout + '\'' + ", _kafkaFetcherSizeBytes='" + _kafkaFetcherSizeBytes + '\'' + ", _kafkaFetcherMinBytes='"
+        + _kafkaFetcherMinBytes + '\'' + '}';
   }
 
   @Override
@@ -109,7 +127,9 @@ public class KafkaLowLevelStreamConfig {
     return EqualityUtils.isEqual(_kafkaTopicName, that._kafkaTopicName) && EqualityUtils
         .isEqual(_bootstrapHosts, that._bootstrapHosts) && EqualityUtils
         .isEqual(_kafkaBufferSize, that._kafkaBufferSize) && EqualityUtils
-        .isEqual(_kafkaSocketTimeout, that._kafkaSocketTimeout);
+        .isEqual(_kafkaSocketTimeout, that._kafkaSocketTimeout) && EqualityUtils
+        .isEqual(_kafkaFetcherSizeBytes, that._kafkaFetcherSizeBytes) && EqualityUtils
+        .isEqual(_kafkaFetcherMinBytes, that._kafkaFetcherMinBytes);
   }
 
   @Override
@@ -118,6 +138,8 @@ public class KafkaLowLevelStreamConfig {
     result = EqualityUtils.hashCodeOf(result, _bootstrapHosts);
     result = EqualityUtils.hashCodeOf(result, _kafkaBufferSize);
     result = EqualityUtils.hashCodeOf(result, _kafkaSocketTimeout);
+    result = EqualityUtils.hashCodeOf(result, _kafkaFetcherSizeBytes);
+    result = EqualityUtils.hashCodeOf(result, _kafkaFetcherMinBytes);
     return result;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
@@ -39,20 +39,20 @@ public class KafkaPartitionLevelConsumer extends KafkaConnectionHandler implemen
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaPartitionLevelConsumer.class);
 
   private final int _fetchRequestMinBytes;
-  private final int _fetchRequestSize;
+  private final int _fetchRequestSizeBytes;
 
   public KafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition) {
     super(clientId, streamConfig, partition, new KafkaSimpleConsumerFactoryImpl());
-    this._fetchRequestSize = getkafkaLowLevelStreamConfig().getKafkaFetcherSizeBytes();
-    this._fetchRequestMinBytes = getkafkaLowLevelStreamConfig().getKafkaFetcherMinBytes();
+    _fetchRequestSizeBytes = getkafkaLowLevelStreamConfig().getKafkaFetcherSizeBytes();
+    _fetchRequestMinBytes = getkafkaLowLevelStreamConfig().getKafkaFetcherMinBytes();
   }
 
   @VisibleForTesting
   public KafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition,
       KafkaSimpleConsumerFactory kafkaSimpleConsumerFactory) {
     super(clientId, streamConfig, partition, kafkaSimpleConsumerFactory);
-    this._fetchRequestSize = getkafkaLowLevelStreamConfig().getKafkaFetcherSizeBytes();
-    this._fetchRequestMinBytes = getkafkaLowLevelStreamConfig().getKafkaFetcherMinBytes();
+    _fetchRequestSizeBytes = getkafkaLowLevelStreamConfig().getKafkaFetcherSizeBytes();
+    _fetchRequestMinBytes = getkafkaLowLevelStreamConfig().getKafkaFetcherMinBytes();
   }
 
   /**
@@ -83,7 +83,7 @@ public class KafkaPartitionLevelConsumer extends KafkaConnectionHandler implemen
 
     FetchResponse fetchResponse = _simpleConsumer.fetch(
         new FetchRequestBuilder().minBytes(_fetchRequestMinBytes).maxWait(timeoutMillis)
-            .addFetch(_topic, _partition, startOffset, _fetchRequestSize).build());
+            .addFetch(_topic, _partition, startOffset, _fetchRequestSizeBytes).build());
 
     if (!fetchResponse.hasError()) {
       final Iterable<MessageAndOffset> messageAndOffsetIterable =
@@ -117,7 +117,7 @@ public class KafkaPartitionLevelConsumer extends KafkaConnectionHandler implemen
 
   @VisibleForTesting
   public int getFetchRequestSize() {
-    return _fetchRequestSize;
+    return _fetchRequestSizeBytes;
   }
 
   @VisibleForTesting

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
@@ -43,9 +43,12 @@ public class KafkaStreamConfigProperties {
   public static class LowLevelConsumer {
     public static final String KAFKA_BROKER_LIST = "kafka.broker.list";
     public static final String KAFKA_BUFFER_SIZE = "kafka.buffer.size";
-    public static final int KAFKA_BUFFER_SIZE_DEFAULT = 512000;
+    public static final int KAFKA_BUFFER_SIZE_DEFAULT = 5120000;
     public static final String KAFKA_SOCKET_TIMEOUT = "kafka.socket.timeout";
     public static final int KAFKA_SOCKET_TIMEOUT_DEFAULT = 10000;
+    public static final String KAFKA_FETCHER_SIZE_BYTES = "kafka.fetcher.size";
+    public static final String KAFKA_FETCHER_MIN_BYTES = "kafka.fetcher.minBytes";
+    public static final int KAFKA_FETCHER_MIN_BYTES_DEFAULT = 100000;
   }
 
   public static final String KAFKA_CONSUMER_PROP_PREFIX = "kafka.consumer.prop";

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
@@ -43,7 +43,7 @@ public class KafkaStreamConfigProperties {
   public static class LowLevelConsumer {
     public static final String KAFKA_BROKER_LIST = "kafka.broker.list";
     public static final String KAFKA_BUFFER_SIZE = "kafka.buffer.size";
-    public static final int KAFKA_BUFFER_SIZE_DEFAULT = 5120000;
+    public static final int KAFKA_BUFFER_SIZE_DEFAULT = 512000;
     public static final String KAFKA_SOCKET_TIMEOUT = "kafka.socket.timeout";
     public static final int KAFKA_SOCKET_TIMEOUT_DEFAULT = 10000;
     public static final String KAFKA_FETCHER_SIZE_BYTES = "kafka.fetcher.size";

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfigTest.java
@@ -29,7 +29,12 @@ import org.testng.annotations.Test;
 public class KafkaLowLevelStreamConfigTest {
 
   private KafkaLowLevelStreamConfig getStreamConfig(String topic, String bootstrapHosts, String buffer,
-      String socketTimeout) {
+                                                    String socketTimeout) {
+    return getStreamConfig(topic, bootstrapHosts, buffer, socketTimeout, null, null);
+  }
+
+  private KafkaLowLevelStreamConfig getStreamConfig(String topic, String bootstrapHosts, String buffer,
+      String socketTimeout, String fetcherSize, String fetcherMinBytes) {
     Map<String, String> streamConfigMap = new HashMap<>();
     String streamType = "kafka";
     String consumerType = StreamConfig.ConsumerType.LOWLEVEL.toString();
@@ -53,7 +58,13 @@ public class KafkaLowLevelStreamConfigTest {
       streamConfigMap.put("stream.kafka.buffer.size", buffer);
     }
     if (socketTimeout != null) {
-      streamConfigMap.put("stream.kafka.socket.timeout", String.valueOf(socketTimeout));
+      streamConfigMap.put("stream.kafka.socket.timeout", socketTimeout);
+    }
+    if (fetcherSize != null) {
+      streamConfigMap.put("stream.kafka.fetcher.size", fetcherSize);
+    }
+    if (fetcherMinBytes != null) {
+      streamConfigMap.put("stream.kafka.fetcher.minBytes", fetcherMinBytes);
     }
     return new KafkaLowLevelStreamConfig(new StreamConfig(streamConfigMap));
   }
@@ -108,5 +119,43 @@ public class KafkaLowLevelStreamConfigTest {
     // correct config
     config = getStreamConfig("topic", "host1", "", "100");
     Assert.assertEquals(100, config.getKafkaSocketTimeout());
+  }
+
+  @Test
+  public void testGetFetcherSize() {
+    // test default
+    KafkaLowLevelStreamConfig config = getStreamConfig("topic", "host1", "", "", "",null);
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT,
+        config.getKafkaFetcherSizeBytes());
+
+    config = getStreamConfig("topic", "host1", "100", "", "", null);
+    Assert.assertEquals(100, config.getKafkaFetcherSizeBytes());
+
+    config = getStreamConfig("topic", "host1", "100", "", "bad value", null);
+    Assert.assertEquals(100, config.getKafkaFetcherSizeBytes());
+
+    // correct config
+    config = getStreamConfig("topic", "host1", "100", "", "200", null);
+    Assert.assertEquals(200, config.getKafkaFetcherSizeBytes());
+  }
+
+  @Test
+  public void testGetFetcherMinBytes() {
+    // test default
+    KafkaLowLevelStreamConfig config = getStreamConfig("topic", "host1", "", "", "", null);
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_FETCHER_MIN_BYTES_DEFAULT,
+        config.getKafkaFetcherMinBytes());
+
+    config = getStreamConfig("topic", "host1", "", "", "", "");
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_FETCHER_MIN_BYTES_DEFAULT,
+        config.getKafkaFetcherMinBytes());
+
+    config = getStreamConfig("topic", "host1", "", "", "", "bad value");
+    Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_FETCHER_MIN_BYTES_DEFAULT,
+        config.getKafkaFetcherMinBytes());
+
+    // correct config
+    config = getStreamConfig("topic", "host1", "", "", "", "100");
+    Assert.assertEquals(100, config.getKafkaFetcherMinBytes());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/kafka/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/kafka/KafkaPartitionLevelConsumerTest.java
@@ -235,6 +235,8 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap
         .put("stream.kafka.consumer.factory.class.name", mockKafkaSimpleConsumerFactory.getClass().getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
+    streamConfigMap.put("stream.kafka.fetcher.size", "10000");
+    streamConfigMap.put("stream.kafka.fetcher.minBytes", "20000");
     StreamConfig streamConfig = new StreamConfig(streamConfigMap);
 
     KafkaStreamMetadataProvider streamMetadataProvider =
@@ -244,10 +246,15 @@ public class KafkaPartitionLevelConsumerTest {
     KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer =
         new KafkaPartitionLevelConsumer(clientId, streamConfig, 0, mockKafkaSimpleConsumerFactory);
     kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
+
     Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT,
         kafkaSimpleStreamConsumer.getSimpleConsumer().bufferSize());
     Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_SOCKET_TIMEOUT_DEFAULT,
         kafkaSimpleStreamConsumer.getSimpleConsumer().soTimeout());
+
+    // test parsing values
+    Assert.assertEquals(10000, kafkaSimpleStreamConsumer.getFetchRequestSize());
+    Assert.assertEquals(20000, kafkaSimpleStreamConsumer.getFetchRequestMinBytes());
 
     // test user defined values
     streamConfigMap.put("stream.kafka.buffer.size", "100");


### PR DESCRIPTION
1. currently we hardcode the fetcher size to 500k. If this consumer fetched a larger message we will fail simple consumer silently and kafka consumer will get stuck. Our previous attempts try to fix this issue (https://github.com/apache/incubator-pinot/pull/3584) turns out to be not completed and we verify that we need one more fix

2. we increase the default from 500k to 5m to handle more use-cases and pinot consumer should handle it fine for larger memory.