### PR TITLE
Run cursor selected query in query-console

### DIFF
--- a/pinot-controller/src/main/resources/static/js/init.js
+++ b/pinot-controller/src/main/resources/static/js/init.js
@@ -65,7 +65,7 @@ $(document).ready(function() {
 
   $("#execute-query").click(function() {
     // execute query and draw the results
-    var query = EDITOR.getValue().trim();
+    var query = EDITOR.getSelection().trim() || EDITOR.getValue().trim();
     var traceEnabled = document.getElementById('trace-enabled').checked;
     HELPERS.executeQuery(query, traceEnabled, function(data) {
       RESULTS.setValue(js_beautify(data, JS_BEAUTIFY_SETTINGS));


### PR DESCRIPTION
Support running `cursor selected query` in code editor, in this way we don't need to clear editor to running new query, like this:
![image](https://user-images.githubusercontent.com/95261/60392585-bf366e00-9b38-11e9-805c-5340d403e691.png)
It will execute the second query only and don't need to clear first and third query.
