### PR TITLE
[TE] Use multimap in metric urn as dimension

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/api/user/dashboard/UserDashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/api/user/dashboard/UserDashboardResource.java
@@ -246,7 +246,7 @@ public class UserDashboardResource {
       summary.setMetricId(metricId);
 
       if (metricId > 0) {
-        summary.setMetricUrn(this.getMetricUrn(anomaly));
+        summary.setMetricUrn(anomaly.getMetricUrn());
       }
 
       // TODO use alert filter if necessary
@@ -393,15 +393,5 @@ public class UserDashboardResource {
     } catch (Exception e) {
       return -1;
     }
-  }
-
-  /**
-   * Returns an URN matching the anomalies associated metric (and dimensions)
-   *
-   * @param anomaly anomaly dto
-   * @return metric urn
-   */
-  private String getMetricUrn(MergedAnomalyResultDTO anomaly) {
-    return MetricEntity.fromMetric(1.0, this.getMetricId(anomaly), ResourceUtils.getAnomalyFilters(anomaly, this.datasetDAO)).getUrn();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/rootcause/AnomalyEventFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/rootcause/AnomalyEventFormatter.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
+import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
 
 
 public class AnomalyEventFormatter extends RootCauseEventEntityFormatter {
@@ -149,7 +150,7 @@ public class AnomalyEventFormatter extends RootCauseEventEntityFormatter {
     }
 
     // dimensions as attributes and label
-    SetMultimap<String, String> filters = ResourceUtils.getAnomalyFilters(anomaly, this.datasetDAO);
+    Multimap<String, String> filters = MetricEntity.fromURN(anomaly.getMetricUrn()).getFilters();
 
     List<String> dimensionStrings = new ArrayList<>();
     for (Map.Entry<String, String> entry : filters.entries()) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionUtils.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pinot.thirdeye.common.dimension.DimensionMap;
 import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.dataframe.BooleanSeries;
@@ -55,8 +56,8 @@ public class DetectionUtils {
   // TODO anomaly should support multimap
   public static DimensionMap toFilterMap(Multimap<String, String> filters) {
     DimensionMap map = new DimensionMap();
-    for (Map.Entry<String, String> entry : filters.entries()) {
-      map.put(entry.getKey(), entry.getValue());
+    for (Map.Entry<String, Collection<String>> entry: filters.asMap().entrySet()){
+      map.put(entry.getKey(), String.join(", ", entry.getValue()));
     }
     return map;
   }


### PR DESCRIPTION
Previously we use a map to store the dimension values so that for each dimension, there can only be one value. In this PR, we fix the issue by using the information stored in the metric urn to construct a multi-map. 