### PR TITLE
[TE] Speed up minute level detection

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/AlertUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/AlertUtils.java
@@ -24,9 +24,6 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-import org.apache.pinot.thirdeye.constant.AnomalyFeedbackType;
-import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
-import com.mysql.jdbc.StringUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,6 +34,7 @@ import javax.annotation.Nullable;
 import javax.mail.internet.InternetAddress;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 
 
 public class AlertUtils {


### PR DESCRIPTION
1. Speed up minute level detection
If detection window >= 1 day, set the bucketPeriod, windowSize, windowUnit to 1 day.

2. Change EARLY_TERMINATE_WINDOW from 10 to 5 to fail early.

3. Remove pre-cache for detection window for two reasons:
a. We need to load the data anyway so pre-cache doesn't help.
b. If the detection consistently fail and triggered early-terminate then pre-cache everything is a waste of time.