### PR TITLE
Cleanup singletons for 3 classes in ControllerStarter

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -56,6 +56,7 @@ import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTaskScheduler;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.controller.helix.core.realtime.PinotRealtimeSegmentManager;
+import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceSegmentStrategyFactory;
 import org.apache.pinot.controller.helix.core.relocation.RealtimeSegmentRelocator;
 import org.apache.pinot.controller.helix.core.retention.RetentionManager;
@@ -108,6 +109,8 @@ public class ControllerStarter {
   private ControllerPeriodicTaskScheduler _controllerPeriodicTaskScheduler;
   private PinotHelixTaskResourceManager _helixTaskResourceManager;
   private PinotRealtimeSegmentManager _realtimeSegmentsManager;
+  private PinotLLCRealtimeSegmentManager _pinotLLCRealtimeSegmentManager;
+  private SegmentCompletionManager _segmentCompletionManager;
   private ControllerLeadershipManager _controllerLeadershipManager;
   private List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbackList;
 
@@ -259,8 +262,16 @@ public class ControllerStarter {
 
     // Helix resource manager must be started in order to create PinotLLCRealtimeSegmentManager
     LOGGER.info("Starting realtime segment manager");
-    PinotLLCRealtimeSegmentManager
-        .create(_helixResourceManager, _config, _controllerMetrics, _controllerLeadershipManager);
+
+    _pinotLLCRealtimeSegmentManager =
+        new PinotLLCRealtimeSegmentManager(_helixResourceManager, _config, _controllerMetrics,
+            _controllerLeadershipManager);
+    // TODO: Need to put this inside HelixResourceManager when ControllerLeadershipManager is removed.
+    _helixResourceManager.registerPinotLLCRealtimeSegmentManager(_pinotLLCRealtimeSegmentManager);
+    _segmentCompletionManager =
+        new SegmentCompletionManager(helixParticipantManager, _pinotLLCRealtimeSegmentManager, _controllerMetrics,
+            _controllerLeadershipManager, _config.getSegmentCommitTimeoutSeconds());
+
     _realtimeSegmentsManager = new PinotRealtimeSegmentManager(_helixResourceManager, _controllerLeadershipManager);
     _realtimeSegmentsManager.start(_controllerMetrics);
 
@@ -270,8 +281,9 @@ public class ControllerStarter {
     _controllerPeriodicTaskScheduler = new ControllerPeriodicTaskScheduler();
     _controllerPeriodicTaskScheduler.init(controllerPeriodicTasks, _controllerLeadershipManager);
 
-    LOGGER.info("Creating rebalance segments factory");
-    RebalanceSegmentStrategyFactory.createInstance(helixParticipantManager);
+    LOGGER.info("Registering rebalance segments factory");
+    _helixResourceManager
+        .registerRebalanceSegmentStrategyFactory(new RebalanceSegmentStrategyFactory(helixParticipantManager));
 
     String accessControlFactoryClass = _config.getAccessControlFactoryClass();
     LOGGER.info("Use class: {} as the AccessControlFactory", accessControlFactoryClass);
@@ -298,6 +310,7 @@ public class ControllerStarter {
         bind(_config).to(ControllerConf.class);
         bind(_helixResourceManager).to(PinotHelixResourceManager.class);
         bind(_helixTaskResourceManager).to(PinotHelixTaskResourceManager.class);
+        bind(_segmentCompletionManager).to(SegmentCompletionManager.class);
         bind(_taskManager).to(PinotTaskManager.class);
         bind(connectionManager).to(HttpConnectionManager.class);
         bind(_executorService).to(Executor.class);
@@ -418,8 +431,9 @@ public class ControllerStarter {
         new OfflineSegmentIntervalChecker(_config, _helixResourceManager, new ValidationMetrics(_metricsRegistry),
             _controllerMetrics);
     periodicTasks.add(_offlineSegmentIntervalChecker);
-    _realtimeSegmentValidationManager = new RealtimeSegmentValidationManager(_config, _helixResourceManager,
-        PinotLLCRealtimeSegmentManager.getInstance(), new ValidationMetrics(_metricsRegistry), _controllerMetrics);
+    _realtimeSegmentValidationManager =
+        new RealtimeSegmentValidationManager(_config, _helixResourceManager, _pinotLLCRealtimeSegmentManager,
+            new ValidationMetrics(_metricsRegistry), _controllerMetrics);
     periodicTasks.add(_realtimeSegmentValidationManager);
     _brokerResourceValidationManager =
         new BrokerResourceValidationManager(_config, _helixResourceManager, _controllerMetrics);
@@ -460,7 +474,7 @@ public class ControllerStarter {
 
       // Stop PinotLLCSegmentManager before stopping Jersey API. It is possible that stopping Jersey API
       // may interrupt the handlers waiting on an I/O.
-      PinotLLCRealtimeSegmentManager.getInstance().stop();
+      _pinotLLCRealtimeSegmentManager.stop();
 
       LOGGER.info("Closing PinotFS classes");
       PinotFSFactory.shutdown();
@@ -473,9 +487,6 @@ public class ControllerStarter {
 
       LOGGER.info("Stopping resource manager");
       _helixResourceManager.stop();
-
-      LOGGER.info("Stopping rebalance segments factory");
-      RebalanceSegmentStrategyFactory.stop();
 
       _executorService.shutdownNow();
     } catch (final Exception e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -75,6 +75,9 @@ public class LLCSegmentCompletionHandlers {
   @Inject
   ControllerConf _controllerConf;
 
+  @Inject
+  SegmentCompletionManager _segmentCompletionManager;
+
   @VisibleForTesting
   public static String getScheme() {
     return SCHEME;
@@ -104,7 +107,7 @@ public class LLCSegmentCompletionHandlers {
         .withExtraTimeSec(extraTimeSec);
     LOGGER.info("Processing extendBuildTime:{}", requestParams.toString());
 
-    SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance().extendBuildTime(requestParams);
+    SegmentCompletionProtocol.Response response = _segmentCompletionManager.extendBuildTime(requestParams);
 
     final String responseStr = response.toJsonString();
     LOGGER.info("Response to extendBuildTime:{}", responseStr);
@@ -130,7 +133,7 @@ public class LLCSegmentCompletionHandlers {
         .withMemoryUsedBytes(memoryUsedBytes).withNumRows(numRows);
     LOGGER.info("Processing segmentConsumed:{}", requestParams.toString());
 
-    SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance().segmentConsumed(requestParams);
+    SegmentCompletionProtocol.Response response = _segmentCompletionManager.segmentConsumed(requestParams);
     final String responseStr = response.toJsonString();
     LOGGER.info("Response to segmentConsumed:{}", responseStr);
     return responseStr;
@@ -153,7 +156,7 @@ public class LLCSegmentCompletionHandlers {
     LOGGER.info("Processing segmentStoppedConsuming:{}", requestParams.toString());
 
     SegmentCompletionProtocol.Response response =
-        SegmentCompletionManager.getInstance().segmentStoppedConsuming(requestParams);
+        _segmentCompletionManager.segmentStoppedConsuming(requestParams);
     final String responseStr = response.toJsonString();
     LOGGER.info("Response to segmentStoppedConsuming:{}", responseStr);
     return responseStr;
@@ -183,7 +186,7 @@ public class LLCSegmentCompletionHandlers {
     LOGGER.info("Processing segmentCommitStart:{}", requestParams.toString());
 
     SegmentCompletionProtocol.Response response =
-        SegmentCompletionManager.getInstance().segmentCommitStart(requestParams);
+        _segmentCompletionManager.segmentCommitStart(requestParams);
     final String responseStr = response.toJsonString();
     LOGGER.info("Response to segmentCommitStart:{}", responseStr);
     return responseStr;
@@ -230,7 +233,7 @@ public class LLCSegmentCompletionHandlers {
 
     CommittingSegmentDescriptor committingSegmentDescriptor =
         CommittingSegmentDescriptor.fromSegmentCompletionReqParamsAndMetadata(requestParams, segmentMetadata);
-    SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance()
+    SegmentCompletionProtocol.Response response = _segmentCompletionManager
         .segmentCommitEnd(requestParams, isSuccess, isSplitCommit, committingSegmentDescriptor);
     final String responseStr = response.toJsonString();
     LOGGER.info("Response to segmentCommitEnd:{}", responseStr);
@@ -255,7 +258,7 @@ public class LLCSegmentCompletionHandlers {
         .withNumRows(numRows).withMemoryUsedBytes(memoryUsedBytes);
     LOGGER.info("Processing segmentCommit:{}", requestParams.toString());
 
-    final SegmentCompletionManager segmentCompletionManager = SegmentCompletionManager.getInstance();
+    final SegmentCompletionManager segmentCompletionManager = _segmentCompletionManager;
     SegmentCompletionProtocol.Response response = segmentCompletionManager.segmentCommitStart(requestParams);
 
     CommittingSegmentDescriptor committingSegmentDescriptor =
@@ -297,7 +300,7 @@ public class LLCSegmentCompletionHandlers {
               // check for existing segment file and remove it. So, the block cannot be removed altogether.
               // For now, we live with these corner cases. Once we have split-commit enabled and working, this code will no longer
               // be used.
-              synchronized (SegmentCompletionManager.getInstance()) {
+              synchronized (_segmentCompletionManager) {
                 if (pinotFS.exists(segmentFileURI)) {
                   LOGGER.warn("Segment file {} exists. Replacing with upload from {} for segment {}",
                       segmentFileURI.toString(), instanceId, segmentName);
@@ -406,7 +409,7 @@ public class LLCSegmentCompletionHandlers {
       LOGGER.error("Segment metadata extraction failure for segment {}", segmentName);
       return SegmentCompletionProtocol.RESP_FAILED.toJsonString();
     }
-    SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance()
+    SegmentCompletionProtocol.Response response = _segmentCompletionManager
         .segmentCommitEnd(requestParams, isSuccess, isSplitCommit,
             CommittingSegmentDescriptor.fromSegmentCompletionReqParamsAndMetadata(requestParams, segmentMetadata));
     final String responseStr = response.toJsonString();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -118,8 +118,9 @@ public class PinotTableIdealStateBuilder {
     return idealState;
   }
 
-  public static void buildLowLevelRealtimeIdealStateFor(String realtimeTableName, TableConfig realtimeTableConfig,
-      IdealState idealState, boolean enableBatchMessageMode) {
+  public static void buildLowLevelRealtimeIdealStateFor(PinotLLCRealtimeSegmentManager pinotLLCRealtimeSegmentManager,
+      String realtimeTableName, TableConfig realtimeTableConfig, IdealState idealState,
+      boolean enableBatchMessageMode) {
 
     // Validate replicasPerPartition here.
     final String replicasPerPartitionStr = realtimeTableConfig.getValidationConfig().getReplicasPerPartition();
@@ -136,9 +137,8 @@ public class PinotTableIdealStateBuilder {
     if (idealState == null) {
       idealState = buildEmptyRealtimeIdealStateFor(realtimeTableName, nReplicas, enableBatchMessageMode);
     }
-    final PinotLLCRealtimeSegmentManager segmentManager = PinotLLCRealtimeSegmentManager.getInstance();
     try {
-      segmentManager.setupNewTable(realtimeTableConfig, idealState);
+      pinotLLCRealtimeSegmentManager.setupNewTable(realtimeTableConfig, idealState);
     } catch (InvalidConfigException e) {
       throw new IllegalStateException("Caught exception when creating table " + realtimeTableName, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSegmentStrategyFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSegmentStrategyFactory.java
@@ -24,35 +24,18 @@ import org.apache.pinot.controller.helix.core.sharding.SegmentAssignmentStrategy
 
 
 /**
- * Singleton factory class, to fetch the right rebalance segments strategy based on table config
+ * This class is used to fetch the right rebalance segments strategy based on table config.
  */
 public class RebalanceSegmentStrategyFactory {
 
-  // TODO: fix the misuse of singleton.
-  private static RebalanceSegmentStrategyFactory INSTANCE = null;
-
   private HelixManager _helixManager;
 
-  private RebalanceSegmentStrategyFactory(HelixManager helixManager) {
+  public RebalanceSegmentStrategyFactory(HelixManager helixManager) {
     _helixManager = helixManager;
   }
 
-  public static void createInstance(HelixManager helixManager) {
-    if (INSTANCE != null) {
-      throw new RuntimeException("Instance already created for " + RebalanceSegmentStrategyFactory.class.getName());
-    }
-    INSTANCE = new RebalanceSegmentStrategyFactory(helixManager);
-  }
-
-  public static RebalanceSegmentStrategyFactory getInstance() {
-    if (INSTANCE == null) {
-      throw new RuntimeException("Instance not yet created for " + RebalanceSegmentStrategyFactory.class.getName());
-    }
-    return INSTANCE;
-  }
-
   public RebalanceSegmentStrategy getRebalanceSegmentsStrategy(TableConfig tableConfig) {
-    // If we use replica group segment assignment strategy, we pick the replica group rebalancer
+    // If we use replica group segment assignment strategy, we pick the replica group rebalancer.
     String segmentAssignmentStrategy = tableConfig.getValidationConfig().getSegmentAssignmentStrategy();
     if (segmentAssignmentStrategy == null) {
       return new DefaultRebalanceSegmentStrategy(_helixManager);
@@ -63,9 +46,5 @@ public class RebalanceSegmentStrategyFactory {
       default:
         return new DefaultRebalanceSegmentStrategy(_helixManager);
     }
-  }
-
-  public static void stop() {
-    INSTANCE = null;
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
@@ -103,6 +103,17 @@ public class PinotControllerModeTest extends ControllerTest {
         "Failed to start " + config.getControllerMode() + " controller in " + TIMEOUT_IN_MS + "ms.");
     Assert.assertEquals(_controllerStarter.getControllerMode(), ControllerConf.ControllerMode.PINOT_ONLY);
 
+    // Start a second Pinot only controller.
+    config.setControllerPort(Integer.toString(Integer.parseInt(config.getControllerPort()) + controllerPortOffset++));
+    ControllerStarter secondControllerStarter = new TestOnlyControllerStarter(config);
+
+    secondControllerStarter.start();
+    // Two controller instances assigned to cluster.
+    TestUtils.waitForCondition(aVoid -> _helixResourceManager.getAllInstances().size() == 2, TIMEOUT_IN_MS,
+        "Failed to start the 2nd pinot only controller in " + TIMEOUT_IN_MS + "ms.");
+
+    secondControllerStarter.stop();
+
     stopController();
     _controllerStarter = null;
     helixControllerStarter.stop();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerLeadershipManager;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
@@ -39,6 +40,7 @@ import org.testng.annotations.Test;
 
 import static org.apache.pinot.common.protocols.SegmentCompletionProtocol.ControllerResponseStatus;
 import static org.apache.pinot.common.protocols.SegmentCompletionProtocol.Request;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,8 +67,10 @@ public class SegmentCompletionTest {
 
   public void testCaseSetup(boolean isLeader, boolean isConnected)
       throws Exception {
-    segmentManager = new MockPinotLLCRealtimeSegmentManager(isLeader, isConnected);
-    ControllerLeadershipManager controllerLeadershipManager = segmentManager.getControllerLeadershipManager();
+    PinotHelixResourceManager mockPinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    HelixManager mockHelixManager = createMockHelixManager(isLeader, isConnected);
+    when(mockPinotHelixResourceManager.getHelixZkManager()).thenReturn(mockHelixManager);
+    segmentManager = new MockPinotLLCRealtimeSegmentManager(mockPinotHelixResourceManager);
     final int partitionId = 23;
     final int seqId = 12;
     final long now = System.currentTimeMillis();
@@ -78,8 +82,7 @@ public class SegmentCompletionTest {
     metadata.setNumReplicas(3);
     segmentManager._segmentMetadata = metadata;
 
-    segmentCompletionMgr =
-        new MockSegmentCompletionManager(segmentManager, isLeader, isConnected);
+    segmentCompletionMgr = new MockSegmentCompletionManager(segmentManager, isLeader, isConnected);
     segmentManager._segmentCompletionMgr = segmentCompletionMgr;
 
     Field fsmMapField = SegmentCompletionManager.class.getDeclaredField("_fsmMap");
@@ -1142,9 +1145,9 @@ public class SegmentCompletionTest {
     public String _stoppedInstance;
     public HelixManager _helixManager = mock(HelixManager.class);
 
-    protected MockPinotLLCRealtimeSegmentManager(boolean isLeader, boolean isConnected) {
-      super(null, clusterName, null, null, null, CONTROLLER_CONF, new ControllerMetrics(new MetricsRegistry()),
-          new ControllerLeadershipManager(createMockHelixManager(isLeader, isConnected)));
+    protected MockPinotLLCRealtimeSegmentManager(PinotHelixResourceManager pinotHelixResourceManager) {
+      super(pinotHelixResourceManager, CONTROLLER_CONF, new ControllerMetrics(new MetricsRegistry()),
+          new ControllerLeadershipManager(pinotHelixResourceManager.getHelixZkManager()));
     }
 
     @Override
@@ -1191,18 +1194,18 @@ public class SegmentCompletionTest {
 
     protected MockSegmentCompletionManager(PinotLLCRealtimeSegmentManager segmentManager, boolean isLeader,
         boolean isConnected) {
-      this(createMockHelixManager(isLeader, isConnected), segmentManager, isLeader, isConnected);
-    }
-
-    protected MockSegmentCompletionManager(HelixManager helixManager, PinotLLCRealtimeSegmentManager segmentManager, boolean isLeader,
-        boolean isConnected) {
-      this(helixManager, segmentManager, isLeader, isConnected, new ControllerLeadershipManager(helixManager));
+      this(createMockHelixManager(isLeader, isConnected), segmentManager, isLeader);
     }
 
     protected MockSegmentCompletionManager(HelixManager helixManager, PinotLLCRealtimeSegmentManager segmentManager,
-        boolean isLeader, boolean isConnected, ControllerLeadershipManager controllerLeadershipManager) {
-      super(helixManager, segmentManager, new ControllerMetrics(new MetricsRegistry()),
-          controllerLeadershipManager);
+        boolean isLeader) {
+      this(helixManager, segmentManager, isLeader, new ControllerLeadershipManager(helixManager));
+    }
+
+    protected MockSegmentCompletionManager(HelixManager helixManager, PinotLLCRealtimeSegmentManager segmentManager,
+        boolean isLeader, ControllerLeadershipManager controllerLeadershipManager) {
+      super(helixManager, segmentManager, new ControllerMetrics(new MetricsRegistry()), controllerLeadershipManager,
+          SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds());
       _isLeader = isLeader;
     }
 


### PR DESCRIPTION
This PR cleans up singletons for `PinotLLCRealtimeSegmentManager`, `SegmentCompletionManager` and `RebalanceSegmentStrategyFactory`.

The benefits are: 
* `SegmentCompletionManager` should be injected instead of using a singleton pattern.
* `PinotLLCRealtimeSegmentManager` should be put inside HelixResourceManager (right now these two code are mixed together).
* `RebalanceSegmentStrategyFactory` is only used in `HelixResourceManager`, which shouldn't be a global object.
* Basically singleton shouldn't be created and explicitly freed.
* Singleton isn't the only way to identify there's only 1 object. Using instanceId to differentiate controller processes should be good enough.