### PR TITLE
Add config to disable HLC realtime segment completion

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -32,7 +32,6 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.StringUtil;
-import org.apache.pinot.controller.helix.core.util.HelixSetupUtils;
 import org.apache.pinot.filesystem.LocalPinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,8 +135,8 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS =
       "controller.realtime.segment.metadata.commit.numLocks";
   private static final String ENABLE_STORAGE_QUOTA_CHECK = "controller.enable.storage.quota.check";
-
   private static final String ENABLE_BATCH_MESSAGE_MODE = "controller.enable.batch.message.mode";
+  private static final String ALLOW_HLC_TABLES = "controller.allow.hlc.tables";
 
   // Defines the kind of storage and the underlying PinotFS implementation
   private static final String PINOT_FS_FACTORY_CLASS_PREFIX = "controller.storage.factory.class";
@@ -155,6 +154,7 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final int DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = 64;
   private static final boolean DEFAULT_ENABLE_STORAGE_QUOTA_CHECK = true;
   private static final boolean DEFAULT_ENABLE_BATCH_MESSAGE_MODE = false;
+  private static final boolean DEFAULT_ALLOW_HLC_TABLES = true;
   private static final String DEFAULT_CONTROLLER_MODE = ControllerMode.DUAL.name();
 
   private static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
@@ -636,5 +636,13 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public ControllerMode getControllerMode() {
     return ControllerMode.valueOf(getString(CONTROLLER_MODE, DEFAULT_CONTROLLER_MODE).toUpperCase());
+  }
+
+  public boolean getHLCTablesAllowed() {
+    return getBoolean(ALLOW_HLC_TABLES, DEFAULT_ALLOW_HLC_TABLES);
+  }
+
+  public void setHLCTablesAllowed(boolean allowHLCTables) {
+    setProperty(ALLOW_HLC_TABLES, allowHLCTables);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -136,6 +136,9 @@ public class ControllerConf extends PropertiesConfiguration {
       "controller.realtime.segment.metadata.commit.numLocks";
   private static final String ENABLE_STORAGE_QUOTA_CHECK = "controller.enable.storage.quota.check";
   private static final String ENABLE_BATCH_MESSAGE_MODE = "controller.enable.batch.message.mode";
+  // It is used to disable the HLC realtime segment completion and disallow HLC table in the cluster. True by default.
+  // If it's set to false, existing HLC realtime tables will stop consumption, and creation of new HLC tables will be disallowed.
+  // Please make sure there is no HLC table running in the cluster before disallowing it.
   private static final String ALLOW_HLC_TABLES = "controller.allow.hlc.tables";
 
   // Defines the kind of storage and the underlying PinotFS implementation

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -275,11 +275,11 @@ public class ControllerStarter {
             _controllerLeadershipManager, _config.getSegmentCommitTimeoutSeconds());
 
     if (_config.getHLCTablesAllowed()) {
-      LOGGER.info("HLC table is allowed. HLC realtime segment completion is enabled.");
+      LOGGER.info("Realtime tables with High Level consumers will be supported");
       _realtimeSegmentsManager = new PinotRealtimeSegmentManager(_helixResourceManager, _controllerLeadershipManager);
       _realtimeSegmentsManager.start(_controllerMetrics);
     } else {
-      LOGGER.info("HLC table is disallowed. HLC realtime segment completion is disabled.");
+      LOGGER.info("Realtime tables with High Level consumers will NOT be supported");
       _realtimeSegmentsManager = null;
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -131,6 +131,7 @@ public class PinotHelixResourceManager {
   private final long _externalViewOnlineToOfflineTimeoutMillis;
   private final boolean _isSingleTenantCluster;
   private final boolean _enableBatchMessageMode;
+  private final boolean _allowHLCTables;
 
   private HelixManager _helixZkManager;
   private HelixAdmin _helixAdmin;
@@ -145,7 +146,7 @@ public class PinotHelixResourceManager {
 
   public PinotHelixResourceManager(@Nonnull String zkURL, @Nonnull String helixClusterName,
       @Nonnull String controllerInstanceId, String dataDir, long externalViewOnlineToOfflineTimeoutMillis,
-      boolean isSingleTenantCluster, boolean enableBatchMessageMode) {
+      boolean isSingleTenantCluster, boolean enableBatchMessageMode, boolean allowHLCTables) {
     _helixZkURL = HelixConfig.getAbsoluteZkPathForHelix(zkURL);
     _helixClusterName = helixClusterName;
     _instanceId = controllerInstanceId;
@@ -153,19 +154,20 @@ public class PinotHelixResourceManager {
     _externalViewOnlineToOfflineTimeoutMillis = externalViewOnlineToOfflineTimeoutMillis;
     _isSingleTenantCluster = isSingleTenantCluster;
     _enableBatchMessageMode = enableBatchMessageMode;
+    _allowHLCTables = allowHLCTables;
   }
 
   public PinotHelixResourceManager(@Nonnull String zkURL, @Nonnull String helixClusterName,
       @Nonnull String controllerInstanceId, @Nonnull String dataDir) {
     this(zkURL, helixClusterName, controllerInstanceId, dataDir, DEFAULT_EXTERNAL_VIEW_UPDATE_TIMEOUT_MILLIS, false,
-        true);
+        true, true);
   }
 
   public PinotHelixResourceManager(@Nonnull ControllerConf controllerConf) {
     this(controllerConf.getZkStr(), controllerConf.getHelixClusterName(),
         controllerConf.getControllerHost() + "_" + controllerConf.getControllerPort(), controllerConf.getDataDir(),
         controllerConf.getExternalViewOnlineToOfflineTimeout(), controllerConf.tenantIsolationEnabled(),
-        controllerConf.getEnableBatchMessageMode());
+        controllerConf.getEnableBatchMessageMode(), controllerConf.getHLCTablesAllowed());
   }
 
   /**
@@ -1098,6 +1100,13 @@ public class PinotHelixResourceManager {
         updateReplicaGroupPartitionAssignment(tableConfig);
         break;
       case REALTIME:
+        // Check if HLC table is allowed
+        IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+        StreamConfig streamConfig = new StreamConfig(indexingConfig.getStreamConfigs());
+        if (streamConfig.hasHighLevelConsumerType() && !_allowHLCTables) {
+          throw new InvalidTableConfigException("Creating HLC table is not allowed for Table: " + tableNameWithType);
+        }
+
         // Ensure that realtime table is not created if schema is not present
         Schema schema =
             ZKMetadataProvider.getSchema(_propertyStore, TableNameBuilder.extractRawTableName(tableNameWithType));
@@ -1130,7 +1139,6 @@ public class PinotHelixResourceManager {
          * We also need to support the case when a high-level consumer already exists for a table and we are adding
          * the low-level consumers.
          */
-        IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
         ensureRealtimeClusterIsSetUp(tableConfig, tableNameWithType, indexingConfig);
 
         LOGGER.info("Successfully added or updated the table {} ", tableNameWithType);
@@ -1346,12 +1354,17 @@ public class PinotHelixResourceManager {
       throws IOException {
 
     if (tableType == TableType.REALTIME) {
+      // Check if HLC table is allowed
+      IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+      StreamConfig streamConfig = new StreamConfig(indexingConfig.getStreamConfigs());
+      if (streamConfig.hasHighLevelConsumerType() && !_allowHLCTables) {
+        throw new InvalidTableConfigException("HLC table is not allowed for Table: " + tableNameWithType);
+      }
       // Update replica group partition assignment to the property store if applicable
       if (ReplicationUtils.setupRealtimeReplicaGroups(tableConfig)) {
         updateReplicaGroupPartitionAssignment(tableConfig);
       }
       ZKMetadataProvider.setRealtimeTableConfig(_propertyStore, tableNameWithType, tableConfig.toZNRecord());
-      IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
       ensureRealtimeClusterIsSetUp(tableConfig, tableNameWithType, indexingConfig);
     } else if (tableType == TableType.OFFLINE) {
       // Update replica group partition assignment to the property store if applicable
@@ -1408,6 +1421,11 @@ public class PinotHelixResourceManager {
     setExistingTableConfig(tableConfig, tableNameWithType, type);
 
     if (type == TableType.REALTIME) {
+      // Check if HLC table is allowed
+      StreamConfig streamConfig = new StreamConfig(newConfigs.getStreamConfigs());
+      if (streamConfig.hasHighLevelConsumerType() && !_allowHLCTables) {
+        throw new InvalidTableConfigException("HLC table is not allowed for Table: " + tableNameWithType);
+      }
       ensureRealtimeClusterIsSetUp(tableConfig, tableName, newConfigs);
     }
   }


### PR DESCRIPTION
This PR adds a config to explicitly disable HLC realtime segment completion.
By default it is enabled.