### PR TITLE
Add support for custom record-readers in the create-segment tool

### DIFF
--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -126,6 +126,15 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-tools</artifactId>
+      <!-- Uncomment and add appropriate modules to add support for custom record readers
+           The example below is for ORC readers
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-orc</artifactId>
+        </exclusion>
+      </exclusions>
+      -->
     </dependency>
     <dependency>
       <groupId>com.101tec</groupId>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -42,6 +42,13 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
     </dependency>
+    <!-- Uncomment and add appropriate modules to add support for custom record readers
+         The example below is for ORC readers
+    <dependency>
+    <groupId>org.apache.pinot</groupId>
+    <artifactId>pinot-orc</artifactId>
+    </dependency>
+    -->
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-server</artifactId>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -228,15 +228,17 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
       }
     }
 
-    FileFormat configFormat = segmentGeneratorConfig.getFormat();
-    if (_format == null) {
-      if (configFormat == null) {
-        throw new RuntimeException("Format cannot be null in config file.");
-      }
-      _format = configFormat;
-    } else {
-      if (configFormat != _format && configFormat != FileFormat.AVRO) {
-        LOGGER.warn("Find format conflict in command line and config file, use config in command line: {}", _format);
+    if (segmentGeneratorConfig.getRecordReaderPath() == null) {
+      FileFormat configFormat = segmentGeneratorConfig.getFormat();
+      if (_format == null) {
+        if (configFormat == null) {
+          throw new RuntimeException("Either recordReaderPath (via generatorConfigFile option) or format must be specified.");
+        }
+        _format = configFormat;
+      } else {
+        if (configFormat != _format && configFormat != FileFormat.AVRO) {
+          LOGGER.warn("Find format conflict in command line and config file, use config in command line: {}", _format);
+        }
       }
     }
 
@@ -291,7 +293,10 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
     File[] files = dir.listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {
-        return name.toLowerCase().endsWith(_format.toString().toLowerCase());
+        if (_format != null) {
+          return name.toLowerCase().endsWith(_format.toString().toLowerCase());
+        }
+        return true;
       }
     });
 


### PR DESCRIPTION
Currently,  via pinot-admin, we can only work with builtin record-readers. This change adds support to work with either the format option or recordReaderPath option in the generationConfigFile.

For users to successfully use this for custom record readers, the pom file will need to updated to bundle the appropriate jars. I've included commented out examples for using ORC.

Testing done:
Tested generating pinot segment from ORC file with the following options:
cat ~/config:
{
"recordReaderPath": "org.apache.pinot.orc.data.readers.ORCRecordReader"
}

Command used to generate segments:
bin/pinot-admin.sh CreateSegment -dataDir ~/segments -schemaFile ~/schema -tableName testTable -outDir ~/segments_out -generatorConfigFile ~/config -segmentName testTable