### PR TITLE
[TE] add time format for MySQL: yyyy-mm-dd hh:mm:ss.S

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/import-sql-metric/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/import-sql-metric/controller.js
@@ -20,7 +20,7 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
     this.aggregationOptions = ['SUM', 'AVG', 'COUNT', 'MAX' ];
-    this.timeFormatOptions = ['EPOCH', 'yyyyMMdd', 'yyyy-MM-dd', 'yyyy-MM-dd-HH', 'yyyy-MM-dd HH:mm:ss', 'yyyyMMddHHmmss'];
+    this.timeFormatOptions = ['EPOCH', 'yyyyMMdd', 'yyyy-MM-dd', 'yyyy-MM-dd-HH', 'yyyy-MM-dd HH:mm:ss', 'yyyy-MM-dd HH:mm:ss.S', 'yyyyMMddHHmmss'];
     this.timeGranularityOptions = ['1MILLISECONDS', '1SECONDS', '1MINUTES', '1HOURS', '1DAYS', '1WEEKs', '1MONTHS', '1YEARS'];
     this.timezoneOptions = ["UTC", "Pacific/Midway", "US/Hawaii", "US/Alaska", "US/Pacific", "US/Arizona", "US/Mountain", "US/Central",
       "US/Eastern", "America/Caracas", "America/Manaus", "America/Santiago", "Canada/Newfoundland", "Brazil/East", "America/Buenos_Aires", 


### PR DESCRIPTION
MySQL returns yyyy-MM-dd HH:mm:ss.S for datetime. My original code was to eliminate everything after the '.' so a usual yyyy-MM-dd HH:mm:ss formatter can parse it, but it broke Pinot datasource when some dimension values contains dot. My bad. This is fixed by Jihao in https://github.com/apache/incubator-pinot/pull/4125.

The proper way is just to add a new time format.