### PR TITLE
Download query result as excel on query console

### DIFF
--- a/pinot-controller/src/main/resources/static/css/pinot.css
+++ b/pinot-controller/src/main/resources/static/css/pinot.css
@@ -82,3 +82,17 @@ body {
   color:black;
   font-size:14px;
 }
+
+.dataTables_filter input {
+  display: inline;
+  width: auto;
+}
+
+.dataTables_length {
+  padding-left: 1em;
+}
+
+.dataTables_length select {
+  width: auto;
+  padding-right: 1.5em;
+}

--- a/pinot-controller/src/main/resources/static/js/init.js
+++ b/pinot-controller/src/main/resources/static/js/init.js
@@ -128,6 +128,16 @@ $(document).ready(function() {
         columns: columnList,
         scrollX: true
       });
+
+      new $.fn.dataTable.Buttons(table, {
+        buttons: [
+          'copy', 'excel', 'csv'
+        ]
+      });
+
+      table.buttons().container().prependTo(
+        table.table().container()
+      );
     })
   });
 });

--- a/pinot-controller/src/main/resources/static/query/index.html
+++ b/pinot-controller/src/main/resources/static/query/index.html
@@ -23,7 +23,10 @@
 <head>
 
 <script src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.5/jszip.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/1.5.6/js/dataTables.buttons.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.html5.min.js"></script>
 <script src="js/lib/handlebars.js"></script>
 <script src="js/lib/underscore.js"></script>
 <script src="js/lib/foundation/foundation.js"></script>
@@ -35,7 +38,8 @@
 <script src="js/lib/underscore-min.js"></script>
 <script src="js/lib/beautify.js"></script>
 
-<link href="https://cdn.datatables.net/1.10.7/css/jquery.dataTables.css" type="text/css" rel="stylesheet">
+<link href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css" type="text/css" rel="stylesheet">
+<link href="https://cdn.datatables.net/buttons/1.5.6/css/buttons.dataTables.min.css" type="text/css" rel="stylesheet">
 <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 
 <link href="css/lib/normalize.css" type="text/css" rel="stylesheet">


### PR DESCRIPTION
Download query result as excel or csv is a common usage, this PR adds downloading query result as excel or csv or copy on query-console, like:
![image](https://user-images.githubusercontent.com/95261/60814252-d96eec80-a1c7-11e9-8b7c-97766a19239e.png)

Other updates:
1. Upgrades jquery version to 1.10.19
2. Updates `select` and `filter` style of `datatables`  to keep consist with datatables