### PR TITLE
Refresh schema when reloading segments

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -180,10 +180,8 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     Preconditions.checkNotNull(tableConfig);
 
     Schema schema = null;
-    // For OFFLINE table, try to get schema for default columns
-    if (TableNameBuilder.OFFLINE.tableHasTypeSuffix(tableNameWithType)) {
-      schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableNameWithType);
-    }
+    // For REALTIME and OFFLINE tables, try to get schema for default columns
+    schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableNameWithType);
 
     reloadSegment(tableNameWithType, segmentMetadata, tableConfig, schema);
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -179,9 +179,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
     Preconditions.checkNotNull(tableConfig);
 
-    Schema schema = null;
-    // For REALTIME and OFFLINE tables, try to get schema for default columns
-    schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableNameWithType);
+    Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableNameWithType);
 
     reloadSegment(tableNameWithType, segmentMetadata, tableConfig, schema);
 


### PR DESCRIPTION
Now when reloading segments, schema is re-fetched only for OFFLINE table. For realtime tables, it will still reload with the old schema, ignoring new columns recently added.

This diff will reload schemas for REALTIME and OFFLINE tables before reloading segments, as a follow-up on https://github.com/apache/incubator-pinot/issues/4225#issuecomment-502896395

Tested on a few REALTIME (HLC and LLC) tables.