### PR TITLE
[TE] avoid tuning the detector and baseline provider separately if both interfaces are implemented in the same class

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionRegistry.java
@@ -54,7 +54,7 @@ public class DetectionRegistry {
   private static final Logger LOG = LoggerFactory.getLogger(DetectionRegistry.class);
   private static final String KEY_CLASS_NAME = "className";
   private static final String KEY_ANNOTATION = "annotation";
-  private static final String KEY_IS_BASELINE_PROVIDER = "isBaseline";
+  private static final String KEY_IS_BASELINE_PROVIDER = "isBaselineProvider";
 
   private static DetectionRegistry INSTANCE;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/CompositePipelineConfigTranslator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/CompositePipelineConfigTranslator.java
@@ -197,7 +197,7 @@ public class CompositePipelineConfigTranslator extends YamlDetectionConfigTransl
     this.datasetConfig = this.dataProvider.fetchDatasets(Collections.singletonList(metricConfig.getDataset()))
         .get(metricConfig.getDataset());
     Preconditions.checkNotNull(this.datasetConfig, "dataset not found");
-    this.mergerProperties = MapUtils.getMap(yamlConfig, PROP_MERGER, new HashMap());
+    this.mergerProperties = MapUtils.getMap(yamlConfig, PROP_MERGER, new HashMap<String, Object>());
     this.filterMaps = MapUtils.getMap(yamlConfig, PROP_FILTERS);
     this.metricUrn = buildMetricUrn(filterMaps, this.metricConfig.getId());
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/CompositePipelineConfigTranslator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/CompositePipelineConfigTranslator.java
@@ -171,14 +171,11 @@ public class CompositePipelineConfigTranslator extends YamlDetectionConfigTransl
     // do not tune for alerts migrated from legacy anomaly function.
     DetectionRegistry.registerComponent("com.linkedin.thirdeye.detection.components.AdLibAlertFilter",
         "MIGRATED_ALGORITHM_FILTER");
-    DetectionRegistry.registerComponent("com.linkedin.thirdeye.detection.components.AdLibAnomalyDetectorAndBaselineProvider",
+    DetectionRegistry.registerComponent("com.linkedin.thirdeye.detection.components.AdLibAnomalyDetector",
         "MIGRATED_ALGORITHM");
   }
   private static final Set<String> TUNING_OFF_COMPONENTS =
       ImmutableSet.of("MIGRATED_ALGORITHM_FILTER", "MIGRATED_ALGORITHM", "MIGRATED_ALGORITHM_BASELINE");
-  private static final Map<String, String> DETECTOR_TO_BASELINE =
-      ImmutableMap.of("ALGORITHM", "ALGORITHM_BASELINE", "MIGRATED_ALGORITHM", "MIGRATED_ALGORITHM_BASELINE",
-          "HOLT_WINTERS_RULE", "HOLT_WINTERS_RULE");
   private static final Set<String> MOVING_WINDOW_DETECTOR_TYPES = ImmutableSet.of("ALGORITHM", "MIGRATED_ALGORITHM");
 
   private final Map<String, Object> components = new HashMap<>();
@@ -281,9 +278,6 @@ public class CompositePipelineConfigTranslator extends YamlDetectionConfigTransl
       properties.put(PROP_BASELINE_PROVIDER, detectorKey);
     } else {
       String baselineProviderType = DEFAULT_BASELINE_PROVIDER_YAML_TYPE;
-      if (DETECTOR_TO_BASELINE.containsKey(detectorType)) {
-        baselineProviderType = DETECTOR_TO_BASELINE.get(detectorType);
-      }
       String baselineProviderKey = makeComponentKey(baselineProviderType, name);
       buildComponentSpec(yamlConfig, baselineProviderType, baselineProviderKey);
       properties.put(PROP_BASELINE_PROVIDER, baselineProviderKey);


### PR DESCRIPTION
Previously, the baseline provider and detector are decoupled into separated class and tunning need to be triggered for both detector and baseline provider. This PR makes the following optimization: If both interfaces are implemented by the same detector class, the tunable will be only triggered once, which improves the performance by 50%.