### PR TITLE
[TE] Change process timeout to 2 minutes

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/alert/util/EmailScreenshotHelper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/alert/util/EmailScreenshotHelper.java
@@ -110,7 +110,7 @@ public class EmailScreenshotHelper {
         } while (line != null);
       }
     }
-    boolean isComplete = proc.waitFor(3, TimeUnit.MINUTES);
+    boolean isComplete = proc.waitFor(2, TimeUnit.MINUTES);
     if (!isComplete) {
       proc.destroyForcibly();
       throw new Exception("PhantomJS process timeout");


### PR DESCRIPTION
Since the phantomJS process is started from a separate thread and this thread has a timeout of 3 minutes. Need to reduce the phantomJS process timeout so it could be called. 