### PR TITLE
Randomly choose segments that need to be moved

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceSegmentStrategy.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.helix.core.rebalance;
 
 import com.google.common.base.Function;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -454,6 +455,8 @@ public class ReplicaGroupRebalanceSegmentStrategy implements RebalanceSegmentStr
     // Remove segments from servers that has more segments
     for (String server : serversInReplicaGroup) {
       LinkedList<String> segmentsInServer = serverToSegments.get(server);
+      // randomize the segments to be moved
+      Collections.shuffle(segmentsInServer);
       int segmentToMove = numSegmentsPerServer - segmentsInServer.size();
       if (segmentToMove < 0) {
         // Server has more segments than needed, remove segments from this server
@@ -463,6 +466,8 @@ public class ReplicaGroupRebalanceSegmentStrategy implements RebalanceSegmentStr
       }
     }
 
+    // randomize the segments to be added
+    Collections.shuffle(segmentsToAdd);
     // Add segments to servers that has less segments than numSegmentsPerServer
     for (String server : serversInReplicaGroup) {
       LinkedList<String> segmentsInServer = serverToSegments.get(server);


### PR DESCRIPTION
*Motivation*
We have observed that with ReplicaGroupRebalanceStrategy, when a server has more segments, the segments that get moved off the server tend to be older segments that get retained out (due to inherent ordering of segments). This results in imbalance once retention-manager runs as the servers that had fewer segments will end up with fewer segments yet again.

This change simply randomizes the segments before the choice of segments to move is made to ensure that segments moved are a mix of old and new ones.

*Testing done*
Existing tests pass; they validate the properties that the strategy need to adhere to.