### PR TITLE
Update read-the-docs high level organization. More changes to follow

### DIFF
--- a/docs/README
+++ b/docs/README
@@ -17,13 +17,7 @@
 .. under the License.
 ..
 
-.. _reference:
-
-.. toctree::
-   :maxdepth: 1
-
-   pql_examples
-   index_techniques
-   client_api
-   management_api
-   pinot_hadoop
+Updating the docs:
+1. Edit or add files as needed.
+2. Run "make html"
+3. Open _build/html/index.html in your favorite browser and ensure contents and links work correctly.

--- a/docs/admin_guide.rst
+++ b/docs/admin_guide.rst
@@ -17,14 +17,11 @@
 .. under the License.
 ..
 
-Coding Guidelines
-=================
-Verifying code-style
-^^^^^^^^^^^^^^^^^^^^
+.. toctree::
+   :maxdepth: 1
 
-Run the following command to verify the code-style before posting a PR
-
-.. code-block:: none
-
-    mvn checkstyle:check
-
+   in_production
+   management_api
+   multitenancy
+   customizations
+   tuning_pinot

--- a/docs/code_modues.rst
+++ b/docs/code_modues.rst
@@ -17,14 +17,5 @@
 .. under the License.
 ..
 
-Coding Guidelines
-=================
-Verifying code-style
-^^^^^^^^^^^^^^^^^^^^
-
-Run the following command to verify the code-style before posting a PR
-
-.. code-block:: none
-
-    mvn checkstyle:check
-
+Code Modules and organization
+=============================

--- a/docs/customizations.rst
+++ b/docs/customizations.rst
@@ -17,14 +17,6 @@
 .. under the License.
 ..
 
-Coding Guidelines
-=================
-Verifying code-style
-^^^^^^^^^^^^^^^^^^^^
 
-Run the following command to verify the code-style before posting a PR
-
-.. code-block:: none
-
-    mvn checkstyle:check
-
+Customization points in Pinot
+=============================

--- a/docs/dev_env.rst
+++ b/docs/dev_env.rst
@@ -17,14 +17,23 @@
 .. under the License.
 ..
 
-Coding Guidelines
-=================
-Verifying code-style
-^^^^^^^^^^^^^^^^^^^^
+Dev Environment Setup
+=====================
 
-Run the following command to verify the code-style before posting a PR
+To contribute to Pinot, please follow the code-style as described below:
 
-.. code-block:: none
+Intellij
+^^^^^^^^
 
-    mvn checkstyle:check
+* `Import <https://www.jetbrains.com/help/idea/settings-code-style.html>`_ code style to Intellij
+* Navigate to ``Preferences`` -> ``Editor`` -> ``Code Style`` -> ``Java``
+* Select ``Import Scheme`` -> ``Intellij IDES code style XML``
+* Choose ``codestyle-intellij.xml``
+
+Eclipse
+^^^^^^^
+.. todo::
+
+   Add instructions for eclipse here
+
 

--- a/docs/dev_guide.rst
+++ b/docs/dev_guide.rst
@@ -17,14 +17,10 @@
 .. under the License.
 ..
 
-Coding Guidelines
-=================
-Verifying code-style
-^^^^^^^^^^^^^^^^^^^^
+.. toctree::
+   :maxdepth: 1
 
-Run the following command to verify the code-style before posting a PR
-
-.. code-block:: none
-
-    mvn checkstyle:check
-
+   dev_env
+   coding_guidelines
+   code_modules
+   extensions

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -17,14 +17,13 @@
 .. under the License.
 ..
 
-Coding Guidelines
-=================
-Verifying code-style
-^^^^^^^^^^^^^^^^^^^^
+Extending Pinot
+===============
+This section provides an overview of options to extend Pinot code to make Pinot work for environments not covered by default.
 
-Run the following command to verify the code-style before posting a PR
+.. toctree::
+   :maxdepth: 1
 
-.. code-block:: none
-
-    mvn checkstyle:check
-
+   pluggable_streams
+   segment_fetcher
+   pluggable_storage

--- a/docs/getting_involved.rst
+++ b/docs/getting_involved.rst
@@ -17,14 +17,5 @@
 .. under the License.
 ..
 
-Coding Guidelines
-=================
-Verifying code-style
-^^^^^^^^^^^^^^^^^^^^
-
-Run the following command to verify the code-style before posting a PR
-
-.. code-block:: none
-
-    mvn checkstyle:check
-
+.. toctree::
+   :maxdepth: 1

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -17,8 +17,8 @@
 .. under the License.
 ..
 
-Quick Demo
-==========
+Getting Started
+===============
 
 A quick way to get familiar with Pinot is to run the Pinot examples. The examples can be run either by compiling the
 code or by running the prepackaged Docker images.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,30 +32,35 @@ Introduction
 
    intro
    architecture
-   trying_pinot
+   getting_started
 
 #########
-Reference
+User Guide
 #########
 
 .. toctree::
    :maxdepth: 1
 
+   user_guide
 
-   reference
-   in_production
+
+#########
+Admin Guide
+#########
+
+.. toctree::
+   :maxdepth: 1
+
+   admin_guide
 
 #################
-Customizing Pinot
+Developer Guide
 #################
 
 .. toctree::
    :maxdepth: 1
 
-
-   pluggable_streams
-   segment_fetcher
-   pluggable_storage
+   dev_guide
 
 ################
 Getting Involved
@@ -64,4 +69,4 @@ Getting Involved
 .. toctree::
    :maxdepth: 1
 
-   coding_guidelines
+   getting_involved

--- a/docs/index_techniques.rst
+++ b/docs/index_techniques.rst
@@ -19,6 +19,7 @@
 
 .. TODO: add more details
 
+
 Index Techniques
 ================
 

--- a/docs/tuning_pinot.rst
+++ b/docs/tuning_pinot.rst
@@ -17,14 +17,11 @@
 .. under the License.
 ..
 
-Coding Guidelines
-=================
-Verifying code-style
-^^^^^^^^^^^^^^^^^^^^
+Tuning Pinot
+============
+This section provides information on various options to tune Pinot cluster for storage and query efficiency.
 
-Run the following command to verify the code-style before posting a PR
+.. toctree::
+   :maxdepth: 1
 
-.. code-block:: none
-
-    mvn checkstyle:check
-
+   index_techniques

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -17,14 +17,9 @@
 .. under the License.
 ..
 
-Coding Guidelines
-=================
-Verifying code-style
-^^^^^^^^^^^^^^^^^^^^
+.. toctree::
+   :maxdepth: 1
 
-Run the following command to verify the code-style before posting a PR
-
-.. code-block:: none
-
-    mvn checkstyle:check
+   pql_examples
+   client_api
 


### PR DESCRIPTION
Re-organize the sections at the high level. This PR just includes skeletal changes, so rest of us can then work in parallel.

The new page looks as shown in the attached screenshot.
![screenshot from 2019-03-05 09-24-16](https://user-images.githubusercontent.com/3123798/53824675-5c85ea80-3f29-11e9-8f24-259a03354fcd.png)
