### PR TITLE
[TE] Fix MySQL and H2 timestamp automatic timezone conversion issues

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/import-sql-metric/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/import-sql-metric/controller.js
@@ -14,7 +14,7 @@ export default Controller.extend({
   timeColumn: '',
   selectedTimeFormat: '',
   selectedTimeGranularity: '',
-  selectedTimezone: '',
+  selectedTimezone: 'UTC',
   response: '',
 
   init() {
@@ -22,7 +22,7 @@ export default Controller.extend({
     this.aggregationOptions = ['SUM', 'AVG', 'COUNT', 'MAX' ];
     this.timeFormatOptions = ['EPOCH', 'yyyyMMdd', 'yyyy-MM-dd', 'yyyy-MM-dd-HH', 'yyyy-MM-dd HH:mm:ss', 'yyyyMMddHHmmss'];
     this.timeGranularityOptions = ['1MILLISECONDS', '1SECONDS', '1MINUTES', '1HOURS', '1DAYS', '1WEEKs', '1MONTHS', '1YEARS'];
-    this.timezoneOptions = ["Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Arizona", "US/Mountain", "US/Central",
+    this.timezoneOptions = ["UTC", "Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Arizona", "US/Mountain", "US/Central",
       "US/Eastern", "America/Caracas", "America/Manaus", "America/Santiago", "Canada/Newfoundland", "Brazil/East", "America/Buenos_Aires", 
       "America/Godthab", "America/Montevideo", "Atlantic/South_Georgia", "Atlantic/Azores", "Atlantic/Cape_Verde", "Africa/Casablanca",
       "Europe/London", "Europe/Berlin", "Europe/Belgrade", "Europe/Brussels", "Europe/Warsaw", "Africa/Algiers", "Asia/Amman", "Europe/Athens",

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -198,7 +198,8 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
         metricFunctionToResultSetList.put(metricFunction, resultSetGroup.getResultSets());
       }
 
-      List<String[]> resultRows = ThirdEyeResultSetUtils.parseResultSets(request, metricFunctionToResultSetList, "Pinot");
+      List<String[]> resultRows = ThirdEyeResultSetUtils.parseResultSets(request, metricFunctionToResultSetList,
+          "Pinot");
       return new RelationalThirdEyeResponse(request, resultRows, timeSpec);
 
     } catch (Exception e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlThirdEyeDataSource.java
@@ -45,9 +45,6 @@ public class SqlThirdEyeDataSource implements ThirdEyeDataSource {
   private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
   protected LoadingCache<RelationalQuery, ThirdEyeResultSetGroup> sqlResponseCache;
   private SqlResponseCacheLoader sqlResponseCacheLoader;
-  public static final String DATA_SOURCE_NAME = SqlThirdEyeDataSource.class.getSimpleName();
-
-
 
   public SqlThirdEyeDataSource(Map<String, Object> properties) throws Exception {
     sqlResponseCacheLoader = new SqlResponseCacheLoader(properties);
@@ -62,8 +59,8 @@ public class SqlThirdEyeDataSource implements ThirdEyeDataSource {
   @Override
   public ThirdEyeResponse execute(ThirdEyeRequest request) throws Exception {
     LinkedHashMap<MetricFunction, List<ThirdEyeResultSet>> metricFunctionToResultSetList = new LinkedHashMap<>();
-
     TimeSpec timeSpec = null;
+    String sourceName = "";
     try {
       for (MetricFunction metricFunction : request.getMetricFunctions()) {
         String dataset = metricFunction.getDataset();
@@ -75,7 +72,7 @@ public class SqlThirdEyeDataSource implements ThirdEyeDataSource {
         }
 
         String[] tableComponents = dataset.split("\\.");
-        String sourceName = tableComponents[0];
+        sourceName = tableComponents[0];
         String dbName = tableComponents[1];
 
         String sqlQuery = SqlUtils.getSql(request, metricFunction, request.getFilterSet(), dataTimeSpec, sourceName);
@@ -85,7 +82,8 @@ public class SqlThirdEyeDataSource implements ThirdEyeDataSource {
         metricFunctionToResultSetList.put(metricFunction, thirdEyeResultSetGroup.getResultSets());
 
       }
-      List<String[]> resultRows = ThirdEyeResultSetUtils.parseResultSets(request, metricFunctionToResultSetList, "SQL");
+      List<String[]> resultRows = ThirdEyeResultSetUtils.parseResultSets(request, metricFunctionToResultSetList,
+          sourceName);
 
       return new RelationalThirdEyeResponse(request, resultRows, timeSpec);
     } catch (Exception e) {


### PR DESCRIPTION
Context: For MySQL and H2, the "timestamp" field will be automatically converted to connection timezone (thirdeye backend timezone), which may cause inconsistency issue in local and prod. So I am giving user the option to set server timezone. 