### PR TITLE
Segment creation with flexible file paths

### DIFF
--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentCreationJob.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentCreationJob.java
@@ -104,6 +104,10 @@ public class SegmentCreationJob extends BaseSegmentJob {
 
   @Override
   protected boolean isDataFile(String fileName) {
+    // Other files may have different extensions, eg: orc can have no extension
+    if (_properties.getProperty(JobConfigConstants.RECORD_READER_PATH) != null) {
+      return true;
+    }
     return fileName.endsWith(".avro") || fileName.endsWith(".csv") || fileName.endsWith(".json") || fileName
         .endsWith(".thrift");
   }


### PR DESCRIPTION
* Currently, we enforce segments to have certain file extensions. If record reader path is there, we will allow any extensions.