### PR TITLE
Add more key/value pairs into LOG2M_TO_SIZE_IN_BYTES in HllSizeUtils

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/startree/hll/HllSizeUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/startree/hll/HllSizeUtils.java
@@ -28,7 +28,19 @@ import com.google.common.collect.ImmutableBiMap;
 public class HllSizeUtils {
 
   private static final ImmutableBiMap<Integer, Integer> LOG2M_TO_SIZE_IN_BYTES =
-      ImmutableBiMap.of(5, 32, 6, 52, 7, 96, 8, 180, 9, 352);
+      ImmutableBiMap.<Integer, Integer>builder()
+          .put(5, 32)
+          .put(6, 52)
+          .put(7, 96)
+          .put(8, 180)
+          .put(9, 352)
+          .put(10, 692)
+          .put(11, 1376)
+          .put(12, 2740)
+          .put(13, 5472)
+          .put(14, 10932)
+          .put(15, 21856)
+          .build();
 
   public static ImmutableBiMap<Integer, Integer> getLog2mToSizeInBytes() {
     return LOG2M_TO_SIZE_IN_BYTES;

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/HllFieldSizeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/HllFieldSizeTest.java
@@ -34,7 +34,7 @@ public class HllFieldSizeTest {
   @Test
   public void testHllFieldSerializedSize()
       throws Exception {
-    for (int i = 5; i < 10; i++) {
+    for (int i = 5; i < 16; i++) {
       HyperLogLog hll = new HyperLogLog(i);
       Assert.assertEquals(HllSizeUtils.getHllFieldSizeFromLog2m(i), hll.getBytes().length);
       LOGGER.info("Estimated: " + hll.cardinality());


### PR DESCRIPTION
This change would allow more options for log2m in HLL config.