### PR TITLE
Implement OffHeapMutableBytesStore for real-time var-length bytes store

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/OffHeapMutableBytesStore.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/OffHeapMutableBytesStore.java
@@ -1,0 +1,259 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.realtime.impl.dictionary;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+
+
+/**
+ * Off-heap variable length mutable bytes store.
+ * <p>The class is thread-safe for single writer and multiple readers.
+ * <p>There are two sets of buffers allocated for the store:
+ * <ul>
+ *   <li>
+ *     Offset buffer: stores the value end offsets. The end offset here is the global offset for all the value buffers
+ *     instead of the offset inside one value buffer (e.g. offset 9 in the 5th value buffer will have global offset of
+ *     4 * VALUE_BUFFER_SIZE + 9). New offset buffer is allocated when the previous buffer is filled up. The first entry
+ *     of each offset buffer stores the end offset of the last value (or 0 for the first offset buffer) so that we can
+ *     always get the previous and current value's end offset from the same buffer. Note that we use int type for the
+ *     offset, so each bytes store can hold at most 2^31 = 2GB total size of values.
+ *   </li>
+ *   <li>
+ *     Value buffer: stores the values. For performance concern, to avoid reading one value from multiple buffers, each
+ *     value is stored in one value buffer (no cross-buffer value allowed), and has a size limit of the
+ *     VALUE_BUFFER_SIZE (1MB). New value buffer is allocated when the previous buffer cannot hold the new added value.
+ *   </li>
+ * </ul>
+ * <p>The maximum capacity for the bytes store is 2^24 ~= 17M values and 2^31 = 2GB total size of values.
+ */
+@ThreadSafe
+public class OffHeapMutableBytesStore implements Closeable {
+  private static final byte[] EMPTY_BYTES = new byte[0];
+
+  // Each offset buffer holds 8_192 end offsets and one extra end offset for the last value in the previous buffer (or 0
+  // for the first buffer)
+  // OFFSET_BUFFER_SIZE = (8_192 + 1) * 4 = 32_772
+  private static final int OFFSET_BUFFER_SHIFT_OFFSET = 13;
+  private static final int OFFSET_BUFFER_SIZE = ((1 << OFFSET_BUFFER_SHIFT_OFFSET) + 1) << 2;
+  private static final int OFFSET_BUFFER_MASK = (1 << OFFSET_BUFFER_SHIFT_OFFSET) - 1;
+
+  // Each value buffer holds up to 1_048_576 bytes, which is also the size limit for each value
+  // VALUE_BUFFER_SIZE = 1_048_576
+  private static final int VALUE_BUFFER_SHIFT_OFFSET = 20;
+  private static final int VALUE_BUFFER_SIZE = 1 << VALUE_BUFFER_SHIFT_OFFSET;
+  private static final int VALUE_BUFFER_MASK = (1 << VALUE_BUFFER_SHIFT_OFFSET) - 1;
+
+  // With at most 2_048 buffers, we can store about 17M values of total size up to 2GB
+  // MAX_NUM_BUFFERS = 2_048
+  private static final int MAX_NUM_BUFFERS = 1 << 11;
+
+  private final AtomicReferenceArray<PinotDataBuffer> _offsetBuffers = new AtomicReferenceArray<>(MAX_NUM_BUFFERS);
+  private final AtomicReferenceArray<PinotDataBuffer> _valueBuffers = new AtomicReferenceArray<>(MAX_NUM_BUFFERS);
+  private final PinotDataBufferMemoryManager _memoryManager;
+  private final String _allocationContext;
+
+  // Global end offset of the previous added value
+  private int _previousValueEndOffset;
+  // Number of values added
+  private transient int _numValues;
+  // Total size of the OffHeap buffers (both offset buffers and value buffers)
+  private transient int _totalBufferSize;
+
+  public OffHeapMutableBytesStore(PinotDataBufferMemoryManager memoryManager, String allocationContext) {
+    _memoryManager = memoryManager;
+    _allocationContext = allocationContext;
+  }
+
+  /**
+   * Adds a value into the bytes store. The size of the given value should be smaller or equal to the VALUE_BUFFER_SIZE
+   * (1MB).
+   */
+  public int add(byte[] value) {
+    int offsetBufferIndex = _numValues >>> OFFSET_BUFFER_SHIFT_OFFSET;
+    int offsetIndex = _numValues & OFFSET_BUFFER_MASK;
+
+    PinotDataBuffer offsetBuffer;
+    // If this is the first entry in the offset buffer, allocate a new buffer and store the end offset of the previous
+    // value
+    if (offsetIndex == 0) {
+      offsetBuffer = _memoryManager.allocate(OFFSET_BUFFER_SIZE, _allocationContext);
+      offsetBuffer.putInt(0, _previousValueEndOffset);
+      _offsetBuffers.set(offsetBufferIndex, offsetBuffer);
+      _totalBufferSize += OFFSET_BUFFER_SIZE;
+    } else {
+      offsetBuffer = _offsetBuffers.get(offsetBufferIndex);
+    }
+
+    int valueLength = value.length;
+    if (valueLength == 0) {
+      offsetBuffer.putInt((offsetIndex + 1) << 2, _previousValueEndOffset);
+      return _numValues++;
+    }
+
+    int valueBufferIndex = (_previousValueEndOffset + valueLength - 1) >>> VALUE_BUFFER_SHIFT_OFFSET;
+    PinotDataBuffer valueBuffer;
+    int valueStartOffset;
+    // If the current value buffer does not have enough space, allocate a new buffer to store the value
+    if ((_previousValueEndOffset - 1) >>> VALUE_BUFFER_SHIFT_OFFSET != valueBufferIndex) {
+      valueBuffer = _memoryManager.allocate(VALUE_BUFFER_SIZE, _allocationContext);
+      _valueBuffers.set(valueBufferIndex, valueBuffer);
+      _totalBufferSize += VALUE_BUFFER_SIZE;
+      valueStartOffset = valueBufferIndex << VALUE_BUFFER_SHIFT_OFFSET;
+    } else {
+      valueBuffer = _valueBuffers.get(valueBufferIndex);
+      valueStartOffset = _previousValueEndOffset;
+    }
+
+    int valueEndOffset = valueStartOffset + valueLength;
+    offsetBuffer.putInt((offsetIndex + 1) << 2, valueEndOffset);
+    valueBuffer.readFrom(valueStartOffset & VALUE_BUFFER_MASK, value);
+    _previousValueEndOffset = valueEndOffset;
+
+    return _numValues++;
+  }
+
+  /**
+   * Returns the value at the given index. The given index should be smaller than the number of values already added.
+   */
+  @SuppressWarnings("Duplicates")
+  public byte[] get(int index) {
+    assert index < _numValues;
+
+    int offsetBufferIndex = index >>> OFFSET_BUFFER_SHIFT_OFFSET;
+    PinotDataBuffer offsetBuffer = _offsetBuffers.get(offsetBufferIndex);
+    int offsetIndex = index & OFFSET_BUFFER_MASK;
+    int previousValueEndOffset = offsetBuffer.getInt(offsetIndex << 2);
+    int valueEndOffset = offsetBuffer.getInt((offsetIndex + 1) << 2);
+
+    if (previousValueEndOffset == valueEndOffset) {
+      return EMPTY_BYTES;
+    }
+
+    int valueBufferIndex = (valueEndOffset - 1) >>> VALUE_BUFFER_SHIFT_OFFSET;
+    int startOffsetInValueBuffer;
+    int valueLength;
+    if ((previousValueEndOffset - 1) >>> VALUE_BUFFER_SHIFT_OFFSET != valueBufferIndex) {
+      // The first value in the value buffer
+      startOffsetInValueBuffer = 0;
+      valueLength = valueEndOffset & VALUE_BUFFER_MASK;
+    } else {
+      // Not the first value in the value buffer
+      startOffsetInValueBuffer = previousValueEndOffset & VALUE_BUFFER_MASK;
+      valueLength = valueEndOffset - previousValueEndOffset;
+    }
+
+    byte[] value = new byte[valueLength];
+    _valueBuffers.get(valueBufferIndex).copyTo(startOffsetInValueBuffer, value);
+    return value;
+  }
+
+  /**
+   * Returns whether the value at the given index equals the given value. The given index should be smaller than the
+   * number of values already added.
+   * <p>This method should be preferable when checking whether a value equals the value at a specific index in the bytes
+   * store compared to calling {@link #get(int)} and then compare the values because if the value length does not match,
+   * the value fetch can be skipped.
+   */
+  @SuppressWarnings("Duplicates")
+  public boolean equalsValueAt(int index, byte[] valueToCompare) {
+    assert index < _numValues;
+
+    int offsetBufferIndex = index >>> OFFSET_BUFFER_SHIFT_OFFSET;
+    PinotDataBuffer offsetBuffer = _offsetBuffers.get(offsetBufferIndex);
+    int offsetIndex = index & OFFSET_BUFFER_MASK;
+    int previousValueEndOffset = offsetBuffer.getInt(offsetIndex << 2);
+    int valueEndOffset = offsetBuffer.getInt((offsetIndex + 1) << 2);
+
+    int inputValueLength = valueToCompare.length;
+    if (previousValueEndOffset == valueEndOffset) {
+      return inputValueLength == 0;
+    }
+
+    // Check value length first
+    int valueBufferIndex = (valueEndOffset - 1) >>> VALUE_BUFFER_SHIFT_OFFSET;
+    int startOffsetInValueBuffer;
+    if ((previousValueEndOffset - 1) >>> VALUE_BUFFER_SHIFT_OFFSET != valueBufferIndex) {
+      // The first value in the value buffer
+      if ((valueEndOffset & VALUE_BUFFER_MASK) != inputValueLength) {
+        return false;
+      }
+      startOffsetInValueBuffer = 0;
+    } else {
+      // Not the first value in the value buffer
+      if (valueEndOffset - previousValueEndOffset != inputValueLength) {
+        return false;
+      }
+      startOffsetInValueBuffer = previousValueEndOffset & VALUE_BUFFER_MASK;
+    }
+
+    // Value length matches, check value
+    PinotDataBuffer valueBuffer = _valueBuffers.get(valueBufferIndex);
+    if (inputValueLength <= PinotDataBuffer.BULK_BYTES_PROCESSING_THRESHOLD) {
+      for (int i = 0; i < inputValueLength; i++) {
+        if (valueToCompare[i] != valueBuffer.getByte(startOffsetInValueBuffer + i)) {
+          return false;
+        }
+      }
+      return true;
+    } else {
+      byte[] value = new byte[inputValueLength];
+      valueBuffer.copyTo(startOffsetInValueBuffer, value);
+      for (int i = 0; i < inputValueLength; i++) {
+        if (valueToCompare[i] != value[i]) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
+  public int getNumValues() {
+    return _numValues;
+  }
+
+  public int getTotalBufferSize() {
+    return _totalBufferSize;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    for (int i = 0; i < MAX_NUM_BUFFERS; i++) {
+      PinotDataBuffer offsetBuffer = _offsetBuffers.get(i);
+      if (offsetBuffer != null) {
+        offsetBuffer.close();
+      } else {
+        break;
+      }
+    }
+    for (int i = 0; i < MAX_NUM_BUFFERS; i++) {
+      PinotDataBuffer valueBuffer = _valueBuffers.get(i);
+      if (valueBuffer != null) {
+        valueBuffer.close();
+      } else {
+        break;
+      }
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotDataBuffer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotDataBuffer.java
@@ -61,7 +61,7 @@ public abstract class PinotDataBuffer implements Closeable {
   // We use this threshold to decide whether we use bulk bytes processing or not
   // With number of bytes less than this threshold, we get/put bytes one by one
   // With number of bytes more than this threshold, we create a ByteBuffer from the buffer and use bulk get/put method
-  protected static int BULK_BYTES_PROCESSING_THRESHOLD = 10;
+  public static int BULK_BYTES_PROCESSING_THRESHOLD = 10;
 
   private static class BufferContext {
     enum Type {

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/dictionary/OffHeapMutableBytesStoreTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/dictionary/OffHeapMutableBytesStoreTest.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.realtime.impl.dictionary;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.apache.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import org.apache.pinot.core.io.writer.impl.DirectMemoryManager;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class OffHeapMutableBytesStoreTest {
+  private static final int NUM_VALUES = 100_000;
+  private static final int MAX_NUM_BYTES_PER_VALUE = 512;
+  private static final long RANDOM_SEED = System.currentTimeMillis();
+  private static final Random RANDOM = new Random(RANDOM_SEED);
+
+  private final PinotDataBufferMemoryManager _memoryManager = new DirectMemoryManager("testSegment");
+  private final byte[][] _values = new byte[NUM_VALUES][];
+
+  @BeforeClass
+  public void setUp() {
+    System.out.println("Random seed: " + RANDOM_SEED);
+
+    for (int i = 0; i < NUM_VALUES; i++) {
+      int numBytes = RANDOM.nextInt(MAX_NUM_BYTES_PER_VALUE);
+      byte[] value = new byte[numBytes];
+      RANDOM.nextBytes(value);
+      _values[i] = value;
+    }
+  }
+
+  @Test
+  public void testAdd()
+      throws Exception {
+    try (OffHeapMutableBytesStore offHeapMutableBytesStore = new OffHeapMutableBytesStore(_memoryManager, null)) {
+      for (int i = 0; i < NUM_VALUES; i++) {
+        assertEquals(offHeapMutableBytesStore.add(_values[i]), i);
+      }
+    }
+  }
+
+  @Test
+  public void testGet()
+      throws Exception {
+    try (OffHeapMutableBytesStore offHeapMutableBytesStore = new OffHeapMutableBytesStore(_memoryManager, null)) {
+      for (int i = 0; i < NUM_VALUES; i++) {
+        offHeapMutableBytesStore.add(_values[i]);
+      }
+      for (int i = 0; i < NUM_VALUES; i++) {
+        int index = RANDOM.nextInt(NUM_VALUES);
+        assertTrue(Arrays.equals(offHeapMutableBytesStore.get(index), _values[index]));
+      }
+    }
+  }
+
+  @Test
+  public void testEqualsValueAt()
+      throws Exception {
+    try (OffHeapMutableBytesStore offHeapMutableBytesStore = new OffHeapMutableBytesStore(_memoryManager, null)) {
+      for (int i = 0; i < NUM_VALUES; i++) {
+        offHeapMutableBytesStore.add(_values[i]);
+      }
+      for (int i = 0; i < NUM_VALUES; i++) {
+        int index = RANDOM.nextInt(NUM_VALUES);
+        assertTrue(offHeapMutableBytesStore.equalsValueAt(index, _values[index]));
+        if (!Arrays.equals(_values[index], _values[0])) {
+          assertFalse(offHeapMutableBytesStore.equalsValueAt(0, _values[index]));
+          assertFalse(offHeapMutableBytesStore.equalsValueAt(index, _values[0]));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void concurrentReadWrite()
+      throws Exception {
+    int numReaders = 4;
+    ExecutorService executorService = Executors.newFixedThreadPool(numReaders + 1);
+    List<Future> futures = new ArrayList<>(numReaders + 1);
+    try (OffHeapMutableBytesStore offHeapMutableBytesStore = new OffHeapMutableBytesStore(_memoryManager, null)) {
+      // Write one value before starting the reader threads
+      offHeapMutableBytesStore.add(_values[0]);
+
+      // Writer thread
+      futures.add(executorService.submit(() -> {
+        for (int i = 1; i < NUM_VALUES; i++) {
+          offHeapMutableBytesStore.add(_values[i]);
+        }
+      }));
+
+      // Reader threads
+      for (int i = 0; i < numReaders; i++) {
+        futures.add(executorService.submit(() -> {
+          while (true) {
+            int numValues = offHeapMutableBytesStore.getNumValues();
+            // Read at random index
+            int index = RANDOM.nextInt(numValues);
+            assertTrue(Arrays.equals(offHeapMutableBytesStore.get(index), _values[index]));
+            // Read the last added value
+            assertTrue(Arrays.equals(offHeapMutableBytesStore.get(numValues - 1), _values[numValues - 1]));
+            // Stop after all values are added
+            if (numValues == NUM_VALUES) {
+              return;
+            }
+          }
+        }));
+      }
+
+      executorService.shutdown();
+      for (Future future : futures) {
+        future.get();
+      }
+    }
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkOffHeapMutableBytesStore.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkOffHeapMutableBytesStore.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import org.apache.pinot.core.io.writer.impl.DirectMemoryManager;
+import org.apache.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
+import org.apache.pinot.core.realtime.impl.dictionary.OffHeapMutableBytesStore;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 30)
+@Measurement(iterations = 5, time = 30)
+@Fork(1)
+@State(Scope.Benchmark)
+public class BenchmarkOffHeapMutableBytesStore {
+  private static final int NUM_VALUES = 1_000_000;
+
+  @Param({"8", "16", "32", "64", "128", "256", "512", "1024"})
+  private int _maxValueLength;
+
+  private PinotDataBufferMemoryManager _memoryManager;
+  private byte[][] _values;
+  private OffHeapMutableBytesStore _offHeapMutableBytesStore;
+  private MutableOffHeapByteArrayStore _mutableOffHeapByteArrayStore;
+
+  @Setup
+  public void setUp() {
+    _memoryManager = new DirectMemoryManager("");
+
+    _values = new byte[NUM_VALUES][];
+    Random random = new Random();
+    for (int i = 0; i < NUM_VALUES; i++) {
+      int valueLength = random.nextInt(_maxValueLength + 1);
+      byte[] value = new byte[valueLength];
+      random.nextBytes(value);
+      _values[i] = value;
+    }
+
+    _offHeapMutableBytesStore = new OffHeapMutableBytesStore(_memoryManager, null);
+    for (byte[] value : _values) {
+      _offHeapMutableBytesStore.add(value);
+    }
+    System.out
+        .println("\nBytes allocated for OffHeapMutableBytesStore: " + _offHeapMutableBytesStore.getTotalBufferSize());
+
+    _mutableOffHeapByteArrayStore =
+        new MutableOffHeapByteArrayStore(_memoryManager, null, NUM_VALUES, _maxValueLength / 2);
+    for (byte[] value : _values) {
+      _mutableOffHeapByteArrayStore.add(value);
+    }
+    System.out.println("\nBytes allocated for MutableOffHeapByteArrayStore: " + _mutableOffHeapByteArrayStore
+        .getTotalOffHeapMemUsed());
+  }
+
+  @TearDown
+  public void tearDown()
+      throws IOException {
+    _mutableOffHeapByteArrayStore.close();
+    _offHeapMutableBytesStore.close();
+    _memoryManager.close();
+  }
+
+  @Benchmark
+  public int offHeapMutableBytesStoreRead() {
+    int sum = 0;
+    for (int i = 0; i < NUM_VALUES; i++) {
+      sum += _offHeapMutableBytesStore.get(i).length;
+    }
+    return sum;
+  }
+
+  @Benchmark
+  public int mutableOffHeapByteArrayStoreRead() {
+    int sum = 0;
+    for (int i = 0; i < NUM_VALUES; i++) {
+      sum += _mutableOffHeapByteArrayStore.get(i).length;
+    }
+    return sum;
+  }
+
+  @Benchmark
+  public int offHeapMutableBytesStoreWrite()
+      throws IOException {
+    int sum = 0;
+    try (OffHeapMutableBytesStore offHeapMutableBytesStore = new OffHeapMutableBytesStore(_memoryManager, null)) {
+      for (byte[] value : _values) {
+        sum += offHeapMutableBytesStore.add(value);
+      }
+    }
+    return sum;
+  }
+
+  @Benchmark
+  public int mutableOffHeapByteArrayStoreWrite()
+      throws IOException {
+    int sum = 0;
+    try (MutableOffHeapByteArrayStore mutableOffHeapByteArrayStore = new MutableOffHeapByteArrayStore(_memoryManager,
+        null, NUM_VALUES, _maxValueLength / 2)) {
+      for (byte[] value : _values) {
+        sum += mutableOffHeapByteArrayStore.add(value);
+      }
+    }
+    return sum;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkOffHeapMutableBytesStore.class.getSimpleName());
+    new Runner(opt.build()).run();
+  }
+}


### PR DESCRIPTION
Comparing with the MutableOffHeapByteArrayStore:
1. Read/Write speed improvement
2. Buffer size is fixed and buffers are allocated on demand, so memory is always used effeciently
3. No need to estimate the buffer size beforehead, and performance is guaranteed (for MutableOffHeapByteArrayStore, if buffer size is under-estimated, pay huge penalty on allocating a huge buffer at runtime, and also read/write speed degration

Added benchmark to compare the read/write speed:
```
Benchmark                                                            (_maxValueLength)  Mode  Cnt     Score    Error  Units
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreRead                   8  avgt    5    29.875 ±  0.370  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreRead                  16  avgt    5    32.344 ±  0.765  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreRead                  32  avgt    5    35.027 ±  0.460  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreRead                  64  avgt    5    40.811 ±  0.414  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreRead                 128  avgt    5    51.767 ±  0.185  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreRead                 256  avgt    5    77.065 ±  1.627  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreRead                 512  avgt    5   127.167 ±  1.075  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreRead                1024  avgt    5   283.145 ±  2.829  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreWrite                  8  avgt    5    16.755 ±  0.374  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreWrite                 16  avgt    5    25.579 ±  0.293  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreWrite                 32  avgt    5    23.953 ±  0.507  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreWrite                 64  avgt    5    51.442 ±  1.230  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreWrite                128  avgt    5    64.334 ±  0.069  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreWrite                256  avgt    5   260.415 ±  1.823  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreWrite                512  avgt    5   615.528 ±  3.180  ms/op
BenchmarkOffHeapMutableBytesStore.mutableOffHeapByteArrayStoreWrite               1024  avgt    5  1168.779 ± 16.961  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreRead                       8  avgt    5    28.978 ±  0.535  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreRead                      16  avgt    5    33.420 ±  0.400  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreRead                      32  avgt    5    37.120 ±  0.272  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreRead                      64  avgt    5    39.552 ±  0.317  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreRead                     128  avgt    5    42.861 ±  0.588  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreRead                     256  avgt    5    47.025 ±  0.189  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreRead                     512  avgt    5    60.740 ±  0.677  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreRead                    1024  avgt    5    89.509 ±  1.838  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreWrite                      8  avgt    5    21.327 ±  0.509  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreWrite                     16  avgt    5    28.494 ±  0.304  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreWrite                     32  avgt    5    33.399 ±  0.533  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreWrite                     64  avgt    5    50.755 ±  1.700  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreWrite                    128  avgt    5    75.702 ±  1.079  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreWrite                    256  avgt    5   129.677 ±  1.942  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreWrite                    512  avgt    5   222.697 ±  2.109  ms/op
BenchmarkOffHeapMutableBytesStore.offHeapMutableBytesStoreWrite                   1024  avgt    5   392.053 ±  3.200  ms/op
```