### PR TITLE
Add validations to table config before updating a table config

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -302,7 +302,7 @@ public class PinotTableRestletResource {
 
       ensureMinReplicas(tableConfig);
       verifyTableConfigs(tableConfig);
-      _pinotHelixResourceManager.setExistingTableConfig(tableConfig, tableNameWithType, tableType);
+      _pinotHelixResourceManager.updateTableConfig(tableConfig, tableNameWithType, tableType);
     } catch (PinotHelixResourceManager.InvalidTableConfigException e) {
       String errStr = String.format("Failed to update configuration for %s due to: %s", tableName, e.getMessage());
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -102,6 +102,11 @@ public class PinotTableRestletResource {
   @Inject
   ExecutorService _executorService;
 
+  /**
+   * API to create a table. Before adding, validations will be done (min number of replicas,
+   * checking offline and realtime table configs match, checking for tenants existing)
+   * @param tableConfigStr
+   */
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1145,7 +1145,8 @@ public class PinotHelixResourceManager {
       if (realtimeConsumingTag != null) {
         if (!TagNameUtils.hasValidServerTagSuffix(realtimeConsumingTag)) {
           throw new PinotHelixResourceManager.InvalidTableConfigException(
-              "Invalid realtime consuming tag: " + realtimeConsumingTag + ". Must have suffix _REALTIME or _OFFLINE");
+              "Invalid realtime consuming tag: " + realtimeConsumingTag + " for table " + tableNameWithType
+                  + ". Must have suffix _REALTIME or _OFFLINE");
         }
         if (HelixHelper.getInstancesWithTag(_helixZkManager, realtimeConsumingTag).isEmpty()) {
           throw new PinotHelixResourceManager.InvalidTableConfigException(
@@ -1158,7 +1159,8 @@ public class PinotHelixResourceManager {
       if (realtimeCompletedTag != null) {
         if (!TagNameUtils.hasValidServerTagSuffix(realtimeCompletedTag)) {
           throw new PinotHelixResourceManager.InvalidTableConfigException(
-              "Invalid realtime completed tag: " + realtimeCompletedTag + ". Must have suffix _REALTIME or _OFFLINE");
+              "Invalid realtime completed tag: " + realtimeCompletedTag + " for table " + tableNameWithType
+                  + ". Must have suffix _REALTIME or _OFFLINE");
         }
         if (HelixHelper.getInstancesWithTag(_helixZkManager, realtimeCompletedTag).isEmpty()) {
           throw new PinotHelixResourceManager.InvalidTableConfigException(

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1131,25 +1131,25 @@ public class PinotHelixResourceManager {
   @VisibleForTesting
   protected void validateTableTenantConfig(TableConfig tableConfig, String tableNameWithType, TableType tableType) {
     if (tableConfig == null) {
-      throw new PinotHelixResourceManager.InvalidTableConfigException(
+      throw new InvalidTableConfigException(
           "Table config is null for table: " + tableNameWithType);
     }
     TenantConfig tenantConfig = tableConfig.getTenantConfig();
     if (tenantConfig == null || tenantConfig.getBroker() == null || tenantConfig.getServer() == null) {
-      throw new PinotHelixResourceManager.InvalidTableConfigException(
+      throw new InvalidTableConfigException(
           "Tenant is not configured for table: " + tableNameWithType);
     }
     // Check if tenant exists before creating the table
     String brokerTenantName = TagNameUtils.getBrokerTagForTenant(tenantConfig.getBroker());
     List<String> brokersForTenant = getInstancesWithTag(brokerTenantName);
     if (brokersForTenant.isEmpty()) {
-      throw new PinotHelixResourceManager.InvalidTableConfigException(
+      throw new InvalidTableConfigException(
           "Broker tenant: " + brokerTenantName + " does not exist for table: " + tableNameWithType);
     }
     String serverTenantName =
         TagNameUtils.getTagFromTenantAndServerType(tenantConfig.getServer(), tableType.getServerType());
     if (getInstancesWithTag(serverTenantName).isEmpty()) {
-      throw new PinotHelixResourceManager.InvalidTableConfigException(
+      throw new InvalidTableConfigException(
           "Server tenant: " + serverTenantName + " does not exist for table: " + tableNameWithType);
     }
     TagOverrideConfig tagOverrideConfig = tenantConfig.getTagOverrideConfig();
@@ -1157,12 +1157,12 @@ public class PinotHelixResourceManager {
       String realtimeConsumingTag = tagOverrideConfig.getRealtimeConsuming();
       if (realtimeConsumingTag != null) {
         if (!TagNameUtils.hasValidServerTagSuffix(realtimeConsumingTag)) {
-          throw new PinotHelixResourceManager.InvalidTableConfigException(
+          throw new InvalidTableConfigException(
               "Invalid realtime consuming tag: " + realtimeConsumingTag + " for table " + tableNameWithType
                   + ". Must have suffix _REALTIME or _OFFLINE");
         }
         if (getInstancesWithTag(realtimeConsumingTag).isEmpty()) {
-          throw new PinotHelixResourceManager.InvalidTableConfigException(
+          throw new InvalidTableConfigException(
               "No instances found with overridden realtime consuming tag: " + realtimeConsumingTag + " for table: "
                   + tableNameWithType);
         }
@@ -1171,12 +1171,12 @@ public class PinotHelixResourceManager {
       String realtimeCompletedTag = tagOverrideConfig.getRealtimeCompleted();
       if (realtimeCompletedTag != null) {
         if (!TagNameUtils.hasValidServerTagSuffix(realtimeCompletedTag)) {
-          throw new PinotHelixResourceManager.InvalidTableConfigException(
+          throw new InvalidTableConfigException(
               "Invalid realtime completed tag: " + realtimeCompletedTag + " for table " + tableNameWithType
                   + ". Must have suffix _REALTIME or _OFFLINE");
         }
         if (getInstancesWithTag(realtimeCompletedTag).isEmpty()) {
-          throw new PinotHelixResourceManager.InvalidTableConfigException(
+          throw new InvalidTableConfigException(
               "No instances found with overridden realtime completed tag: " + realtimeCompletedTag + " for table: "
                   + tableNameWithType);
         }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1033,69 +1033,22 @@ public class PinotHelixResourceManager {
   }
 
   /**
-   * Table APIs
-   * @throws InvalidTableConfigException
+   * Performs validations of table config and adds the table to zookeeper
+   * @throws InvalidTableConfigException if validations fail
    * @throws TableAlreadyExistsException for offline tables only if the table already exists
    */
   public void addTable(@Nonnull TableConfig tableConfig)
       throws IOException {
     final String tableNameWithType = tableConfig.getTableName();
+    TableType tableType = tableConfig.getTableType();
 
-    TenantConfig tenantConfig;
     if (isSingleTenantCluster()) {
-      tenantConfig = new TenantConfig();
+      TenantConfig tenantConfig = new TenantConfig();
       tenantConfig.setBroker(TagNameUtils.DEFAULT_TENANT_NAME);
       tenantConfig.setServer(TagNameUtils.DEFAULT_TENANT_NAME);
       tableConfig.setTenantConfig(tenantConfig);
-    } else {
-      tenantConfig = tableConfig.getTenantConfig();
-      if (tenantConfig.getBroker() == null || tenantConfig.getServer() == null) {
-        throw new InvalidTableConfigException("Tenant is not configured for table: " + tableNameWithType);
-      }
     }
-
-    // Check if tenant exists before creating the table
-    TableType tableType = tableConfig.getTableType();
-    String brokerTenantName = TagNameUtils.getBrokerTagForTenant(tenantConfig.getBroker());
-    List<String> brokersForTenant = HelixHelper.getInstancesWithTag(_helixZkManager, brokerTenantName);
-    if (brokersForTenant.isEmpty()) {
-      throw new InvalidTableConfigException(
-          "Broker tenant: " + brokerTenantName + " does not exist for table: " + tableNameWithType);
-    }
-    String serverTenantName =
-        TagNameUtils.getTagFromTenantAndServerType(tenantConfig.getServer(), tableType.getServerType());
-    if (HelixHelper.getInstancesWithTag(_helixZkManager, serverTenantName).isEmpty()) {
-      throw new InvalidTableConfigException(
-          "Server tenant: " + serverTenantName + " does not exist for table: " + tableNameWithType);
-    }
-    TagOverrideConfig tagOverrideConfig = tenantConfig.getTagOverrideConfig();
-    if (tagOverrideConfig != null) {
-      String realtimeConsumingTag = tagOverrideConfig.getRealtimeConsuming();
-      if (realtimeConsumingTag != null) {
-        if (!TagNameUtils.hasValidServerTagSuffix(realtimeConsumingTag)) {
-          throw new InvalidTableConfigException(
-              "Invalid realtime consuming tag: " + realtimeConsumingTag + ". Must have suffix _REALTIME or _OFFLINE");
-        }
-        if (HelixHelper.getInstancesWithTag(_helixZkManager, realtimeConsumingTag).isEmpty()) {
-          throw new InvalidTableConfigException(
-              "No instances found with overridden realtime consuming tag: " + realtimeConsumingTag + " for table: "
-                  + tableNameWithType);
-        }
-      }
-
-      String realtimeCompletedTag = tagOverrideConfig.getRealtimeCompleted();
-      if (realtimeCompletedTag != null) {
-        if (!TagNameUtils.hasValidServerTagSuffix(realtimeCompletedTag)) {
-          throw new InvalidTableConfigException(
-              "Invalid realtime completed tag: " + realtimeCompletedTag + ". Must have suffix _REALTIME or _OFFLINE");
-        }
-        if (HelixHelper.getInstancesWithTag(_helixZkManager, realtimeCompletedTag).isEmpty()) {
-          throw new InvalidTableConfigException(
-              "No instances found with overridden realtime completed tag: " + realtimeCompletedTag + " for table: "
-                  + tableNameWithType);
-        }
-      }
-    }
+    validateTableTenantConfig(tableConfig, tableNameWithType, tableType);
 
     SegmentsValidationAndRetentionConfig segmentsConfig = tableConfig.getValidationConfig();
     switch (tableType) {
@@ -1160,7 +1113,60 @@ public class PinotHelixResourceManager {
         throw new InvalidTableConfigException("UnSupported table type: " + tableType);
     }
 
-    handleBrokerResource(tableNameWithType, brokersForTenant);
+    String brokerTenantName = TagNameUtils.getBrokerTagForTenant(tableConfig.getTenantConfig().getBroker());
+    handleBrokerResource(tableNameWithType, HelixHelper.getInstancesWithTag(_helixZkManager, brokerTenantName));
+  }
+
+  /**
+   * Validates the tenant config for the table
+   */
+  private void validateTableTenantConfig(TableConfig tableConfig, String tableNameWithType, TableType tableType) {
+    TenantConfig tenantConfig = tableConfig.getTenantConfig();
+    if (tenantConfig == null || tenantConfig.getBroker() == null || tenantConfig.getServer() == null) {
+      throw new PinotHelixResourceManager.InvalidTableConfigException(
+          "Tenant is not configured for table: " + tableNameWithType);
+    }
+    // Check if tenant exists before creating the table
+    String brokerTenantName = TagNameUtils.getBrokerTagForTenant(tenantConfig.getBroker());
+    List<String> brokersForTenant = HelixHelper.getInstancesWithTag(_helixZkManager, brokerTenantName);
+    if (brokersForTenant.isEmpty()) {
+      throw new PinotHelixResourceManager.InvalidTableConfigException(
+          "Broker tenant: " + brokerTenantName + " does not exist for table: " + tableNameWithType);
+    }
+    String serverTenantName =
+        TagNameUtils.getTagFromTenantAndServerType(tenantConfig.getServer(), tableType.getServerType());
+    if (HelixHelper.getInstancesWithTag(_helixZkManager, serverTenantName).isEmpty()) {
+      throw new PinotHelixResourceManager.InvalidTableConfigException(
+          "Server tenant: " + serverTenantName + " does not exist for table: " + tableNameWithType);
+    }
+    TagOverrideConfig tagOverrideConfig = tenantConfig.getTagOverrideConfig();
+    if (tagOverrideConfig != null) {
+      String realtimeConsumingTag = tagOverrideConfig.getRealtimeConsuming();
+      if (realtimeConsumingTag != null) {
+        if (!TagNameUtils.hasValidServerTagSuffix(realtimeConsumingTag)) {
+          throw new PinotHelixResourceManager.InvalidTableConfigException(
+              "Invalid realtime consuming tag: " + realtimeConsumingTag + ". Must have suffix _REALTIME or _OFFLINE");
+        }
+        if (HelixHelper.getInstancesWithTag(_helixZkManager, realtimeConsumingTag).isEmpty()) {
+          throw new PinotHelixResourceManager.InvalidTableConfigException(
+              "No instances found with overridden realtime consuming tag: " + realtimeConsumingTag + " for table: "
+                  + tableNameWithType);
+        }
+      }
+
+      String realtimeCompletedTag = tagOverrideConfig.getRealtimeCompleted();
+      if (realtimeCompletedTag != null) {
+        if (!TagNameUtils.hasValidServerTagSuffix(realtimeCompletedTag)) {
+          throw new PinotHelixResourceManager.InvalidTableConfigException(
+              "Invalid realtime completed tag: " + realtimeCompletedTag + ". Must have suffix _REALTIME or _OFFLINE");
+        }
+        if (HelixHelper.getInstancesWithTag(_helixZkManager, realtimeCompletedTag).isEmpty()) {
+          throw new PinotHelixResourceManager.InvalidTableConfigException(
+              "No instances found with overridden realtime completed tag: " + realtimeCompletedTag + " for table: "
+                  + tableNameWithType);
+        }
+      }
+    }
   }
 
   /**
@@ -1272,19 +1278,34 @@ public class PinotHelixResourceManager {
     }
   }
 
-  public void setExistingTableConfig(TableConfig config, String tableNameWithType, TableType type)
+  /**
+   * Validate the table config and update it
+   * @throws IOException
+   */
+  public void updateTableConfig(TableConfig tableConfig, String tableNameWithType, TableType tableType)
       throws IOException {
-    if (type == TableType.REALTIME) {
-      ZKMetadataProvider.setRealtimeTableConfig(_propertyStore, tableNameWithType, config.toZNRecord());
-      ensureRealtimeClusterIsSetUp(config, tableNameWithType, config.getIndexingConfig());
-    } else if (type == TableType.OFFLINE) {
-      // Update replica group partition assignment to the property store if applicable
-      updateReplicaGroupPartitionAssignment(config);
 
-      ZKMetadataProvider.setOfflineTableConfig(_propertyStore, tableNameWithType, config.toZNRecord());
+    validateTableTenantConfig(tableConfig, tableNameWithType, tableType);
+    setExistingTableConfig(tableConfig, tableNameWithType, tableType);
+  }
+
+  /**
+   * Sets the given table config into zookeeper
+   */
+  public void setExistingTableConfig(TableConfig tableConfig, String tableNameWithType, TableType tableType)
+      throws IOException {
+
+    if (tableType == TableType.REALTIME) {
+      ZKMetadataProvider.setRealtimeTableConfig(_propertyStore, tableNameWithType, tableConfig.toZNRecord());
+      ensureRealtimeClusterIsSetUp(tableConfig, tableNameWithType, tableConfig.getIndexingConfig());
+    } else if (tableType == TableType.OFFLINE) {
+      // Update replica group partition assignment to the property store if applicable
+      updateReplicaGroupPartitionAssignment(tableConfig);
+
+      ZKMetadataProvider.setOfflineTableConfig(_propertyStore, tableNameWithType, tableConfig.toZNRecord());
       IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableNameWithType);
-      final String configReplication = config.getValidationConfig().getReplication();
-      if (configReplication != null && !config.getValidationConfig().getReplication()
+      final String configReplication = tableConfig.getValidationConfig().getReplication();
+      if (configReplication != null && !tableConfig.getValidationConfig().getReplication()
           .equals(idealState.getReplicas())) {
         HelixHelper.updateIdealState(_helixZkManager, tableNameWithType, new Function<IdealState, IdealState>() {
           @Nullable

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.common.config.TableTaskConfig;
+import org.apache.pinot.common.config.TagNameUtils;
 import org.apache.pinot.common.utils.KafkaStarterUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.ZkStarter;
@@ -173,6 +174,16 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   @Nullable
   protected TableTaskConfig getTaskConfig() {
     return null;
+  }
+
+  @Nullable
+  protected  String getServerTenant() {
+    return TagNameUtils.DEFAULT_TENANT_NAME;
+  }
+
+  @Nullable
+  protected String getBrokerTenant() {
+    return TagNameUtils.DEFAULT_TENANT_NAME;
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -100,9 +100,10 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
     String timeType = outgoingTimeUnit.toString();
 
     addRealtimeTable(getTableName(), useLlc(), KafkaStarterUtils.DEFAULT_KAFKA_BROKER, KafkaStarterUtils.DEFAULT_ZK_STR,
-        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName, null, null,
-        getLoadMode(), getSortedColumn(), getInvertedIndexColumns(), getBloomFilterIndexColumns(), getRawIndexColumns(),
-        getTaskConfig(), getStreamConsumerFactoryClassName());
+        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName,
+        getBrokerTenant(), getServerTenant(), getLoadMode(), getSortedColumn(),
+        getInvertedIndexColumns(), getBloomFilterIndexColumns(), getRawIndexColumns(), getTaskConfig(),
+        getStreamConsumerFactoryClassName());
 
     completeTableConfiguration();
   }


### PR DESCRIPTION
We did not enforce any tenant level validations to update requests (like we do in add table) that come from update rest api. This can result in incorrect tenant configs being added to live tables.