### PR TITLE
Change ControllerTest default prot to 18998

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,6 @@ test-output
 pinot-transport/test-output/
 pinot-broker/test-output/
 pinot-core/test-output/
-pinot-dashboard/.env
-pinot-dashboard/activate
-pinot-dashboard/config.yml
-pinot-dashboard/logs/*
-pinot-dashboard/dist
-pinot-dashboard/pinotui.egg-info
 *.log
 .doppelganger
 docs/_build

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -57,7 +57,7 @@ import org.testng.Assert;
 public abstract class ControllerTest {
   public static final String LOCAL_HOST = "localhost";
 
-  private static final int DEFAULT_CONTROLLER_PORT = 8998;
+  private static final int DEFAULT_CONTROLLER_PORT = 18998;
   private static final String DEFAULT_DATA_DIR =
       new File(FileUtils.getTempDirectoryPath(), "test-controller-" + System.currentTimeMillis()).getAbsolutePath();
 


### PR DESCRIPTION
Port 8998 is commonly used, which might cause address already in use problem.
Change it to 18998 to avoid this.
Also remove redundant entries in gitignore.