### PR TITLE
readthedocs: Provide links for high level sections

### DIFF
--- a/docs/admin_guide.rst
+++ b/docs/admin_guide.rst
@@ -17,6 +17,12 @@
 .. under the License.
 ..
 
+###########
+Admin Guide
+###########
+
+.. _admin-guide:
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/dev_guide.rst
+++ b/docs/dev_guide.rst
@@ -17,6 +17,12 @@
 .. under the License.
 ..
 
+###############
+Developer Guide
+###############
+
+.. _dev-guide:
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -17,31 +17,15 @@
 .. under the License.
 ..
 
-.. Pinot documentation master file, created by
-   sphinx-quickstart on Fri Feb  9 14:54:43 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+############
+Introduction
+############
 
-#####
-Pinot
-#####
+.. _introduction:
 
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 1
 
-   introduction
-
-.. toctree::
-   :maxdepth: 2
-
-   user_guide
-
-.. toctree::
-   :maxdepth: 2
-
-   admin_guide
-
-.. toctree::
-   :maxdepth: 2
-
-   dev_guide
+    intro
+    architecture
+    getting_started

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -17,6 +17,12 @@
 .. under the License.
 ..
 
+##########
+User Guide
+##########
+
+.. _user-guide:
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
Updated the layout to provide links for high level sections. See screenshot for details.
![Screenshot from 2019-03-08 11-23-38](https://user-images.githubusercontent.com/3123798/54050804-01f0c680-4195-11e9-95a6-56c9e8651df4.png)
