### PR TITLE
Remove jboss and chibi repository from pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,30 +185,6 @@
       </build>
     </profile>
   </profiles>
-
-  <repositories>
-    <repository>
-      <id>jboss.org</id>
-      <url>http://repository.jboss.org</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>chibi</id>
-      <url>http://www.chibi.ubc.ca/maven2/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
Since we do not need jboss and chibi repositories for building
Pinot, thir pr removes the unnecessary repositories.