### PR TITLE
Fix SegmentGeneratorConfig where the time format in schema is not picked up

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -382,11 +382,7 @@ public class SegmentGeneratorConfig {
   }
 
   public String getTimeColumnName() {
-    if (_segmentTimeColumnName != null) {
-      return _segmentTimeColumnName;
-    }
-    // TODO: if segmentTimeColumnName is null, getQualifyingFields DATETIME. If multiple found, throw exception "must specify primary timeColumnName"
-    return getQualifyingFields(FieldType.TIME, true);
+    return _segmentTimeColumnName;
   }
 
   public void setTimeColumnName(String timeColumnName) {
@@ -461,7 +457,7 @@ public class SegmentGeneratorConfig {
     _schema = schema;
 
     // Set time related fields
-    // TODO: remove all time related fields and always extract from schema
+    // TODO: support datetime field as time column
     TimeFieldSpec timeFieldSpec = _schema.getTimeFieldSpec();
     if (timeFieldSpec != null) {
       TimeGranularitySpec timeGranularitySpec = timeFieldSpec.getOutgoingGranularitySpec();

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -114,10 +114,6 @@ public class RealtimeSegmentConverter {
       genConfig.enableStarTreeIndex(starTreeIndexSpec);
     }
 
-    // TODO: use timeColumnName field
-    genConfig.setTimeColumnName(dataSchema.getTimeFieldSpec().getOutgoingTimeColumnName());
-    // TODO: find timeColumnName in schema.getDateTimeFieldSpec, in order to get the timeUnit
-    genConfig.setSegmentTimeUnit(dataSchema.getTimeFieldSpec().getOutgoingGranularitySpec().getTimeType());
     if (segmentVersion != null) {
       genConfig.setSegmentVersion(segmentVersion);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -341,11 +341,11 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         properties.setProperty(SEGMENT_END_TIME, Preconditions.checkNotNull(config.getEndTime()));
         properties.setProperty(TIME_UNIT, Preconditions.checkNotNull(config.getSegmentTimeUnit()));
       } else {
-        Object minTime = timeColumnIndexCreationInfo.getMin();
-        Object maxTime = timeColumnIndexCreationInfo.getMax();
+        Object minTime = Preconditions.checkNotNull(timeColumnIndexCreationInfo.getMin());
+        Object maxTime = Preconditions.checkNotNull(timeColumnIndexCreationInfo.getMax());
 
-        // Convert time value into millis since epoch for SIMPLE_DATE
         if (config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
+          // For simple date format, convert time value into millis since epoch
           DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(config.getSimpleDateFormat());
           properties.setProperty(SEGMENT_START_TIME, dateTimeFormatter.parseMillis(minTime.toString()));
           properties.setProperty(SEGMENT_END_TIME, dateTimeFormatter.parseMillis(maxTime.toString()));
@@ -353,7 +353,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         } else {
           properties.setProperty(SEGMENT_START_TIME, minTime);
           properties.setProperty(SEGMENT_END_TIME, maxTime);
-          properties.setProperty(TIME_UNIT, config.getSegmentTimeUnit());
+          properties.setProperty(TIME_UNIT, Preconditions.checkNotNull(config.getSegmentTimeUnit()));
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.common.data.DateTimeFieldSpec;
@@ -335,9 +336,10 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     ColumnIndexCreationInfo timeColumnIndexCreationInfo = indexCreationInfoMap.get(timeColumn);
     if (timeColumnIndexCreationInfo != null) {
       // Use start/end time in config if defined
-      if (config.getStartTime() != null && config.getEndTime() != null) {
+      if (config.getStartTime() != null) {
         properties.setProperty(SEGMENT_START_TIME, config.getStartTime());
-        properties.setProperty(SEGMENT_END_TIME, config.getEndTime());
+        properties.setProperty(SEGMENT_END_TIME, Preconditions.checkNotNull(config.getEndTime()));
+        properties.setProperty(TIME_UNIT, Preconditions.checkNotNull(config.getSegmentTimeUnit()));
       } else {
         Object minTime = timeColumnIndexCreationInfo.getMin();
         Object maxTime = timeColumnIndexCreationInfo.getMax();
@@ -347,13 +349,13 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(config.getSimpleDateFormat());
           properties.setProperty(SEGMENT_START_TIME, dateTimeFormatter.parseMillis(minTime.toString()));
           properties.setProperty(SEGMENT_END_TIME, dateTimeFormatter.parseMillis(maxTime.toString()));
+          properties.setProperty(TIME_UNIT, TimeUnit.MILLISECONDS);
         } else {
           properties.setProperty(SEGMENT_START_TIME, minTime);
           properties.setProperty(SEGMENT_END_TIME, maxTime);
+          properties.setProperty(TIME_UNIT, config.getSegmentTimeUnit());
         }
       }
-
-      properties.setProperty(TIME_UNIT, config.getSegmentTimeUnit());
     }
 
     for (Map.Entry<String, String> entry : config.getCustomProperties().entrySet()) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfigTest.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.indexsegment.generator;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.Schema;
+import org.apache.pinot.common.data.TimeGranularitySpec;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class SegmentGeneratorConfigTest {
+
+  @Test
+  public void testEpochTime() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch")).build();
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    assertEquals(segmentGeneratorConfig.getTimeColumnName(), "daysSinceEpoch");
+    assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.EPOCH);
+    assertEquals(segmentGeneratorConfig.getSegmentTimeUnit(), TimeUnit.DAYS);
+    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
+  }
+
+  @Test
+  public void testSimpleDateFormat() {
+    Schema schema = new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(FieldSpec.DataType.STRING, TimeUnit.DAYS,
+        TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "Date")).build();
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    assertEquals(segmentGeneratorConfig.getTimeColumnName(), "Date");
+    assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE);
+    assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
+    assertEquals(segmentGeneratorConfig.getSimpleDateFormat(), "yyyyMMdd");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfigTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 
+// TODO: add more tests here.
 public class SegmentGeneratorConfigTest {
 
   @Test


### PR DESCRIPTION
Fix the issue where the time related specs in schema are not picked up by SegmentGeneratorConfig
Also fix the bug in SegmentGeneratorConfig.loadConfigFiles() where incoming time unit is picked (should use outgoing time unit)