### PR TITLE
In TimeUtils.timeUnitFromString(), return null if input is null or empty

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/SegmentsValidationAndRetentionConfig.java
@@ -93,7 +93,7 @@ public class SegmentsValidationAndRetentionConfig {
   }
 
   public void setTimeType(String timeType) {
-    _timeType = timeType != null ? TimeUtils.timeUnitFromString(timeType) : null;
+    _timeType = TimeUtils.timeUnitFromString(timeType);
   }
 
   public String getRetentionTimeUnit() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/time/TimeUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/time/TimeUtils.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils.time;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
@@ -47,7 +48,8 @@ public class TimeUtils {
   private static final long VALID_MAX_TIME_MILLIS = new DateTime(2071, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
 
   /**
-   * Converts a time unit string into {@link TimeUnit}, ignoring case.
+   * Converts a time unit string into {@link TimeUnit}, ignoring case. For {@code null} or empty time unit string,
+   * returns {@code null}.
    * <p>Supports the following legacy time unit strings:
    * <ul>
    *   <li>"daysSinceEpoch" -> DAYS</li>
@@ -59,7 +61,12 @@ public class TimeUtils {
    * @param timeUnitString The time unit string to convert, e.g. "DAYS" or "SECONDS"
    * @return The corresponding {@link TimeUnit}
    */
-  public static TimeUnit timeUnitFromString(String timeUnitString) {
+  @Nullable
+  public static TimeUnit timeUnitFromString(@Nullable String timeUnitString) {
+    // NOTE: for backward-compatibility, return null if time unit string is null or empty
+    if (timeUnitString == null || timeUnitString.isEmpty()) {
+      return null;
+    }
     String upperCaseTimeUnitString = timeUnitString.toUpperCase();
     TimeUnit timeUnit = TIME_UNIT_MAP.get(upperCaseTimeUnitString);
     if (timeUnit != null) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/UtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/UtilsTest.java
@@ -25,6 +25,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
 
 
 /**
@@ -49,6 +51,14 @@ public class UtilsTest {
     assertEquals(TimeUtils.timeUnitFromString("HOURSSINCEEPOCH"), TimeUnit.HOURS);
     assertEquals(TimeUtils.timeUnitFromString("MinutesSinceEpoch"), TimeUnit.MINUTES);
     assertEquals(TimeUtils.timeUnitFromString("SeCoNdSsInCeEpOcH"), TimeUnit.SECONDS);
+    assertNull(TimeUtils.timeUnitFromString(null));
+    assertNull(TimeUtils.timeUnitFromString(""));
+    try {
+      TimeUtils.timeUnitFromString("unknown");
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
   }
 
   @Test

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -180,6 +180,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
         .containsKey(SEGMENT_END_TIME) && segmentMetadataPropertiesConfiguration.containsKey(TIME_UNIT)) {
       try {
         _timeUnit = TimeUtils.timeUnitFromString(segmentMetadataPropertiesConfiguration.getString(TIME_UNIT));
+        assert _timeUnit != null;
         _timeGranularity = new Duration(_timeUnit.toMillis(1));
         String startTimeString = segmentMetadataPropertiesConfiguration.getString(SEGMENT_START_TIME);
         String endTimeString = segmentMetadataPropertiesConfiguration.getString(SEGMENT_END_TIME);


### PR DESCRIPTION
For backward compatible