### PR TITLE
Raise the threshold of using MMAP for inverted index creation from 100M to 2G

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
@@ -52,8 +52,8 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  * <p>Based on the number of values we need to store, we use direct memory or MMap file to allocate the buffer.
  */
 public final class OffHeapBitmapInvertedIndexCreator implements InvertedIndexCreator {
-  // Use MMapBuffer if the buffer size is larger than 100MB
-  private static final int NUM_VALUES_THRESHOLD_FOR_MMAP_BUFFER = 25_000_000;
+  // Use MMapBuffer if the value buffer size is larger than 2G
+  private static final int NUM_VALUES_THRESHOLD_FOR_MMAP_BUFFER = 500_000_000;
 
   private static final String FORWARD_INDEX_VALUE_BUFFER_SUFFIX = ".fwd.idx.val.buf";
   private static final String FORWARD_INDEX_LENGTH_BUFFER_SUFFIX = ".fwd.idx.len.buf";


### PR DESCRIPTION
We have experienced very high GC stopping the thread time while generating huge inverted index with MMAP files
Writing to MMAP files could potentially cause super long stopping the thread time and cause the server/minion lose ZK connection
Raise the threshold to 2G (use direct memory if value buffer size is smaller than 2G) to solve the issue
Generating extremely large inverted index (over 500M values) could still face the same issue, but we want to keep the threshold to prevent running out of direct memory