### PR TITLE
[TE] frontend - harleyjj/preview - remove day from graph x-axis and s…

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-details/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-details/component.js
@@ -39,7 +39,7 @@ const TIME_PICKER_INCREMENT = 5; // tells date picker hours field how granularly
 const DEFAULT_ACTIVE_DURATION = '1m'; // setting this date range selection as default (Last 24 Hours)
 const UI_DATE_FORMAT = 'MMM D, YYYY hh:mm a'; // format for date picker to use (usually varies by route or metric)
 const DISPLAY_DATE_FORMAT = 'YYYY-MM-DD HH:mm'; // format used consistently across app to display custom date range
-const TIME_RANGE_OPTIONS = ['1d', '1w', '1m', '3m'];
+const TIME_RANGE_OPTIONS = ['48h', '1w', '1m', '3m'];
 const ANOMALY_LEGEND_THRESHOLD = 20; // If number of anomalies is larger than this threshold, don't show the legend
 
 export default Component.extend({
@@ -48,7 +48,7 @@ export default Component.extend({
   anomalyMapping: {},
   timeseries: null,
   isLoading: false,
-  analysisRange: [moment().subtract(1, 'day').startOf('day').valueOf(), moment().add(1, 'day').startOf('day').valueOf()],
+  analysisRange: [moment().subtract(2, 'day').startOf('day').valueOf(), moment().add(1, 'day').startOf('day').valueOf()],
   isPendingData: false,
   colorMapping: colorMapping,
   zoom: {
@@ -346,7 +346,7 @@ export default Component.extend({
             format: (d) => {
               const t = makeTime(d);
               if (t.valueOf() === t.clone().startOf('day').valueOf()) {
-                return t.format('MMM D (ddd)');
+                return t.format('MMM D');
               }
               return t.format('h:mm a');
             }
@@ -727,7 +727,7 @@ export default Component.extend({
       this._fetchAnomalies();
     } else {
       this.setProperties({
-        duration: '1d',
+        duration: '48h',
         selectedBaseline: 'predicted'
       });
     }

--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-summary/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-summary/component.js
@@ -117,7 +117,7 @@ export default Component.extend({
             format: (d) => {
               const t = makeTime(d);
               if (t.valueOf() === t.clone().startOf('day').valueOf()) {
-                return t.format('MMM D (ddd)');
+                return t.format('MMM D');
               }
               return t.format('h:mm a');
             }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -134,7 +134,7 @@ export default Component.extend({
             format: (d) => {
               const t = makeTime(d);
               if (t.valueOf() === t.clone().startOf('day').valueOf()) {
-                return t.format('MMM D (ddd)');
+                return t.format('MMM D');
               }
               return t.format('h:mm a');
             }

--- a/thirdeye/thirdeye-frontend/app/pods/screenshot/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/screenshot/controller.js
@@ -150,7 +150,7 @@ export default Controller.extend({
             format: (d) => {
               const t = makeTime(d);
               if (t.valueOf() === t.clone().startOf('day').valueOf()) {
-                return t.format('MMM D (ddd)');
+                return t.format('MMM D');
               }
               return t.format('h:mm a');
             }

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -158,7 +158,8 @@ export function setUpTimeRangeOptions(datesKeys, duration) {
       [ '2w', ['Last 2 Weeks', 2, 'week'] ],
       [ '1w', ['Last Week', 1, 'week'] ],
       [ '2d', ['Yesterday', 2, 'day'] ],
-      [ '1d', ['Last 24 hours', 1, 'day'] ],
+      [ '1d', ['Last 24 Hours', 1, 'day'] ],
+      [ '48h', ['Last 48 Hours', 2, 'day'] ],
       [ 'today', ['Today'] ]
     ]);
 
@@ -166,6 +167,7 @@ export function setUpTimeRangeOptions(datesKeys, duration) {
     const currVal = dateKeyMap.get(value);
     const label = currVal[0];
     let start = moment().subtract(currVal[1], currVal[2]).startOf('day');
+    // overrides map above
     switch(label) {
       case 'Today':
         start = moment().startOf('day');


### PR DESCRIPTION
…et default time range to 48 hours before

1) Removes the day of the week from the graph's x-axis
2) Sets default time range of preview to 48 hours before today + today, to ensure daily metrics will preview properly