### PR TITLE
 Handle exceptions during teardown

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -243,7 +243,7 @@ public abstract class ClusterTest extends ControllerTest {
       try {
         minionStarter.stop();
       } catch (Exception e) {
-        LOGGER.error("Encountered exception while stopping server {}", e.getMessage());
+        LOGGER.error("Encountered exception while stopping minion {}", e.getMessage());
       }
     }
     FileUtils.deleteQuietly(new File(Minion.DEFAULT_INSTANCE_BASE_DIR));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -81,6 +81,7 @@ import org.testng.Assert;
  * Base class for integration tests that involve a complete Pinot cluster.
  */
 public abstract class ClusterTest extends ControllerTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterTest.class);
   private static final Random RANDOM = new Random();
   private static final int DEFAULT_BROKER_PORT = 18099;
 
@@ -218,20 +219,32 @@ public abstract class ClusterTest extends ControllerTest {
 
   protected void stopBroker() {
     for (HelixBrokerStarter brokerStarter : _brokerStarters) {
-      BrokerTestUtils.stopBroker(brokerStarter);
+      try {
+        BrokerTestUtils.stopBroker(brokerStarter);
+      } catch (Exception e) {
+        LOGGER.error("Encountered exception while stopping broker {}", e.getMessage());
+      }
     }
   }
 
   protected void stopServer() {
     for (HelixServerStarter helixServerStarter : _serverStarters) {
-      helixServerStarter.stop();
+      try {
+        helixServerStarter.stop();
+      } catch (Exception e) {
+        LOGGER.error("Encountered exception while stopping server {}", e.getMessage());
+      }
     }
     FileUtils.deleteQuietly(new File(Server.DEFAULT_INSTANCE_BASE_DIR));
   }
 
   protected void stopMinion() {
     for (MinionStarter minionStarter : _minionStarters) {
-      minionStarter.stop();
+      try {
+        minionStarter.stop();
+      } catch (Exception e) {
+        LOGGER.error("Encountered exception while stopping server {}", e.getMessage());
+      }
     }
     FileUtils.deleteQuietly(new File(Minion.DEFAULT_INSTANCE_BASE_DIR));
   }


### PR DESCRIPTION
We see random integration test failures in SegmentStatusCheckerIntegrationTest.tearDown
with the trace:  
java.lang.NullPointerException
at org.apache.helix.participant.HelixStateMachineEngine.reset(HelixStateMachineEngine.java:156)
at org.apache.helix.messaging.handling.HelixTaskExecutor.reset(HelixTaskExecutor.java:602)
at org.apache.helix.messaging.handling.HelixTaskExecutor.shutdown(HelixTaskExecutor.java:1128)
at org.apache.helix.manager.zk.ZKHelixManager.disconnect(ZKHelixManager.java:701)
at org.apache.pinot.server.starter.helix.HelixServerStarter.stop(HelixServerStarter.java:362)
at org.apache.pinot.integration.tests.ClusterTest.stopServer(ClusterTest.java:227)
at org.apache.pinot.integration.tests.controller.periodic.tasks.SegmentStatusCheckerIntegrationTest.tearDown(SegmentStatusCheckerIntegrationTest.java:282)

Its unclear if this is due to an issue in Helix's task framework that has been fixed in subsequent releases. However, this does point to the case where the teardown might abort due to an exception (we attempt to stop broker, server and minion) and an unclean shutdown *may* cause other issues.

This change just  handles exceptions so we can still proceed with the rest of the cleanup.