### PR TITLE
[TE] detection - two side threshold filter

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DefaultDataProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DefaultDataProvider.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.dataframe.DataFrame;
+import org.apache.pinot.thirdeye.dataframe.LongSeries;
 import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
 import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.EventManager;
@@ -194,7 +195,10 @@ public class DefaultDataProvider implements DataProvider {
       final long deadline = System.currentTimeMillis() + TIMEOUT;
       Map<MetricSlice, DataFrame> output = new HashMap<>();
       for (MetricSlice slice : slices) {
-        output.put(slice, futures.get(slice).get(makeTimeout(deadline), TimeUnit.MILLISECONDS));
+        DataFrame result = futures.get(slice).get(makeTimeout(deadline), TimeUnit.MILLISECONDS);
+        // fill in time stamps
+        result.dropSeries(COL_TIME).addSeries(COL_TIME, LongSeries.fillValues(result.size(), slice.getStart())).setIndex(COL_TIME);
+        output.put(slice, result);
       }
       return output;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/SitewideImpactRuleAnomalyFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/SitewideImpactRuleAnomalyFilter.java
@@ -92,16 +92,16 @@ public class SitewideImpactRuleAnomalyFilter implements AnomalyFilter<SitewideIm
         .getAggregates();
 
     double currentValue = getValueFromAggregates(currentSlice, aggregates);
-    double baselineValue = baselineSlice == null ? anomaly.getAvgBaselineVal() : getValueFromAggregates(baselineSlice, aggregates);
-    double siteWideBaselineValue = getValueFromAggregates(siteWideSlice, aggregates);
+    double baselineValue = baseline == null ? anomaly.getAvgBaselineVal() :  this.baseline.gather(currentSlice, aggregates).getDouble(COL_VALUE, 0);
+    double siteWideValue = getValueFromAggregates(siteWideSlice, aggregates);
 
     // if inconsistent with up/down, filter the anomaly
     if (!pattern.equals(Pattern.UP_OR_DOWN) && (currentValue < baselineValue && pattern.equals(Pattern.UP)) || (currentValue > baselineValue && pattern.equals(Pattern.DOWN))) {
       return false;
     }
     // if doesn't pass the threshold, filter the anomaly
-    if (siteWideBaselineValue != 0
-        && (Math.abs(currentValue - baselineValue) / siteWideBaselineValue) < this.threshold) {
+    if (siteWideValue != 0
+        && (Math.abs(currentValue - baselineValue) / siteWideValue) < this.threshold) {
       return false;
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/PercentageChangeRuleAnomalyFilterSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/PercentageChangeRuleAnomalyFilterSpec.java
@@ -21,9 +21,11 @@ package org.apache.pinot.thirdeye.detection.spec;
 
 public class PercentageChangeRuleAnomalyFilterSpec extends AbstractSpec {
   private String timezone = "UTC";
-  private double threshold = Double.NaN;
   private String offset;
   private String pattern= "UP_OR_DOWN";
+  private double threshold = 0.0; // by default set threshold to 0 to pass all anomalies
+  private double upThreshold = Double.NaN;
+  private double downThreshold = Double.NaN;
 
   public String getTimezone() {
     return timezone;
@@ -55,5 +57,21 @@ public class PercentageChangeRuleAnomalyFilterSpec extends AbstractSpec {
 
   public void setPattern(String pattern) {
     this.pattern = pattern;
+  }
+
+  public double getUpThreshold() {
+    return upThreshold;
+  }
+
+  public void setUpThreshold(double upThreshold) {
+    this.upThreshold = upThreshold;
+  }
+
+  public double getDownThreshold() {
+    return downThreshold;
+  }
+
+  public void setDownThreshold(double downThreshold) {
+    this.downThreshold = downThreshold;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/AbsoluteChangeRuleAnomalyFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/AbsoluteChangeRuleAnomalyFilterTest.java
@@ -58,10 +58,10 @@ public class AbsoluteChangeRuleAnomalyFilterTest {
     MetricSlice baselineSlice2 = this.baseline.scatter(slice2).get(0);
 
     Map<MetricSlice, DataFrame> aggregates = new HashMap<>();
-    aggregates.put(slice1, new DataFrame().addSeries(COL_VALUE, 150));
-    aggregates.put(baselineSlice1, new DataFrame().addSeries(COL_VALUE, 200));
-    aggregates.put(slice2, new DataFrame().addSeries(COL_VALUE, 500));
-    aggregates.put(baselineSlice2, new DataFrame().addSeries(COL_VALUE, 1000));
+    aggregates.put(slice1, new DataFrame().addSeries(COL_VALUE, 150).addSeries(COL_TIME, slice1.getStart()).setIndex(COL_TIME));
+    aggregates.put(baselineSlice1, new DataFrame().addSeries(COL_VALUE, 200).addSeries(COL_TIME, baselineSlice1.getStart()).setIndex(COL_TIME));
+    aggregates.put(slice2, new DataFrame().addSeries(COL_VALUE, 500).addSeries(COL_TIME, slice2.getStart()).setIndex(COL_TIME));
+    aggregates.put(baselineSlice2, new DataFrame().addSeries(COL_VALUE, 1000).addSeries(COL_TIME, baselineSlice2.getStart()).setIndex(COL_TIME));
 
     this.testDataProvider = new MockDataProvider().setAggregates(aggregates);
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleAnomalyFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleAnomalyFilterTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.pinot.thirdeye.detection.components;
 
+import java.util.stream.Stream;
 import org.apache.pinot.thirdeye.dataframe.DataFrame;
 import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
@@ -49,18 +50,22 @@ public class PercentageChangeRuleAnomalyFilterTest {
 
   @BeforeMethod
   public void beforeMethod() {
-    this.baseline = BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MEDIAN, 1, 1, DateTimeZone.forID("UTC"));
+    this.baseline = BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MEAN, 1, 1, DateTimeZone.forID("UTC"));
 
-    MetricSlice slice1 = MetricSlice.from(123L, 0, 2);
+    MetricSlice slice1 = MetricSlice.from(123L, 1555570800000L, 1555693200000L);
     MetricSlice baselineSlice1 = this.baseline.scatter(slice1).get(0);
-    MetricSlice slice2 = MetricSlice.from(123L, 4, 6);
+    MetricSlice slice2 = MetricSlice.from(123L, 1554163200000L, 1554249600000L);
     MetricSlice baselineSlice2 = this.baseline.scatter(slice2).get(0);
+    MetricSlice slice3 = MetricSlice.from(123L, 1554076800000L, 1554163200000L);
+    MetricSlice baselineSlice3 = this.baseline.scatter(slice3).get(0);
 
     Map<MetricSlice, DataFrame> aggregates = new HashMap<>();
-    aggregates.put(slice1, new DataFrame().addSeries(COL_VALUE, 150));
-    aggregates.put(baselineSlice1, new DataFrame().addSeries(COL_VALUE, 200));
-    aggregates.put(slice2, new DataFrame().addSeries(COL_VALUE, 500));
-    aggregates.put(baselineSlice2, new DataFrame().addSeries(COL_VALUE, 1000));
+    aggregates.put(slice1, new DataFrame().addSeries(COL_TIME, slice1.getStart()).addSeries(COL_VALUE, 150).setIndex(COL_TIME));
+    aggregates.put(baselineSlice1, new DataFrame().addSeries(COL_TIME, baselineSlice1.getStart()).addSeries(COL_VALUE, 200).setIndex(COL_TIME));
+    aggregates.put(slice2, new DataFrame().addSeries(COL_VALUE, 500).addSeries(COL_TIME, slice2.getStart()).setIndex(COL_TIME));
+    aggregates.put(baselineSlice2, new DataFrame().addSeries(COL_VALUE, 1000).addSeries(COL_TIME, baselineSlice2.getStart()).setIndex(COL_TIME));
+    aggregates.put(slice3, new DataFrame().addSeries(COL_VALUE, 200).addSeries(COL_TIME, slice3.getStart()).setIndex(COL_TIME));
+    aggregates.put(baselineSlice3, new DataFrame().addSeries(COL_VALUE, 150).addSeries(COL_TIME, baselineSlice3.getStart()).setIndex(COL_TIME));
 
     this.testDataProvider = new MockDataProvider().setAggregates(aggregates);
   }
@@ -68,16 +73,32 @@ public class PercentageChangeRuleAnomalyFilterTest {
   @Test
   public void testPercentageChangeFilter(){
     PercentageChangeRuleAnomalyFilterSpec spec = new PercentageChangeRuleAnomalyFilterSpec();
-    spec.setOffset("median1w");
+    spec.setOffset("mean1w");
     spec.setThreshold(0.5);
     spec.setPattern("up_or_down");
     AnomalyFilter filter = new PercentageChangeRuleAnomalyFilter();
     filter.init(spec, new DefaultInputDataFetcher(this.testDataProvider, 125L));
     List<Boolean> results =
-        Arrays.asList(makeAnomaly(0, 2), makeAnomaly(4, 6)).stream().map(anomaly -> filter.isQualified(anomaly)).collect(
+        Stream.of(makeAnomaly(1555570800000L, 1555693200000L), makeAnomaly(1554163200000L, 1554249600000L)).map(anomaly -> filter.isQualified(anomaly)).collect(
             Collectors.toList());
     Assert.assertEquals(results, Arrays.asList(false, true));
   }
+
+  @Test
+  public void testPercentageChangeFilterTwoSide(){
+    PercentageChangeRuleAnomalyFilterSpec spec = new PercentageChangeRuleAnomalyFilterSpec();
+    spec.setOffset("mean1w");
+    spec.setUpThreshold(0.25);
+    spec.setDownThreshold(0.5);
+    spec.setPattern("up_or_down");
+    AnomalyFilter filter = new PercentageChangeRuleAnomalyFilter();
+    filter.init(spec, new DefaultInputDataFetcher(this.testDataProvider, 125L));
+    List<Boolean> results =
+        Stream.of(makeAnomaly(1555570800000L, 1555693200000L), makeAnomaly(1554163200000L, 1554249600000L), makeAnomaly(1554076800000L, 1554163200000L)).map(anomaly -> filter.isQualified(anomaly)).collect(
+            Collectors.toList());
+    Assert.assertEquals(results, Arrays.asList(false, true, true));
+  }
+
 
 
   private static MergedAnomalyResultDTO makeAnomaly(long start, long end) {

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/SitewideImpactRuleAnomalyFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/SitewideImpactRuleAnomalyFilterTest.java
@@ -56,10 +56,10 @@ public class SitewideImpactRuleAnomalyFilterTest {
     MetricSlice baselineSlice2 = this.baseline.scatter(slice2).get(0);
 
     Map<MetricSlice, DataFrame> aggregates = new HashMap<>();
-    aggregates.put(slice1, new DataFrame().addSeries(COL_VALUE, 150));
-    aggregates.put(baselineSlice1, new DataFrame().addSeries(COL_VALUE, 200));
-    aggregates.put(slice2, new DataFrame().addSeries(COL_VALUE, 500));
-    aggregates.put(baselineSlice2, new DataFrame().addSeries(COL_VALUE, 1000));
+    aggregates.put(slice1, new DataFrame().addSeries(COL_VALUE, 150).addSeries(COL_TIME, slice1.getStart()).setIndex(COL_TIME));
+    aggregates.put(baselineSlice1, new DataFrame().addSeries(COL_VALUE, 200).addSeries(COL_TIME, baselineSlice1.getStart()).setIndex(COL_TIME));
+    aggregates.put(slice2, new DataFrame().addSeries(COL_VALUE, 500).addSeries(COL_TIME, slice2.getStart()).setIndex(COL_TIME));
+    aggregates.put(baselineSlice2, new DataFrame().addSeries(COL_VALUE, 1000).addSeries(COL_TIME, baselineSlice2.getStart()).setIndex(COL_TIME));
 
     this.testDataProvider = new MockDataProvider().setAggregates(aggregates);
   }


### PR DESCRIPTION
- This PR makes it possible to set different threshold in different anomaly pattern in percentage change anomaly filter.
- Fix baseline values gathering in rule-based anomaly filters. Previously, the calculation of the baseline values in some anomaly filters only considers the first metric slice's value, which might result in wrong values in some cases.
- Unit tests.