### PR TITLE
Add pinot community inviter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ bin/quick-start-offline.sh
 ```
 
 ## Getting Involved
- - Ask questions on [Slack](https://join.slack.com/t/apache-pinot/shared_invite/enQtNDY4NDczOTYyNjk1LTExODVjY2QxYzBkMzJjNTk0ZGQ3NThiYTU2YzdlNjE0MWI5ZjUwYjI2ZTgxNjNiYWJiNmEzYjkxMTIzMzUxNTQ)
+ - Ask questions on [Apache Pinot Slack](https://communityinviter.com/apps/apache-pinot/apache-pinot)
  - Please join Apache Pinot mailing lists  
    dev-subscribe@pinot.apache.org (subscribe to pinot-dev mailing list)  
    dev@pinot.apache.org (posting to pinot-dev mailing list)  

--- a/thirdeye/README.md
+++ b/thirdeye/README.md
@@ -33,6 +33,7 @@ ThirdEye does not replace your issue tracker - it integrates with it. ThirdEye s
 ThirdEye is not a generic dashboard builder toolkit. ThirdEye attempts to bring overview data from different sources into one single place on-demand. In-depth data about events, such as A/B experiments and deployments, should be kept in their respective systems. ThirdEye can link to these directly.
 
 ## Getting Involved
+ 
  - Ask questions on [Apache ThirdEye Slack](https://communityinviter.com/apps/apache-thirdeye/apache-thirdeye)
 
 ## Documentation

--- a/thirdeye/README.md
+++ b/thirdeye/README.md
@@ -34,11 +34,6 @@ ThirdEye is not a generic dashboard builder toolkit. ThirdEye attempts to bring 
 
 ## Getting Involved
  - Ask questions on [Apache ThirdEye Slack](https://communityinviter.com/apps/apache-thirdeye/apache-thirdeye)
- - Please join Apache Pinot mailing lists  
-   dev-subscribe@pinot.apache.org (subscribe to pinot-dev mailing list)  
-   dev@pinot.apache.org (posting to pinot-dev mailing list)  
-   users-subscribe@pinot.apache.org (subscribe to pinot-user mailing list)  
-   users@pinot.apache.org (positng to pinot-user mailing list)
 
 ## Documentation
 
@@ -48,4 +43,3 @@ Detailed documentation can be found at [ThirdEye documentation](https://thirdeye
 - [Data Sources Setup](https://thirdeye.readthedocs.io/en/latest/datasources.html)
 - [Production Settings](https://thirdeye.readthedocs.io/en/latest/production.html)
 - [Alert Setup](https://thirdeye.readthedocs.io/en/latest/alert_setup.html)
-- [Chat](https://communityinviter.com/apps/apache-thirdeye/apache-thirdeye)

--- a/thirdeye/README.md
+++ b/thirdeye/README.md
@@ -32,6 +32,13 @@ ThirdEye does not replace your issue tracker - it integrates with it. ThirdEye s
 
 ThirdEye is not a generic dashboard builder toolkit. ThirdEye attempts to bring overview data from different sources into one single place on-demand. In-depth data about events, such as A/B experiments and deployments, should be kept in their respective systems. ThirdEye can link to these directly.
 
+## Getting Involved
+ - Ask questions on [Apache ThirdEye Slack](https://communityinviter.com/apps/apache-thirdeye/apache-thirdeye)
+ - Please join Apache Pinot mailing lists  
+   dev-subscribe@pinot.apache.org (subscribe to pinot-dev mailing list)  
+   dev@pinot.apache.org (posting to pinot-dev mailing list)  
+   users-subscribe@pinot.apache.org (subscribe to pinot-user mailing list)  
+   users@pinot.apache.org (positng to pinot-user mailing list)
 
 ## Documentation
 
@@ -41,3 +48,4 @@ Detailed documentation can be found at [ThirdEye documentation](https://thirdeye
 - [Data Sources Setup](https://thirdeye.readthedocs.io/en/latest/datasources.html)
 - [Production Settings](https://thirdeye.readthedocs.io/en/latest/production.html)
 - [Alert Setup](https://thirdeye.readthedocs.io/en/latest/alert_setup.html)
+- [Chat](https://communityinviter.com/apps/apache-thirdeye/apache-thirdeye)


### PR DESCRIPTION
The current process to onboard new users into the Pinot & ThirdEye Slack community requires a manual invite. Community inviter is a free service that can automate the new user registration with the Slack community and reduce the friction for onboarding new users to the community.