### PR TITLE
Adding util methods for controller that will be used in offline push

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -98,7 +98,6 @@ public class FileUploadDownloadClient implements Closeable {
   private static final String SCHEMA_PATH = "/schemas";
   private static final String OLD_SEGMENT_PATH = "/segments";
   private static final String SEGMENT_PATH = "/v2/segments";
-  private static final String DELETE_SEGMENT_PATH = "/segments";
   private static final String SEGMENT_METADATA_PATH = "/segmentmetadata";
   private static final String TABLES_PATH = "/tables";
   private static final String TYPE_DELIMITER = "?type=";
@@ -134,7 +133,7 @@ public class FileUploadDownloadClient implements Closeable {
   public static URI getDeleteSegmentHttpUri(String host, int port, String rawTableName, String segmentName,
       String tableType)
       throws URISyntaxException, UnsupportedEncodingException {
-    return getURI(HTTP, host, port, DELETE_SEGMENT_PATH + "/" + rawTableName + "/" + URLEncoder.encode(segmentName, "UTF-8") + "?type=" + tableType);
+    return getURI(HTTP, host, port, OLD_SEGMENT_PATH + "/" + rawTableName + "/" + URLEncoder.encode(segmentName, "UTF-8") + "?type=" + tableType);
   }
 
   public static URI getRetrieveAllSegmentWithTableTypeHttpUri(String host, int port, String rawTableName, String tableType) throws URISyntaxException {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
@@ -133,11 +134,13 @@ public class FileUploadDownloadClient implements Closeable {
   public static URI getDeleteSegmentHttpUri(String host, int port, String rawTableName, String segmentName,
       String tableType)
       throws URISyntaxException, UnsupportedEncodingException {
-    return getURI(HTTP, host, port, OLD_SEGMENT_PATH + "/" + rawTableName + "/" + URLEncoder.encode(segmentName, "UTF-8") + "?type=" + tableType);
+    return new URI(StringUtil.join("/", StringUtils.chomp(HTTP + "://" + host + ":" + port, "/"),
+        OLD_SEGMENT_PATH, rawTableName + "/" + URLEncoder.encode(segmentName, "UTF-8") + TYPE_DELIMITER + tableType));
   }
 
   public static URI getRetrieveAllSegmentWithTableTypeHttpUri(String host, int port, String rawTableName, String tableType) throws URISyntaxException {
-    return getURI(HTTP, host, port, OLD_SEGMENT_PATH + "/" + rawTableName + "?type=" + tableType);
+    return new URI(StringUtil.join("/", StringUtils.chomp(HTTP + "://" + host + ":" + port, "/"),
+        OLD_SEGMENT_PATH, rawTableName + TYPE_DELIMITER + tableType));
   }
 
   public static URI getRetrieveSchemaHttpURI(String host, int port, String schemaName)

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/ControllerRestApi.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/ControllerRestApi.java
@@ -35,4 +35,13 @@ public interface ControllerRestApi extends Closeable {
   void pushSegments(FileSystem fileSystem, List<Path> tarFilePaths);
 
   void sendSegmentUris(List<String> segmentUris);
+
+  /**
+   * Delete extra segments after push during REFRESH use cases. Also used in APPEND use cases where
+   * a day that has been re-pushed has extra segments.
+   * @param segmentUris
+   */
+  void deleteExtraSegmentUris(List<String> segmentUris);
+
+  List<String> getAllSegments(String tableType);
 }

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/ControllerRestApi.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/ControllerRestApi.java
@@ -36,12 +36,7 @@ public interface ControllerRestApi extends Closeable {
 
   void sendSegmentUris(List<String> segmentUris);
 
-  /**
-   * Delete extra segments after push during REFRESH use cases. Also used in APPEND use cases where
-   * a day that has been re-pushed has extra segments.
-   * @param segmentUris
-   */
-  void deleteExtraSegmentUris(List<String> segmentUris);
+  void deleteSegmentUris(List<String> segmentUris);
 
   List<String> getAllSegments(String tableType);
 }

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/DefaultControllerRestApi.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/DefaultControllerRestApi.java
@@ -155,7 +155,7 @@ public class DefaultControllerRestApi implements ControllerRestApi {
 
   @Override
   public List<String> getAllSegments(String tableType) {
-    LOGGER.info("Getting all segments");
+    LOGGER.info("Getting all segments of table {}", _rawTableName);
     for (PushLocation pushLocation : _pushLocations) {
       try {
         SimpleHttpResponse response = _fileUploadDownloadClient.sendGetRequest(

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DeleteAPIHybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DeleteAPIHybridClusterIntegrationTest.java
@@ -19,13 +19,18 @@
 package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import junit.framework.Assert;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.JsonUtils;
+import org.apache.pinot.hadoop.job.ControllerRestApi;
+import org.apache.pinot.hadoop.job.DefaultControllerRestApi;
+import org.apache.pinot.hadoop.utils.PushLocation;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -237,8 +242,26 @@ public class DeleteAPIHybridClusterIntegrationTest extends HybridClusterIntegrat
         forSegmentListAPIWithTableType(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE.toString()));
     JsonNode offlineSegmentsListReturn =
         getSegmentsFromJsonSegmentAPI(postDeleteSegmentList, CommonConstants.Helix.TableType.OFFLINE.toString());
+
+    // Get all segments
+    PushLocation pushLocation = new PushLocation("localhost", 18998);
+    List<PushLocation> pushLocations = new ArrayList<>();
+    pushLocations.add(pushLocation);
+    ControllerRestApi controllerRestApi = new DefaultControllerRestApi(pushLocations, "mytable");
+    List<String> allSegments = controllerRestApi.getAllSegments("OFFLINE");
+    Assert.assertEquals(allSegments.size(), offlineSegmentsListReturn.size());
+
     removeValue(offlineSegmentsList, removedSegment);
     Assert.assertEquals(offlineSegmentsListReturn, offlineSegmentsList);
+
+    // Test Delete one more segment
+    String segmentUri = allSegments.get(0);
+    List<String> deleteSegmentUris = new ArrayList<>();
+    deleteSegmentUris.add(segmentUri);
+    controllerRestApi.deleteSegmentUris(deleteSegmentUris);
+    allSegments.remove(0);
+    List<String> postDelete = controllerRestApi.getAllSegments("OFFLINE");
+    Assert.assertEquals(postDelete.size(), allSegments.size());
 
     // Testing Delete All API here
     sendGetRequest(_controllerRequestURLBuilder.


### PR DESCRIPTION
-Adding util methods to support segment delete after push
-Split because it is necessary to refactor segment naming code and internal code that currently uses the same controller rest api interface
-Final Design: https://github.com/apache/incubator-pinot/issues/4353