### PR TITLE
Logging time duration for generating onheap dictionary

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapDoubleDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapDoubleDictionary.java
@@ -20,7 +20,10 @@ package org.apache.pinot.core.segment.index.readers;
 
 import it.unimi.dsi.fastutil.doubles.Double2IntOpenHashMap;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -33,6 +36,8 @@ import org.apache.pinot.core.segment.memory.PinotDataBuffer;
  * <p>This helps avoid creation of double from byte[].
  */
 public class OnHeapDoubleDictionary extends OnHeapDictionary {
+  Logger LOGGER = LoggerFactory.getLogger(OnHeapDoubleDictionary.class);
+
   private final Double2IntOpenHashMap _valToDictId;
   private final double[] _dictIdToVal;
 
@@ -50,11 +55,14 @@ public class OnHeapDoubleDictionary extends OnHeapDictionary {
     _valToDictId.defaultReturnValue(-1);
     _dictIdToVal = new double[length];
 
+    long startTime = System.currentTimeMillis();
     for (int dictId = 0; dictId < length; dictId++) {
       double value = getDouble(dictId);
       _dictIdToVal[dictId] = value;
       _valToDictId.put(value, dictId);
     }
+    LOGGER.info("On-heap double dictionary is generated successfully in {} seconds",
+        TimeUnit.SECONDS.toSeconds(System.currentTimeMillis() - startTime));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapFloatDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapFloatDictionary.java
@@ -20,7 +20,10 @@ package org.apache.pinot.core.segment.index.readers;
 
 import it.unimi.dsi.fastutil.floats.Float2IntOpenHashMap;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -33,6 +36,8 @@ import org.apache.pinot.core.segment.memory.PinotDataBuffer;
  * <p>This helps avoid creation of float from byte[].
  */
 public class OnHeapFloatDictionary extends OnHeapDictionary {
+  Logger LOGGER = LoggerFactory.getLogger(OnHeapFloatDictionary.class);
+
   private final Float2IntOpenHashMap _valToDictId;
   private final float[] _dictIdToVal;
 
@@ -50,11 +55,14 @@ public class OnHeapFloatDictionary extends OnHeapDictionary {
     _valToDictId.defaultReturnValue(-1);
     _dictIdToVal = new float[length];
 
+    long startTime = System.currentTimeMillis();
     for (int dictId = 0; dictId < length; dictId++) {
       float value = getFloat(dictId);
       _dictIdToVal[dictId] = value;
       _valToDictId.put(value, dictId);
     }
+    LOGGER.info("On-heap float dictionary is generated successfully in {} seconds",
+        TimeUnit.SECONDS.toSeconds(System.currentTimeMillis() - startTime));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapIntDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapIntDictionary.java
@@ -20,7 +20,10 @@ package org.apache.pinot.core.segment.index.readers;
 
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -33,6 +36,8 @@ import org.apache.pinot.core.segment.memory.PinotDataBuffer;
  * <p>This helps avoid creation of int from byte[].
  */
 public class OnHeapIntDictionary extends OnHeapDictionary {
+  Logger LOGGER = LoggerFactory.getLogger(OnHeapIntDictionary.class);
+
   private final Int2IntOpenHashMap _valToDictId;
   private final int[] _dictIdToVal;
 
@@ -50,11 +55,14 @@ public class OnHeapIntDictionary extends OnHeapDictionary {
     _valToDictId.defaultReturnValue(-1);
     _dictIdToVal = new int[length];
 
+    long startTime = System.currentTimeMillis();
     for (int dictId = 0; dictId < length; dictId++) {
       int value = getInt(dictId);
       _dictIdToVal[dictId] = value;
       _valToDictId.put(value, dictId);
     }
+    LOGGER.info("On-heap int dictionary is generated successfully in {} seconds",
+        TimeUnit.SECONDS.toSeconds(System.currentTimeMillis() - startTime));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapLongDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapLongDictionary.java
@@ -20,7 +20,10 @@ package org.apache.pinot.core.segment.index.readers;
 
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -33,6 +36,8 @@ import org.apache.pinot.core.segment.memory.PinotDataBuffer;
  * <p>This helps avoid creation of Long from byte[].
  */
 public class OnHeapLongDictionary extends OnHeapDictionary {
+  Logger LOGGER = LoggerFactory.getLogger(OnHeapLongDictionary.class);
+
   private final Long2IntOpenHashMap _valToDictId;
   private final long[] _dictIdToVal;
 
@@ -50,11 +55,14 @@ public class OnHeapLongDictionary extends OnHeapDictionary {
     _valToDictId.defaultReturnValue(-1);
     _dictIdToVal = new long[length];
 
+    long startTime = System.currentTimeMillis();
     for (int dictId = 0; dictId < length; dictId++) {
       long value = getLong(dictId);
       _dictIdToVal[dictId] = value;
       _valToDictId.put(value, dictId);
     }
+    LOGGER.info("On-heap long dictionary is generated successfully in {} seconds",
+        TimeUnit.SECONDS.toSeconds(System.currentTimeMillis() - startTime));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapStringDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapStringDictionary.java
@@ -21,7 +21,10 @@ package org.apache.pinot.core.segment.index.readers;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -34,6 +37,8 @@ import org.apache.pinot.core.segment.memory.PinotDataBuffer;
  * <p>This helps avoid creation of String from byte[], which is expensive as well as creates garbage.
  */
 public class OnHeapStringDictionary extends OnHeapDictionary {
+  Logger LOGGER = LoggerFactory.getLogger(OnHeapStringDictionary.class);
+
   private final byte _paddingByte;
   private final String[] _unpaddedStrings;
   private final String[] _paddedStrings;
@@ -48,6 +53,7 @@ public class OnHeapStringDictionary extends OnHeapDictionary {
     _unpaddedStrings = new String[length];
     _unPaddedStringToIdMap = new HashMap<>(length);
 
+    long startTime = System.currentTimeMillis();
     for (int i = 0; i < length; i++) {
       _unpaddedStrings[i] = getUnpaddedString(i, buffer);
       _unPaddedStringToIdMap.put(_unpaddedStrings[i], i);
@@ -65,6 +71,8 @@ public class OnHeapStringDictionary extends OnHeapDictionary {
         _paddedStringToIdMap.put(_paddedStrings[i], i);
       }
     }
+    LOGGER.info("On-heap string dictionary is generated successfully in {} seconds",
+        TimeUnit.SECONDS.toSeconds(System.currentTimeMillis() - startTime));
   }
 
   @Override


### PR DESCRIPTION
Some use cases using onheap dictionary are suffering from
high latency until we load all the data on heap. This pr
will provide us how long it takes to generate on-heap
dictionary.
