### PR TITLE
Fix the race condition for real-time inverted index reader

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BitmapBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BitmapBasedFilterOperator.java
@@ -25,12 +25,9 @@ import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class BitmapBasedFilterOperator extends BaseFilterOperator {
-  private static final Logger LOGGER = LoggerFactory.getLogger(BitmapBasedFilterOperator.class);
   private static final String OPERATOR_NAME = "BitmapBasedFilterOperator";
 
   private final PredicateEvaluator _predicateEvaluator;

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReader.java
@@ -41,7 +41,7 @@ public class RealtimeInvertedIndexReader implements InvertedIndexReader<MutableR
   }
 
   /**
-   * Adds the doc Id to the given dict Id's bitmap.
+   * Adds the document id to the bitmap of the given dictionary id.
    */
   public void add(int dictId, int docId) {
     if (_bitmaps.size() == dictId) {
@@ -64,10 +64,10 @@ public class RealtimeInvertedIndexReader implements InvertedIndexReader<MutableR
     ThreadSafeMutableRoaringBitmap bitmap;
     try {
       _readLock.lock();
-      // NOTE: the given dict Id might not be added to the inverted index yet. We first add the value to the dictionary.
-      // Before the value is added to the inverted index, the query might have predicates that match the newly added
-      // value. In that case, the given dictionary Id does not exist in the inverted index, and we return an empty
-      // bitmap. For multi-valued column, the dict Id might be larger than the bitmap size (not equal).
+      // NOTE: the given dictionary id might not be added to the inverted index yet. We first add the value to the
+      // dictionary. Before the value is added to the inverted index, the query might have predicates that match the
+      // newly added value. In that case, the given dictionary id does not exist in the inverted index, and we return an
+      // empty bitmap. For multi-valued column, the dictionary id might be larger than the bitmap size (not equal).
       if (_bitmaps.size() <= dictId) {
         return new MutableRoaringBitmap();
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReader.java
@@ -60,6 +60,13 @@ public class RealtimeInvertedIndexReader implements InvertedIndexReader<MutableR
     ThreadSafeMutableRoaringBitmap bitmap;
     try {
       _readLock.lock();
+      // NOTE: the given dict Id might not be added to the inverted index yet. We first add the value to the dictionary.
+      // Before the value is added to the inverted index, the query might have a predicate which matches the newly added
+      // value. In that case, the given dictionary Id does not exist in the inverted index, and we return an empty
+      // bitmap.
+      if (_bitmaps.size() == dictId) {
+        return new MutableRoaringBitmap();
+      }
       bitmap = _bitmaps.get(dictId);
     } finally {
       _readLock.unlock();

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReaderTest.java
@@ -32,47 +32,75 @@ public class RealtimeInvertedIndexReaderTest {
   public void testRealtimeInvertedIndexReader() {
     RealtimeInvertedIndexReader realtimeInvertedIndexReader = new RealtimeInvertedIndexReader();
 
-    // Dict Id not added yet
+    // Add dict Id 0, doc Id 0 to the inverted index (single-value dict Id not added yet)
+    // Before adding
     MutableRoaringBitmap docIds = realtimeInvertedIndexReader.getDocIds(0);
     assertNotNull(docIds);
     assertTrue(docIds.isEmpty());
-
-    // Add dict Id 0, doc Id 0 to the inverted index
+    // After adding
     realtimeInvertedIndexReader.add(0, 0);
     docIds = realtimeInvertedIndexReader.getDocIds(0);
     assertNotNull(docIds);
     assertFalse(docIds.isEmpty());
     assertTrue(docIds.contains(0));
     assertFalse(docIds.contains(1));
+
+    // Add dict Id 0, doc Id 1 to the inverted index (single-value dict Id already added)
+    // Before adding
     docIds = realtimeInvertedIndexReader.getDocIds(1);
     assertNotNull(docIds);
     assertTrue(docIds.isEmpty());
-
-    // Add dict Id 0, doc Id 1 to the inverted index
     realtimeInvertedIndexReader.add(0, 1);
+    // After adding
     docIds = realtimeInvertedIndexReader.getDocIds(0);
     assertNotNull(docIds);
     assertFalse(docIds.isEmpty());
     assertTrue(docIds.contains(0));
     assertTrue(docIds.contains(1));
+
+    // Add dict Id 1 and 2, doc Id 2 to the inverted index (multi-value dict Ids not added yet)
+    // Before adding dict Id 1
     docIds = realtimeInvertedIndexReader.getDocIds(1);
     assertNotNull(docIds);
     assertTrue(docIds.isEmpty());
-
-    // Add dict Id 1, doc Id 1 to the inverted index
-    realtimeInvertedIndexReader.add(1, 1);
+    docIds = realtimeInvertedIndexReader.getDocIds(2);
+    assertNotNull(docIds);
+    assertTrue(docIds.isEmpty());
+    // After adding dict Id 1 but before adding dict Id 2
+    realtimeInvertedIndexReader.add(1, 2);
     docIds = realtimeInvertedIndexReader.getDocIds(0);
     assertNotNull(docIds);
     assertFalse(docIds.isEmpty());
     assertTrue(docIds.contains(0));
     assertTrue(docIds.contains(1));
+    assertFalse(docIds.contains(2));
     docIds = realtimeInvertedIndexReader.getDocIds(1);
     assertNotNull(docIds);
     assertFalse(docIds.isEmpty());
     assertFalse(docIds.contains(0));
-    assertTrue(docIds.contains(1));
+    assertFalse(docIds.contains(1));
+    assertTrue(docIds.contains(2));
     docIds = realtimeInvertedIndexReader.getDocIds(2);
     assertNotNull(docIds);
     assertTrue(docIds.isEmpty());
+    // After adding dict Id 2
+    realtimeInvertedIndexReader.add(2, 2);
+    docIds = realtimeInvertedIndexReader.getDocIds(0);
+    assertNotNull(docIds);
+    assertFalse(docIds.isEmpty());
+    assertTrue(docIds.contains(0));
+    assertTrue(docIds.contains(1));
+    assertFalse(docIds.contains(2));
+    docIds = realtimeInvertedIndexReader.getDocIds(1);
+    assertNotNull(docIds);
+    assertFalse(docIds.isEmpty());
+    assertFalse(docIds.contains(0));
+    assertFalse(docIds.contains(1));
+    assertTrue(docIds.contains(2));
+    docIds = realtimeInvertedIndexReader.getDocIds(2);
+    assertFalse(docIds.isEmpty());
+    assertFalse(docIds.contains(0));
+    assertFalse(docIds.contains(1));
+    assertTrue(docIds.contains(2));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReaderTest.java
@@ -32,7 +32,7 @@ public class RealtimeInvertedIndexReaderTest {
   public void testRealtimeInvertedIndexReader() {
     RealtimeInvertedIndexReader realtimeInvertedIndexReader = new RealtimeInvertedIndexReader();
 
-    // Add dict Id 0, doc Id 0 to the inverted index (single-value dict Id not added yet)
+    // Add dictionary id 0, document id 0 to the inverted index (single-value dictionary id not added yet)
     // Before adding
     MutableRoaringBitmap docIds = realtimeInvertedIndexReader.getDocIds(0);
     assertNotNull(docIds);
@@ -45,7 +45,7 @@ public class RealtimeInvertedIndexReaderTest {
     assertTrue(docIds.contains(0));
     assertFalse(docIds.contains(1));
 
-    // Add dict Id 0, doc Id 1 to the inverted index (single-value dict Id already added)
+    // Add dictionary id 0, document id 1 to the inverted index (single-value dictionary id already added)
     // Before adding
     docIds = realtimeInvertedIndexReader.getDocIds(1);
     assertNotNull(docIds);
@@ -58,15 +58,15 @@ public class RealtimeInvertedIndexReaderTest {
     assertTrue(docIds.contains(0));
     assertTrue(docIds.contains(1));
 
-    // Add dict Id 1 and 2, doc Id 2 to the inverted index (multi-value dict Ids not added yet)
-    // Before adding dict Id 1
+    // Add dictionary id 1 and 2, document id 2 to the inverted index (multi-value dictionary ids not added yet)
+    // Before adding dictionary id 1
     docIds = realtimeInvertedIndexReader.getDocIds(1);
     assertNotNull(docIds);
     assertTrue(docIds.isEmpty());
     docIds = realtimeInvertedIndexReader.getDocIds(2);
     assertNotNull(docIds);
     assertTrue(docIds.isEmpty());
-    // After adding dict Id 1 but before adding dict Id 2
+    // After adding dictionary id 1 but before adding dictionary id 2
     realtimeInvertedIndexReader.add(1, 2);
     docIds = realtimeInvertedIndexReader.getDocIds(0);
     assertNotNull(docIds);
@@ -83,7 +83,7 @@ public class RealtimeInvertedIndexReaderTest {
     docIds = realtimeInvertedIndexReader.getDocIds(2);
     assertNotNull(docIds);
     assertTrue(docIds.isEmpty());
-    // After adding dict Id 2
+    // After adding dictionary id 2
     realtimeInvertedIndexReader.add(2, 2);
     docIds = realtimeInvertedIndexReader.getDocIds(0);
     assertNotNull(docIds);

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeInvertedIndexReaderTest.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.realtime.impl.invertedindex;
+
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class RealtimeInvertedIndexReaderTest {
+
+  @Test
+  public void testRealtimeInvertedIndexReader() {
+    RealtimeInvertedIndexReader realtimeInvertedIndexReader = new RealtimeInvertedIndexReader();
+
+    // Dict Id not added yet
+    MutableRoaringBitmap docIds = realtimeInvertedIndexReader.getDocIds(0);
+    assertNotNull(docIds);
+    assertTrue(docIds.isEmpty());
+
+    // Add dict Id 0, doc Id 0 to the inverted index
+    realtimeInvertedIndexReader.add(0, 0);
+    docIds = realtimeInvertedIndexReader.getDocIds(0);
+    assertNotNull(docIds);
+    assertFalse(docIds.isEmpty());
+    assertTrue(docIds.contains(0));
+    assertFalse(docIds.contains(1));
+    docIds = realtimeInvertedIndexReader.getDocIds(1);
+    assertNotNull(docIds);
+    assertTrue(docIds.isEmpty());
+
+    // Add dict Id 0, doc Id 1 to the inverted index
+    realtimeInvertedIndexReader.add(0, 1);
+    docIds = realtimeInvertedIndexReader.getDocIds(0);
+    assertNotNull(docIds);
+    assertFalse(docIds.isEmpty());
+    assertTrue(docIds.contains(0));
+    assertTrue(docIds.contains(1));
+    docIds = realtimeInvertedIndexReader.getDocIds(1);
+    assertNotNull(docIds);
+    assertTrue(docIds.isEmpty());
+
+    // Add dict Id 1, doc Id 1 to the inverted index
+    realtimeInvertedIndexReader.add(1, 1);
+    docIds = realtimeInvertedIndexReader.getDocIds(0);
+    assertNotNull(docIds);
+    assertFalse(docIds.isEmpty());
+    assertTrue(docIds.contains(0));
+    assertTrue(docIds.contains(1));
+    docIds = realtimeInvertedIndexReader.getDocIds(1);
+    assertNotNull(docIds);
+    assertFalse(docIds.isEmpty());
+    assertFalse(docIds.contains(0));
+    assertTrue(docIds.contains(1));
+    docIds = realtimeInvertedIndexReader.getDocIds(2);
+    assertNotNull(docIds);
+    assertTrue(docIds.isEmpty());
+  }
+}


### PR DESCRIPTION
When getting doc Ids from RealtimeInvertedIndexReader, the given
dict Id might not be added to the inverted index yet. We first add
the value to the dictionary. Before the value is added to the
inverted index, the query might have a predicate which matches the
newly added value. In that case, the given dictionary Id does not
exist in the inverted index, and we return an empty bitmap.

Simplify BitmapBasedFilterOperator because getDocIds() never
returns null.
Add a test for the change.