### PR TITLE
Add multiple locks which can be obtained based on segment name in lookupOrCreateFSM

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -96,7 +96,9 @@ public class SegmentCompletionManager {
     SegmentCompletionProtocol
         .setMaxSegmentCommitTimeMs(TimeUnit.MILLISECONDS.convert(segmentCommitTimeoutSeconds, TimeUnit.SECONDS));
     _fsmLocks = new Lock[NUM_FSM_LOCKS];
-    Arrays.fill(_fsmLocks, new ReentrantLock());
+    for (int i = 0; i < NUM_FSM_LOCKS; i ++) {
+      _fsmLocks[i] = new ReentrantLock();
+    }
   }
 
   public boolean isSplitCommitEnabled() {


### PR DESCRIPTION
Adding segment name based locks instead of synchronizing the method lookupOrCreateFSM. The latter prevents even other segments from entering the method and accessing their own fsm. A stall in a single call (could be on zk access, gc) can create a ripple effect delay in all segments waiting on that method