### PR TITLE
Use hex string as the representation of byte array for queries

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
@@ -51,15 +51,16 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   public BytesOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize,
       PinotDataBufferMemoryManager memoryManager, String allocationContext, int avgLength) {
     super(estimatedCardinality, maxOverflowHashSize, memoryManager, allocationContext);
-    _byteStore = new MutableOffHeapByteArrayStore(memoryManager, allocationContext,
-        estimatedCardinality, avgLength);
+    _byteStore = new MutableOffHeapByteArrayStore(memoryManager, allocationContext, estimatedCardinality, avgLength);
   }
 
   @Override
   public int indexOf(Object rawValue) {
     byte[] bytes = null;
     // Convert hex string to byte[].
-    if (rawValue instanceof String) {
+    if (rawValue instanceof byte[]) {
+      bytes = (byte[]) rawValue;
+    } else if (rawValue instanceof String) {
       try {
         bytes = Hex.decodeHex(((String) rawValue).toCharArray());
       } catch (DecoderException e) {
@@ -67,7 +68,6 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
       }
     } else {
       assert rawValue instanceof byte[];
-      bytes = (byte[]) rawValue;
     }
     return getDictId(new ByteArray(bytes), bytes);
   }
@@ -113,8 +113,7 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   }
 
   @Override
-  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare,
-      boolean includeLower,
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
       boolean includeUpper) {
     throw new UnsupportedOperationException("In-range not supported for Bytes data type.");
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
@@ -57,7 +57,6 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
   @Override
   public int indexOf(Object rawValue) {
-    assert rawValue instanceof byte[];
     byte[] bytes = null;
     // Convert hex string to byte[].
     if (rawValue instanceof String) {
@@ -67,6 +66,7 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
         Utils.rethrowException(e);
       }
     } else {
+      assert rawValue instanceof byte[];
       bytes = (byte[]) rawValue;
     }
     return getDictId(new ByteArray(bytes), bytes);
@@ -95,7 +95,6 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
   @Override
   public void index(@Nonnull Object rawValue) {
-    assert rawValue instanceof byte[];
     byte[] bytes = null;
     // Convert hex string to byte[].
     if (rawValue instanceof String) {
@@ -105,6 +104,7 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
         Utils.rethrowException(e);
       }
     } else {
+      assert rawValue instanceof byte[];
       bytes = (byte[]) rawValue;
     }
     ByteArray byteArray = new ByteArray(bytes);

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
@@ -20,6 +20,9 @@ package org.apache.pinot.core.realtime.impl.dictionary;
 
 import java.util.Arrays;
 import javax.annotation.Nonnull;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.utils.primitive.ByteArray;
 
 
@@ -27,13 +30,25 @@ import org.apache.pinot.common.utils.primitive.ByteArray;
  * OnHeap mutable dictionary of Bytes type.
  */
 public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
+
   private ByteArray _min = null;
   private ByteArray _max = null;
 
   @Override
   public int indexOf(Object rawValue) {
     assert rawValue instanceof byte[];
-    return getDictId(new ByteArray((byte[]) rawValue));
+    byte[] bytes = null;
+    // Convert hex string to byte[].
+    if (rawValue instanceof String) {
+      try {
+        bytes = Hex.decodeHex(((String) rawValue).toCharArray());
+      } catch (DecoderException e) {
+        Utils.rethrowException(e);
+      }
+    } else {
+      bytes = (byte[]) rawValue;
+    }
+    return getDictId(new ByteArray(bytes));
   }
 
   @Override
@@ -49,13 +64,25 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   @Override
   public void index(@Nonnull Object rawValue) {
     assert rawValue instanceof byte[];
-    ByteArray byteArray = new ByteArray((byte[]) rawValue);
+    byte[] bytes = null;
+    // Convert hex string to byte[].
+    if (rawValue instanceof String) {
+      try {
+        bytes = Hex.decodeHex(((String) rawValue).toCharArray());
+      } catch (DecoderException e) {
+        Utils.rethrowException(e);
+      }
+    } else {
+      bytes = (byte[]) rawValue;
+    }
+    ByteArray byteArray = new ByteArray(bytes);
     indexValue(byteArray);
     updateMinMax(byteArray);
   }
 
   @Override
-  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare,
+      boolean includeLower,
       boolean includeUpper) {
     throw new UnsupportedOperationException("In-range not supported for Bytes data type.");
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
@@ -38,7 +38,9 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   public int indexOf(Object rawValue) {
     byte[] bytes = null;
     // Convert hex string to byte[].
-    if (rawValue instanceof String) {
+    if (rawValue instanceof byte[]) {
+      bytes = (byte[]) rawValue;
+    } else if (rawValue instanceof String) {
       try {
         bytes = Hex.decodeHex(((String) rawValue).toCharArray());
       } catch (DecoderException e) {
@@ -46,7 +48,6 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
       }
     } else {
       assert rawValue instanceof byte[];
-      bytes = (byte[]) rawValue;
     }
     return getDictId(new ByteArray(bytes));
   }
@@ -81,8 +82,7 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   }
 
   @Override
-  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare,
-      boolean includeLower,
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
       boolean includeUpper) {
     throw new UnsupportedOperationException("In-range not supported for Bytes data type.");
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
@@ -36,7 +36,6 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
-    assert rawValue instanceof byte[];
     byte[] bytes = null;
     // Convert hex string to byte[].
     if (rawValue instanceof String) {
@@ -46,6 +45,7 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
         Utils.rethrowException(e);
       }
     } else {
+      assert rawValue instanceof byte[];
       bytes = (byte[]) rawValue;
     }
     return getDictId(new ByteArray(bytes));
@@ -63,7 +63,6 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public void index(@Nonnull Object rawValue) {
-    assert rawValue instanceof byte[];
     byte[] bytes = null;
     // Convert hex string to byte[].
     if (rawValue instanceof String) {
@@ -73,6 +72,7 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
         Utils.rethrowException(e);
       }
     } else {
+      assert rawValue instanceof byte[];
       bytes = (byte[]) rawValue;
     }
     ByteArray byteArray = new ByteArray(bytes);

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/dictionary/MutableDictionaryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/dictionary/MutableDictionaryTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.utils.primitive.ByteArray;
@@ -174,7 +175,8 @@ public class MutableDictionaryTest {
       Comparable value =
           (i == 0 && dataType == FieldSpec.DataType.INT) ? Integer.MIN_VALUE : makeRandomObjectOfType(dataType);
 
-      Object rawValue = dataType == FieldSpec.DataType.BYTES ? ((ByteArray) value).getBytes() : value;
+      Object rawValue = dataType == FieldSpec.DataType.BYTES ? ((i % 2 == 0) ? ((ByteArray) value).getBytes()
+          : Hex.encodeHexString(((ByteArray) value).getBytes())) : value;
       if (valueToDictId.containsKey(value)) {
         Assert.assertEquals(dictionary.indexOf(rawValue), (int) valueToDictId.get(value));
       } else {


### PR DESCRIPTION
Use hex string to represent byte[] value in query.
Refer to https://github.com/apache/incubator-pinot/issues/4040

