### PR TITLE
Fixing PerfBenchmarkDriver

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
@@ -158,7 +158,7 @@ public class PerfBenchmarkDriverConf {
     this.brokerHost = brokerHost;
   }
 
-  public boolean isStartBroker() {
+  public boolean shouldStartBroker() {
     return startBroker;
   }
 
@@ -194,16 +194,8 @@ public class PerfBenchmarkDriverConf {
     return resultsOutputDirectory;
   }
 
-  public boolean isStartServer() {
-    return startServer;
-  }
-
   public void setStartServer(boolean startServer) {
     this.startServer = startServer;
-  }
-
-  public boolean isStartController() {
-    return startController;
   }
 
   public void setStartController(boolean startController) {


### PR DESCRIPTION
Due to the change in #3864, controller now registers as a helix
participant. This causes the issue with PerfBenchmarkDriver
because it separately create helixZkManager and it tries to
register controller participant with the same host and port.
This pr resolves the issue.