### PR TITLE
Emit metrics to track performance against specific Service-Level-Objectives (SLO)

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -171,7 +171,7 @@ public class HelixBrokerStarter {
     _helixExternalViewBasedRouting.init(_spectatorHelixManager);
     _helixExternalViewBasedQueryQuotaManager = new HelixExternalViewBasedQueryQuotaManager();
     _helixExternalViewBasedQueryQuotaManager.init(_spectatorHelixManager);
-    _brokerServerBuilder = new BrokerServerBuilder(_brokerConf, _helixExternalViewBasedRouting,
+    _brokerServerBuilder = new BrokerServerBuilder(_brokerConf,_propertyStore, _helixExternalViewBasedRouting,
         _helixExternalViewBasedRouting.getTimeBoundaryService(), _helixExternalViewBasedQueryQuotaManager);
     BrokerRequestHandler brokerRequestHandler = _brokerServerBuilder.getBrokerRequestHandler();
     if (brokerRequestHandler instanceof ConnectionPoolBrokerRequestHandler) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ConnectionPoolBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ConnectionPoolBrokerRequestHandler.java
@@ -86,8 +86,9 @@ public class ConnectionPoolBrokerRequestHandler extends BaseBrokerRequestHandler
 
   public ConnectionPoolBrokerRequestHandler(Configuration config, RoutingTable routingTable,
       TimeBoundaryService timeBoundaryService, AccessControlFactory accessControlFactory,
-      QueryQuotaManager queryQuotaManager, BrokerMetrics brokerMetrics, MetricsRegistry metricsRegistry) {
-    super(config, routingTable, timeBoundaryService, accessControlFactory, queryQuotaManager, brokerMetrics);
+      QueryQuotaManager queryQuotaManager, LazyTableConfigCache cache,
+      BrokerMetrics brokerMetrics, MetricsRegistry metricsRegistry) {
+    super(config, routingTable, timeBoundaryService, accessControlFactory, queryQuotaManager, cache, brokerMetrics);
 
     TransportClientConf transportClientConf = new TransportClientConf();
     transportClientConf.init(_config.subset(TRANSPORT_CONFIG_PREFIX));

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/LazyTableConfigCache.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/LazyTableConfigCache.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+
+
+/**
+ * A cache for table-config objects maintained by the broker. The cache is implemented as a lazy-cache: i.e., on a
+ * cache miss, the value is fetched asynchronously/lazily - the caller is not blocked and can expect to get null or
+ * a previously cached value.
+ *
+ * This cache should be used only for best-effort cases, where absence of the value does not have critical implications.
+ *
+ * The cache is unbounded as we don't expect an ever-growing or very large number of tables to be served by a single
+ * broker.
+ */
+@ThreadSafe
+public class LazyTableConfigCache {
+
+  private static final int CACHE_TIMEOUT_MINS = 60;
+
+  private final LoadingCache<String, TableConfig> _configCache;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final ExecutorService _executorService;
+
+  public LazyTableConfigCache(ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _propertyStore = propertyStore;
+    _executorService = Executors.newCachedThreadPool();
+
+    _configCache = CacheBuilder.newBuilder().refreshAfterWrite(CACHE_TIMEOUT_MINS, TimeUnit.MINUTES)
+        .build(new CacheLoader<String, TableConfig>() {
+          @Override
+          public TableConfig load(@Nonnull String rawTableName) {
+            return ZKMetadataProvider.getTableConfig(_propertyStore, rawTableName);
+          }
+
+          @Override
+          public ListenableFuture<TableConfig> reload(String tableName, TableConfig oldValue) {
+            ListenableFutureTask<TableConfig> task =
+                ListenableFutureTask.create(() -> ZKMetadataProvider.getTableConfig(_propertyStore, tableName));
+            _executorService.execute(task);
+            return task;
+          }
+        });
+  }
+
+  /**
+   * Returns the table-config if present - kicks off a lazy load otherwise.
+   */
+  @Nullable
+  public TableConfig get(String tableName) {
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+
+    TableConfig config = _configCache.getIfPresent(rawTableName);
+    if (config == null) {
+      // load the value asynchronously
+      ListenableFutureTask<TableConfig> task =
+          ListenableFutureTask.create(() -> _configCache.get(rawTableName));
+      _executorService.execute(task);
+    }
+
+    return config;
+  }
+
+  /**
+   * Shut the cache down and any running tasks/threads.
+   */
+  public void shutDown() {
+    _executorService.shutdown();
+  }
+}
+
+

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -55,8 +55,8 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
   public SingleConnectionBrokerRequestHandler(Configuration config, RoutingTable routingTable,
       TimeBoundaryService timeBoundaryService, AccessControlFactory accessControlFactory,
-      QueryQuotaManager queryQuotaManager, BrokerMetrics brokerMetrics) {
-    super(config, routingTable, timeBoundaryService, accessControlFactory, queryQuotaManager, brokerMetrics);
+      QueryQuotaManager queryQuotaManager, LazyTableConfigCache cache, BrokerMetrics brokerMetrics) {
+    super(config, routingTable, timeBoundaryService, accessControlFactory, queryQuotaManager, cache, brokerMetrics);
     _queryRouter = new QueryRouter(_brokerId, brokerMetrics);
   }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LazyTableConfigCacheTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LazyTableConfigCacheTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.config.QuotaConfig;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.config.TableCustomConfig;
+import org.apache.pinot.common.config.TagOverrideConfig;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+
+
+public class LazyTableConfigCacheTest {
+
+  // Test is disabled as it relies on unreliable/sleep-based verification of async execution. Test is being included
+  // regardless, so manual verifications can be done in the future if the class changes.
+  @Test(enabled = false)
+  public void testLazyLoading() throws Exception {
+
+    String tableName = "tableName";
+    ZkHelixPropertyStore<ZNRecord> mockStore = Mockito.mock(ZkHelixPropertyStore.class);
+    TableConfig config = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(tableName)
+        .setCustomConfig(new TableCustomConfig())
+        .setQuotaConfig(new QuotaConfig()).setServerTenant("").setBrokerTenant("")
+        .setTagOverrideConfig(new TagOverrideConfig()).build();
+    Mockito.when(mockStore.get(anyString(), any(), anyInt())).thenReturn(config.toZNRecord());
+    LazyTableConfigCache cache = new LazyTableConfigCache(mockStore);
+
+    Assert.assertNull(cache.get(tableName));
+    Thread.sleep(1000);
+    Mockito.verify(mockStore, Mockito.atMost(1)).get(anyString(), any(), anyInt());
+    // calling the cache a second time should find the value
+    Assert.assertEquals(cache.get(tableName), config);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/SloConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/SloConfig.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.lang.reflect.Field;
+import org.apache.pinot.common.utils.EqualityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Section of the table config that provides service-level objectives for specific dimensions such as
+ * latency, freshness.
+ *
+ * Note that analytical query latencies can be highly variable - the SLO should include the maximum tolerable latency
+ * for servicing the common, high latency queries.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SloConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SloConfig.class);
+
+  @ConfigKey("latencyMs")
+  @ConfigDoc("Latency SLO in milliseconds for queries of this table")
+  private long latencyMs;
+
+  @ConfigKey("freshnessLagMs")
+  @ConfigDoc("Freshness Lag SLO in milliseconds for queries of this table (realtime only)")
+  private long freshnessLagMs;
+
+  public long getLatencyMs() {
+    return latencyMs;
+  }
+
+  public void setLatencyMs(long latencyMs) {
+    this.latencyMs = latencyMs;
+  }
+
+  public long getFreshnessLagMs() {
+    return freshnessLagMs;
+  }
+
+  public void setFreshnessLagMs(long freshnessLagMs) {
+    this.freshnessLagMs = freshnessLagMs;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder result = new StringBuilder();
+    final String newLine = System.getProperty("line.separator");
+
+    result.append(this.getClass().getName());
+    result.append(" Object {");
+    result.append(newLine);
+
+    //determine fields declared in this class only (no fields of superclass)
+    final Field[] fields = this.getClass().getDeclaredFields();
+
+    //print field names paired with their values
+    for (final Field field : fields) {
+      result.append("  ");
+      try {
+        result.append(field.getName());
+        result.append(": ");
+        //requires access to private field:
+        result.append(field.get(this));
+      } catch (final IllegalAccessException ex) {
+        if (LOGGER.isWarnEnabled()) {
+          LOGGER.warn("Caught exception while processing field " + field, ex);
+        }
+      }
+      result.append(newLine);
+    }
+    result.append("}");
+
+    return result.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (EqualityUtils.isSameReference(this, o)) {
+      return true;
+    }
+
+    if (EqualityUtils.isNullOrNotSameClass(this, o)) {
+      return false;
+    }
+
+    SloConfig that = (SloConfig) o;
+
+    return EqualityUtils.isEqual(latencyMs, that.latencyMs) &&
+        EqualityUtils.isEqual(freshnessLagMs, that.freshnessLagMs);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = EqualityUtils.hashCodeOf(latencyMs);
+    result = EqualityUtils.hashCodeOf(result, latencyMs);
+    return result;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TableConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TableConfig.java
@@ -49,6 +49,8 @@ public class TableConfig {
   public static final String QUOTA_CONFIG_KEY = "quota";
   public static final String TASK_CONFIG_KEY = "task";
   public static final String ROUTING_CONFIG_KEY = "routing";
+  // config for service-level-objectives
+  public static final String SLO_CONFIG_KEY = "slo";
 
   private static final String FIELD_MISSING_MESSAGE_TEMPLATE = "Mandatory field '%s' is missing";
 
@@ -82,6 +84,9 @@ public class TableConfig {
   @NestedConfig
   private RoutingConfig _routingConfig;
 
+  @NestedConfig
+  private SloConfig _sloConfig;
+
   /**
    * NOTE: DO NOT use this constructor, use builder instead. This constructor is for deserializer only.
    */
@@ -93,7 +98,8 @@ public class TableConfig {
 
   private TableConfig(String tableName, TableType tableType, SegmentsValidationAndRetentionConfig validationConfig,
       TenantConfig tenantConfig, IndexingConfig indexingConfig, TableCustomConfig customConfig,
-      @Nullable QuotaConfig quotaConfig, @Nullable TableTaskConfig taskConfig, @Nullable RoutingConfig routingConfig) {
+      @Nullable QuotaConfig quotaConfig, @Nullable TableTaskConfig taskConfig, @Nullable RoutingConfig routingConfig,
+      @Nullable SloConfig sloConfig) {
     _tableName = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
     _tableType = tableType;
     _validationConfig = validationConfig;
@@ -103,6 +109,7 @@ public class TableConfig {
     _quotaConfig = quotaConfig;
     _taskConfig = taskConfig;
     _routingConfig = routingConfig;
+    _sloConfig = sloConfig;
   }
 
   public static TableConfig fromJsonString(String jsonString)
@@ -146,8 +153,10 @@ public class TableConfig {
 
     RoutingConfig routingConfig = extractChildConfig(jsonConfig, ROUTING_CONFIG_KEY, RoutingConfig.class);
 
+    SloConfig sloConfig = extractChildConfig(jsonConfig, SLO_CONFIG_KEY, SloConfig.class);
+
     return new TableConfig(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig,
-        quotaConfig, taskConfig, routingConfig);
+        quotaConfig, taskConfig, routingConfig, sloConfig);
   }
 
   /**
@@ -191,6 +200,9 @@ public class TableConfig {
     }
     if (_routingConfig != null) {
       jsonConfig.set(ROUTING_CONFIG_KEY, JsonUtils.objectToJsonNode(_routingConfig));
+    }
+    if (_sloConfig != null) {
+      jsonConfig.set(SLO_CONFIG_KEY, JsonUtils.objectToJsonNode(_sloConfig));
     }
 
     return jsonConfig;
@@ -250,8 +262,14 @@ public class TableConfig {
       routingConfig = JsonUtils.stringToObject(routingConfigString, RoutingConfig.class);
     }
 
+    SloConfig sloConfig = null;
+    String sloConfigString = simpleFields.get(SLO_CONFIG_KEY);
+    if (sloConfigString != null) {
+      sloConfig = JsonUtils.stringToObject(sloConfigString, SloConfig.class);
+    }
+
     return new TableConfig(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig,
-        quotaConfig, taskConfig, routingConfig);
+        quotaConfig, taskConfig, routingConfig, sloConfig);
   }
 
   public ZNRecord toZNRecord()
@@ -277,6 +295,9 @@ public class TableConfig {
     }
     if (_routingConfig != null) {
       simpleFields.put(ROUTING_CONFIG_KEY, JsonUtils.objectToString(_routingConfig));
+    }
+    if (_sloConfig != null) {
+      simpleFields.put(SLO_CONFIG_KEY, JsonUtils.objectToString(_sloConfig));
     }
 
     ZNRecord znRecord = new ZNRecord(_tableName);
@@ -372,6 +393,15 @@ public class TableConfig {
     _routingConfig = routingConfig;
   }
 
+  @Nullable
+  public SloConfig getSloConfig() {
+    return _sloConfig;
+  }
+
+  public void setSloConfig(SloConfig sloConfig) {
+    _sloConfig = sloConfig;
+  }
+
   @Override
   public String toString() {
     try {
@@ -393,7 +423,8 @@ public class TableConfig {
           .isEqual(_tenantConfig, that._tenantConfig) && EqualityUtils.isEqual(_indexingConfig, that._indexingConfig)
           && EqualityUtils.isEqual(_customConfig, that._customConfig) && EqualityUtils
           .isEqual(_quotaConfig, that._quotaConfig) && EqualityUtils.isEqual(_taskConfig, that._taskConfig)
-          && EqualityUtils.isEqual(_routingConfig, that._routingConfig);
+          && EqualityUtils.isEqual(_routingConfig, that._routingConfig)
+          && EqualityUtils.isEqual(_sloConfig, that._sloConfig);
     }
     return false;
   }
@@ -409,6 +440,8 @@ public class TableConfig {
     result = EqualityUtils.hashCodeOf(result, _quotaConfig);
     result = EqualityUtils.hashCodeOf(result, _taskConfig);
     result = EqualityUtils.hashCodeOf(result, _routingConfig);
+    result = EqualityUtils.hashCodeOf(result, _sloConfig);
+
     return result;
   }
 
@@ -458,6 +491,7 @@ public class TableConfig {
     private RoutingConfig _routingConfig;
     private HllConfig _hllConfig;
     private StarTreeIndexSpec _starTreeIndexSpec;
+    private SloConfig _sloConfig;
 
     public Builder(TableType tableType) {
       _tableType = tableType;
@@ -609,6 +643,11 @@ public class TableConfig {
       return this;
     }
 
+    public Builder setSloConfig(SloConfig sloConfig) {
+      _sloConfig = sloConfig;
+      return this;
+    }
+
     public TableConfig build() {
       // Validation config
       SegmentsValidationAndRetentionConfig validationConfig = new SegmentsValidationAndRetentionConfig();
@@ -654,7 +693,7 @@ public class TableConfig {
       }
 
       return new TableConfig(_tableName, _tableType, validationConfig, tenantConfig, indexingConfig, _customConfig,
-          _quotaConfig, _taskConfig, _routingConfig);
+          _quotaConfig, _taskConfig, _routingConfig, _sloConfig);
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -99,7 +99,18 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   NETTY_CONNECTION_BYTES_SENT("nettyConnection", true),
   NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),
 
-  PROACTIVE_CLUSTER_CHANGE_CHECK("proactiveClusterChangeCheck", true);
+  PROACTIVE_CLUSTER_CHANGE_CHECK("proactiveClusterChangeCheck", true),
+
+  // responses that are considered errors
+  ERROR_RESPONSE("queries", false),
+  // responses that are considered partial (for various reasons)
+  PARTIAL_RESPONSE("queries", false),
+  // responses that are considered stale
+  STALE_RESPONSE("queries", false),
+  // responses that are considered latent/slow
+  LATENT_RESPONSE("queries", false),
+  // responses that were considered healthy
+  HEALTHY_RESPONSE("queries", false);
 
   private final String brokerMeterName;
   private final String unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -35,7 +35,7 @@ public interface DataTable {
   String NUM_SEGMENTS_QUERIED = "numSegmentsQueried";
   String NUM_SEGMENTS_PROCESSED = "numSegmentsProcessed";
   String NUM_SEGMENTS_MATCHED = "numSegmentsMatched";
-  String NUM_CONSUMING_SEGMENTS_QUERIED = "numConsumingSegmentsQueried";
+  String NUM_CONSUMING_SEGMENTS_PROCESSED = "numConsumingSegmentsProcessed";
   String MIN_CONSUMING_FRESHNESS_TIME_MS = "minConsumingFreshnessTimeMs";
   String TOTAL_DOCS_METADATA_KEY = "totalDocs";
   String NUM_GROUPS_LIMIT_REACHED_KEY = "numGroupsLimitReached";

--- a/pinot-common/src/test/java/org/apache/pinot/common/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/config/TableConfigTest.java
@@ -32,6 +32,9 @@ import static org.testng.Assert.*;
 
 public class TableConfigTest {
 
+  private static final long FRESHNESS_LAG_MS = 10000;
+  private static final long LATENCY_MS = 100;
+
   @Test
   public void testSerializeMandatoryFields()
       throws Exception {
@@ -322,6 +325,16 @@ public class TableConfigTest {
       tableConfigToCompare = TableConfig.fromZnRecord(tableConfig.toZNRecord());
       checkTableConfigWithHllConfig(tableConfig, tableConfigToCompare);
     }
+    {
+      // with slo config
+      SloConfig sloConfig = new SloConfig();
+      sloConfig.setFreshnessLagMs(FRESHNESS_LAG_MS);
+      sloConfig.setLatencyMs(LATENCY_MS);
+      TableConfig tableConfig = tableConfigBuilder.setSloConfig(sloConfig).build();
+
+      TableConfig tableConfigToCompare = TableConfig.fromJsonConfig(tableConfig.toJsonConfig());
+      checkTableConfigWithSloConfig(tableConfig, tableConfigToCompare);
+    }
   }
 
   private void checkTableConfigWithAssignmentConfig(TableConfig tableConfig, TableConfig tableConfigToCompare) {
@@ -380,5 +393,14 @@ public class TableConfigTest {
     assertEquals(hllConfig.getColumnsToDeriveHllFields(), columns);
     assertEquals(hllConfig.getHllLog2m(), 9);
     assertEquals(hllConfig.getHllDeriveColumnSuffix(), "suffix");
+  }
+
+  private void checkTableConfigWithSloConfig(TableConfig tableConfig, TableConfig tableConfigToCompare) {
+    assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
+    assertNotNull(tableConfigToCompare.getSloConfig());
+
+    SloConfig config = tableConfigToCompare.getSloConfig();
+    assertEquals(config.getLatencyMs(), LATENCY_MS);
+    assertEquals(config.getFreshnessLagMs(), FRESHNESS_LAG_MS);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -151,13 +151,13 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       TraceContext.register(requestId);
     }
 
-    int numConsumingSegmentsQueried = 0;
+    int numConsumingSegmentsProcessed = 0;
     long minIndexTimeMs = Long.MAX_VALUE;
     long minIngestionTimeMs = Long.MAX_VALUE;
     // gather stats for realtime consuming segments
     for (SegmentDataManager segmentMgr : segmentDataManagers) {
       if (segmentMgr.getSegment() instanceof MutableSegment) {
-        numConsumingSegmentsQueried += 1;
+        numConsumingSegmentsProcessed += 1;
         SegmentMetadata metadata = segmentMgr.getSegment().getSegmentMetadata();
         long indexedTime = metadata.getLastIndexedTimestamp();
         if (indexedTime != Long.MIN_VALUE && indexedTime < minIndexTimeMs) {
@@ -171,12 +171,13 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
 
     long minConsumingFreshnessTimeMs = minIngestionTimeMs;
-    if (numConsumingSegmentsQueried > 0) {
+    if (numConsumingSegmentsProcessed > 0) {
       if (minIngestionTimeMs == Long.MAX_VALUE) {
         LOGGER.debug("Did not find valid ingestionTimestamp across consuming segments! Using indexTime instead");
         minConsumingFreshnessTimeMs = minIndexTimeMs;
       }
-      LOGGER.debug("Querying {} consuming segments with min minConsumingFreshnessTimeMs {}", numConsumingSegmentsQueried, minConsumingFreshnessTimeMs);
+      LOGGER.debug("Querying {} consuming segments with min minConsumingFreshnessTimeMs {}",
+          numConsumingSegmentsProcessed, minConsumingFreshnessTimeMs);
     }
 
     DataTable dataTable = null;
@@ -256,8 +257,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_MISSING_SEGMENTS, missingSegments);
     }
 
-    if (numConsumingSegmentsQueried > 0) {
-      dataTable.getMetadata().put(DataTable.NUM_CONSUMING_SEGMENTS_QUERIED, Integer.toString(numConsumingSegmentsQueried));
+    if (numConsumingSegmentsProcessed > 0) {
+      dataTable.getMetadata().put(DataTable.NUM_CONSUMING_SEGMENTS_PROCESSED, Integer.toString(numConsumingSegmentsProcessed));
       dataTable.getMetadata().put(DataTable.MIN_CONSUMING_FRESHNESS_TIME_MS, Long.toString(minConsumingFreshnessTimeMs));
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -84,7 +84,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     long numSegmentsQueried = 0L;
     long numSegmentsProcessed = 0L;
     long numSegmentsMatched = 0L;
-    long numConsumingSegmentsQueried = 0L;
+    long numConsumingSegmentsProcessed = 0L;
     long minConsumingFreshnessTimeMs = Long.MAX_VALUE;
     long numTotalRawDocs = 0L;
     boolean numGroupsLimitReached = false;
@@ -140,9 +140,9 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
         numSegmentsMatched += Long.parseLong(numSegmentsMatchedString);
       }
 
-      String numConsumingString = metadata.get(DataTable.NUM_CONSUMING_SEGMENTS_QUERIED);
+      String numConsumingString = metadata.get(DataTable.NUM_CONSUMING_SEGMENTS_PROCESSED);
       if (numConsumingString != null) {
-        numConsumingSegmentsQueried += Long.parseLong(numConsumingString);
+        numConsumingSegmentsProcessed += Long.parseLong(numConsumingString);
       }
 
       String minConsumingFreshnessTimeMsString = metadata.get(DataTable.MIN_CONSUMING_FRESHNESS_TIME_MS);
@@ -182,8 +182,8 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     brokerResponseNative.setNumSegmentsMatched(numSegmentsMatched);
     brokerResponseNative.setTotalDocs(numTotalRawDocs);
     brokerResponseNative.setNumGroupsLimitReached(numGroupsLimitReached);
-    if (numConsumingSegmentsQueried > 0) {
-      brokerResponseNative.setNumConsumingSegmentsQueried(numConsumingSegmentsQueried);
+    if (numConsumingSegmentsProcessed > 0) {
+      brokerResponseNative.setNumConsumingSegmentsQueried(numConsumingSegmentsProcessed);
       brokerResponseNative.setMinConsumingFreshnessTimeMs(minConsumingFreshnessTimeMs);
     }
 
@@ -197,7 +197,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       brokerMetrics
           .addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_POST_FILTER, numEntriesScannedPostFilter);
 
-      if (numConsumingSegmentsQueried > 0 && minConsumingFreshnessTimeMs > 0) {
+      if (numConsumingSegmentsProcessed > 0 && minConsumingFreshnessTimeMs > 0) {
         brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.FRESHNESS_LAG_MS,
             System.currentTimeMillis() - minConsumingFreshnessTimeMs, TimeUnit.MILLISECONDS);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -177,7 +177,7 @@ public abstract class QueryScheduler {
     long numSegmentsMatched =
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_SEGMENTS_MATCHED, INVALID_SEGMENTS_COUNT));
     long numSegmentsConsuming =
-        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_CONSUMING_SEGMENTS_QUERIED, INVALID_SEGMENTS_COUNT));
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_CONSUMING_SEGMENTS_PROCESSED, INVALID_SEGMENTS_COUNT));
     long minConsumingFreshnessMs =
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.MIN_CONSUMING_FRESHNESS_TIME_MS, INVALID_FRESHNESS_MS));
 


### PR DESCRIPTION
This change builds on issue #4007. The main contribution of this PR is to emit metrics that can track performance of queries against a table for a given set of service-level objectives. We break the tracking into 5 categories: responses that are errors, responses that have partial-data, responses that don't meet latency objectives (latentResponses), responses that don't meet freshness objectives (staleResponses) - all others are considered "healthy", as in - they meet the SLO. The availability of the system can then be measured as: (healthyResponses)/(healthyResponses+partialResponses+errorResponses+latentResponses+staleResponses). This PR does not address the availability calculation as this can be computed outside of the system - and can be computed by assigning differnt weights for different categories. For e.g., the above equation assigns 0 healthyWeight for partialResponses - however, operators can choose to penalize partialResponses lesser and so on.

The SLO are now part of table-config that the broker fetches in order to emit the metrics natively.

Changes in this PR include:
- Updates to TableConfig to expose SloConfig
- Support a Lazy-loading Table-Config on the broker side to allow emitting the metrics.
- Categorize different scenarios into the specified response type classifications.
- Name change:  numConsumingSegmentsQueried -> numConsumingSegmentsProcessed

Testing done:
- Basic unit tests to cover newly added functionality
- Manual integration tests to cover metric emission and validations.