### PR TITLE
Reduce ZK access

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -100,9 +100,10 @@ public class SegmentDeletionManager {
 
   protected synchronized void deleteSegmentFromPropertyStoreAndLocal(String tableName, Collection<String> segmentIds,
       long deletionDelay) {
-    // Check if segment got removed from ExternalView and IdealStates
-    if (_helixAdmin.getResourceExternalView(_helixClusterName, tableName) == null
-        || _helixAdmin.getResourceIdealState(_helixClusterName, tableName) == null) {
+    // Check if segment got removed from ExternalView or IdealState
+    ExternalView externalView = _helixAdmin.getResourceExternalView(_helixClusterName, tableName);
+    IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableName);
+    if (externalView == null || idealState == null) {
       LOGGER.warn("Resource: {} is not set up in idealState or ExternalView, won't do anything", tableName);
       return;
     }
@@ -111,9 +112,6 @@ public class SegmentDeletionManager {
     Set<String> segmentsToRetryLater = new HashSet<>(segmentIds.size());  // List of segments that we need to retry
 
     try {
-      ExternalView externalView = _helixAdmin.getResourceExternalView(_helixClusterName, tableName);
-      IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableName);
-
       for (String segmentId : segmentIds) {
         Map<String, String> segmentToInstancesMapFromExternalView = externalView.getStateMap(segmentId);
         Map<String, String> segmentToInstancesMapFromIdealStates = idealState.getInstanceStateMap(segmentId);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotSegmentRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotSegmentRebalancer.java
@@ -59,9 +59,9 @@ public class PinotSegmentRebalancer extends PinotZKChanger {
    * return true if IdealState = ExternalView
    * @return
    */
-  public int isStable(String tableName) {
-    IdealState idealState = helixAdmin.getResourceIdealState(clusterName, tableName);
-    ExternalView externalView = helixAdmin.getResourceExternalView(clusterName, tableName);
+  public int isStable(String tableNameWithType) {
+    IdealState idealState = helixAdmin.getResourceIdealState(clusterName, tableNameWithType);
+    ExternalView externalView = helixAdmin.getResourceExternalView(clusterName, tableNameWithType);
     Map<String, Map<String, String>> mapFieldsIS = idealState.getRecord().getMapFields();
     Map<String, Map<String, String>> mapFieldsEV = externalView.getRecord().getMapFields();
     int numDiff = 0;


### PR DESCRIPTION
Currently `SegmentDeletionManager` fetches IdealState and ExternalView two times. 
This PR reduces the ZK access.