### PR TITLE
Fix the issue where ZkCacheBaseDataAccessor.getChildren() can return list with null znRecords

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -297,21 +297,28 @@ public class ZKMetadataProvider {
    */
   public static List<OfflineSegmentZKMetadata> getOfflineSegmentZKMetadataListForTable(
       ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName) {
-    List<OfflineSegmentZKMetadata> resultList = new ArrayList<>();
-    if (propertyStore == null) {
-      return resultList;
-    }
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
-    if (propertyStore.exists(constructPropertyStorePathForResource(offlineTableName), AccessOption.PERSISTENT)) {
-      List<ZNRecord> znRecordList = propertyStore
-          .getChildren(constructPropertyStorePathForResource(offlineTableName), null, AccessOption.PERSISTENT);
-      if (znRecordList != null) {
-        for (ZNRecord record : znRecordList) {
-          resultList.add(new OfflineSegmentZKMetadata(record));
+    String parentPath = constructPropertyStorePathForResource(offlineTableName);
+    List<ZNRecord> znRecords = propertyStore.getChildren(parentPath, null, AccessOption.PERSISTENT);
+    if (znRecords != null) {
+      int numZNRecords = znRecords.size();
+      List<OfflineSegmentZKMetadata> offlineSegmentZKMetadataList = new ArrayList<>(numZNRecords);
+      for (ZNRecord znRecord : znRecords) {
+        // NOTE: it is possible that znRecord is null if the record gets removed while calling this method
+        if (znRecord != null) {
+          offlineSegmentZKMetadataList.add(new OfflineSegmentZKMetadata(znRecord));
         }
       }
+      int numNullZNRecords = numZNRecords - offlineSegmentZKMetadataList.size();
+      if (numNullZNRecords > 0) {
+        LOGGER.warn("Failed to read {}/{} offline segment ZK metadata under path: {}", numZNRecords - numNullZNRecords,
+            numZNRecords, parentPath);
+      }
+      return offlineSegmentZKMetadataList;
+    } else {
+      LOGGER.warn("Path: {} does not exist", parentPath);
+      return Collections.emptyList();
     }
-    return resultList;
   }
 
   /**
@@ -319,22 +326,29 @@ public class ZKMetadataProvider {
    * segment names are needed.
    */
   public static List<RealtimeSegmentZKMetadata> getRealtimeSegmentZKMetadataListForTable(
-      ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceName) {
-    List<RealtimeSegmentZKMetadata> resultList = new ArrayList<>();
-    if (propertyStore == null) {
-      return resultList;
-    }
-    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(resourceName);
-    if (propertyStore.exists(constructPropertyStorePathForResource(realtimeTableName), AccessOption.PERSISTENT)) {
-      List<ZNRecord> znRecordList = propertyStore
-          .getChildren(constructPropertyStorePathForResource(realtimeTableName), null, AccessOption.PERSISTENT);
-      if (znRecordList != null) {
-        for (ZNRecord record : znRecordList) {
-          resultList.add(new RealtimeSegmentZKMetadata(record));
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName) {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    String parentPath = constructPropertyStorePathForResource(realtimeTableName);
+    List<ZNRecord> znRecords = propertyStore.getChildren(parentPath, null, AccessOption.PERSISTENT);
+    if (znRecords != null) {
+      int numZNRecords = znRecords.size();
+      List<RealtimeSegmentZKMetadata> realtimeSegmentZKMetadataList = new ArrayList<>(numZNRecords);
+      for (ZNRecord znRecord : znRecords) {
+        // NOTE: it is possible that znRecord is null if the record gets removed while calling this method
+        if (znRecord != null) {
+          realtimeSegmentZKMetadataList.add(new RealtimeSegmentZKMetadata(znRecord));
         }
       }
+      int numNullZNRecords = numZNRecords - realtimeSegmentZKMetadataList.size();
+      if (numNullZNRecords > 0) {
+        LOGGER.warn("Failed to read {}/{} realtime segment ZK metadata under path: {}", numZNRecords - numNullZNRecords,
+            numZNRecords, parentPath);
+      }
+      return realtimeSegmentZKMetadataList;
+    } else {
+      LOGGER.warn("Path: {} does not exist", parentPath);
+      return Collections.emptyList();
     }
-    return resultList;
   }
 
   /**
@@ -342,25 +356,29 @@ public class ZKMetadataProvider {
    * only segment names are needed.
    */
   public static List<LLCRealtimeSegmentZKMetadata> getLLCRealtimeSegmentZKMetadataListForTable(
-      ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceName) {
-    List<LLCRealtimeSegmentZKMetadata> resultList = new ArrayList<>();
-    if (propertyStore == null) {
-      return resultList;
-    }
-    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(resourceName);
-    if (propertyStore.exists(constructPropertyStorePathForResource(realtimeTableName), AccessOption.PERSISTENT)) {
-      List<ZNRecord> znRecordList = propertyStore
-          .getChildren(constructPropertyStorePathForResource(realtimeTableName), null, AccessOption.PERSISTENT);
-      if (znRecordList != null) {
-        for (ZNRecord record : znRecordList) {
-          RealtimeSegmentZKMetadata realtimeSegmentZKMetadata = new RealtimeSegmentZKMetadata(record);
-          if (SegmentName.isLowLevelConsumerSegmentName(realtimeSegmentZKMetadata.getSegmentName())) {
-            resultList.add(new LLCRealtimeSegmentZKMetadata(record));
-          }
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName) {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    String parentPath = constructPropertyStorePathForResource(realtimeTableName);
+    List<ZNRecord> znRecords = propertyStore.getChildren(parentPath, null, AccessOption.PERSISTENT);
+    if (znRecords != null) {
+      int numZNRecords = znRecords.size();
+      List<LLCRealtimeSegmentZKMetadata> llcRealtimeSegmentZKMetadataList = new ArrayList<>(numZNRecords);
+      for (ZNRecord znRecord : znRecords) {
+        // NOTE: it is possible that znRecord is null if the record gets removed while calling this method
+        if (znRecord != null) {
+          llcRealtimeSegmentZKMetadataList.add(new LLCRealtimeSegmentZKMetadata(znRecord));
         }
       }
+      int numNullZNRecords = numZNRecords - llcRealtimeSegmentZKMetadataList.size();
+      if (numNullZNRecords > 0) {
+        LOGGER.warn("Failed to read {}/{} LLC realtime segment ZK metadata under path: {}",
+            numZNRecords - numNullZNRecords, numZNRecords, parentPath);
+      }
+      return llcRealtimeSegmentZKMetadataList;
+    } else {
+      LOGGER.warn("Path: {} does not exist", parentPath);
+      return Collections.emptyList();
     }
-    return resultList;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -289,8 +289,18 @@ public class PinotHelixResourceManager {
    */
   public List<InstanceConfig> getAllHelixInstanceConfigs() {
     List<ZNRecord> znRecords = _cacheInstanceConfigsDataAccessor.getChildren("/", null, AccessOption.PERSISTENT);
-    List<InstanceConfig> instanceConfigs = new ArrayList<>(znRecords.size());
-    znRecords.forEach(znRecord -> instanceConfigs.add(new InstanceConfig(znRecord)));
+    int numZNRecords = znRecords.size();
+    List<InstanceConfig> instanceConfigs = new ArrayList<>(numZNRecords);
+    for (ZNRecord znRecord : znRecords) {
+      // NOTE: it is possible that znRecord is null if the record gets removed while calling this method
+      if (znRecord != null) {
+        instanceConfigs.add(new InstanceConfig(znRecord));
+      }
+    }
+    int numNullZNRecords = numZNRecords - instanceConfigs.size();
+    if (numNullZNRecords > 0) {
+      LOGGER.warn("Failed to read {}/{} instance configs", numZNRecords - numNullZNRecords, numZNRecords);
+    }
     return instanceConfigs;
   }
 


### PR DESCRIPTION
This can happen if the record gets removed while calling this method.
Need to handle it to prevent NPE.