### PR TITLE
Added maxUsableHostMemory argument to realtime provision helper.

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimator.java
@@ -44,15 +44,15 @@ import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
  */
 public class MemoryEstimator {
 
-  private static final long MAX_MEMORY_BYTES = DataSize.toBytes("48G");
   private static final String NOT_APPLICABLE = "NA";
   private static final String TMP_DIR = System.getProperty("java.io.tmpdir") + File.separator;
   private static final String STATS_FILE_NAME = "stats.ser";
   private static final String STATS_FILE_COPY_NAME = "stats.copy.ser";
 
-  private TableConfig _tableConfig;
-  private File _sampleCompletedSegment;
-  private long _sampleSegmentConsumedSeconds;
+  private final TableConfig _tableConfig;
+  private final File _sampleCompletedSegment;
+  private final long _sampleSegmentConsumedSeconds;
+  private final long _maxUsableHostMemory;
 
   private SegmentMetadataImpl _segmentMetadata;
   private long _sampleCompletedSegmentSizeBytes;
@@ -65,7 +65,8 @@ public class MemoryEstimator {
   private String[][] _optimalSegmentSize;
   private String[][] _consumingMemoryPerHost;
 
-  public MemoryEstimator(TableConfig tableConfig, File sampleCompletedSegment, long sampleSegmentConsumedSeconds) {
+  public MemoryEstimator(TableConfig tableConfig, File sampleCompletedSegment, long sampleSegmentConsumedSeconds, long maxUsableHostMemory) {
+    _maxUsableHostMemory = maxUsableHostMemory;
     _tableConfig = tableConfig;
     _sampleCompletedSegment = sampleCompletedSegment;
     _sampleSegmentConsumedSeconds = sampleSegmentConsumedSeconds;
@@ -242,7 +243,7 @@ public class MemoryEstimator {
             memoryForConsumingSegmentPerPartition * totalConsumingPartitionsPerHost;
         long totalMemoryPerHostBytes = totalMemoryForCompletedSegmentsPerHost + totalMemoryForConsumingSegmentsPerHost;
 
-        if (totalMemoryPerHostBytes > MAX_MEMORY_BYTES) {
+        if (totalMemoryPerHostBytes > _maxUsableHostMemory) {
           _totalMemoryPerHost[i][j] = NOT_APPLICABLE;
           _consumingMemoryPerHost[i][j] = NOT_APPLICABLE;
           _optimalSegmentSize[i][j] = NOT_APPLICABLE;


### PR DESCRIPTION

In installations where hosts have memory limits other than 48G, the admin can
specify other memory limits to be used to provision realtime hosts