### PR TITLE
Enhance the time boundary service to get consistent result

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -307,8 +307,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     if (_queryLogRateLimiter.tryAcquire() || forceLog(brokerResponse, totalTimeMs)) {
       // Table name might have been changed (with suffix _OFFLINE/_REALTIME appended)
-      LOGGER.info(
-          "RequestId:{}, table:{}, timeMs:{}, docs:{}/{}, entries:{}/{},"
+      LOGGER.info("RequestId:{}, table:{}, timeMs:{}, docs:{}/{}, entries:{}/{},"
               + " segments(queried/processed/matched/consuming):{}/{}/{}/{}, consumingFreshnessTimeMs:{},"
               + " servers:{}/{}, groupLimitReached:{}, exceptions:{}, serverStats:{}, query:{}", requestId,
           brokerRequest.getQuerySource().getTableName(), totalTimeMs, brokerResponse.getNumDocsScanned(),
@@ -441,7 +440,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     timeFilterQuery.setId(-1);
     timeFilterQuery.setColumn(timeBoundaryInfo.getTimeColumn());
     String timeValue = timeBoundaryInfo.getTimeValue();
-    String filterValue = isOfflineRequest ? "(*\t\t" + timeValue + "]" : "(" + timeValue + "\t\t*)";
+    String filterValue = isOfflineRequest ? "(*\t\t" + timeValue + ")" : "[" + timeValue + "\t\t*)";
     timeFilterQuery.setValue(Collections.singletonList(filterValue));
     timeFilterQuery.setOperator(FilterOperator.RANGE);
     timeFilterQuery.setNestedFilterQueryIds(Collections.emptyList());

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -261,7 +261,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
     TimeBoundaryService.TimeBoundaryInfo tbi = _helixBrokerStarter.getHelixExternalViewBasedRouting().
         getTimeBoundaryService().getTimeBoundaryInfoFor(DINING_TABLE_NAME);
 
-    Assert.assertEquals(tbi.getTimeValue(), Long.toString(currentTimeBoundary - 1));
+    Assert.assertEquals(tbi.getTimeValue(), Long.toString(currentTimeBoundary));
 
     List<String> segmentNames = _helixResourceManager.getSegmentsFor(DINING_TABLE_NAME);
     long endTime = currentTimeBoundary + 10;


### PR DESCRIPTION
When pushing multiple offline segments, the first pushed offline segment will push forward the time boundary before the other offline segments arrived. If we directly push the time boundary to the segment end time, we might get inconsistent result before all the segments arrived. In order to address this issue:
- Case 1: segment has the same start and end time, directly use the end time as the time boundary. It is OK to directly use the end time as the time boundary because all the records in the new segments have the same time value and the time filter will filter all of them out, so the result is consistent. The reason why we handle this case separately is because there are use cases with time unit other than DAYS, but have time value rounded to the start of the day for offline table (offline segments have the same start and end time), and un-rounded time value for real-time table (real-time segments have different start and end time). In order to get the correct result, must attach filter 'time < endTime' to the offline side and filter 'time >= endTime' to the real-time side.
- Case 2. segment has different start and end time, rewind the end time with the push interval and use it as the time boundary. The assumption we made here is that the push will finish in the push interval, and next push will push the time boundary forward again and make the records within the last push interval queryable.

#4156 Broke the backward-compatibility for case 1, and this PR is restoring it.