### PR TITLE
Add RealtimeConsumptionCatchupServiceCallback

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -240,11 +240,9 @@ public class HelixBrokerStarter {
     LOGGER.info("Registering service status handler");
     double minResourcePercentForStartup = _brokerConf.getDouble(Broker.CONFIG_OF_BROKER_MIN_RESOURCE_PERCENT_FOR_START,
         Broker.DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START);
-    ServiceStatus.setServiceStatusCallback(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList
-        .of(new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_participantHelixManager,
-                _clusterName, _brokerId, minResourcePercentForStartup),
-            new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_participantHelixManager,
-                _clusterName, _brokerId, minResourcePercentForStartup))));
+    ServiceStatus.setServiceStatusCallback(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList.of(
+        new ServiceStatus.IdealStateServiceStatusCallback(_participantHelixManager, _clusterName, _brokerId,
+            minResourcePercentForStartup))));
 
     LOGGER.info("Finish starting Pinot broker");
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -35,6 +35,7 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Message;
 import org.apache.helix.participant.StateMachineEngine;
@@ -237,14 +238,30 @@ public class HelixBrokerStarter {
         .addPreConnectCallback(() -> brokerMetrics.addMeteredGlobalValue(BrokerMeter.HELIX_ZOOKEEPER_RECONNECTS, 1L));
 
     // Register the service status handler
-    LOGGER.info("Registering service status handler");
-    double minResourcePercentForStartup = _brokerConf.getDouble(Broker.CONFIG_OF_BROKER_MIN_RESOURCE_PERCENT_FOR_START,
-        Broker.DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START);
-    ServiceStatus.setServiceStatusCallback(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList.of(
-        new ServiceStatus.IdealStateServiceStatusCallback(_participantHelixManager, _clusterName, _brokerId,
-            minResourcePercentForStartup))));
+    registerServiceStatusHandler();
 
     LOGGER.info("Finish starting Pinot broker");
+  }
+
+  /**
+   * Fetches the resources to monitor and registers the {@link org.apache.pinot.common.utils.ServiceStatus.ServiceStatusCallback}s
+   */
+  private void registerServiceStatusHandler() {
+    List<String> resourcesToMonitor = new ArrayList<>(1);
+    IdealState resourceIdealState = _helixAdmin.getResourceIdealState(_clusterName, Helix.BROKER_RESOURCE_INSTANCE);
+    if (resourceIdealState != null && resourceIdealState.isEnabled()) {
+      resourcesToMonitor.add(Helix.BROKER_RESOURCE_INSTANCE);
+    }
+
+    double minResourcePercentForStartup = _brokerConf.getDouble(Broker.CONFIG_OF_BROKER_MIN_RESOURCE_PERCENT_FOR_START,
+        Broker.DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START);
+
+    LOGGER.info("Registering service status handler");
+    ServiceStatus.setServiceStatusCallback(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList.of(
+        new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_participantHelixManager, _clusterName,
+            _brokerId, resourcesToMonitor, minResourcePercentForStartup),
+        new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_participantHelixManager, _clusterName,
+            _brokerId, resourcesToMonitor, minResourcePercentForStartup))));
   }
 
   private void addInstanceTagIfNeeded() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -248,9 +248,14 @@ public class HelixBrokerStarter {
    */
   private void registerServiceStatusHandler() {
     List<String> resourcesToMonitor = new ArrayList<>(1);
-    IdealState resourceIdealState = _helixAdmin.getResourceIdealState(_clusterName, Helix.BROKER_RESOURCE_INSTANCE);
-    if (resourceIdealState != null && resourceIdealState.isEnabled()) {
-      resourcesToMonitor.add(Helix.BROKER_RESOURCE_INSTANCE);
+    IdealState brokerResourceIdealState = _helixAdmin.getResourceIdealState(_clusterName, Helix.BROKER_RESOURCE_INSTANCE);
+    if (brokerResourceIdealState != null && brokerResourceIdealState.isEnabled()) {
+      for (String partitionName : brokerResourceIdealState.getPartitionSet()) {
+        if (brokerResourceIdealState.getInstanceSet(partitionName).contains(_brokerId)) {
+          resourcesToMonitor.add(Helix.BROKER_RESOURCE_INSTANCE);
+          break;
+        }
+      }
     }
 
     double minResourcePercentForStartup = _brokerConf.getDouble(Broker.CONFIG_OF_BROKER_MIN_RESOURCE_PERCENT_FOR_START,

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TableNameBuilder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TableNameBuilder.java
@@ -131,7 +131,7 @@ public class TableNameBuilder {
   }
 
   /**
-   * Return whether the given resource name represents an realtime table resource.
+   * Return whether the given resource name represents a realtime table resource.
    */
   public static boolean isRealtimeTableResource(@Nonnull String resourceName) {
     return REALTIME.tableHasTypeSuffix(resourceName);

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TableNameBuilder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TableNameBuilder.java
@@ -129,4 +129,11 @@ public class TableNameBuilder {
   public static boolean isOfflineTableResource(@Nonnull String resourceName) {
     return OFFLINE.tableHasTypeSuffix(resourceName);
   }
+
+  /**
+   * Return whether the given resource name represents an realtime table resource.
+   */
+  public static boolean isRealtimeTableResource(@Nonnull String resourceName) {
+    return REALTIME.tableHasTypeSuffix(resourceName);
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -187,6 +187,9 @@ public class CommonConstants {
     public static final String CONFIG_OF_SERVER_MIN_RESOURCE_PERCENT_FOR_START =
         "pinot.server.startup.minResourcePercent";
     public static final double DEFAULT_SERVER_MIN_RESOURCE_PERCENT_FOR_START = 100.0;
+    public static final String CONFIG_OF_STARTUP_REALTIME_CONSUMPTION_CATCHUP_WAIT_MS =
+        "pinot.server.starter.realtimeConsumptionCatchupWaitMs";
+    public static final int DEFAULT_STARTUP_REALTIME_CONSUMPTION_CATCHUP_WAIT_MS = 0;
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String DEFAULT_READ_MODE = "heap";

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.common.utils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -216,9 +215,9 @@ public class ServiceStatus {
       implements ServiceStatusCallback {
 
     protected final String _clusterName;
-    final String _instanceName;
+    protected final String _instanceName;
     protected final HelixAdmin _helixAdmin;
-    final HelixDataAccessor _helixDataAccessor;
+    protected final HelixDataAccessor _helixDataAccessor;
 
     private final Set<String> _resourcesToMonitor;
     private final int _numTotalResourcesToMonitor;
@@ -230,10 +229,10 @@ public class ServiceStatus {
 
     public IdealStateMatchServiceStatusCallback(HelixManager helixManager, String clusterName, String instanceName,
         double minResourcesStartPercent) {
-      _helixAdmin = helixManager.getClusterManagmentTool();
-      _helixDataAccessor = helixManager.getHelixDataAccessor();
       _clusterName = clusterName;
       _instanceName = instanceName;
+      _helixAdmin = helixManager.getClusterManagmentTool();
+      _helixDataAccessor = helixManager.getHelixDataAccessor();
 
       _resourcesToMonitor = new HashSet<>();
       for (String resourceName : _helixAdmin.getResourcesInCluster(_clusterName)) {
@@ -262,10 +261,10 @@ public class ServiceStatus {
 
     public IdealStateMatchServiceStatusCallback(HelixManager helixManager, String clusterName, String instanceName,
         List<String> resourcesToMonitor, double minResourcesStartPercent) {
-      _helixAdmin = helixManager.getClusterManagmentTool();
-      _helixDataAccessor = helixManager.getHelixDataAccessor();
       _clusterName = clusterName;
       _instanceName = instanceName;
+      _helixAdmin = helixManager.getClusterManagmentTool();
+      _helixDataAccessor = helixManager.getHelixDataAccessor();
 
       _resourcesToMonitor = new HashSet<>(resourcesToMonitor);
       _numTotalResourcesToMonitor = _resourcesToMonitor.size();
@@ -369,17 +368,8 @@ public class ServiceStatus {
       return Status.GOOD;
     }
 
-    @Override
-    public synchronized String getStatusDescription() {
-      return _statusDescription;
-    }
-
-    protected IdealState getResourceIdealState(String resourceName) {
-      return _helixAdmin.getResourceIdealState(_clusterName, resourceName);
-    }
-
     private StatusDescriptionPair evaluateResourceStatus(String resourceName) {
-      IdealState idealState = _helixAdmin.getResourceIdealState(_clusterName, resourceName);;
+      IdealState idealState = getResourceIdealState(resourceName);
       // If the resource has been removed or disabled, ignore it
       if (idealState == null || !idealState.isEnabled()) {
         return new StatusDescriptionPair(Status.GOOD, STATUS_DESCRIPTION_NONE);
@@ -433,6 +423,14 @@ public class ServiceStatus {
       return stringBuilder.append("...]").toString();
     }
 
+    @Override
+    public synchronized String getStatusDescription() {
+      return _statusDescription;
+    }
+
+    protected IdealState getResourceIdealState(String resourceName) {
+      return _helixAdmin.getResourceIdealState(_clusterName, resourceName);
+    }
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -190,6 +190,7 @@ public class ServiceStatus {
         long realtimeConsumptionCatchupWaitMs) {
       super(helixManager, clusterName, instanceName);
 
+      long startTime = System.currentTimeMillis();
       boolean hasConsumingSegments = false;
 
       for (String resourceName : getResourcesInCluster()) {
@@ -217,7 +218,6 @@ public class ServiceStatus {
         _serviceStatus = Status.GOOD;
         _statusDescription = "No consuming segments to monitor. Setting status GOOD";
       } else {
-        long startTime = System.currentTimeMillis();
         // A consuming segment will actually be ready to serve queries after (time of creation of partition consumer) + (configured max time to catchup)
         // We are approximating it to (time of server startup) + (configured max time to catch up)
         _endWaitTime = startTime + TimeUnit.SECONDS.toMillis(realtimeConsumptionCatchupWaitMs);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -130,9 +130,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       if (instance.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE) || instance
           .startsWith(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)) {
         _serviceStatusCallbacks.add(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList
-            .of(new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_helixManager, _clusterName,
+            .of(new ServiceStatus.IdealStateServiceStatusCallback(_helixManager, _clusterName,
                     instance, 100.0),
-                new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixManager, _clusterName,
+                new ServiceStatus.IdealStateServiceStatusCallback(_helixManager, _clusterName,
                     instance, 100.0))));
       }
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -197,16 +197,12 @@ public class HelixServerStarter {
     // Register the service status handler
     double minResourcePercentForStartup = _serverConf
         .getDouble(CONFIG_OF_SERVER_MIN_RESOURCE_PERCENT_FOR_START, DEFAULT_SERVER_MIN_RESOURCE_PERCENT_FOR_START);
-    int consumptionCatchupWaitMs = _serverConf.getInt(
+    int realtimeConsumptionCatchupWaitMs = _serverConf.getInt(
         CommonConstants.Server.CONFIG_OF_STARTUP_REALTIME_CONSUMPTION_CATCHUP_WAIT_MS,
         CommonConstants.Server.DEFAULT_STARTUP_REALTIME_CONSUMPTION_CATCHUP_WAIT_MS);
     ServiceStatus.setServiceStatusCallback(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList.of(
-        new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_helixManager, _helixClusterName,
-            _instanceId, minResourcePercentForStartup),
-        new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixManager, _helixClusterName,
-            _instanceId, minResourcePercentForStartup),
-        new ServiceStatus.RealtimeConsumptionCatchupServiceStatusCallback(_helixManager, _helixClusterName, _instanceId,
-            consumptionCatchupWaitMs))));
+        new ServiceStatus.IdealStateServiceStatusCallback(_helixManager, _helixClusterName,
+            _instanceId, minResourcePercentForStartup, realtimeConsumptionCatchupWaitMs))));
 
     ControllerLeaderLocator.create(_helixManager);
 


### PR DESCRIPTION
Creating a ServiceCallback within ServiceStatus, to check that realtime consuming segments have caught up. This will help with latency issues which can happen during server startup, because the server has to catchup on a lot of consumption.
For the initial version, this only adds a static wait time (configurable). More smarts can be added later (monitor stability or idleness of stream consumption rate)