### PR TITLE
[TE] Use strict strategy in model mapper for spec class

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpec.java
@@ -32,6 +32,7 @@ public abstract class AbstractSpec {
   public static <T extends AbstractSpec> T fromProperties(Map<String, Object> properties, Class<T> specClass) {
     // don't reuse model mapper instance. It caches typeMaps and will result in unexpected mappings
     ModelMapper modelMapper = new ModelMapper();
+    // use strict mapping to ensure no mismatches or ambiguity occurs
     modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
     return modelMapper.map(properties, specClass);
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpec.java
@@ -21,6 +21,7 @@ package org.apache.pinot.thirdeye.detection.spec;
 
 import java.util.Map;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 
 
 /**
@@ -31,6 +32,7 @@ public abstract class AbstractSpec {
   public static <T extends AbstractSpec> T fromProperties(Map<String, Object> properties, Class<T> specClass) {
     // don't reuse model mapper instance. It caches typeMaps and will result in unexpected mappings
     ModelMapper modelMapper = new ModelMapper();
+    modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
     return modelMapper.map(properties, specClass);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpecTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpecTest.java
@@ -68,9 +68,10 @@ public class AbstractSpecTest {
 
   @Test
   public void testAbstractSpecMappingAmbiguityFalse() {
-    TestSpec spec = AbstractSpec.fromProperties(ImmutableMap.of("upThreshold", 0.1), TestSpec.class);
-    Assert.assertEquals(spec.getUpThreshold(), 0.1);
-    Assert.assertEquals(spec.getThreshold(), 0.2);
+    TestSpec spec = AbstractSpec.fromProperties(ImmutableMap.of("upThreshold", 0.2, "downThreshold", 0.3), TestSpec.class);
+    Assert.assertEquals(spec.getUpThreshold(), 0.2);
+    Assert.assertEquals(spec.getThreshold(), 0.1);
+    Assert.assertEquals(spec.getDownThreshold(), 0.3);
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpecTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpecTest.java
@@ -65,5 +65,13 @@ public class AbstractSpecTest {
     Assert.assertEquals(spec.getC(), "default");
     Assert.assertEquals(spec.getConfiguration(), ImmutableMap.of("k1", "v1", "k2", "v2"));
   }
+
+  @Test
+  public void testAbstractSpecMappingAmbiguityFalse() {
+    TestSpec spec = AbstractSpec.fromProperties(ImmutableMap.of("upThreshold", 0.1), TestSpec.class);
+    Assert.assertEquals(spec.getUpThreshold(), 0.1);
+    Assert.assertEquals(spec.getThreshold(), 0.2);
+  }
+
 }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/spec/TestSpec.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/spec/TestSpec.java
@@ -26,8 +26,9 @@ public class TestSpec extends AbstractSpec{
   private String c = "default";
   private RuleBaselineProvider baselineProvider;
   private Map<String, String> configuration;
-  private double threshold = 0.2;
+  private double threshold = 0.1;
   private double upThreshold;
+  private double downThreshold;
 
   public Map<String, String> getConfiguration() {
     return configuration;
@@ -83,6 +84,14 @@ public class TestSpec extends AbstractSpec{
 
   public void setUpThreshold(double upThreshold) {
     this.upThreshold = upThreshold;
+  }
+
+  public double getDownThreshold() {
+    return downThreshold;
+  }
+
+  public void setDownThreshold(double downThreshold) {
+    this.downThreshold = downThreshold;
   }
 }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/spec/TestSpec.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/spec/TestSpec.java
@@ -26,6 +26,8 @@ public class TestSpec extends AbstractSpec{
   private String c = "default";
   private RuleBaselineProvider baselineProvider;
   private Map<String, String> configuration;
+  private double threshold = 0.2;
+  private double upThreshold;
 
   public Map<String, String> getConfiguration() {
     return configuration;
@@ -65,6 +67,22 @@ public class TestSpec extends AbstractSpec{
 
   public void setC(String c) {
     this.c = c;
+  }
+
+  public double getThreshold() {
+    return threshold;
+  }
+
+  public void setThreshold(double threshold) {
+    this.threshold = threshold;
+  }
+
+  public double getUpThreshold() {
+    return upThreshold;
+  }
+
+  public void setUpThreshold(double upThreshold) {
+    this.upThreshold = upThreshold;
   }
 }
 


### PR DESCRIPTION
Use strict strategy in model mapper factory. Otherwise, it will cause subtle bugs caused by ambiguous mapping. For example, it will map the value for "upThreshold" to  both "threshold" and "downThreshold".