### PR TITLE
[TE] add a thread pool to run preview tasks

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/DetectionPreviewConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/DetectionPreviewConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.apache.pinot.thirdeye.dashboard;
+
+import java.util.concurrent.TimeUnit;
+
+
+public class DetectionPreviewConfiguration {
+  // 5 detection previews are running at the same time at most
+  private static final int DEFAULT_PREVIEW_PARALLELISM = 5;
+  // max time allowed for a preview task
+  private static final long DEFAULT_PREVIEW_TIMEOUT = TimeUnit.MINUTES.toMillis(5);
+
+  private int parallelism = DEFAULT_PREVIEW_PARALLELISM;
+  private long timeout = DEFAULT_PREVIEW_TIMEOUT;
+
+  public int getParallelism() {
+    return parallelism;
+  }
+
+  public void setParallelism(int parallelism) {
+    this.parallelism = parallelism;
+  }
+
+  public long getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(long timeout) {
+    this.timeout = timeout;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -191,7 +191,7 @@ public class ThirdEyeDashboardApplication
         DAO_REGISTRY.getTaskDAO(), DAO_REGISTRY.getAnomalyFunctionDAO()));
     env.jersey().register(new DetectionResource());
     env.jersey().register(new DetectionAlertResource(DAO_REGISTRY.getDetectionAlertConfigManager()));
-    env.jersey().register(new YamlResource());
+    env.jersey().register(new YamlResource(config.getDetectionPreviewConfig()));
     env.jersey().register(new SqlDataSourceResource());
 
     TimeSeriesLoader timeSeriesLoader = new DefaultTimeSeriesLoader(

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardConfiguration.java
@@ -30,6 +30,15 @@ public class ThirdEyeDashboardConfiguration extends ThirdEyeConfiguration {
   AuthConfiguration authConfig;
   RootCauseConfiguration rootCause;
   List<ResourceConfiguration> resourceConfig;
+  DetectionPreviewConfiguration detectionPreviewConfig = new DetectionPreviewConfiguration();
+
+  public DetectionPreviewConfiguration getDetectionPreviewConfig() {
+    return detectionPreviewConfig;
+  }
+
+  public void setDetectionPreviewConfig(DetectionPreviewConfiguration detectionPreviewConfig) {
+    this.detectionPreviewConfig = detectionPreviewConfig;
+  }
 
   public List<ResourceConfiguration> getResourceConfig() {
     return resourceConfig;

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlResourceTest.java
@@ -2,6 +2,7 @@ package org.apache.pinot.thirdeye.detection.yaml;
 
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
+import org.apache.pinot.thirdeye.dashboard.DetectionPreviewConfiguration;
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
 import org.apache.pinot.thirdeye.datalayer.dto.ApplicationDTO;
@@ -34,7 +35,7 @@ public class YamlResourceTest {
   public void beforeClass() {
     testDAOProvider = DAOTestBase.getInstance();
     this.user = new ThirdEyePrincipal("test", "test");
-    this.yamlResource = new YamlResource();
+    this.yamlResource = new YamlResource(new DetectionPreviewConfiguration());
     this.daoRegistry = DAORegistry.getInstance();
     DetectionConfigManager detectionDAO = this.daoRegistry.getDetectionConfigManager();
     DetectionConfigDTO config1 = new DetectionConfigDTO();


### PR DESCRIPTION
This PR adds a thread pool to run preview tasks for the dashboard. It adds the following limits to prevent excessive server usage.
1. The number of preview task running at the same time 
2. The timeout for a preview task 