### PR TITLE
Fix the potential resource leak from NettyServer

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/request/ScheduledRequestHandler.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/request/ScheduledRequestHandler.java
@@ -21,13 +21,11 @@ package org.apache.pinot.server.request;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
-import java.net.InetSocketAddress;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.metrics.ServerQueryPhase;
 import org.apache.pinot.common.request.InstanceRequest;
+import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
 import org.apache.pinot.serde.SerDe;
@@ -51,20 +49,14 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
   }
 
   @Override
-  public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
+  public ListenableFuture<byte[]> processRequest(byte[] request) {
     long queryArrivalTimeMs = System.currentTimeMillis();
     serverMetrics.addMeteredGlobalValue(ServerMeter.QUERIES, 1);
 
-    LOGGER.debug("Processing request : {}", request);
-
-    byte[] byteArray = new byte[request.readableBytes()];
-    request.readBytes(byteArray);
     SerDe serDe = new SerDe(new TCompactProtocol.Factory());
-    final InstanceRequest instanceRequest = new InstanceRequest();
-
-    if (!serDe.deserialize(instanceRequest, byteArray)) {
-      LOGGER.error("Failed to deserialize query request from broker ip: {}",
-          ((InetSocketAddress) channelHandlerContext.channel().remoteAddress()).getAddress().getHostAddress());
+    InstanceRequest instanceRequest = new InstanceRequest();
+    if (!serDe.deserialize(instanceRequest, request)) {
+      LOGGER.error("Failed to deserialize query request: {}", BytesUtils.toHexString(request));
       serverMetrics.addMeteredGlobalValue(ServerMeter.REQUEST_DESERIALIZATION_EXCEPTIONS, 1);
       return Futures.immediateFuture(null);
     }

--- a/pinot-server/src/test/java/org/apache/pinot/server/request/ScheduledRequestHandlerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/request/ScheduledRequestHandlerTest.java
@@ -23,11 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.yammer.metrics.core.MetricsRegistry;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandlerContext;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -54,14 +50,11 @@ import org.apache.pinot.core.query.scheduler.resources.UnboundedResourceManager;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.serde.SerDe;
 import org.apache.thrift.protocol.TCompactProtocol;
-import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 public class ScheduledRequestHandlerTest {
@@ -70,7 +63,6 @@ public class ScheduledRequestHandlerTest {
   private static final Configuration DEFAULT_SCHEDULER_CONFIG = new PropertiesConfiguration();
 
   private ServerMetrics serverMetrics;
-  private ChannelHandlerContext channelHandlerContext;
   private QueryScheduler queryScheduler;
   private QueryExecutor queryExecutor;
   private UnboundedResourceManager resourceManager;
@@ -79,10 +71,6 @@ public class ScheduledRequestHandlerTest {
   @BeforeClass
   public void setUp() {
     serverMetrics = new ServerMetrics(new MetricsRegistry());
-    channelHandlerContext = mock(ChannelHandlerContext.class, RETURNS_DEEP_STUBS);
-    when(channelHandlerContext.channel().remoteAddress())
-        .thenAnswer((Answer<InetSocketAddress>) invocationOnMock -> new InetSocketAddress("localhost", 60000));
-
     queryScheduler = mock(QueryScheduler.class);
     queryExecutor = new ServerQueryExecutorV1Impl();
     latestQueryTime = new LongAccumulator(Long::max, 0);
@@ -93,10 +81,8 @@ public class ScheduledRequestHandlerTest {
   public void testBadRequest()
       throws Exception {
     ScheduledRequestHandler handler = new ScheduledRequestHandler(queryScheduler, serverMetrics);
-    String requestBadString = "foobar";
-    byte[] requestData = requestBadString.getBytes();
-    ByteBuf buffer = Unpooled.wrappedBuffer(requestData);
-    ListenableFuture<byte[]> response = handler.processRequest(channelHandlerContext, buffer);
+    String badRequest = "foobar";
+    ListenableFuture<byte[]> response = handler.processRequest(badRequest.getBytes());
     // The handler method is expected to return immediately
     Assert.assertTrue(response.isDone());
     byte[] responseBytes = response.get();
@@ -113,10 +99,8 @@ public class ScheduledRequestHandlerTest {
     return request;
   }
 
-  private ByteBuf getSerializedInstanceRequest(InstanceRequest request) {
-    SerDe serDe = new SerDe(new TCompactProtocol.Factory());
-    byte[] requestData = serDe.serialize(request);
-    return Unpooled.wrappedBuffer(requestData);
+  private byte[] getSerializedInstanceRequest(InstanceRequest request) {
+    return new SerDe(new TCompactProtocol.Factory()).serialize(request);
   }
 
   @Test
@@ -131,7 +115,8 @@ public class ScheduledRequestHandlerTest {
             // Specifying it for less ambiguity.
             ListenableFuture<DataTable> dataTable = resourceManager.getQueryRunners().submit(new Callable<DataTable>() {
               @Override
-              public DataTable call() throws Exception {
+              public DataTable call()
+                  throws Exception {
                 throw new RuntimeException("query processing error");
               }
             });
@@ -154,8 +139,8 @@ public class ScheduledRequestHandlerTest {
           }
         }, serverMetrics);
 
-    ByteBuf requestBuf = getSerializedInstanceRequest(getInstanceRequest());
-    ListenableFuture<byte[]> responseFuture = handler.processRequest(channelHandlerContext, requestBuf);
+    ListenableFuture<byte[]> responseFuture =
+        handler.processRequest(getSerializedInstanceRequest(getInstanceRequest()));
     byte[] bytes = responseFuture.get(2, TimeUnit.SECONDS);
     // we get DataTable with exception information in case of query processing exception
     Assert.assertTrue(bytes.length > 0);
@@ -202,8 +187,8 @@ public class ScheduledRequestHandlerTest {
           }
         }, serverMetrics);
 
-    ByteBuf requestBuf = getSerializedInstanceRequest(getInstanceRequest());
-    ListenableFuture<byte[]> responseFuture = handler.processRequest(channelHandlerContext, requestBuf);
+    ListenableFuture<byte[]> responseFuture =
+        handler.processRequest(getSerializedInstanceRequest(getInstanceRequest()));
     byte[] responseBytes = responseFuture.get(2, TimeUnit.SECONDS);
     DataTable responseDT = DataTableFactory.getDataTable(responseBytes);
     Assert.assertEquals(responseDT.getNumberOfRows(), 2);

--- a/pinot-transport/src/test/java/org/apache/pinot/transport/netty/NettyTestUtils.java
+++ b/pinot-transport/src/test/java/org/apache/pinot/transport/netty/NettyTestUtils.java
@@ -21,8 +21,6 @@ package org.apache.pinot.transport.netty;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -51,10 +49,8 @@ public class NettyTestUtils {
     }
 
     @Override
-    public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
-      byte[] bytes = new byte[request.readableBytes()];
-      request.readBytes(bytes);
-      _request = new String(bytes);
+    public ListenableFuture<byte[]> processRequest(byte[] request) {
+      _request = new String(request);
       if (_responseHandlingLatch != null) {
         while (true) {
           try {

--- a/pinot-transport/src/test/java/org/apache/pinot/transport/perf/ScatterGatherPerfServer.java
+++ b/pinot-transport/src/test/java/org/apache/pinot/transport/perf/ScatterGatherPerfServer.java
@@ -20,8 +20,6 @@ package org.apache.pinot.transport.perf;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 import java.util.concurrent.CountDownLatch;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -152,9 +150,7 @@ public class ScatterGatherPerfServer {
     }
 
     @Override
-    public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
-      byte[] b = new byte[request.readableBytes()];
-      request.readBytes(b);
+    public ListenableFuture<byte[]> processRequest(byte[] request) {
       if (null != _responseHandlingLatch) {
         try {
           _responseHandlingLatch.await();
@@ -162,7 +158,7 @@ public class ScatterGatherPerfServer {
           e.printStackTrace();
         }
       }
-      _request = new String(b);
+      _request = new String(request);
 
       if (_responseLatencyMs > 0) {
         try {

--- a/pinot-transport/src/test/java/org/apache/pinot/transport/scattergather/ScatterGatherTest.java
+++ b/pinot-transport/src/test/java/org/apache/pinot/transport/scattergather/ScatterGatherTest.java
@@ -19,12 +19,9 @@
 package org.apache.pinot.transport.scattergather;
 
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.yammer.metrics.core.MetricsRegistry;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
@@ -305,20 +302,15 @@ public class ScatterGatherTest {
 
     @Override
     public RequestHandler createNewRequestHandler() {
-      return new RequestHandler() {
-        @Override
-        public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
-          Uninterruptibles.sleepUninterruptibly(_delayMs, TimeUnit.MILLISECONDS);
+      return request -> {
+        Uninterruptibles.sleepUninterruptibly(_delayMs, TimeUnit.MILLISECONDS);
 
-          if (_throwError) {
-            throw new RuntimeException();
-          }
-
-          // Return the request as response
-          byte[] requestBytes = new byte[request.readableBytes()];
-          request.readBytes(requestBytes);
-          return Futures.immediateFuture(requestBytes);
+        if (_throwError) {
+          throw new RuntimeException();
         }
+
+        // Return the request as response
+        return Futures.immediateFuture(request);
       };
     }
   }


### PR DESCRIPTION
- Release the ByteBuf immediately after reading the bytes
- De-couple RequestHandler from Netty ChannelHandlerContext and ByteBuf
- Change RequestHandler.processRequest() to directly take byte[] instead of the ByteBuf
- Fix the resource leak issue when RequestHandler.processRequest() throws Exception