### PR TITLE
Fix reporting/logging of numEntriesScannedPostFilter

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -150,7 +150,7 @@ public abstract class QueryScheduler {
     long numEntriesScannedInFilter = Long.parseLong(
         dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, INVALID_NUM_SCANNED));
     long numEntriesScannedPostFilter =
-        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_SEGMENTS_QUERIED, INVALID_NUM_SCANNED));
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, INVALID_NUM_SCANNED));
     long numSegmentsProcessed =
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_SEGMENTS_PROCESSED, INVALID_SEGMENTS_COUNT));
     long numSegmentsMatched =


### PR DESCRIPTION
#3739 introduced a typo where we started reporting number of segments queried as the value for number of entries scanned post filter. (The PR was for auto reformatting the code, but looks like there were also a few manual changes that resulted in the typo)

Detection/Verification: both manual at this time. We have tests that verify the execution stats at the operator levels, but none at the queryscheduler level. We should add/update tests to verify these values as well. Tracking it via  #3871