### PR TITLE
[TE] populate the feedback in DTO for child anomalies

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -456,7 +456,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
         }
 
         MergedAnomalyResultBean childBean = genericPojoDao.get(id, MergedAnomalyResultBean.class);
-        MergedAnomalyResultDTO child = MODEL_MAPPER.map(childBean, MergedAnomalyResultDTO.class);
+        MergedAnomalyResultDTO child = convertMergedAnomalyBean2DTO(childBean);
         children.add(child);
       }
     }


### PR DESCRIPTION
Previously, the DTO for the child anomaly is loaded with the model mapper, which won't populate the feedbacks object. This PR fixes the issue by explicitly converting it into a DTO.