### PR TITLE
Enable SegmentCompleteionIntegrationTest

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -426,15 +426,10 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
     completeTableConfiguration();
   }
 
-  protected void completeTableConfiguration() {
+  protected void completeTableConfiguration() throws IOException {
     if (isUsingNewConfigFormat()) {
       CombinedConfig combinedConfig = new CombinedConfig(_offlineTableConfig, _realtimeTableConfig, _schema);
-      try {
-        sendPostRequest(_controllerRequestURLBuilder.forNewTableCreate(), Serializer.serializeToString(combinedConfig));
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+      sendPostRequest(_controllerRequestURLBuilder.forNewTableCreate(), Serializer.serializeToString(combinedConfig));
     }
   }
-
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.integration.tests;
 
 import com.google.common.base.Function;
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -28,15 +29,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import kafka.server.KafkaServerStartable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.common.config.ColumnPartitionConfig;
+import org.apache.pinot.common.config.CombinedConfig;
 import org.apache.pinot.common.config.SegmentPartitionConfig;
+import org.apache.pinot.common.config.Serializer;
 import org.apache.pinot.common.config.TableTaskConfig;
 import org.apache.pinot.common.config.TagNameUtils;
+import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.core.realtime.impl.kafka.KafkaConsumerFactory;
@@ -398,4 +403,38 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
     ClusterIntegrationTestUtils
         .testQuery(sqlQuery, "sql", _brokerBaseApiUrl, getPinotConnection(), sqlQueries, getH2Connection());
   }
+
+  protected void setUpRealtimeTable(File avroFile)
+      throws Exception {
+    File schemaFile = getSchemaFile();
+    Schema schema = Schema.fromFile(schemaFile);
+    String schemaName = schema.getSchemaName();
+    addSchema(schemaFile, schemaName);
+
+    String timeColumnName = schema.getTimeColumnName();
+    Assert.assertNotNull(timeColumnName);
+    TimeUnit outgoingTimeUnit = schema.getOutgoingTimeUnit();
+    Assert.assertNotNull(outgoingTimeUnit);
+    String timeType = outgoingTimeUnit.toString();
+
+    addRealtimeTable(getTableName(), useLlc(), KafkaStarterUtils.DEFAULT_KAFKA_BROKER, KafkaStarterUtils.DEFAULT_ZK_STR,
+        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName,
+        getBrokerTenant(), getServerTenant(), getLoadMode(), getSortedColumn(),
+        getInvertedIndexColumns(), getBloomFilterIndexColumns(), getRawIndexColumns(), getTaskConfig(),
+        getStreamConsumerFactoryClassName());
+
+    completeTableConfiguration();
+  }
+
+  protected void completeTableConfiguration() {
+    if (isUsingNewConfigFormat()) {
+      CombinedConfig combinedConfig = new CombinedConfig(_offlineTableConfig, _realtimeTableConfig, _schema);
+      try {
+        sendPostRequest(_controllerRequestURLBuilder.forNewTableCreate(), Serializer.serializeToString(combinedConfig));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -492,17 +492,6 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     }, 60_000L, errorMessage);
   }
 
-  protected void completeTableConfiguration() {
-    if (isUsingNewConfigFormat()) {
-      CombinedConfig combinedConfig = new CombinedConfig(_offlineTableConfig, _realtimeTableConfig, _schema);
-      try {
-        sendPostRequest(_controllerRequestURLBuilder.forNewTableCreate(), Serializer.serializeToString(combinedConfig));
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-  }
-
   protected void updateTableConfiguration() {
     if (isUsingNewConfigFormat()) {
       CombinedConfig combinedConfig = new CombinedConfig(_offlineTableConfig, _realtimeTableConfig, _schema);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -71,32 +71,10 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
     executor.awaitTermination(10, TimeUnit.MINUTES);
 
     // Create Pinot table
-    setUpTable(avroFiles.get(0));
+    setUpRealtimeTable(avroFiles.get(0));
 
     // Wait for all documents loaded
     waitForAllDocsLoaded(600_000L);
-  }
-
-  protected void setUpTable(File avroFile)
-      throws Exception {
-    File schemaFile = getSchemaFile();
-    Schema schema = Schema.fromFile(schemaFile);
-    String schemaName = schema.getSchemaName();
-    addSchema(schemaFile, schemaName);
-
-    String timeColumnName = schema.getTimeColumnName();
-    Assert.assertNotNull(timeColumnName);
-    TimeUnit outgoingTimeUnit = schema.getOutgoingTimeUnit();
-    Assert.assertNotNull(outgoingTimeUnit);
-    String timeType = outgoingTimeUnit.toString();
-
-    addRealtimeTable(getTableName(), useLlc(), KafkaStarterUtils.DEFAULT_KAFKA_BROKER, KafkaStarterUtils.DEFAULT_ZK_STR,
-        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName,
-        getBrokerTenant(), getServerTenant(), getLoadMode(), getSortedColumn(),
-        getInvertedIndexColumns(), getBloomFilterIndexColumns(), getRawIndexColumns(), getTaskConfig(),
-        getStreamConsumerFactoryClassName());
-
-    completeTableConfiguration();
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTest.java
@@ -52,7 +52,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
-public class SegmentCompletionIntegrationTests extends LLCRealtimeClusterIntegrationTest {
+public class SegmentCompletionIntegrationTest extends BaseClusterIntegrationTest {
   private static final int NUM_KAFKA_PARTITIONS = 1;
 
   private String _serverInstance;
@@ -77,7 +77,12 @@ public class SegmentCompletionIntegrationTests extends LLCRealtimeClusterIntegra
     startKafka();
 
     // Create Pinot table
-    setUpTable(null);
+    setUpRealtimeTable(null);
+  }
+
+  @Override
+  protected boolean useLlc() {
+    return true;
   }
 
   /**
@@ -185,66 +190,12 @@ public class SegmentCompletionIntegrationTests extends LLCRealtimeClusterIntegra
     }, 60_000L, "Failed to get a new segment reaching CONSUMING state");
   }
 
-  @Test(enabled = false)
-  @Override
-  public void testQueriesFromQueryFile()
-      throws Exception {
-    // Skipped
-  }
-
-  @Test(enabled = false)
-  @Override
-  public void testSqlQueriesFromQueryFile()
-      throws Exception {
-    // Skipped
-  }
-
-  @Test(enabled = false)
-  @Override
-  public void testGeneratedQueriesWithMultiValues()
-      throws Exception {
-    // Skipped
-  }
-
-  @Test(enabled = false)
-  @Override
-  public void testInstanceShutdown()
-      throws Exception {
-    // Skipped
-  }
-
-  @Test(enabled = false)
-  @Override
-  public void testSegmentFlushSize()
-      throws Exception {
-    // Skipped
-  }
-
-  @Test(enabled = false)
-  @Override
-  public void testDictionaryBasedQueries()
-      throws Exception {
-    // Skipped
-  }
-
-  @Test(enabled = false)
-  @Override
-  public void testQueryExceptions()
-      throws Exception {
-    // Skipped
-  }
-
-  @Test(enabled = false)
-  public void testConsumerDirectoryExists() {
-    // Skipped
-  }
-
   @AfterClass
-  public void tearDown()
-      throws Exception {
+  public void tearDown() {
     stopFakeServer();
     stopBroker();
     stopController();
+    stopKafka();
     stopZk();
   }
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRealtimeConsumptionSpeed.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRealtimeConsumptionSpeed.java
@@ -82,7 +82,7 @@ public class BenchmarkRealtimeConsumptionSpeed extends RealtimeClusterIntegratio
     startServer();
 
     // Create realtime table
-    setUpTable(avroFiles.get(0));
+    setUpRealtimeTable(avroFiles.get(0));
 
     // Wait a couple of seconds for all Helix state transitions to happen
     Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/RealtimeStressTest.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/RealtimeStressTest.java
@@ -86,7 +86,7 @@ public class RealtimeStressTest extends RealtimeClusterIntegrationTest {
     startServer();
 
     // Create realtime table
-    setUpTable(avroFiles.get(0));
+    setUpRealtimeTable(avroFiles.get(0));
 
     // Wait a couple of seconds for all Helix state transitions to happen
     Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);


### PR DESCRIPTION
This test was not running because of a typo in the class name.
Also, re-organized the test so that it does not have to override
methods from upper level tests each time new tests are added.