### PR TITLE
When refreshing the segment with identical segment, still update creation time and refresh time in ZK metadata

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -152,8 +152,12 @@ public class ZKOperator {
       long newCrc = Long.valueOf(segmentMetadata.getCrc());
       if (newCrc == existingCrc) {
         LOGGER.info(
-            "New segment crc {} is same as existing segment crc {} for segment {}. Updating ZK metadata without refreshing the segment {}",
-            newCrc, existingCrc, segmentName);
+            "New segment crc '{}' is the same as existing segment crc for segment '{}'. Updating ZK metadata without refreshing the segment.",
+            newCrc, segmentName);
+        // NOTE: even though we don't need to refresh the segment, we should still update creation time and refresh time
+        // (creation time is not included in the crc)
+        existingSegmentZKMetadata.setCreationTime(segmentMetadata.getIndexCreationTime());
+        existingSegmentZKMetadata.setRefreshTime(System.currentTimeMillis());
         if (!_pinotHelixResourceManager.updateZkMetadata(existingSegmentZKMetadata)) {
           throw new RuntimeException(
               "Failed to update ZK metadata for segment: " + segmentName + " of table: " + offlineTableName);


### PR DESCRIPTION
We check crc to identify whether two segments are identical.
Segment creation time is not included in crc, so the segment
creation time might be different. This make sense since we might
generate segment with same data but at different time, and we don't
need to refresh the segment. In such case we should still update
creation time and refresh time.