### PR TITLE
Default PinotAdmin Commands to not use System.exit(...).

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -104,7 +104,7 @@ public class PinotAdministrator {
   public static void main(String[] args) {
     PinotAdministrator pinotAdministrator = new PinotAdministrator();
     pinotAdministrator.execute(args);
-    if (!System.getProperties().getProperty("pinot.admin.system.exit", "true").equalsIgnoreCase("false")) {
+    if (System.getProperties().getProperty("pinot.admin.system.exit", "false").equalsIgnoreCase("true")) {
       System.exit(pinotAdministrator.getStatus() ? 0 : 1);
     }
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -63,6 +63,16 @@ import org.slf4j.LoggerFactory;
 /**
  * Class to implement Pinot Administrator, that provides the following commands:
  *
+ * System property: `pinot.admin.system.exit`(default to false) is used to decide if System.exit(...) will be called with exit code.
+ *
+ * Sample Usage in Commandline:
+ *  JAVA_OPTS="-Xms4G -Xmx4G -Dpinot.admin.system.exit=true" \
+ *  bin/pinot-admin.sh AddSchema \
+ *    -schemaFile /my/path/to/schema/schema.json \
+ *    -controllerHost localhost \
+ *    -controllerPort 9000 \
+ *    -exec
+ *
  */
 public class PinotAdministrator {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotAdministrator.class);


### PR DESCRIPTION
A fix for issue raised in https://github.com/apache/incubator-pinot/pull/4065

This change will change back the logic to not use System.exit() by default. And user could enable it by explicitly set env params.
E.g.
`JAVA_OPTS="-Xms4G -Xmx4G -XX:MaxDirectMemorySize=30g -Dlog4j.configuration=conf/pinot-admin-log4j.properties -Dpinot.admin.system.exit=true" bin/pinot-admin.sh AddSchema -schemaFile ~/my/path/to/schema/schema.json -controllerHost localhost  -controllerPort 9000  -exec`

Result:

> -> % echo $?
> 1

