### PR TITLE
[TE] detection - percentage change zero divide fix

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetector.java
@@ -91,7 +91,7 @@ public class PercentageChangeRuleDetector implements AnomalyDetector<PercentageC
     // calculate percentage change
     df.addSeries(COL_CHANGE, map((Series.DoubleFunction) values -> {
       if (values[1] == 0) {
-        return values[0] > 0 ? Double.POSITIVE_INFINITY : Double.NEGATIVE_INFINITY;
+        return values[0] == 0 ? 0.0 : (values[0] > 0 ? Double.POSITIVE_INFINITY : Double.NEGATIVE_INFINITY);
       }
       return values[0] / values[1];
     }, df.getDoubles(COL_CURR), df.get(COL_BASE)).subtract(1));

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetectorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetectorTest.java
@@ -77,6 +77,10 @@ public class PercentageChangeRuleDetectorTest {
     timeseries.put(MetricSlice.from(1L, 1543536000000L, 1548633600000L),
         new DataFrame().addSeries(COL_TIME, 1543536000000L, 1546214400000L)
             .addSeries(COL_VALUE, 100, 100));
+    timeseries.put(MetricSlice.from(1L, 1551398400000L, 1551571200000L),
+        new DataFrame().addSeries(COL_TIME, 1551398400000L, 1551484800000L).addSeries(COL_VALUE, 0, 200));
+    timeseries.put(MetricSlice.from(1L, 1550793600000L, 1550966400000L),
+        new DataFrame().addSeries(COL_TIME, 1550793600000L, 1550880000000L).addSeries(COL_VALUE, 0, 0));
 
     this.provider = new MockDataProvider()
         .setTimeseries(timeseries)
@@ -169,4 +173,17 @@ public class PercentageChangeRuleDetectorTest {
     Assert.assertEquals(anomalies.get(0).getEndTime(), 1551312000000L);
   }
 
+  @Test
+  public void testZeroDivide() {
+    AnomalyDetector percentageRule = new PercentageChangeRuleDetector();
+    PercentageChangeRuleDetectorSpec spec = new PercentageChangeRuleDetectorSpec();
+    spec.setOffset("wo1w");
+    spec.setPercentageChange(0.1);
+    percentageRule.init(spec, new DefaultInputDataFetcher(this.provider, -1));
+    List<MergedAnomalyResultDTO> anomalies = percentageRule.runDetection(new Interval(1551398400000L, 1551571200000L), "thirdeye:metric:1");
+    Assert.assertEquals(anomalies.size(), 1);
+    Assert.assertEquals(anomalies.get(0).getStartTime(), 1551398400000L);
+    Assert.assertEquals(anomalies.get(0).getEndTime(), 1551488400000L);
+
+  }
 }


### PR DESCRIPTION
Don't report as an anomaly in percentage change detector if the metric change from 0 to 0.