### PR TITLE
Unify controller base url in integration test

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NewConfigApplyIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NewConfigApplyIntegrationTest.java
@@ -65,32 +65,32 @@ public class NewConfigApplyIntegrationTest extends BaseClusterIntegrationTest {
     FileUtils.copyDirectoryToDirectory(configFiles.get(2).getParentFile(), new File("."));
 
     // Create a new table using the command line tools without a profile
-    runAdminCommand("ApplyTableConfig", "-controllerUrl", "http://localhost:8998/", "-tableConfigFile",
+    runAdminCommand("ApplyTableConfig", "-controllerUrl", _controllerBaseApiUrl, "-tableConfigFile",
         configFiles.get(0).getAbsolutePath());
 
     // Check that the table exists
-    String tableConfiguration = sendGetRequestRaw("http://localhost:8998/v2/tables/mytable");
+    String tableConfiguration = sendGetRequestRaw(_controllerBaseApiUrl + "/v2/tables/mytable");
     CombinedConfig tableConfigurationObject = CombinedConfigLoader.loadCombinedConfig(tableConfiguration);
     assertEquals(tableConfigurationObject.getOfflineTableConfig().getTableName(), "mytable_OFFLINE");
     assertEquals(tableConfigurationObject.getOfflineTableConfig().getValidationConfig().getReplicationNumber(), 3);
 
     // Update the table using a configuration profile
-    runAdminCommand("ApplyTableConfig", "-controllerUrl", "http://localhost:8998/", "-tableConfigFile",
+    runAdminCommand("ApplyTableConfig", "-controllerUrl", _controllerBaseApiUrl, "-tableConfigFile",
         configFiles.get(1).getAbsolutePath(), "-profile", "test2");
 
     // Check that the table is updated
-    tableConfiguration = sendGetRequestRaw("http://localhost:8998/v2/tables/mytable");
+    tableConfiguration = sendGetRequestRaw(_controllerBaseApiUrl + "/v2/tables/mytable");
     tableConfigurationObject = CombinedConfigLoader.loadCombinedConfig(tableConfiguration);
     assertEquals(tableConfigurationObject.getOfflineTableConfig().getTableName(), "mytable_OFFLINE");
     assertEquals(tableConfigurationObject.getOfflineTableConfig().getValidationConfig().getReplicationNumber(), 4);
     assertEquals(tableConfigurationObject.getOfflineTableConfig().getIndexingConfig().getLoadMode(), "MMAP");
 
     // Update the table using a configuration profile
-    runAdminCommand("ApplyTableConfig", "-controllerUrl", "http://localhost:8998/", "-tableConfigFile",
+    runAdminCommand("ApplyTableConfig", "-controllerUrl", _controllerBaseApiUrl, "-tableConfigFile",
         configFiles.get(0).getAbsolutePath(), "-profile", "test1");
 
     // Check that the table is updated
-    tableConfiguration = sendGetRequestRaw("http://localhost:8998/v2/tables/mytable");
+    tableConfiguration = sendGetRequestRaw(_controllerBaseApiUrl + "/v2/tables/mytable");
     tableConfigurationObject = CombinedConfigLoader.loadCombinedConfig(tableConfiguration);
     assertEquals(tableConfigurationObject.getOfflineTableConfig().getTableName(), "mytable_OFFLINE");
     assertEquals(tableConfigurationObject.getOfflineTableConfig().getValidationConfig().getReplicationNumber(), 3);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PinotURIUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PinotURIUploadIntegrationTest.java
@@ -270,7 +270,7 @@ public class PinotURIUploadIntegrationTest extends BaseClusterIntegrationTestSet
   private List<String> getAllSegments(String tablename)
       throws IOException {
     List<String> allSegments = new ArrayList<>();
-    HttpHost controllerHttpHost = new HttpHost("localhost", 8998);
+    HttpHost controllerHttpHost = new HttpHost("localhost", _controllerPort);
     HttpClient controllerClient = new DefaultHttpClient();
     HttpGet req = new HttpGet("/segments/" + URLEncoder.encode(tablename, "UTF-8"));
     HttpResponse res = controllerClient.execute(controllerHttpHost, req);


### PR DESCRIPTION
This PR unifies controller base url in integration test, so that all the tests uses the same controller url.