### PR TITLE
[TE] Fix the dimension values that contain dot to show up correctly in ThirdEye

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -62,6 +62,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
   private static final Logger LOG = LoggerFactory.getLogger(PinotThirdEyeDataSource.class);
   private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
   public static final String DATA_SOURCE_NAME = PinotThirdEyeDataSource.class.getSimpleName();
+  private static final String PINOT = "Pinot";
 
   private static final long CONNECTION_TIMEOUT = 60000;
 
@@ -199,7 +200,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
       }
 
       List<String[]> resultRows = ThirdEyeResultSetUtils.parseResultSets(request, metricFunctionToResultSetList,
-          "Pinot");
+          PINOT);
       return new RelationalThirdEyeResponse(request, resultRows, timeSpec);
 
     } catch (Exception e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetUtils.java
@@ -47,6 +47,7 @@ public class ThirdEyeResultSetUtils {
   private static final Logger LOG = LoggerFactory.getLogger(ThirdEyeResultSetUtils.class);
   private static final String MYSQL = "MySQL";
   private static final String H2 = "H2";
+  private static final String PINOT = "Pinot";
 
   public static List<String[]> parseResultSets(ThirdEyeRequest request,
       Map<MetricFunction, List<ThirdEyeResultSet>> metricFunctionToResultSetList,
@@ -111,9 +112,6 @@ public class ThirdEyeResultSetUtils {
               String groupKeyVal = "";
               try {
                 groupKeyVal = resultSet.getGroupKeyColumnValue(r, grpKeyIdx);
-                if (groupKeyVal.indexOf('.') > 0) {
-                  groupKeyVal = groupKeyVal.substring(0, groupKeyVal.indexOf('.'));
-                }
               } catch (Exception e) {
                 // IGNORE FOR NOW, workaround for Pinot Bug
               }
@@ -190,7 +188,7 @@ public class ThirdEyeResultSetUtils {
       return (aggregate * prevCount + value) / (prevCount + 1);
     } else if (aggFunction.equals(MetricAggFunction.MAX)) {
       return Math.max(aggregate, value);
-    } else if (aggFunction.equals(MetricAggFunction.COUNT) && sourceName.equals("Pinot")) {
+    } else if (aggFunction.equals(MetricAggFunction.COUNT) && sourceName.equals(PINOT)) {
       return aggregate + 1;
     } else if (aggFunction.equals(MetricAggFunction.COUNT)) { // For all other COUNT cases
       return aggregate + value;


### PR DESCRIPTION
- If there is a dot in a dimension value, it won't be able to show up correctly in the RCA page. This also affects the time series fetching cause it's querying a wrong dimension name. This is caused by a hack to parse the timestamps that contain a dot in the sql result. This PR removes this hack and resolves the issue. The timestamp parsing should be configured in the data set time stamp format instead.
- Add static final constants to decrease memory footprint. 