### PR TITLE
Prompt when get table schema failed on query-console

### DIFF
--- a/pinot-controller/src/main/resources/static/js/init.js
+++ b/pinot-controller/src/main/resources/static/js/init.js
@@ -178,6 +178,8 @@ var HELPERS = {
         "paging": false,
         "info": false
       });
+    }).fail(function() {
+      $(".schema-detail-view").html("Table " + tableName + " schema not found")
     });
   },
 


### PR DESCRIPTION
When click table name on query-console, if the schema could not getted for some reason there is no prompt about it. It may be make user confusing especially when clicked the other table name before.
E.g, car_order_tbl1 has no schema, it still shows transcript schema but car_order_tbl1 default query result
![image](https://user-images.githubusercontent.com/95261/60561099-ff8a2c00-9d84-11e9-9244-c03fa8826d57.png)

this pr shows `schema not found`
![image](https://user-images.githubusercontent.com/95261/60561248-7de6ce00-9d85-11e9-88cc-4559828f2298.png)


 