### PR TITLE
[TE] pass predicted time series thought out the detection pipeline

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResult.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.detection;
 
+import java.util.Collections;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.HashMap;
 import java.util.List;
@@ -29,38 +30,42 @@ public class DetectionPipelineResult {
   public static String DIAGNOSTICS_DATA = "data";
   public static String DIAGNOSTICS_CHANGE_POINTS = "changepoints";
 
-  Map<String, Object> diagnostics;
-  List<MergedAnomalyResultDTO> anomalies;
-  long lastTimestamp;
+  private final List<MergedAnomalyResultDTO> anomalies;
+  private final long lastTimestamp;
+  private final List<PredictionResult> predictedTimeSeries;
+  private Map<String, Object> diagnostics;
 
   public DetectionPipelineResult(List<MergedAnomalyResultDTO> anomalies) {
     this.anomalies = anomalies;
     this.lastTimestamp = getMaxTime(anomalies);
     this.diagnostics = new HashMap<>();
+    this.predictedTimeSeries = Collections.emptyList();
   }
 
   public DetectionPipelineResult(List<MergedAnomalyResultDTO> anomalies, long lastTimestamp) {
     this.anomalies = anomalies;
     this.lastTimestamp = lastTimestamp;
+    this.predictedTimeSeries = Collections.emptyList();
+    this.diagnostics = new HashMap<>();
+  }
+
+  public DetectionPipelineResult(List<MergedAnomalyResultDTO> anomalies, long lastTimestamp,
+      List<PredictionResult> predictedTimeSeries) {
+    this.anomalies = anomalies;
+    this.lastTimestamp = lastTimestamp;
+    this.predictedTimeSeries = predictedTimeSeries;
+    this.diagnostics = new HashMap<>();
   }
 
   public List<MergedAnomalyResultDTO> getAnomalies() {
     return anomalies;
   }
 
-  public DetectionPipelineResult setAnomalies(List<MergedAnomalyResultDTO> anomalies) {
-    this.anomalies = anomalies;
-    return this;
-  }
 
   public long getLastTimestamp() {
     return lastTimestamp;
   }
 
-  public DetectionPipelineResult setLastTimestamp(long lastTimestamp) {
-    this.lastTimestamp = lastTimestamp;
-    return this;
-  }
 
   public Map<String, Object> getDiagnostics() {
     return diagnostics;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResult.java
@@ -30,10 +30,10 @@ public class DetectionPipelineResult {
   public static String DIAGNOSTICS_DATA = "data";
   public static String DIAGNOSTICS_CHANGE_POINTS = "changepoints";
 
+  private Map<String, Object> diagnostics;
   private final List<MergedAnomalyResultDTO> anomalies;
   private final long lastTimestamp;
   private final List<PredictionResult> predictions;
-  private Map<String, Object> diagnostics;
 
   public DetectionPipelineResult(List<MergedAnomalyResultDTO> anomalies) {
     this.anomalies = anomalies;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResult.java
@@ -31,21 +31,20 @@ public class DetectionPipelineResult {
   public static String DIAGNOSTICS_CHANGE_POINTS = "changepoints";
 
   private Map<String, Object> diagnostics;
+  // detected anomalies
   private final List<MergedAnomalyResultDTO> anomalies;
+  // last time stamp, all data point before this time stamp has been inspected
   private final long lastTimestamp;
+  // predicted baselines result
   private final List<PredictionResult> predictions;
 
   public DetectionPipelineResult(List<MergedAnomalyResultDTO> anomalies) {
-    this.anomalies = anomalies;
-    this.lastTimestamp = getMaxTime(anomalies);
+    this(anomalies, getMaxTime(anomalies), Collections.emptyList());
     this.diagnostics = new HashMap<>();
-    this.predictions = Collections.emptyList();
   }
 
   public DetectionPipelineResult(List<MergedAnomalyResultDTO> anomalies, long lastTimestamp) {
-    this.anomalies = anomalies;
-    this.lastTimestamp = lastTimestamp;
-    this.predictions = Collections.emptyList();
+    this(anomalies, lastTimestamp, Collections.emptyList());
     this.diagnostics = new HashMap<>();
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResult.java
@@ -32,20 +32,20 @@ public class DetectionPipelineResult {
 
   private final List<MergedAnomalyResultDTO> anomalies;
   private final long lastTimestamp;
-  private final List<PredictionResult> predictedTimeSeries;
+  private final List<PredictionResult> predictions;
   private Map<String, Object> diagnostics;
 
   public DetectionPipelineResult(List<MergedAnomalyResultDTO> anomalies) {
     this.anomalies = anomalies;
     this.lastTimestamp = getMaxTime(anomalies);
     this.diagnostics = new HashMap<>();
-    this.predictedTimeSeries = Collections.emptyList();
+    this.predictions = Collections.emptyList();
   }
 
   public DetectionPipelineResult(List<MergedAnomalyResultDTO> anomalies, long lastTimestamp) {
     this.anomalies = anomalies;
     this.lastTimestamp = lastTimestamp;
-    this.predictedTimeSeries = Collections.emptyList();
+    this.predictions = Collections.emptyList();
     this.diagnostics = new HashMap<>();
   }
 
@@ -53,8 +53,12 @@ public class DetectionPipelineResult {
       List<PredictionResult> predictedTimeSeries) {
     this.anomalies = anomalies;
     this.lastTimestamp = lastTimestamp;
-    this.predictedTimeSeries = predictedTimeSeries;
+    this.predictions = predictedTimeSeries;
     this.diagnostics = new HashMap<>();
+  }
+
+  public List<PredictionResult> getPredictions() {
+    return predictions;
   }
 
   public List<MergedAnomalyResultDTO> getAnomalies() {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionResource.java
@@ -459,7 +459,7 @@ public class DetectionResource {
       return Response.serverError().entity(responseMessage).build();
     }
 
-    LOG.info("Replay detection pipeline {} generated {} anomalies.", detectionId, result.anomalies.size());
+    LOG.info("Replay detection pipeline {} generated {} anomalies.", detectionId, result.getAnomalies().size());
     return Response.ok(result).build();
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/PredictionResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/PredictionResult.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ *
+ */
+
+package org.apache.pinot.thirdeye.detection;
+
+import org.apache.pinot.thirdeye.detection.spi.model.TimeSeries;
+
+
+/**
+ * The time series prediction result
+ */
+public class PredictionResult {
+  private final String detectorName;
+  private final String metricUrn;
+  private final TimeSeries baselineTimeSeries;
+
+  public PredictionResult(String detectorName, String metricUrn, TimeSeries baselineTimeSeries) {
+    this.detectorName = detectorName;
+    this.metricUrn = metricUrn;
+    this.baselineTimeSeries = baselineTimeSeries;
+  }
+
+  public String getDetectorName() {
+    return detectorName;
+  }
+
+  public String getMetricUrn() {
+    return metricUrn;
+  }
+
+  public TimeSeries getBaselineTimeSeries() {
+    return baselineTimeSeries;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/PredictionResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/PredictionResult.java
@@ -22,7 +22,7 @@
 
 package org.apache.pinot.thirdeye.detection;
 
-import org.apache.pinot.thirdeye.detection.spi.model.TimeSeries;
+import org.apache.pinot.thirdeye.dataframe.DataFrame;
 
 
 /**
@@ -31,12 +31,18 @@ import org.apache.pinot.thirdeye.detection.spi.model.TimeSeries;
 public class PredictionResult {
   private final String detectorName;
   private final String metricUrn;
-  private final TimeSeries baselineTimeSeries;
+  private final DataFrame predictedTimeSeries;
 
-  public PredictionResult(String detectorName, String metricUrn, TimeSeries baselineTimeSeries) {
+  /**
+   * Construct a prediction result
+   * @param detectorName the name for the detector, for example "detection_rule_1:PERCENTAGE_RULE"
+   * @param metricUrn the metric urn
+   * @param predictedTimeSeries the predicted time series
+   */
+  public PredictionResult(String detectorName, String metricUrn, DataFrame predictedTimeSeries) {
     this.detectorName = detectorName;
     this.metricUrn = metricUrn;
-    this.baselineTimeSeries = baselineTimeSeries;
+    this.predictedTimeSeries = predictedTimeSeries;
   }
 
   public String getDetectorName() {
@@ -47,7 +53,13 @@ public class PredictionResult {
     return metricUrn;
   }
 
-  public TimeSeries getBaselineTimeSeries() {
-    return baselineTimeSeries;
+  public DataFrame getPredictedTimeSeries() {
+    return predictedTimeSeries;
+  }
+
+  @Override
+  public String toString() {
+    return "PredictionResult{" + "detectorName='" + detectorName + '\'' + ", metricUrn='" + metricUrn + '\''
+        + ", predictedTimeSeries=" + predictedTimeSeries + '}';
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
@@ -34,6 +34,7 @@ import org.apache.pinot.thirdeye.detection.DetectionPipelineException;
 import org.apache.pinot.thirdeye.detection.DetectionPipeline;
 import org.apache.pinot.thirdeye.detection.DetectionPipelineResult;
 import org.apache.pinot.thirdeye.detection.DetectionUtils;
+import org.apache.pinot.thirdeye.detection.PredictionResult;
 import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -222,6 +223,7 @@ public class DimensionWrapper extends DetectionPipeline {
     }
 
     List<MergedAnomalyResultDTO> anomalies = new ArrayList<>();
+    List<PredictionResult> predictionResults = new ArrayList<>();
     Map<String, Object> diagnostics = new HashMap<>();
     Set<Long> lastTimeStamps = new HashSet<>();
 
@@ -239,6 +241,7 @@ public class DimensionWrapper extends DetectionPipeline {
           lastTimeStamps.add(intermediate.getLastTimestamp());
           anomalies.addAll(intermediate.getAnomalies());
           diagnostics.put(metric.getUrn(), intermediate.getDiagnostics());
+          predictionResults.addAll(intermediate.getPredictions());
         }
         successNestedMetrics++;
       } catch (Exception e) {
@@ -249,7 +252,7 @@ public class DimensionWrapper extends DetectionPipeline {
     }
 
     checkNestedMetricsStatus(totalNestedMetrics, successNestedMetrics, lastException);
-    return new DetectionPipelineResult(anomalies, DetectionUtils.consolidateNestedLastTimeStamps(lastTimeStamps))
+    return new DetectionPipelineResult(anomalies, DetectionUtils.consolidateNestedLastTimeStamps(lastTimeStamps), predictionResults)
         .setDiagnostics(diagnostics);
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/MergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/MergeWrapper.java
@@ -40,6 +40,7 @@ import org.apache.pinot.thirdeye.detection.DataProvider;
 import org.apache.pinot.thirdeye.detection.DetectionPipeline;
 import org.apache.pinot.thirdeye.detection.DetectionPipelineResult;
 import org.apache.pinot.thirdeye.detection.DetectionUtils;
+import org.apache.pinot.thirdeye.detection.PredictionResult;
 import org.apache.pinot.thirdeye.detection.spi.model.AnomalySlice;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,7 +107,7 @@ public class MergeWrapper extends DetectionPipeline {
 
     // generate anomalies
     List<MergedAnomalyResultDTO> generated = new ArrayList<>();
-
+    List<PredictionResult> predictionResults = new ArrayList<>();
     int i = 0;
     Set<Long> lastTimeStamps = new HashSet<>();
     for (Map<String, Object> properties : this.nestedProperties) {
@@ -125,6 +126,7 @@ public class MergeWrapper extends DetectionPipeline {
       lastTimeStamps.add(intermediate.getLastTimestamp());
 
       generated.addAll(intermediate.getAnomalies());
+      predictionResults.addAll(intermediate.getPredictions());
       diagnostics.put(String.valueOf(i), intermediate.getDiagnostics());
 
       i++;
@@ -135,7 +137,7 @@ public class MergeWrapper extends DetectionPipeline {
     all.addAll(retrieveAnomaliesFromDatabase(generated));
     all.addAll(generated);
 
-    return new DetectionPipelineResult(this.merge(all), DetectionUtils.consolidateNestedLastTimeStamps(lastTimeStamps)).setDiagnostics(diagnostics);
+    return new DetectionPipelineResult(this.merge(all), DetectionUtils.consolidateNestedLastTimeStamps(lastTimeStamps), predictionResults).setDiagnostics(diagnostics);
   }
 
   protected List<MergedAnomalyResultDTO> retrieveAnomaliesFromDatabase(List<MergedAnomalyResultDTO> generated) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spi/components/AnomalyDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spi/components/AnomalyDetector.java
@@ -19,7 +19,6 @@
 
 package org.apache.pinot.thirdeye.detection.spi.components;
 
-import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.detection.spec.AbstractSpec;
 import org.apache.pinot.thirdeye.detection.spi.exception.DetectorException;
 import org.apache.pinot.thirdeye.detection.spi.model.DetectionResult;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spi/components/AnomalyDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spi/components/AnomalyDetector.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.detection.spi.components;
 
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.detection.spec.AbstractSpec;
 import org.apache.pinot.thirdeye.detection.spi.exception.DetectorException;
 import org.apache.pinot.thirdeye.detection.spi.model.DetectionResult;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spi/model/TimeSeries.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spi/model/TimeSeries.java
@@ -75,9 +75,14 @@ public class TimeSeries {
    * return a empty time series
    * @return a empty time series
    */
-  public static TimeSeries empty(){
+  public static TimeSeries empty() {
     TimeSeries ts = new TimeSeries();
-    ts.df.addSeries(COL_TIME, LongSeries.empty()).addSeries(COL_VALUE, DoubleSeries.empty()).setIndex(COL_TIME);
+    ts.df.addSeries(COL_TIME, LongSeries.empty())
+        .addSeries(COL_VALUE, DoubleSeries.empty())
+        .addSeries(COL_CURRENT, DoubleSeries.empty())
+        .addSeries(COL_UPPER_BOUND, DoubleSeries.empty())
+        .addSeries(COL_LOWER_BOUND, DoubleSeries.empty())
+        .setIndex(COL_TIME);
     return ts;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapper.java
@@ -212,7 +212,13 @@ public class AnomalyDetectorWrapper extends DetectionPipeline {
     return new DetectionPipelineResult(anomalyResults, lastTimeStamp, Collections.singletonList(predictedTimeSeries));
   }
 
-  TimeSeries consolidateTimeSeries(TimeSeries ts1, TimeSeries ts2) {
+  /**
+   * Join two time series, including current, baseline, lower bound and upper bound. If two time series have overlapped region, take the average
+   * @param ts1 timeseries 1
+   * @param ts2 timeseries 2
+   * @return the consolidated time series
+   */
+  static TimeSeries consolidateTimeSeries(TimeSeries ts1, TimeSeries ts2) {
     DataFrame df1 = ts1.getDataFrame();
     DataFrame df2 = ts2.getDataFrame();
     DataFrame joinedDf = df1.joinOuter(df2, COL_TIME);
@@ -223,7 +229,7 @@ public class AnomalyDetectorWrapper extends DetectionPipeline {
     return TimeSeries.fromDataFrame(joinedDf);
   }
 
-  private void consolidateJoinedDf(DataFrame joinedDf, String columnName) {
+  private static void consolidateJoinedDf(DataFrame joinedDf, String columnName) {
     String columnNameLeft = columnName + DataFrame.COLUMN_JOIN_LEFT;
     String columnNameRight = columnName + DataFrame.COLUMN_JOIN_RIGHT;
     if (joinedDf.contains(columnNameLeft) && joinedDf.contains(columnNameRight)) {
@@ -231,7 +237,13 @@ public class AnomalyDetectorWrapper extends DetectionPipeline {
     }
   }
 
-  private DoubleSeries robustAverage(DoubleSeries s1, DoubleSeries s2) {
+  /**
+   * Calculate the average of two double time series. If the value in either one is missing, take the available value as the result
+   * @param s1 series 1
+   * @param s2 series 2
+   * @return the averaged time series
+   */
+  private static DoubleSeries robustAverage(DoubleSeries s1, DoubleSeries s2) {
     Preconditions.checkArgument(s1.size() == s2.size());
     double[] series = new double[s1.size()];
     for (int i = 0 ; i < s1.size() ; i++) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapper.java
@@ -206,8 +206,10 @@ public class AnomalyDetectorWrapper extends DetectionPipeline {
       anomaly.getProperties().put(PROP_DETECTOR_COMPONENT_NAME, this.detectorName);
     }
     long lastTimeStamp = this.getLastTimeStamp();
-    return new DetectionPipelineResult(anomalies.stream().filter(anomaly -> anomaly.getEndTime() <= lastTimeStamp).collect(
-        Collectors.toList()), lastTimeStamp, Collections.singletonList(new PredictionResult(this.detectorName, this.metricUrn, predictedResult)));
+    List<MergedAnomalyResultDTO> anomalyResults = anomalies.stream().filter(anomaly -> anomaly.getEndTime() <= lastTimeStamp).collect(
+        Collectors.toList());
+    PredictionResult predictedTimeSeries = new PredictionResult(this.detectorName, this.metricUrn, predictedResult.getDataFrame());
+    return new DetectionPipelineResult(anomalyResults, lastTimeStamp, Collections.singletonList(predictedTimeSeries));
   }
 
   TimeSeries consolidateTimeSeries(TimeSeries ts1, TimeSeries ts2) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyFilterWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyFilterWrapper.java
@@ -30,6 +30,7 @@ import org.apache.pinot.thirdeye.detection.DataProvider;
 import org.apache.pinot.thirdeye.detection.DetectionPipeline;
 import org.apache.pinot.thirdeye.detection.DetectionPipelineResult;
 import org.apache.pinot.thirdeye.detection.DetectionUtils;
+import org.apache.pinot.thirdeye.detection.PredictionResult;
 import org.apache.pinot.thirdeye.detection.spi.components.AnomalyFilter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -73,6 +74,8 @@ public class AnomalyFilterWrapper extends DetectionPipeline {
   @Override
   public final DetectionPipelineResult run() throws Exception {
     List<MergedAnomalyResultDTO> candidates = new ArrayList<>();
+    List<PredictionResult> predictionResults = new ArrayList<>();
+
     Set<Long> lastTimeStamps = new HashSet<>();
     for (Map<String, Object> properties : this.nestedProperties) {
       DetectionConfigDTO nestedConfig = new DetectionConfigDTO();
@@ -91,12 +94,13 @@ public class AnomalyFilterWrapper extends DetectionPipeline {
 
       DetectionPipelineResult intermediate = pipeline.run();
       lastTimeStamps.add(intermediate.getLastTimestamp());
+      predictionResults.addAll(intermediate.getPredictions());
       candidates.addAll(intermediate.getAnomalies());
     }
 
     Collection<MergedAnomalyResultDTO> anomalies =
         Collections2.filter(candidates, mergedAnomaly -> mergedAnomaly != null && !mergedAnomaly.isChild() && anomalyFilter.isQualified(mergedAnomaly));
 
-    return new DetectionPipelineResult(new ArrayList<>(anomalies), DetectionUtils.consolidateNestedLastTimeStamps(lastTimeStamps));
+    return new DetectionPipelineResult(new ArrayList<>(anomalies), DetectionUtils.consolidateNestedLastTimeStamps(lastTimeStamps), predictionResults);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapperTest.java
@@ -191,4 +191,21 @@ public class AnomalyDetectorWrapperTest {
     Assert.assertEquals(result.getPredictedUpperBound(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
     Assert.assertEquals(result.getPredictedLowerBound(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
   }
+
+  @Test
+  public void testConsolidateTimeSeriesWithNull() {
+    TimeSeries ts1 =
+        new TimeSeries(LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
+            DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
+            DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0));
+    TimeSeries ts2 =
+        new TimeSeries(LongSeries.buildFrom(2L, 3L, 4L, 5L, 6L), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0));
+    TimeSeries result = AnomalyDetectorWrapper.consolidateTimeSeries(ts1, ts2);
+    Assert.assertEquals(result.getTime(), LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L, 6L));
+    Assert.assertEquals(result.getCurrent(), DoubleSeries.buildFrom(1L, 2L, 3L, 4L, 5L, Double.NaN));
+    Assert.assertEquals(result.getPredictedBaseline(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
+    Assert.assertEquals(result.getPredictedUpperBound(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0, Double.NaN));
+    Assert.assertEquals(result.getPredictedLowerBound(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0, Double.NaN));
+  }
+
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapperTest.java
@@ -194,18 +194,13 @@ public class AnomalyDetectorWrapperTest {
 
   @Test
   public void testConsolidateTimeSeriesWithNull() {
-    TimeSeries ts1 =
-        new TimeSeries(LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
-            DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
-            DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0));
-    TimeSeries ts2 =
-        new TimeSeries(LongSeries.buildFrom(2L, 3L, 4L, 5L, 6L), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0));
-    TimeSeries result = AnomalyDetectorWrapper.consolidateTimeSeries(ts1, ts2);
+    TimeSeries ts1 = TimeSeries.empty();
+    TimeSeries ts2 = new TimeSeries(LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L), DoubleSeries.buildFrom(1.0, 20.0, 30.0, 40.0, 50.0));
+    TimeSeries ts3 = new TimeSeries(LongSeries.buildFrom(2L, 3L, 4L, 5L, 6L), DoubleSeries.buildFrom(2.0 ,3.0, 4.0, Double.NaN, 6.0));
+    TimeSeries result1 = AnomalyDetectorWrapper.consolidateTimeSeries(ts1, ts2);
+    TimeSeries result = AnomalyDetectorWrapper.consolidateTimeSeries(result1, ts3);
     Assert.assertEquals(result.getTime(), LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L, 6L));
-    Assert.assertEquals(result.getCurrent(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0, Double.NaN));
-    Assert.assertEquals(result.getPredictedBaseline(), DoubleSeries.buildFrom(1.0, 1.0, 2.0, 3.0, 4.0, 5.0));
-    Assert.assertEquals(result.getPredictedUpperBound(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0, Double.NaN));
-    Assert.assertEquals(result.getPredictedLowerBound(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0, Double.NaN));
+    Assert.assertEquals(result.getPredictedBaseline(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, Double.NaN, 6.0));
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapperTest.java
@@ -19,9 +19,12 @@ package org.apache.pinot.thirdeye.detection.wrapper;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
+import java.sql.Time;
 import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.common.time.TimeSpec;
 import org.apache.pinot.thirdeye.dataframe.DataFrame;
+import org.apache.pinot.thirdeye.dataframe.DoubleSeries;
+import org.apache.pinot.thirdeye.dataframe.LongSeries;
 import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
 import org.apache.pinot.thirdeye.datalayer.dto.DatasetConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
@@ -34,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.thirdeye.detection.spi.model.TimeSeries;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.testng.Assert;
@@ -168,5 +172,23 @@ public class AnomalyDetectorWrapperTest {
     AnomalyDetectorWrapper detectionPipeline =
         new AnomalyDetectorWrapper(this.provider, this.config, 1546819200000L, 1546905600000L);
     Assert.assertEquals(detectionPipeline.getLastTimeStamp(), -1);
+  }
+
+  @Test
+  public void testConsolidateTimeSeries() {
+    TimeSeries ts1 =
+        new TimeSeries(LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
+            DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
+            DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0));
+    TimeSeries ts2 =
+        new TimeSeries(LongSeries.buildFrom(2L, 3L, 4L, 5L, 6L), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
+            DoubleSeries.buildFrom(2.0, 3.0, 4.0, 5.0, 6.0), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
+            DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0));
+    TimeSeries result = AnomalyDetectorWrapper.consolidateTimeSeries(ts1, ts2);
+    Assert.assertEquals(result.getTime(), LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L, 6L));
+    Assert.assertEquals(result.getCurrent(), DoubleSeries.buildFrom(1L, 2L, 3L, 4L, 5L, 6L));
+    Assert.assertEquals(result.getPredictedBaseline(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
+    Assert.assertEquals(result.getPredictedUpperBound(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
+    Assert.assertEquals(result.getPredictedLowerBound(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapperTest.java
@@ -177,7 +177,7 @@ public class AnomalyDetectorWrapperTest {
   @Test
   public void testConsolidateTimeSeries() {
     TimeSeries ts1 =
-        new TimeSeries(LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
+        new TimeSeries(LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L), DoubleSeries.buildFrom(1.0, 20.0, 30.0, 40.0, 50.0),
             DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0),
             DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0));
     TimeSeries ts2 =
@@ -186,10 +186,10 @@ public class AnomalyDetectorWrapperTest {
             DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0));
     TimeSeries result = AnomalyDetectorWrapper.consolidateTimeSeries(ts1, ts2);
     Assert.assertEquals(result.getTime(), LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L, 6L));
-    Assert.assertEquals(result.getCurrent(), DoubleSeries.buildFrom(1L, 2L, 3L, 4L, 5L, 6L));
-    Assert.assertEquals(result.getPredictedBaseline(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
-    Assert.assertEquals(result.getPredictedUpperBound(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
-    Assert.assertEquals(result.getPredictedLowerBound(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
+    Assert.assertEquals(result.getCurrent(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0, 6.0));
+    Assert.assertEquals(result.getPredictedBaseline(), DoubleSeries.buildFrom(1.0, 1.0, 2.0, 3.0, 4.0, 5.0));
+    Assert.assertEquals(result.getPredictedUpperBound(), DoubleSeries.buildFrom(1.0, 1.0, 2.0, 3.0, 4.0, 5.0));
+    Assert.assertEquals(result.getPredictedLowerBound(), DoubleSeries.buildFrom(1.0, 1.0, 2.0, 3.0, 4.0, 5.0));
   }
 
   @Test
@@ -202,8 +202,8 @@ public class AnomalyDetectorWrapperTest {
         new TimeSeries(LongSeries.buildFrom(2L, 3L, 4L, 5L, 6L), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0));
     TimeSeries result = AnomalyDetectorWrapper.consolidateTimeSeries(ts1, ts2);
     Assert.assertEquals(result.getTime(), LongSeries.buildFrom(1L, 2L, 3L, 4L, 5L, 6L));
-    Assert.assertEquals(result.getCurrent(), DoubleSeries.buildFrom(1L, 2L, 3L, 4L, 5L, Double.NaN));
-    Assert.assertEquals(result.getPredictedBaseline(), DoubleSeries.buildFrom(1.0, 1.5, 2.5, 3.5, 4.5, 5.0));
+    Assert.assertEquals(result.getCurrent(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0, Double.NaN));
+    Assert.assertEquals(result.getPredictedBaseline(), DoubleSeries.buildFrom(1.0, 1.0, 2.0, 3.0, 4.0, 5.0));
     Assert.assertEquals(result.getPredictedUpperBound(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0, Double.NaN));
     Assert.assertEquals(result.getPredictedLowerBound(), DoubleSeries.buildFrom(1.0, 2.0, 3.0, 4.0, 5.0, Double.NaN));
   }


### PR DESCRIPTION
We've changed the detector interface to pass predicted time series from detector to detection pipeline. This PR updates each stage of the detection pipeline to pass the time series. This makes the time series available in preview endpoints. Also, this makes the evaluation metrics calculation possible.