### PR TITLE
[TE] cleaned up error messages when running in demo mode

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -54,7 +54,7 @@
     <commons-dbcp2.version>2.1.1</commons-dbcp2.version>
     <commons-conf2.version>2.5</commons-conf2.version>
     <commons-collection4.version>4.1</commons-collection4.version>
-    <reflections.version>0.9.11</reflections.version>
+    <reflections.version>0.9.10</reflections.version>
     <mrunit.version>1.1.0</mrunit.version>
     <slf4j-api.version>1.7.12</slf4j-api.version>
     <jodatime.version>2.7</jodatime.version>

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/mock/AutoOnboardMockDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/mock/AutoOnboardMockDataSource.java
@@ -105,20 +105,24 @@ public class AutoOnboardMockDataSource extends AutoOnboard {
 
     // NOTE: save in order as mock datasource expects metric ids first
     for (MetricConfigDTO metricConfig : metricConfigs) {
-      Long id = this.metricDAO.save(metricConfig);
-      if (id != null) {
-        LOG.info("Created metric '{}' with id {}", metricConfig.getAlias(), id);
-      } else {
-        LOG.warn("Could not create metric '{}'", metricConfig.getAlias());
+      if (this.metricDAO.findByMetricAndDataset(metricConfig.getName(), metricConfig.getDataset()) == null) {
+        Long id = this.metricDAO.save(metricConfig);
+        if (id != null) {
+          LOG.info("Created metric '{}' with id {}", metricConfig.getAlias(), id);
+        } else {
+          LOG.warn("Could not create metric '{}'", metricConfig.getAlias());
+        }
       }
     }
 
     for (DatasetConfigDTO datasetConfig : datasetConfigs) {
-      Long id = this.datasetDAO.save(datasetConfig);
-      if (id != null) {
-        LOG.info("Created dataset '{}' with id {}", datasetConfig.getDataset(), id);
-      } else {
-        LOG.warn("Could not create dataset '{}'", datasetConfig.getDataset());
+      if (this.datasetDAO.findByDataset(datasetConfig.getDataset()) == null) {
+        Long id = this.datasetDAO.save(datasetConfig);
+        if (id != null) {
+          LOG.info("Created dataset '{}' with id {}", datasetConfig.getDataset(), id);
+        } else {
+          LOG.warn("Could not create dataset '{}'", datasetConfig.getDataset());
+        }
       }
     }
   }


### PR DESCRIPTION
1. Downgrade reflection to 0.9.10 since 0.9.11 has bugs with logs of error messages.
2. Check metrics existence before inserting into demo database. 