### PR TITLE
Upgrade RoaringBitmap to 0.8.0

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/BitmapDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/BitmapDocIdSet.java
@@ -40,10 +40,7 @@ public class BitmapDocIdSet implements FilterBlockDocIdSet {
       _bitmap = orBitmap;
     } else if (numBitmaps == 1) {
       if (exclusive) {
-        // NOTE: cannot use ImmutableRoaringBitmap.flip() because the library has a bug in that method
-        // TODO: the bug has been fixed in the latest version of ImmutableRoaringBitmap, update the version
-        MutableRoaringBitmap bitmap = bitmaps[0].toMutableRoaringBitmap();
-        bitmap.flip(startDocId, endDocId + 1);
+        MutableRoaringBitmap bitmap = ImmutableRoaringBitmap.flip(bitmaps[0], startDocId, endDocId + 1);
         _bitmap = bitmap;
       } else {
         _bitmap = bitmaps[0];

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/docidsets/BitmapDocIdSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/docidsets/BitmapDocIdSetTest.java
@@ -54,14 +54,12 @@ public class BitmapDocIdSetTest {
         originalSet.add(docId);
         mutableRoaringBitmap.add(docId);
       }
-      ByteArrayOutputStream bos = new ByteArrayOutputStream();
-      DataOutputStream dos = new DataOutputStream(bos);
-      // could call "rr1.runOptimize()" and "rr2.runOptimize" if there
+      // could call "rr1.runOptimize()" and "rr2.runOptimize" if
       // there were runs to compress
-      mutableRoaringBitmap.serialize(dos);
-      dos.close();
-      ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
-      ImmutableRoaringBitmap immutableRoaringBitmap = new ImmutableRoaringBitmap(bb);
+      final ByteBuffer buffer = ByteBuffer.allocate(mutableRoaringBitmap.serializedSizeInBytes());
+      mutableRoaringBitmap.serialize(buffer);
+      buffer.flip();
+      ImmutableRoaringBitmap immutableRoaringBitmap = new ImmutableRoaringBitmap(buffer);
       list.add(immutableRoaringBitmap);
     }
     ImmutableRoaringBitmap[] bitmaps = new ImmutableRoaringBitmap[list.size()];

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.5.10</version>
+        <version>0.8.0</version>
       </dependency>
       <dependency>
         <groupId>com.101tec</groupId>


### PR DESCRIPTION
Current RoaringBitmap is 0.5.10, this PR upgrade RoaringBitmap to 0.8.0 to pick up bug-fixes, new feature and optimize between these new releases.
For `BitmapDocIdSetTest.java`, it minor refactors to direct serialize to ByteBuffer.