### PR TITLE
Cleaning up getTableName() for segment zk metadata

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -113,7 +113,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
     List<String> segmentsToDelete = new ArrayList<>();
     for (OfflineSegmentZKMetadata offlineSegmentZKMetadata : _pinotHelixResourceManager
         .getOfflineSegmentMetadata(offlineTableName)) {
-      if (retentionStrategy.isPurgeable(offlineSegmentZKMetadata)) {
+      if (retentionStrategy.isPurgeable(offlineTableName, offlineSegmentZKMetadata)) {
         segmentsToDelete.add(offlineSegmentZKMetadata.getSegmentName());
       }
     }
@@ -141,7 +141,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
         }
       } else {
         // Sealed segment
-        if (retentionStrategy.isPurgeable(realtimeSegmentZKMetadata)) {
+        if (retentionStrategy.isPurgeable(realtimeTableName, realtimeSegmentZKMetadata)) {
           segmentsToDelete.add(segmentName);
         }
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/RetentionStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/RetentionStrategy.java
@@ -29,8 +29,9 @@ public interface RetentionStrategy {
   /**
    * Returns whether the segment should be purged
    *
+   * @param tableNameWithType Table name with type
    * @param segmentZKMetadata Segment ZK metadata
    * @return Whether the segment should be purged
    */
-  boolean isPurgeable(SegmentZKMetadata segmentZKMetadata);
+  boolean isPurgeable(String tableNameWithType, SegmentZKMetadata segmentZKMetadata);
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategy.java
@@ -38,11 +38,11 @@ public class TimeRetentionStrategy implements RetentionStrategy {
   }
 
   @Override
-  public boolean isPurgeable(SegmentZKMetadata segmentZKMetadata) {
+  public boolean isPurgeable(String tableNameWithType, SegmentZKMetadata segmentZKMetadata) {
     TimeUnit timeUnit = segmentZKMetadata.getTimeUnit();
     if (timeUnit == null) {
       LOGGER.warn("Time unit is not set for {} segment: {} of table: {}", segmentZKMetadata.getSegmentType(),
-          segmentZKMetadata.getSegmentName(), segmentZKMetadata.getTableName());
+          segmentZKMetadata.getSegmentName(), tableNameWithType);
       return false;
     }
     long endTime = segmentZKMetadata.getEndTime();
@@ -51,7 +51,7 @@ public class TimeRetentionStrategy implements RetentionStrategy {
     // Check that the end time is between 1971 and 2071
     if (!TimeUtils.timeValueInValidRange(endTimeMs)) {
       LOGGER.warn("{} segment: {} of table: {} has invalid end time: {} {}", segmentZKMetadata.getSegmentType(),
-          segmentZKMetadata.getSegmentName(), segmentZKMetadata.getTableName(), endTime, timeUnit);
+          segmentZKMetadata.getSegmentName(), tableNameWithType, endTime, timeUnit);
       return false;
     }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategyTest.java
@@ -34,34 +34,35 @@ public class TimeRetentionStrategyTest {
 
   @Test
   public void testTimeRetention() {
+    String tableNameWithType = "myTable_OFFLINE";
     TimeRetentionStrategy retentionStrategy = new TimeRetentionStrategy(TimeUnit.DAYS, 30L);
 
     SegmentZKMetadata metadata = new OfflineSegmentZKMetadata();
 
     // Without setting time unit or end time, should not throw exception
-    assertFalse(retentionStrategy.isPurgeable(metadata));
+    assertFalse(retentionStrategy.isPurgeable(tableNameWithType, metadata));
     metadata.setTimeUnit(TimeUnit.DAYS);
-    assertFalse(retentionStrategy.isPurgeable(metadata));
+    assertFalse(retentionStrategy.isPurgeable(tableNameWithType, metadata));
 
     // Set end time to Jan 2nd, 1970 (not purgeable due to bogus timestamp)
     metadata.setEndTime(1L);
-    assertFalse(retentionStrategy.isPurgeable(metadata));
+    assertFalse(retentionStrategy.isPurgeable(tableNameWithType, metadata));
 
     // Set end time to today
     long today = TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis());
     metadata.setEndTime(today);
-    assertFalse(retentionStrategy.isPurgeable(metadata));
+    assertFalse(retentionStrategy.isPurgeable(tableNameWithType, metadata));
 
     // Set end time to two weeks ago
     metadata.setEndTime(today - 14);
-    assertFalse(retentionStrategy.isPurgeable(metadata));
+    assertFalse(retentionStrategy.isPurgeable(tableNameWithType, metadata));
 
     // Set end time to two months ago (purgeable due to being past the retention period)
     metadata.setEndTime(today - 60);
-    assertTrue(retentionStrategy.isPurgeable(metadata));
+    assertTrue(retentionStrategy.isPurgeable(tableNameWithType, metadata));
 
     // Set end time to 200 years in the future (not purgeable due to bogus timestamp)
     metadata.setEndTime(today + (365 * 200));
-    assertFalse(retentionStrategy.isPurgeable(metadata));
+    assertFalse(retentionStrategy.isPurgeable(tableNameWithType, metadata));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -258,7 +258,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           // lets convert the segment now
           RealtimeSegmentConverter converter =
               new RealtimeSegmentConverter(realtimeSegment, tempSegmentFolder.getAbsolutePath(), schema,
-                  realtimeSegmentZKMetadata.getTableName(), timeColumnName, realtimeSegmentZKMetadata.getSegmentName(),
+                  tableName, timeColumnName, realtimeSegmentZKMetadata.getSegmentName(),
                   sortedColumn, HLRealtimeSegmentDataManager.this.invertedIndexColumns, noDictionaryColumns,
                   null/*StarTreeIndexSpec*/); // Star tree not supported for HLC.
 
@@ -348,7 +348,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           try {
             segmentLogger.info("Marking current segment as completed in Helix");
             RealtimeSegmentZKMetadata metadataToOverwrite = new RealtimeSegmentZKMetadata();
-            metadataToOverwrite.setTableName(realtimeSegmentZKMetadata.getTableName());
+            metadataToOverwrite.setTableName(tableName);
             metadataToOverwrite.setSegmentName(realtimeSegmentZKMetadata.getSegmentName());
             metadataToOverwrite.setSegmentType(SegmentType.OFFLINE);
             metadataToOverwrite.setStatus(Status.DONE);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -661,7 +661,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       // lets convert the segment now
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), _schema,
-              _segmentZKMetadata.getTableName(), _timeColumnName, _segmentZKMetadata.getSegmentName(), _sortedColumn,
+              _tableName, _timeColumnName, _segmentZKMetadata.getSegmentName(), _sortedColumn,
               _invertedIndexColumns, _noDictionaryColumns, _starTreeIndexSpec);
       segmentLogger.info("Trying to build segment");
       try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -68,7 +68,6 @@ import org.apache.pinot.core.realtime.stream.StreamConsumerFactory;
 import org.apache.pinot.core.realtime.stream.StreamConsumerFactoryProvider;
 import org.apache.pinot.core.realtime.stream.StreamDecoderProvider;
 import org.apache.pinot.core.realtime.stream.StreamMessageDecoder;
-import org.apache.pinot.core.realtime.stream.StreamMessageMetadata;
 import org.apache.pinot.core.realtime.stream.StreamMetadataProvider;
 import org.apache.pinot.core.realtime.stream.TransientConsumerException;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
@@ -234,7 +233,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private PartitionLevelConsumer _partitionLevelConsumer = null;
   private StreamMetadataProvider _streamMetadataProvider = null;
   private final File _resourceTmpDir;
-  private final String _tableName;
+  private final String _tableNameWithType;
   private final String _timeColumnName;
   private final List<String> _invertedIndexColumns;
   private final List<String> _noDictionaryColumns;
@@ -661,7 +660,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       // lets convert the segment now
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), _schema,
-              _tableName, _timeColumnName, _segmentZKMetadata.getSegmentName(), _sortedColumn,
+              _tableNameWithType, _timeColumnName, _segmentZKMetadata.getSegmentName(), _sortedColumn,
               _invertedIndexColumns, _noDictionaryColumns, _starTreeIndexSpec);
       segmentLogger.info("Trying to build segment");
       try {
@@ -1047,11 +1046,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     _segmentNameStr = _segmentZKMetadata.getSegmentName();
     _segmentName = new LLCSegmentName(_segmentNameStr);
     _streamPartitionId = _segmentName.getPartitionId();
-    _tableName = _tableConfig.getTableName();
+    _tableNameWithType = _tableConfig.getTableName();
     _timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
-    _metricKeyName = _tableName + "-" + _streamTopic + "-" + _streamPartitionId;
+    _metricKeyName = _tableNameWithType + "-" + _streamTopic + "-" + _streamPartitionId;
     segmentLogger = LoggerFactory.getLogger(LLRealtimeSegmentDataManager.class.getName() + "_" + _segmentNameStr);
-    _tableStreamName = _tableName + "_" + _streamTopic;
+    _tableStreamName = _tableNameWithType + "_" + _streamTopic;
     _memoryManager = getMemoryManager(realtimeTableDataManager.getConsumerDir(), _segmentNameStr,
         indexLoadingConfig.isRealtimeOffheapAllocation(), indexLoadingConfig.isDirectRealtimeOffheapAllocation(),
         serverMetrics);
@@ -1193,7 +1192,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // Number of rows indexed should be used for DOCUMENT_COUNT metric, and also for segment flush. Whereas,
     // Number of rows consumed should be used for consumption metric.
     long rowsIndexed = _numRowsIndexed - _lastUpdatedRowsIndexed.get();
-    _serverMetrics.addValueToTableGauge(_tableName, ServerGauge.DOCUMENT_COUNT, rowsIndexed);
+    _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.DOCUMENT_COUNT, rowsIndexed);
     _lastUpdatedRowsIndexed.set(_numRowsIndexed);
     final long now = now();
     final int rowsConsumed = _numRowsConsumed - _lastConsumedCount;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -111,7 +111,7 @@ public class SegmentFetcherAndLoader {
             localSegmentMetadata = null;
           }
           try {
-            if (!isNewSegmentMetadata(newSegmentZKMetadata, localSegmentMetadata)) {
+            if (!isNewSegmentMetadata(tableNameWithType, newSegmentZKMetadata, localSegmentMetadata)) {
               LOGGER.info("Segment metadata same as before, loading {} of table {} (crc {}) from disk", segmentName,
                   tableNameWithType, localSegmentMetadata.getCrc());
               _instanceDataManager.addOfflineSegment(tableNameWithType, segmentName, indexDir);
@@ -143,7 +143,7 @@ public class SegmentFetcherAndLoader {
       // If we get here, then either it is the case that we have the segment loaded in memory (and therefore present
       // in disk) or, we need to load from the server. In the former case, we still need to check if the metadata
       // that we have is different from that in zookeeper.
-      if (isNewSegmentMetadata(newSegmentZKMetadata, localSegmentMetadata)) {
+      if (isNewSegmentMetadata(tableNameWithType, newSegmentZKMetadata, localSegmentMetadata)) {
         if (localSegmentMetadata == null) {
           LOGGER.info("Loading new segment {} of table {} from controller", segmentName, tableNameWithType);
         } else {
@@ -172,20 +172,19 @@ public class SegmentFetcherAndLoader {
     }
   }
 
-  private boolean isNewSegmentMetadata(@Nonnull OfflineSegmentZKMetadata newSegmentZKMetadata,
-      @Nullable SegmentMetadata existedSegmentMetadata) {
-    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(newSegmentZKMetadata.getTableName());
+  private boolean isNewSegmentMetadata(@Nonnull String tableNameWithType,
+      @Nonnull OfflineSegmentZKMetadata newSegmentZKMetadata, @Nullable SegmentMetadata existedSegmentMetadata) {
     String segmentName = newSegmentZKMetadata.getSegmentName();
 
     if (existedSegmentMetadata == null) {
-      LOGGER.info("Existed segment metadata is null for segment: {} in table: {}", segmentName, offlineTableName);
+      LOGGER.info("Existed segment metadata is null for segment: {} in table: {}", segmentName, tableNameWithType);
       return true;
     }
 
     long newCrc = newSegmentZKMetadata.getCrc();
     long existedCrc = Long.valueOf(existedSegmentMetadata.getCrc());
     LOGGER.info("New segment CRC: {}, existed segment CRC: {} for segment: {} in table: {}", newCrc, existedCrc,
-        segmentName, offlineTableName);
+        segmentName, tableNameWithType);
     return newCrc != existedCrc;
   }
 


### PR DESCRIPTION
Removing unnecessary calls to segmentZKMetadata.getTableName()