### PR TITLE
Add metrics to track work done in group-by phase

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -59,7 +59,11 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NUM_SEGMENTS_MATCHED("numSegmentsMatched", false),
   NUM_MISSING_SEGMENTS("segments", false),
   RELOAD_FAILURES("segments", false),
-  REFRESH_FAILURES("segments", false);
+  REFRESH_FAILURES("segments", false),
+  NUM_GROUPS_IGNORED_PRE_COMBINE("numGroupsIgnoredPreCombine", false),
+  NUM_GROUPS_IGNORED_IN_COMBINE("numGroupsIgnoredInCombine", false),
+  NUM_GROUPS_AGGR_IN_COMBINE("numGroupsAggrInCombine", false),
+  NUM_GROUPS_IGNORED_POST_COMBINE("numGroupsIgnoredPostCombine", false);
 
   private final String meterName;
   private final String unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -37,6 +37,10 @@ public interface DataTable {
   String NUM_SEGMENTS_MATCHED = "numSegmentsMatched";
   String TOTAL_DOCS_METADATA_KEY = "totalDocs";
   String NUM_GROUPS_LIMIT_REACHED_KEY = "numGroupsLimitReached";
+  String NUM_GROUPS_IGNORED_PRE_COMBINE = "numGroupsIgnoredPreCombine";
+  String NUM_GROUPS_IGNORED_IN_COMBINE = "numGroupsIgnoredInCombine";
+  String NUM_GROUPS_AGGR_IN_COMBINE = "numGroupsAggrInCombine";
+  String NUM_GROUPS_IGNORED_POST_COMBINE = "numGroupsIgnoredPostCombine";
   String TIME_USED_MS_METADATA_KEY = "timeUsedMs";
   String TRACE_INFO_METADATA_KEY = "traceInfo";
   String REQUEST_ID_METADATA_KEY = "requestId";

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ExecutionStatistics.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ExecutionStatistics.java
@@ -28,6 +28,11 @@ public class ExecutionStatistics {
   private long _numTotalRawDocs;
   private long _numSegmentsProcessed;
   private long _numSegmentsMatched;
+  private long _numGroupsIgnoredPreCombine;
+  private long _numGroupsIgnoredInCombine;
+  // number of groups aggregated in combine phase
+  private int _numGroupsAggrInCombine;
+  private int _numGroupsIgnoredPostCombine;
 
   public ExecutionStatistics() {
   }
@@ -66,6 +71,14 @@ public class ExecutionStatistics {
     return _numSegmentsMatched;
   }
 
+  public void setNumGroupsIgnoredPreCombine(long ignored) {
+   _numGroupsIgnoredPreCombine = ignored;
+  }
+
+  public long getNumGroupsIgnoredPreCombine() {
+    return _numGroupsIgnoredPreCombine;
+  }
+
   /**
    * Merge another execution statistics into the current one.
    *
@@ -78,6 +91,7 @@ public class ExecutionStatistics {
     _numTotalRawDocs += executionStatisticsToMerge._numTotalRawDocs;
     _numSegmentsProcessed += executionStatisticsToMerge._numSegmentsProcessed;
     _numSegmentsMatched += executionStatisticsToMerge._numSegmentsMatched;
+    _numGroupsIgnoredPreCombine += executionStatisticsToMerge._numGroupsIgnoredPreCombine;
   }
 
   @Override
@@ -85,6 +99,7 @@ public class ExecutionStatistics {
     return "Execution Statistics:" + "\n  numDocsScanned: " + _numDocsScanned + "\n  numEntriesScannedInFilter: "
         + _numEntriesScannedInFilter + "\n  numEntriesScannedPostFilter: " + _numEntriesScannedPostFilter
         + "\n  numTotalRawDocs: " + _numTotalRawDocs + "\n  numSegmentsProcessed: " + _numSegmentsProcessed
-        + "\n  numSegmentsMatched: " + _numSegmentsMatched;
+        + "\n  numSegmentsMatched: " + _numSegmentsMatched
+        + "\n  numGroupsIgnoredPreCombine: " + _numGroupsIgnoredPreCombine;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -59,6 +59,10 @@ public class IntermediateResultsBlock implements Block {
   private long _numSegmentsProcessed;
   private long _numSegmentsMatched;
   private boolean _numGroupsLimitReached;
+  private long _numGroupsIgnoredInCombine;
+  private long _numGroupsIgnoredPreCombine;
+  private int _numGroupsAggrInCombine;
+  private int _numGroupsIgnoredPostCombine;
 
   /**
    * Constructor for selection result.
@@ -198,9 +202,26 @@ public class IntermediateResultsBlock implements Block {
     _numTotalRawDocs = numTotalRawDocs;
   }
 
+  public void setNumGroupsIgnoredInCombine(long ignored) {
+    _numGroupsIgnoredInCombine = ignored;
+  }
+
+  public void setNumGroupsIgnoredPreCombine(long ignored) {
+    _numGroupsIgnoredPreCombine = ignored;
+  }
+
+  public void setNumGroupsAggrInCombine(int aggr) {
+    _numGroupsAggrInCombine = aggr;
+  }
+
+  public void setNumGroupsIgnoredPostCombine(int ignored) {
+    _numGroupsIgnoredPostCombine = _numGroupsIgnoredPostCombine;
+  }
+
   public void setNumGroupsLimitReached(boolean numGroupsLimitReached) {
     _numGroupsLimitReached = numGroupsLimitReached;
   }
+
 
   @Nonnull
   public DataTable getDataTable()
@@ -296,11 +317,10 @@ public class IntermediateResultsBlock implements Block {
   }
 
   private DataTable attachMetadataToDataTable(DataTable dataTable) {
+
     dataTable.getMetadata().put(DataTable.NUM_DOCS_SCANNED_METADATA_KEY, String.valueOf(_numDocsScanned));
-    dataTable.getMetadata()
-        .put(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedInFilter));
-    dataTable.getMetadata()
-        .put(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedPostFilter));
+    dataTable.getMetadata().put(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedInFilter));
+    dataTable.getMetadata().put(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedPostFilter));
     dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_PROCESSED, String.valueOf(_numSegmentsProcessed));
     dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_MATCHED, String.valueOf(_numSegmentsMatched));
 
@@ -308,6 +328,10 @@ public class IntermediateResultsBlock implements Block {
     if (_numGroupsLimitReached) {
       dataTable.getMetadata().put(DataTable.NUM_GROUPS_LIMIT_REACHED_KEY, "true");
     }
+    dataTable.getMetadata().put(DataTable.NUM_GROUPS_IGNORED_PRE_COMBINE, String.valueOf(_numGroupsIgnoredPreCombine));
+    dataTable.getMetadata().put(DataTable.NUM_GROUPS_IGNORED_IN_COMBINE, String.valueOf(_numGroupsIgnoredInCombine));
+    dataTable.getMetadata().put(DataTable.NUM_GROUPS_AGGR_IN_COMBINE, String.valueOf(_numGroupsAggrInCombine));
+    dataTable.getMetadata().put(DataTable.NUM_GROUPS_IGNORED_POST_COMBINE, String.valueOf(_numGroupsIgnoredPostCombine));
     if (_processingExceptions != null && _processingExceptions.size() > 0) {
       for (ProcessingException exception : _processingExceptions) {
         dataTable.addException(exception);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOperator.java
@@ -29,6 +29,7 @@ import org.apache.pinot.core.query.aggregation.AggregationFunctionContext;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.aggregation.groupby.DefaultGroupByExecutor;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByExecutor;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByStatistics;
 import org.apache.pinot.core.startree.executor.StarTreeGroupByExecutor;
 
 
@@ -36,6 +37,7 @@ import org.apache.pinot.core.startree.executor.StarTreeGroupByExecutor;
  * The <code>AggregationOperator</code> class provides the operator for aggregation group-by query on a single segment.
  */
 public class AggregationGroupByOperator extends BaseOperator<IntermediateResultsBlock> {
+
   private static final String OPERATOR_NAME = "AggregationGroupByOperator";
 
   private final AggregationFunctionContext[] _functionContexts;
@@ -81,6 +83,7 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
       groupByExecutor.process(transformBlock);
     }
     AggregationGroupByResult groupByResult = groupByExecutor.getResult();
+    GroupByStatistics stats = groupByExecutor.getStatistics();
 
     // Gather execution statistics
     long numEntriesScannedInFilter = _transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
@@ -88,6 +91,7 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
     _executionStatistics =
         new ExecutionStatistics(numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
             _numTotalRawDocs);
+    _executionStatistics.setNumGroupsIgnoredPreCombine(stats.getNumGroupsIgnored());
 
     // Build intermediate result block based on aggregation group-by result from the executor
     return new IntermediateResultsBlock(_functionContexts, groupByResult);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -171,4 +171,9 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
   public AggregationGroupByResult getResult() {
     return new AggregationGroupByResult(_groupKeyGenerator, _functions, _resultHolders);
   }
+
+  @Override
+  public GroupByStatistics getStatistics() {
+    return new GroupByStatistics(_groupKeyGenerator.getNumIgnoredGroups());
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
@@ -162,6 +162,11 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
   }
 
   @Override
+  public long getNumIgnoredGroups() {
+    return _rawKeyHolder.getNumIgnoredGroups();
+  }
+
+  @Override
   public Iterator<GroupKey> getUniqueGroupKeys() {
     return _rawKeyHolder.iterator();
   }
@@ -190,6 +195,11 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
      * @return Upper bound of group id inside the holder
      */
     int getGroupIdUpperBound();
+
+    /**
+     * Get the number of groups ignored as the max-group-by limit was reached.
+     */
+    long getNumIgnoredGroups();
   }
 
   private class ArrayBasedHolder implements RawKeyHolder {
@@ -222,6 +232,11 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
     @Override
     public int getGroupIdUpperBound() {
       return _globalGroupIdUpperBound;
+    }
+
+    @Override
+    public long getNumIgnoredGroups() {
+      return 0;
     }
 
     @Nonnull
@@ -262,6 +277,7 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
     private final Int2IntOpenHashMap _rawKeyToGroupIdMap = new Int2IntOpenHashMap();
 
     private int _numGroups = 0;
+    private long _numIgnoredGroups = 0;
 
     public IntMapBasedHolder() {
       _rawKeyToGroupIdMap.defaultReturnValue(INVALID_ID);
@@ -296,6 +312,8 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         if (_numGroups < _globalGroupIdUpperBound) {
           groupId = _numGroups;
           _rawKeyToGroupIdMap.put(rawKey, _numGroups++);
+        } else {
+          _numIgnoredGroups++;
         }
       }
       return groupId;
@@ -304,6 +322,11 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
     @Override
     public int getGroupIdUpperBound() {
       return _numGroups;
+    }
+
+    @Override
+    public long getNumIgnoredGroups() {
+      return _numIgnoredGroups;
     }
 
     @Nonnull
@@ -440,6 +463,7 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
     private final Long2IntOpenHashMap _rawKeyToGroupIdMap = new Long2IntOpenHashMap();
 
     private int _numGroups = 0;
+    private long _numIgnoredGroups = 0;
 
     public LongMapBasedHolder() {
       _rawKeyToGroupIdMap.defaultReturnValue(INVALID_ID);
@@ -475,6 +499,8 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         if (_numGroups < _globalGroupIdUpperBound) {
           groupId = _numGroups;
           _rawKeyToGroupIdMap.put(rawKey, _numGroups++);
+        } else {
+          _numIgnoredGroups++;
         }
       }
       return groupId;
@@ -483,6 +509,11 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
     @Override
     public int getGroupIdUpperBound() {
       return _numGroups;
+    }
+
+    @Override
+    public long getNumIgnoredGroups() {
+      return _numIgnoredGroups;
     }
 
     @Nonnull
@@ -610,6 +641,7 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
     private final Object2IntOpenHashMap<IntArray> _rawKeyToGroupIdMap = new Object2IntOpenHashMap<>();
 
     private int _numGroups = 0;
+    private long _numIgnoredGroups = 0;
 
     public ArrayMapBasedHolder() {
       _rawKeyToGroupIdMap.defaultReturnValue(INVALID_ID);
@@ -645,6 +677,8 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         if (_numGroups < _globalGroupIdUpperBound) {
           groupId = _numGroups;
           _rawKeyToGroupIdMap.put(rawKey, _numGroups++);
+        } else {
+          _numIgnoredGroups++;
         }
       }
       return groupId;
@@ -653,6 +687,11 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
     @Override
     public int getGroupIdUpperBound() {
       return _numGroups;
+    }
+
+    @Override
+    public long getNumIgnoredGroups() {
+      return _numIgnoredGroups;
     }
 
     @Nonnull

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupByStatistics.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupByStatistics.java
@@ -18,34 +18,35 @@
  */
 package org.apache.pinot.core.query.aggregation.groupby;
 
-import javax.annotation.Nonnull;
-import org.apache.pinot.core.operator.blocks.TransformBlock;
-
-
 /**
- * Interface class for executing the actual group-by operation.
+ * Statistics recorded during the execution of group-by operator.
  */
-public interface GroupByExecutor {
+public class GroupByStatistics {
+  private long _numGroupsIgnored;
+
+  public GroupByStatistics() {
+  }
+
+  public GroupByStatistics(long numGroupsIgnored) {
+    _numGroupsIgnored = numGroupsIgnored;
+  }
+
+  public long getNumGroupsIgnored() {
+    return _numGroupsIgnored;
+  }
 
   /**
-   * Performs the group-by aggregation on the given transform block.
+   * Merge another group-by statistics into the current one.
    *
-   * @param transformBlock Transform block
+   * @param statsToMerge statistics to merge.
    */
-  void process(@Nonnull TransformBlock transformBlock);
+  public void merge(GroupByStatistics statsToMerge) {
+    _numGroupsIgnored += statsToMerge._numGroupsIgnored;
+  }
 
-  /**
-   * Returns the result of group-by aggregation.
-   * <p>Should be called after all transform blocks has been processed.
-   *
-   * @return Result of aggregation
-   */
-  AggregationGroupByResult getResult();
-
-  /**
-   * Returns the statistics collected during group-by aggregation.
-   *
-   * @return group-by statistics
-   */
-  GroupByStatistics getStatistics();
+  @Override
+  public String toString() {
+    return "GroupBy Statistics:" + "\n  numGroupsIgnored: " + _numGroupsIgnored;
+  }
 }
+

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
@@ -66,6 +66,11 @@ public interface GroupKeyGenerator {
   int getCurrentGroupKeyUpperBound();
 
   /**
+   * Return the number of groups that were ignored as the max-group-limit was hit.
+   */
+  long getNumIgnoredGroups();
+
+  /**
    * Returns an iterator of group keys. Use this interface to iterate through all the group keys.
    *
    * @return iterator of group keys.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
@@ -53,6 +53,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
   private final int _globalGroupIdUpperBound;
 
   private int _numGroups = 0;
+  private long _numIgnoredGroups = 0;
 
   public NoDictionaryMultiColumnGroupKeyGenerator(TransformOperator transformOperator,
       TransformExpressionTree[] groupByExpressions, int numGroupsLimit) {
@@ -146,6 +147,11 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
   }
 
   @Override
+  public long getNumIgnoredGroups() {
+    return _numIgnoredGroups;
+  }
+
+  @Override
   public Iterator<GroupKey> getUniqueGroupKeys() {
     return new GroupKeyIterator(_groupKeyMap);
   }
@@ -162,6 +168,8 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       if (_numGroups < _globalGroupIdUpperBound) {
         groupId = _numGroups;
         _groupKeyMap.put(keyList, _numGroups++);
+      } else {
+        _numIgnoredGroups++;
       }
     }
     return groupId;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
@@ -50,6 +50,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   private final int _globalGroupIdUpperBound;
 
   private int _numGroups = 0;
+  private long _numIgnoredGroups = 0;
 
   public NoDictionarySingleColumnGroupKeyGenerator(TransformOperator transformOperator,
       TransformExpressionTree groupByExpression, int numGroupsLimit) {
@@ -163,6 +164,11 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   }
 
   @Override
+  public long getNumIgnoredGroups() {
+    return _numIgnoredGroups;
+  }
+
+  @Override
   public Iterator<GroupKey> getUniqueGroupKeys() {
     return new GroupKeyIterator(_groupKeyMap);
   }
@@ -175,6 +181,8 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
       if (_numGroups < _globalGroupIdUpperBound) {
         groupId = _numGroups;
         map.put(value, _numGroups++);
+      } else {
+        _numIgnoredGroups++;
       }
     }
     return groupId;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -168,15 +168,44 @@ public abstract class QueryScheduler {
           numEntriesScannedPostFilter);
     }
 
+    // emit group-by metrics
+    long numGroupsIgnoredPreCombine =
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_GROUPS_IGNORED_PRE_COMBINE, "0"));
+    if (numGroupsIgnoredPreCombine > 0) {
+      serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_GROUPS_IGNORED_PRE_COMBINE,
+          numGroupsIgnoredPreCombine);
+    }
+
+    long numGroupsIgnoredInCombine =
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_GROUPS_IGNORED_IN_COMBINE, "0"));
+    if (numGroupsIgnoredInCombine > 0) {
+      serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_GROUPS_IGNORED_IN_COMBINE,
+          numGroupsIgnoredInCombine);
+    }
+    long numGroupsAggrInCombine =
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_GROUPS_AGGR_IN_COMBINE, "0"));
+    if (numGroupsAggrInCombine > 0) {
+      serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_GROUPS_AGGR_IN_COMBINE,
+          numGroupsAggrInCombine);
+    }
+    long numGroupsIgnoredPostCombine =
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_GROUPS_IGNORED_POST_COMBINE, "0"));
+    if (numGroupsIgnoredPostCombine > 0) {
+      serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_GROUPS_IGNORED_POST_COMBINE,
+          numGroupsIgnoredPostCombine);
+    }
+
     TimerContext timerContext = queryRequest.getTimerContext();
     int numSegmentsQueried = queryRequest.getSegmentsToQuery().size();
     LOGGER.info(
-        "Processed requestId={},table={},segments(queried/processed/matched)={}/{}/{},schedulerWaitMs={},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={}",
+        "Processed requestId={},table={},segments(queried/processed/matched)={}/{}/{},schedulerWaitMs={},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},"
+            + "numGroupsIgnoredPreCombine={},numGroupsIgnoredInCombine={},numGroupsAggrInCombine={},numGroupsIgnoredPostCombine={},sched={}",
         requestId, tableNameWithType, numSegmentsQueried, numSegmentsProcessed, numSegmentsMatched,
         timerContext.getPhaseDurationMs(ServerQueryPhase.SCHEDULER_WAIT),
         timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
         timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), queryRequest.getBrokerId(), numDocsScanned,
-        numEntriesScannedInFilter, numEntriesScannedPostFilter, name());
+        numEntriesScannedInFilter, numEntriesScannedPostFilter, numGroupsIgnoredPreCombine,
+        numGroupsIgnoredInCombine, numGroupsAggrInCombine, numGroupsIgnoredPostCombine, name());
 
     serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_QUERIED, numSegmentsQueried);
     serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_PROCESSED, numSegmentsProcessed);


### PR DESCRIPTION
Add code to log and emit metrics related to group-by execution:
- Number of groups ignored when generating group-by keys per segment (IgnoredPreCombine)
- Number of groups ignored during the combine phase (IgnoredInCombine)
- Number of groups aggregated during combine phase (AggrInCombine)
- Number of groups ignored/trimmed after aggregation (PostCombine)