### PR TITLE
Cleaning up getTableName() for segment metadata

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -96,7 +96,8 @@ public class HelixBrokerStarterTest extends ControllerTest {
 
     for (int i = 0; i < 5; i++) {
       _helixResourceManager
-          .addNewSegment(SegmentMetadataMockUtils.mockSegmentMetadata(RAW_DINING_TABLE_NAME), "downloadUrl");
+          .addNewSegment(DINING_TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(RAW_DINING_TABLE_NAME),
+              "downloadUrl");
     }
 
     Thread.sleep(1000);
@@ -216,7 +217,8 @@ public class HelixBrokerStarterTest extends ControllerTest {
         5);
 
     _helixResourceManager
-        .addNewSegment(SegmentMetadataMockUtils.mockSegmentMetadata(RAW_DINING_TABLE_NAME), "downloadUrl");
+        .addNewSegment(DINING_TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(RAW_DINING_TABLE_NAME),
+            "downloadUrl");
 
     // Wait up to 30s for external view to reach the expected size
     waitForPredicate(new Callable<Boolean>() {
@@ -268,7 +270,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
       OfflineSegmentZKMetadata offlineSegmentZKMetadata =
           _helixResourceManager.getOfflineSegmentZKMetadata(RAW_DINING_TABLE_NAME, segment);
       Assert.assertNotNull(offlineSegmentZKMetadata);
-      _helixResourceManager.refreshSegment(
+      _helixResourceManager.refreshSegment(DINING_TABLE_NAME,
           SegmentMetadataMockUtils.mockSegmentMetadataWithEndTimeInfo(RAW_DINING_TABLE_NAME, segment, endTime++),
           offlineSegmentZKMetadata);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidator.java
@@ -68,8 +68,8 @@ public class SegmentValidator {
     _controllerLeadershipManager = controllerLeadershipManager;
   }
 
-  public SegmentValidatorResponse validateSegment(SegmentMetadata segmentMetadata, File tempSegmentDir) {
-    String rawTableName = segmentMetadata.getTableName();
+  public SegmentValidatorResponse validateSegment(String rawTableName, SegmentMetadata segmentMetadata,
+      File tempSegmentDir) {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
     String segmentName = segmentMetadata.getName();
     TableConfig offlineTableConfig =
@@ -86,7 +86,7 @@ public class SegmentValidator {
         _pinotHelixResourceManager.getSegmentMetadataZnRecord(offlineTableName, segmentName);
     // Checks whether it's a new segment or an existing one.
     if (segmentMetadataZnRecord == null) {
-      assignedInstances = _pinotHelixResourceManager.getAssignedInstancesForSegment(segmentMetadata);
+      assignedInstances = _pinotHelixResourceManager.getAssignedInstancesForSegment(rawTableName, segmentMetadata);
       if (assignedInstances.isEmpty()) {
         throw new ControllerApplicationException(LOGGER, "No assigned Instances for Segment: " + segmentName
             + ". Please check whether the table config is misconfigured.", Response.Status.INTERNAL_SERVER_ERROR);
@@ -136,7 +136,7 @@ public class SegmentValidator {
     StorageQuotaChecker quotaChecker =
         new StorageQuotaChecker(offlineTableConfig, tableSizeReader, _controllerMetrics, _pinotHelixResourceManager,
             _controllerLeadershipManager);
-    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(metadata.getTableName());
+    String offlineTableName = offlineTableConfig.getTableName();
     return quotaChecker.isSegmentStorageWithinQuota(segmentFile, offlineTableName, metadata.getName(),
         _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -57,11 +57,11 @@ public class ZKOperator {
     _controllerMetrics = controllerMetrics;
   }
 
-  public void completeSegmentOperations(SegmentMetadata segmentMetadata, URI finalSegmentLocationURI,
-      File currentSegmentLocation, boolean enableParallelPushProtection, HttpHeaders headers, String zkDownloadURI,
-      boolean moveSegmentToFinalLocation, SegmentValidatorResponse segmentValidatorResponse)
+  public void completeSegmentOperations(String rawTableName, SegmentMetadata segmentMetadata,
+      URI finalSegmentLocationURI, File currentSegmentLocation, boolean enableParallelPushProtection,
+      HttpHeaders headers, String zkDownloadURI, boolean moveSegmentToFinalLocation,
+      SegmentValidatorResponse segmentValidatorResponse)
       throws Exception {
-    String rawTableName = segmentMetadata.getTableName();
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
     String segmentName = segmentMetadata.getName();
 
@@ -176,7 +176,7 @@ public class ZKOperator {
               zkDownloadURI);
         }
 
-        _pinotHelixResourceManager.refreshSegment(segmentMetadata, existingSegmentZKMetadata);
+        _pinotHelixResourceManager.refreshSegment(offlineTableName, segmentMetadata, existingSegmentZKMetadata);
       }
     } catch (Exception e) {
       if (!_pinotHelixResourceManager.updateZkMetadata(existingSegmentZKMetadata)) {
@@ -223,7 +223,7 @@ public class ZKOperator {
       LOGGER.info("Skipping segment move, keeping segment {} from table {} at {}", segmentName, rawTableName,
           zkDownloadURI);
     }
-    _pinotHelixResourceManager.addNewSegment(segmentMetadata, zkDownloadURI, crypter, assignedInstances);
+    _pinotHelixResourceManager.addNewSegment(rawTableName, segmentMetadata, zkDownloadURI, crypter, assignedInstances);
   }
 
   private void moveSegmentToPermanentDirectory(File currentSegmentLocation, URI finalSegmentLocationURI)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
@@ -47,9 +47,8 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
 
   @Override
   public List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin,
-      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, SegmentMetadata segmentMetadata,
-      int numReplicas, String tenantName) {
-    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, String tableNameWithType,
+      SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
     String serverTenantName = TagNameUtils.getOfflineTagForTenant(tenantName);
 
     List<String> selectedInstances = new ArrayList<>();
@@ -61,7 +60,7 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
     }
 
     // Count number of segments assigned to each instance
-    IdealState idealState = helixAdmin.getResourceIdealState(helixClusterName, offlineTableName);
+    IdealState idealState = helixAdmin.getResourceIdealState(helixClusterName, tableNameWithType);
     if (idealState != null) {
       for (String partitionName : idealState.getPartitionSet()) {
         Map<String, String> instanceToStateMap = idealState.getInstanceStateMap(partitionName);
@@ -92,8 +91,8 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
       selectedInstances.add(priorityQueue.poll().getB());
     }
 
-    LOGGER.info("Segment assignment result for : " + segmentMetadata.getName() + ", in resource : " + segmentMetadata
-        .getTableName() + ", selected instances: " + Arrays.toString(selectedInstances.toArray()));
+    LOGGER.info("Segment assignment result for : " + segmentMetadata.getName() + ", in resource : " + tableNameWithType
+        + ", selected instances: " + Arrays.toString(selectedInstances.toArray()));
     return selectedInstances;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
@@ -42,8 +42,8 @@ public class BucketizedSegmentStrategy implements SegmentAssignmentStrategy {
 
   @Override
   public List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin,
-      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, SegmentMetadata segmentMetadata,
-      int numReplicas, String tenantName) {
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, String tableNameWithType,
+      SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
     String serverTenantName = TagNameUtils.getOfflineTagForTenant(tenantName);
 
     List<String> allInstances = HelixHelper.getEnabledInstancesWithTag(helixManager, serverTenantName);
@@ -55,8 +55,9 @@ public class BucketizedSegmentStrategy implements SegmentAssignmentStrategy {
           selectedInstanceList.add(instance);
         }
       }
-      LOGGER.info("Segment assignment result for : " + segmentMetadata.getName() + ", in resource : " + segmentMetadata
-          .getTableName() + ", selected instances: " + Arrays.toString(selectedInstanceList.toArray()));
+      LOGGER.info(
+          "Segment assignment result for : " + segmentMetadata.getName() + ", in resource : " + tableNameWithType
+              + ", selected instances: " + Arrays.toString(selectedInstanceList.toArray()));
       return selectedInstanceList;
     } else {
       throw new RuntimeException("Segment missing sharding key!");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
@@ -44,8 +44,8 @@ public class RandomAssignmentStrategy implements SegmentAssignmentStrategy {
 
   @Override
   public List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin,
-      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, SegmentMetadata segmentMetadata,
-      int numReplicas, String tenantName) {
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType, String helixClusterName,
+      SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
     String serverTenantName = TagNameUtils.getOfflineTagForTenant(tenantName);
     final Random random = new Random(System.currentTimeMillis());
 
@@ -56,8 +56,8 @@ public class RandomAssignmentStrategy implements SegmentAssignmentStrategy {
       selectedInstanceList.add(allInstanceList.get(idx));
       allInstanceList.remove(idx);
     }
-    LOGGER.info("Segment assignment result for : " + segmentMetadata.getName() + ", in resource : " + segmentMetadata
-        .getTableName() + ", selected instances: " + Arrays.toString(selectedInstanceList.toArray()));
+    LOGGER.info("Segment assignment result for : " + segmentMetadata.getName() + ", in resource : " + tableNameWithType
+        + ", selected instances: " + Arrays.toString(selectedInstanceList.toArray()));
 
     return selectedInstanceList;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/ReplicaGroupSegmentAssignmentStrategy.java
@@ -52,18 +52,17 @@ public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentS
 
   @Override
   public List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin,
-      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, SegmentMetadata segmentMetadata,
-      int numReplicas, String tenantName) {
-    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, String tableNameWithType,
+      SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
 
     // Fetch the partition mapping table from the property store.
     ReplicaGroupPartitionAssignmentGenerator partitionAssignmentGenerator =
         new ReplicaGroupPartitionAssignmentGenerator(propertyStore);
     ReplicaGroupPartitionAssignment replicaGroupPartitionAssignment =
-        partitionAssignmentGenerator.getReplicaGroupPartitionAssignment(offlineTableName);
+        partitionAssignmentGenerator.getReplicaGroupPartitionAssignment(tableNameWithType);
 
     // Fetch the segment assignment related configurations.
-    TableConfig tableConfig = ZKMetadataProvider.getTableConfig(propertyStore, offlineTableName);
+    TableConfig tableConfig = ZKMetadataProvider.getTableConfig(propertyStore, tableNameWithType);
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
         tableConfig.getValidationConfig().getReplicaGroupStrategyConfig();
     boolean mirrorAssignmentAcrossReplicaGroups = replicaGroupStrategyConfig.getMirrorAssignmentAcrossReplicaGroups();
@@ -98,8 +97,8 @@ public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentS
       selectedInstanceList.add(instancesInReplicaGroup.get(index));
     }
 
-    LOGGER.info("Segment assignment result for : " + segmentMetadata.getName() + ", in resource : " + segmentMetadata
-        .getTableName() + ", selected instances: " + Arrays.toString(selectedInstanceList.toArray()));
+    LOGGER.info("Segment assignment result for : " + segmentMetadata.getName() + ", in resource : " + tableNameWithType
+        + ", selected instances: " + Arrays.toString(selectedInstanceList.toArray()));
 
     return selectedInstanceList;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/SegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/sharding/SegmentAssignmentStrategy.java
@@ -34,8 +34,8 @@ import org.apache.pinot.common.segment.SegmentMetadata;
 public interface SegmentAssignmentStrategy {
 
   List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin,
-      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, SegmentMetadata segmentMetadata,
-      int numReplicas, String tenantName);
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, String tableNameWithType,
+      SegmentMetadata segmentMetadata, int numReplicas, String tenantName);
 }
 
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
@@ -87,7 +87,7 @@ public class PinotSegmentRestletResourceTest extends ControllerTest {
     // Upload Segments
     for (int i = 0; i < 5; ++i) {
       SegmentMetadata segmentMetadata = SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME);
-      _helixResourceManager.addNewSegment(segmentMetadata, "downloadUrl");
+      _helixResourceManager.addNewSegment(TABLE_NAME, segmentMetadata, "downloadUrl");
       segmentMetadataTable.put(segmentMetadata.getName(), segmentMetadata);
     }
 
@@ -97,7 +97,7 @@ public class PinotSegmentRestletResourceTest extends ControllerTest {
     // Add more segments
     for (int i = 0; i < 5; ++i) {
       SegmentMetadata segmentMetadata = SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME);
-      _helixResourceManager.addNewSegment(segmentMetadata, "downloadUrl");
+      _helixResourceManager.addNewSegment(TABLE_NAME, segmentMetadata, "downloadUrl");
       segmentMetadataTable.put(segmentMetadata.getName(), segmentMetadata);
     }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/TableViewsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/TableViewsTest.java
@@ -65,9 +65,8 @@ public class TableViewsTest extends ControllerTest {
             .setNumReplicas(2).build();
     Assert.assertEquals(_helixManager.getInstanceType(), InstanceType.CONTROLLER);
     _helixResourceManager.addTable(tableConfig);
-    _helixResourceManager
-        .addNewSegment(SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, OFFLINE_SEGMENT_NAME),
-            "downloadUrl");
+    _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, OFFLINE_SEGMENT_NAME), "downloadUrl");
 
     // Create the hybrid table
     tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(HYBRID_TABLE_NAME)

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -70,7 +70,8 @@ public class ControllerInstanceToggleTest extends ControllerTest {
 
     // Add segments
     for (int i = 0; i < NUM_INSTANCES; i++) {
-      _helixResourceManager.addNewSegment(SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME), "downloadUrl");
+      _helixResourceManager
+          .addNewSegment(RAW_TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME), "downloadUrl");
       Assert.assertEquals(_helixAdmin.getResourceIdealState(_helixClusterName, OFFLINE_TABLE_NAME).getNumPartitions(),
           i + 1);
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerSentinelTestV2.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerSentinelTestV2.java
@@ -71,7 +71,8 @@ public class ControllerSentinelTestV2 extends ControllerTest {
       Assert
           .assertEquals(_helixAdmin.getResourceIdealState(_helixClusterName, tableName + "_OFFLINE").getNumPartitions(),
               i);
-      _helixResourceManager.addNewSegment(SegmentMetadataMockUtils.mockSegmentMetadata(tableName), "downloadUrl");
+      _helixResourceManager
+          .addNewSegment(tableName, SegmentMetadataMockUtils.mockSegmentMetadata(tableName), "downloadUrl");
       Assert
           .assertEquals(_helixAdmin.getResourceIdealState(_helixClusterName, tableName + "_OFFLINE").getNumPartitions(),
               i + 1);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
@@ -102,7 +102,8 @@ public class PinotResourceManagerTest extends ControllerTest {
 
     // Basic add/delete case
     for (int i = 1; i <= 2; i++) {
-      _helixResourceManager.addNewSegment(SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME), "downloadUrl");
+      _helixResourceManager
+          .addNewSegment(TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME), "downloadUrl");
     }
     IdealState idealState = _helixAdmin.getResourceIdealState(getHelixClusterName(), offlineTableName);
     Set<String> segments = idealState.getPartitionSet();
@@ -122,7 +123,7 @@ public class PinotResourceManagerTest extends ControllerTest {
         public void run() {
           for (int i = 0; i < 10; i++) {
             _helixResourceManager
-                .addNewSegment(SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME), "downloadUrl");
+                .addNewSegment(TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME), "downloadUrl");
           }
         }
       });

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -306,7 +306,6 @@ public class RetentionManagerTest {
   private SegmentMetadata mockSegmentMetadata(long startTime, long endTime, TimeUnit timeUnit) {
     long creationTime = System.currentTimeMillis();
     SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
-    when(segmentMetadata.getTableName()).thenReturn(TEST_TABLE_NAME);
     when(segmentMetadata.getName()).thenReturn(TEST_TABLE_NAME + creationTime);
     when(segmentMetadata.getIndexCreationTime()).thenReturn(creationTime);
     when(segmentMetadata.getCrc()).thenReturn(Long.toString(creationTime));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyTest.java
@@ -118,7 +118,8 @@ public class SegmentAssignmentStrategyTest extends ControllerTest {
 
     for (int i = 0; i < 10; ++i) {
       _helixResourceManager
-          .addNewSegment(SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME_RANDOM), "downloadUrl");
+          .addNewSegment(TABLE_NAME_RANDOM, SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME_RANDOM),
+              "downloadUrl");
 
       // Wait for all segments appear in the external view
       while (!allSegmentsPushedToIdealState(TABLE_NAME_RANDOM, i + 1)) {
@@ -153,7 +154,8 @@ public class SegmentAssignmentStrategyTest extends ControllerTest {
     int numSegments = 20;
     for (int i = 0; i < numSegments; ++i) {
       _helixResourceManager
-          .addNewSegment(SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME_BALANCED), "downloadUrl");
+          .addNewSegment(TABLE_NAME_BALANCED, SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME_BALANCED),
+              "downloadUrl");
     }
 
     // Wait for all segments appear in the external view

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/utils/ReplicaGroupTestUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/utils/ReplicaGroupTestUtils.java
@@ -45,7 +45,7 @@ public class ReplicaGroupTestUtils {
       String segmentName = SEGMENT_PREFIX + i;
       SegmentMetadata segmentMetadata = SegmentMetadataMockUtils
           .mockSegmentMetadataWithPartitionInfo(tableName, segmentName, partitionColumn, partition);
-      resourceManager.addNewSegment(segmentMetadata, "downloadUrl");
+      resourceManager.addNewSegment(tableName, segmentMetadata, "downloadUrl");
       if (!segmentsPerPartition.containsKey(partition)) {
         segmentsPerPartition.put(partition, new HashSet<String>());
       }
@@ -58,7 +58,7 @@ public class ReplicaGroupTestUtils {
       String partitionColumn, PinotHelixResourceManager resourceManager) {
     SegmentMetadata segmentMetadata =
         SegmentMetadataMockUtils.mockSegmentMetadataWithPartitionInfo(tableName, segmentName, partitionColumn, 0);
-    resourceManager.addNewSegment(segmentMetadata, "downloadUrl");
+    resourceManager.addNewSegment(tableName, segmentMetadata, "downloadUrl");
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ValidationManagerTest.java
@@ -128,7 +128,7 @@ public class ValidationManagerTest extends ControllerTest {
       throws Exception {
     SegmentMetadata segmentMetadata = SegmentMetadataMockUtils.mockSegmentMetadata(TEST_TABLE_NAME, TEST_SEGMENT_NAME);
 
-    _helixResourceManager.addNewSegment(segmentMetadata, "http://dummy/");
+    _helixResourceManager.addNewSegment(TEST_TABLE_NAME, segmentMetadata, "http://dummy/");
     OfflineSegmentZKMetadata offlineSegmentZKMetadata =
         _helixResourceManager.getOfflineSegmentZKMetadata(TEST_TABLE_NAME, TEST_SEGMENT_NAME);
     long pushTime = offlineSegmentZKMetadata.getPushTime();
@@ -139,7 +139,7 @@ public class ValidationManagerTest extends ControllerTest {
 
     // Refresh the segment
     Mockito.when(segmentMetadata.getCrc()).thenReturn(Long.toString(System.nanoTime()));
-    _helixResourceManager.refreshSegment(segmentMetadata, offlineSegmentZKMetadata);
+    _helixResourceManager.refreshSegment(TEST_TABLE_NAME, segmentMetadata, offlineSegmentZKMetadata);
 
     offlineSegmentZKMetadata =
         _helixResourceManager.getOfflineSegmentZKMetadata(TEST_TABLE_NAME, TEST_SEGMENT_NAME);

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -135,9 +135,8 @@ public class ImmutableSegmentLoader {
         FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
         VirtualColumnProvider provider =
             VirtualColumnProviderFactory.buildProvider(fieldSpec.getVirtualColumnProvider());
-        VirtualColumnContext context =
-            new VirtualColumnContext(NetUtil.getHostnameOrAddress(), segmentMetadata.getTableName(), segmentName,
-                columnName, segmentMetadata.getTotalDocs());
+        VirtualColumnContext context = new VirtualColumnContext(NetUtil.getHostnameOrAddress(), segmentName, columnName,
+            segmentMetadata.getTotalDocs());
         indexContainerMap.put(columnName, provider.buildColumnIndexContainer(context));
         segmentMetadata.getColumnMetadataMap().put(columnName, provider.buildMetadata(context));
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -431,8 +431,7 @@ public class MutableSegmentImpl implements MutableSegment {
 
   private ColumnDataSource getVirtualDataSource(String column) {
     VirtualColumnContext virtualColumnContext =
-        new VirtualColumnContext(NetUtil.getHostnameOrAddress(), _segmentMetadata.getTableName(), getSegmentName(),
-            column, _numDocsIndexed + 1);
+        new VirtualColumnContext(NetUtil.getHostnameOrAddress(), getSegmentName(), column, _numDocsIndexed + 1);
     VirtualColumnProvider provider =
         VirtualColumnProviderFactory.buildProvider(_schema.getFieldSpecFor(column).getVirtualColumnProvider());
     return new ColumnDataSource(provider.buildColumnIndexContainer(virtualColumnContext),

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/BackfillDateTimeColumn.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/BackfillDateTimeColumn.java
@@ -56,14 +56,16 @@ import org.slf4j.LoggerFactory;
 public class BackfillDateTimeColumn {
   private static final Logger LOGGER = LoggerFactory.getLogger(BackfillDateTimeColumn.class);
 
+  private final String _rawTableName;
   private final File _originalIndexDir;
   private final File _backfilledIndexDir;
   private final TimeFieldSpec _srcTimeFieldSpec;
   private final DateTimeFieldSpec _destDateTimeFieldSpec;
 
-  public BackfillDateTimeColumn(@Nonnull File originalIndexDir, @Nonnull File backfilledIndexDir,
+  public BackfillDateTimeColumn(@Nonnull String rawTableName, @Nonnull File originalIndexDir, @Nonnull File backfilledIndexDir,
       @Nonnull TimeFieldSpec srcTimeSpec, @Nonnull DateTimeFieldSpec destDateTimeSpec)
       throws Exception {
+    _rawTableName = rawTableName;
     _originalIndexDir = originalIndexDir;
     _backfilledIndexDir = backfilledIndexDir;
     Preconditions.checkArgument(!_originalIndexDir.getAbsolutePath().equals(_backfilledIndexDir.getAbsolutePath()),
@@ -76,8 +78,7 @@ public class BackfillDateTimeColumn {
       throws Exception {
     SegmentMetadataImpl originalSegmentMetadata = new SegmentMetadataImpl(_originalIndexDir);
     String segmentName = originalSegmentMetadata.getName();
-    String tableName = originalSegmentMetadata.getTableName();
-    LOGGER.info("Start backfilling segment: {} in table: {}", segmentName, tableName);
+    LOGGER.info("Start backfilling segment: {} in table: {}", segmentName, _rawTableName);
 
     PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader(_originalIndexDir);
     BackfillDateTimeRecordReader wrapperReader =
@@ -90,7 +91,7 @@ public class BackfillDateTimeColumn {
     config.setFormat(FileFormat.PINOT);
     config.setOutDir(_backfilledIndexDir.getAbsolutePath());
     config.setOverwrite(true);
-    config.setTableName(tableName);
+    config.setTableName(_rawTableName);
     config.setSegmentName(segmentName);
     config.setSchema(wrapperReader.getSchema());
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/virtualcolumn/VirtualColumnContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/virtualcolumn/VirtualColumnContext.java
@@ -23,15 +23,13 @@ package org.apache.pinot.core.segment.virtualcolumn;
  */
 public class VirtualColumnContext {
   private String _hostname;
-  private String _tableName;
   private String _segmentName;
   private String _columnName;
   private int _totalDocCount;
 
-  public VirtualColumnContext(String hostname, String tableName, String segmentName, String columnName,
+  public VirtualColumnContext(String hostname, String segmentName, String columnName,
       int totalDocCount) {
     _hostname = hostname;
-    _tableName = tableName;
     _segmentName = segmentName;
     _columnName = columnName;
     _totalDocCount = totalDocCount;
@@ -39,10 +37,6 @@ public class VirtualColumnContext {
 
   public String getHostname() {
     return _hostname;
-  }
-
-  public String getTableName() {
-    return _tableName;
   }
 
   public String getSegmentName() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/BackfillDateTimeRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/BackfillDateTimeRecordReaderTest.java
@@ -49,7 +49,7 @@ import org.testng.annotations.Test;
  */
 public class BackfillDateTimeRecordReaderTest {
   private static final int NUM_ROWS = 10000;
-
+  private static final String TABLE_NAME = "myTable";
   private static String D1 = "d1";
   private static String D2 = "d2";
   private static String M1 = "m1";
@@ -138,7 +138,8 @@ public class BackfillDateTimeRecordReaderTest {
       DateTimeFieldSpec dateTimeFieldSpec, Schema schemaExpected)
       throws Exception {
     BackfillDateTimeColumn backfillDateTimeColumn =
-        new BackfillDateTimeColumn(new File("original"), new File("backup"), timeFieldSpec, dateTimeFieldSpec);
+        new BackfillDateTimeColumn(TABLE_NAME, new File("original"), new File("backup"), timeFieldSpec,
+            dateTimeFieldSpec);
     try (BackfillDateTimeRecordReader wrapperReader = backfillDateTimeColumn
         .getBackfillDateTimeRecordReader(baseRecordReader)) {
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -116,7 +116,7 @@ public class SegmentPurgerTest {
     };
 
     SegmentPurger segmentPurger =
-        new SegmentPurger(_originalIndexDir, PURGED_SEGMENT_DIR, recordPurger, recordModifier);
+        new SegmentPurger(TABLE_NAME, _originalIndexDir, PURGED_SEGMENT_DIR, recordPurger, recordModifier);
     File purgedIndexDir = segmentPurger.purgeSegment();
 
     // Check the purge/modify counter in segment purger

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.config.PinotTaskConfig;
+import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.RawIndexConverter;
@@ -35,7 +36,9 @@ public class ConvertToRawIndexTaskExecutor extends BaseSingleSegmentConversionEx
       @Nonnull File workingDir)
       throws Exception {
     Map<String, String> configs = pinotTaskConfig.getConfigs();
-    new RawIndexConverter(originalIndexDir, workingDir,
+    String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
+    String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    new RawIndexConverter(rawTableName, originalIndexDir, workingDir,
         configs.get(MinionConstants.ConvertToRawIndexTask.COLUMNS_TO_CONVERT_KEY)).convert();
     return new SegmentConversionResult.Builder().setFile(workingDir)
         .setTableNameWithType(configs.get(MinionConstants.TABLE_NAME_KEY))

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PurgeTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PurgeTaskExecutor.java
@@ -49,7 +49,7 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     SegmentPurger.RecordModifierFactory recordModifierFactory = MINION_CONTEXT.getRecordModifierFactory();
     SegmentPurger.RecordModifier recordModifier =
         recordModifierFactory != null ? recordModifierFactory.getRecordModifier(rawTableName) : null;
-    SegmentPurger segmentPurger = new SegmentPurger(originalIndexDir, workingDir, recordPurger, recordModifier);
+    SegmentPurger segmentPurger = new SegmentPurger(rawTableName, originalIndexDir, workingDir, recordPurger, recordModifier);
 
     File purgedSegmentFile = segmentPurger.purgeSegment();
     if (purgedSegmentFile == null) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
@@ -102,16 +102,12 @@ public class BenchmarkQueryEngine {
     _perfBenchmarkDriver = new PerfBenchmarkDriver(conf);
     _perfBenchmarkDriver.run();
 
-    Set<String> tables = new HashSet<String>();
     File[] segments = new File(DATA_DIRECTORY, TABLE_NAME).listFiles();
     for (File segmentDir : segments) {
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segmentDir);
-      if (!tables.contains(segmentMetadata.getTableName())) {
-        _perfBenchmarkDriver.configureTable(segmentMetadata.getTableName());
-        tables.add(segmentMetadata.getTableName());
-      }
+      _perfBenchmarkDriver.configureTable(TABLE_NAME);
       System.out.println("Adding segment " + segmentDir.getAbsolutePath());
-      _perfBenchmarkDriver.addSegment(segmentMetadata);
+      _perfBenchmarkDriver.addSegment(TABLE_NAME, segmentMetadata);
     }
 
     ZkClient client = new ZkClient("localhost:2191", 10000, 10000, new ZNRecordSerializer());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BackfillDateTimeColumnCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BackfillDateTimeColumnCommand.java
@@ -21,6 +21,7 @@ package org.apache.pinot.tools.admin.command;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.data.DateTimeFieldSpec;
 import org.apache.pinot.common.data.TimeFieldSpec;
 import org.apache.pinot.common.utils.CommonConstants.Segment.SegmentType;
@@ -196,10 +197,11 @@ public class BackfillDateTimeColumnCommand extends AbstractBaseAdminCommand impl
       }
 
       // create new segment
+      String rawTableName = TableNameBuilder.extractRawTableName(_tableName);
       File segmentDir = new File(downloadSegmentDir, segmentName);
       File outputDir = new File(downloadSegmentDir, OUTPUT_FOLDER);
       BackfillDateTimeColumn backfillDateTimeColumn =
-          new BackfillDateTimeColumn(segmentDir, outputDir, timeFieldSpec, dateTimeFieldSpec);
+          new BackfillDateTimeColumn(rawTableName, segmentDir, outputDir, timeFieldSpec, dateTimeFieldSpec);
       boolean backfillStatus = backfillDateTimeColumn.backfill();
       LOGGER
           .info("Backfill status for segment {} in {} to {} is {}", segmentName, segmentDir, outputDir, backfillStatus);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -319,9 +319,10 @@ public class PerfBenchmarkDriver {
    *
    * @param segmentMetadata segment metadata.
    */
-  public void addSegment(SegmentMetadata segmentMetadata) {
+  public void addSegment(String tableName, SegmentMetadata segmentMetadata) {
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
     _helixResourceManager
-        .addNewSegment(segmentMetadata, "http://" + _controllerAddress + "/" + segmentMetadata.getName());
+        .addNewSegment(rawTableName, segmentMetadata, "http://" + _controllerAddress + "/" + segmentMetadata.getName());
   }
 
   public static void waitForExternalViewUpdate(String zkAddress, final String clusterName, long timeoutInMilliseconds) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -163,10 +163,10 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
     for (File segment : segments) {
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segment);
       if (!tableConfigured) {
-        driver.configureTable(segmentMetadata.getTableName(), invertedIndexColumns, bloomFilterColumns);
+        driver.configureTable(tableName, invertedIndexColumns, bloomFilterColumns);
         tableConfigured = true;
       }
-      driver.addSegment(segmentMetadata);
+      driver.addSegment(tableName, segmentMetadata);
     }
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/StarTreeQueryGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/StarTreeQueryGenerator.java
@@ -324,12 +324,13 @@ public class StarTreeQueryGenerator {
   public static void main(String[] args)
       throws Exception {
     if (args.length != 2) {
-      System.err.println("Usage: StarTreeQueryGenerator starTreeSegmentsDirectory numQueries");
+      System.err.println("Usage: StarTreeQueryGenerator tableName starTreeSegmentsDirectory numQueries");
       return;
     }
 
     // Get segment metadata for the first segment to get table name and verify query is fit for star tree.
-    File segmentsDir = new File(args[0]);
+    String tableName = args[0];
+    File segmentsDir = new File(args[1]);
     Preconditions.checkState(segmentsDir.exists());
     Preconditions.checkState(segmentsDir.isDirectory());
     File[] segments = segmentsDir.listFiles();
@@ -337,11 +338,10 @@ public class StarTreeQueryGenerator {
     File segment = segments[0];
     IndexSegment indexSegment = ImmutableSegmentLoader.load(segment, ReadMode.heap);
     SegmentMetadata segmentMetadata = indexSegment.getSegmentMetadata();
-    String tableName = segmentMetadata.getTableName();
 
     // Set up star tree query generator.
-    int numQueries = Integer.parseInt(args[1]);
-    SegmentInfoProvider infoProvider = new SegmentInfoProvider(args[0]);
+    int numQueries = Integer.parseInt(args[2]);
+    SegmentInfoProvider infoProvider = new SegmentInfoProvider(args[1]);
     StarTreeQueryGenerator generator =
         new StarTreeQueryGenerator(tableName, infoProvider.getSingleValueDimensionColumns(),
             infoProvider.getMetricColumns(), infoProvider.getSingleValueDimensionValuesMap());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimator.java
@@ -36,7 +36,6 @@ import org.apache.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
 import org.apache.pinot.core.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
-import org.apache.pinot.core.realtime.stream.StreamMessageMetadata;
 import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
 
 
@@ -51,6 +50,7 @@ public class MemoryEstimator {
   private static final String STATS_FILE_COPY_NAME = "stats.copy.ser";
 
   private final TableConfig _tableConfig;
+  private final String _tableNameWithType;
   private final File _sampleCompletedSegment;
   private final long _sampleSegmentConsumedSeconds;
   private final long _maxUsableHostMemory;
@@ -69,6 +69,7 @@ public class MemoryEstimator {
   public MemoryEstimator(TableConfig tableConfig, File sampleCompletedSegment, long sampleSegmentConsumedSeconds, long maxUsableHostMemory) {
     _maxUsableHostMemory = maxUsableHostMemory;
     _tableConfig = tableConfig;
+    _tableNameWithType = tableConfig.getTableName();
     _sampleCompletedSegment = sampleCompletedSegment;
     _sampleSegmentConsumedSeconds = sampleSegmentConsumedSeconds;
 
@@ -87,7 +88,7 @@ public class MemoryEstimator {
     }
     _avgMultiValues = getAvgMultiValues();
 
-    _tableDataDir = new File(TMP_DIR, _segmentMetadata.getTableName());
+    _tableDataDir = new File(TMP_DIR, _tableNameWithType);
     try {
       FileUtils.deleteDirectory(_tableDataDir);
     } catch (IOException e) {
@@ -120,7 +121,7 @@ public class MemoryEstimator {
     // create a config
     RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
         new RealtimeSegmentConfig.Builder().setSegmentName(_segmentMetadata.getName())
-            .setStreamName(_segmentMetadata.getTableName()).setSchema(_segmentMetadata.getSchema())
+            .setStreamName(_tableNameWithType).setSchema(_segmentMetadata.getSchema())
             .setCapacity(_segmentMetadata.getTotalDocs()).setAvgNumMultiValues(_avgMultiValues)
             .setNoDictionaryColumns(_noDictionaryColumns).setInvertedIndexColumns(_invertedIndexColumns)
             .setRealtimeSegmentZKMetadata(segmentZKMetadata).setOffHeap(true).setMemoryManager(memoryManager)
@@ -218,7 +219,7 @@ public class MemoryEstimator {
 
       RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
           new RealtimeSegmentConfig.Builder().setSegmentName(_segmentMetadata.getName())
-              .setStreamName(_segmentMetadata.getTableName()).setSchema(_segmentMetadata.getSchema())
+              .setStreamName(_tableNameWithType).setSchema(_segmentMetadata.getSchema())
               .setCapacity(totalDocs).setAvgNumMultiValues(_avgMultiValues).setNoDictionaryColumns(_noDictionaryColumns)
               .setInvertedIndexColumns(_invertedIndexColumns).setRealtimeSegmentZKMetadata(segmentZKMetadata)
               .setOffHeap(true).setMemoryManager(memoryManager).setStatsHistory(statsHistory);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimator.java
@@ -318,7 +318,6 @@ public class MemoryEstimator {
     realtimeSegmentZKMetadata.setStartTime(segmentMetadata.getStartTime());
     realtimeSegmentZKMetadata.setEndTime(segmentMetadata.getEndTime());
     realtimeSegmentZKMetadata.setCreationTime(segmentMetadata.getIndexCreationTime());
-    realtimeSegmentZKMetadata.setTableName(segmentMetadata.getTableName());
     realtimeSegmentZKMetadata.setSegmentName(segmentMetadata.getName());
     realtimeSegmentZKMetadata.setTimeUnit(segmentMetadata.getTimeUnit());
     realtimeSegmentZKMetadata.setTotalRawDocs(totalDocs);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/SegmentQueryProcessor.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/SegmentQueryProcessor.java
@@ -54,7 +54,6 @@ class SegmentQueryProcessor {
   private final SegmentMetadataImpl _metadata;
   private final ImmutableSegment _immutableSegment;
 
-  private final String _tableName;
   private final String _segmentName;
   private final int _totalDocs;
 
@@ -64,7 +63,6 @@ class SegmentQueryProcessor {
 
     _immutableSegment = ImmutableSegmentLoader.load(_segmentDir, ReadMode.mmap);
     _metadata = new SegmentMetadataImpl(_segmentDir);
-    _tableName = _metadata.getTableName();
     _segmentName = _metadata.getName();
 
     _totalDocs = _metadata.getTotalDocs();
@@ -139,12 +137,6 @@ class SegmentQueryProcessor {
   }
 
   private boolean pruneSegment(BrokerRequest brokerRequest) {
-    // Check if segment belongs to the table being queried.
-    if (!_tableName.equals(brokerRequest.getQuerySource().getTableName())) {
-      LOGGER.debug("Skipping segment {} from different table {}", _segmentName, _tableName);
-      return true;
-    }
-
     // Check if any column in the query does not exist in the segment.
     Set<String> allColumns = _metadata.getAllColumns();
     if (brokerRequest.isSetAggregationsInfo()) {


### PR DESCRIPTION
Removing unnecessary calls to segmentMetadata.getTableName()

After this change, only 3 places will call `segmentMetadata.getTableName()`:
1. From upload API, derive table name from segment metadata that is being uploaded
2. `ZKMetadataUtil.updateSegmentMetadata()` - updating segment zk metadata from segment metadata during segment upload
3. `ColumnarToStarTreeConverter` provides table name to generator config from segment metadata.