### PR TITLE
Add metric on ControllerLeadershipManager

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -45,6 +45,9 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   DISABLED_TABLE_COUNT("TableCount", true),
   PERIODIC_TASK_NUM_TABLES_PROCESSED("PeriodicTaskNumTablesProcessed", true),
 
+  // Pinot controller leader
+  PINOT_CONTROLLER_LEADER("PinotControllerLeader", true),
+
   // Number of extra live instances needed
   SHORT_OF_LIVE_INSTANCES("ShortOfLiveInstances", false),
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -224,6 +224,7 @@ public class ControllerStarter {
     // Emit helix controller metrics
     _controllerMetrics.addCallbackGauge(CommonConstants.Helix.INSTANCE_CONNECTED_METRIC_NAME,
         () -> _helixControllerManager.isConnected() ? 1L : 0L);
+    // Deprecated, since getting the leadership of Helix does not mean Helix has been ready for pinot.
     _controllerMetrics.addCallbackGauge("helix.leader", () -> _helixControllerManager.isLeader() ? 1L : 0L);
     _helixControllerManager.addPreConnectCallback(
         () -> _controllerMetrics.addMeteredGlobalValue(ControllerMeter.HELIX_ZOOKEEPER_RECONNECTS, 1L));
@@ -252,9 +253,9 @@ public class ControllerStarter {
     // Note: Currently leadership depends on helix controller, thus assign helixControllerManager to ControllerLeadershipManager.
     // TODO: In the future when Helix separation is completed, leadership only depends on the master in leadControllerResource, and ControllerLeadershipManager will be removed.
     if (_helixControllerManager != null) {
-      _controllerLeadershipManager = new ControllerLeadershipManager(_helixControllerManager);
+      _controllerLeadershipManager = new ControllerLeadershipManager(_helixControllerManager, _controllerMetrics);
     } else {
-      _controllerLeadershipManager = new ControllerLeadershipManager(helixParticipantManager);
+      _controllerLeadershipManager = new ControllerLeadershipManager(helixParticipantManager, _controllerMetrics);
     }
 
     LOGGER.info("Starting task resource manager");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -1359,8 +1359,13 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     protected FakePinotLLCRealtimeSegmentManager(PinotHelixResourceManager pinotHelixResourceManager,
         List<String> existingLLCSegments) {
-      super(pinotHelixResourceManager, CONTROLLER_CONF, new ControllerMetrics(new MetricsRegistry()),
-          new ControllerLeadershipManager(pinotHelixResourceManager.getHelixZkManager()));
+      this(pinotHelixResourceManager, existingLLCSegments, new ControllerMetrics(new MetricsRegistry()));
+    }
+
+    protected FakePinotLLCRealtimeSegmentManager(PinotHelixResourceManager pinotHelixResourceManager,
+        List<String> existingLLCSegments, ControllerMetrics controllerMetrics) {
+      super(pinotHelixResourceManager, CONTROLLER_CONF, controllerMetrics,
+          new ControllerLeadershipManager(pinotHelixResourceManager.getHelixZkManager(), controllerMetrics));
 
       try {
         TableConfigCache mockCache = mock(TableConfigCache.class);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1146,8 +1146,13 @@ public class SegmentCompletionTest {
     public HelixManager _helixManager = mock(HelixManager.class);
 
     protected MockPinotLLCRealtimeSegmentManager(PinotHelixResourceManager pinotHelixResourceManager) {
-      super(pinotHelixResourceManager, CONTROLLER_CONF, new ControllerMetrics(new MetricsRegistry()),
-          new ControllerLeadershipManager(pinotHelixResourceManager.getHelixZkManager()));
+      this(pinotHelixResourceManager, new ControllerMetrics(new MetricsRegistry()));
+    }
+
+    protected MockPinotLLCRealtimeSegmentManager(PinotHelixResourceManager pinotHelixResourceManager,
+        ControllerMetrics controllerMetrics) {
+      super(pinotHelixResourceManager, CONTROLLER_CONF, controllerMetrics,
+          new ControllerLeadershipManager(pinotHelixResourceManager.getHelixZkManager(), controllerMetrics));
     }
 
     @Override
@@ -1199,12 +1204,13 @@ public class SegmentCompletionTest {
 
     protected MockSegmentCompletionManager(HelixManager helixManager, PinotLLCRealtimeSegmentManager segmentManager,
         boolean isLeader) {
-      this(helixManager, segmentManager, isLeader, new ControllerLeadershipManager(helixManager));
+      this(helixManager, segmentManager, isLeader, new ControllerMetrics(new MetricsRegistry()));
     }
 
     protected MockSegmentCompletionManager(HelixManager helixManager, PinotLLCRealtimeSegmentManager segmentManager,
-        boolean isLeader, ControllerLeadershipManager controllerLeadershipManager) {
-      super(helixManager, segmentManager, new ControllerMetrics(new MetricsRegistry()), controllerLeadershipManager,
+        boolean isLeader, ControllerMetrics controllerMetrics) {
+      super(helixManager, segmentManager, controllerMetrics,
+          new ControllerLeadershipManager(helixManager, controllerMetrics),
           SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds());
       _isLeader = isLeader;
     }


### PR DESCRIPTION
In large cluster, when a helix controller acquires the leadership, it needs to do a bunch of work to prepare for the leadership, like subscribing all the current state, etc. And Pinot leadership's related methods won't be called until Helix cluster finishes its work. Thus, it will take time for Pinot to start the leader's work while Helix immediately mark this controller as leader (Helix leader).

This PR marks the metric of checking Helix leader to be deprecated, and adds a new one of checking Pinot's leadership, so that we know it will always be the true Pinot leader when the metric is 1, and helix leadership preparation is completed.