### PR TITLE
Building with helix 0.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.7.6</avro.version>
     <parquet.version>1.8.0</parquet.version>
-    <helix.version>0.8.2</helix.version>
+    <helix.version>0.8.4</helix.version>
     <!-- jfim: for Kafka 0.9.0.0, use zkclient 0.7 -->
     <kafka.version>0.9.0.1</kafka.version>
     <zkclient.version>0.7</zkclient.version>


### PR DESCRIPTION
Hotfix - will not be checked in
java.lang.NoSuchMethodError: org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy.computePartitionAssignment(Ljava/util/List;Ljava/ut
il/List;Ljava/util/Map;Lorg/apache/helix/controller/stages/ClusterDataCache;)Lorg/apache/helix/ZNRecord;
        at org.apache.pinot.controller.helix.core.rebalance.DefaultRebalanceSegmentStrategy.rebalanceServingSegments(DefaultRebalanceSegmentStrategy.java:279)