### PR TITLE
Replace deprecated ZkClient APIs

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/TableQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/TableQueryQuotaManagerTest.java
@@ -77,7 +77,7 @@ public class TableQueryQuotaManagerTest {
       super(clusterName, instanceName, instanceType, zkAddress);
       super._zkclient = new ZkClient(StringUtil.join("/", StringUtils.chomp(ZkStarter.DEFAULT_ZK_STR, "/")),
           ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, new ZNRecordSerializer());
-      _zkclient.deleteRecursive("/" + clusterName + "/PROPERTYSTORE");
+      _zkclient.deleteRecursively("/" + clusterName + "/PROPERTYSTORE");
       _zkclient.createPersistent("/" + clusterName + "/PROPERTYSTORE", true);
       setPropertyStore(clusterName);
     }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/TimeBoundaryServiceTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/TimeBoundaryServiceTest.java
@@ -53,7 +53,7 @@ public class TimeBoundaryServiceTest {
     _zkClient = new ZkClient(StringUtil.join("/", StringUtils.chomp(ZkStarter.DEFAULT_ZK_STR, "/")),
         ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, new ZNRecordSerializer());
     String helixClusterName = "TestTimeBoundaryService";
-    _zkClient.deleteRecursive("/" + helixClusterName + "/PROPERTYSTORE");
+    _zkClient.deleteRecursively("/" + helixClusterName + "/PROPERTYSTORE");
     _zkClient.createPersistent("/" + helixClusterName + "/PROPERTYSTORE", true);
     _propertyStore = new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<ZNRecord>(_zkClient),
         "/" + helixClusterName + "/PROPERTYSTORE", null);


### PR DESCRIPTION
It was discovered that for some reason the compiler is not able to locate deleteRecursively() in zkClient. For TableQueryQuotaManagerTest and TimeBoundaryServiceTest, their zkClient initializations refer to the same ZkClient import, yet the former doesn't recognize it as a valid API. This probably has to do with the ambiguity of the imports and multiple ZkClient classes in different paths, and it is just better to replace them with non-deprecated APIs.