### PR TITLE
[Parsing][PQL] Allow more than one dot in the identifier

### DIFF
--- a/pinot-common/src/main/antlr4/org/apache/pinot/pql/parsers/PQL2.g4
+++ b/pinot-common/src/main/antlr4/org/apache/pinot/pql/parsers/PQL2.g4
@@ -40,8 +40,7 @@ outputColumnProjection:
   expression (AS (IDENTIFIER | STRING_LITERAL))?    # OutputColumn;
 
 expression:
-  IDENTIFIER                                    # Identifier
-  | IDENTIFIER '.' IDENTIFIER                   # Identifier
+  IDENTIFIER ('.' IDENTIFIER)*                  # Identifier
   | literal                                     # Constant
   | '(' expression ')'                          # ExpressionParenthesisGroup
   | function '(' expressions? ')'               # FunctionCall

--- a/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
@@ -134,6 +134,16 @@ public class Pql2CompilerTest {
   }
 
   @Test
+  public void testDotColumns() {
+    BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest("select veggie.type.code from vegetables where name != 'Brussels sprouts'");
+    Assert.assertEquals(brokerRequest.getSelections().getSelectionColumns().get(0), "veggie.type.code");
+    brokerRequest = COMPILER.compileToBrokerRequest("select veggie.type.code, sum(veggie.price) from vegetables where veggie.name != 'Brussels sprouts' group by veggie.type.code");
+    Assert.assertEquals(brokerRequest.getGroupBy().getExpressions().get(0), "veggie.type.code");
+    Assert.assertEquals(brokerRequest.getAggregationsInfo().get(0).getAggregationParams().get("column"), "veggie.price");
+    Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "veggie.name");
+  }
+
+  @Test
   public void testCompilationWithHaving() {
     BrokerRequest brokerRequest = COMPILER
         .compileToBrokerRequest("select avg(age) as avg_age from person group by address_city having avg(age)=20");


### PR DESCRIPTION
Summary: Allow column names to contain more than one dot in them.

Pinot allows queries of the form: "select a.b from foo limit 1". But it
forbids "select a.b.c from foo limit 1".

Context: At Uber, we flatten out our deeply nested kafka schemas into
columns containing multiple dots. So we have columns like this:
msg.data, msg.data.head, msg.data.tail, msg.app.author.name and so on.

Without this diff, we could not select these columns. But now with this
diff we can. (earlier we could have selected msg.data only but not the
other multiple-dot column names)

Test Plan: Ran this on Uber's Pinot clusters with such production kafka
topics and verified.

Also tested locally by modifying the baseBall stats CSV file to contain
"dots" in the column names header. And correspondingly edited the
baseBall schema json to contain "dot" column names. And ran queries
locally.