### PR TITLE
skip bit-map inverted index generation for sorted column

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -159,11 +159,8 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
         // Initialize inverted index creator
         // Do not created inverted index if sorted, clean up invertedIndexColumns
-        if (invertedIndexColumns.contains(columnName)) {
-          if (indexCreationInfo.isSorted()){
-            invertedIndexColumns.remove(columnName);
-            //config.getInvertedIndexCreationColumns().remove(columnName); Do we clean up config?
-          } else if (segmentCreationSpec.isOnHeap()) {
+        if (invertedIndexColumns.contains(columnName) && !indexCreationInfo.isSorted()) {
+          if (segmentCreationSpec.isOnHeap()) {
             _invertedIndexCreatorMap
                 .put(columnName, new OnHeapBitmapInvertedIndexCreator(_indexDir, columnName, cardinality));
           } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -158,8 +158,12 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         }
 
         // Initialize inverted index creator
+        // Do not created inverted index if sorted, clean up invertedIndexColumns
         if (invertedIndexColumns.contains(columnName)) {
-          if (segmentCreationSpec.isOnHeap()) {
+          if (indexCreationInfo.isSorted()){
+            invertedIndexColumns.remove(columnName);
+            //config.getInvertedIndexCreationColumns().remove(columnName); Do we clean up config?
+          } else if (segmentCreationSpec.isOnHeap()) {
             _invertedIndexCreatorMap
                 .put(columnName, new OnHeapBitmapInvertedIndexCreator(_indexDir, columnName, cardinality));
           } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -158,7 +158,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         }
 
         // Initialize inverted index creator
-        // Skip creating inverted index if sorted; _invertedIndexCreatorMap is also correctly populated for index collection and metadata writing
+        // Skip creating inverted index if sorted; _invertedIndexCreatorMap is also correctly populated for metadata writing
         if (invertedIndexColumns.contains(columnName) && !indexCreationInfo.isSorted()) {
           if (segmentCreationSpec.isOnHeap()) {
             _invertedIndexCreatorMap

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -157,8 +157,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
                   indexCreationInfo.getTotalNumberOfEntries()));
         }
 
-        // Initialize inverted index creator
-        // Skip creating inverted index if sorted; _invertedIndexCreatorMap is also correctly populated for metadata writing
+        // Initialize inverted index creator; skip creating inverted index if sorted
         if (invertedIndexColumns.contains(columnName) && !indexCreationInfo.isSorted()) {
           if (segmentCreationSpec.isOnHeap()) {
             _invertedIndexCreatorMap

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -158,7 +158,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         }
 
         // Initialize inverted index creator
-        // Do not created inverted index if sorted, clean up invertedIndexColumns
+        // Skip creating inverted index if sorted; _invertedIndexCreatorMap is now correct for index collection and metadata writing
         if (invertedIndexColumns.contains(columnName) && !indexCreationInfo.isSorted()) {
           if (segmentCreationSpec.isOnHeap()) {
             _invertedIndexCreatorMap

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -158,7 +158,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         }
 
         // Initialize inverted index creator
-        // Skip creating inverted index if sorted; _invertedIndexCreatorMap is now correct for index collection and metadata writing
+        // Skip creating inverted index if sorted; _invertedIndexCreatorMap is also correctly populated for index collection and metadata writing
         if (invertedIndexColumns.contains(columnName) && !indexCreationInfo.isSorted()) {
           if (segmentCreationSpec.isOnHeap()) {
             _invertedIndexCreatorMap


### PR DESCRIPTION
It is redundant for a sorted column to have a bitmap index. Skipping this here won't have side effect for meta data generation.