### PR TITLE
Remove kafka dependency from PartitionFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/partition/ByteArrayPartitionFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/partition/ByteArrayPartitionFunction.java
@@ -19,8 +19,7 @@
 package org.apache.pinot.core.data.partition;
 
 import com.google.common.base.Preconditions;
-import kafka.producer.ByteArrayPartitioner;
-
+import java.util.Arrays;
 
 /**
  * Implementation of {@link Byte array partitioner}
@@ -29,7 +28,6 @@ import kafka.producer.ByteArrayPartitioner;
 public class ByteArrayPartitionFunction implements PartitionFunction {
   private static final String NAME = "ByteArray";
   private final int _numPartitions;
-  public ByteArrayPartitioner _byteArrayPartitioner;
 
   /**
    * Constructor for the class.
@@ -38,12 +36,11 @@ public class ByteArrayPartitionFunction implements PartitionFunction {
   public ByteArrayPartitionFunction(int numPartitions) {
     Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0, specified", numPartitions);
     _numPartitions = numPartitions;
-    _byteArrayPartitioner = new ByteArrayPartitioner(null);
   }
 
   @Override
   public int getPartition(Object valueIn) {
-    return _byteArrayPartitioner.partition(valueIn.toString().getBytes(), _numPartitions);
+    return abs(Arrays.hashCode(valueIn.toString().getBytes())) % _numPartitions;
   }
 
   @Override
@@ -54,6 +51,10 @@ public class ByteArrayPartitionFunction implements PartitionFunction {
   @Override
   public String toString() {
     return NAME;
+  }
+
+  private int abs(int n) {
+    return (n == Integer.MIN_VALUE) ? 0 : Math.abs(n);
   }
 }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/partition/MurmurPartitionFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/partition/MurmurPartitionFunction.java
@@ -19,19 +19,11 @@
 package org.apache.pinot.core.data.partition;
 
 import com.google.common.base.Preconditions;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.pinot.common.utils.StringUtil;
 
 
 /**
- * Implementation of {@link PartitionFunction} that mimics Kafka's
- * {@link org.apache.kafka.clients.producer.internals.DefaultPartitioner}.
- *
- * **** ALERT ****
- * However, this is not general purpose. It assumes that the partition key
- * was a string as used by the Tracking Producer. This is only a reference
- * implementation and users should create their own for their specific partitioner.
- *
+ * Implementation of {@link PartitionFunction} which partitions based on 32 bit murmur hash
  */
 public class MurmurPartitionFunction implements PartitionFunction {
   private static final String NAME = "Murmur";
@@ -49,7 +41,7 @@ public class MurmurPartitionFunction implements PartitionFunction {
   @Override
   public int getPartition(Object valueIn) {
     String value = (valueIn instanceof String) ? (String) valueIn : valueIn.toString();
-    return (Utils.murmur2(StringUtil.encodeUtf8(value)) & 0x7fffffff) % _numPartitions;
+    return (murmur2(StringUtil.encodeUtf8(value)) & 0x7fffffff) % _numPartitions;
   }
 
   @Override
@@ -60,5 +52,52 @@ public class MurmurPartitionFunction implements PartitionFunction {
   @Override
   public String toString() {
     return NAME;
+  }
+
+  /**
+   * Generates 32 bit murmur2 hash from byte array
+   * @param data byte array to hash
+   * @return 32 bit hash of the given array
+   */
+  private int murmur2(final byte[] data) {
+    int length = data.length;
+    int seed = 0x9747b28c;
+    // 'm' and 'r' are mixing constants generated offline.
+    // They're not really 'magic', they just happen to work well.
+    final int m = 0x5bd1e995;
+    final int r = 24;
+
+    // Initialize the hash to a random value
+    int h = seed ^ length;
+    int length4 = length / 4;
+
+    for (int i = 0; i < length4; i++) {
+      final int i4 = i * 4;
+      int k =
+          (data[i4 + 0] & 0xff) + ((data[i4 + 1] & 0xff) << 8) + ((data[i4 + 2] & 0xff) << 16) + ((data[i4 + 3] & 0xff)
+              << 24);
+      k *= m;
+      k ^= k >>> r;
+      k *= m;
+      h *= m;
+      h ^= k;
+    }
+
+    // Handle the last few bytes of the input array
+    switch (length % 4) {
+      case 3:
+        h ^= (data[(length & ~3) + 2] & 0xff) << 16;
+      case 2:
+        h ^= (data[(length & ~3) + 1] & 0xff) << 8;
+      case 1:
+        h ^= data[length & ~3] & 0xff;
+        h *= m;
+    }
+
+    h ^= h >>> 13;
+    h *= m;
+    h ^= h >>> 15;
+
+    return h;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/partition/MurmurPartitionFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/partition/MurmurPartitionFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.data.partition;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.pinot.common.utils.StringUtil;
 
@@ -55,11 +56,14 @@ public class MurmurPartitionFunction implements PartitionFunction {
   }
 
   /**
+   * NOTE: This code has been copied over from org.apache.kafka.common.utils.Utils::murmur2
+   *
    * Generates 32 bit murmur2 hash from byte array
    * @param data byte array to hash
    * @return 32 bit hash of the given array
    */
-  private int murmur2(final byte[] data) {
+  @VisibleForTesting
+  int murmur2(final byte[] data) {
     int length = data.length;
     int seed = 0x9747b28c;
     // 'm' and 'r' are mixing constants generated offline.

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/partition/PartitionFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/partition/PartitionFunctionFactory.java
@@ -63,6 +63,9 @@ public class PartitionFunctionFactory {
    * @param numPartitions Number of partitions.
    * @return Partition function
    */
+  // TODO: introduce a way to inject custom partition function
+  // a custom partition function could be used in the realtime stream partitioning or offline segment partitioning.
+  // The PartitionFunctionFactory should be able to support these default implementations, as well as instantiate based on config
   public static PartitionFunction getPartitionFunction(@Nonnull String functionName, int numPartitions) {
     PartitionFunctionType function = PartitionFunctionType.fromString(functionName);
     switch (function) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/partition/PartitionFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/partition/PartitionFunctionTest.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.core.data.partition;
 
 import java.util.Random;
-import kafka.producer.ByteArrayPartitioner;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.pinot.common.utils.StringUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;


### PR DESCRIPTION
As discussed in issue https://github.com/apache/incubator-pinot/issues/3998, we want to remove kafka dependency from pinot-core and pinot-common. The Murmur and ByteArray PartitionFunctions depend on kafka classes. We do not really need to depend on those classes. The hash logic is generic and can be copied over to our internal implementations.
Have added a note to introduce a clean way to inject custom PartitionFunctions.