### PR TITLE
Make RetentionManager and OfflineSegmentIntervalChecker initial delays configurable

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -84,6 +84,10 @@ public class ControllerConf extends PropertiesConfiguration {
     // Initial delays
     private static final String STATUS_CHECKER_INITIAL_DELAY_IN_SECONDS =
         "controller.statusChecker.initialDelayInSeconds";
+    private static final String RETENTION_MANAGER_INITIAL_DELAY_IN_SECONDS =
+        "controller.retentionManager.initialDelayInSeconds";
+    private static final String OFFLINE_SEGMENT_INTERVAL_CHECKER_INITIAL_DELAY_IN_SECONDS =
+        "controller.offlineSegmentIntervalChecker.initialDelayInSeconds";
 
     public static final int MIN_INITIAL_DELAY_IN_SECONDS = 120;
     public static final int MAX_INITIAL_DELAY_IN_SECONDS = 300;
@@ -572,6 +576,16 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public long getStatusCheckerInitialDelayInSeconds() {
     return getLong(ControllerPeriodicTasksConf.STATUS_CHECKER_INITIAL_DELAY_IN_SECONDS,
+        ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
+  }
+
+  public long getRetentionManagerInitialDelayInSeconds() {
+    return getLong(ControllerPeriodicTasksConf.RETENTION_MANAGER_INITIAL_DELAY_IN_SECONDS,
+        ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
+  }
+
+  public long getOfflineSegmentIntervalCheckerInitialDelayInSeconds() {
+    return getLong(ControllerPeriodicTasksConf.OFFLINE_SEGMENT_INTERVAL_CHECKER_INITIAL_DELAY_IN_SECONDS,
         ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -57,7 +57,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
   public RetentionManager(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf config,
       ControllerMetrics controllerMetrics) {
     super("RetentionManager", config.getRetentionControllerFrequencyInSeconds(),
-        config.getPeriodicTaskInitialDelayInSeconds(), pinotHelixResourceManager, controllerMetrics);
+        config.getRetentionManagerInitialDelayInSeconds(), pinotHelixResourceManager, controllerMetrics);
     _deletedSegmentsRetentionInDays = config.getDeletedSegmentsRetentionInDays();
 
     LOGGER.info("Starting RetentionManager with runFrequencyInSeconds: {}, deletedSegmentsRetentionInDays: {}",

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
@@ -51,7 +51,7 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask<Void> 
   public OfflineSegmentIntervalChecker(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
       ValidationMetrics validationMetrics, ControllerMetrics controllerMetrics) {
     super("OfflineSegmentIntervalChecker", config.getOfflineSegmentIntervalCheckerFrequencyInSeconds(),
-        config.getPeriodicTaskInitialDelayInSeconds(), pinotHelixResourceManager, controllerMetrics);
+        config.getOfflineSegmentIntervalCheckerInitialDelayInSeconds(), pinotHelixResourceManager, controllerMetrics);
     _validationMetrics = validationMetrics;
   }
 


### PR DESCRIPTION
*Motivation*: In one of our clusters that hosts 1000's of tables with 1000's of segments each, we are noticing frequent controller leadership changes due to long GC pauses. Analysis shows that the GC pressure might be due to heavy hitting tasks running concurrently. RetentionManager and OfflineSegmentIntervalChecker tasks hold tables segment metadata in memory while working with tables and are likely to cause high GC pressure when run concurrently.  While the issue can be addressed in many ways, this change attempts a simpler/short-term fix to stagger the start time by making them configurable.

*Testing done*: Existing tests pass. 