### PR TITLE
Always enable default column feature, remove the configuration

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -41,8 +41,6 @@ public interface InstanceDataManagerConfig {
 
   String getAvgMultiValueCount();
 
-  boolean isEnableDefaultColumns();
-
   boolean isEnableSplitCommit();
 
   boolean isEnableSplitCommitEndWithMetadata();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -50,8 +50,6 @@ public class IndexLoadingConfig {
   private Set<String> _bloomFilterColumns = new HashSet<>();
 
   private SegmentVersion _segmentVersion;
-  // This value will remain true only when the empty constructor is invoked.
-  private boolean _enableDefaultColumns = true;
   private ColumnMinMaxValueGeneratorMode _columnMinMaxValueGeneratorMode = ColumnMinMaxValueGeneratorMode.DEFAULT_MODE;
   private int _realtimeAvgMultiValueCount = DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT;
   private boolean _enableSplitCommit;
@@ -124,8 +122,6 @@ public class IndexLoadingConfig {
     if (instanceSegmentVersion != null) {
       _segmentVersion = SegmentVersion.valueOf(instanceSegmentVersion.toLowerCase());
     }
-
-    _enableDefaultColumns = instanceDataManagerConfig.isEnableDefaultColumns();
 
     _enableSplitCommit = instanceDataManagerConfig.isEnableSplitCommit();
 
@@ -216,15 +212,13 @@ public class IndexLoadingConfig {
     _segmentVersion = segmentVersion;
   }
 
-  public boolean isEnableDefaultColumns() {
-    return _enableDefaultColumns;
-  }
-
   public boolean isEnableSplitCommit() {
     return _enableSplitCommit;
   }
 
-  public boolean isEnableSplitCommitEndWithMetadata() { return _enableSplitCommitEndWithMetadata; }
+  public boolean isEnableSplitCommitEndWithMetadata() {
+    return _enableSplitCommitEndWithMetadata;
+  }
 
   public boolean isRealtimeOffheapAllocation() {
     return _isRealtimeOffheapAllocation;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
@@ -84,7 +84,7 @@ public class SegmentPreProcessor implements AutoCloseable {
 
     try (SegmentDirectory.Writer segmentWriter = _segmentDirectory.createWriter()) {
       // Update default columns according to the schema.
-      if (_indexLoadingConfig.isEnableDefaultColumns() && (_schema != null)) {
+      if (_schema != null) {
         DefaultColumnHandler defaultColumnHandler =
             DefaultColumnHandlerFactory.getDefaultColumnHandler(_indexDir, _schema, _segmentMetadata, segmentWriter);
         defaultColumnHandler.updateDefaultColumns();

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -654,7 +654,6 @@ public class LLRealtimeSegmentDataManagerTest {
       when(dataManagerConfig.getReadMode()).thenReturn(null);
       when(dataManagerConfig.getAvgMultiValueCount()).thenReturn(null);
       when(dataManagerConfig.getSegmentFormatVersion()).thenReturn(null);
-      when(dataManagerConfig.isEnableDefaultColumns()).thenReturn(false);
       when(dataManagerConfig.isEnableSplitCommit()).thenReturn(false);
       when(dataManagerConfig.isRealtimeOffHeapAllocation()).thenReturn(false);
       return dataManagerConfig;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -57,9 +57,6 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   // Key of the segment format this server can read
   public static final String SEGMENT_FORMAT_VERSION = "segment.format.version";
 
-  // Key of whether to enable default columns
-  private static final String ENABLE_DEFAULT_COLUMNS = "enable.default.columns";
-
   // Key of how many parallel realtime segments can be built.
   // A value of <= 0 indicates unlimited.
   // Unlimited parallel builds can cause high GC pauses during segment builds, causing
@@ -153,11 +150,6 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public String getSegmentFormatVersion() {
     return _instanceDataManagerConfiguration.getString(SEGMENT_FORMAT_VERSION);
-  }
-
-  @Override
-  public boolean isEnableDefaultColumns() {
-    return _instanceDataManagerConfiguration.getBoolean(ENABLE_DEFAULT_COLUMNS, false);
   }
 
   @Override


### PR DESCRIPTION
The configuration is introduced to test the default column feature.
Since it has been tested thoroughly for years, remove the
configuration and always enable it.