### PR TITLE
Reduce MAX_SEGMENT_COMPLETION_TIME_MILLIS to 5 minutes

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -92,6 +92,9 @@ public class HelixHelper {
           IdealState updatedIdealState;
           try {
             updatedIdealState = updater.apply(idealStateCopy);
+          } catch (PermanentUpdaterException e) {
+            LOGGER.error("Caught permanent exception while updating ideal state for resource: {}", resourceName, e);
+            throw e;
           } catch (Exception e) {
             LOGGER.error("Caught exception while updating ideal state for resource: {}", resourceName, e);
             return false;
@@ -137,6 +140,20 @@ public class HelixHelper {
       });
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while updating ideal state for resource: " + resourceName, e);
+    }
+  }
+
+  /**
+   * Exception to be thrown by updater function to exit from retry in {@link HelixHelper::updatedIdealState}
+   */
+  public static class PermanentUpdaterException extends RuntimeException {
+
+    public PermanentUpdaterException(String message) {
+      super(message);
+    }
+
+    public PermanentUpdaterException(Throwable cause) {
+      super(cause);
     }
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/partition/IdealStateBuilderUtil.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/partition/IdealStateBuilderUtil.java
@@ -45,6 +45,12 @@ public class IdealStateBuilderUtil {
     _idealState = new IdealState(tableNameWithType);
   }
 
+  public IdealStateBuilderUtil(IdealState idealState, String tableNameWithType) {
+    _tableName = tableNameWithType;
+    _rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    _idealState = idealState;
+  }
+
   public IdealState build() {
     return _idealState;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -107,7 +107,7 @@ public class PinotLLCRealtimeSegmentManager {
   private static final String METADATA_TEMP_DIR_SUFFIX = ".metadata.tmp";
   private static final String METADATA_EVENT_NOTIFIER_PREFIX = "metadata.event.notifier";
 
-  // Max time to wait for all LLC segments to complete committing their metadata.
+  // Max time to wait for all LLC segments to complete committing their metadata while stopping the controller.
   private static final long MAX_LLC_SEGMENT_METADATA_COMMIT_TIME_MILLIS = 30_000L;
 
   // TODO: make this configurable with default set to 10
@@ -118,7 +118,7 @@ public class PinotLLCRealtimeSegmentManager {
    * This includes any backoffs and retries for the steps 2 and 3
    * The segment will be eligible for repairs by the validation manager, if the time  exceeds this value
    */
-  private static int MAX_SEGMENT_COMPLETION_TIME_MINS = 10;
+  private static int MAX_SEGMENT_COMPLETION_TIME_MILLIS = 300_000; // 5 MINUTES
 
   private static PinotLLCRealtimeSegmentManager INSTANCE = null;
 
@@ -500,7 +500,7 @@ public class PinotLLCRealtimeSegmentManager {
     // TODO Introduce a controller failure here for integration testing
 
     // When multiple segments of the same table complete around the same time it is possible that
-    // the idealstate udpate fails due to contention. We serialize the updates to the idealstate
+    // the idealstate update fails due to contention. We serialize the updates to the idealstate
     // to reduce this contention. We may still contend with RetentionManager, or other updates
     // to idealstate from other controllers, but then we have the retry mechanism to get around that.
     // hash code can be negative, so make sure we are getting a positive lock index
@@ -1049,7 +1049,7 @@ public class PinotLLCRealtimeSegmentManager {
     Stat stat = new Stat();
     LLCRealtimeSegmentZKMetadata metadata = getRealtimeSegmentZKMetadata(tableNameWithType, segmentId, stat);
     long metadataUpdateTime = stat.getMtime();
-    if (now < metadataUpdateTime + TimeUnit.MILLISECONDS.convert(MAX_SEGMENT_COMPLETION_TIME_MINS, TimeUnit.MINUTES)) {
+    if (now < metadataUpdateTime + MAX_SEGMENT_COMPLETION_TIME_MILLIS) {
       LOGGER.info("Too soon to correct segment:{} updateTime: {} now:{}", segmentId, metadataUpdateTime, now);
       return true;
     }
@@ -1354,7 +1354,7 @@ public class PinotLLCRealtimeSegmentManager {
       @Nonnull String currentSegmentId, @Nonnull String newSegmentId,
       @Nonnull PartitionAssignment partitionAssignment) {
 
-    Map<String, List<String>> instanceAssignments = null;
+    Map<String, List<String>> instanceAssignments;
 
     RealtimeSegmentAssignmentStrategy strategy = new ConsumingSegmentAssignmentStrategy();
     try {
@@ -1372,15 +1372,16 @@ public class PinotLLCRealtimeSegmentManager {
           PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
     }
 
-    // We may have (for whatever reason) a different instance list in the idealstate for the new segment.
-    // If so, clear it, and then set the instance state for the set of instances that we know should be there.
+    // The {@link RealtimeSegmentValidationManager} will fix metadata and ideal state after {@link MAX_SEGMENT_COMPLETION_TIME_MILLIS} of inactivity on the committing segment
+    // If the ideal state update during completion took longer than {@link MAX_SEGMENT_COMPLETION_TIME_MILLIS},the update could already have been done by the fixer thread .
+    // We do not want to overwrite the ideal state. It is possible that the new segment created by the fixer has already progressed to ONLINE.
+    // If we let the below update happen, we will be bringing an ONLINE segment back to CONSUMING, and end up with 2 CONSUMING segments for the partition
     Map<String, String> stateMap = idealState.getInstanceStateMap(newSegmentId);
-    if (stateMap != null) {
-      stateMap.clear();
-    }
-    for (String instance : newSegmentInstances) {
-      idealState
-          .setPartitionState(newSegmentId, instance, PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
+    if (stateMap == null) {
+      for (String instance : newSegmentInstances) {
+        idealState
+            .setPartitionState(newSegmentId, instance, PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
+      }
     }
 
     return idealState;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -1102,6 +1102,71 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Assert.assertFalse(status); // Committing segment metadata failed.
   }
 
+  /**
+   * Tests the scenario where ideal state for new segment, was already updated by some external thread, after step 2 and before step 3 of segment commit.
+   * This can happen if step 3 (ideal state update) took longer than {@link PinotLLCRealtimeSegmentManager::MAX_SEGMENT_COMPLETION_TIME_MILLIS},
+   * making the segment eligible for repairs by {@link org.apache.pinot.controller.validation.RealtimeSegmentValidationManager}
+   * @throws InvalidConfigException
+   */
+  @Test
+  public void testIdealStateAlreadyUpdated() throws InvalidConfigException {
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(null);
+    String tableNameWithType = "tableName_REALTIME";
+    String rawTableName = "tableName";
+    int nPartitions = 4;
+    int nReplicas = 2;
+    int nInstances = 3;
+    setupSegmentManager(segmentManager, tableNameWithType, nPartitions, nReplicas, nInstances);
+
+    IdealState idealState = segmentManager._tableIdealState;
+    TableConfig tableConfig = segmentManager._tableConfigStore.getTableConfig(tableNameWithType);
+    PartitionAssignment partitionAssignment =
+        segmentManager._partitionAssignmentGenerator.getStreamPartitionAssignmentFromIdealState(tableConfig,
+            idealState);
+    int partitionId = 0;
+    int seq = 0;
+    IdealStateBuilderUtil idealStateBuilderUtil = new IdealStateBuilderUtil(idealState, tableNameWithType);
+    String currentSegmentId = idealStateBuilderUtil.getSegment(partitionId, seq);
+    LLCSegmentName newSegment = new LLCSegmentName(rawTableName, partitionId, ++seq, System.currentTimeMillis());
+    String newSegmentId = newSegment.getSegmentName();
+    ZNRecordSerializer znRecordSerializer = new ZNRecordSerializer();
+    IdealState idealStateCopy =
+        new IdealState((ZNRecord) znRecordSerializer.deserialize(znRecordSerializer.serialize(idealState.getRecord())));
+    segmentManager.updateIdealStateOnSegmentCompletion(idealState, currentSegmentId, newSegmentId, partitionAssignment);
+
+    // check ideal state updates
+    Assert.assertNotEquals(idealState, idealStateCopy);
+
+    // progress ideal state, but send update for old. Should not update
+    currentSegmentId = newSegmentId;
+    List<String> instances = idealStateBuilderUtil.getInstances(partitionId, seq);
+    idealStateBuilderUtil.setSegmentState(partitionId, seq, "ONLINE");
+    idealStateBuilderUtil.addConsumingSegment(partitionId, ++seq, nReplicas, instances);
+    newSegmentId = idealStateBuilderUtil.getSegment(partitionId, seq);
+    idealStateBuilderUtil.setSegmentState(partitionId, seq, "ONLINE");
+    idealStateBuilderUtil.addConsumingSegment(partitionId, ++seq, nReplicas, instances);
+    idealState = idealStateBuilderUtil.build();
+    idealStateCopy =
+        new IdealState((ZNRecord) znRecordSerializer.deserialize(znRecordSerializer.serialize(idealState.getRecord())));
+
+    segmentManager.updateIdealStateOnSegmentCompletion(idealState, currentSegmentId, newSegmentId, partitionAssignment);
+
+    // check no change
+    Assert.assertEquals(idealState, idealStateCopy);
+  }
+
+  private void setupSegmentManager(FakePinotLLCRealtimeSegmentManager segmentManager, String rtTableName, int nPartitions, int nReplicas, int nInstances)
+      throws InvalidConfigException {
+
+    List<String> instances = getInstanceList(nInstances);
+    TableConfig tableConfig = makeTableConfig(rtTableName, nReplicas, DUMMY_HOST, DEFAULT_SERVER_TENANT);
+    IdealState idealState = PinotTableIdealStateBuilder.buildEmptyRealtimeIdealStateFor(rtTableName, nReplicas, true);
+
+    segmentManager.addTableToStore(rtTableName, tableConfig, nPartitions);
+    segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+    segmentManager.setupNewTable(tableConfig, idealState);
+  }
+
   private void setupSegmentManager(FakePinotLLCRealtimeSegmentManager segmentManager, String rtTableName)
       throws InvalidConfigException {
     final int nInstances = 6;


### PR DESCRIPTION
Reducing MAX_SEGMENT_COMPLETION_TIME_MILLIS from 10 minutes to 5 (and possibly lower in the future). 10 minutes is a lot for segment completion. This 10 minutes gets added into our SLA of being able to fix consuming partitions, no matter how fast we can run RealtimeSegmentValidationManager.

Reducing this time will increase the chance of RealtimeSegmentValidationManager fixing a segment in ideal state, because the ideal state update took too long in the regular segment commit path (gc, zk issue, etc). Added a change to prevent over-writing the  new segment's ideal state update in segment commit, if it already exists in ideal state.