### PR TITLE
#4401 Reuse a ThreadLocal byte[] when reading String elements from the variable length value reader.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/StringUtil.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/StringUtil.java
@@ -72,9 +72,9 @@ public class StringUtil {
     return decodeUtf8(bytes, 0, bytes.length);
   }
 
-  public static String decodeUtf8(byte[] bytes, int startIndex, int endIndex) {
+  public static String decodeUtf8(byte[] bytes, int startIndex, int length) {
     try {
-      return new String(bytes, startIndex, endIndex, charSet);
+      return new String(bytes, startIndex, length, charSet);
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Fix for https://github.com/apache/incubator-pinot/issues/4401

@mayankshriv @kishoreg  Please review this when you get time.