### PR TITLE
Fix 500 issue with 'GET /tenants' API call

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TagNameUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.config;
 
+import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.utils.ServerType;
 import org.apache.pinot.common.utils.TenantRole;
 
@@ -44,7 +45,7 @@ public class TagNameUtils {
     return false;
   }
 
-  public static TenantRole getTenantRoleFromTag(String tagName) {
+  public static TenantRole getTenantRoleFromTag(String tagName) throws InvalidConfigException {
     if (tagName.endsWith(ServerType.REALTIME.toString())) {
       return TenantRole.SERVER;
     }
@@ -54,7 +55,7 @@ public class TagNameUtils {
     if (tagName.endsWith(TenantRole.BROKER.toString())) {
       return TenantRole.BROKER;
     }
-    throw new RuntimeException("Cannot identify tenant type from tag name : " + tagName);
+    throw new InvalidConfigException("Cannot identify tenant type from tag name : " + tagName);
   }
 
   public static String getTagFromTenantAndServerType(String tenantName, ServerType type) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -817,8 +817,15 @@ public class PinotHelixResourceManager {
             .equals(CommonConstants.Minion.UNTAGGED_INSTANCE)) {
           continue;
         }
-        if (TagNameUtils.getTenantRoleFromTag(tag) == TenantRole.BROKER) {
-          tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
+        TenantRole tenantRole;
+        try {
+          tenantRole = TagNameUtils.getTenantRoleFromTag(tag);
+          if (tenantRole == TenantRole.BROKER) {
+            tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
+          }
+        } catch (InvalidConfigException e) {
+          LOGGER.warn("Instance {} contains an invalid tag: {}", instanceName, tag);
+          continue;
         }
       }
     }
@@ -836,8 +843,15 @@ public class PinotHelixResourceManager {
             .equals(CommonConstants.Minion.UNTAGGED_INSTANCE)) {
           continue;
         }
-        if (TagNameUtils.getTenantRoleFromTag(tag) == TenantRole.SERVER) {
-          tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
+        TenantRole tenantRole;
+        try {
+          tenantRole = TagNameUtils.getTenantRoleFromTag(tag);
+          if (tenantRole == TenantRole.SERVER) {
+            tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
+          }
+        } catch (InvalidConfigException e) {
+          LOGGER.warn("Instance {} contains an invalid tag: {}", instanceName, tag);
+          continue;
         }
       }
     }


### PR DESCRIPTION
When a server has a wrong formatted tag, current implemantation
would return 500 error for GET /tenants call.
In that case, we should not fail and return the list of valid
tenants.

For the wrong formatted tags, this pr adds the log so that one can
look up the logs when cleaning up the tags.