### PR TITLE
Add wait_time flag for Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ addons:
   firefox: latest
 
 install:
-  - ./.travis_install.sh
+  - travis_wait 30 ./.travis_install.sh
 
 script:
-  - ./.travis_test.sh
+  - travis_wait 30 ./.travis_test.sh
 
 branches:
   only:


### PR DESCRIPTION
When the test takes more than 10 minutes without producing any output,
Travis job will fail. This pr makes Travis to emit a short log for
every minute for 30 minutes (Our current travis job runtime is 30~35min)

https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received