### PR TITLE
Avoid negative sleep time in startupServiceStatusCheck

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -342,14 +342,15 @@ public class HelixServerStarter {
         throw new IllegalStateException("Service status is BAD");
       }
       long sleepTimeMs = Math.min(checkIntervalMs, endTimeMs - currentTimeMs);
-      LOGGER.info("Sleep for {}ms as service status has not turned GOOD: {}", sleepTimeMs,
-          ServiceStatus.getStatusDescription());
-      try {
-        Thread.sleep(sleepTimeMs);
-      } catch (InterruptedException e) {
-        LOGGER.warn("Got interrupted while checking service status", e);
-        Thread.currentThread().interrupt();
-        break;
+      if (sleepTimeMs > 0) {
+        LOGGER.info("Sleep for {}ms as service status has not turned GOOD: {}", sleepTimeMs, ServiceStatus.getStatusDescription());
+        try {
+          Thread.sleep(sleepTimeMs);
+        } catch (InterruptedException e) {
+          LOGGER.warn("Got interrupted while checking service status", e);
+          Thread.currentThread().interrupt();
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
We should not sleep if sleepTime <= 0 in startupServiceStatusCheck. 