### PR TITLE
3891: Check for validity of segment start/end time during segment generation

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/time/TimeUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/time/TimeUtils.java
@@ -167,4 +167,19 @@ public class TimeUtils {
     }
     return periodStr;
   }
+
+  /**
+   * Verify that start and end time (should be in milliseconds from epoch) of the segment
+   * are in valid range.
+   * @param startMillis start time (in milliseconds)
+   * @param endMillis end time (in milliseconds)
+   * @return true if start and end time are in range, false otherwise
+   *
+   * Note: this function assumes that given times are in milliseconds. The
+   * caller should take care of converting to millis from epoch before
+   * trying to validate the times.
+   */
+  public static boolean checkSegmentTimeValidity(final long startMillis, final long endMillis) {
+    return timeValueInValidRange(startMillis) && timeValueInValidRange(endMillis);
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidator.java
@@ -156,7 +156,7 @@ public class SegmentValidator {
     long startMillis = interval.getStartMillis();
     long endMillis = interval.getEndMillis();
 
-    if (!TimeUtils.timeValueInValidRange(startMillis) || !TimeUtils.timeValueInValidRange(endMillis)) {
+    if (!TimeUtils.checkSegmentTimeValidity(startMillis, endMillis)) {
       Date minDate = new Date(TimeUtils.getValidMinTimeMillis());
       Date maxDate = new Date(TimeUtils.getValidMaxTimeMillis());
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -112,6 +112,7 @@ public class SegmentGeneratorConfig {
   private String _simpleDateFormat = null;
   // Use on-heap or off-heap memory to generate index (currently only affect inverted index and star-tree v2)
   private boolean _onHeap = false;
+  private boolean _checkTimeColumnValidityDuringGeneration = true;
 
   public SegmentGeneratorConfig() {
   }
@@ -160,6 +161,7 @@ public class SegmentGeneratorConfig {
     _simpleDateFormat = config._simpleDateFormat;
     _onHeap = config._onHeap;
     _recordReaderPath = config._recordReaderPath;
+    _checkTimeColumnValidityDuringGeneration = config._checkTimeColumnValidityDuringGeneration;
   }
 
   /**
@@ -591,6 +593,14 @@ public class SegmentGeneratorConfig {
 
   public void setOnHeap(boolean onHeap) {
     _onHeap = onHeap;
+  }
+
+  public boolean isCheckTimeColumnValidityDuringGeneration() {
+    return _checkTimeColumnValidityDuringGeneration;
+  }
+
+  public void setCheckTimeColumnValidityDuringGeneration(boolean checkTimeColumnValidityDuringGeneration) {
+    _checkTimeColumnValidityDuringGeneration = checkTimeColumnValidityDuringGeneration;
   }
 
   public Map<String, ChunkCompressorFactory.CompressionType> getRawIndexCompressionType() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
@@ -69,11 +69,13 @@ public class SegmentConverter {
   private RecordAggregator _recordAggregator;
   private List<String> _groupByColumns;
   private IndexingConfig _indexingConfig;
+  private boolean _checkTimeValidityDuringGeneration;
 
   public SegmentConverter(@Nonnull List<File> inputIndexDirs, @Nonnull File workingDir, @Nonnull String tableName,
       @Nonnull String segmentName, int totalNumPartition, @Nonnull RecordTransformer recordTransformer,
       @Nullable RecordPartitioner recordPartitioner, @Nullable RecordAggregator recordAggregator,
-      @Nullable List<String> groupByColumns, @Nullable IndexingConfig indexingConfig) {
+      @Nullable List<String> groupByColumns, @Nullable IndexingConfig indexingConfig,
+      boolean checkTimeValidityDuringGeneration) {
     _inputIndexDirs = inputIndexDirs;
     _workingDir = workingDir;
     _recordTransformer = recordTransformer;
@@ -86,6 +88,8 @@ public class SegmentConverter {
     _recordAggregator = recordAggregator;
     _groupByColumns = groupByColumns;
     _indexingConfig = indexingConfig;
+
+    _checkTimeValidityDuringGeneration = checkTimeValidityDuringGeneration;
   }
 
   public List<File> convertSegment()
@@ -148,6 +152,7 @@ public class SegmentConverter {
     segmentGeneratorConfig.setOutDir(outputPath);
     segmentGeneratorConfig.setTableName(tableName);
     segmentGeneratorConfig.setSegmentName(segmentName);
+    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(_checkTimeValidityDuringGeneration);
     if (indexingConfig != null) {
       segmentGeneratorConfig.setInvertedIndexCreationColumns(indexingConfig.getInvertedIndexColumns());
       if (indexingConfig.getStarTreeIndexSpec() != null) {
@@ -173,6 +178,9 @@ public class SegmentConverter {
     private RecordAggregator _recordAggregator;
     private List<String> _groupByColumns;
     private IndexingConfig _indexingConfig;
+
+    // enabled by default
+    private boolean _checkTimeValidityDuringGeneration = true;
 
     public Builder setInputIndexDirs(List<File> inputIndexDirs) {
       _inputIndexDirs = inputIndexDirs;
@@ -224,6 +232,11 @@ public class SegmentConverter {
       return this;
     }
 
+    public Builder setCheckTimeValidityDuringGeneration(final boolean checkTimeValidity) {
+      _checkTimeValidityDuringGeneration = checkTimeValidity;
+      return this;
+    }
+
     public SegmentConverter build() {
       // Check that the group-by columns and record aggregator are configured together
       if (_groupByColumns != null && _groupByColumns.size() > 0) {
@@ -235,7 +248,8 @@ public class SegmentConverter {
       }
 
       return new SegmentConverter(_inputIndexDirs, _workingDir, _tableName, _segmentName, _totalNumPartition,
-          _recordTransformer, _recordPartitioner, _recordAggregator, _groupByColumns, _indexingConfig);
+          _recordTransformer, _recordPartitioner, _recordAggregator, _groupByColumns, _indexingConfig,
+          _checkTimeValidityDuringGeneration);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -95,6 +95,7 @@ public class RealtimeSegmentConverter {
       reader = new RealtimeSegmentRecordReader(realtimeSegmentImpl, dataSchema, sortedColumn);
     }
     SegmentGeneratorConfig genConfig = new SegmentGeneratorConfig(dataSchema);
+    genConfig.setCheckTimeColumnValidityDuringGeneration(false);
     if (invertedIndexColumns != null && !invertedIndexColumns.isEmpty()) {
       for (String column : invertedIndexColumns) {
         genConfig.createInvertedIndexForColumn(column);

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -95,6 +95,11 @@ public class RealtimeSegmentConverter {
       reader = new RealtimeSegmentRecordReader(realtimeSegmentImpl, dataSchema, sortedColumn);
     }
     SegmentGeneratorConfig genConfig = new SegmentGeneratorConfig(dataSchema);
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. We don't want the realtime consumption to stop (if an exception
+    // is thrown) and thus the time validity check is explicitly disabled for
+    // realtime segment generation
     genConfig.setCheckTimeColumnValidityDuringGeneration(false);
     if (invertedIndexColumns != null && !invertedIndexColumns.isEmpty()) {
       for (String column : invertedIndexColumns) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -350,7 +350,14 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         Object minTime = Preconditions.checkNotNull(timeColumnIndexCreationInfo.getMin());
         Object maxTime = Preconditions.checkNotNull(timeColumnIndexCreationInfo.getMax());
 
-        if (config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
+        if (config.getSegmentTimeUnit() == TimeUnit.DAYS) {
+          final long minTimeMillis = TimeUnit.DAYS.toMillis(((Integer) minTime).longValue());
+          final long maxTimeMillis =  TimeUnit.DAYS.toMillis(((Integer) maxTime).longValue());
+          checkTime(config, minTimeMillis, maxTimeMillis, segmentName);
+          properties.setProperty(SEGMENT_START_TIME, minTimeMillis);
+          properties.setProperty(SEGMENT_END_TIME, maxTimeMillis);
+          properties.setProperty(TIME_UNIT, TimeUnit.MILLISECONDS);
+        } else if (config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
           // For simple date format, convert time value into millis since epoch
           DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(config.getSimpleDateFormat());
           final Long minTimeMillis = dateTimeFormatter.parseMillis(minTime.toString());
@@ -416,8 +423,8 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       throw new RuntimeException("Expecting non-null start/end time for segment: " + segmentName);
     }
 
-    long startMillis = 0;
-    long endMillis = 0;
+    long startMillis;
+    long endMillis;
 
     if (startTime instanceof Long && endTime instanceof Long) {
       startMillis = (long)startTime;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -431,13 +431,22 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       end = ((Integer) endTime).longValue();
     } else {
       final StringBuilder err = new StringBuilder();
-      err.append(
-          "Unable to interpret type of time column value. Failed to validate start and end time of segment time column")
-          .append(" uninterpreted type: ").append(startTime.getClass()).append(" start time: ").append(startTime)
-          .append(" end time: ").append(endTime).append(" time column name: ").append(config.getTimeColumnName())
-          .append(" segment name: ").append(segmentName).append(" segment time column unit: ")
-          .append(config.getSegmentTimeUnit().toString()).append(" segment time column type: ")
-          .append(config.getTimeColumnType().toString()).append(" time field spec data type: ")
+      err.append("Unable to interpret type of time column value. Failed to validate start and end time of segment")
+          .append(" uninterpreted type: ")
+          .append(startTime.getClass())
+          .append(" start time: ")
+          .append(startTime)
+          .append(" end time: ")
+          .append(endTime)
+          .append(" time column name: ")
+          .append(config.getTimeColumnName())
+          .append(" segment name: ")
+          .append(segmentName)
+          .append(" segment time column unit: ")
+          .append(config.getSegmentTimeUnit().toString())
+          .append(" segment time column type: ")
+          .append(config.getTimeColumnType().toString())
+          .append(" time field spec data type: ")
           .append(config.getSchema().getTimeFieldSpec().getDataType().toString());
       LOGGER.error(err.toString());
       throw new RuntimeException(err.toString());
@@ -480,8 +489,11 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           if (config.getSegmentTimeUnit() != TimeUnit.MILLISECONDS) {
             // we should never be here
             final StringBuilder err = new StringBuilder();
-            err.append("Unexpected time unit: ").append(config.getSegmentTimeUnit().toString())
-                .append(" for time column: ").append(config.getTimeColumnName()).append(" for segment: ")
+            err.append("Unexpected time unit: ")
+                .append(config.getSegmentTimeUnit().toString())
+                .append(" for time column: ")
+                .append(config.getTimeColumnName())
+                .append(" for segment: ")
                 .append(segmentName);
             LOGGER.error(err.toString());
             throw new RuntimeException(err.toString());
@@ -493,12 +505,24 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       final Date minDate = new Date(TimeUtils.getValidMinTimeMillis());
       final Date maxDate = new Date(TimeUtils.getValidMaxTimeMillis());
       final StringBuilder err = new StringBuilder();
-      err.append("Invalid start/end time.").append(" segment name: ").append(segmentName).append(" time column name: ")
-          .append(config.getTimeColumnName()).append(" given start time: ").append(start).append("ms")
-          .append(" given end time: ").append(end).append("ms").append(" start and end time must be between ")
-          .append(minDate).append(" and ").append(maxDate).append(" segment time column unit: ")
-          .append(config.getSegmentTimeUnit().toString()).append(" segment time column type: ")
-          .append(config.getTimeColumnType().toString()).append(" time field spec data type: ")
+      err.append("Invalid start/end time.")
+          .append(" segment name: ")
+          .append(segmentName)
+          .append(" time column name: ")
+          .append(config.getTimeColumnName())
+          .append(" given start time: ")
+          .append(start).append("ms")
+          .append(" given end time: ")
+          .append(end).append("ms")
+          .append(" start and end time must be between ")
+          .append(minDate)
+          .append(" and ")
+          .append(maxDate)
+          .append(" segment time column unit: ")
+          .append(config.getSegmentTimeUnit().toString())
+          .append(" segment time column type: ")
+          .append(config.getTimeColumnType().toString())
+          .append(" time field spec data type: ")
           .append(config.getSchema().getTimeFieldSpec().getDataType().toString());
       LOGGER.error(err.toString());
       throw new RuntimeException(err.toString());

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -351,7 +351,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         Object maxTime = Preconditions.checkNotNull(timeColumnIndexCreationInfo.getMax());
 
         if (config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
-          // For simple date format, convert time value into millis since epoch
+          // For TimeColumnType.SIMPLE_DATE_FORMAT, convert time value into millis since epoch
           DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(config.getSimpleDateFormat());
           final long minTimeMillis = dateTimeFormatter.parseMillis(minTime.toString());
           final long maxTimeMillis = dateTimeFormatter.parseMillis(maxTime.toString());
@@ -360,7 +360,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           properties.setProperty(SEGMENT_END_TIME, maxTimeMillis);
           properties.setProperty(TIME_UNIT, TimeUnit.MILLISECONDS);
         } else {
-          // by default, time column type is EPOCH
+          // by default, time column type is TimeColumnType.EPOCH
           checkTime(config, minTime, maxTime, segmentName);
           properties.setProperty(SEGMENT_START_TIME, minTime);
           properties.setProperty(SEGMENT_END_TIME, maxTime);
@@ -417,39 +417,43 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       throw new RuntimeException("Expecting non-null start/end time for segment: " + segmentName);
     }
 
+    if (!(startTime.getClass().equals(endTime.getClass()))) {
+      final StringBuilder err = new StringBuilder();
+      err.append("Start and end time of segment should be of same type.").append(" segment name: ").append(segmentName)
+          .append(" start time: ").append(startTime).append(" end time: ").append(endTime).append(" start time class: ")
+          .append(startTime.getClass()).append(" end time class: ").append(endTime.getClass());
+      throw new RuntimeException(err.toString());
+    }
+
     long start;
     long end;
 
-    if (startTime instanceof Long && endTime instanceof Long) {
-      start = (long) startTime;
-      end = (long) endTime;
-    } else if (startTime instanceof String && endTime instanceof String) {
-      start = Long.parseLong((String) startTime);
-      end = Long.parseLong((String) endTime);
-    } else if (startTime instanceof Integer && endTime instanceof Integer) {
-      start = ((Integer) startTime).longValue();
-      end = ((Integer) endTime).longValue();
-    } else {
-      final StringBuilder err = new StringBuilder();
-      err.append("Unable to interpret type of time column value. Failed to validate start and end time of segment")
-          .append(" uninterpreted type: ")
-          .append(startTime.getClass())
-          .append(" start time: ")
-          .append(startTime)
-          .append(" end time: ")
-          .append(endTime)
-          .append(" time column name: ")
-          .append(config.getTimeColumnName())
-          .append(" segment name: ")
-          .append(segmentName)
-          .append(" segment time column unit: ")
-          .append(config.getSegmentTimeUnit().toString())
-          .append(" segment time column type: ")
-          .append(config.getTimeColumnType().toString())
-          .append(" time field spec data type: ")
-          .append(config.getSchema().getTimeFieldSpec().getDataType().toString());
-      LOGGER.error(err.toString());
-      throw new RuntimeException(err.toString());
+    final String cl = startTime.getClass().getSimpleName();
+
+    switch (cl) {
+      case "Long":
+        start = (long) startTime;
+        end = (long) endTime;
+        break;
+      case "String":
+        start = Long.parseLong((String) startTime);
+        end = Long.parseLong((String) endTime);
+        break;
+      case "Integer":
+        start = ((Integer) startTime).longValue();
+        end = ((Integer) endTime).longValue();
+        break;
+      default:
+        final StringBuilder err = new StringBuilder();
+        err.append("Unable to interpret type of time column value. Failed to validate start and end time of segment")
+            .append(" uninterpreted type: ").append(startTime.getClass()).append(" start time: ").append(startTime)
+            .append(" end time: ").append(endTime).append(" time column name: ").append(config.getTimeColumnName())
+            .append(" segment name: ").append(segmentName).append(" segment time column unit: ")
+            .append(config.getSegmentTimeUnit().toString()).append(" segment time column type: ")
+            .append(config.getTimeColumnType().toString()).append(" time field spec data type: ")
+            .append(config.getSchema().getTimeFieldSpec().getDataType().toString());
+        LOGGER.error(err.toString());
+        throw new RuntimeException(err.toString());
     }
 
     // note that handling of SimpleDateFormat (TimeColumnType.SIMPLE)
@@ -489,11 +493,8 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           if (config.getSegmentTimeUnit() != TimeUnit.MILLISECONDS) {
             // we should never be here
             final StringBuilder err = new StringBuilder();
-            err.append("Unexpected time unit: ")
-                .append(config.getSegmentTimeUnit().toString())
-                .append(" for time column: ")
-                .append(config.getTimeColumnName())
-                .append(" for segment: ")
+            err.append("Unexpected time unit: ").append(config.getSegmentTimeUnit().toString())
+                .append(" for time column: ").append(config.getTimeColumnName()).append(" for segment: ")
                 .append(segmentName);
             LOGGER.error(err.toString());
             throw new RuntimeException(err.toString());
@@ -501,28 +502,16 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       }
     }
 
-    if (!TimeUtils.timeValueInValidRange(start) || !TimeUtils.timeValueInValidRange(end)) {
+    if (!TimeUtils.checkSegmentTimeValidity(start, end)) {
       final Date minDate = new Date(TimeUtils.getValidMinTimeMillis());
       final Date maxDate = new Date(TimeUtils.getValidMaxTimeMillis());
       final StringBuilder err = new StringBuilder();
-      err.append("Invalid start/end time.")
-          .append(" segment name: ")
-          .append(segmentName)
-          .append(" time column name: ")
-          .append(config.getTimeColumnName())
-          .append(" given start time: ")
-          .append(start).append("ms")
-          .append(" given end time: ")
-          .append(end).append("ms")
-          .append(" start and end time must be between ")
-          .append(minDate)
-          .append(" and ")
-          .append(maxDate)
-          .append(" segment time column unit: ")
-          .append(config.getSegmentTimeUnit().toString())
-          .append(" segment time column type: ")
-          .append(config.getTimeColumnType().toString())
-          .append(" time field spec data type: ")
+      err.append("Invalid start/end time.").append(" segment name: ").append(segmentName).append(" time column name: ")
+          .append(config.getTimeColumnName()).append(" given start time: ").append(start).append("ms")
+          .append(" given end time: ").append(end).append("ms").append(" start and end time must be between ")
+          .append(minDate).append(" and ").append(maxDate).append(" segment time column unit: ")
+          .append(config.getSegmentTimeUnit().toString()).append(" segment time column type: ")
+          .append(config.getTimeColumnType().toString()).append(" time field spec data type: ")
           .append(config.getSchema().getTimeFieldSpec().getDataType().toString());
       LOGGER.error(err.toString());
       throw new RuntimeException(err.toString());

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -342,7 +342,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     if (timeColumnIndexCreationInfo != null) {
       // Use start/end time in config if defined
       if (config.getStartTime() != null) {
-        checkTime(config.getStartTime(), config.getEndTime(), segmentName);
+        checkTime(config, config.getStartTime(), config.getEndTime(), segmentName);
         properties.setProperty(SEGMENT_START_TIME, config.getStartTime());
         properties.setProperty(SEGMENT_END_TIME, Preconditions.checkNotNull(config.getEndTime()));
         properties.setProperty(TIME_UNIT, Preconditions.checkNotNull(config.getSegmentTimeUnit()));
@@ -355,12 +355,12 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(config.getSimpleDateFormat());
           final Long minTimeMillis = dateTimeFormatter.parseMillis(minTime.toString());
           final Long maxTimeMillis = dateTimeFormatter.parseMillis(maxTime.toString());
-          checkTime(minTimeMillis, maxTimeMillis, segmentName);
+          checkTime(config, minTimeMillis, maxTimeMillis, segmentName);
           properties.setProperty(SEGMENT_START_TIME, minTimeMillis);
           properties.setProperty(SEGMENT_END_TIME, maxTimeMillis);
           properties.setProperty(TIME_UNIT, TimeUnit.MILLISECONDS);
         } else {
-          checkTime(minTime, maxTime, segmentName);
+          checkTime(config, minTime, maxTime, segmentName);
           properties.setProperty(SEGMENT_START_TIME, minTime);
           properties.setProperty(SEGMENT_END_TIME, maxTime);
           properties.setProperty(TIME_UNIT, Preconditions.checkNotNull(config.getSegmentTimeUnit()));
@@ -406,7 +406,12 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
    * @param endTime segment end time
    * @param segmentName segment name
    */
-  private void checkTime(final Object startTime, final Object endTime, final String segmentName) {
+  private void checkTime(final SegmentGeneratorConfig config, final Object startTime,
+      final Object endTime, final String segmentName) {
+    if (!config.isCheckTimeColumnValidityDuringGeneration()) {
+      return;
+    }
+
     if (startTime == null || endTime == null) {
       throw new RuntimeException("Expecting non-null start/end time for segment: " + segmentName);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.MetricFieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.data.TimeFieldSpec;
+import org.apache.pinot.common.utils.time.TimeUtils;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
@@ -58,7 +59,7 @@ public class SegmentConverterTest {
   private static final String T = "t";
 
   private List<File> _segmentIndexDirList;
-  private final long _referenceTimestamp = System.currentTimeMillis();
+  private final long _referenceTimestamp = TimeUtils.getValidMinTimeMillis();
 
   @BeforeClass
   public void setUp()
@@ -144,7 +145,8 @@ public class SegmentConverterTest {
 
     SegmentConverter segmentConverter =
         new SegmentConverter.Builder().setTableName(TABLE_NAME).setSegmentName("segmentRollupWithTimeConversion")
-            .setInputIndexDirs(_segmentIndexDirList).setWorkingDir(WORKING_DIR).setRecordTransformer((row) -> {
+            .setInputIndexDirs(_segmentIndexDirList).setWorkingDir(WORKING_DIR).setCheckTimeValidityDuringGeneration(false)
+            .setRecordTransformer((row) -> {
           long[] input = new long[1];
           long[] output = new long[1];
           input[0] = (Long) row.getValue(T);

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
@@ -143,6 +143,16 @@ public class SegmentConverterTest {
     final BaseDateTimeTransformer dateTimeTransformer =
         DateTimeTransformerFactory.getDateTimeTransformer("1:MILLISECONDS:EPOCH", "1:DAYS:EPOCH", "1:DAYS");
 
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we have explicitly disabled the check since the segment
+    // conversion is happening along with transforming each input record by converting
+    // the time column value (from millis since epoch) into days since epoch. While the
+    // source data is under range, the transformed data (days since epoch) goes out of range
+    // since segment conversion follows the same schema -- it does not create new schema. This
+    // means that time column spec doesn't change and still carries the time unit as milliseconds
+    // for the converted segment even though values we are writing are "days since epoch" and
+    // not "millis since epoch". Thus SegmentColumnarIndexCreator throws exception.
     SegmentConverter segmentConverter =
         new SegmentConverter.Builder().setTableName(TABLE_NAME).setSegmentName("segmentRollupWithTimeConversion")
             .setInputIndexDirs(_segmentIndexDirList).setWorkingDir(WORKING_DIR).setCheckTimeValidityDuringGeneration(false)

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -94,6 +94,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
     segmentGeneratorConfig
         .setInvertedIndexCreationColumns(Arrays.asList("column6", "column7", "column11", "column17", "column18"));
 
@@ -121,6 +122,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME_STARTREE);
     segmentGeneratorConfig.setOutDir(INDEX_DIR_STARTREE.getAbsolutePath());
     segmentGeneratorConfig.enableStarTreeIndex(new StarTreeIndexSpec());
+    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
 
     // Build the index segment.
     driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -94,6 +94,11 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
     segmentGeneratorConfig
         .setInvertedIndexCreationColumns(Arrays.asList("column6", "column7", "column11", "column17", "column18"));
@@ -122,6 +127,11 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME_STARTREE);
     segmentGeneratorConfig.setOutDir(INDEX_DIR_STARTREE.getAbsolutePath());
     segmentGeneratorConfig.enableStarTreeIndex(new StarTreeIndexSpec());
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
 
     // Build the index segment.

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/ColumnMetadataTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/ColumnMetadataTest.java
@@ -68,6 +68,11 @@ public class ColumnMetadataTest {
             "testTable");
     config.setSegmentNamePostfix("1");
     config.setTimeColumnName("daysSinceEpoch");
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     config.setCheckTimeColumnValidityDuringGeneration(false);
     return config;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/ColumnMetadataTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/ColumnMetadataTest.java
@@ -68,6 +68,7 @@ public class ColumnMetadataTest {
             "testTable");
     config.setSegmentNamePostfix("1");
     config.setTimeColumnName("daysSinceEpoch");
+    config.setCheckTimeColumnValidityDuringGeneration(false);
     return config;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/SegmentMetadataImplTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/SegmentMetadataImplTest.java
@@ -57,6 +57,11 @@ public class SegmentMetadataImplTest {
             "testTable");
     config.setSegmentNamePostfix("1");
     config.setTimeColumnName("daysSinceEpoch");
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     config.setCheckTimeColumnValidityDuringGeneration(false);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/SegmentMetadataImplTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/SegmentMetadataImplTest.java
@@ -57,6 +57,7 @@ public class SegmentMetadataImplTest {
             "testTable");
     config.setSegmentNamePostfix("1");
     config.setTimeColumnName("daysSinceEpoch");
+    config.setCheckTimeColumnValidityDuringGeneration(false);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverterTest.java
@@ -64,6 +64,7 @@ public class SegmentV1V2ToV3FormatConverterTest {
             "testTable");
     config.setSegmentNamePostfix("1");
     config.setTimeColumnName("daysSinceEpoch");
+    config.setCheckTimeColumnValidityDuringGeneration(false);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverterTest.java
@@ -64,6 +64,11 @@ public class SegmentV1V2ToV3FormatConverterTest {
             "testTable");
     config.setSegmentNamePostfix("1");
     config.setTimeColumnName("daysSinceEpoch");
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     config.setCheckTimeColumnValidityDuringGeneration(false);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -97,7 +97,7 @@ public class SegmentGenerationWithTimeColumnTest {
       Schema schema = createSchema(false);
       buildSegment(schema, false, true);
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Invalid start/end time for segment: testSegment"));
+      Assert.assertTrue(e.getMessage().contains("Invalid start/end time for segment: testSegment for time column: date"));
       error = true;
     }
     Assert.assertTrue(error);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -92,15 +92,13 @@ public class SegmentGenerationWithTimeColumnTest {
 
   @Test
   public void testSegmentGenerationWithInvalidTime() {
-    boolean error = false;
+    Schema schema = createSchema(false);
     try {
-      Schema schema = createSchema(false);
       buildSegment(schema, false, true);
+      Assert.fail("Expecting exception from buildSegment for invalid start/end time of segment");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Invalid start/end time for segment: testSegment for time column: date"));
-      error = true;
+      Assert.assertTrue(e.getMessage().contains("Invalid start/end time. segment name: testSegment time column name: date"));
     }
-    Assert.assertTrue(error);
   }
 
   private Schema createSchema(boolean isSimpleDate) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -30,6 +30,7 @@ import org.apache.pinot.common.data.DimensionFieldSpec;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.data.TimeFieldSpec;
+import org.apache.pinot.common.utils.time.TimeUtils;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
@@ -37,6 +38,7 @@ import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl
 import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -56,6 +58,7 @@ public class SegmentGenerationWithTimeColumnTest {
 
   private Random _random = new Random(System.nanoTime());
 
+  private long validMinTime = TimeUtils.getValidMinTimeMillis();
   private long minTime;
   private long maxTime;
   private long startTime = System.currentTimeMillis();
@@ -71,7 +74,7 @@ public class SegmentGenerationWithTimeColumnTest {
   public void testSimpleDateSegmentGeneration()
       throws Exception {
     Schema schema = createSchema(true);
-    File segmentDir = buildSegment(schema, true);
+    File segmentDir = buildSegment(schema, true, false);
     SegmentMetadataImpl metadata = SegmentDirectory.loadSegmentMetadata(segmentDir);
     Assert.assertEquals(metadata.getStartTime(), sdfToMillis(minTime));
     Assert.assertEquals(metadata.getEndTime(), sdfToMillis(maxTime));
@@ -81,10 +84,23 @@ public class SegmentGenerationWithTimeColumnTest {
   public void testEpochDateSegmentGeneration()
       throws Exception {
     Schema schema = createSchema(false);
-    File segmentDir = buildSegment(schema, false);
+    File segmentDir = buildSegment(schema, false, false);
     SegmentMetadataImpl metadata = SegmentDirectory.loadSegmentMetadata(segmentDir);
     Assert.assertEquals(metadata.getStartTime(), minTime);
     Assert.assertEquals(metadata.getEndTime(), maxTime);
+  }
+
+  @Test
+  public void testSegmentGenerationWithInvalidTime() {
+    boolean error = false;
+    try {
+      Schema schema = createSchema(false);
+      buildSegment(schema, false, true);
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Invalid start/end time for segment: testSegment"));
+      error = true;
+    }
+    Assert.assertTrue(error);
   }
 
   private Schema createSchema(boolean isSimpleDate) {
@@ -98,7 +114,8 @@ public class SegmentGenerationWithTimeColumnTest {
     return schema;
   }
 
-  private File buildSegment(Schema schema, boolean isSimpleDate)
+  private File buildSegment(final Schema schema, final boolean isSimpleDate,
+      final boolean isInvalidDate)
       throws Exception {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
     config.setRawIndexCreationColumns(schema.getDimensionNames());
@@ -117,7 +134,7 @@ public class SegmentGenerationWithTimeColumnTest {
       for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
         Object value;
 
-        value = getRandomValueForColumn(fieldSpec, isSimpleDate);
+        value = getRandomValueForColumn(fieldSpec, isSimpleDate, isInvalidDate);
         map.put(fieldSpec.getName(), value);
       }
 
@@ -133,18 +150,21 @@ public class SegmentGenerationWithTimeColumnTest {
     return driver.getOutputDirectory();
   }
 
-  private Object getRandomValueForColumn(FieldSpec fieldSpec, boolean isSimpleDate) {
+  private Object getRandomValueForColumn(FieldSpec fieldSpec, boolean isSimpleDate, boolean isInvalidDate) {
     if (fieldSpec.getName().equals(TIME_COL_NAME)) {
-      return getRandomValueForTimeColumn(isSimpleDate);
+      return getRandomValueForTimeColumn(isSimpleDate, isInvalidDate);
     }
     return RawIndexCreatorTest.getRandomValue(_random, fieldSpec.getDataType());
   }
 
-  private Object getRandomValueForTimeColumn(boolean isSimpleDate) {
-    long randomMs = ThreadLocalRandom.current().nextLong(startTime);
+  private Object getRandomValueForTimeColumn(boolean isSimpleDate, boolean isInvalidDate) {
+    long randomMs = ThreadLocalRandom.current().nextLong(validMinTime, startTime);
     long dateColVal = randomMs;
     Object result;
-    if (isSimpleDate) {
+    if (isInvalidDate) {
+      result = new Long(new DateTime(2072, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis());
+      return result;
+    } else if (isSimpleDate) {
       DateTime dateTime = new DateTime(randomMs);
       LocalDateTime localDateTime = dateTime.toLocalDateTime();
       int year = localDateTime.getYear();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
@@ -119,6 +119,7 @@ public class SegmentPreProcessorTest {
     SegmentGeneratorConfig segmentGeneratorConfig =
         SegmentTestUtils.getSegmentGeneratorConfigWithSchema(_avroFile, INDEX_DIR, "testTable", _schema);
     segmentGeneratorConfig.setInvertedIndexCreationColumns(Collections.singletonList(COLUMN7_NAME));
+    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
     SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(segmentGeneratorConfig);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
@@ -119,6 +119,11 @@ public class SegmentPreProcessorTest {
     SegmentGeneratorConfig segmentGeneratorConfig =
         SegmentTestUtils.getSegmentGeneratorConfigWithSchema(_avroFile, INDEX_DIR, "testTable", _schema);
     segmentGeneratorConfig.setInvertedIndexCreationColumns(Collections.singletonList(COLUMN7_NAME));
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
     SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(segmentGeneratorConfig);

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
@@ -85,6 +85,11 @@ public class StarTreeIndexTestSegmentHelper {
     config.setFormat(FileFormat.AVRO);
     config.setSegmentName(segmentName);
     config.setHllConfig(hllConfig);
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     config.setCheckTimeColumnValidityDuringGeneration(false);
 
     List<GenericRow> rows = new ArrayList<>(numRows);

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
@@ -85,6 +85,7 @@ public class StarTreeIndexTestSegmentHelper {
     config.setFormat(FileFormat.AVRO);
     config.setSegmentName(segmentName);
     config.setHllConfig(hllConfig);
+    config.setCheckTimeColumnValidityDuringGeneration(false);
 
     List<GenericRow> rows = new ArrayList<>(numRows);
     for (int rowId = 0; rowId < numRows; rowId++) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/TestStarTreeMetadata.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/TestStarTreeMetadata.java
@@ -96,6 +96,11 @@ public class TestStarTreeMetadata {
     starTreeIndexSpec.setSkipMaterializationForDimensions(SKIP_MATERIALIZATION_DIMENSIONS);
 
     config.enableStarTreeIndex(starTreeIndexSpec);
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     config.setCheckTimeColumnValidityDuringGeneration(false);
 
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/TestStarTreeMetadata.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/TestStarTreeMetadata.java
@@ -96,6 +96,7 @@ public class TestStarTreeMetadata {
     starTreeIndexSpec.setSkipMaterializationForDimensions(SKIP_MATERIALIZATION_DIMENSIONS);
 
     config.enableStarTreeIndex(starTreeIndexSpec);
+    config.setCheckTimeColumnValidityDuringGeneration(false);
 
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
@@ -134,6 +134,7 @@ public class SegmentWithHllIndexCreateHelper {
     segmentGenConfig.createInvertedIndexForAllColumns();
     segmentGenConfig.setSegmentName(segmentName);
     segmentGenConfig.setSegmentNamePostfix("1");
+    segmentGenConfig.setCheckTimeColumnValidityDuringGeneration(false);
 
     if (enableStarTree) {
       setupStarTreeConfig(segmentGenConfig);

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
@@ -134,6 +134,11 @@ public class SegmentWithHllIndexCreateHelper {
     segmentGenConfig.createInvertedIndexForAllColumns();
     segmentGenConfig.setSegmentName(segmentName);
     segmentGenConfig.setSegmentNamePostfix("1");
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     segmentGenConfig.setCheckTimeColumnValidityDuringGeneration(false);
 
     if (enableStarTree) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/CrcUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/CrcUtilsTest.java
@@ -83,6 +83,11 @@ public class CrcUtilsTest {
             "testTable");
     config.setSegmentNamePostfix("1");
     config.setTimeColumnName("daysSinceEpoch");
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     config.setCheckTimeColumnValidityDuringGeneration(false);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/CrcUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/CrcUtilsTest.java
@@ -83,6 +83,7 @@ public class CrcUtilsTest {
             "testTable");
     config.setSegmentNamePostfix("1");
     config.setTimeColumnName("daysSinceEpoch");
+    config.setCheckTimeColumnValidityDuringGeneration(false);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
@@ -91,7 +91,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
         .addMultiValueDimension("column6", FieldSpec.DataType.INT)
         .addMultiValueDimension("column7", FieldSpec.DataType.INT)
         .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
-        .addMetric("column10", FieldSpec.DataType.INT).addTime("daysSinceEpoch", TimeUnit.DAYS, FieldSpec.DataType.INT)
+        .addMetric("column10", FieldSpec.DataType.INT).addTime("daysSinceEpoch", TimeUnit.MILLISECONDS, FieldSpec.DataType.LONG)
         .build();
 
     // Create the segment generator config.
@@ -100,6 +100,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
     segmentGeneratorConfig.setInvertedIndexCreationColumns(Arrays.asList("column3", "column7", "column8", "column9"));
+    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
 
     // Build the index segment.
     SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
@@ -100,6 +100,11 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
     segmentGeneratorConfig.setInvertedIndexCreationColumns(Arrays.asList("column3", "column7", "column8", "column9"));
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
 
     // Build the index segment.

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
@@ -91,7 +91,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
         .addMultiValueDimension("column6", FieldSpec.DataType.INT)
         .addMultiValueDimension("column7", FieldSpec.DataType.INT)
         .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
-        .addMetric("column10", FieldSpec.DataType.INT).addTime("daysSinceEpoch", TimeUnit.MILLISECONDS, FieldSpec.DataType.LONG)
+        .addMetric("column10", FieldSpec.DataType.INT).addTime("daysSinceEpoch", TimeUnit.DAYS, FieldSpec.DataType.INT)
         .build();
 
     // Create the segment generator config.

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -101,6 +101,11 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setInputFilePath(filePath);
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
     segmentGeneratorConfig
         .setInvertedIndexCreationColumns(Arrays.asList("column6", "column7", "column11", "column17", "column18"));

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -101,6 +101,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setInputFilePath(filePath);
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
     segmentGeneratorConfig
         .setInvertedIndexCreationColumns(Arrays.asList("column6", "column7", "column11", "column17", "column18"));
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -235,6 +235,11 @@ public class FastHllQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setInputFilePath(filePath);
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
     segmentGeneratorConfig
         .setInvertedIndexCreationColumns(Arrays.asList("column6", "column7", "column11", "column17", "column18"));

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -235,6 +235,7 @@ public class FastHllQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setInputFilePath(filePath);
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
     segmentGeneratorConfig
         .setInvertedIndexCreationColumns(Arrays.asList("column6", "column7", "column11", "column17", "column18"));
     if (hasPreGeneratedHllColumns) {

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
@@ -94,6 +94,7 @@ public class DictionariesTest {
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "time_day", TimeUnit.DAYS,
             "test");
 
+    config.setCheckTimeColumnValidityDuringGeneration(false);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
@@ -94,6 +94,11 @@ public class DictionariesTest {
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "time_day", TimeUnit.DAYS,
             "test");
 
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     config.setCheckTimeColumnValidityDuringGeneration(false);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/IntArraysTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/IntArraysTest.java
@@ -70,6 +70,11 @@ public class IntArraysTest {
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "weeksSinceEpochSunday",
             TimeUnit.DAYS, "test");
     config.setTimeColumnName("weeksSinceEpochSunday");
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
     config.setCheckTimeColumnValidityDuringGeneration(false);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/IntArraysTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/IntArraysTest.java
@@ -70,6 +70,7 @@ public class IntArraysTest {
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "weeksSinceEpochSunday",
             TimeUnit.DAYS, "test");
     config.setTimeColumnName("weeksSinceEpochSunday");
+    config.setCheckTimeColumnValidityDuringGeneration(false);
     driver.init(config);
     driver.build();
 

--- a/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
+++ b/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
@@ -147,10 +147,10 @@ public class PinotOutputFormatTest {
 
     public int id;
     public String name;
-    public long epochDays;
+    public int epochDays;
     public int salary;
 
-    public Emp(int id, String name, long epochDays, int salary) {
+    public Emp(int id, String name, int epochDays, int salary) {
       this.id = id;
       this.name = name;
       this.epochDays = epochDays;
@@ -171,7 +171,7 @@ public class PinotOutputFormatTest {
         + "    },\n" + "    {\n" + "      \"name\": \"name\",\n" + "      \"dataType\" : \"STRING\",\n"
         + "      \"delimiter\" : null,\n" + "      \"singleValueField\" : true\n" + "    }\n" + "  ],\n"
         + "  \"timeFieldSpec\" : {\n" + "    \"incomingGranularitySpec\" : {\n" + "      \"timeType\" : \"DAYS\",\n"
-        + "      \"dataType\" : \"LONG\",\n" + "      \"name\" : \"epochDays\"\n" + "    }\n" + "  },\n"
+        + "      \"dataType\" : \"INT\",\n" + "      \"name\" : \"epochDays\"\n" + "    }\n" + "  },\n"
         + "  \"metricFieldSpecs\" : [\n" + "    {\n" + "      \"name\" : \"salary\",\n"
         + "      \"dataType\" : \"INT\",\n" + "      \"delimiter\" : null,\n" + "      \"singleValueField\" : true\n"
         + "    }\n" + "   ],\n" + "  \"schemaName\" : \"emp\"\n" + "}";

--- a/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
+++ b/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.mapreduce.TaskID;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
+import org.apache.pinot.common.utils.time.TimeUtils;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.data.readers.RecordReader;
@@ -129,7 +130,7 @@ public class PinotOutputFormatTest {
 
   private Map<Integer, Emp> addTestData()
       throws IOException, InterruptedException {
-    int days = 2000;
+    long days = TimeUtils.getValidMinTimeMillis();
     int sal = 20;
     RecordWriter<Object, Emp> writer = outputFormat.getRecordWriter(fakeTaskAttemptContext);
     Map<Integer, Emp> inputMap = new HashMap<>();
@@ -147,10 +148,10 @@ public class PinotOutputFormatTest {
 
     public int id;
     public String name;
-    public int epochDays;
+    public long epochDays;
     public int salary;
 
-    public Emp(int id, String name, int epochDays, int salary) {
+    public Emp(int id, String name, long epochDays, int salary) {
       this.id = id;
       this.name = name;
       this.epochDays = epochDays;
@@ -171,7 +172,7 @@ public class PinotOutputFormatTest {
         + "    },\n" + "    {\n" + "      \"name\": \"name\",\n" + "      \"dataType\" : \"STRING\",\n"
         + "      \"delimiter\" : null,\n" + "      \"singleValueField\" : true\n" + "    }\n" + "  ],\n"
         + "  \"timeFieldSpec\" : {\n" + "    \"incomingGranularitySpec\" : {\n" + "      \"timeType\" : \"DAYS\",\n"
-        + "      \"dataType\" : \"INT\",\n" + "      \"name\" : \"epochDays\"\n" + "    }\n" + "  },\n"
+        + "      \"dataType\" : \"LONG\",\n" + "      \"name\" : \"epochDays\"\n" + "    }\n" + "  },\n"
         + "  \"metricFieldSpecs\" : [\n" + "    {\n" + "      \"name\" : \"salary\",\n"
         + "      \"dataType\" : \"INT\",\n" + "      \"delimiter\" : null,\n" + "      \"singleValueField\" : true\n"
         + "    }\n" + "   ],\n" + "  \"schemaName\" : \"emp\"\n" + "}";

--- a/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
+++ b/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.mapreduce.TaskID;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
-import org.apache.pinot.common.utils.time.TimeUtils;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.data.readers.RecordReader;
@@ -130,7 +129,7 @@ public class PinotOutputFormatTest {
 
   private Map<Integer, Emp> addTestData()
       throws IOException, InterruptedException {
-    long days = TimeUtils.getValidMinTimeMillis();
+    int days = 2000;
     int sal = 20;
     RecordWriter<Object, Emp> writer = outputFormat.getRecordWriter(fakeTaskAttemptContext);
     Map<Integer, Emp> inputMap = new HashMap<>();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -270,7 +270,6 @@ public class ClusterIntegrationTestUtils {
 
           // Build the segment
           SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
-          segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
           driver.init(segmentGeneratorConfig);
           driver.build();
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -270,6 +270,7 @@ public class ClusterIntegrationTestUtils {
 
           // Build the segment
           SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
+          segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
           driver.init(segmentGeneratorConfig);
           driver.build();
 


### PR DESCRIPTION
This will allow us to fail-fast during segment generation if there is incorrect data as opposed to detecting this later during segment upload. The check during segment upload is still retained though