### PR TITLE
Added service status logs to indicate more znode information

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -318,10 +318,11 @@ public class ServiceStatus {
           if ("ERROR".equals(currentStateStatus)) {
             LOGGER.error(String.format("Resource: %s, partition: %s is in ERROR state", resourceName, partitionName));
           } else {
+            HelixProperty.Stat stat = helixState.getStat();
             String description = String
                 .format("partition=%s, expected=%s, found=%s, creationTime=%d, modifiedTime=%d, version=%d", partitionName,
-                    idealStateStatus, currentStateStatus, helixState.getStat().getCreationTime(),
-                    helixState.getStat().getModifiedTime(), helixState.getStat().getVersion());
+                    idealStateStatus, currentStateStatus, stat != null ? stat.getCreationTime() : -1,
+                    stat != null ? stat.getModifiedTime() : -1, stat != null ? stat.getVersion() : -1);
             return new StatusDescriptionPair(Status.STARTING, description);
           }
         }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
+import org.apache.helix.HelixProperty;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.ExternalView;
@@ -131,7 +132,7 @@ public class ServiceStatus {
    * Service status callback that compares ideal state with another Helix state. Used to share most of the logic between
    * the ideal state/external view comparison and ideal state/current state comparison.
    */
-  private static abstract class IdealStateMatchServiceStatusCallback<T> implements ServiceStatusCallback {
+  private static abstract class IdealStateMatchServiceStatusCallback<T extends HelixProperty> implements ServiceStatusCallback {
     protected final String _clusterName;
     protected final String _instanceName;
     protected final HelixAdmin _helixAdmin;
@@ -318,7 +319,9 @@ public class ServiceStatus {
             LOGGER.error(String.format("Resource: %s, partition: %s is in ERROR state", resourceName, partitionName));
           } else {
             String description = String
-                .format("partition=%s, expected=%s, found=%s", partitionName, idealStateStatus, currentStateStatus);
+                .format("partition=%s, expected=%s, found=%s, creationTime=%d, modifiedTime=%d, version=%d", partitionName,
+                    idealStateStatus, currentStateStatus, helixState.getStat().getCreationTime(),
+                    helixState.getStat().getModifiedTime(), helixState.getStat().getVersion());
             return new StatusDescriptionPair(Status.STARTING, description);
           }
         }


### PR DESCRIPTION
Added the creation/modification times and znode version so that we
can get more debug information when we wait for a resource partition
to converge with idealstate.