### PR TITLE
[TE] frontend - harleyjj/yaml-editor - user can create a new subscrip…

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/component.js
@@ -35,6 +35,8 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import config from 'thirdeye-frontend/config/environment';
 
+const CREATE_GROUP_TEXT = 'Create a new subscription group';
+
 export default Component.extend({
   classNames: ['yaml-editor'],
   notifications: service('toast'),
@@ -52,12 +54,10 @@ export default Component.extend({
   subscriptionMsg: '',                //General subscription failures
   detectionYaml: null,                // The YAML for the anomaly detection
   subscriptionYaml:  null,            // The YAML for the subscription group
-  yamlAlertProps: yamlAlertProps,
-  yamlAlertSettings: yamlAlertSettings,
+  currentYamlAlertOriginal: yamlAlertProps,
+  currentYamlSettingsOriginal: yamlAlertSettings,
   showAnomalyModal: false,
   showNotificationModal: false,
-  currentYamlAlertOriginal: '',
-  currentYamlSettingsOriginal: '',
   toggleCollapsed: true,
   alertDataIsCurrent: true,
 
@@ -65,19 +65,13 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    // In edit mode, sets subscription group to an existing group by default and sets default yamls
-    if (get(this, 'isEditMode')) {
-      const subscriptionGroupNames = get(this, 'subscriptionGroupNames');
-      // Checks to make sure there is a subscription group array with at least one subscription group
-      if (subscriptionGroupNames && Array.isArray(subscriptionGroupNames) && subscriptionGroupNames.length > 0) {
-        const firstGroup = subscriptionGroupNames[0];
-        set(this, 'subscriptionYaml', firstGroup.yaml);
-        set(this, 'groupName', firstGroup);
-        set(this, 'subscriptionGroupId', firstGroup.id);
-      }
-      // Sets default yamls after checking for and setting default subscription group
-      set(this, 'currentYamlAlertOriginal', get(this, 'detectionYaml') || get(this, 'yamlAlertProps'));
-      set(this, 'currentYamlSettingsOriginal', get(this, 'subscriptionYaml') || get(this, 'yamlAlertSettings'));
+    const subscriptionGroupNamesDisplay = get(this, 'subscriptionGroupNamesDisplay');
+    // Checks to make sure there is a subscription group array with at least one subscription group
+    if (subscriptionGroupNamesDisplay && Array.isArray(subscriptionGroupNamesDisplay) && subscriptionGroupNamesDisplay.length > 0) {
+      const firstGroup = subscriptionGroupNamesDisplay[0];
+      set(this, 'subscriptionYaml', firstGroup.yaml);
+      set(this, 'groupName', firstGroup);
+      set(this, 'subscriptionGroupId', firstGroup.id);
     }
   },
 
@@ -89,12 +83,21 @@ export default Component.extend({
   subscriptionGroupNamesDisplay: computed(
     'subscriptionGroupNames',
     async function() {
-      const isEditMode = get(this, 'isEditMode');
+      const {
+        isEditMode,
+        subscriptionGroupNames
+      } = this.getProperties('isEditMode', 'subscriptionGroupNames');
+      const createGroup = {
+        name: CREATE_GROUP_TEXT,
+        id: 'n/a',
+        yaml: yamlAlertSettings
+      };
+      const moddedArray = [createGroup];
       if (isEditMode) {
-        return get(this, 'subscriptionGroupNames');
+        return [...moddedArray, ...subscriptionGroupNames];
       }
       const subscriptionGroups = await get(this, '_fetchSubscriptionGroups').perform();
-      return get(this, 'subscriptionGroupNames') || subscriptionGroups;
+      return [...moddedArray, ...subscriptionGroups];
     }
   ),
 
@@ -115,7 +118,7 @@ export default Component.extend({
   ),
 
   /**
-   * sets Yaml value displayed to contents of detectionYaml or yamlAlertProps
+   * sets Yaml value displayed to contents of detectionYaml or currentYamlAlertOriginal
    * @method currentYamlAlert
    * @return {String}
    */
@@ -123,12 +126,12 @@ export default Component.extend({
     'detectionYaml',
     function() {
       const inputYaml = get(this, 'detectionYaml');
-      return inputYaml || get(this, 'yamlAlertProps');
+      return inputYaml || get(this, 'currentYamlAlertOriginal');
     }
   ),
 
   /**
-   * sets Yaml value displayed to contents of subscriptionYaml or yamlAlertSettings
+   * sets Yaml value displayed to contents of subscriptionYaml or currentYamlSettingsOriginal
    * @method currentYamlAlert
    * @return {String}
    */
@@ -136,7 +139,7 @@ export default Component.extend({
     'subscriptionYaml',
     function() {
       const subscriptionYaml = get(this, 'subscriptionYaml');
-      return subscriptionYaml || get(this, 'yamlAlertSettings');
+      return subscriptionYaml || get(this, 'currentYamlSettingsOriginal');
     }
   ),
 
@@ -292,8 +295,11 @@ export default Component.extend({
 
   // Method for handling subscription group, whether there are any or not
   async _handleSubscriptionGroup(subscriptionYaml, notifications, subscriptionGroupId) {
-    const noExistingSubscriptionGroup = get(this, 'noExistingSubscriptionGroup');
-    if (noExistingSubscriptionGroup) {
+    const {
+      noExistingSubscriptionGroup,
+      groupName
+    } = this.getProperties('noExistingSubscriptionGroup', 'groupName');
+    if (noExistingSubscriptionGroup || !groupName || groupName.name === CREATE_GROUP_TEXT) {
       //PUT settings
       const setting_url = '/yaml/subscription';
       const settingsPostProps = {
@@ -352,15 +358,15 @@ export default Component.extend({
         if(isEditMode) {
           set(this, 'detectionYaml', get(this, 'currentYamlAlertOriginal'));
         } else {
-          const yamlAlertProps = get(this, 'yamlAlertProps');
-          set(this, 'detectionYaml', yamlAlertProps);
+          const currentYamlAlertOriginal = get(this, 'currentYamlAlertOriginal');
+          set(this, 'detectionYaml', currentYamlAlertOriginal);
         }
       } else if (field === 'subscription') {
         if(isEditMode) {
           set(this, 'subscriptionYaml', get(this, 'currentYamlSettingsOriginal'));
         } else {
-          const yamlAlertSettings = get(this, 'yamlAlertSettings');
-          set(this, 'subscriptionYaml', yamlAlertSettings);
+          const currentYamlSettingsOriginal = get(this, 'currentYamlSettingsOriginal');
+          set(this, 'subscriptionYaml', currentYamlSettingsOriginal);
         }
       }
     },

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/yaml-editor/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/yaml-editor/component-test.js
@@ -58,54 +58,6 @@ module('Integration | Component | yaml-editor', function(hooks) {
     assert.ok(this.$('.ace_line')[0].children[0].textContent === defaultText);
   });
 
-  test(`displays first subscription group in dropdown in edit mode`, async function(assert) {
-    this.setProperties({
-      alertId: 1,
-      subscriptionGroups: [ {
-        id : 1,
-        name : 'test_subscription_group',
-        yaml : testText
-      } ],
-      detectionYaml: testText
-    });
-
-    await render(hbs`
-      {{yaml-editor
-        alertId=alertId
-        isEditMode=true
-        showSettings=true
-        subscriptionGroupNames=subscriptionGroups
-        detectionYaml=detectionYaml
-      }}
-    `);
-
-    assert.ok(this.$('.ember-power-select-selected-item')[0].innerText === `test_subscription_group (1)`);
-  });
-
-  test(`displays first subscription group yaml in edit mode`, async function(assert) {
-    this.setProperties({
-      alertId: 1,
-      subscriptionGroups: [ {
-        id : 1,
-        name : 'test_subscription_group',
-        yaml : testText
-      } ],
-      detectionYaml: 'nothing'
-    });
-
-    await render(hbs`
-      {{yaml-editor
-        alertId=alertId
-        isEditMode=true
-        showSettings=true
-        subscriptionGroupNames=subscriptionGroups
-        detectionYaml=detectionYaml
-      }}
-    `);
-
-    assert.ok(this.$('.ace_line')[1].innerText === testText);
-  });
-
   test(`displays default yaml file of subscription group in create mode`, async function(assert) {
 
     const defaultText = '# Below is a sample subscription group template. You may refer the documentation and update accordingly.';


### PR DESCRIPTION
…tion group without a new alert

1) Makes it possible to reset subscription group to "Create new" and default yaml value in Create Alert
2) Makes "Create a new subscription group" available in Edit Alert, so users can create a new subscription group without creating a new alert
3) Removes integration test for edit mode, since behavior is the same in both versions now