### PR TITLE
[TE] Fix MySql data source to read the epoch time stamps

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetUtils.java
@@ -95,7 +95,7 @@ public class ThirdEyeResultSetUtils {
         isISOFormat = true;
         inputDataDateTimeFormatter = DateTimeFormat.forPattern(timeFormat).withZone(dateTimeZone);
       }
-      if (sourceName.equals(MYSQL) || sourceName.equals(H2) ) {
+      if (isISOFormat && (sourceName.equals(MYSQL) || sourceName.equals(H2))) {
         serverDataDateTimeFormatter = DateTimeFormat.forPattern(timeFormat).withZone(DateTimeZone.getDefault());
       }
 


### PR DESCRIPTION
MySQL data source will throw an exception when reading the epoch timestamps dataset. This PR fixes the bug.