### PR TITLE
[TE] Clean up anomalyTimelinesView for anomalies order than 90 days

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorConfiguration.java
@@ -26,7 +26,7 @@ public class MonitorConfiguration {
   private int defaultRetentionDays = MonitorConstants.DEFAULT_RETENTION_DAYS;
   private int completedJobRetentionDays = MonitorConstants.DEFAULT_COMPLETED_JOB_RETENTION_DAYS;
   private int detectionStatusRetentionDays = MonitorConstants.DEFAULT_DETECTION_STATUS_RETENTION_DAYS;
-  private int rawAnomalyRetentionDays = MonitorConstants.DEFAULT_RAW_ANOMALY_RETENTION_DAYS;
+  private int mergedAnomalyCleanupDays = MonitorConstants.DEFAULT_MERGED_ANOMALY_CLEANUP_DAYS;
   private TimeGranularity monitorFrequency = MonitorConstants.DEFAULT_MONITOR_FREQUENCY;
 
   public int getCompletedJobRetentionDays() {
@@ -53,12 +53,12 @@ public class MonitorConfiguration {
     this.detectionStatusRetentionDays = detectionStatusRetentionDays;
   }
 
-  public int getRawAnomalyRetentionDays() {
-    return rawAnomalyRetentionDays;
+  public int getMergedAnomalyCleanupDays() {
+    return mergedAnomalyCleanupDays;
   }
 
-  public void setRawAnomalyRetentionDays(int rawAnomalyRetentionDays) {
-    this.rawAnomalyRetentionDays = rawAnomalyRetentionDays;
+  public void setMergedAnomalyCleanupDays(int mergedAnomalyCleanupDays) {
+    this.mergedAnomalyCleanupDays = mergedAnomalyCleanupDays;
   }
 
   public TimeGranularity getMonitorFrequency() {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorConstants.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorConstants.java
@@ -32,7 +32,7 @@ public class MonitorConstants {
   public static int DEFAULT_RETENTION_DAYS = 30;
   public static int DEFAULT_COMPLETED_JOB_RETENTION_DAYS = 14;
   public static int DEFAULT_DETECTION_STATUS_RETENTION_DAYS = 7;
-  public static int DEFAULT_RAW_ANOMALY_RETENTION_DAYS = 30;
+  public static int DEFAULT_MERGED_ANOMALY_CLEANUP_DAYS = 90;
   public static TimeGranularity DEFAULT_MONITOR_FREQUENCY = new TimeGranularity(15, TimeUnit.MINUTES);
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskInfo.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskInfo.java
@@ -31,7 +31,7 @@ public class MonitorTaskInfo implements TaskInfo {
   private int defaultRetentionDays;
   private int completedJobRetentionDays;
   private int detectionStatusRetentionDays;
-  private int rawAnomalyRetentionDays;
+  private int mergedAnomalyCleanupDays;
 
   public MonitorTaskInfo() {
 
@@ -69,12 +69,12 @@ public class MonitorTaskInfo implements TaskInfo {
     this.detectionStatusRetentionDays = detectionStatusRetentionDays;
   }
 
-  public int getRawAnomalyRetentionDays() {
-    return rawAnomalyRetentionDays;
+  public int getMergedAnomalyCleanupDays() {
+    return mergedAnomalyCleanupDays;
   }
 
-  public void setRawAnomalyRetentionDays(int rawAnomalyRetentionDays) {
-    this.rawAnomalyRetentionDays = rawAnomalyRetentionDays;
+  public void setMergedAnomalyCleanupDays(int mergedAnomalyCleanupDays) {
+    this.mergedAnomalyCleanupDays = mergedAnomalyCleanupDays;
   }
 
   @Override
@@ -89,13 +89,13 @@ public class MonitorTaskInfo implements TaskInfo {
     return completedJobRetentionDays == that.completedJobRetentionDays
         && defaultRetentionDays == that.defaultRetentionDays
         && detectionStatusRetentionDays == that.detectionStatusRetentionDays
-        && rawAnomalyRetentionDays == that.rawAnomalyRetentionDays && monitorType == that.monitorType;
+        && mergedAnomalyCleanupDays == that.mergedAnomalyCleanupDays && monitorType == that.monitorType;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(monitorType, completedJobRetentionDays, defaultRetentionDays, detectionStatusRetentionDays,
-        rawAnomalyRetentionDays);
+        mergedAnomalyCleanupDays);
   }
 
   @Override
@@ -105,7 +105,7 @@ public class MonitorTaskInfo implements TaskInfo {
         .add("completedJobRetentionDays", completedJobRetentionDays)
         .add("defaultRetentionDays", defaultRetentionDays)
         .add("detectionStatusRetentionDays", detectionStatusRetentionDays)
-        .add("rawAnomalyRetentionDays", rawAnomalyRetentionDays)
+        .add("mergedAnomalyCleanupDays", mergedAnomalyCleanupDays)
         .toString();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskRunner.java
@@ -111,9 +111,10 @@ public class MonitorTaskRunner implements TaskRunner {
     }
   }
 
-  private int cleanUpMergedAnomalies(int cleanUpDays) {
-    DateTime cleanupStartDate = new DateTime().withTimeAtStartOfDay().minusDays(cleanUpDays);
-    DateTime cleanupEndDate = cleanupStartDate.plusDays(1);
+  private int cleanupMergedAnomalies(int cleanupDays, int cleanupWindow) {
+    // will clean up anomalies with (cleanupDays - cleanupWindow, cleanupDays)
+    DateTime cleanupEndDate = new DateTime().withTimeAtStartOfDay().minusDays(cleanupDays);
+    DateTime cleanupStartDate = cleanupEndDate.minusDays(cleanupWindow);
     List<MergedAnomalyResultDTO> mergedAnomalies =
         DAO_REGISTRY.getMergedAnomalyResultDAO().findByTime(cleanupStartDate.getMillis(), cleanupEndDate.getMillis());
 
@@ -184,8 +185,9 @@ public class MonitorTaskRunner implements TaskRunner {
 
     try {
       int cleanupDays = monitorTaskInfo.getMergedAnomalyCleanupDays();
-      int cleanedUpAnomalies = cleanUpMergedAnomalies(cleanupDays);
-      LOG.info("Cleaned up {} raw anomalies that are older than {} days.", cleanedUpAnomalies, cleanupDays);
+      int cleanupWindow = 3;
+      int cleanedUpAnomalies = cleanupMergedAnomalies(cleanupDays, cleanupWindow);
+      LOG.info("Cleaned up {} raw anomalies that are between {} and {} days.", cleanedUpAnomalies, cleanupDays, cleanupDays + cleanupWindow);
     } catch (Exception e) {
       LOG.error("Exception when cleaning up merged anomalies.", e);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskRunner.java
@@ -119,18 +119,16 @@ public class MonitorTaskRunner implements TaskRunner {
         DAO_REGISTRY.getMergedAnomalyResultDAO().findByTime(cleanupStartDate.getMillis(), cleanupEndDate.getMillis());
 
     int cleanedAnomalyCount = 0;
-    List<MergedAnomalyResultDTO> updatedAnomalies = new ArrayList<>();
     for (MergedAnomalyResultDTO mergedAnomaly : mergedAnomalies) {
       if (mergedAnomaly.getProperties() != null && mergedAnomaly.getProperties().containsKey(ANOMALY_TIMELINES_VIEW)) {
         Map<String, String> properties = mergedAnomaly.getProperties();
         properties.remove(ANOMALY_TIMELINES_VIEW);
         mergedAnomaly.setProperties(properties);
-        updatedAnomalies.add(mergedAnomaly);
+        DAO_REGISTRY.getMergedAnomalyResultDAO().update(mergedAnomaly);
         cleanedAnomalyCount++;
       }
     }
 
-    DAO_REGISTRY.getMergedAnomalyResultDAO().update(updatedAnomalies);
     return cleanedAnomalyCount;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/task/TaskGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/task/TaskGenerator.java
@@ -96,7 +96,7 @@ public class TaskGenerator {
     updateTaskInfo.setCompletedJobRetentionDays(monitorConfiguration.getCompletedJobRetentionDays());
     updateTaskInfo.setDefaultRetentionDays(monitorConfiguration.getDefaultRetentionDays());
     updateTaskInfo.setDetectionStatusRetentionDays(monitorConfiguration.getDetectionStatusRetentionDays());
-    updateTaskInfo.setRawAnomalyRetentionDays(monitorConfiguration.getRawAnomalyRetentionDays());
+    updateTaskInfo.setMergedAnomalyCleanupDays(monitorConfiguration.getMergedAnomalyCleanupDays());
     tasks.add(updateTaskInfo);
 
     // Generates the task to expire (delete) old jobs and tasks in DB
@@ -105,7 +105,7 @@ public class TaskGenerator {
     expireTaskInfo.setCompletedJobRetentionDays(monitorConfiguration.getCompletedJobRetentionDays());
     expireTaskInfo.setDefaultRetentionDays(monitorConfiguration.getDefaultRetentionDays());
     expireTaskInfo.setDetectionStatusRetentionDays(monitorConfiguration.getDetectionStatusRetentionDays());
-    expireTaskInfo.setRawAnomalyRetentionDays(monitorConfiguration.getRawAnomalyRetentionDays());
+    expireTaskInfo.setMergedAnomalyCleanupDays(monitorConfiguration.getMergedAnomalyCleanupDays());
     tasks.add(expireTaskInfo);
 
     return tasks;

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -186,7 +186,7 @@ public class AnomalyApplicationEndToEndTest {
     monitorConfiguration.setDefaultRetentionDays(MonitorConstants.DEFAULT_RETENTION_DAYS);
     monitorConfiguration.setCompletedJobRetentionDays(MonitorConstants.DEFAULT_COMPLETED_JOB_RETENTION_DAYS);
     monitorConfiguration.setDetectionStatusRetentionDays(MonitorConstants.DEFAULT_DETECTION_STATUS_RETENTION_DAYS);
-    monitorConfiguration.setRawAnomalyRetentionDays(MonitorConstants.DEFAULT_RAW_ANOMALY_RETENTION_DAYS);
+    monitorConfiguration.setMergedAnomalyCleanupDays(MonitorConstants.DEFAULT_MERGED_ANOMALY_CLEANUP_DAYS);
     monitorConfiguration.setMonitorFrequency(new TimeGranularity(3, TimeUnit.SECONDS));
     thirdeyeAnomalyConfig.setMonitorConfiguration(monitorConfiguration);
     // Task config


### PR DESCRIPTION
1. Remove anomalyTimelinesView if anomaly is older than 90 days.
2. Remove legacy code which cleans up raw anomalies.