### PR TITLE
[TE] frontend - harleyjj/create-alert - break yaml editor into two co…

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/detection-yaml/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/detection-yaml/component.js
@@ -1,0 +1,291 @@
+/**
+ * Component to render the detection configuration yaml editor.
+ * @module components/detection-editor
+ * @property {Number} alertId - alertId needed in edit mode, to submit changes to alert config
+ * @property {boolean} isEditMode - to activate the edit mode
+ * @property {String} detectionYaml - the detection yaml
+ * @property {function} setDetectionYaml - updates the detectionYaml in parent
+ * @example
+   {{detection-yaml
+     alertId=model.alertId
+     isEditMode=true
+     detectionYaml=detectionYaml
+     setDetectionYaml=updateDetectionYaml
+   }}
+ * @authors lohuynh and hjackson
+ */
+
+import Component from '@ember/component';
+import {computed, set, get, getProperties, setProperties} from '@ember/object';
+import {checkStatus} from 'thirdeye-frontend/utils/utils';
+import {yamlAlertProps, toastOptions} from 'thirdeye-frontend/utils/constants';
+import yamljs from 'yamljs';
+import RSVP from "rsvp";
+import fetch from 'fetch';
+import {
+  selfServeApiGraph, selfServeApiCommon
+} from 'thirdeye-frontend/utils/api/self-serve';
+import {inject as service} from '@ember/service';
+import config from 'thirdeye-frontend/config/environment';
+
+export default Component.extend({
+  classNames: ['yaml-editor'],
+  notifications: service('toast'),
+  /**
+   * Properties we expect to receive for the yaml-editor
+   */
+  currentMetric: null,
+  isYamlParseable: true,
+  alertTitle: 'Define detection configuration',
+  isEditMode: false,
+  disableYamlSave: true,
+  detectionMsg: '',                   //General alert failures
+  detectionYaml: null,                // The YAML for the anomaly detection
+  currentYamlAlertOriginal: yamlAlertProps,
+  alertId: null, // only needed in edit mode
+  setDetectionYaml: null, // bubble up detectionYaml changes to parent
+
+
+
+  /**
+   * sets Yaml value displayed to contents of detectionYaml or currentYamlAlertOriginal
+   * @method currentYamlAlert
+   * @return {String}
+   */
+  currentYamlAlert: computed(
+    'detectionYaml',
+    function() {
+      const inputYaml = get(this, 'detectionYaml');
+      return inputYaml || get(this, 'currentYamlAlertOriginal');
+    }
+  ),
+
+  isDetectionMsg: computed(
+    'detectionMsg',
+    function() {
+      const detectionMsg = get(this, 'detectionMsg');
+      return detectionMsg !== '';
+    }
+  ),
+
+  /**
+   * Calls api's for specific metric's autocomplete
+   * @method _loadAutocompleteById
+   * @return Promise
+   */
+  _loadAutocompleteById(metricId) {
+    const promiseHash = {
+      filters: fetch(selfServeApiGraph.metricFilters(metricId)).then(res => checkStatus(res, 'get', true)),
+      dimensions: fetch(selfServeApiGraph.metricDimensions(metricId)).then(res => checkStatus(res, 'get', true))
+    };
+    return RSVP.hash(promiseHash);
+  },
+
+  /**
+   * Get autocomplete suggestions from relevant api
+   * @method _buildYamlSuggestions
+   * @return Promise
+   */
+  _buildYamlSuggestions(currentMetric, yamlAsObject, prefix, noResultsArray,
+    filtersCache, dimensionsCache, position) {
+    // holds default result to return if all checks fail
+    let defaultReturn = Promise.resolve(noResultsArray);
+    // when metric is being autocompleted, entire text field will be replaced and metricId stored in editor
+    if (yamlAsObject.metric === prefix) {
+      return fetch(selfServeApiCommon.metricAutoComplete(prefix))
+        .then(checkStatus)
+        .then(metrics => {
+          if (metrics && metrics.length > 0) {
+            return metrics.map(metric => {
+              const [dataset, metricname] = metric.alias.split('::');
+              return {
+                value: metricname,
+                caption: metric.alias,
+                row: position.row,
+                column: position.column,
+                metricname,
+                dataset,
+                id: metric.id,
+                completer:{
+                  insertMatch: (editor, data) => {
+                    // replace metric row with selected metric
+                    editor.session.replace({
+                      start: { row: data.row, column: 0 },
+                      end: { row: data.row, column: Number.MAX_VALUE }},
+                    `metric: ${data.metricname}`);
+                    // find dataset: field in text
+                    const datasetLocation = editor.find('dataset:');
+                    // if found, replace with dataset
+                    if (datasetLocation) {
+                      editor.session.replace({
+                        start: { row: datasetLocation.start.row, column: 0},
+                        end: { row: datasetLocation.end.row, column: Number.MAX_VALUE }},
+                      `dataset: ${data.dataset}`);
+                      // otherwise, add it to the line below the metric field
+                    } else {
+                      editor.session.insert({
+                        row: data.row + 1, column: 0 },
+                      `dataset: ${data.dataset}\n`);
+                    }
+                    editor.metricId = data.id;
+                  }
+                }};
+            });
+          }
+          return noResultsArray;
+        })
+        .catch(() => {
+          return noResultsArray;
+        });
+    }
+    // if a currentMetric has been stored, we can check autocomplete filters and dimensions
+    if (currentMetric) {
+      const dimensionValues = yamlAsObject.dimensionExploration.dimensions;
+      const filterTypes = typeof yamlAsObject.filters === "object" ? Object.keys(yamlAsObject.filters) : [];
+      if (Array.isArray(dimensionValues) && dimensionValues.includes(prefix)) {
+        if (dimensionsCache.length > 0) {
+          // wraps result in Promise.resolve because return of Promise is expected by yamlSuggestions
+          return Promise.resolve(dimensionsCache.map(dimension => {
+            return {
+              value: dimension
+            };
+          }));
+        }
+      }
+      let filterKey = '';
+      let i = 0;
+      while (i < filterTypes.length) {
+        if (filterTypes[i] === prefix){
+          i = filterTypes.length;
+          // wraps result in Promise.resolve because return of Promise is expected by yamlSuggestions
+          return Promise.resolve(Object.keys(filtersCache).map(filterType => {
+            return {
+              value: `${filterType}:`,
+              caption: `${filterType}:`,
+              snippet: filterType
+            };
+          }));
+        }
+        if (Array.isArray(yamlAsObject.filters[filterTypes[i]]) && yamlAsObject.filters[filterTypes[i]].includes(prefix)) {
+          filterKey = filterTypes[i];
+        }
+        i++;
+      }
+      if (filterKey) {
+        // wraps result in Promise.resolve because return of Promise is expected by yamlSuggestions
+        return Promise.resolve(filtersCache[filterKey].map(filterParam => {
+          return {
+            value: filterParam
+          };
+        }));
+      }
+    }
+    return defaultReturn;
+  },
+
+  actions: {
+    /**
+     * resets given yaml field to default value for creation mode and server value for edit mode
+     */
+    resetYAML() {
+      const setDetectionYaml = get(this, 'setDetectionYaml');
+      setDetectionYaml(get(this, 'currentYamlAlertOriginal'));
+    },
+
+    /**
+     * Brings up appropriate modal, based on which yaml field is clicked
+     */
+    triggerDoc() {
+      window.open(config.docs.detectionConfig);
+    },
+
+    /**
+     * returns array of suggestions for Yaml editor autocompletion
+     */
+    yamlSuggestions(editor, session, position, prefix) {
+      const {
+        detectionYaml,
+        noResultsArray
+      } = getProperties(this, 'detectionYaml', 'noResultsArray');
+      let yamlAsObject = {};
+      try {
+        yamlAsObject = yamljs.parse(detectionYaml);
+        set(this, 'isYamlParseable', true);
+      }
+      catch(err){
+        set(this, 'isYamlParseable', false);
+        return noResultsArray;
+      }
+      // if editor.metricId field contains a value, metric was just chosen.  Populate caches for filters and dimensions
+      if(editor.metricId){
+        const currentMetric = set(this, 'currentMetric', editor.metricId);
+        editor.metricId = '';
+        return get(this, '_loadAutocompleteById')(currentMetric)
+          .then(resultObj => {
+            const { filters, dimensions } = resultObj;
+            setProperties(this, {
+              dimensionsCache: dimensions,
+              filtersCache: filters
+            });
+          })
+          .then(() => {
+            return get(this, '_buildYamlSuggestions')(currentMetric,
+              yamlAsObject, prefix, noResultsArray, get(this, 'filtersCache'),
+              get(this, 'dimensionsCache'), position)
+              .then(results => results);
+          });
+      }
+      const currentMetric = get(this, 'currentMetric');
+      // deals with no metricId, which could be autocomplete for metric or for filters and dimensions already cached
+      return get(this, '_buildYamlSuggestions')(currentMetric, yamlAsObject,
+        prefix, noResultsArray, get(this, 'filtersCache'),
+        get(this, 'dimensionsCache'), position)
+        .then(results => results);
+
+    },
+
+    /**
+     * Activates 'Create changes' button and stores YAML content in detectionYaml
+     */
+    onEditingDetectionYamlAction(value) {
+      const setDetectionYaml = get(this, 'setDetectionYaml');
+      setDetectionYaml(value);
+      setProperties(this, {
+        detectionMsg: ''
+      });
+    },
+
+    /**
+     * Fired by alert button in YAML UI in edit mode
+     * Grabs alert yaml and puts it to the backend.
+     */
+    async submitAlertEdit() {
+      const {
+        detectionYaml,
+        notifications,
+        alertId
+      } = getProperties(this, 'detectionYaml', 'notifications', 'alertId');
+
+      //PUT alert
+      const alert_url = `/yaml/${alertId}`;
+      const alertPostProps = {
+        method: 'PUT',
+        body: detectionYaml,
+        headers: { 'content-type': 'text/plain' }
+      };
+      try {
+        const alert_result = await fetch(alert_url, alertPostProps);
+        const alert_status  = get(alert_result, 'status');
+        const alert_json = await alert_result.json();
+        if (alert_status !== 200) {
+          set(this, 'errorMsg', get(alert_json, 'message'));
+          notifications.error(`Failed to save the detection configuration due to: ${alert_json.message}.`, 'Error', toastOptions);
+        } else {
+          notifications.success('Detection configuration saved successfully', 'Done', toastOptions);
+        }
+      } catch (error) {
+        notifications.error('Error while saving detection config.', error, toastOptions);
+      }
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/detection-yaml/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/detection-yaml/template.hbs
@@ -1,0 +1,58 @@
+<div class="col-xs-12">
+  <legend class="te-form__section-title">{{alertTitle}}</legend>
+</div>
+<div class="col-xs-12 {{if isEditMode "bottom-margin"}}">
+  {{#unless isEditMode}}
+    <label for="select-metric" class="control-label te-label te-label--taller required">Can't find your metric?
+      {{#link-to "self-serve.import-metric" class="thirdeye-link-secondary thirdeye-link-secondary--inside"}}
+        Import a Metric From InGraphs
+      {{/link-to}}
+    </label>
+  {{/unless}}
+  <div class="pull-right">
+    {{bs-button
+      defaultText="Reset"
+      type="outline-primary"
+      buttonType="reset"
+      onClick=(action "resetYAML")
+      class="te-button te-button--link"
+    }}
+    {{bs-button
+      defaultText="View Docs & Examples"
+      type="outline-primary"
+      buttonType="link"
+      onClick=(action "triggerDoc")
+      class="te-button te-button--cancel"
+    }}
+  </div>
+</div>
+<div class="col-xs-12 {{if isEditMode "bottom-margin"}}">
+  {{ember-ace
+    lines=35
+    value=currentYamlAlert
+    suggestCompletions=(action 'yamlSuggestions')
+    enableLiveAutocompletion=true
+    update=(action "onEditingDetectionYamlAction")
+    mode="ace/mode/yaml"
+  }}
+  {{#if isEditMode}}
+    <div class="pull-right">
+      {{bs-button
+        defaultText="Update Alert"
+        type="primary"
+        buttonType="submit"
+        disabled=disableYamlSave
+        onClick=(action "submitAlertEdit")
+        class="te-button te-button--submit"
+      }}
+    </div>
+  {{/if}}
+</div>
+<div class="col-xs-12">
+  {{#if isDetectionMsg}}
+    <div class="yaml-editor-msg">
+      <p class="yaml-editor-msg__icon"><i class="yaml-editor-msg__icon--error glyphicon glyphicon-remove-circle"></i>Error in alert yaml</p>
+      <p>Message: {{detectionMsg}}</p>
+    </div>
+  {{/if}}
+</div>

--- a/thirdeye/thirdeye-frontend/app/pods/components/subscription-yaml/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/subscription-yaml/component.js
@@ -1,0 +1,264 @@
+/**
+ * Component to render the subscription group yaml editor.
+ * @module components/subscription-yaml
+ * @property {number} subscriptionGroupId - the subscription group id in edit mode
+ * @property {boolean} isEditMode - to activate the edit mode
+ * @property {Object} subscriptionGroupNames - the list of subscription groups
+ * @property {Object} subscriptionYaml - the subscription group yaml
+ * @property {function} updateSubscriptionYaml - bubble up the subscription group yaml to parent
+ * @example
+   {{subscription-yaml
+     subscriptionGroupId=model.subscriptionGroupId
+     isEditMode=true
+     subscriptionGroupNames=model.subscriptionGroupNames
+     subscriptionYaml=model.subscriptionYaml
+     setSubscriptionYaml=updateSubscriptionYaml
+   }}
+ * @authors lohuynh and hjackson
+ */
+
+import Component from '@ember/component';
+import {computed, set, get, getProperties} from '@ember/object';
+import {yamlAlertSettings, toastOptions} from 'thirdeye-frontend/utils/constants';
+import fetch from 'fetch';
+import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
+import config from 'thirdeye-frontend/config/environment';
+
+const CREATE_GROUP_TEXT = 'Create a new subscription group';
+
+export default Component.extend({
+  classNames: ['yaml-editor'],
+  notifications: service('toast'),
+  /**
+   * Properties we expect to receive for the yaml-editor
+   */
+  currentMetric: null,
+  isYamlParseable: true,
+  alertSettingsTitle: 'Define subscription configuration',
+  isEditMode: false,
+  showSettings: true,
+  disableSubGroupSave: true,
+  subscriptionMsg: '',                //General subscription failures
+  subscriptionYaml:  null,            // The YAML for the subscription group
+  currentYamlSettingsOriginal: yamlAlertSettings,
+  showAnomalyModal: false,
+  showNotificationModal: false,
+  setSubscriptionYaml: null, // function passed in from parent
+
+
+
+  init() {
+    this._super(...arguments);
+    const subscriptionGroupNamesDisplay = get(this, 'subscriptionGroupNamesDisplay');
+    // Checks to make sure there is a subscription group array with at least one subscription group
+    if (subscriptionGroupNamesDisplay && Array.isArray(subscriptionGroupNamesDisplay) && subscriptionGroupNamesDisplay.length > 0) {
+      const firstGroup = subscriptionGroupNamesDisplay[0];
+      const setSubscriptionYaml = get(this, 'setSubscriptionYaml');
+      setSubscriptionYaml(firstGroup.yaml);
+      set(this, 'groupName', firstGroup);
+      set(this, 'subscriptionGroupId', firstGroup.id);
+    }
+  },
+
+  /**
+   * populates subscription group dropdown with options from fetch or model
+   * @method subscriptionGroupNamesDisplay
+   * @return {Object}
+   */
+  subscriptionGroupNamesDisplay: computed(
+    'subscriptionGroupNames',
+    async function() {
+      const {
+        isEditMode,
+        subscriptionGroupNames
+      } = this.getProperties('isEditMode', 'subscriptionGroupNames');
+      const createGroup = {
+        name: CREATE_GROUP_TEXT,
+        id: 'n/a',
+        yaml: yamlAlertSettings
+      };
+      const moddedArray = [createGroup];
+      if (isEditMode) {
+        return [...moddedArray, ...subscriptionGroupNames];
+      }
+      const subscriptionGroups = await get(this, '_fetchSubscriptionGroups').perform();
+      return [...moddedArray, ...subscriptionGroups];
+    }
+  ),
+
+  /**
+   * Flag to trigger special case of no existing subscription groups for an alert
+   * @method noExistingSubscriptionGroup
+   * @return {Boolean}
+   */
+  noExistingSubscriptionGroup: computed(
+    'subscriptionGroupNames',
+    function() {
+      const subscriptionGroupNames = get(this, 'subscriptionGroupNames');
+      if (subscriptionGroupNames && Array.isArray(subscriptionGroupNames) && subscriptionGroupNames.length > 0) {
+        return false;
+      }
+      return true;
+    }
+  ),
+
+  /**
+   * Change subscription group button text depending on whether creating or updating
+   * @method subGroupButtonText
+   * @return {String}
+   */
+  subGroupButtonText: computed(
+    'noExistingSubscriptionGroup',
+    'groupName',
+    function() {
+      const {
+        noExistingSubscriptionGroup,
+        groupName
+      } = this.getProperties('noExistingSubscriptionGroup', 'groupName');
+      return (noExistingSubscriptionGroup || !groupName || groupName.name === CREATE_GROUP_TEXT) ? "Create Group" : "Update Group";
+    }
+  ),
+
+  /**
+   * sets Yaml value displayed to contents of subscriptionYaml or currentYamlSettingsOriginal
+   * @method currentSubscriptionYaml
+   * @return {String}
+   */
+  currentSubscriptionYaml: computed(
+    'subscriptionYaml',
+    function() {
+      const subscriptionYaml = get(this, 'subscriptionYaml');
+      return subscriptionYaml || get(this, 'currentYamlSettingsOriginal');
+    }
+  ),
+
+  isSubscriptionMsg: computed(
+    'subscriptionMsg',
+    function() {
+      const subscriptionMsg = get(this, 'subscriptionMsg');
+      return subscriptionMsg !== '';
+    }
+  ),
+
+  _fetchSubscriptionGroups: task(function* () {
+    //dropdown of subscription groups
+    const url2 = `/detection/subscription-groups`;
+    const postProps2 = {
+      method: 'get',
+      headers: { 'content-type': 'application/json' }
+    };
+    const notifications = get(this, 'notifications');
+
+    try {
+      const response = yield fetch(url2, postProps2);
+      const json = yield response.json();
+      return json.filterBy('yaml');
+    } catch (error) {
+      notifications.error('Failed to retrieve subscription groups.', 'Error', toastOptions);
+    }
+  }).drop(),
+
+  // Method for handling subscription group, whether there are any or not
+  async _handleSubscriptionGroup(subscriptionYaml, notifications, subscriptionGroupId) {
+    const {
+      noExistingSubscriptionGroup,
+      groupName
+    } = this.getProperties('noExistingSubscriptionGroup', 'groupName');
+    if (noExistingSubscriptionGroup || !groupName || groupName.name === CREATE_GROUP_TEXT) {
+      //POST settings
+      const setting_url = '/yaml/subscription';
+      const settingsPostProps = {
+        method: 'POST',
+        body: subscriptionYaml,
+        headers: { 'content-type': 'text/plain' }
+      };
+      try {
+        const settings_result = await fetch(setting_url, settingsPostProps);
+        const settings_status  = get(settings_result, 'status');
+        const settings_json = await settings_result.json();
+        if (settings_status !== 200) {
+          set(this, 'errorMsg', get(settings_json, 'message'));
+          notifications.error(`Failed to save the subscription configuration due to: ${settings_json.message}.`, 'Error', toastOptions);
+        } else {
+          notifications.success('Subscription configuration saved successfully', 'Done', toastOptions);
+        }
+      } catch (error) {
+        notifications.error('Error while saving subscription config.', error, toastOptions);
+      }
+    } else {
+      //PUT settings
+      const setting_url = `/yaml/subscription/${subscriptionGroupId}`;
+      const settingsPostProps = {
+        method: 'PUT',
+        body: subscriptionYaml,
+        headers: { 'content-type': 'text/plain' }
+      };
+      try {
+        const settings_result = await fetch(setting_url, settingsPostProps);
+        const settings_status  = get(settings_result, 'status');
+        const settings_json = await settings_result.json();
+        if (settings_status !== 200) {
+          set(this, 'errorMsg', get(settings_json, 'message'));
+          notifications.error(`Failed to save the subscription configuration due to: ${settings_json.message}.`, 'Error', toastOptions);
+        } else {
+          notifications.success('Subscription configuration saved successfully', 'Done', toastOptions);
+        }
+      } catch (error) {
+        notifications.error('Error while saving subscription config.', error, toastOptions);
+      }
+    }
+  },
+
+  actions: {
+    /**
+     * resets given yaml field to default value for creation mode and server value for edit mode
+     */
+    resetYAML() {
+      const setSubscriptionYaml = get(this, 'setSubscriptionYaml');
+      setSubscriptionYaml(get(this, 'currentYamlSettingsOriginal'));
+    },
+
+    /**
+     * Links to subscription group configuration section of wiki
+     */
+    triggerDoc() {
+      window.open(config.docs.subscriptionConfig);
+    },
+
+    /**
+     * Activates 'Create changes' button and stores YAML content in subscriptionYaml
+     */
+    onEditingSubscriptionYamlAction(value) {
+      const setSubscriptionYaml = get(this, 'setSubscriptionYaml');
+      setSubscriptionYaml(value);
+      set(this, 'disableSubGroupSave', false);
+    },
+
+    /**
+     * Updates the subscription settings yaml with user section
+     */
+    onSubscriptionGroupSelectionAction(value) {
+      if(value.yaml) {
+        const setSubscriptionYaml = get(this, 'setSubscriptionYaml');
+        setSubscriptionYaml(value.yaml);
+        set(this, 'groupName', value);
+        set(this, 'subscriptionGroupId', value.id);
+      }
+    },
+
+    /**
+     * Fired by subscription group button in YAML UI in edit mode
+     * Grabs subscription group yaml and posts or puts it to the backend.
+     */
+    async submitSubscriptionGroup() {
+      const {
+        subscriptionYaml,
+        notifications,
+        subscriptionGroupId
+      } = getProperties(this, 'subscriptionYaml', 'notifications', 'subscriptionGroupId');
+      // If there is no existing subscription group, this method will handle it
+      this._handleSubscriptionGroup(subscriptionYaml, notifications, subscriptionGroupId);
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/subscription-yaml/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/subscription-yaml/template.hbs
@@ -1,0 +1,67 @@
+<div class="col-xs-12">
+  <legend class="te-form__section-title">{{alertSettingsTitle}}</legend>
+</div>
+<div class="col-xs-4">
+  <label class="te-label te-label--small">Add this alert to a subscription group</label>
+
+  {{!--  subscription group --}}
+  {{#power-select
+    placeholder="Create a new subscription group"
+    options=subscriptionGroupNamesDisplay
+    selected=groupName
+    searchField="name"
+    onchange=(action 'onSubscriptionGroupSelectionAction')
+    as |groupName|
+  }}
+    {{groupName.name}} ({{groupName.id}})
+  {{/power-select}}
+</div>
+<div class="col-xs-12">
+  <label for="select-metric" class="control-label te-label te-label--taller required">Can't find your team? Contact
+    <a class="thirdeye-link-secondary" target="_blank" href="mailto:ask_thirdeye@linkedin.com">ask_thirdeye@linkedin.com</a>
+  </label>
+  <div class="pull-right">
+    {{bs-button
+      defaultText="Reset"
+      type="outline-primary"
+      buttonType="reset"
+      onClick=(action "resetYAML" "subscription")
+      class="te-button te-button--link"
+    }}
+    {{bs-button
+      defaultText="View Docs & Examples"
+      type="outline-primary"
+      buttonType="link"
+      onClick=(action "triggerDoc" "subscription")
+      class="te-button te-button--cancel"
+    }}
+  </div>
+</div>
+<div class="col-xs-12">
+  {{!-- subscription settings editor --}}
+  {{ember-ace
+    lines=25
+    value=currentSubscriptionYaml
+    update=(action "onEditingSubscriptionYamlAction")
+    mode="ace/mode/yaml"
+  }}
+</div>
+<div class="col-xs-12">
+  {{#if isSubscriptionMsg}}
+    <div class="yaml-editor-msg">
+      <p class="yaml-editor-msg__icon"><i class="yaml-editor-msg__icon--error glyphicon glyphicon-remove-circle"></i>Error in the subscription yaml</p>
+      <p>Message: {{subscriptionMsg}}</p>
+    </div>
+  {{/if}}
+</div>
+
+{{#if isEditMode}}
+  {{bs-button
+      defaultText=subGroupButtonText
+      type="primary"
+      buttonType="submit"
+      disabled=disableSubGroupSave
+      onClick=(action "submitSubscriptionGroup")
+      class="te-button te-button--submit"
+    }}
+{{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/home/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/index/route.js
@@ -50,7 +50,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
    */
   async model(params) {
     const { appName, startDate, endDate, duration, feedbackType, subGroup } = params;//check params
-    const applications = await this.get('anomaliesApiService').queryApplications(appName, startDate);// Get all applicatons available
+    const applications = await this.get('anomaliesApiService').queryApplications();// Get all applicatons available
     const subscriptionGroups = await this.get('anomaliesApiService').querySubscriptionGroups(); // Get all subscription groups available
 
     return hash({

--- a/thirdeye/thirdeye-frontend/app/pods/home/share-dashboard/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/share-dashboard/route.js
@@ -43,7 +43,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
   async model(params) {
     const { appName, startDate, endDate, duration, feedbackType, shareId, subGroup } = params;//check params
-    const applications = await get(this, 'anomaliesApiService').queryApplications(appName, startDate);// Get all applicatons available
+    const applications = await get(this, 'anomaliesApiService').queryApplications();// Get all applicatons available
     const subscriptionGroups = await this.get('anomaliesApiService').querySubscriptionGroups(); // Get all subscription groups available
 
     return hash({

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
@@ -4,7 +4,7 @@
  * @exports alert create model
  */
 import fetch from 'fetch';
-import RSVP from 'rsvp';
+import { hash } from 'rsvp';
 import moment from 'moment';
 import Route from '@ember/routing/route';
 import { task, timeout } from 'ember-concurrency';
@@ -19,6 +19,7 @@ import { get } from '@ember/object';
 let onboardStartTime = {};
 
 export default Route.extend({
+  anomaliesApiService: service('services/api/anomalies'),
   session: service(),
 
   /**
@@ -26,11 +27,14 @@ export default Route.extend({
    * @method model
    * @return {Object}
    */
-  model(params, transition) {
+  async model(params, transition) {
     const debug = transition.state.queryParams.debug || '';
-    return RSVP.hash({
-      allConfigGroups: fetch(selfServeApiCommon.allConfigGroups).then(checkStatus),
-      allAppNames: fetch(selfServeApiCommon.allApplications).then(checkStatus),
+    const applications = await this.get('anomaliesApiService').queryApplications(); // Get all applicatons available
+    const subscriptionGroups = await this.get('anomaliesApiService').querySubscriptionGroups(); // Get all subscription groups available
+
+    return hash({
+      subscriptionGroups,
+      applications,
       debug
     });
   },

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -23,13 +23,13 @@
   {{#if isForm}}
     <fieldset class="te-form__section te-form__section--first row">
       <div class="col-xs-12">
-        <legend class="te-form__section-title">Select a metric to monitor</legend>
+        <legend class="te-form__section-title">Define metric</legend>
       </div>
       <div class="col-xs-12 col-sm-8">
-        <label for="select-metric" class="control-label te-label te-label--taller required">Search for a metric, or
+        <label for="select-metric" class="control-label te-label te-label--taller required">Select a metric to monitor, or
           {{#link-to "self-serve.import-metric" class="thirdeye-link-secondary thirdeye-link-secondary--inside"}}
-            Import a Metric From InGraphs
-          {{/link-to}} 
+            Import from InGraphs
+          {{/link-to}}
           {{!-- or
           {{#link-to "self-serve.import-sql-metric" class="thirdeye-link-secondary thirdeye-link-secondary--inside"}}
             Import a Metric From Presto or MySQL
@@ -56,7 +56,7 @@
       </div>
 
       <div class="te-form__custom-field te-form__custom-field--lower col-xs-6 col-sm-4">
-        <label for="select-granularity" class="control-label te-label te-label--taller">Monitor at this data granularity</label>
+        <label for="select-granularity" class="control-label te-label te-label--taller">Data granularity</label>
         {{#power-select
           options=metricGranularityOptions
           selected=selectedGranularity
@@ -426,11 +426,58 @@
       {{/if}}
     </fieldset>
   {{else}}
-    {{#yaml-editor
-      isEditMode=false
-      showSettings=true
-    }}
-    {{/yaml-editor}}
+    <fieldset class="te-form__section te-form__section--first row">
+
+      {{#detection-yaml
+        isEditMode=false
+        detectionYaml=detectionYaml
+        setDetectionYaml=(action "updateDetectionYaml")
+      }}
+      {{/detection-yaml}}
+
+      <div class="col-xs-12">
+        {{#bs-accordion onChange=(action "changeAccordion") as |acc|}}
+          {{#acc.item value=preview as |aitem|}}
+            {{#aitem.title}}
+              <section class="dashboard-container__title thirdeye-link-secondary">Preview alert [Beta] {{if toggleCollapsed "/ Enter YAML configuration to preview alert." ""}}
+                <span class="pull-right"><i class="glyphicon glyphicon-menu-{{if toggleCollapsed "down" "up"}}"></i></span>
+              </section>
+            {{/aitem.title}}
+            {{#aitem.body}}
+              {{#alert-details
+                isPreviewMode=true
+                alertYaml=detectionYaml
+                dataIsCurrent=alertDataIsCurrent
+              }}
+                {{yield}}
+              {{/alert-details}}
+            {{/aitem.body}}
+          {{/acc.item}}
+        {{/bs-accordion}}
+      </div>
+
+      <div class="col-xs-12">
+        <hr/>
+      </div>
+
+      {{#subscription-yaml
+        isEditMode=false
+        subscriptionYaml=subscriptionYaml
+        setSubscriptionYaml=(action "updateSubscriptionYaml")
+      }}
+      {{/subscription-yaml}}
+
+    </fieldset>
+    <fieldset class="te-form__section-submit">
+      {{bs-button
+        defaultText="Create alert"
+        type="primary"
+        buttonType="submit"
+        disabled=disableYamlSave
+        onClick=(action "createAlertYamlAction")
+        class="te-button te-button--submit"
+      }}
+    </fieldset>
   {{/if}}
   {{outlet}}
 </main>

--- a/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
@@ -111,17 +111,15 @@ export default Service.extend({
   /**
    * @summary Fetch all application names. We can use it to list in the select box.
    * @method queryApplications
-   * @param {String} appName - the application name for creating the cacheKey
    * @return {Ember.RSVP.Promise}
    * @example: /thirdeye/entity/APPLICATION
      usage: `this.get('anomaliesApiService').queryApplications();`
    */
-  async queryApplications(appName, start) {
+  async queryApplications() {
     const queryCache = this.get('queryCache');
     const modelName = 'application';
-    const query = { appName, start };//remove end to persist cache
     const cacheKey = queryCache.urlForQueryKey(modelName, {});//TODO: Won't pass all the `query` here. The `cacheKey` do not need to be uniqued, since all apps has the same list of apps.
-    const applications = await queryCache.query(modelName, query, { reload: false, cacheKey });
+    const applications = await queryCache.query(modelName, {}, { reload: false, cacheKey });
     return applications;
   },
 


### PR DESCRIPTION
…mponents

1) breaks yaml-editor into two separate components: detection-yaml and subscription-yaml
2) Installs new components on create-alert
3) Moves preview directly onto create-alert and migrates shared props to controller

These actions will help prepare the create-alert route for forms (full ui).
The next step is to install new components on edit alert.  