### PR TITLE
Create leadControllerResource in helix cluster

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
@@ -37,10 +37,6 @@ public class TagNameUtils {
     return tenantName + "_" + TenantRole.BROKER.toString();
   }
 
-  public static boolean hasValidServerTagSuffix(String tagName) {
-    return tagName.endsWith(ServerType.REALTIME.toString()) || tagName.endsWith(ServerType.OFFLINE.toString());
-  }
-
   public static boolean isServerTag(String tagName) {
     return isOfflineServerTag(tagName) || isRealtimeServerTag(tagName);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
@@ -58,7 +58,7 @@ public class TagNameUtils {
     return tagName.endsWith(ServerType.REALTIME.toString());
   }
 
-  public static boolean isBrokerTags(String tagName) {
+  public static boolean isBrokerTag(String tagName) {
     return tagName.endsWith(TenantRole.BROKER.toString());
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.common.config;
 
-import org.apache.pinot.common.exception.InvalidConfigException;
-import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.ServerType;
 import org.apache.pinot.common.utils.TenantRole;
 
@@ -40,10 +38,7 @@ public class TagNameUtils {
   }
 
   public static boolean hasValidServerTagSuffix(String tagName) {
-    if (tagName.endsWith(ServerType.REALTIME.toString()) || tagName.endsWith(ServerType.OFFLINE.toString())) {
-      return true;
-    }
-    return false;
+    return tagName.endsWith(ServerType.REALTIME.toString()) || tagName.endsWith(ServerType.OFFLINE.toString());
   }
 
   public static boolean isServerTag(String tagName) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.common.config;
 
 import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.ServerType;
 import org.apache.pinot.common.utils.TenantRole;
 
@@ -45,8 +46,18 @@ public class TagNameUtils {
     return false;
   }
 
-  public static TenantRole getTenantRoleFromTag(String tagName)
+  public static boolean isServerTag(String tagName)
       throws InvalidConfigException {
+    return TenantRole.SERVER == getTenantRoleFromTag(tagName);
+  }
+
+  public static boolean isBrokerTags(String tagName)
+      throws InvalidConfigException {
+    return TenantRole.BROKER == getTenantRoleFromTag(tagName);
+  }
+
+  // Make this method private to avoid exposing null out of this class.
+  private static TenantRole getTenantRoleFromTag(String tagName) throws InvalidConfigException {
     if (tagName.endsWith(ServerType.REALTIME.toString())) {
       return TenantRole.SERVER;
     }
@@ -55,6 +66,11 @@ public class TagNameUtils {
     }
     if (tagName.endsWith(TenantRole.BROKER.toString())) {
       return TenantRole.BROKER;
+    }
+    // Helix uses this tag to support full-auto.
+    // Return null if the tag is controller, which isn't a type of tenant in Pinot.
+    if (tagName.equalsIgnoreCase(CommonConstants.Helix.CONTROLLER_INSTANCE_TYPE)) {
+      return null;
     }
     throw new InvalidConfigException("Cannot identify tenant type from tag name : " + tagName);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
@@ -46,33 +46,20 @@ public class TagNameUtils {
     return false;
   }
 
-  public static boolean isServerTag(String tagName)
-      throws InvalidConfigException {
-    return TenantRole.SERVER == getTenantRoleFromTag(tagName);
+  public static boolean isServerTag(String tagName) {
+    return isOfflineServerTag(tagName) || isRealtimeServerTag(tagName);
   }
 
-  public static boolean isBrokerTags(String tagName)
-      throws InvalidConfigException {
-    return TenantRole.BROKER == getTenantRoleFromTag(tagName);
+  public static boolean isOfflineServerTag(String tagName) {
+    return tagName.endsWith(ServerType.OFFLINE.toString());
   }
 
-  // Make this method private to avoid exposing null out of this class.
-  private static TenantRole getTenantRoleFromTag(String tagName) throws InvalidConfigException {
-    if (tagName.endsWith(ServerType.REALTIME.toString())) {
-      return TenantRole.SERVER;
-    }
-    if (tagName.endsWith(ServerType.OFFLINE.toString())) {
-      return TenantRole.SERVER;
-    }
-    if (tagName.endsWith(TenantRole.BROKER.toString())) {
-      return TenantRole.BROKER;
-    }
-    // Helix uses this tag to support full-auto.
-    // Return null if the tag is controller, which isn't a type of tenant in Pinot.
-    if (tagName.equalsIgnoreCase(CommonConstants.Helix.CONTROLLER_INSTANCE_TYPE)) {
-      return null;
-    }
-    throw new InvalidConfigException("Cannot identify tenant type from tag name : " + tagName);
+  public static boolean isRealtimeServerTag(String tagName) {
+    return tagName.endsWith(ServerType.REALTIME.toString());
+  }
+
+  public static boolean isBrokerTags(String tagName) {
+    return tagName.endsWith(TenantRole.BROKER.toString());
   }
 
   public static String getTagFromTenantAndServerType(String tenantName, ServerType type) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -44,8 +44,8 @@ public class CommonConstants {
 
     // More information on why these numbers are set can be found in the following doc:
     // https://cwiki.apache.org/confluence/display/PINOT/Controller+Separation+between+Helix+and+Pinot
-    public static final int NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE = 17;
-    public static final int NUMBER_OF_CONTROLLER_REPLICAS = 1;
+    public static final int NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE = 24;
+    public static final int LEAD_CONTROLLER_RESOURCE_REPLICA_COUNT = 1;
 
     public static final String UNTAGGED_SERVER_INSTANCE = "server_untagged";
     public static final String UNTAGGED_BROKER_INSTANCE = "broker_untagged";

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -46,6 +46,9 @@ public class CommonConstants {
     // https://cwiki.apache.org/confluence/display/PINOT/Controller+Separation+between+Helix+and+Pinot
     public static final int NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE = 24;
     public static final int LEAD_CONTROLLER_RESOURCE_REPLICA_COUNT = 1;
+    public static final boolean ENABLE_DELAY_REBALANCE = true;
+    public static final int MIN_ACTIVE_REPLICAS = 0;
+    public static final long REBALANCE_DELAY_MS = 300_000L; // 5 minutes.
 
     public static final String UNTAGGED_SERVER_INSTANCE = "server_untagged";
     public static final String UNTAGGED_BROKER_INSTANCE = "broker_untagged";

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -37,8 +37,16 @@ public class CommonConstants {
 
     public static final String SERVER_INSTANCE_TYPE = "server";
     public static final String BROKER_INSTANCE_TYPE = "broker";
+    public static final String CONTROLLER_INSTANCE_TYPE = "controller";
 
     public static final String BROKER_RESOURCE_INSTANCE = "brokerResource";
+    public static final String LEAD_CONTROLLER_RESOURCE_NAME = "leadControllerResource";
+
+    // This is for specifying the number of partitions in leadControllerResource.
+    // In most of the cases there won't be more than 17 controllers in one single cluster.
+    // Hard code the number of partitions to 17 since it's rarely changed and for less changes of hash collision.
+    public static final int DEFAULT_NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE = 17;
+    public static final int DEFAULT_NUMBER_OF_CONTROLLER_REPLICAS = 1;
 
     public static final String UNTAGGED_SERVER_INSTANCE = "server_untagged";
     public static final String UNTAGGED_BROKER_INSTANCE = "broker_untagged";

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -42,11 +42,10 @@ public class CommonConstants {
     public static final String BROKER_RESOURCE_INSTANCE = "brokerResource";
     public static final String LEAD_CONTROLLER_RESOURCE_NAME = "leadControllerResource";
 
-    // This is for specifying the number of partitions in leadControllerResource.
-    // In most of the cases there won't be more than 17 controllers in one single cluster.
-    // Hard code the number of partitions to 17 since it's rarely changed and for less changes of hash collision.
-    public static final int DEFAULT_NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE = 17;
-    public static final int DEFAULT_NUMBER_OF_CONTROLLER_REPLICAS = 1;
+    // More information on why these numbers are set can be found in the following doc:
+    // https://cwiki.apache.org/confluence/display/PINOT/Controller+Separation+between+Helix+and+Pinot
+    public static final int NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE = 17;
+    public static final int NUMBER_OF_CONTROLLER_REPLICAS = 1;
 
     public static final String UNTAGGED_SERVER_INSTANCE = "server_untagged";
     public static final String UNTAGGED_BROKER_INSTANCE = "broker_untagged";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -57,8 +57,6 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String CONSOLE_WEBAPP_USE_HTTPS = "controller.query.console.useHttps";
   private static final String EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT = "controller.upload.onlineToOfflineTimeout";
   private static final String CONTROLLER_MODE = "controller.mode";
-  private static final String NUMBER_OF_CONTROLLER_REPLICAS = "controller.number.replicas";
-  private static final String NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE = "controller.number.partitions";
 
   public enum ControllerMode {
     DUAL,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -57,6 +57,8 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String CONSOLE_WEBAPP_USE_HTTPS = "controller.query.console.useHttps";
   private static final String EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT = "controller.upload.onlineToOfflineTimeout";
   private static final String CONTROLLER_MODE = "controller.mode";
+  private static final String NUMBER_OF_CONTROLLER_REPLICAS = "controller.number.replicas";
+  private static final String NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE = "controller.number.partitions";
 
   public enum ControllerMode {
     DUAL,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -220,7 +220,7 @@ public class ControllerStarter {
     // Register and connect instance as Helix controller.
     LOGGER.info("Starting Helix controller");
     _helixControllerManager = HelixSetupUtils
-        .setup(_helixClusterName, _helixZkURL, _instanceId, _isUpdateStateModel, _enableBatchMessageMode);
+        .setup(_helixClusterName, _helixZkURL, _instanceId);
 
     // Emit helix controller metrics
     _controllerMetrics.addCallbackGauge(CommonConstants.Helix.INSTANCE_CONNECTED_METRIC_NAME,
@@ -243,6 +243,9 @@ public class ControllerStarter {
     if (_controllerMode == ControllerConf.ControllerMode.PINOT_ONLY && !isPinotOnlyModeSupported()) {
       throw new RuntimeException("Pinot only controller currently isn't supported in production yet.");
     }
+
+    // Set up Pinot cluster in Helix
+    HelixSetupUtils.setupPinotCluster(_helixClusterName, _helixZkURL, _isUpdateStateModel, _enableBatchMessageMode);
 
     // Start all components
     initPinotFSFactory();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -219,8 +219,7 @@ public class ControllerStarter {
   private void setUpHelixController() {
     // Register and connect instance as Helix controller.
     LOGGER.info("Starting Helix controller");
-    _helixControllerManager = HelixSetupUtils
-        .setup(_helixClusterName, _helixZkURL, _instanceId);
+    _helixControllerManager = HelixSetupUtils.setup(_helixClusterName, _helixZkURL, _instanceId);
 
     // Emit helix controller metrics
     _controllerMetrics.addCallbackGauge(CommonConstants.Helix.INSTANCE_CONNECTED_METRIC_NAME,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1170,7 +1170,7 @@ public class PinotHelixResourceManager {
     if (tagOverrideConfig != null) {
       String realtimeConsumingTag = tagOverrideConfig.getRealtimeConsuming();
       if (realtimeConsumingTag != null) {
-        if (!TagNameUtils.hasValidServerTagSuffix(realtimeConsumingTag)) {
+        if (!TagNameUtils.isServerTag(realtimeConsumingTag)) {
           throw new InvalidTableConfigException(
               "Invalid realtime consuming tag: " + realtimeConsumingTag + " for table " + tableNameWithType
                   + ". Must have suffix _REALTIME or _OFFLINE");
@@ -1184,7 +1184,7 @@ public class PinotHelixResourceManager {
 
       String realtimeCompletedTag = tagOverrideConfig.getRealtimeCompleted();
       if (realtimeCompletedTag != null) {
-        if (!TagNameUtils.hasValidServerTagSuffix(realtimeCompletedTag)) {
+        if (!TagNameUtils.isServerTag(realtimeCompletedTag)) {
           throw new InvalidTableConfigException(
               "Invalid realtime completed tag: " + realtimeCompletedTag + " for table " + tableNameWithType
                   + ". Must have suffix _REALTIME or _OFFLINE");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -288,7 +288,6 @@ public class PinotHelixResourceManager {
    * Add instance group tag for controller so that pinot controller can be assigned to lead controller resource.
    */
   private void addInstanceGroupTag() {
-    _helixZkManager.getClusterManagmentTool().enableInstance(_helixClusterName, _controllerParticipantInstanceId, true);
     InstanceConfig instanceConfig = getHelixInstanceConfig(_controllerParticipantInstanceId);
     instanceConfig.addTag(CommonConstants.Helix.CONTROLLER_INSTANCE_TYPE);
     HelixDataAccessor accessor = _helixZkManager.getHelixDataAccessor();
@@ -862,12 +861,8 @@ public class PinotHelixResourceManager {
             .equals(CommonConstants.Minion.UNTAGGED_INSTANCE)) {
           continue;
         }
-        try {
-          if (TagNameUtils.isBrokerTags(tag)) {
-            tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
-          }
-        } catch (InvalidConfigException e) {
-          LOGGER.warn("Instance {} contains an invalid tag: {}", instanceName, tag);
+        if (TagNameUtils.isBrokerTags(tag)) {
+          tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
         }
       }
     }
@@ -885,12 +880,8 @@ public class PinotHelixResourceManager {
             .equals(CommonConstants.Minion.UNTAGGED_INSTANCE)) {
           continue;
         }
-        try {
-          if (TagNameUtils.isServerTag(tag)) {
-            tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
-          }
-        } catch (InvalidConfigException e) {
-          LOGGER.warn("Instance {} contains an invalid tag: {}", instanceName, tag);
+        if (TagNameUtils.isServerTag(tag)) {
+          tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
         }
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix.core.util;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,8 +28,7 @@ import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyPathConfig;
-import org.apache.helix.PropertyType;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.controller.HelixControllerMain;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
@@ -64,13 +64,12 @@ import static org.apache.pinot.common.utils.CommonConstants.Helix.LEAD_CONTROLLE
  *
  */
 public class HelixSetupUtils {
-
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixSetupUtils.class);
 
   public static synchronized HelixManager setup(String helixClusterName, String zkPath,
-      String pinotControllerInstanceId, boolean isUpdateStateModel, boolean enableBatchMessageMode) {
+      String pinotControllerInstanceId) {
     try {
-      setupHelixCluster(helixClusterName, zkPath, isUpdateStateModel, enableBatchMessageMode);
+      setupHelixCluster(helixClusterName, zkPath);
     } catch (final Exception e) {
       LOGGER.error("Caught exception when setting up Helix cluster: {}", helixClusterName, e);
       return null;
@@ -84,124 +83,152 @@ public class HelixSetupUtils {
     }
   }
 
-  public static void setupHelixCluster(String helixClusterName, String zkPath, boolean isUpdateStateModel,
-      boolean enableBatchMessageMode) {
+  /**
+   * Set up a brand new Helix cluster if it doesn't exist.
+   */
+  public static void setupHelixCluster(String helixClusterName, String zkPath) {
     final HelixAdmin admin = new ZKHelixAdmin(zkPath);
-
-    createHelixClusterIfNeeded(helixClusterName, zkPath, admin, isUpdateStateModel, enableBatchMessageMode);
-
-    createLeadControllerResourceIfNeeded(helixClusterName, admin, enableBatchMessageMode);
-  }
-
-  public static void createHelixClusterIfNeeded(String helixClusterName, String zkPath, HelixAdmin admin,
-      boolean isUpdateStateModel, boolean enableBatchMessageMode) {
-    final String segmentStateModelName =
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.PINOT_SEGMENT_ONLINE_OFFLINE_STATE_MODEL;
-
     if (admin.getClusters().contains(helixClusterName)) {
-      LOGGER.info("cluster already exists ********************************************* ");
-      if (isUpdateStateModel) {
-        final StateModelDefinition curStateModelDef = admin.getStateModelDef(helixClusterName, segmentStateModelName);
-        List<String> states = curStateModelDef.getStatesPriorityList();
-        if (states.contains(PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE)) {
-          LOGGER.info("State model {} already updated to contain CONSUMING state", segmentStateModelName);
-          return;
-        } else {
-          LOGGER.info("Updating {} to add states for low level consumers", segmentStateModelName);
-          StateModelDefinition newStateModelDef =
-              PinotHelixSegmentOnlineOfflineStateModelGenerator.generatePinotStateModelDefinition();
-          ZkClient zkClient = new ZkClient(zkPath);
-          zkClient.waitUntilConnected(CommonConstants.Helix.ZkClient.DEFAULT_CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
-          zkClient.setZkSerializer(new ZNRecordSerializer());
-          HelixDataAccessor accessor =
-              new ZKHelixDataAccessor(helixClusterName, new ZkBaseDataAccessor<ZNRecord>(zkClient));
-          PropertyKey.Builder keyBuilder = accessor.keyBuilder();
-          accessor.setProperty(keyBuilder.stateModelDef(segmentStateModelName), newStateModelDef);
-          LOGGER.info("Completed updating statemodel {}", segmentStateModelName);
-          zkClient.close();
-        }
-      }
+      LOGGER.info("Helix cluster: {} already exists", helixClusterName);
       return;
     }
-
-    LOGGER.info("Creating a new cluster, as the helix cluster : " + helixClusterName
-        + " was not found ********************************************* ");
+    LOGGER.info("Creating a new Helix cluster: {}", helixClusterName);
     admin.addCluster(helixClusterName, false);
-
-    LOGGER.info("Enable auto join.");
-    final HelixConfigScope scope =
-        new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(helixClusterName).build();
-
-    final Map<String, String> props = new HashMap<String, String>();
-    props.put(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, String.valueOf(true));
-    //we need only one segment to be loaded at a time
-    props.put(MessageType.STATE_TRANSITION + "." + HelixTaskExecutor.MAX_THREADS, String.valueOf(1));
-
-    admin.setConfig(scope, props);
-
-    LOGGER.info(
-        "Adding state model {} (with CONSUMED state) generated using {} **********************************************",
-        segmentStateModelName, PinotHelixSegmentOnlineOfflineStateModelGenerator.class.toString());
-
-    // If this is a fresh cluster we are creating, then the cluster will see the CONSUMING state in the
-    // state model. But then the servers will never be asked to go to that STATE (whether they have the code
-    // to handle it or not) unil we complete the feature using low-level consumers and turn the feature on.
-    admin.addStateModelDef(helixClusterName, segmentStateModelName,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.generatePinotStateModelDefinition());
-
-    LOGGER.info("Adding state model definition named : "
-        + PinotHelixBrokerResourceOnlineOfflineStateModelGenerator.PINOT_BROKER_RESOURCE_ONLINE_OFFLINE_STATE_MODEL
-        + " generated using : " + PinotHelixBrokerResourceOnlineOfflineStateModelGenerator.class.toString()
-        + " ********************************************** ");
-
-    admin.addStateModelDef(helixClusterName,
-        PinotHelixBrokerResourceOnlineOfflineStateModelGenerator.PINOT_BROKER_RESOURCE_ONLINE_OFFLINE_STATE_MODEL,
-        PinotHelixBrokerResourceOnlineOfflineStateModelGenerator.generatePinotStateModelDefinition());
-
-    LOGGER.info("Adding empty ideal state for Broker!");
-    HelixHelper.updateResourceConfigsFor(new HashMap<String, String>(), CommonConstants.Helix.BROKER_RESOURCE_INSTANCE,
-        helixClusterName, admin);
-    IdealState idealState = PinotTableIdealStateBuilder
-        .buildEmptyIdealStateForBrokerResource(admin, helixClusterName, enableBatchMessageMode);
-    admin.setResourceIdealState(helixClusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, idealState);
-    initPropertyStorePath(helixClusterName, zkPath);
-    LOGGER.info("New Cluster setup completed... ********************************************** ");
-  }
-
-  private static void initPropertyStorePath(String helixClusterName, String zkPath) {
-    String propertyStorePath = PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, helixClusterName);
-    ZkHelixPropertyStore<ZNRecord> propertyStore =
-        new ZkHelixPropertyStore<ZNRecord>(zkPath, new ZNRecordSerializer(), propertyStorePath);
-    propertyStore.create("/CONFIGS", new ZNRecord(""), AccessOption.PERSISTENT);
-    propertyStore.create("/CONFIGS/CLUSTER", new ZNRecord(""), AccessOption.PERSISTENT);
-    propertyStore.create("/CONFIGS/TABLE", new ZNRecord(""), AccessOption.PERSISTENT);
-    propertyStore.create("/CONFIGS/INSTANCE", new ZNRecord(""), AccessOption.PERSISTENT);
-    propertyStore.create("/SCHEMAS", new ZNRecord(""), AccessOption.PERSISTENT);
-    propertyStore.create("/SEGMENTS", new ZNRecord(""), AccessOption.PERSISTENT);
+    LOGGER.info("New Cluster: {} created.", helixClusterName);
   }
 
   private static HelixManager startHelixControllerInStandadloneMode(String helixClusterName, String zkUrl,
       String pinotControllerInstanceId) {
     LOGGER.info("Starting Helix Standalone Controller ... ");
-    return HelixControllerMain
-        .startHelixController(zkUrl, helixClusterName, pinotControllerInstanceId, HelixControllerMain.STANDALONE);
+    return HelixControllerMain.startHelixController(zkUrl, helixClusterName, pinotControllerInstanceId,
+        HelixControllerMain.STANDALONE);
+  }
+
+  /**
+   * Customizes existing Helix cluster to run Pinot components.
+   */
+  public static void setupPinotCluster(String helixClusterName, String zkPath, boolean isUpdateStateModel,
+      boolean enableBatchMessageMode) {
+    final HelixAdmin admin = new ZKHelixAdmin(zkPath);
+    if (!admin.getClusters().contains(helixClusterName)) {
+      LOGGER.error("Helix cluster: {} hasn't been set up", helixClusterName);
+      throw new RuntimeException();
+    }
+
+    // Ensure auto join.
+    ensureAutoJoin(helixClusterName, admin);
+
+    // Add segment state model definition if needed
+    addSegmentStateModelDefinitionIfNeeded(helixClusterName, admin, zkPath, isUpdateStateModel);
+
+    // Add broker resource online offline state model definition if needed
+    addBrokerResourceOnlineOfflineStateModelDefinitionIfNeeded(helixClusterName, admin);
+
+    // Add broker resource if needed
+    createBrokerResourceIfNeeded(helixClusterName, admin, enableBatchMessageMode);
+
+    // Add lead controller resource if needed
+    createLeadControllerResourceIfNeeded(helixClusterName, admin, enableBatchMessageMode);
+
+    // Init property store if needed
+    initPropertyStoreIfNeeded(helixClusterName, zkPath);
+  }
+
+  private static void ensureAutoJoin(String helixClusterName, HelixAdmin admin) {
+    final HelixConfigScope scope =
+        new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(helixClusterName).build();
+    String stateTransitionMaxThreads = MessageType.STATE_TRANSITION + "." + HelixTaskExecutor.MAX_THREADS;
+    List<String> keys = new ArrayList<>();
+    keys.add(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN);
+    keys.add(stateTransitionMaxThreads);
+    Map<String, String> configs = admin.getConfig(scope, keys);
+    if (!Boolean.TRUE.toString().equals(configs.get(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN))) {
+      configs.put(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, Boolean.TRUE.toString());
+    }
+    if (!Integer.toString(1).equals(configs.get(stateTransitionMaxThreads))) {
+      configs.put(stateTransitionMaxThreads, String.valueOf(1));
+    }
+    admin.setConfig(scope, configs);
+  }
+
+  private static void addSegmentStateModelDefinitionIfNeeded(String helixClusterName, HelixAdmin admin, String zkPath,
+      boolean isUpdateStateModel) {
+    final String segmentStateModelName =
+        PinotHelixSegmentOnlineOfflineStateModelGenerator.PINOT_SEGMENT_ONLINE_OFFLINE_STATE_MODEL;
+    StateModelDefinition stateModelDefinition = admin.getStateModelDef(helixClusterName, segmentStateModelName);
+    if (stateModelDefinition == null) {
+      LOGGER.info(
+          "Adding state model {} (with CONSUMED state) generated using {}",
+          segmentStateModelName, PinotHelixSegmentOnlineOfflineStateModelGenerator.class.toString());
+
+      // If this is a fresh cluster we are creating, then the cluster will see the CONSUMING state in the
+      // state model. But then the servers will never be asked to go to that STATE (whether they have the code
+      // to handle it or not) unil we complete the feature using low-level consumers and turn the feature on.
+      admin.addStateModelDef(helixClusterName, segmentStateModelName,
+          PinotHelixSegmentOnlineOfflineStateModelGenerator.generatePinotStateModelDefinition());
+    } else if (isUpdateStateModel) {
+      final StateModelDefinition curStateModelDef = admin.getStateModelDef(helixClusterName, segmentStateModelName);
+      List<String> states = curStateModelDef.getStatesPriorityList();
+      if (states.contains(PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE)) {
+        LOGGER.info("State model {} already updated to contain CONSUMING state", segmentStateModelName);
+      } else {
+        LOGGER.info("Updating {} to add states for low level consumers", segmentStateModelName);
+        StateModelDefinition newStateModelDef =
+            PinotHelixSegmentOnlineOfflineStateModelGenerator.generatePinotStateModelDefinition();
+        ZkClient zkClient = new ZkClient(zkPath);
+        zkClient.waitUntilConnected(CommonConstants.Helix.ZkClient.DEFAULT_CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+        zkClient.setZkSerializer(new ZNRecordSerializer());
+        HelixDataAccessor accessor = new ZKHelixDataAccessor(helixClusterName, new ZkBaseDataAccessor<>(zkClient));
+        PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+        accessor.setProperty(keyBuilder.stateModelDef(segmentStateModelName), newStateModelDef);
+        LOGGER.info("Completed updating statemodel {}", segmentStateModelName);
+        zkClient.close();
+      }
+    }
+  }
+
+  private static void addBrokerResourceOnlineOfflineStateModelDefinitionIfNeeded(String helixClusterName,
+      HelixAdmin admin) {
+    StateModelDefinition brokerResourceStateModelDefinition = admin.getStateModelDef(helixClusterName,
+        PinotHelixBrokerResourceOnlineOfflineStateModelGenerator.PINOT_BROKER_RESOURCE_ONLINE_OFFLINE_STATE_MODEL);
+    if (brokerResourceStateModelDefinition == null) {
+      LOGGER.info("Adding state model definition named : {} generated using : {}",
+          PinotHelixBrokerResourceOnlineOfflineStateModelGenerator.PINOT_BROKER_RESOURCE_ONLINE_OFFLINE_STATE_MODEL,
+          PinotHelixBrokerResourceOnlineOfflineStateModelGenerator.class.toString());
+      admin.addStateModelDef(helixClusterName,
+          PinotHelixBrokerResourceOnlineOfflineStateModelGenerator.PINOT_BROKER_RESOURCE_ONLINE_OFFLINE_STATE_MODEL,
+          PinotHelixBrokerResourceOnlineOfflineStateModelGenerator.generatePinotStateModelDefinition());
+    }
+  }
+
+  private static void createBrokerResourceIfNeeded(String helixClusterName, HelixAdmin admin,
+      boolean enableBatchMessageMode) {
+    IdealState brokerResourceIdealState =
+        admin.getResourceIdealState(helixClusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
+    if (brokerResourceIdealState == null) {
+      LOGGER.info("Adding empty ideal state for Broker!");
+      HelixHelper.updateResourceConfigsFor(new HashMap<>(), CommonConstants.Helix.BROKER_RESOURCE_INSTANCE,
+          helixClusterName, admin);
+      IdealState idealState = PinotTableIdealStateBuilder.buildEmptyIdealStateForBrokerResource(admin, helixClusterName,
+          enableBatchMessageMode);
+      admin.setResourceIdealState(helixClusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, idealState);
+    }
   }
 
   private static void createLeadControllerResourceIfNeeded(String helixClusterName, HelixAdmin admin,
       boolean enableBatchMessageMode) {
-    IdealState leadControllerResourceIdealState = admin.getResourceIdealState(helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME);
+    IdealState leadControllerResourceIdealState =
+        admin.getResourceIdealState(helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME);
     if (leadControllerResourceIdealState == null) {
-      LOGGER.info("Cluster {} doesn't contain {}. Creating one..", helixClusterName,
-          LEAD_CONTROLLER_RESOURCE_NAME);
+      LOGGER.info("Cluster {} doesn't contain {}. Creating one.", helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME);
 
       admin.addStateModelDef(helixClusterName, MasterSlaveSMD.name, MasterSlaveSMD.build());
 
-      HelixHelper.updateResourceConfigsFor(new HashMap<>(), LEAD_CONTROLLER_RESOURCE_NAME,
-          helixClusterName, admin);
+      HelixHelper.updateResourceConfigsFor(new HashMap<>(), LEAD_CONTROLLER_RESOURCE_NAME, helixClusterName, admin);
       // FULL-AUTO Master-Slave state model with CrushED rebalance strategy.
       admin.addResource(helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME,
-          CommonConstants.Helix.DEFAULT_NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE,
-          MasterSlaveSMD.name, IdealState.RebalanceMode.FULL_AUTO.toString(), CrushEdRebalanceStrategy.class.getName());
+          CommonConstants.Helix.NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE, MasterSlaveSMD.name,
+          IdealState.RebalanceMode.FULL_AUTO.toString(), CrushEdRebalanceStrategy.class.getName());
 
       // Set instance group tag for lead controller resource.
       IdealState leadControllerIdealState =
@@ -209,13 +236,36 @@ public class HelixSetupUtils {
       leadControllerIdealState.setInstanceGroupTag(CommonConstants.Helix.CONTROLLER_INSTANCE_TYPE);
       leadControllerIdealState.setBatchMessageMode(enableBatchMessageMode);
       leadControllerIdealState.setMinActiveReplicas(0);
-      admin.setResourceIdealState(helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME,
-          leadControllerIdealState);
+      admin.setResourceIdealState(helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME, leadControllerIdealState);
 
       LOGGER.info("Re-balance lead controller resource with replicas: {}",
-          CommonConstants.Helix.DEFAULT_NUMBER_OF_CONTROLLER_REPLICAS);
+          CommonConstants.Helix.NUMBER_OF_CONTROLLER_REPLICAS);
       admin.rebalance(helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME,
-          CommonConstants.Helix.DEFAULT_NUMBER_OF_CONTROLLER_REPLICAS);
+          CommonConstants.Helix.NUMBER_OF_CONTROLLER_REPLICAS);
+    }
+  }
+
+  private static void initPropertyStoreIfNeeded(String helixClusterName, String zkPath) {
+    String propertyStorePath = PropertyPathBuilder.propertyStore(helixClusterName);
+    ZkHelixPropertyStore<ZNRecord> propertyStore =
+        new ZkHelixPropertyStore<>(zkPath, new ZNRecordSerializer(), propertyStorePath);
+    if (!propertyStore.exists("/CONFIGS", AccessOption.PERSISTENT)) {
+      propertyStore.create("/CONFIGS", new ZNRecord(""), AccessOption.PERSISTENT);
+    }
+    if (!propertyStore.exists("/CONFIGS/CLUSTER", AccessOption.PERSISTENT)) {
+      propertyStore.create("/CONFIGS/CLUSTER", new ZNRecord(""), AccessOption.PERSISTENT);
+    }
+    if (!propertyStore.exists("/CONFIGS/TABLE", AccessOption.PERSISTENT)) {
+      propertyStore.create("/CONFIGS/TABLE", new ZNRecord(""), AccessOption.PERSISTENT);
+    }
+    if (!propertyStore.exists("/CONFIGS/INSTANCE", AccessOption.PERSISTENT)) {
+      propertyStore.create("/CONFIGS/INSTANCE", new ZNRecord(""), AccessOption.PERSISTENT);
+    }
+    if (!propertyStore.exists("/SCHEMAS", AccessOption.PERSISTENT)) {
+      propertyStore.create("/SCHEMAS", new ZNRecord(""), AccessOption.PERSISTENT);
+    }
+    if (!propertyStore.exists("/SEGMENTS", AccessOption.PERSISTENT)) {
+      propertyStore.create("/SEGMENTS", new ZNRecord(""), AccessOption.PERSISTENT);
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -69,19 +69,9 @@ public class HelixSetupUtils {
 
   public static synchronized HelixManager setup(String helixClusterName, String zkPath,
       String helixControllerInstanceId) {
-    try {
-      setupHelixCluster(helixClusterName, zkPath);
-    } catch (final Exception e) {
-      LOGGER.error("Caught exception when setting up Helix cluster: {}", helixClusterName, e);
-      throw e;
-    }
+    setupHelixCluster(helixClusterName, zkPath);
 
-    try {
-      return startHelixControllerInStandadloneMode(helixClusterName, zkPath, helixControllerInstanceId);
-    } catch (final Exception e) {
-      LOGGER.error("Caught exception when starting helix controller", e);
-      throw e;
-    }
+    return startHelixControllerInStandadloneMode(helixClusterName, zkPath, helixControllerInstanceId);
   }
 
   /**
@@ -101,8 +91,8 @@ public class HelixSetupUtils {
   private static HelixManager startHelixControllerInStandadloneMode(String helixClusterName, String zkUrl,
       String pinotControllerInstanceId) {
     LOGGER.info("Starting Helix Standalone Controller ... ");
-    return HelixControllerMain.startHelixController(zkUrl, helixClusterName, pinotControllerInstanceId,
-        HelixControllerMain.STANDALONE);
+    return HelixControllerMain
+        .startHelixController(zkUrl, helixClusterName, pinotControllerInstanceId, HelixControllerMain.STANDALONE);
   }
 
   /**
@@ -197,10 +187,11 @@ public class HelixSetupUtils {
         admin.getResourceIdealState(helixClusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
     if (brokerResourceIdealState == null) {
       LOGGER.info("Adding empty ideal state for Broker!");
-      HelixHelper.updateResourceConfigsFor(new HashMap<>(), CommonConstants.Helix.BROKER_RESOURCE_INSTANCE,
-          helixClusterName, admin);
-      IdealState idealState = PinotTableIdealStateBuilder.buildEmptyIdealStateForBrokerResource(admin, helixClusterName,
-          enableBatchMessageMode);
+      HelixHelper
+          .updateResourceConfigsFor(new HashMap<>(), CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, helixClusterName,
+              admin);
+      IdealState idealState = PinotTableIdealStateBuilder
+          .buildEmptyIdealStateForBrokerResource(admin, helixClusterName, enableBatchMessageMode);
       admin.setResourceIdealState(helixClusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, idealState);
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
@@ -46,7 +46,8 @@ public class PinotControllerModeTest extends ControllerTest {
   }
 
   @Test
-  public void testHelixOnlyController() throws Exception {
+  public void testHelixOnlyController()
+      throws Exception {
     config.setControllerMode(ControllerConf.ControllerMode.HELIX_ONLY);
     config.setControllerPort(Integer.toString(Integer.parseInt(config.getControllerPort()) + controllerPortOffset++));
 
@@ -61,7 +62,8 @@ public class PinotControllerModeTest extends ControllerTest {
   }
 
   @Test
-  public void testDualModeController() throws Exception {
+  public void testDualModeController()
+      throws Exception {
     config.setControllerMode(ControllerConf.ControllerMode.DUAL);
     config.setControllerPort(Integer.toString(Integer.parseInt(config.getControllerPort()) + controllerPortOffset++));
 
@@ -83,9 +85,9 @@ public class PinotControllerModeTest extends ControllerTest {
 
     ControllerStarter secondDualModeController = new TestOnlyControllerStarter(controllerConfig);
     secondDualModeController.start();
-    TestUtils.waitForCondition(
-        aVoid -> secondDualModeController.getHelixResourceManager().getHelixZkManager().isConnected(), TIMEOUT_IN_MS,
-        "Failed to start " + config.getControllerMode() + " controller in " + TIMEOUT_IN_MS + "ms.");
+    TestUtils
+        .waitForCondition(aVoid -> secondDualModeController.getHelixResourceManager().getHelixZkManager().isConnected(),
+            TIMEOUT_IN_MS, "Failed to start " + config.getControllerMode() + " controller in " + TIMEOUT_IN_MS + "ms.");
     Assert.assertEquals(secondDualModeController.getControllerMode(), ControllerConf.ControllerMode.DUAL);
 
     secondDualModeController.stop();
@@ -96,7 +98,8 @@ public class PinotControllerModeTest extends ControllerTest {
   // TODO: enable it after removing ControllerLeadershipManager which requires both CONTROLLER and PARTICIPANT
   //       HelixManager
   @Test(enabled = false)
-  public void testPinotOnlyController() throws Exception {
+  public void testPinotOnlyController()
+      throws Exception {
     config.setControllerMode(ControllerConf.ControllerMode.PINOT_ONLY);
     config.setControllerPort(Integer.toString(Integer.parseInt(config.getControllerPort()) + controllerPortOffset++));
 
@@ -147,8 +150,9 @@ public class PinotControllerModeTest extends ControllerTest {
     ControllerStarter secondControllerStarter = new TestOnlyControllerStarter(config4);
     secondControllerStarter.start();
     // Two controller instances assigned to cluster.
-    TestUtils.waitForCondition(aVoid -> firstPinotOnlyPinotHelixResourceManager.getAllInstances().size() == 2,
-        TIMEOUT_IN_MS, "Failed to start the 2nd pinot only controller in " + TIMEOUT_IN_MS + "ms.");
+    TestUtils
+        .waitForCondition(aVoid -> firstPinotOnlyPinotHelixResourceManager.getAllInstances().size() == 2, TIMEOUT_IN_MS,
+            "Failed to start the 2nd pinot only controller in " + TIMEOUT_IN_MS + "ms.");
 
     // Disable lead controller resource, all the participants are in offline state (from slave state).
     helixAdmin.enableResource(getHelixClusterName(), CommonConstants.Helix.LEAD_CONTROLLER_RESOURCE_NAME, false);
@@ -191,8 +195,8 @@ public class PinotControllerModeTest extends ControllerTest {
     // Shutdown the only one controller left, the partition map should be empty.
     firstPinotOnlyController.stop();
     TestUtils.waitForCondition(aVoid -> {
-      ExternalView leadControllerResourceExternalView = helixAdmin.getResourceExternalView(getHelixClusterName(),
-          CommonConstants.Helix.LEAD_CONTROLLER_RESOURCE_NAME);
+      ExternalView leadControllerResourceExternalView = helixAdmin
+          .getResourceExternalView(getHelixClusterName(), CommonConstants.Helix.LEAD_CONTROLLER_RESOURCE_NAME);
       for (String partition : leadControllerResourceExternalView.getPartitionSet()) {
         Map<String, String> stateMap = leadControllerResourceExternalView.getStateMap(partition);
         // There's no participant in all the partitions.


### PR DESCRIPTION
This PR creates lead controller resource in Helix cluster (if applicable) when starting a helix controller.

This new resource will be used for getting lead controller of each participant in this resource, so that these lead controllers can do the **periodic tasks** and **realtime segment completion** for their own partition.

The logic of handling this new resource will be added in the next following PR (controller and server separately).

Design doc: https://cwiki.apache.org/confluence/display/PINOT/Controller+Separation+between+Helix+and+Pinot
Test plan:
https://github.com/apache/incubator-pinot/issues/3957