### PR TITLE
Reduce logging in controller

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -118,7 +118,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
       }
     }
     if (!segmentsToDelete.isEmpty()) {
-      LOGGER.info("Deleting segments: {} from table: {}", segmentsToDelete, offlineTableName);
+      LOGGER.info("Deleting {} segments from table: {}", segmentsToDelete.size(), offlineTableName);
       _pinotHelixResourceManager.deleteSegments(offlineTableName, segmentsToDelete);
     }
   }
@@ -147,7 +147,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
       }
     }
     if (!segmentsToDelete.isEmpty()) {
-      LOGGER.info("Deleting segments: {} from table: {}", segmentsToDelete, realtimeTableName);
+      LOGGER.info("Deleting {} segments from table: {}", segmentsToDelete.size(), realtimeTableName);
       _pinotHelixResourceManager.deleteSegments(realtimeTableName, segmentsToDelete);
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -47,6 +48,8 @@ import org.slf4j.LoggerFactory;
  */
 public class TableSizeReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReader.class);
+
+  private static final int MAX_MISSING_SEGMENTS_TO_LIST = 5;
   private final Executor _executor;
   private final HttpConnectionManager _connectionManager;
   private final PinotHelixResourceManager _helixResourceManager;
@@ -225,14 +228,13 @@ public class TableSizeReader {
           .setValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT,
               missingPercent);
       if (subTypeSizeDetails.missingSegments == numSegments) {
-        LOGGER.warn("Failed to get size report for all {} segments: {} for table: {}", numSegments, missingSegments,
-            tableNameWithType);
+        LOGGER.warn("Failed to get size report for all {} segments of table: {}", numSegments, tableNameWithType);
         subTypeSizeDetails.reportedSizeInBytes = -1;
         subTypeSizeDetails.estimatedSizeInBytes = -1;
       } else {
-        LOGGER
-            .warn("Missing size report for {} out of {} segments: {} for table {}", subTypeSizeDetails.missingSegments,
-                numSegments, missingSegments, tableNameWithType);
+        LOGGER.warn("Missing size report for {} out of {} segments for table {}. Listing {} segments: {}",
+            subTypeSizeDetails.missingSegments, numSegments, tableNameWithType, MAX_MISSING_SEGMENTS_TO_LIST,
+            missingSegments.stream().limit(MAX_MISSING_SEGMENTS_TO_LIST).collect(Collectors.toList()));
       }
     } else {
       _controllerMetrics

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
@@ -232,7 +232,7 @@ public class TableSizeReader {
         subTypeSizeDetails.reportedSizeInBytes = -1;
         subTypeSizeDetails.estimatedSizeInBytes = -1;
       } else {
-        LOGGER.warn("Missing size report for {} out of {} segments for table {}. Listing {} segments: {}",
+        LOGGER.warn("Missing size report for {} out of {} segments for table {}. Listing up to {} segments: {}",
             subTypeSizeDetails.missingSegments, numSegments, tableNameWithType, MAX_MISSING_SEGMENTS_TO_LIST,
             missingSegments.stream().limit(MAX_MISSING_SEGMENTS_TO_LIST).collect(Collectors.toList()));
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -49,7 +48,6 @@ import org.slf4j.LoggerFactory;
 public class TableSizeReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReader.class);
 
-  private static final int MAX_MISSING_SEGMENTS_TO_LIST = 5;
   private final Executor _executor;
   private final HttpConnectionManager _connectionManager;
   private final PinotHelixResourceManager _helixResourceManager;
@@ -232,9 +230,8 @@ public class TableSizeReader {
         subTypeSizeDetails.reportedSizeInBytes = -1;
         subTypeSizeDetails.estimatedSizeInBytes = -1;
       } else {
-        LOGGER.warn("Missing size report for {} out of {} segments for table {}. Listing up to {} segments: {}",
-            subTypeSizeDetails.missingSegments, numSegments, tableNameWithType, MAX_MISSING_SEGMENTS_TO_LIST,
-            missingSegments.stream().limit(MAX_MISSING_SEGMENTS_TO_LIST).collect(Collectors.toList()));
+        LOGGER.warn("Missing size report for {} out of {} segments for table {}", subTypeSizeDetails.missingSegments,
+            numSegments, tableNameWithType);
       }
     } else {
       _controllerMetrics

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
@@ -98,8 +98,8 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask<Void> 
         }
       }
       if (!segmentsWithInvalidInterval.isEmpty()) {
-        LOGGER.warn("Table: {} has segments with invalid interval. Listing {} of {}: {}", offlineTableName,
-            MAX_SEGMENTS_WITH_INVALID_INTERVALS_TO_LOG, numSegmentsWithInvalidIntervals, segmentsWithInvalidInterval);
+        LOGGER.warn("Table: {} has {} segments with invalid interval. Listing up to {}: {}", offlineTableName,
+            numSegmentsWithInvalidIntervals, MAX_SEGMENTS_WITH_INVALID_INTERVALS_TO_LOG, segmentsWithInvalidInterval);
       }
       Duration frequency = convertToDuration(validationConfig.getSegmentPushFrequency());
       numMissingSegments = computeNumMissingSegments(segmentIntervals, frequency);


### PR DESCRIPTION
Reducing some long/redundant logs
1) Removing log from retention manager which prints all segments, as it is done again in PinotHelixResourceManager::deleteSegments
2) Reducing the number of segments printed in OfflineSegmentIntervalChecker
3) Reducing the number of segments printed in TableSizeReader