### PR TITLE
[TE] detection dimensional cache

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/util/DataFrameUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/util/DataFrameUtils.java
@@ -323,6 +323,22 @@ public class DataFrameUtils {
     return new TimeSeriesRequestContainer(request, expressions, start, end, granularity.toPeriod());
   }
 
+  /**
+   * Constructs and wraps a request for a metric with multiple dimension filters. Resolves all
+   * required dependencies from the Thirdeye database. Also aligns start and end timestamps by
+   * rounding them down (start) and up (end) to align with metric time granularity boundaries.
+   * <br/><b>NOTE:</b> the aligned end timestamp is still exclusive.
+   *
+   * @param startTime the start time
+   * @param endTime the end time
+   * @param filters a list of dimension filters
+   * @param timeGranularity the result time granularity
+   * @param reference unique identifier for request
+   * @param metric metric config DTO
+   * @param dataset dataset config DTO
+   * @return TimeSeriesRequestContainer
+   * @throws Exception
+   */
   public static TimeSeriesRequestContainer makeTimeSeriesRequestAlignedBatch(
       long startTime,
       long endTime,

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/util/MetricSlice.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/util/MetricSlice.java
@@ -108,6 +108,12 @@ public final class MetricSlice {
         slice.start >= this.start && slice.end <= this.end;
   }
 
+  /**
+   * check if two filter multi-maps are equal regardless of dimension value orders
+   * @param filters1 filter 1
+   * @param filters2 filter 2
+   * @return <tt>true</tt> if two filters are equal
+   */
   private static boolean filtersEquals(Multimap<String, String> filters1, Multimap<String, String> filters2) {
     Map<String, Collection<String>> filterMaps1 = filters1.asMap();
     Map<String, Collection<String>> filterMaps2 = filters2.asMap();

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/util/MetricSlice.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/util/MetricSlice.java
@@ -101,7 +101,7 @@ public final class MetricSlice {
    * check if current metric slice contains another metric slice
    */
   public boolean containSlice(MetricSlice slice) {
-    return slice.metricId == this.metricId && slice.granularity.equals(this.granularity) && slice.getFilters().equals(this.getFilters()) &&
+    return slice.metricId == this.metricId && slice.granularity.equals(this.granularity) && slice.getFilters().asMap().equals(this.getFilters().asMap()) &&
         slice.start >= this.start && slice.end <= this.end;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/util/MetricSlice.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/util/MetricSlice.java
@@ -21,11 +21,14 @@ package org.apache.pinot.thirdeye.dataframe.util;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.pinot.thirdeye.common.time.TimeGranularity;
+import org.apache.pinot.thirdeye.rootcause.Entity;
 
 
 /**
@@ -101,8 +104,25 @@ public final class MetricSlice {
    * check if current metric slice contains another metric slice
    */
   public boolean containSlice(MetricSlice slice) {
-    return slice.metricId == this.metricId && slice.granularity.equals(this.granularity) && slice.getFilters().asMap().equals(this.getFilters().asMap()) &&
+    return slice.metricId == this.metricId && slice.granularity.equals(this.granularity) && filtersEquals(this.getFilters(), slice.getFilters()) &&
         slice.start >= this.start && slice.end <= this.end;
+  }
+
+  private static boolean filtersEquals(Multimap<String, String> filters1, Multimap<String, String> filters2) {
+    Map<String, Collection<String>> filterMaps1 = filters1.asMap();
+    Map<String, Collection<String>> filterMaps2 = filters2.asMap();
+
+    if (!filterMaps1.keySet().equals(filterMaps2.keySet())) {
+      return false;
+    }
+    for (Map.Entry<String, Collection<String>> entry : filterMaps1.entrySet()) {
+      Collection<String> filter1Values = entry.getValue();
+      Collection<String> filter2Values = filterMaps2.get(entry.getKey());
+      if (!(filter1Values.containsAll(filter2Values) && filter2Values.containsAll(filter1Values))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/ThirdEyeRequest.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/ThirdEyeRequest.java
@@ -50,11 +50,12 @@ public class ThirdEyeRequest {
   private final List<MetricFunction> metricFunctions;
   private final DateTime startTime;
   private final DateTime endTime;
-  private final Multimap<String, String> filterSet; // D1 IN (V1, V2) AND D2 in (V3,V4)
+  private final Multimap<String, String> filterSet; // WHERE D1 IN (V1, V2) AND D2 in (V3,V4)
   // TODO - what kind of advanced expressions do we want here? This could potentially force code to
   // depend on a specific client implementation
+
   // multiple filters in one query
-  private final Collection<Multimap<String, String>> filterSets;  // ((D1=V1) AND (D2=V2)) OR ((D1=V1) AND (D2=V3))
+  private final Collection<Multimap<String, String>> filterSets;  // WHERE ((D1=V1) AND (D2=V2)) OR ((D1=V1) AND (D2=V3))
   private final String filterClause;
   private final List<String> groupByDimensions;
   private final TimeGranularity groupByTimeGranularity;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/DefaultTimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/DefaultTimeSeriesLoader.java
@@ -90,7 +90,7 @@ public class DefaultTimeSeriesLoader implements TimeSeriesLoader {
         DatasetConfigDTO dataset = retriveDataset(metric);
         if (dataset.getDataSource().equals(PinotThirdEyeDataSource.class.getSimpleName()) && dataset.isAdditive()
             && !metric.isDimensionAsMetric()) {
-          // if it's pinot data source, batch load the data for multiple dimension values in one query
+          // if it's pinot data source, and the dataset is additive, batch load the data for multiple dimension values in one query
           output.putAll(loadFromBatchQuery(queryGroup, metric, dataset));
         } else {
           for (MetricSlice metricSlice : queryGroup.slices) {
@@ -117,7 +117,7 @@ public class DefaultTimeSeriesLoader implements TimeSeriesLoader {
   private Map<MetricSlice, DataFrame> evaluateResultForQueryGroup(QueryGroup queryGroup, DataFrame df){
     Map<MetricSlice, DataFrame> output = new HashMap<>();
     for (MetricSlice slice: queryGroup.slices) {
-      DataFrame result = df;
+      DataFrame result = df.copy();
       for (Map.Entry<String, Collection<String>> entry: slice.getFilters().asMap().entrySet()){
         // pick the result for the respective dimension values
         result = result.filter(result.getStrings(entry.getKey()).map(

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/DefaultTimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/DefaultTimeSeriesLoader.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.dataframe.DataFrame;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/DefaultTimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/DefaultTimeSeriesLoader.java
@@ -19,14 +19,28 @@
 
 package org.apache.pinot.thirdeye.datasource.loader;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.dataframe.DataFrame;
+import org.apache.pinot.thirdeye.dataframe.Series;
 import org.apache.pinot.thirdeye.dataframe.util.DataFrameUtils;
 import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
 import org.apache.pinot.thirdeye.dataframe.util.TimeSeriesRequestContainer;
 import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.MetricConfigManager;
+import org.apache.pinot.thirdeye.datalayer.dto.DatasetConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.MetricConfigDTO;
 import org.apache.pinot.thirdeye.datasource.ThirdEyeResponse;
 import org.apache.pinot.thirdeye.datasource.cache.QueryCache;
+import org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,9 +68,136 @@ public class DefaultTimeSeriesLoader implements TimeSeriesLoader {
   @Override
   public DataFrame load(MetricSlice slice) throws Exception {
     LOG.info("Loading time series for '{}'", slice);
-
-    TimeSeriesRequestContainer rc = DataFrameUtils.makeTimeSeriesRequestAligned(slice, "ref", this.metricDAO, this.datasetDAO);
+    MetricConfigDTO metric = retriveMetric(slice.getMetricId());
+    TimeSeriesRequestContainer rc =
+        DataFrameUtils.makeTimeSeriesRequestAligned(slice, "ref", metric, retriveDataset(metric));
     ThirdEyeResponse response = this.cache.getQueryResult(rc.getRequest());
     return DataFrameUtils.evaluateResponse(response, rc);
+  }
+
+  @Override
+  public Map<MetricSlice, DataFrame> loadTimeSeries(Collection<MetricSlice> slices) throws Exception {
+    Map<MetricSlice, DataFrame> output = new HashMap<>();
+
+    Collection<QueryGroup> queryGroups = getQueryGroups(slices);
+    for (QueryGroup queryGroup : queryGroups) {
+      if (queryGroup.slices.size() == 1) {
+        MetricSlice slice = queryGroup.slices.stream().findFirst().get();
+        output.put(slice, this.load(slice));
+      } else {
+        MetricConfigDTO metric = retriveMetric(queryGroup.metricId);
+        DatasetConfigDTO dataset = retriveDataset(metric);
+        if (dataset.getDataSource().equals(PinotThirdEyeDataSource.class.getSimpleName()) && dataset.isAdditive()
+            && !metric.isDimensionAsMetric()) {
+          // batch loading
+          output.putAll(loadFromBatchQuery(queryGroup, metric, dataset));
+        } else {
+          for (MetricSlice metricSlice : queryGroup.slices) {
+            output.put(metricSlice, this.load(metricSlice));
+          }
+        }
+      }
+    }
+    return output;
+  }
+
+  private Map<MetricSlice, DataFrame> loadFromBatchQuery(QueryGroup queryGroup, MetricConfigDTO metric,
+      DatasetConfigDTO dataset) throws Exception {
+    TimeSeriesRequestContainer rc =
+        DataFrameUtils.makeTimeSeriesRequestAlignedBatch(queryGroup.startTime, queryGroup.endTime,
+            queryGroup.slices.stream().map(MetricSlice::getFilters).collect(Collectors.toList()), queryGroup.dimensions,
+            queryGroup.granularity, "ref", metric, dataset);
+    ThirdEyeResponse response = this.cache.getQueryResult(rc.getRequest());
+    DataFrame df = DataFrameUtils.evaluateResponse(response, rc);
+    return evaluateResultForQueryGroup(queryGroup, df);
+  }
+
+  private Map<MetricSlice, DataFrame> evaluateResultForQueryGroup(QueryGroup queryGroup, DataFrame df){
+    Map<MetricSlice, DataFrame> output = new HashMap<>();
+    for (MetricSlice slice: queryGroup.slices) {
+      DataFrame result = df;
+      for (Map.Entry<String, Collection<String>> entry: slice.getFilters().asMap().entrySet()){
+        result = result.filter(result.getStrings(entry.getKey()).map(
+            (Series.StringConditional) values -> entry.getValue().contains(values[0]))).dropNull(entry.getKey());
+      }
+      result.retainSeries(COL_TIME, COL_VALUE);
+      output.put(slice, result);
+    }
+    return output;
+  }
+
+  private MetricConfigDTO retriveMetric(long id) {
+    MetricConfigDTO metric = metricDAO.findById(id);
+    if (metric == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve metric id %d", id));
+    }
+    return metric;
+  }
+
+  private DatasetConfigDTO retriveDataset(MetricConfigDTO metric) {
+    DatasetConfigDTO dataset = datasetDAO.findByDataset(metric.getDataset());
+    if (dataset == null) {
+      throw new IllegalArgumentException(
+          String.format("Could not resolve dataset '%s' for metric id '%d'", metric.getDataset(), metric.getId()));
+    }
+    return dataset;
+  }
+
+  private Collection<QueryGroup> getQueryGroups(Collection<MetricSlice> slices) {
+    List<QueryGroup> queryGroups = new ArrayList<>();
+    // group by metric, start time, end time and granularity
+    Map<List<Object>, List<MetricSlice>> timeRangeAndMetricGroups = slices.stream()
+        .collect(Collectors.groupingBy(
+            slice -> Arrays.asList(slice.getStart(), slice.getEnd(), slice.getMetricId(), slice.getGranularity()),
+            Collectors.toList()));
+
+    // group by dimension filters
+    for (List<MetricSlice> timeRangeAndMetricGroup : timeRangeAndMetricGroups.values()) {
+//      // filter out slices with multiple values
+//      List<MetricSlice> slicesWithMultipleFilterValues = timeRangeAndMetricGroup.stream()
+//          .filter(metricSlice -> metricSlice.getFilters()
+//              .asMap()
+//              .entrySet()
+//              .stream()
+//              .anyMatch(entry -> entry.getValue().size() > 1))
+//          .collect(Collectors.toList());
+//      queryGroups.addAll(
+//          slicesWithMultipleFilterValues.stream().map(QueryGroup::fromSlice).collect(Collectors.toList()));
+//
+//      timeRangeAndMetricGroup.removeAll(slicesWithMultipleFilterValues);
+      Map<Set<String>, List<MetricSlice>> groups = timeRangeAndMetricGroup.stream()
+          .collect(Collectors.groupingBy(slice -> slice.getFilters().keySet(), Collectors.toList()));
+      for (List<MetricSlice> groupedSlices : groups.values()) {
+        MetricSlice slice = groupedSlices.stream().findFirst().get();
+        queryGroups.add(
+            new QueryGroup(groupedSlices, slice.getMetricId(), slice.getStart(), slice.getEnd(), slice.getGranularity(),
+                new ArrayList<>(slice.getFilters().keySet())));
+      }
+    }
+    return queryGroups;
+  }
+
+  private static class QueryGroup {
+    final Collection<MetricSlice> slices;
+    final long metricId;
+    final long startTime;
+    final long endTime;
+    final TimeGranularity granularity;
+    final List<String> dimensions;
+
+    static QueryGroup fromSlice(MetricSlice slice) {
+      return new QueryGroup(Collections.singleton(slice), slice.getMetricId(), slice.getStart(), slice.getEnd(),
+          slice.getGranularity(), new ArrayList<>(slice.getFilters().keySet()));
+    }
+
+    QueryGroup(Collection<MetricSlice> slices, long metricId, long startTime, long endTime, TimeGranularity granularity,
+        List<String> dimensions) {
+      this.slices = slices;
+      this.metricId = metricId;
+      this.startTime = startTime;
+      this.endTime = endTime;
+      this.granularity = granularity;
+      this.dimensions = dimensions;
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/TimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/TimeSeriesLoader.java
@@ -19,6 +19,8 @@
 
 package org.apache.pinot.thirdeye.datasource.loader;
 
+import java.util.Collection;
+import java.util.Map;
 import org.apache.pinot.thirdeye.dataframe.DataFrame;
 import org.apache.pinot.thirdeye.dataframe.util.DataFrameUtils;
 import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
@@ -44,4 +46,6 @@ public interface TimeSeriesLoader {
    * @return dataframe with aligned timestamps and values
    */
   DataFrame load(MetricSlice slice) throws Exception;
+
+  Map<MetricSlice, DataFrame> loadTimeSeries(Collection<MetricSlice> slices) throws Exception;
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/TimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/TimeSeriesLoader.java
@@ -47,5 +47,18 @@ public interface TimeSeriesLoader {
    */
   DataFrame load(MetricSlice slice) throws Exception;
 
+  /**
+   * Returns the metric time series for a collection of slices, If the underlying time series resolution
+   * does not correspond to the desired time granularity, it is up-sampled (via forward fill) or down-sampled
+   * (via sum if additive, or last value otherwise) transparently.
+   *
+   * Send the queries in batches for various dimension combinations if possible
+   *
+   * <br/><b>NOTE:</b> if the start timestamp does not align with the time
+   * resolution, it is aligned with the nearest lower time stamp.
+   *
+   * @param slices metric slices to fetch
+   * @return a map of data frame with aligned timestamps and values keyed by metric slices
+   */
   Map<MetricSlice, DataFrame> loadTimeSeries(Collection<MetricSlice> slices) throws Exception;
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DefaultDataProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DefaultDataProvider.java
@@ -149,20 +149,6 @@ public class DefaultDataProvider implements DataProvider {
       // if not in cache, fetch from data source
       output.putAll(this.timeseriesLoader.loadTimeSeries(slices.stream().filter(slice -> !output.containsKey(slice)).collect(
           Collectors.toList())));
-//      Map<MetricSlice, Future<DataFrame>> futures = new HashMap<>();
-//      for (final MetricSlice slice : slices) {
-//        if (!output.containsKey(slice)){
-//          futures.put(slice, this.executor.submit(() -> DefaultDataProvider.this.timeseriesLoader.load(slice)));
-//        }
-//      }
-//      //LOG.info("Fetching {} slices of timeseries, {} cache hit, {} cache miss", slices.size(), output.size(), futures.size());
-//      final long deadline = System.currentTimeMillis() + TIMEOUT;
-//      for (MetricSlice slice : slices) {
-//        if (!output.containsKey(slice)) {
-//          output.put(slice, futures.get(slice).get(makeTimeout(deadline), TimeUnit.MILLISECONDS));
-//        }
-//      }
-      //LOG.info("Fetching {} slices used {} milliseconds", slices.size(), System.currentTimeMillis() - ts);
       return output;
 
     } catch (Exception e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DefaultDataProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DefaultDataProvider.java
@@ -138,10 +138,8 @@ public class DefaultDataProvider implements DataProvider {
           if (entry.getKey().containSlice(slice)){
             DataFrame df = entry.getValue().filter(entry.getValue().getLongs(COL_TIME).between(slice.getStart(), slice.getEnd())).dropNull(COL_TIME);
             // double check if it is cache hit
-            if (df.getLongs(COL_TIME).size() > 0) {
               output.put(slice, df);
               break;
-            }
           }
         }
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
@@ -29,6 +29,7 @@ import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.EvaluationDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.datasource.comparison.Row;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.detection.DataProvider;
 import org.apache.pinot.thirdeye.detection.DetectionPipelineException;
@@ -224,10 +225,11 @@ public class DimensionWrapper extends DetectionPipeline {
     }
     if (nestedMetrics.size() > MAX_DIMENSION_COMBINATIONS) {
       throw new DetectionPipelineException(String.format(
-          "Dimension combination for {} is {} which exceeds limit of {}",
+          "Dimension combination for %d is %d which exceeds limit of %d",
           this.config.getId(), nestedMetrics.size(), MAX_DIMENSION_COMBINATIONS));
     }
 
+    // pre-fetch time series for multiple dimensions in one query
     if (this.cachingPeriodLookback >= 0) {
       this.provider.fetchTimeseries(nestedMetrics.stream().map(metricEntity -> MetricSlice.from(metricEntity.getId(), startTime - cachingPeriodLookback, endTime,
           metricEntity.getFilters())).collect(Collectors.toList()));

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
@@ -86,7 +86,8 @@ public class DimensionWrapper extends DetectionPipeline {
   // Stop running if the first several dimension combinations all failed.
   private static final int EARLY_STOP_THRESHOLD = 10;
 
-  // the maximum number of time series we fetch in one query
+  // the maximum number of time series we fetch in one query, if too large,
+  // the data fetching might hit the limitations in query sending and result passing
   private static final int BATCH_QUERY_MAX_SIZE = 50;
   private static final long DEFAULT_CACHING_PERIOD_LOOKBACK = -1;
   private static final long CACHING_PERIOD_LOOKBACK_DAILY = TimeUnit.DAYS.toMillis(90);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapper.java
@@ -81,12 +81,6 @@ public class AnomalyDetectorWrapper extends DetectionPipeline {
   private static final String PROP_DETECTOR_COMPONENT_NAME = "detectorComponentName";
   private static final String PROP_TIMEZONE = "timezone";
   private static final String PROP_BUCKET_PERIOD = "bucketPeriod";
-  private static final String PROP_CACHE_PERIOD_LOOKBACK = "cachingPeriodLookback";
-  private static final long DEFAULT_CACHING_PERIOD_LOOKBACK = -1;
-  private static final long CACHING_PERIOD_LOOKBACK_DAILY = TimeUnit.DAYS.toMillis(90);
-  private static final long CACHING_PERIOD_LOOKBACK_HOURLY = TimeUnit.DAYS.toMillis(60);
-  // disable minute level cache warm up
-  private static final long CACHING_PERIOD_LOOKBACK_MINUTELY = -1;
   // fail detection job if it failed successively for the first 5 windows
   private static final long EARLY_TERMINATE_WINDOW = 5;
   // expression to consolidate the time series
@@ -110,7 +104,6 @@ public class AnomalyDetectorWrapper extends DetectionPipeline {
   private final DatasetConfigDTO dataset;
   private final DateTimeZone dateTimeZone;
   private Period bucketPeriod;
-  private final long cachingPeriodLookback;
 
   public AnomalyDetectorWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime) {
     super(provider, config, startTime, endTime);
@@ -146,24 +139,11 @@ public class AnomalyDetectorWrapper extends DetectionPipeline {
 
     String bucketStr = MapUtils.getString(config.getProperties(), PROP_BUCKET_PERIOD);
     this.bucketPeriod = bucketStr == null ? this.getBucketSizePeriodForDataset() : Period.parse(bucketStr);
-    this.cachingPeriodLookback = config.getProperties().containsKey(PROP_CACHE_PERIOD_LOOKBACK) ?
-        MapUtils.getLong(config.getProperties(), PROP_CACHE_PERIOD_LOOKBACK) : getCachingPeriodLookback(this.dataset.bucketTimeGranularity());
-
     speedUpMinuteLevelDetection();
   }
 
   @Override
   public DetectionPipelineResult run() throws Exception {
-    // pre-cache time series with default granularity. this is used in multiple places:
-    // 1. get the last time stamp for the time series.
-    // 2. to calculate current values and  baseline values for the anomalies detected
-    // 3. anomaly detection current and baseline time series value
-    if (this.cachingPeriodLookback >= 0) {
-      MetricSlice cacheSlice = MetricSlice.from(this.metricEntity.getId(), startTime - cachingPeriodLookback, endTime,
-          this.metricEntity.getFilters());
-      this.provider.fetchTimeseries(Collections.singleton(cacheSlice));
-    }
-
     List<Interval> monitoringWindows = this.getMonitoringWindows();
     List<MergedAnomalyResultDTO> anomalies = new ArrayList<>();
     TimeSeries predictedResult = TimeSeries.empty();
@@ -298,24 +278,6 @@ public class AnomalyDetectorWrapper extends DetectionPipeline {
       }
     }
     return Collections.singletonList(new Interval(startTime, endTime));
-  }
-
-  private long getCachingPeriodLookback(TimeGranularity granularity) {
-    long period;
-    switch (granularity.getUnit()) {
-      case DAYS:
-        period = CACHING_PERIOD_LOOKBACK_DAILY;
-        break;
-      case HOURS:
-        period = CACHING_PERIOD_LOOKBACK_HOURLY;
-        break;
-      case MINUTES:
-        period = CACHING_PERIOD_LOOKBACK_MINUTELY;
-        break;
-      default:
-        period = DEFAULT_CACHING_PERIOD_LOOKBACK;
-    }
-    return period;
   }
 
   // get the list of monitoring window end times

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
@@ -82,7 +82,6 @@ import org.apache.pinot.thirdeye.detection.validators.SubscriptionConfigValidato
 import org.apache.pinot.thirdeye.detection.yaml.translator.DetectionConfigTranslator;
 import org.apache.pinot.thirdeye.detection.yaml.translator.SubscriptionConfigTranslator;
 import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
-import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -645,10 +644,8 @@ public class YamlResource {
       }
 
       Preconditions.checkNotNull(detectionConfig);
-      long i = System.currentTimeMillis();
       DetectionPipeline pipeline = this.loader.from(this.provider, detectionConfig, start, end);
       result = pipeline.run();
-      LOG.info("Preview took {} milliseconds", System.currentTimeMillis() - i);
 
     } catch (IllegalArgumentException e) {
       return processBadRequestResponse(YamlOperations.PREVIEW.name(), YamlOperations.RUNNING.name(), payload, e);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
@@ -82,6 +82,7 @@ import org.apache.pinot.thirdeye.detection.validators.SubscriptionConfigValidato
 import org.apache.pinot.thirdeye.detection.yaml.translator.DetectionConfigTranslator;
 import org.apache.pinot.thirdeye.detection.yaml.translator.SubscriptionConfigTranslator;
 import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
+import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -644,8 +645,10 @@ public class YamlResource {
       }
 
       Preconditions.checkNotNull(detectionConfig);
+      long i = System.currentTimeMillis();
       DetectionPipeline pipeline = this.loader.from(this.provider, detectionConfig, start, end);
       result = pipeline.run();
+      LOG.info("Preview took {} milliseconds", System.currentTimeMillis() - i);
 
     } catch (IllegalArgumentException e) {
       return processBadRequestResponse(YamlOperations.PREVIEW.name(), YamlOperations.RUNNING.name(), payload, e);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/rootcause/impl/MetricAnalysisPipeline2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/rootcause/impl/MetricAnalysisPipeline2.java
@@ -348,7 +348,13 @@ public class MetricAnalysisPipeline2 extends Pipeline {
     List<TimeSeriesRequestContainer> requests = new ArrayList<>();
     for(MetricSlice slice : slices) {
       try {
-        requests.add(DataFrameUtils.makeTimeSeriesRequestAligned(slice, makeIdentifier(slice), this.metricDAO, this.datasetDAO));
+        MetricConfigDTO metric = metricDAO.findById(slice.getMetricId());
+        if(metric == null)
+          throw new IllegalArgumentException(String.format("Could not resolve metric id %d", slice.getMetricId()));
+        DatasetConfigDTO dataset = datasetDAO.findByDataset(metric.getDataset());
+        if(dataset == null)
+          throw new IllegalArgumentException(String.format("Could not resolve dataset '%s' for metric id '%d'", metric.getDataset(), metric.getId()));
+        requests.add(DataFrameUtils.makeTimeSeriesRequestAligned(slice, makeIdentifier(slice), metric, dataset));
       } catch (Exception ex) {
         LOG.warn(String.format("Could not make request. Skipping."), ex);
       }


### PR DESCRIPTION
For high dimensional metrics, currently, the detection will send a query for each dimension and then run the anomaly detection. This PR implements an optimization to fetch time series for multiple dimension values in batch from Pinot and run then detection. This could reduce the number of queries sent to pinot and improves the overall detection performance.

- Support batch loading in time series loader
- Support send the request for multiple dimension filter sets in one Pinot query
- Move the caching from Anomaly Detector Wrapper to Dimension Wrapper

