### PR TITLE
[TE] frontend - harleyjj/edit-alert - decouple alert and subscription…

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/component.js
@@ -50,6 +50,7 @@ export default Component.extend({
   isEditMode: false,
   showSettings: true,
   disableYamlSave: true,
+  disableSubGroupSave: true,
   detectionMsg: '',                   //General alert failures
   subscriptionMsg: '',                //General subscription failures
   detectionYaml: null,                // The YAML for the anomaly detection
@@ -114,6 +115,23 @@ export default Component.extend({
         return false;
       }
       return true;
+    }
+  ),
+
+  /**
+   * Change subscription group button text depending on whether creating or updating
+   * @method subGroupButtonText
+   * @return {String}
+   */
+  subGroupButtonText: computed(
+    'noExistingSubscriptionGroup',
+    'groupName',
+    function() {
+      const {
+        noExistingSubscriptionGroup,
+        groupName
+      } = this.getProperties('noExistingSubscriptionGroup', 'groupName');
+      return (noExistingSubscriptionGroup || !groupName || groupName.name === CREATE_GROUP_TEXT) ? "Create Group" : "Update Group";
     }
   ),
 
@@ -300,7 +318,7 @@ export default Component.extend({
       groupName
     } = this.getProperties('noExistingSubscriptionGroup', 'groupName');
     if (noExistingSubscriptionGroup || !groupName || groupName.name === CREATE_GROUP_TEXT) {
-      //PUT settings
+      //POST settings
       const setting_url = '/yaml/subscription';
       const settingsPostProps = {
         method: 'POST',
@@ -445,7 +463,7 @@ export default Component.extend({
      */
     onEditingSubscriptionYamlAction(value) {
       setProperties(this, {
-        disableYamlSave: false,
+        disableSubGroupSave: false,
         subscriptionYaml: value
       });
     },
@@ -498,17 +516,15 @@ export default Component.extend({
     },
 
     /**
-     * Fired by save button in YAML UI
-     * Grabs each yaml (alert and settings) and save them to their respective apis.
+     * Fired by alert button in YAML UI in edit mode
+     * Grabs alert yaml and puts it to the backend.
      */
-    async saveEditYamlAction() {
+    async submitAlertEdit() {
       const {
         detectionYaml,
-        subscriptionYaml,
         notifications,
-        alertId,
-        subscriptionGroupId
-      } = getProperties(this, 'detectionYaml', 'subscriptionYaml', 'notifications', 'alertId', 'subscriptionGroupId');
+        alertId
+      } = getProperties(this, 'detectionYaml', 'notifications', 'alertId');
 
       //PUT alert
       const alert_url = `/yaml/${alertId}`;
@@ -530,6 +546,18 @@ export default Component.extend({
       } catch (error) {
         notifications.error('Error while saving detection config.', error, toastOptions);
       }
+    },
+
+    /**
+     * Fired by subscription group button in YAML UI in edit mode
+     * Grabs subscription group yaml and posts or puts it to the backend.
+     */
+    async submitSubscriptionGroup() {
+      const {
+        subscriptionYaml,
+        notifications,
+        subscriptionGroupId
+      } = getProperties(this, 'subscriptionYaml', 'notifications', 'subscriptionGroupId');
       // If there is no existing subscription group, this method will handle it
       this._handleSubscriptionGroup(subscriptionYaml, notifications, subscriptionGroupId);
     }

--- a/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/yaml-editor/template.hbs
@@ -27,7 +27,7 @@
       }}
     </div>
   </div>
-  <div class="col-xs-12">
+  <div class="col-xs-12 {{if isEditMode "bottom-margin"}}">
     {{ember-ace
       lines=35
       value=currentYamlAlert
@@ -36,6 +36,18 @@
       update=(action "onEditingDetectionYamlAction")
       mode="ace/mode/yaml"
     }}
+    {{#if isEditMode}}
+      <div class="pull-right">
+        {{bs-button
+          defaultText="Update Alert"
+          type="primary"
+          buttonType="submit"
+          disabled=disableYamlSave
+          onClick=(action "submitAlertEdit")
+          class="te-button te-button--submit"
+        }}
+      </div>
+    {{/if}}
   </div>
   <div class="col-xs-12">
     {{#if isDetectionMsg}}
@@ -142,13 +154,13 @@
 <fieldset class="te-form__section-submit">
   {{#if isEditMode}}
     {{bs-button
-      defaultText="Save changes"
-      type="primary"
-      buttonType="submit"
-      disabled=disableYamlSave
-      onClick=(action "saveEditYamlAction")
-      class="te-button te-button--submit"
-    }}
+        defaultText=subGroupButtonText
+        type="primary"
+        buttonType="submit"
+        disabled=disableSubGroupSave
+        onClick=(action "submitSubscriptionGroup")
+        class="te-button te-button--submit"
+      }}
   {{else}}
     {{bs-button
       defaultText="Create alert"


### PR DESCRIPTION
… configurations on edit alert

On the Edit Alert page, users can just edit their alert, create a subscription group, or edit their subscription group.  The alert and subscription configurations will be decoupled and use separate buttons on the Edit Alert page.