### PR TITLE
[TE] add padding to baseline endpoints

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionResource.java
@@ -540,6 +540,7 @@ public class DetectionResource {
       throw new IllegalArgumentException(String.format("Could not resolve anomaly id %d", anomalyId));
     }
     if (padding) {
+      // add paddings for the time range
       DatasetConfigDTO dataset = this.datasetDAO.findByDataset(anomaly.getCollection());
       if (dataset == null) {
         throw new IllegalArgumentException(String.format("Could not resolve dataset '%s' for anomaly id %d", anomaly.getCollection(), anomalyId));
@@ -551,6 +552,7 @@ public class DetectionResource {
     }
     MetricEntity me = MetricEntity.fromURN(anomaly.getMetricUrn());
     TimeSeries baselineTimeseries = DetectionUtils.getBaselineTimeseries(anomaly, me.getFilters(), me.getId(), configDAO.findById(anomaly.getDetectionConfigId()), start, end, loader, provider);
+    // add current time series
     MetricSlice currentSlice = MetricSlice.from(me.getId(), start, end, me.getFilters());
     DataFrame dfCurrent = this.provider.fetchTimeseries(Collections.singleton(currentSlice)).get(currentSlice).renameSeries(COL_VALUE, COL_CURRENT);
     return Response.ok(dfCurrent.joinOuter(baselineTimeseries.getDataFrame())).build();

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/AbsoluteChangeRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/AbsoluteChangeRuleDetector.java
@@ -117,7 +117,7 @@ public class AbsoluteChangeRuleDetector implements AnomalyDetector<AbsoluteChang
 
   @Override
   public TimeSeries computePredictedTimeSeries(MetricSlice slice) {
-    DataFrame df = RuleBaselineProvider.buildCurrentAndBaselines(slice, this.baseline, this.dataFetcher);
+    DataFrame df = RuleBaselineProvider.buildBaselines(slice, this.baseline, this.dataFetcher);
     return TimeSeries.fromDataFrame(constructAbsoluteChangeBoundaries(df));
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/AbsoluteChangeRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/AbsoluteChangeRuleDetector.java
@@ -117,9 +117,8 @@ public class AbsoluteChangeRuleDetector implements AnomalyDetector<AbsoluteChang
 
   @Override
   public TimeSeries computePredictedTimeSeries(MetricSlice slice) {
-    InputData data = this.dataFetcher.fetchData(new InputDataSpec().withTimeseriesSlices(this.baseline.scatter(slice)));
-    DataFrame dfBase = this.baseline.gather(slice, data.getTimeseries());
-    return TimeSeries.fromDataFrame(constructAbsoluteChangeBoundaries(dfBase));
+    DataFrame df = RuleBaselineProvider.buildCurrentAndBaselines(slice, this.baseline, this.dataFetcher);
+    return TimeSeries.fromDataFrame(constructAbsoluteChangeBoundaries(df));
   }
 
   private DataFrame constructAbsoluteChangeBoundaries(DataFrame dfBase) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetector.java
@@ -121,7 +121,7 @@ public class PercentageChangeRuleDetector implements AnomalyDetector<PercentageC
 
   @Override
   public TimeSeries computePredictedTimeSeries(MetricSlice slice) {
-    DataFrame df = RuleBaselineProvider.buildCurrentAndBaselines(slice, this.baseline, this.dataFetcher);
+    DataFrame df = RuleBaselineProvider.buildBaselines(slice, this.baseline, this.dataFetcher);
     return TimeSeries.fromDataFrame(constructPercentageChangeBoundaries(df));
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetector.java
@@ -121,9 +121,8 @@ public class PercentageChangeRuleDetector implements AnomalyDetector<PercentageC
 
   @Override
   public TimeSeries computePredictedTimeSeries(MetricSlice slice) {
-    InputData data = this.dataFetcher.fetchData(new InputDataSpec().withTimeseriesSlices(this.baseline.scatter(slice)));
-    DataFrame dfBase = this.baseline.gather(slice, data.getTimeseries());
-    return TimeSeries.fromDataFrame(constructPercentageChangeBoundaries(dfBase));
+    DataFrame df = RuleBaselineProvider.buildCurrentAndBaselines(slice, this.baseline, this.dataFetcher);
+    return TimeSeries.fromDataFrame(constructPercentageChangeBoundaries(df));
   }
 
   private DataFrame constructPercentageChangeBoundaries(DataFrame dfBase) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/RuleBaselineProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/RuleBaselineProvider.java
@@ -46,17 +46,13 @@ public class RuleBaselineProvider implements BaselineProvider<RuleBaselineProvid
 
   @Override
   public TimeSeries computePredictedTimeSeries(MetricSlice slice) {
-    return TimeSeries.fromDataFrame(buildCurrentAndBaselines(slice, this.baseline, this.dataFetcher));
+    return TimeSeries.fromDataFrame(buildBaselines(slice, this.baseline, this.dataFetcher));
   }
 
-  static DataFrame buildCurrentAndBaselines(MetricSlice slice, Baseline baseline, InputDataFetcher dataFetcher) {
-    List<MetricSlice> slices = new ArrayList<>();
-    slices.add(slice);
-    slices.addAll(baseline.scatter(slice));
+  static DataFrame buildBaselines(MetricSlice slice, Baseline baseline, InputDataFetcher dataFetcher) {
+    List<MetricSlice> slices = new ArrayList<>(baseline.scatter(slice));
     InputData data = dataFetcher.fetchData(new InputDataSpec().withTimeseriesSlices(slices));
-    DataFrame dfBase = baseline.gather(slice, data.getTimeseries());
-    DataFrame dfCurr = data.getTimeseries().get(slice).renameSeries(COL_VALUE, COL_CURRENT);
-    return new DataFrame(dfCurr).addSeries(dfBase);
+    return baseline.gather(slice, data.getTimeseries());
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/RuleBaselineProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/RuleBaselineProvider.java
@@ -19,8 +19,10 @@
 
 package org.apache.pinot.thirdeye.detection.components;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.BaselineParsingUtils;
-import org.apache.pinot.thirdeye.dataframe.Series;
+import org.apache.pinot.thirdeye.dataframe.DataFrame;
 import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
 import org.apache.pinot.thirdeye.detection.InputDataFetcher;
 import org.apache.pinot.thirdeye.detection.annotation.Components;
@@ -44,8 +46,17 @@ public class RuleBaselineProvider implements BaselineProvider<RuleBaselineProvid
 
   @Override
   public TimeSeries computePredictedTimeSeries(MetricSlice slice) {
-    InputData data = this.dataFetcher.fetchData(new InputDataSpec().withTimeseriesSlices(this.baseline.scatter(slice)));
-    return TimeSeries.fromDataFrame(this.baseline.gather(slice, data.getTimeseries()));
+    return TimeSeries.fromDataFrame(buildCurrentAndBaselines(slice, this.baseline, this.dataFetcher));
+  }
+
+  static DataFrame buildCurrentAndBaselines(MetricSlice slice, Baseline baseline, InputDataFetcher dataFetcher) {
+    List<MetricSlice> slices = new ArrayList<>();
+    slices.add(slice);
+    slices.addAll(baseline.scatter(slice));
+    InputData data = dataFetcher.fetchData(new InputDataSpec().withTimeseriesSlices(slices));
+    DataFrame dfBase = baseline.gather(slice, data.getTimeseries());
+    DataFrame dfCurr = data.getTimeseries().get(slice).renameSeries(COL_VALUE, COL_CURRENT);
+    return new DataFrame(dfCurr).addSeries(dfBase);
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
@@ -101,7 +101,6 @@ public class ThresholdRuleDetector implements AnomalyDetector<ThresholdRuleDetec
     InputData data =
         this.dataFetcher.fetchData(new InputDataSpec().withTimeseriesSlices(Collections.singletonList(slice)));
     DataFrame df = data.getTimeseries().get(slice);
-    df = df.joinOuter(df.copy().renameSeries(COL_VALUE, COL_CURRENT), COL_TIME);
     return TimeSeries.fromDataFrame(constructThresholdBoundaries(df));
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
@@ -43,7 +43,6 @@ import org.apache.pinot.thirdeye.detection.spi.model.InputDataSpec;
 import org.apache.pinot.thirdeye.detection.spi.model.TimeSeries;
 import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
 import org.joda.time.Interval;
-import org.joda.time.Period;
 
 import static org.apache.pinot.thirdeye.dataframe.util.DataFrameUtils.*;
 
@@ -102,6 +101,7 @@ public class ThresholdRuleDetector implements AnomalyDetector<ThresholdRuleDetec
     InputData data =
         this.dataFetcher.fetchData(new InputDataSpec().withTimeseriesSlices(Collections.singletonList(slice)));
     DataFrame df = data.getTimeseries().get(slice);
+    df = df.joinRight(df.copy().renameSeries(COL_VALUE, COL_CURRENT), COL_TIME);
     return TimeSeries.fromDataFrame(constructThresholdBoundaries(df));
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
@@ -101,7 +101,7 @@ public class ThresholdRuleDetector implements AnomalyDetector<ThresholdRuleDetec
     InputData data =
         this.dataFetcher.fetchData(new InputDataSpec().withTimeseriesSlices(Collections.singletonList(slice)));
     DataFrame df = data.getTimeseries().get(slice);
-    df = df.joinRight(df.copy().renameSeries(COL_VALUE, COL_CURRENT), COL_TIME);
+    df = df.joinOuter(df.copy().renameSeries(COL_VALUE, COL_CURRENT), COL_TIME);
     return TimeSeries.fromDataFrame(constructThresholdBoundaries(df));
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/RuleBaselineProviderTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/RuleBaselineProviderTest.java
@@ -16,6 +16,9 @@
 
 package org.apache.pinot.thirdeye.detection.components;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.pinot.thirdeye.dataframe.DataFrame;
 import org.apache.pinot.thirdeye.dataframe.DoubleSeries;
 import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
@@ -23,9 +26,6 @@ import org.apache.pinot.thirdeye.detection.DefaultInputDataFetcher;
 import org.apache.pinot.thirdeye.detection.InputDataFetcher;
 import org.apache.pinot.thirdeye.detection.MockDataProvider;
 import org.apache.pinot.thirdeye.detection.spec.RuleBaselineProviderSpec;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;


### PR DESCRIPTION
- add padding option to the predicted baseline endpoints. 
- refactor rule-based baseline providers to return current, predicted baselines and boundaries. 