### PR TITLE
Added a percent threshold to consider startup of services

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -153,13 +153,15 @@ public class HelixBrokerStarter {
         .registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(), _tbiMessageHandler);
 
     addInstanceTagIfNeeded(helixClusterName, brokerId);
+    final double minResourcePercentForStartup = _pinotHelixProperties.getDouble(CommonConstants.Broker.CONFIG_OF_BROKER_MIN_RESOURCE_PERCENT_FOR_START,
+        CommonConstants.Broker.DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START);
 
     // Register the service status handler
     ServiceStatus.setServiceStatusCallback(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList
         .of(new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_helixManager, helixClusterName,
-                brokerId),
+                brokerId, minResourcePercentForStartup),
             new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixManager, helixClusterName,
-                brokerId))));
+                brokerId, minResourcePercentForStartup))));
 
     _brokerServerBuilder.getBrokerMetrics().addCallbackGauge("helix.connected", new Callable<Long>() {
       @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -124,6 +124,11 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_REFRESH_TIMEBOUNDARY_INFO_SLEEP_INTERVAL =
         "pinot.broker.refresh.timeBoundaryInfo.sleepInterval";
     public static final long DEFAULT_BROKER_REFRESH_TIMEBOUNDARY_INFO_SLEEP_INTERVAL_MS = 10000L;
+    // Configuration to consider the broker ServiceStatus as being STARTED if the percent of resources (tables) that
+    // are ONLINE for this this broker has crossed the threshold percentage of the total number of tables
+    // that it is expected to serve.
+    public static final String CONFIG_OF_BROKER_MIN_RESOURCE_PERCENT_FOR_START = "pinot.broker.startup.minResourcePercent";
+    public static final double DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START = 100.0;
 
     public static class Request {
       public static final String PQL = "pql";
@@ -167,6 +172,11 @@ public class CommonConstants {
         "pinot.server.instance.starter.maxShutdownWaitTime";
     public static final String CONFIG_OF_INSTANCE_CHECK_INTERVAL_TIME =
         "pinot.server.instance.starter.checkIntervalTime";
+    // Configuration to consider the server ServiceStatus as being STARTED if the percent of resources (tables) that
+    // are ONLINE for this this server has crossed the threshold percentage of the total number of tables
+    // that it is expected to serve.
+    public static final String CONFIG_OF_SERVER_MIN_RESOURCE_PERCENT_FOR_START = "pinot.server.startup.minResourcePercent";
+    public static final double DEFAULT_SERVER_MIN_RESOURCE_PERCENT_FOR_START = 100.0;
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final boolean DEFAULT_STARTER_ENABLE_SEGMENTS_LOADING_CHECK = false;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -137,7 +137,8 @@ public class ServiceStatus {
     private final Set<String> _resourcesToMonitor;
     private final int _numTotalResourcesToMonitor;
     private Iterator<String> _resourceIterator = null;
-    private final double _minResourcesStartPercent;
+    // Minimum number of resources to be in converged state before we declare the service state as STARTED
+    private final int _minResourcesStartCount;
 
     private String _statusDescription = STATUS_DESCRIPTION_INIT;
 
@@ -167,7 +168,7 @@ public class ServiceStatus {
         }
       }
       _numTotalResourcesToMonitor = _resourcesToMonitor.size();
-      _minResourcesStartPercent = minResourcesStartPercent;
+      _minResourcesStartCount = (int)Math.round(Math.ceil(minResourcesStartPercent * _numTotalResourcesToMonitor/100));
 
       LOGGER.info("Monitoring {} resources: {} for start up of instance {}", _numTotalResourcesToMonitor,
           _resourcesToMonitor, _instanceName);
@@ -182,8 +183,8 @@ public class ServiceStatus {
 
       _resourcesToMonitor = new HashSet<>(resourcesToMonitor);
       _numTotalResourcesToMonitor = _resourcesToMonitor.size();
-      _minResourcesStartPercent = minResourcesStartPercent;
 
+      _minResourcesStartCount = (int)Math.round(Math.ceil(minResourcesStartPercent * _numTotalResourcesToMonitor/100));
       LOGGER.info("Monitoring {} resources: {} for start up of instance {}", _numTotalResourcesToMonitor,
           _resourcesToMonitor, _instanceName);
     }
@@ -198,8 +199,7 @@ public class ServiceStatus {
       if (_resourcesToMonitor.isEmpty() || _numTotalResourcesToMonitor <= 0) {
         return true;
       }
-      if ((double)(_numTotalResourcesToMonitor - _resourcesToMonitor.size())*100/_numTotalResourcesToMonitor
-          >= _minResourcesStartPercent) {
+      if (_numTotalResourcesToMonitor - _resourcesToMonitor.size() >= _minResourcesStartCount) {
         return true;
       }
       return false;
@@ -285,8 +285,8 @@ public class ServiceStatus {
         _statusDescription = STATUS_DESCRIPTION_NONE;
         LOGGER.info("Instance {} has finished starting up", _instanceName);
       } else {
-        _statusDescription = String.format("waitingFor=%s, numResourcesLeft=%d, numTotalResources=%d, minPercent=%f",
-            getMatchName(), _resourcesToMonitor.size(), _numTotalResourcesToMonitor, _minResourcesStartPercent);
+        _statusDescription = String.format("waitingFor=%s, numResourcesLeft=%d, numTotalResources=%d, minStartCount=%d",
+            getMatchName(), _resourcesToMonitor.size(), _numTotalResourcesToMonitor, _minResourcesStartCount);
         LOGGER.info("Instance {} returning GOOD because {}", _statusDescription);
       }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -136,10 +136,13 @@ public class ServiceStatus {
 
     private final Set<String> _resourcesToMonitor;
     private final int _numTotalResourcesToMonitor;
+    private Iterator<String> _resourceIterator = null;
+    private final double _minResourcesStartPercent;
 
     private String _statusDescription = STATUS_DESCRIPTION_INIT;
 
-    public IdealStateMatchServiceStatusCallback(HelixManager helixManager, String clusterName, String instanceName) {
+    public IdealStateMatchServiceStatusCallback(HelixManager helixManager, String clusterName, String instanceName,
+        double minResourcesStartPercent) {
       _clusterName = clusterName;
       _instanceName = instanceName;
       _helixAdmin = helixManager.getClusterManagmentTool();
@@ -164,13 +167,14 @@ public class ServiceStatus {
         }
       }
       _numTotalResourcesToMonitor = _resourcesToMonitor.size();
+      _minResourcesStartPercent = minResourcesStartPercent;
 
       LOGGER.info("Monitoring {} resources: {} for start up of instance {}", _numTotalResourcesToMonitor,
           _resourcesToMonitor, _instanceName);
     }
 
     public IdealStateMatchServiceStatusCallback(HelixManager helixManager, String clusterName, String instanceName,
-        List<String> resourcesToMonitor) {
+        List<String> resourcesToMonitor, double minResourcesStartPercent) {
       _clusterName = clusterName;
       _instanceName = instanceName;
       _helixAdmin = helixManager.getClusterManagmentTool();
@@ -178,6 +182,7 @@ public class ServiceStatus {
 
       _resourcesToMonitor = new HashSet<>(resourcesToMonitor);
       _numTotalResourcesToMonitor = _resourcesToMonitor.size();
+      _minResourcesStartPercent = minResourcesStartPercent;
 
       LOGGER.info("Monitoring {} resources: {} for start up of instance {}", _numTotalResourcesToMonitor,
           _resourcesToMonitor, _instanceName);
@@ -189,20 +194,50 @@ public class ServiceStatus {
 
     protected abstract String getMatchName();
 
+    private boolean isDone() {
+      if (_resourcesToMonitor.isEmpty() || _numTotalResourcesToMonitor <= 0) {
+        return true;
+      }
+      if ((double)(_numTotalResourcesToMonitor - _resourcesToMonitor.size())*100/_numTotalResourcesToMonitor
+          >= _minResourcesStartPercent) {
+        return true;
+      }
+      return false;
+    }
+
+    // Each time getServiceStatus is called, we move on to the next resource that needs to be examined. If we
+    // reach the end, we set the iterator back to the beginning, starting again on the resource we left off
+    // a while ago.
+    // We do so until minResourcesStartPercent percent of resources have converged their externalview (or currentstate)
+    // to the idealstate. If any resource has not converged (and we have still not reached the threshold percent) then
+    // we return immediately.
+    // This allows us to move forward with resources that have converged as opposed to getting stuck with those that
+    // have not.
+    // In large installations with 1000s of resources, some resources may be stuck in transitions due to zookpeer
+    // connection issues in helix. In such cases, setting a percentage threshold to be (say) 99.9% allows us to move
+    // past and declare the server as having STARTED as opposed to waiting for the one resource that may never converge.
+    // Note:
+    //   - We still keep the number of zk access to a minimum, like before. Another method maybe to get all tables all
+    //     the time, but that may increase the number of zk reads.
+    //   - We may also need to keep track of how many partitions within a resource have converged, and track that
+    //     percentage as well. For now, we keep the code simple(r), and revisit this if necessary.
+    //   - It may be useful to consider a rewrite of this class where we expose the tables and partitions still
+    //     pending, thus allowing an external system to make the decision on whether or not to declare the status
+    //     as STARTING (perhaps depending on SLA for the resource, etc.).
     @Override
     public synchronized Status getServiceStatus() {
-      if (_resourcesToMonitor.isEmpty()) {
-        return Status.GOOD;
-      }
 
-      Iterator<String> iterator = _resourcesToMonitor.iterator();
-      while (iterator.hasNext()) {
-        String resourceName = iterator.next();
+      while (!isDone()) {
+        String resourceName;
+        if (_resourceIterator == null || !_resourceIterator.hasNext()) {
+          _resourceIterator = _resourcesToMonitor.iterator();
+        }
+        resourceName = _resourceIterator.next();
         IdealState idealState = getResourceIdealState(resourceName);
 
         // If the resource has been removed or disabled, ignore it
         if (idealState == null || !idealState.isEnabled()) {
-          iterator.remove();
+          _resourceIterator.remove();
           continue;
         }
 
@@ -243,11 +278,18 @@ public class ServiceStatus {
         }
 
         // Resource is done starting up, remove it from the set
-        iterator.remove();
+        _resourceIterator.remove();
       }
 
-      LOGGER.info("Instance {} has finished starting up", _instanceName);
-      _statusDescription = STATUS_DESCRIPTION_NONE;
+      if (_resourcesToMonitor.isEmpty()) {
+        _statusDescription = STATUS_DESCRIPTION_NONE;
+        LOGGER.info("Instance {} has finished starting up", _instanceName);
+      } else {
+        _statusDescription = String.format("waitingFor=%s, numResourcesLeft=%d, numTotalResources=%d, minPercent=%f",
+            getMatchName(), _resourcesToMonitor.size(), _numTotalResourcesToMonitor, _minResourcesStartPercent);
+        LOGGER.info("Instance {} returning GOOD because {}", _statusDescription);
+      }
+
       return Status.GOOD;
     }
 
@@ -269,13 +311,13 @@ public class ServiceStatus {
   public static class IdealStateAndCurrentStateMatchServiceStatusCallback extends IdealStateMatchServiceStatusCallback<CurrentState> {
     private static final String MATCH_NAME = "CurrentStateMatch";
     public IdealStateAndCurrentStateMatchServiceStatusCallback(HelixManager helixManager, String clusterName,
-        String instanceName) {
-      super(helixManager, clusterName, instanceName);
+        String instanceName, double minResourcesStartPercent) {
+      super(helixManager, clusterName, instanceName, minResourcesStartPercent);
     }
 
     public IdealStateAndCurrentStateMatchServiceStatusCallback(HelixManager helixManager, String clusterName,
-        String instanceName, List<String> resourcesToMonitor) {
-      super(helixManager, clusterName, instanceName, resourcesToMonitor);
+        String instanceName, List<String> resourcesToMonitor, double minResourcesStartPercent) {
+      super(helixManager, clusterName, instanceName, resourcesToMonitor, minResourcesStartPercent);
     }
 
     @Override
@@ -305,13 +347,13 @@ public class ServiceStatus {
   public static class IdealStateAndExternalViewMatchServiceStatusCallback extends IdealStateMatchServiceStatusCallback<ExternalView> {
     private static final String MATCH_NAME = "ExternalViewMatch";
     public IdealStateAndExternalViewMatchServiceStatusCallback(HelixManager helixManager, String clusterName,
-        String instanceName) {
-      super(helixManager, clusterName, instanceName);
+        String instanceName, double minResourcesStartPercent) {
+      super(helixManager, clusterName, instanceName, minResourcesStartPercent);
     }
 
     public IdealStateAndExternalViewMatchServiceStatusCallback(HelixManager helixManager, String clusterName,
-        String instanceName, List<String> resourcesToMonitor) {
-      super(helixManager, clusterName, instanceName, resourcesToMonitor);
+        String instanceName, List<String> resourcesToMonitor, double minResourcesStartPercent) {
+      super(helixManager, clusterName, instanceName, resourcesToMonitor, minResourcesStartPercent);
     }
 
     @Override

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStatusTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStatusTest.java
@@ -19,12 +19,18 @@
 package org.apache.pinot.common.utils;
 
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -72,6 +78,17 @@ public class ServiceStatusTest {
 
   public static final String TABLE_NAME = "myTable_OFFLINE";
   public static final String INSTANCE_NAME = "Server_1.2.3.4_1234";
+
+  private static final String CHARS_IN_RANDOM_TABLE_NAME = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  private static Random random;
+
+  @BeforeClass
+  public void setUp() {
+    long seed = System.currentTimeMillis();
+    random = new Random(seed);
+    // Printing to sysout so that we can re-generate failure cases.
+    System.out.println(ServiceStatusTest.class.getSimpleName() + ":Using random number seed " + seed);
+  }
 
   @Test
   public void testMultipleServiceStatusCallback() {
@@ -188,13 +205,89 @@ public class ServiceStatusTest {
         Collections.singletonList(TABLE_NAME));
   }
 
+  private String generateRandomString(int len) {
+    final int numChars = CHARS_IN_RANDOM_TABLE_NAME.length();
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < len; i++) {
+      builder.append(CHARS_IN_RANDOM_TABLE_NAME.charAt(random.nextInt(numChars)));
+    }
+    return builder.toString();
+  }
+
+  // Create a ServiceStatus object that monitors about 2500 tables
+  // and returns
+  @Test
+  public void testMultipleResourcesAndPercent() throws Exception {
+    testMultipleResourcesAndPercent(98.6);
+    testMultipleResourcesAndPercent(99.3);
+    testMultipleResourcesAndPercent(99.5);
+    testMultipleResourcesAndPercent(99.7);
+    testMultipleResourcesAndPercent(99.95);
+  }
+
+  private void testMultipleResourcesAndPercent(double percentReady) {
+    final long now = System.currentTimeMillis();
+    random = new Random(now);
+    final String clusterName = "noSuchCluster";
+    final List<String> tables = new ArrayList<>();
+    final int tableCount = 2500 + random.nextInt(100);
+    int readyTables = 0;
+    Map<String, IdealState> idealStates = new HashMap<>();
+    Map<String, ExternalView> externalViews = new HashMap<>();
+
+    for (int i = 1; i <= tableCount; i++) {
+      final String tableName = generateRandomString(10) + String.valueOf(i);
+      tables.add(tableName);
+      final String segmentName = "segment1";
+      String evState;
+      if (random.nextDouble() *100  < percentReady) {
+        evState = "ONLINE";
+        readyTables++;
+      } else {
+        evState = "OFFLINE";
+      }
+      IdealState idealState = new IdealState(tableName);
+      idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+      idealState.setPartitionState(segmentName, INSTANCE_NAME, "ONLINE");
+      ExternalView externalView = new ExternalView(tableName);
+      externalView.setState(segmentName, INSTANCE_NAME, evState);
+      idealStates.put(tableName, idealState);
+      externalViews.put(tableName, externalView);
+    }
+
+    final double actualReadyPercent = (double)readyTables * 100 / tableCount;
+    double lowestReadyPercent = (int) Math.round(actualReadyPercent);
+    lowestReadyPercent = lowestReadyPercent > 2 ? lowestReadyPercent - 2: 1;  // Should be 2 below  percentReady
+
+    // Create ServiceCallback objects with minReadyPercent set to values between lowestReadyPercent and 100.
+    // Call getServiceStatus() enough number of times so that we are only left with the tables
+    // that are not ready yet. We need to call getServiceStatus() at most tableCount times.
+    for (double minReadyPercent = lowestReadyPercent; minReadyPercent <= 100; minReadyPercent += 0.1) {
+      TestMultiResourceISAndEVMatchCB callback = new TestMultiResourceISAndEVMatchCB(clusterName, INSTANCE_NAME, tables,
+          minReadyPercent);
+      callback.setIdealStates(idealStates);
+      callback.setExternalViews(externalViews);
+
+      ServiceStatus.Status status = callback.getServiceStatus();
+      for (int i = 1; i < tableCount; i++) {
+        status = callback.getServiceStatus();
+      }
+
+      ServiceStatus.Status expected = minReadyPercent > actualReadyPercent ?
+          ServiceStatus.Status.STARTING : ServiceStatus.Status.GOOD;
+      String errorMsg = "Mismatch at " + minReadyPercent + "%, tableCount=" + tableCount +
+          ", percentTablesReady=" + actualReadyPercent + ":" + callback.getStatusDescription();
+      Assert.assertEquals(status, expected, errorMsg);
+    }
+  }
+
   private static class TestIdealStateAndExternalViewMatchServiceStatusCallback extends ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback {
     private IdealState _idealState;
     private ExternalView _externalView;
 
     public TestIdealStateAndExternalViewMatchServiceStatusCallback(String clusterName, String instanceName,
         List<String> resourcesToMonitor) {
-      super(Mockito.mock(HelixManager.class), clusterName, instanceName, resourcesToMonitor);
+      super(Mockito.mock(HelixManager.class), clusterName, instanceName, resourcesToMonitor, 100.0);
     }
 
     @Override
@@ -213,6 +306,34 @@ public class ServiceStatusTest {
 
     public void setExternalView(ExternalView externalView) {
       _externalView = externalView;
+    }
+  }
+
+  private static class TestMultiResourceISAndEVMatchCB extends ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback {
+    public Map<String, IdealState> _idealStates = new HashMap<>();
+    public Map<String, ExternalView> _externalViews = new HashMap<>();
+
+    public TestMultiResourceISAndEVMatchCB(String clusterName, String instanceName,
+        List<String> resourcesToMonitor, double minResourcesPercent) {
+      super(Mockito.mock(HelixManager.class), clusterName, instanceName, resourcesToMonitor, minResourcesPercent);
+    }
+
+    @Override
+    public IdealState getResourceIdealState(String resourceName) {
+      return _idealStates.get(resourceName);
+    }
+
+    @Override
+    public ExternalView getState(String resourceName) {
+      return _externalViews.get(resourceName);
+    }
+
+    public void setIdealStates(Map<String, IdealState> idealStates) {
+      _idealStates = idealStates;
+    }
+
+    public void setExternalViews(Map<String, ExternalView> externalViews) {
+      _externalViews = externalViews;
     }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -101,14 +101,14 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       if (instance.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE)) {
         _serviceStatusCallbacks.add(
             new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixManager, _clusterName, instance,
-                Collections.singletonList(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)));
+                Collections.singletonList(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE), 100.0));
       }
       if (instance.startsWith(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)) {
         _serviceStatusCallbacks.add(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList
             .of(new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_helixManager, _clusterName,
-                    instance),
+                    instance, 100.0),
                 new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixManager, _clusterName,
-                    instance))));
+                    instance, 100.0))));
       }
     }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -178,11 +178,13 @@ public class HelixServerStarter {
         .addPreConnectCallback(() -> serverMetrics.addMeteredGlobalValue(ServerMeter.HELIX_ZOOKEEPER_RECONNECTS, 1L));
 
     // Register the service status handler
+    final double minResourcePercentForStartup = _helixServerConfig.getDouble(CommonConstants.Server.CONFIG_OF_SERVER_MIN_RESOURCE_PERCENT_FOR_START,
+        CommonConstants.Server.DEFAULT_SERVER_MIN_RESOURCE_PERCENT_FOR_START);
     ServiceStatus.setServiceStatusCallback(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList
         .of(new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_helixManager, _helixClusterName,
-                _instanceId),
+                _instanceId, minResourcePercentForStartup),
             new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixManager, _helixClusterName,
-                _instanceId))));
+                _instanceId, minResourcePercentForStartup))));
 
     ControllerLeaderLocator.create(_helixManager);
 


### PR DESCRIPTION
In installations where each server may host 1000s of tabls, and 10s of
thousands of segments, it is useful in practice to declare a server
as STARTED when "most" segments of "most" of the tables are ready (i.e.
externalview and idealstate match, as do currentstate and idealstate).

This PR makes an attempt at defining "most" (on an experimental basis).

For now, we disregard the number of (helix) partitions within each resource.
Instead, we count the number of resources that have converged state
and declare success if a (configured) percent are ready.

This is still experimental, and it is suggested to set the percent
to 100 all the time (or, not set it at all, and let the default ride).