### PR TITLE
[TE] Trigger expression based grouping of anomalies - AND, OR and combinations

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionUtils.java
@@ -24,6 +24,7 @@ import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +53,13 @@ import static org.apache.pinot.thirdeye.dataframe.util.DataFrameUtils.*;
 
 public class DetectionUtils {
   private static final String PROP_BASELINE_PROVIDER_COMPONENT_NAME = "baselineProviderComponentName";
+
+  private static final Comparator<MergedAnomalyResultDTO> COMPARATOR = new Comparator<MergedAnomalyResultDTO>() {
+    @Override
+    public int compare(MergedAnomalyResultDTO o1, MergedAnomalyResultDTO o2) {
+      return Long.compare(o1.getStartTime(), o2.getStartTime());
+    }
+  };
 
   // TODO anomaly should support multimap
   public static DimensionMap toFilterMap(Multimap<String, String> filters) {
@@ -171,6 +179,55 @@ public class DetectionUtils {
     anomaly.setEndTime(slice.getEnd());
 
     return anomaly;
+  }
+
+  public static void setEntityChildMapping(MergedAnomalyResultDTO parent, MergedAnomalyResultDTO child1) {
+    if (child1 != null) {
+      parent.getChildren().add(child1);
+      child1.setChild(true);
+    }
+
+    parent.setChild(false);
+  }
+
+  public static MergedAnomalyResultDTO makeEntityAnomaly() {
+    MergedAnomalyResultDTO entityAnomaly = new MergedAnomalyResultDTO();
+    // TODO: define anomaly type
+    //entityAnomaly.setType();
+    entityAnomaly.setChild(false);
+
+    return entityAnomaly;
+  }
+
+  public static MergedAnomalyResultDTO makeEntityCopy(MergedAnomalyResultDTO anomaly) {
+    MergedAnomalyResultDTO anomalyCopy = makeEntityAnomaly();
+    anomalyCopy.setStartTime(anomaly.getStartTime());
+    anomalyCopy.setEndTime(anomaly.getEndTime());
+    anomalyCopy.setChild(anomaly.isChild());
+    anomalyCopy.setChildren(anomaly.getChildren());
+    return anomalyCopy;
+  }
+
+  public static MergedAnomalyResultDTO makeParentEntityAnomaly(MergedAnomalyResultDTO childAnomaly) {
+    MergedAnomalyResultDTO newEntityAnomaly = makeEntityAnomaly();
+    newEntityAnomaly.setStartTime(childAnomaly.getStartTime());
+    newEntityAnomaly.setEndTime(childAnomaly.getEndTime());
+    setEntityChildMapping(newEntityAnomaly, childAnomaly);
+    return newEntityAnomaly;
+  }
+
+  public static List<MergedAnomalyResultDTO> mergeAndSortAnomalies(List<MergedAnomalyResultDTO> anomalyListA, List<MergedAnomalyResultDTO> anomalyListB) {
+    List<MergedAnomalyResultDTO> anomalies = new ArrayList<>();
+    if (anomalyListA != null) {
+      anomalies.addAll(anomalyListA);
+    }
+    if (anomalyListB != null) {
+      anomalies.addAll(anomalyListB);
+    }
+
+    // Sort by increasing order of anomaly start time
+    Collections.sort(anomalies, COMPARATOR);
+    return anomalies;
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouper.java
@@ -103,7 +103,6 @@ public class TriggerConditionGrouper implements Grouper<TriggerConditionGrouperS
           setEntityChildMapping(currentAnomaly, anomalies.get(j));
 
           groupedAnomalies.add(currentAnomaly);
-          //groupedAnomalies.addAll(currentAnomaly.getChildren());
         } else {
           break;
         }
@@ -141,12 +140,10 @@ public class TriggerConditionGrouper implements Grouper<TriggerConditionGrouperS
       }  else {
         // No overlap
         groupedAnomalies.add(currentAnomaly);
-        //groupedAnomalies.addAll(currentAnomaly.getChildren());
         currentAnomaly = makeParentEntityAnomaly(anomalies.get(i));
       }
     }
     groupedAnomalies.add(currentAnomaly);
-    //groupedAnomalies.addAll(currentAnomaly.getChildren());
 
     return new ArrayList<>(groupedAnomalies);
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouper.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.thirdeye.detection.components;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.detection.ConfigUtils;
+import org.apache.pinot.thirdeye.detection.InputDataFetcher;
+import org.apache.pinot.thirdeye.detection.annotation.Components;
+import org.apache.pinot.thirdeye.detection.annotation.DetectionTag;
+import org.apache.pinot.thirdeye.detection.spec.TriggerConditionGrouperSpec;
+import org.apache.pinot.thirdeye.detection.spi.components.Grouper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.thirdeye.detection.DetectionUtils.*;
+
+
+/**
+ * Expression based grouper - supports AND, OR and nested combinations of grouping
+ */
+@Components(title = "TriggerCondition", type = "GROUPER",
+    tags = {DetectionTag.GROUPER}, description = "An expression based grouper")
+public class TriggerConditionGrouper implements Grouper<TriggerConditionGrouperSpec> {
+  protected static final Logger LOG = LoggerFactory.getLogger(TriggerConditionGrouper.class);
+
+  private String expression;
+  private String operator;
+  private Map<String, Object> leftOp;
+  private Map<String, Object> rightOp;
+  private InputDataFetcher dataFetcher;
+
+  static final String PROP_DETECTOR_COMPONENT_NAME = "detectorComponentName";
+  static final String PROP_AND = "and";
+  static final String PROP_OR = "or";
+
+  private static final String PROP_OPERATOR = "operator";
+  private static final String PROP_LEFT_OP = "leftOp";
+  private static final String PROP_RIGHT_OP = "rightOp";
+
+  /**
+   * Group based on 'AND' criteria - Entity has anomaly if both sub-entities A and B have anomalies
+   * at the same time. This means we find anomaly overlapping interval.
+   *
+   * Since the anomalies from the respective entities/metrics are merged
+   * before calling the grouper, we do not have to deal with overlapping
+   * anomalies within an entity/metric
+   *
+   * Core logic:
+   * Sort anomalies by start time and iterate through the list
+   * Push first anomaly to stack
+   * For each anomaly following, pop stack and compare with current anomaly
+   * 1. No overlap:
+   *    If the anomaly doesn't overlap, create and push new entity anomaly
+   * 2. Partial overlap:
+   *    If partial overlap, create new grouped entity anomaly and push to stack followed by current anomaly
+   * 3. Full overlap:
+   *    If full overlap, create new grouped entity anomaly and push to stack followed by current anomaly
+   * After the last anomaly, the stack will have one extra anomaly which needs to be popped out.
+   * Now the stack will hold all the grouped/entity anomalies
+   *
+   * Note the each time an entity copy is created, the children needs to be marked and set appropriately
+   *
+   */
+  private List<MergedAnomalyResultDTO> andGrouping(
+      List<MergedAnomalyResultDTO> anomalyListA, List<MergedAnomalyResultDTO> anomalyListB) {
+    Set<MergedAnomalyResultDTO> groupedAnomalies = new HashSet<>();
+    List<MergedAnomalyResultDTO> anomalies = mergeAndSortAnomalies(anomalyListA, anomalyListB);
+
+    Stack<MergedAnomalyResultDTO> anomalyStack = new Stack<>();
+    for (MergedAnomalyResultDTO anomaly : anomalies) {
+      if (anomalyStack.isEmpty()) {
+        anomalyStack.push(makeParentEntityAnomaly(anomaly));
+        continue;
+      }
+
+      MergedAnomalyResultDTO anomalyStackTop = anomalyStack.pop();
+
+      if (anomaly.getStartTime() > anomalyStackTop.getEndTime()) {
+        // No overlap
+        anomalyStack.push(makeParentEntityAnomaly(anomaly));
+      } else if (anomaly.getEndTime() > anomalyStackTop.getEndTime()) {
+        //Partial overlap
+        anomalyStackTop.setStartTime(anomaly.getStartTime());
+        setEntityChildMapping(anomalyStackTop, anomaly);
+
+        anomalyStack.push(anomalyStackTop);
+        anomalyStack.push(makeParentEntityAnomaly(anomaly));
+      } else {
+        // Complete overlap
+        MergedAnomalyResultDTO temp = makeEntityCopy(anomalyStackTop);
+
+        anomalyStackTop.setStartTime(anomaly.getStartTime());
+        anomalyStackTop.setEndTime(anomaly.getEndTime());
+        setEntityChildMapping(anomalyStackTop, anomaly);
+
+        anomalyStack.push(anomalyStackTop);
+        anomalyStack.push(temp);
+      }
+    }
+
+    // Pop the extra anomaly out
+    if (!anomalyStack.isEmpty()) {
+      anomalyStack.pop();
+    }
+
+    // Add all parent anomalies along with their children
+    groupedAnomalies.addAll(anomalyStack);
+    for (MergedAnomalyResultDTO anomaly : anomalyStack) {
+      groupedAnomalies.addAll(anomaly.getChildren());
+    }
+
+    return new ArrayList<>(groupedAnomalies);
+  }
+
+  /**
+   * Group based on 'OR' criteria - Entity has anomaly if either sub-entity A or B have anomalies.
+   * This means we find the total anomaly coverage.
+   *
+   * Since the anomalies from the respective entities/metrics are merged
+   * before calling the grouper, we do not have to deal with overlapping
+   * anomalies within an entity/metric
+   *
+   * Sort anomalies by start time and iterate through the list
+   * Create new entity anomaly with first anomaly as child and push to stack
+   * For each anomaly following, pop stack and compare
+   * 1. No overlap:
+   *    If the anomaly doesn't overlap, push popped anomaly, create new entity anomaly with current as child and push
+   * 2. Partial overlap:
+   *    If partial overlap, update popped anomaly's end time, child and push to stack
+   * 3. Full overlap:
+   *    If full overlap, update popped anomaly with child info and push it back to stack
+   * Note the each time an entity copy is created, the children needs to be marked and set appropriately
+   *
+   */
+  private List<MergedAnomalyResultDTO> orGrouping(
+      List<MergedAnomalyResultDTO> anomalyListA, List<MergedAnomalyResultDTO> anomalyListB) {
+    Set<MergedAnomalyResultDTO> groupedAnomalies = new HashSet<>();
+
+    List<MergedAnomalyResultDTO> anomalies = mergeAndSortAnomalies(anomalyListA, anomalyListB);
+
+    Stack<MergedAnomalyResultDTO> anomalyStack = new Stack<>();
+    for (MergedAnomalyResultDTO anomaly : anomalies) {
+      if (anomalyStack.isEmpty()) {
+        MergedAnomalyResultDTO newEntityAnomaly = makeEntityAnomaly();
+        newEntityAnomaly.setStartTime(anomaly.getStartTime());
+        newEntityAnomaly.setEndTime(anomaly.getEndTime());
+        setEntityChildMapping(newEntityAnomaly, anomaly);
+        anomalyStack.push(newEntityAnomaly);
+        continue;
+      }
+
+      MergedAnomalyResultDTO anomalyStackTop = anomalyStack.pop();
+
+      if (anomaly.getStartTime() > anomalyStackTop.getEndTime()) {
+        // No overlap
+        anomalyStack.push(anomalyStackTop);
+
+        MergedAnomalyResultDTO newEntityAnomaly = makeEntityAnomaly();
+        newEntityAnomaly.setStartTime(anomaly.getStartTime());
+        newEntityAnomaly.setEndTime(anomaly.getEndTime());
+        setEntityChildMapping(newEntityAnomaly, anomaly);
+        anomalyStack.push(newEntityAnomaly);
+      } else if (anomaly.getEndTime() > anomalyStackTop.getEndTime()) {
+        //Partial overlap
+        anomalyStackTop.setEndTime(anomaly.getEndTime());
+        setEntityChildMapping(anomalyStackTop, anomaly);
+
+        anomalyStack.push(anomalyStackTop);
+      } else {
+        // Complete overlap
+        setEntityChildMapping(anomalyStackTop, anomaly);
+
+        anomalyStack.push(anomalyStackTop);
+      }
+    }
+
+    // Add all parent anomalies along with their children
+    groupedAnomalies.addAll(anomalyStack);
+    for (MergedAnomalyResultDTO anomaly : anomalyStack) {
+      groupedAnomalies.addAll(anomaly.getChildren());
+    }
+
+    return new ArrayList<>(groupedAnomalies);
+  }
+
+  /**
+   * Groups the anomalies based on the parsed operator tree
+   */
+  private List<MergedAnomalyResultDTO> groupAnomaliesByOperator(Map<String, Object> operatorNode, List<MergedAnomalyResultDTO> anomalies) {
+    Preconditions.checkNotNull(operatorNode);
+
+    // Base condition - If reached leaf node, then return the anomalies corresponding to the entity/metric
+    String value = MapUtils.getString(operatorNode, "value");
+    if (value != null) {
+      List<MergedAnomalyResultDTO> filteredAnomalies = new ArrayList<>();
+      for (MergedAnomalyResultDTO anomaly : anomalies) {
+        if (anomaly.getProperties() != null && anomaly.getProperties().get(PROP_DETECTOR_COMPONENT_NAME) != null
+            && anomaly.getProperties().get(PROP_DETECTOR_COMPONENT_NAME).startsWith(value)) {
+          filteredAnomalies.add(anomaly);
+        }
+      }
+      return filteredAnomalies;
+    }
+
+    String operator = MapUtils.getString(operatorNode, PROP_OPERATOR);
+    Preconditions.checkNotNull(operator, "No operator provided!");
+    Map<String, Object> leftOp = ConfigUtils.getMap(operatorNode.get(PROP_LEFT_OP));
+    Map<String, Object> rightOp = ConfigUtils.getMap(operatorNode.get(PROP_RIGHT_OP));
+
+    // Post-order traversal - find anomalies from left subtree and right sub-tree and then group them
+    List<MergedAnomalyResultDTO> leftAnomalies = groupAnomaliesByOperator(leftOp, anomalies);
+    List<MergedAnomalyResultDTO> rightAnomalies = groupAnomaliesByOperator(rightOp, anomalies);
+    if (operator.equalsIgnoreCase(PROP_AND)) {
+      return andGrouping(leftAnomalies, rightAnomalies);
+    } else if (operator.equalsIgnoreCase(PROP_OR)) {
+      return orGrouping(leftAnomalies, rightAnomalies);
+    } else {
+      throw new RuntimeException("Unsupported operator");
+    }
+  }
+
+  /**
+   * Groups the anomalies based on the operator string expression
+   */
+  private List<MergedAnomalyResultDTO> groupAnomaliesByExpression(String expression, List<MergedAnomalyResultDTO> anomalies) {
+    groupAnomaliesByOperator(buildOperatorTree(expression), anomalies);
+    return anomalies;
+  }
+
+  // TODO: Build parse tree from string expression and execute
+  private Map<String, Object> buildOperatorTree(String expression) {
+    return new HashMap<>();
+  }
+
+  @Override
+  public List<MergedAnomalyResultDTO> group(List<MergedAnomalyResultDTO> anomalies) {
+    if (operator != null) {
+      Map<String, Object> operatorTreeRoot = new HashMap<>();
+      operatorTreeRoot.put(PROP_OPERATOR, operator);
+      operatorTreeRoot.put(PROP_LEFT_OP, leftOp);
+      operatorTreeRoot.put(PROP_RIGHT_OP, rightOp);
+      return groupAnomaliesByOperator(operatorTreeRoot, anomalies);
+    } else {
+      return groupAnomaliesByExpression(expression, anomalies);
+    }
+  }
+
+  @Override
+  public void init(TriggerConditionGrouperSpec spec, InputDataFetcher dataFetcher) {
+    this.expression = spec.getExpression();
+    this.operator = spec.getOperator();
+    this.leftOp = spec.getLeftOp();
+    this.rightOp = spec.getRightOp();
+    this.dataFetcher = dataFetcher;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouper.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
@@ -141,14 +142,10 @@ public class TriggerConditionGrouper implements Grouper<TriggerConditionGrouperS
     // Base condition - If reached leaf node, then return the anomalies corresponding to the entity/metric
     String value = MapUtils.getString(operatorNode, "value");
     if (value != null) {
-      List<MergedAnomalyResultDTO> filteredAnomalies = new ArrayList<>();
-      for (MergedAnomalyResultDTO anomaly : anomalies) {
-        if (anomaly.getProperties() != null && anomaly.getProperties().get(PROP_DETECTOR_COMPONENT_NAME) != null
-            && anomaly.getProperties().get(PROP_DETECTOR_COMPONENT_NAME).startsWith(value)) {
-          filteredAnomalies.add(anomaly);
-        }
-      }
-      return filteredAnomalies;
+      return anomalies.stream().filter(anomaly ->
+          anomaly.getProperties() != null && anomaly.getProperties().get(PROP_DETECTOR_COMPONENT_NAME) != null
+              && anomaly.getProperties().get(PROP_DETECTOR_COMPONENT_NAME).startsWith(value)
+      ).collect(Collectors.toList());
     }
 
     String operator = MapUtils.getString(operatorNode, PROP_OPERATOR);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouper.java
@@ -68,21 +68,7 @@ public class TriggerConditionGrouper implements Grouper<TriggerConditionGrouperS
    * before calling the grouper, we do not have to deal with overlapping
    * anomalies within an entity/metric
    *
-   * Core logic:
-   * Sort anomalies by start time and iterate through the list
-   * Push first anomaly to stack
-   * For each anomaly following, pop stack and compare with current anomaly
-   * 1. No overlap:
-   *    If the anomaly doesn't overlap, create and push new entity anomaly
-   * 2. Partial overlap:
-   *    If partial overlap, create new grouped entity anomaly and push to stack followed by current anomaly
-   * 3. Full overlap:
-   *    If full overlap, create new grouped entity anomaly and push to stack followed by current anomaly
-   * After the last anomaly, the stack will have one extra anomaly which needs to be popped out.
-   * Now the stack will hold all the grouped/entity anomalies
-   *
-   * Note the each time an entity copy is created, the children needs to be marked and set appropriately
-   *
+   * Sort anomalies and incrementally compare two anomalies for overlap criteria; break when no overlap
    */
   private List<MergedAnomalyResultDTO> andGrouping(
       List<MergedAnomalyResultDTO> anomalyListA, List<MergedAnomalyResultDTO> anomalyListB) {
@@ -91,7 +77,6 @@ public class TriggerConditionGrouper implements Grouper<TriggerConditionGrouperS
     if (anomalies.isEmpty()) {
       return anomalies;
     }
-
 
     for (int i = 0; i < anomalies.size(); i++) {
       for (int j = i + 1; j < anomalies.size(); j++) {
@@ -121,7 +106,6 @@ public class TriggerConditionGrouper implements Grouper<TriggerConditionGrouperS
    * anomalies within an entity/metric
    *
    * Sort anomalies by start time and incrementally merge anomalies
-   *
    */
   private List<MergedAnomalyResultDTO> orGrouping(
       List<MergedAnomalyResultDTO> anomalyListA, List<MergedAnomalyResultDTO> anomalyListB) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/TriggerConditionGrouperSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/TriggerConditionGrouperSpec.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.spec;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Map;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TriggerConditionGrouperSpec extends AbstractSpec {
+  private String expression;
+  private String operator;
+  private Map<String, Object> leftOp;
+  private Map<String, Object> rightOp;
+
+  public String getExpression() {
+    return expression;
+  }
+
+  public void setExpression(String expression) {
+    this.expression = expression;
+  }
+
+  public String getOperator() {
+    return operator;
+  }
+
+  public void setOperator(String operator) {
+    this.operator = operator;
+  }
+
+  public Map<String, Object> getLeftOp() {
+    return leftOp;
+  }
+
+  public void setLeftOp(Map<String, Object> leftOp) {
+    this.leftOp = leftOp;
+  }
+
+  public Map<String, Object> getRightOp() {
+    return rightOp;
+  }
+
+  public void setRightOp(Map<String, Object> rightOp) {
+    this.rightOp = rightOp;
+  }
+}
+

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/TriggerConditionGrouperTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.components;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.detection.DetectionTestUtils;
+import org.apache.pinot.thirdeye.detection.spec.TriggerConditionGrouperSpec;
+import org.apache.pinot.thirdeye.detection.spi.exception.DetectorException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.thirdeye.detection.DetectionUtils.*;
+import static org.apache.pinot.thirdeye.detection.components.TriggerConditionGrouper.*;
+
+
+public class TriggerConditionGrouperTest {
+
+  private static final String PROP_VALUE = "value";
+
+  public static MergedAnomalyResultDTO makeAnomaly(long start, long end, String entity) {
+    MergedAnomalyResultDTO anomaly = DetectionTestUtils.makeAnomaly(1000l, start, end, null, null, Collections.<String, String>emptyMap());
+    Map<String, String> props = new HashMap<>();
+    props.put(PROP_DETECTOR_COMPONENT_NAME, entity);
+    anomaly.setProperties(props);
+    return anomaly;
+  }
+
+  /**
+   *
+   *           0           1000    1500       2000
+   *  A        |-------------|      |-----------|
+   *
+   *                500                       2000     2500      3000
+   *  B              |--------------------------|        |---------|
+   *
+   *                500    1000    1500       2000
+   *  A && B         |-------|      |-----------|
+   *
+   */
+  @Test
+  public void testAndGrouping() {
+    TriggerConditionGrouper grouper = new TriggerConditionGrouper();
+
+    List<MergedAnomalyResultDTO> anomalies = new ArrayList<>();
+    anomalies.add(makeAnomaly(0, 1000, "entityA"));
+    anomalies.add(makeAnomaly(500, 2000, "entityB"));
+    anomalies.add(makeAnomaly(1500, 2000, "entityA"));
+    anomalies.add(makeAnomaly(2500, 3000, "entityB"));
+
+    TriggerConditionGrouperSpec spec = new TriggerConditionGrouperSpec();
+    spec.setOperator(PROP_AND);
+    Map<String, Object> leftOp = new HashMap<>();
+    leftOp.put(PROP_VALUE, "entityA");
+    spec.setLeftOp(leftOp);
+
+    Map<String, Object> rigthOp = new HashMap<>();
+    rigthOp.put(PROP_VALUE, "entityB");
+    spec.setRightOp(rigthOp);
+
+    grouper.init(spec, null);
+    List<MergedAnomalyResultDTO> groupedAnomalies = grouper.group(anomalies);
+
+    Assert.assertEquals(groupedAnomalies.size(), 5);
+
+    int childCounter = 0;
+    List<MergedAnomalyResultDTO> parents = new ArrayList<>();
+    for (MergedAnomalyResultDTO anomaly : groupedAnomalies) {
+      if (anomaly.isChild()) {
+        childCounter++;
+      } else {
+        parents.add(anomaly);
+      }
+    }
+    Assert.assertEquals(childCounter, 3);
+    Assert.assertEquals(parents.size(), 2);
+
+    parents = mergeAndSortAnomalies(parents, null);
+    Assert.assertEquals(parents.get(0).getStartTime(), 500);
+    Assert.assertEquals(parents.get(0).getEndTime(), 1000);
+    Assert.assertEquals(parents.get(1).getStartTime(), 1500);
+    Assert.assertEquals(parents.get(1).getEndTime(), 2000);
+  }
+
+  /**
+   *
+   *           0           1000    1500       2000
+   *  A        |-------------|      |-----------|
+   *
+   *                500                       2000     2500      3000
+   *  B              |--------------------------|       |---------|
+   *
+   *           0                              2000     2500      3000
+   *  A || B   |--------------------------------|       |---------|
+   *
+   */
+  @Test
+  public void testOrGrouping() {
+    TriggerConditionGrouper grouper = new TriggerConditionGrouper();
+
+    List<MergedAnomalyResultDTO> anomalies = new ArrayList<>();
+    anomalies.add(makeAnomaly(0, 1000, "entityA"));
+    anomalies.add(makeAnomaly(500, 2000, "entityB"));
+    anomalies.add(makeAnomaly(1500, 2000, "entityA"));
+    anomalies.add(makeAnomaly(2500, 3000, "entityB"));
+
+    TriggerConditionGrouperSpec spec = new TriggerConditionGrouperSpec();
+    spec.setOperator(PROP_OR);
+    Map<String, Object> leftOp = new HashMap<>();
+    leftOp.put(PROP_VALUE, "entityA");
+    spec.setLeftOp(leftOp);
+
+    Map<String, Object> rigthOp = new HashMap<>();
+    rigthOp.put(PROP_VALUE, "entityB");
+    spec.setRightOp(rigthOp);
+
+    grouper.init(spec, null);
+    List<MergedAnomalyResultDTO> groupedAnomalies = grouper.group(anomalies);
+
+    Assert.assertEquals(groupedAnomalies.size(), 6);
+
+    int childCounter = 0;
+    List<MergedAnomalyResultDTO> parents = new ArrayList<>();
+    for (MergedAnomalyResultDTO anomaly : groupedAnomalies) {
+      if (anomaly.isChild()) {
+        childCounter++;
+      } else {
+        parents.add(anomaly);
+      }
+    }
+    Assert.assertEquals(childCounter, 4);
+    Assert.assertEquals(parents.size(), 2);
+
+    parents = mergeAndSortAnomalies(parents, null);
+    Assert.assertEquals(parents.get(0).getStartTime(), 0);
+    Assert.assertEquals(parents.get(0).getEndTime(), 2000);
+    Assert.assertEquals(parents.get(1).getStartTime(), 2500);
+    Assert.assertEquals(parents.get(1).getEndTime(), 3000);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/translator/pipeline-config-5.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/translator/pipeline-config-5.yaml
@@ -42,7 +42,7 @@ alerts:
     name: composite_alert_on_entity
     alerts:
       - type: METRIC_ALERT
-        name: metric alert on test_metric
+        name: metric_alert_on_test_metric
         metric: test_metric
         dataset: test_dataset
         rules:


### PR DESCRIPTION
Supports grouping of anomalies across multiple metrics and entities on the following criteria
- 'AND' criteria - Entity has anomaly if both sub-entities A and B have anomalies at the same time.
- 'OR' criteria - Entity has anomaly if either sub-entity A or B have anomalies.
- Other nested combinations are also supported. For example, `A && (B || C)`
- The expression input is currently fed by explicitly defining the hierarchy(parse tree) in the form of a map in the yaml config. String expression parser will be supported in the near future.