### PR TITLE
Config for overriding initial rows threshold in segment size auto tuning

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
@@ -41,8 +41,6 @@ public class FlushThresholdUpdateManager {
    * If flush size < 0, create a new DefaultFlushThresholdUpdater with default flush size
    * If flush size > 0, create a new DefaultFlushThresholdUpdater with given flush size.
    * If flush size == 0, create new SegmentSizeBasedFlushThresholdUpdater if not already created. Create only 1 per table, because we want to maintain tuning information for the table in the updater
-   * @param realtimeTableConfig
-   * @return
    */
   public FlushThresholdUpdater getFlushThresholdUpdater(TableConfig realtimeTableConfig) {
     final String tableName = realtimeTableConfig.getTableName();
@@ -50,11 +48,12 @@ public class FlushThresholdUpdateManager {
         new PartitionLevelStreamConfig(realtimeTableConfig.getIndexingConfig().getStreamConfigs());
 
     final int tableFlushSize = streamConfig.getFlushThresholdRows();
-    final long desiredSegmentSize = streamConfig.getFlushSegmentDesiredSizeBytes();
 
     if (tableFlushSize == 0) {
-      return _flushThresholdUpdaterMap
-          .computeIfAbsent(tableName, k -> new SegmentSizeBasedFlushThresholdUpdater(desiredSegmentSize));
+      final long desiredSegmentSize = streamConfig.getFlushSegmentDesiredSizeBytes();
+      final int initialRowsThreshold = streamConfig.getInitialRowsThreshold();
+      return _flushThresholdUpdaterMap.computeIfAbsent(tableName,
+          k -> new SegmentSizeBasedFlushThresholdUpdater(desiredSegmentSize, initialRowsThreshold));
     } else {
       _flushThresholdUpdaterMap.remove(tableName);
       return new DefaultFlushThresholdUpdater(tableFlushSize);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
@@ -31,8 +31,6 @@ import org.slf4j.LoggerFactory;
  */
 public class FlushThresholdUpdateManager {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FlushThresholdUpdateManager.class);
-
   private ConcurrentMap<String, FlushThresholdUpdater> _flushThresholdUpdaterMap = new ConcurrentHashMap<>();
 
   /**
@@ -51,9 +49,9 @@ public class FlushThresholdUpdateManager {
 
     if (tableFlushSize == 0) {
       final long desiredSegmentSize = streamConfig.getFlushSegmentDesiredSizeBytes();
-      final int initialRowsThreshold = streamConfig.getInitialRowsThreshold();
+      final int flushAutotuneInitialRows = streamConfig.getFlushAutotuneInitialRows();
       return _flushThresholdUpdaterMap.computeIfAbsent(tableName,
-          k -> new SegmentSizeBasedFlushThresholdUpdater(desiredSegmentSize, initialRowsThreshold));
+          k -> new SegmentSizeBasedFlushThresholdUpdater(desiredSegmentSize, flushAutotuneInitialRows));
     } else {
       _flushThresholdUpdaterMap.remove(tableName);
       return new DefaultFlushThresholdUpdater(tableFlushSize);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -45,7 +45,7 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
   private static final int MINIMUM_NUM_ROWS_THRESHOLD = 10_000;
 
   private final long _desiredSegmentSizeBytes;
-  private final int _initialRowsThreshold;
+  private final int _autotuneInitialRows;
 
   /** Below this size, we double the rows threshold */
   private final double _optimalSegmentSizeBytesMin;
@@ -53,8 +53,8 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
   private final double _optimalSegmentSizeBytesMax;
 
   @VisibleForTesting
-  int getInitialRowsThreshold() {
-    return _initialRowsThreshold;
+  int getAutotuneInitialRows() {
+    return _autotuneInitialRows;
   }
 
   @VisibleForTesting
@@ -80,11 +80,11 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
   // num rows to segment size ratio of last committed segment for this table
   private double _latestSegmentRowsToSizeRatio = 0;
 
-  public SegmentSizeBasedFlushThresholdUpdater(long desiredSegmentSizeBytes, int initialRowsThreshold) {
+  public SegmentSizeBasedFlushThresholdUpdater(long desiredSegmentSizeBytes, int autotuneInitialRows) {
     _desiredSegmentSizeBytes = desiredSegmentSizeBytes;
     _optimalSegmentSizeBytesMin = _desiredSegmentSizeBytes / 2;
     _optimalSegmentSizeBytesMax = _desiredSegmentSizeBytes * 1.5;
-    _initialRowsThreshold = initialRowsThreshold;
+    _autotuneInitialRows = autotuneInitialRows;
   }
 
   // synchronized since this method could be called for multiple partitions of the same table in different threads
@@ -104,8 +104,8 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
         newSegmentZKMetadata.setSizeThresholdToFlushSegment((int) targetSegmentNumRows);
       } else {
         LOGGER.info("Committing segment zk metadata is not available, setting threshold for {} as {}", newSegmentName,
-            _initialRowsThreshold);
-        newSegmentZKMetadata.setSizeThresholdToFlushSegment(_initialRowsThreshold);
+            _autotuneInitialRows);
+        newSegmentZKMetadata.setSizeThresholdToFlushSegment(_autotuneInitialRows);
       }
       return;
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -39,14 +39,13 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentSizeBasedFlushThresholdUpdater.class);
 
-  private static final int INITIAL_ROWS_THRESHOLD = 100_000;
-
   private static final double CURRENT_SEGMENT_RATIO_WEIGHT = 0.1;
   private static final double PREVIOUS_SEGMENT_RATIO_WEIGHT = 0.9;
   private static final double ROWS_MULTIPLIER_WHEN_TIME_THRESHOLD_HIT = 1.1;
   private static final int MINIMUM_NUM_ROWS_THRESHOLD = 10_000;
 
   private final long _desiredSegmentSizeBytes;
+  private final int _initialRowsThreshold;
 
   /** Below this size, we double the rows threshold */
   private final double _optimalSegmentSizeBytesMin;
@@ -55,7 +54,7 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
 
   @VisibleForTesting
   int getInitialRowsThreshold() {
-    return INITIAL_ROWS_THRESHOLD;
+    return _initialRowsThreshold;
   }
 
   @VisibleForTesting
@@ -81,10 +80,11 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
   // num rows to segment size ratio of last committed segment for this table
   private double _latestSegmentRowsToSizeRatio = 0;
 
-  public SegmentSizeBasedFlushThresholdUpdater(long desiredSegmentSizeBytes) {
+  public SegmentSizeBasedFlushThresholdUpdater(long desiredSegmentSizeBytes, int initialRowsThreshold) {
     _desiredSegmentSizeBytes = desiredSegmentSizeBytes;
     _optimalSegmentSizeBytesMin = _desiredSegmentSizeBytes / 2;
     _optimalSegmentSizeBytesMax = _desiredSegmentSizeBytes * 1.5;
+    _initialRowsThreshold = initialRowsThreshold;
   }
 
   // synchronized since this method could be called for multiple partitions of the same table in different threads
@@ -104,8 +104,8 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
         newSegmentZKMetadata.setSizeThresholdToFlushSegment((int) targetSegmentNumRows);
       } else {
         LOGGER.info("Committing segment zk metadata is not available, setting threshold for {} as {}", newSegmentName,
-            INITIAL_ROWS_THRESHOLD);
-        newSegmentZKMetadata.setSizeThresholdToFlushSegment(INITIAL_ROWS_THRESHOLD);
+            _initialRowsThreshold);
+        newSegmentZKMetadata.setSizeThresholdToFlushSegment(_initialRowsThreshold);
       }
       return;
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 
 public class FlushThresholdUpdaterTest {
   private static final long DESIRED_SEGMENT_SIZE = StreamConfig.getDefaultDesiredSegmentSizeBytes();
-  private static final int DEFAULT_INITIAL_ROWS_THRESHOLD = StreamConfig.getDefaultInitialRowsThreshold();
+  private static final int DEFAULT_INITIAL_ROWS_THRESHOLD = StreamConfig.getDefaultFlushAutotuneInitialRows();
   private Random _random;
   private Map<String, double[][]> datasetGraph;
 
@@ -186,7 +186,7 @@ public class FlushThresholdUpdaterTest {
       segmentSizeBasedFlushThresholdUpdater
           .updateFlushThreshold(newSegmentMetadata, null, committingSegmentDescriptor, null);
       Assert.assertEquals(newSegmentMetadata.getSizeThresholdToFlushSegment(),
-          segmentSizeBasedFlushThresholdUpdater.getInitialRowsThreshold());
+          segmentSizeBasedFlushThresholdUpdater.getAutotuneInitialRows());
 
       System.out.println("NumRowsThreshold, SegmentSize");
       for (int run = 0; run < numRuns; run++) {
@@ -333,15 +333,15 @@ public class FlushThresholdUpdaterTest {
     flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
     Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getDesiredSegmentSizeBytes(),
         desiredSegSize);
-    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getInitialRowsThreshold(),
+    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getAutotuneInitialRows(),
         DEFAULT_INITIAL_ROWS_THRESHOLD);
 
     // initial rows threshold
-    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_INITIAL_ROWS_THRESHOLD, "500000");
+    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS, "500000");
     realtimeTableConfig = tableConfigBuilder.build();
     FlushThresholdUpdateManager newManager = new FlushThresholdUpdateManager();
     flushThresholdUpdater = newManager.getFlushThresholdUpdater(realtimeTableConfig);
-    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getInitialRowsThreshold(),
+    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getAutotuneInitialRows(),
         500_000);
   }
 
@@ -422,7 +422,7 @@ public class FlushThresholdUpdaterTest {
         new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE, DEFAULT_INITIAL_ROWS_THRESHOLD);
     committingSegmentDescriptor = new CommittingSegmentDescriptor(metadata0.getSegmentName(), startOffset, 0);
     flushThresholdUpdater.updateFlushThreshold(metadata0, null, committingSegmentDescriptor, null);
-    Assert.assertEquals(metadata0.getSizeThresholdToFlushSegment(), flushThresholdUpdater.getInitialRowsThreshold());
+    Assert.assertEquals(metadata0.getSizeThresholdToFlushSegment(), flushThresholdUpdater.getAutotuneInitialRows());
 
     // next segment hit time threshold
     startOffset += 1000;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -337,7 +337,7 @@ public class FlushThresholdUpdaterTest {
         DEFAULT_INITIAL_ROWS_THRESHOLD);
 
     // initial rows threshold
-    streamConfigs.put(StreamConfigProperties.SEGMENT_INITIAL_ROWS_THRESHOLD, "500000");
+    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_INITIAL_ROWS_THRESHOLD, "500000");
     realtimeTableConfig = tableConfigBuilder.build();
     FlushThresholdUpdateManager newManager = new FlushThresholdUpdateManager();
     flushThresholdUpdater = newManager.getFlushThresholdUpdater(realtimeTableConfig);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
 
 public class FlushThresholdUpdaterTest {
   private static final long DESIRED_SEGMENT_SIZE = StreamConfig.getDefaultDesiredSegmentSizeBytes();
+  private static final int DEFAULT_INITIAL_ROWS_THRESHOLD = StreamConfig.getDefaultInitialRowsThreshold();
   private Random _random;
   private Map<String, double[][]> datasetGraph;
 
@@ -155,7 +156,7 @@ public class FlushThresholdUpdaterTest {
     for (Map.Entry<String, double[][]> entry : datasetGraph.entrySet()) {
 
       SegmentSizeBasedFlushThresholdUpdater segmentSizeBasedFlushThresholdUpdater =
-          new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE);
+          new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE, DEFAULT_INITIAL_ROWS_THRESHOLD);
 
       double[][] numRowsToSegmentSize = entry.getValue();
 
@@ -310,7 +311,7 @@ public class FlushThresholdUpdaterTest {
     Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
     Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 20000);
 
-    // optimal segment size set to invalid value. Defailt remains the same.
+    // optimal segment size set to invalid value. Default remains the same.
     streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "0");
     streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE, "Invalid");
     realtimeTableConfig = tableConfigBuilder.build();
@@ -332,6 +333,16 @@ public class FlushThresholdUpdaterTest {
     flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
     Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getDesiredSegmentSizeBytes(),
         desiredSegSize);
+    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getInitialRowsThreshold(),
+        DEFAULT_INITIAL_ROWS_THRESHOLD);
+
+    // initial rows threshold
+    streamConfigs.put(StreamConfigProperties.SEGMENT_INITIAL_ROWS_THRESHOLD, "500000");
+    realtimeTableConfig = tableConfigBuilder.build();
+    FlushThresholdUpdateManager newManager = new FlushThresholdUpdateManager();
+    flushThresholdUpdater = newManager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getInitialRowsThreshold(),
+        500_000);
   }
 
   /**
@@ -368,7 +379,8 @@ public class FlushThresholdUpdaterTest {
     Assert.assertNull(metadata0.getTimeThresholdToFlushSegment());
 
     // before committing segment, we switched to size based updation - verify that new thresholds are set as per size based strategy
-    flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE);
+    flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE,
+        DEFAULT_INITIAL_ROWS_THRESHOLD);
 
     startOffset += 1000;
     updateCommittingSegmentMetadata(metadata0, startOffset, 250_000);
@@ -407,7 +419,7 @@ public class FlushThresholdUpdaterTest {
     // initial segment
     LLCRealtimeSegmentZKMetadata metadata0 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
     SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
-        new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE);
+        new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE, DEFAULT_INITIAL_ROWS_THRESHOLD);
     committingSegmentDescriptor = new CommittingSegmentDescriptor(metadata0.getSegmentName(), startOffset, 0);
     flushThresholdUpdater.updateFlushThreshold(metadata0, null, committingSegmentDescriptor, null);
     Assert.assertEquals(metadata0.getSizeThresholdToFlushSegment(), flushThresholdUpdater.getInitialRowsThreshold());
@@ -451,7 +463,7 @@ public class FlushThresholdUpdaterTest {
     LLCRealtimeSegmentZKMetadata metadata0 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
     metadata0.setSegmentName(seg0SegmentName.getSegmentName());
     SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
-        new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE);
+        new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE, DEFAULT_INITIAL_ROWS_THRESHOLD);
     committingSegmentDescriptor =
         new CommittingSegmentDescriptor(seg0SegmentName.getSegmentName(), startOffset, 10_000);
     metadata0.setTotalRawDocs(15);
@@ -486,7 +498,7 @@ public class FlushThresholdUpdaterTest {
     long seg0time = now - 1334_650;
     long seg1time = seg0time + 14_000;
     SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
-        new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE);
+        new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE, DEFAULT_INITIAL_ROWS_THRESHOLD);
 
     // Initial update is from partition 1
     LLCSegmentName seg0SegmentName = new LLCSegmentName(tableName, 1, seqNum, seg0time);

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfig.java
@@ -200,13 +200,13 @@ public class StreamConfig {
     }
 
     int initialRowsThreshold = 0;
-    String initialRowsThresholdValue = streamConfigMap.get(StreamConfigProperties.SEGMENT_INITIAL_ROWS_THRESHOLD);
+    String initialRowsThresholdValue = streamConfigMap.get(StreamConfigProperties.SEGMENT_FLUSH_INITIAL_ROWS_THRESHOLD);
     if (initialRowsThresholdValue != null) {
       try {
         initialRowsThreshold = Integer.parseInt(initialRowsThresholdValue);
       } catch (Exception e) {
-        LOGGER.warn("Caught exception while parsing {}:{}, defaulting to {} ms",
-            StreamConfigProperties.SEGMENT_INITIAL_ROWS_THRESHOLD, initialRowsThresholdValue,
+        LOGGER.warn("Caught exception while parsing {}:{}, defaulting to {}",
+            StreamConfigProperties.SEGMENT_FLUSH_INITIAL_ROWS_THRESHOLD, initialRowsThresholdValue,
             DEFAULT_INITIAL_ROWS_THRESHOLD, e);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfigProperties.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfigProperties.java
@@ -89,6 +89,11 @@ public class StreamConfigProperties {
    */
   public static final String SEGMENT_FLUSH_DESIRED_SIZE = "realtime.segment.flush.desired.size";
 
+  /**
+   * The initial num rows to use for segment size auto tuning. By default 100_000 is used.
+   */
+  public static final String SEGMENT_INITIAL_ROWS_THRESHOLD = "realtime.segment.initial.rows.threshold";
+
   // Time threshold that controller will wait for the segment to be built by the server
   public static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "realtime.segment.commit.timeoutSeconds";
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfigProperties.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfigProperties.java
@@ -92,16 +92,13 @@ public class StreamConfigProperties {
   /**
    * The initial num rows to use for segment size auto tuning. By default 100_000 is used.
    */
-  public static final String SEGMENT_FLUSH_INITIAL_ROWS_THRESHOLD = "realtime.segment.flush.initial.rows.threshold";
+  public static final String SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS = "realtime.segment.flush.autotune.initialRows";
 
   // Time threshold that controller will wait for the segment to be built by the server
   public static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "realtime.segment.commit.timeoutSeconds";
 
   /**
    * Helper method to create a stream specific property
-   * @param streamType
-   * @param property
-   * @return
    */
   public static String constructStreamProperty(String streamType, String property) {
     return Joiner.on(DOT_SEPARATOR).join(STREAM_PREFIX, streamType, property);

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfigProperties.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfigProperties.java
@@ -92,7 +92,7 @@ public class StreamConfigProperties {
   /**
    * The initial num rows to use for segment size auto tuning. By default 100_000 is used.
    */
-  public static final String SEGMENT_INITIAL_ROWS_THRESHOLD = "realtime.segment.initial.rows.threshold";
+  public static final String SEGMENT_FLUSH_INITIAL_ROWS_THRESHOLD = "realtime.segment.flush.initial.rows.threshold";
 
   // Time threshold that controller will wait for the segment to be built by the server
   public static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "realtime.segment.commit.timeoutSeconds";


### PR DESCRIPTION
When using segment size based auto tuning, the initial rows threshold is 100k currently. Adding a config to override the initial num rows, so that it can be changed if a table needs more/less as the initial.