### PR TITLE
Add table name parameter for segment push

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -459,9 +459,10 @@ public class FileUploadDownloadClient implements Closeable {
   /**
    * Upload segment with segment file.
    *
-   * Note: in case of using this API directly, tableName has to be set in the parameter when uploading segments from
-   * Minion or offline push job. Realtime segment upload does not need to add table name parameter. Table name is
-   * derived from the segment name in case of realtime segment commit.
+   * Note: table name needs to be added as a parameter except for the case where this gets called during realtime
+   * segment commit protocol.
+   *
+   * TODO: fix the realtime segment commit protocol to add table name as a parameter.
    *
    * @param uri URI
    * @param segmentName Segment name
@@ -502,9 +503,7 @@ public class FileUploadDownloadClient implements Closeable {
   /**
    * Upload segment with segment file input stream.
    *
-   * Note: in case of using this API directly, tableName has to be set in the parameter when uploading segments from
-   * Minion or offline push job. Realtime segment upload does not need to add table name parameter. Table name is
-   * derived from the segment name in case of realtime segment commit.
+   * Note: table name has to be set as a parameter.
    *
    * @param uri URI
    * @param segmentName Segment name
@@ -542,11 +541,9 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
-   * Send segment uri. Include table name as a request parameter.
+   * Send segment uri.
    *
-   * Note: in case of using this API directly, tableName has to be set in the parameter when uploading segments from
-   * Minion or offline push job. Realtime segment upload does not need to add table name parameter. Table name is
-   * derived from the segment name in case of realtime segment commit.
+   * Note: table name has to be set as a parameter.
    *
    * @param uri URI
    * @param downloadUri Segment download uri

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -55,6 +56,7 @@ import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.slf4j.Logger;
@@ -522,6 +524,28 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Upload segment with segment file. Include table name and segment name headers.
+   *
+   * @param uri URI
+   * @param segmentName Segment name
+   * @param inputStream Segment file input stream
+   * @param rawTableName Raw table name
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public SimpleHttpResponse uploadSegmentWithTableAndSegmentNameHeader(URI uri, String segmentName,
+      InputStream inputStream, String rawTableName)
+      throws IOException, HttpErrorStatusException {
+    // Add table and segment name to headers
+    Header tableNameHeader = new BasicHeader(CommonConstants.Controller.TABLE_NAME_HTTP_HEADER, rawTableName);
+    Header segmentNameHeader = new BasicHeader(CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER, segmentName);
+    List<Header> headers = Arrays.asList(tableNameHeader, segmentNameHeader);
+    return sendRequest(
+        getUploadSegmentRequest(uri, segmentName, inputStream, headers, null, DEFAULT_SOCKET_TIMEOUT_MS));
+  }
+
+  /**
    * Send segment uri.
    *
    * @param uri URI
@@ -551,6 +575,27 @@ public class FileUploadDownloadClient implements Closeable {
   public SimpleHttpResponse sendSegmentUri(URI uri, String downloadUri)
       throws IOException, HttpErrorStatusException {
     return sendSegmentUri(uri, downloadUri, null, null, DEFAULT_SOCKET_TIMEOUT_MS);
+  }
+
+  /**
+   * Send segment uri with table name header. Include table name and segment name headers.
+   *
+   * @param uri URI
+   * @param downloadUri Segment download uri
+   * @param rawTableName Raw table name
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public SimpleHttpResponse sendSegmentUriWithTableAndSegmentNameHeader(URI uri, String downloadUri,
+      String rawTableName)
+      throws IOException, HttpErrorStatusException {
+    // Add table name to headers
+    Header tableNameHeader = new BasicHeader(CommonConstants.Controller.TABLE_NAME_HTTP_HEADER, rawTableName);
+
+    // TODO: add segment name to headers
+    List<Header> headers = Arrays.asList(tableNameHeader);
+    return sendRequest(getSendSegmentUriRequest(uri, downloadUri, headers, null, DEFAULT_SOCKET_TIMEOUT_MS));
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -20,7 +20,6 @@ package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.base.Preconditions;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -231,7 +230,7 @@ public class PinotSegmentUploadRestletResource {
         "All segments of table " + TableNameBuilder.forType(tableType).tableNameWithType(tableName) + " deleted");
   }
 
-  private SuccessResponse uploadSegment(FormDataMultiPart multiPart, boolean enableParallelPushProtection,
+  private SuccessResponse uploadSegment(String tableName, FormDataMultiPart multiPart, boolean enableParallelPushProtection,
       HttpHeaders headers, Request request, boolean moveSegmentToFinalLocation) {
     if (headers != null) {
       LOGGER.info("HTTP Header {} is {}", CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER,
@@ -288,13 +287,12 @@ public class PinotSegmentUploadRestletResource {
           throw new UnsupportedOperationException("Unsupported upload type: " + uploadType);
       }
 
-      // Fetch raw table name. Try to derive the table name from the header and then from segment metadata
-      String rawTableName;
-      List<String> tableNameHeader = headers.getRequestHeader(CommonConstants.Controller.TABLE_NAME_HTTP_HEADER);
-      if (tableNameHeader != null) {
-        Preconditions.checkState(tableNameHeader.size() == 1);
-        rawTableName = headers.getRequestHeader(CommonConstants.Controller.TABLE_NAME_HTTP_HEADER).get(0);
+      // Fetch raw table name. Try to derive the table name from the parameter and then from segment metadata
+      String rawTableName = null;
+      if (tableName != null && !tableName.isEmpty()) {
+        rawTableName = TableNameBuilder.extractRawTableName(tableName);
       } else {
+        // TODO: remove this when we completely deprecate the segment name from segment metadata
         rawTableName = segmentMetadata.getTableName();
       }
       String segmentName = segmentMetadata.getName();
@@ -406,10 +404,11 @@ public class PinotSegmentUploadRestletResource {
   // request if a multipart object is not sent. This endpoint does not move the segment to its final location;
   // it keeps it at the downloadURI header that is set. We will not support this endpoint going forward.
   public void uploadSegmentAsJson(String segmentJsonStr,
+      @ApiParam(value = "Name of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_NAME) String tableName,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false") @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION) boolean enableParallelPushProtection,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
-      asyncResponse.resume(uploadSegment(null, enableParallelPushProtection, headers, request, false));
+      asyncResponse.resume(uploadSegment(tableName, null, enableParallelPushProtection, headers, request, false));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -423,10 +422,11 @@ public class PinotSegmentUploadRestletResource {
   @ApiOperation(value = "Upload a segment", notes = "Upload a segment as binary")
   // For the multipart endpoint, we will always move segment to final location regardless of the segment endpoint.
   public void uploadSegmentAsMultiPart(FormDataMultiPart multiPart,
+      @ApiParam(value = "Name of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_NAME) String tableName,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false") @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION) boolean enableParallelPushProtection,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
-      asyncResponse.resume(uploadSegment(multiPart, enableParallelPushProtection, headers, request, true));
+      asyncResponse.resume(uploadSegment(tableName, multiPart, enableParallelPushProtection, headers, request, true));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -442,10 +442,11 @@ public class PinotSegmentUploadRestletResource {
   // request if a multipart object is not sent. This endpoint is recommended for use. It differs from the first
   // endpoint in how it moves the segment to a Pinot-determined final directory.
   public void uploadSegmentAsJsonV2(String segmentJsonStr,
+      @ApiParam(value = "Name of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_NAME) String tableName,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false") @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION) boolean enableParallelPushProtection,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
-      asyncResponse.resume(uploadSegment(null, enableParallelPushProtection, headers, request, true));
+      asyncResponse.resume(uploadSegment(tableName, null, enableParallelPushProtection, headers, request, true));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -459,10 +460,11 @@ public class PinotSegmentUploadRestletResource {
   @ApiOperation(value = "Upload a segment", notes = "Upload a segment as binary")
   // This behavior does not differ from v1 of the same endpoint.
   public void uploadSegmentAsMultiPartV2(FormDataMultiPart multiPart,
+      @ApiParam(value = "Name of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_NAME) String tableName,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false") @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION) boolean enableParallelPushProtection,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
-      asyncResponse.resume(uploadSegment(multiPart, enableParallelPushProtection, headers, request, true));
+      asyncResponse.resume(uploadSegment(tableName, multiPart, enableParallelPushProtection, headers, request, true));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -287,15 +287,19 @@ public class PinotSegmentUploadRestletResource {
           throw new UnsupportedOperationException("Unsupported upload type: " + uploadType);
       }
 
+      // Fetch segment name
+      String segmentName = segmentMetadata.getName();
+
       // Fetch raw table name. Try to derive the table name from the parameter and then from segment metadata
-      String rawTableName = null;
+      String rawTableName;
       if (tableName != null && !tableName.isEmpty()) {
         rawTableName = TableNameBuilder.extractRawTableName(tableName);
+        LOGGER.info("Uploading segment {} to table: {}, (Derived from API parameter)", segmentName, tableName);
       } else {
         // TODO: remove this when we completely deprecate the segment name from segment metadata
         rawTableName = segmentMetadata.getTableName();
+        LOGGER.info("Uploading a segment {} to table: {}, (Derived from segment metadata)", segmentName, tableName);
       }
-      String segmentName = segmentMetadata.getName();
 
       String zkDownloadUri;
       // This boolean is here for V1 segment upload, where we keep the segment in the downloadURI sent in the header.

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/DefaultControllerRestApi.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/DefaultControllerRestApi.java
@@ -105,7 +105,7 @@ public class DefaultControllerRestApi implements ControllerRestApi {
       for (PushLocation pushLocation : _pushLocations) {
         LOGGER.info("Pushing segment: {} to location: {}", segmentName, pushLocation);
         try (InputStream inputStream = fileSystem.open(tarFilePath)) {
-          SimpleHttpResponse response = _fileUploadDownloadClient.uploadSegmentWithTableAndSegmentNameHeader(
+          SimpleHttpResponse response = _fileUploadDownloadClient.uploadSegment(
               FileUploadDownloadClient.getUploadSegmentHttpURI(pushLocation.getHost(), pushLocation.getPort()),
               segmentName, inputStream, _rawTableName);
           LOGGER.info("Response {}: {}", response.getStatusCode(), response.getResponse());
@@ -124,7 +124,7 @@ public class DefaultControllerRestApi implements ControllerRestApi {
       for (PushLocation pushLocation : _pushLocations) {
         LOGGER.info("Sending segment URI: {} to location: {}", segmentUri, pushLocation);
         try {
-          SimpleHttpResponse response = _fileUploadDownloadClient.sendSegmentUriWithTableAndSegmentNameHeader(
+          SimpleHttpResponse response = _fileUploadDownloadClient.sendSegmentUri(
               FileUploadDownloadClient.getUploadSegmentHttpURI(pushLocation.getHost(), pushLocation.getPort()),
               segmentUri, _rawTableName);
           LOGGER.info("Response {}: {}", response.getStatusCode(), response.getResponse());

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/DefaultControllerRestApi.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/DefaultControllerRestApi.java
@@ -105,9 +105,9 @@ public class DefaultControllerRestApi implements ControllerRestApi {
       for (PushLocation pushLocation : _pushLocations) {
         LOGGER.info("Pushing segment: {} to location: {}", segmentName, pushLocation);
         try (InputStream inputStream = fileSystem.open(tarFilePath)) {
-          SimpleHttpResponse response = _fileUploadDownloadClient.uploadSegment(
+          SimpleHttpResponse response = _fileUploadDownloadClient.uploadSegmentWithTableAndSegmentNameHeader(
               FileUploadDownloadClient.getUploadSegmentHttpURI(pushLocation.getHost(), pushLocation.getPort()),
-              segmentName, inputStream);
+              segmentName, inputStream, _rawTableName);
           LOGGER.info("Response {}: {}", response.getStatusCode(), response.getResponse());
         } catch (Exception e) {
           LOGGER.error("Caught exception while pushing segment: {} to location: {}", segmentName, pushLocation, e);
@@ -124,9 +124,9 @@ public class DefaultControllerRestApi implements ControllerRestApi {
       for (PushLocation pushLocation : _pushLocations) {
         LOGGER.info("Sending segment URI: {} to location: {}", segmentUri, pushLocation);
         try {
-          SimpleHttpResponse response = _fileUploadDownloadClient.sendSegmentUri(
+          SimpleHttpResponse response = _fileUploadDownloadClient.sendSegmentUriWithTableAndSegmentNameHeader(
               FileUploadDownloadClient.getUploadSegmentHttpURI(pushLocation.getHost(), pushLocation.getPort()),
-              segmentUri);
+              segmentUri, _rawTableName);
           LOGGER.info("Response {}: {}", response.getStatusCode(), response.getResponse());
         } catch (Exception e) {
           LOGGER.error("Caught exception while sending segment URI: {} to location: {}", segmentUri, pushLocation, e);

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentTarPushJob.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentTarPushJob.java
@@ -30,6 +30,7 @@ import org.apache.pinot.hadoop.utils.PushLocation;
 public class SegmentTarPushJob extends BaseSegmentJob {
   private final Path _segmentPattern;
   private final List<PushLocation> _pushLocations;
+  private final String _rawTableName;
 
   public SegmentTarPushJob(Properties properties) {
     super(properties);
@@ -37,6 +38,7 @@ public class SegmentTarPushJob extends BaseSegmentJob {
     String[] hosts = StringUtils.split(properties.getProperty(JobConfigConstants.PUSH_TO_HOSTS), ',');
     int port = Integer.parseInt(properties.getProperty(JobConfigConstants.PUSH_TO_PORT));
     _pushLocations = PushLocation.getPushLocations(hosts, port);
+    _rawTableName = Preconditions.checkNotNull(_properties.getProperty(JobConfigConstants.SEGMENT_TABLE_NAME));
   }
 
   @Override
@@ -53,6 +55,6 @@ public class SegmentTarPushJob extends BaseSegmentJob {
   }
 
   protected ControllerRestApi getControllerRestApi() {
-    return new DefaultControllerRestApi(_pushLocations, null);
+    return new DefaultControllerRestApi(_pushLocations, _rawTableName);
   }
 }

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentUriPushJob.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentUriPushJob.java
@@ -32,6 +32,7 @@ public class SegmentUriPushJob extends BaseSegmentJob {
   private final String _segmentUriSuffix;
   private final Path _segmentPattern;
   private final List<PushLocation> _pushLocations;
+  private final String _rawTableName;
 
   public SegmentUriPushJob(Properties properties) {
     super(properties);
@@ -41,6 +42,7 @@ public class SegmentUriPushJob extends BaseSegmentJob {
     String[] hosts = StringUtils.split(properties.getProperty(JobConfigConstants.PUSH_TO_HOSTS), ',');
     int port = Integer.parseInt(properties.getProperty(JobConfigConstants.PUSH_TO_PORT));
     _pushLocations = PushLocation.getPushLocations(hosts, port);
+    _rawTableName = Preconditions.checkNotNull(_properties.getProperty(JobConfigConstants.SEGMENT_TABLE_NAME));
   }
 
   @Override
@@ -61,6 +63,6 @@ public class SegmentUriPushJob extends BaseSegmentJob {
   }
 
   protected ControllerRestApi getControllerRestApi() {
-    return new DefaultControllerRestApi(_pushLocations, null);
+    return new DefaultControllerRestApi(_pushLocations, _rawTableName);
   }
 }

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
@@ -89,7 +89,7 @@ public class SegmentCreationMapper extends Mapper<LongWritable, Text, LongWritab
     _jobConf = context.getConfiguration();
     logConfigurations();
 
-    _rawTableName = Preconditions.checkNotNull(_jobConf.get(JobConfigConstants.SEGMENT_TABLE_NAME));
+    _rawTableName = _jobConf.get(JobConfigConstants.SEGMENT_TABLE_NAME);
     _schema = Schema.fromString(_jobConf.get(JobConfigConstants.SCHEMA));
 
     // Optional

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -273,7 +273,7 @@ public abstract class ClusterTest extends ControllerTest {
    *
    * @param segmentDir Segment directory
    */
-  protected void uploadSegments(@Nonnull File segmentDir)
+  protected void uploadSegments(@Nonnull String tableName, @Nonnull File segmentDir)
       throws Exception {
     String[] segmentNames = segmentDir.list();
     Assert.assertNotNull(segmentNames);
@@ -290,7 +290,7 @@ public abstract class ClusterTest extends ControllerTest {
           @Override
           public Integer call()
               throws Exception {
-            return fileUploadDownloadClient.uploadSegment(uploadSegmentHttpURI, segmentName, segmentFile)
+            return fileUploadDownloadClient.uploadSegment(uploadSegmentHttpURI, segmentName, segmentFile, tableName)
                 .getStatusCode();
           }
         }));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTests.java
@@ -192,7 +192,7 @@ public class ControllerPeriodicTasksIntegrationTests extends BaseClusterIntegrat
         null, null, null, executor);
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);
-    uploadSegments(_tarDir);
+    uploadSegments(getTableName(), _tarDir);
     waitForAllDocsLoaded(600_000L);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DeleteAPIHybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DeleteAPIHybridClusterIntegrationTest.java
@@ -314,7 +314,7 @@ public class DeleteAPIHybridClusterIntegrationTest extends HybridClusterIntegrat
 
   private void repushOfflineSegments()
       throws Exception {
-    uploadSegments(_tarDir);
+    uploadSegments(getTableName(), _tarDir);
     waitForNumRows(nOfflineRows, CommonConstants.Helix.TableType.OFFLINE);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -97,7 +97,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
     setUpTable(avroFiles.get(0));
 
     // Upload all segments
-    uploadSegments(_tarDir);
+    uploadSegments(getTableName(), _tarDir);
 
     // Wait for all documents loaded
     waitForAllDocsLoaded(600_000L);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTestCommandLineRunner.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTestCommandLineRunner.java
@@ -299,7 +299,7 @@ public class HybridClusterIntegrationTestCommandLineRunner {
           _sortedColumn, _invertedIndexColumns, null, null, null, getStreamConsumerFactoryClassName(), null);
 
       // Upload all segments
-      uploadSegments(_tarDir);
+      uploadSegments(getTableName(), _tarDir);
     }
 
     @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MetadataAndDictionaryAggregationPlanClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MetadataAndDictionaryAggregationPlanClusterIntegrationTest.java
@@ -138,7 +138,7 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);
 
-    uploadSegments(_tarDir);
+    uploadSegments(getTableName(), _tarDir);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -124,7 +124,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     completeTableConfiguration();
 
     // Upload all segments
-    uploadSegments(_tarDir);
+    uploadSegments(getTableName(), _tarDir);
 
     // Set up service status callbacks
     // NOTE: put this step after creating the table and uploading all segments so that brokers and servers can find the
@@ -199,7 +199,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // Refresh time is when the segment gets refreshed (existing segment)
     long refreshTime = segmentZKMetadata.getRefreshTime();
 
-    uploadSegments(_tarDir);
+    uploadSegments(getTableName(), _tarDir);
     for (OfflineSegmentZKMetadata segmentZKMetadataAfterUpload : _helixResourceManager
         .getOfflineSegmentMetadata(getTableName())) {
       // Only check one segment

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PinotURIUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PinotURIUploadIntegrationTest.java
@@ -43,9 +43,11 @@ import org.apache.commons.io.FileUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
@@ -252,9 +254,12 @@ public class PinotURIUploadIntegrationTest extends BaseClusterIntegrationTestSet
           @Override
           public Integer call()
               throws Exception {
+            List<NameValuePair> parameters = Collections.singletonList(
+                new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, getTableName()));
+
             return fileUploadDownloadClient
                 .sendSegmentUri(FileUploadDownloadClient.getUploadSegmentHttpURI(LOCAL_HOST, _controllerPort),
-                    downloadUri, httpHeaders, null, 60 * 1000).getStatusCode();
+                    downloadUri, httpHeaders, parameters, 60 * 1000).getStatusCode();
           }
         }));
       }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -135,7 +135,7 @@ public class StarTreeClusterIntegrationTest extends BaseClusterIntegrationTest {
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);
 
-    uploadSegments(_tarDir);
+    uploadSegments(getTableName(), _tarDir);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StarTreeV2ClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StarTreeV2ClusterIntegrationTest.java
@@ -119,7 +119,7 @@ public class StarTreeV2ClusterIntegrationTest extends StarTreeClusterIntegration
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);
 
-    uploadSegments(_tarDir);
+    uploadSegments(getTableName(), _tarDir);
   }
 
   private static StarTreeV2BuilderConfig getBuilderConfig(List<String> dimensions, List<String> metrics) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -121,7 +121,7 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
     executor.shutdown();
     executor.awaitTermination(1L, TimeUnit.MINUTES);
 
-    uploadSegments(segmentTarDir);
+    uploadSegments(getTableName(), segmentTarDir);
 
     FileUtils.forceDelete(avroFile);
     FileUtils.forceDelete(segmentTarDir);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
@@ -22,20 +22,16 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
-import org.apache.http.Header;
 import org.apache.http.NameValuePair;
-import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.pinot.common.config.PinotTaskConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.segment.fetcher.SegmentFetcherFactory;
-import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.common.MinionConstants;
@@ -136,20 +132,15 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         File convertedTarredSegmentFile = tarredSegmentFiles.get(i);
         String resultSegmentName = segmentConversionResults.get(i).getSegmentName();
 
-        // Add table name and segment name to headers
-        Header tableNameHeader = new BasicHeader(CommonConstants.Controller.TABLE_NAME_HTTP_HEADER,
-            TableNameBuilder.extractRawTableName(tableNameWithType));
-        Header segmentNameHeader =
-            new BasicHeader(CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER, resultSegmentName);
-
-        List<Header> httpHeaders = Arrays.asList(tableNameHeader, segmentNameHeader);
-
         // Set parameters for upload request
-        List<NameValuePair> parameters = Collections.singletonList(
-            new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION, "true"));
+        NameValuePair enableParallelPushProtectionParameter =
+            new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION, "true");
+        NameValuePair tableNameParameter = new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME,
+            TableNameBuilder.extractRawTableName(tableNameWithType));
+        List<NameValuePair> parameters = Arrays.asList(enableParallelPushProtectionParameter, tableNameParameter);
 
         SegmentConversionUtils
-            .uploadSegment(configs, httpHeaders, parameters, tableNameWithType, resultSegmentName, uploadURL,
+            .uploadSegment(configs, null, parameters, tableNameWithType, resultSegmentName, uploadURL,
                 convertedTarredSegmentFile);
       }
 

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
@@ -21,16 +21,21 @@ package org.apache.pinot.minion.executor;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
+import org.apache.http.Header;
 import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.pinot.common.config.PinotTaskConfig;
+import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.segment.fetcher.SegmentFetcherFactory;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.common.MinionConstants;
@@ -131,12 +136,21 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         File convertedTarredSegmentFile = tarredSegmentFiles.get(i);
         String resultSegmentName = segmentConversionResults.get(i).getSegmentName();
 
+        // Add table name and segment name to headers
+        Header tableNameHeader = new BasicHeader(CommonConstants.Controller.TABLE_NAME_HTTP_HEADER,
+            TableNameBuilder.extractRawTableName(tableNameWithType));
+        Header segmentNameHeader =
+            new BasicHeader(CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER, resultSegmentName);
+
+        List<Header> httpHeaders = Arrays.asList(tableNameHeader, segmentNameHeader);
+
         // Set parameters for upload request
         List<NameValuePair> parameters = Collections.singletonList(
             new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION, "true"));
 
-        SegmentConversionUtils.uploadSegment(configs, null, parameters, tableNameWithType, resultSegmentName, uploadURL,
-            convertedTarredSegmentFile);
+        SegmentConversionUtils
+            .uploadSegment(configs, httpHeaders, parameters, tableNameWithType, resultSegmentName, uploadURL,
+                convertedTarredSegmentFile);
       }
 
       String outputSegmentNames = segmentConversionResults.stream().map(SegmentConversionResult::getSegmentName)

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
@@ -32,8 +32,10 @@ import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.pinot.common.config.PinotTaskConfig;
+import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.segment.fetcher.SegmentFetcherFactory;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.common.MinionConstants;
@@ -135,7 +137,13 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
           new BasicHeader(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER,
               segmentZKMetadataCustomMapModifier.toJsonString());
 
-      List<Header> httpHeaders = Arrays.asList(ifMatchHeader, segmentZKMetadataCustomMapModifierHeader);
+      // Add table name and segment name to headers
+      Header tableNameHeader = new BasicHeader(CommonConstants.Controller.TABLE_NAME_HTTP_HEADER,
+          TableNameBuilder.extractRawTableName(tableNameWithType));
+      Header segmentNameHeader = new BasicHeader(CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER, segmentName);
+
+      List<Header> httpHeaders =
+          Arrays.asList(ifMatchHeader, segmentZKMetadataCustomMapModifierHeader, tableNameHeader, segmentNameHeader);
 
       // Set parameters for upload request.
       List<NameValuePair> parameters = Collections.singletonList(

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
@@ -21,7 +21,6 @@ package org.apache.pinot.minion.executor;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -137,17 +136,15 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
           new BasicHeader(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER,
               segmentZKMetadataCustomMapModifier.toJsonString());
 
-      // Add table name and segment name to headers
-      Header tableNameHeader = new BasicHeader(CommonConstants.Controller.TABLE_NAME_HTTP_HEADER,
-          TableNameBuilder.extractRawTableName(tableNameWithType));
-      Header segmentNameHeader = new BasicHeader(CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER, segmentName);
-
       List<Header> httpHeaders =
-          Arrays.asList(ifMatchHeader, segmentZKMetadataCustomMapModifierHeader, tableNameHeader, segmentNameHeader);
+          Arrays.asList(ifMatchHeader, segmentZKMetadataCustomMapModifierHeader);
 
       // Set parameters for upload request.
-      List<NameValuePair> parameters = Collections.singletonList(
-          new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION, "true"));
+      NameValuePair enableParallelPushProtectionParameter =
+          new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION, "true");
+      NameValuePair tableNameParameter = new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME,
+          TableNameBuilder.extractRawTableName(tableNameWithType));
+      List<NameValuePair> parameters = Arrays.asList(enableParallelPushProtectionParameter, tableNameParameter);
 
       // Upload the tarred segment
       SegmentConversionUtils

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
@@ -94,7 +94,6 @@ public class BenchmarkQueryEngine {
     conf.setStartController(true);
     conf.setStartServer(true);
     conf.setStartZookeeper(true);
-    conf.setUploadIndexes(false);
     conf.setRunQueries(false);
     conf.setServerInstanceSegmentTarDir(null);
     conf.setServerInstanceDataDir(DATA_DIRECTORY);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BackfillDateTimeColumnCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BackfillDateTimeColumnCommand.java
@@ -208,7 +208,7 @@ public class BackfillDateTimeColumnCommand extends AbstractBaseAdminCommand impl
 
       // upload segment
       LOGGER.info("Uploading segment {} to host: {} port: {}", segmentName, _controllerHost, _controllerPort);
-      backfillSegmentUtils.uploadSegment(segmentName, new File(outputDir, segmentName), outputDir);
+      backfillSegmentUtils.uploadSegment(_tableName, segmentName, new File(outputDir, segmentName), outputDir);
     }
 
     // verify that all segments exist

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -50,6 +50,10 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
   @Option(name = "-segmentDir", required = true, metaVar = "<string>", usage = "Path to segment directory.")
   private String _segmentDir = null;
 
+  // TODO: make this as a requied field once we deprecate the table name from segment metadata
+  @Option(name = "-tableName", required = false, metaVar = "<string>", usage = "Table name to upload.")
+  private String _tableName = null;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -127,7 +131,7 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
         }
 
         LOGGER.info("Uploading segment {}", tgzFile.getName());
-        fileUploadDownloadClient.uploadSegment(uploadSegmentHttpURI, tgzFile.getName(), tgzFile);
+        fileUploadDownloadClient.uploadSegment(uploadSegmentHttpURI, tgzFile.getName(), tgzFile, _tableName);
       }
     } finally {
       // Delete the temporary working directory.

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -50,7 +50,7 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
   @Option(name = "-segmentDir", required = true, metaVar = "<string>", usage = "Path to segment directory.")
   private String _segmentDir = null;
 
-  // TODO: make this as a requied field once we deprecate the table name from segment metadata
+  // TODO: make this as a required field once we deprecate the table name from segment metadata
   @Option(name = "-tableName", required = false, metaVar = "<string>", usage = "Table name to upload.")
   private String _tableName = null;
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/backfill/BackfillSegmentUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/backfill/BackfillSegmentUtils.java
@@ -159,7 +159,7 @@ public class BackfillSegmentUtils {
   /**
    * Uploads the segment tar to the controller.
    */
-  public boolean uploadSegment(String segmentName, File segmentDir, File outputDir) {
+  public boolean uploadSegment(String rawTableName, String segmentName, File segmentDir, File outputDir) {
     boolean success = true;
 
     File segmentTar = new File(outputDir, segmentName + TAR_SUFFIX);
@@ -170,12 +170,13 @@ public class BackfillSegmentUtils {
       try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
         SimpleHttpResponse response = fileUploadDownloadClient.uploadSegment(
             FileUploadDownloadClient.getUploadSegmentHttpURI(_controllerHost, Integer.parseInt(_controllerPort)),
-            segmentName, segmentTar);
+            segmentName, segmentTar, rawTableName);
         int statusCode = response.getStatusCode();
         if (statusCode != HttpStatus.SC_OK) {
           success = false;
         }
-        LOGGER.info("Uploaded segment: {} and got response {}: {}", segmentName, statusCode, response.getResponse());
+        LOGGER.info("Uploaded segment: {} to table {} and got response {}: {}", segmentName, rawTableName, statusCode,
+            response.getResponse());
       }
     } catch (Exception e) {
       LOGGER.error("Exception in segment upload {}", segmentTar, e);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -170,7 +170,6 @@ public class PerfBenchmarkDriver {
     startServer();
     startHelixResourceManager();
     configureResources();
-    uploadIndexSegments();
     waitForExternalViewUpdate(_zkAddress, _clusterName, 60 * 1000L);
     postQueries();
   }
@@ -294,24 +293,6 @@ public class PerfBenchmarkDriver {
         .setSegmentVersion(_segmentFormatVersion).setInvertedIndexColumns(invertedIndexColumns)
         .setBloomFilterColumns(bloomFilterColumns).build();
     _helixResourceManager.addTable(tableConfig);
-  }
-
-  private void uploadIndexSegments()
-      throws Exception {
-    if (!_conf.isUploadIndexes()) {
-      LOGGER.info("Skipping upload index segments step.");
-      return;
-    }
-    String indexDirectory = _conf.getIndexDirectory();
-    File[] indexFiles = new File(indexDirectory).listFiles();
-    Preconditions.checkNotNull(indexFiles);
-    try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
-      URI uploadSegmentHttpURI = FileUploadDownloadClient.getUploadSegmentHttpURI(_controllerHost, _controllerPort);
-      for (File indexFile : indexFiles) {
-        LOGGER.info("Uploading index segment: {}", indexFile.getAbsolutePath());
-        fileUploadDownloadClient.uploadSegment(uploadSegmentHttpURI, indexFile.getName(), indexFile);
-      }
-    }
   }
 
   /**

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
@@ -57,18 +57,6 @@ public class PerfBenchmarkDriverConf {
   String brokerHost = "localhost";
   boolean startBroker = true;
 
-  //data configuration
-  //where is the raw data, mandatory if regenerateIndex = true
-  boolean uploadIndexes = false;
-
-  String rawDataDirectory;
-
-  boolean regenerateIndex = false;
-
-  //by default all files under indexDirectory will be uploaded to the controller if its not already present.
-  //If the indexes are already uploaded, nothing
-  boolean forceReloadIndex = false;
-
   //resource configuration
 
   boolean configureResources = false;
@@ -160,26 +148,6 @@ public class PerfBenchmarkDriverConf {
     return startBroker;
   }
 
-  public boolean isUploadIndexes() {
-    return uploadIndexes;
-  }
-
-  public void setUploadIndexes(boolean uploadIndexes) {
-    this.uploadIndexes = uploadIndexes;
-  }
-
-  public String getRawDataDirectory() {
-    return rawDataDirectory;
-  }
-
-  public boolean isRegenerateIndex() {
-    return regenerateIndex;
-  }
-
-  public boolean isForceReloadIndex() {
-    return forceReloadIndex;
-  }
-
   public String getQueriesDirectory() {
     return queriesDirectory;
   }
@@ -254,18 +222,6 @@ public class PerfBenchmarkDriverConf {
 
   public void setStartBroker(boolean startBroker) {
     this.startBroker = startBroker;
-  }
-
-  public void setRawDataDirectory(String rawDataDirectory) {
-    this.rawDataDirectory = rawDataDirectory;
-  }
-
-  public void setRegenerateIndex(boolean regenerateIndex) {
-    this.regenerateIndex = regenerateIndex;
-  }
-
-  public void setForceReloadIndex(boolean forceReloadIndex) {
-    this.forceReloadIndex = forceReloadIndex;
   }
 
   public boolean isRunQueries() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
@@ -64,8 +64,6 @@ public class PerfBenchmarkDriverConf {
   String rawDataDirectory;
 
   boolean regenerateIndex = false;
-  //if the regenerateIndex is true, the indexes under this directory will be deleted and recreated from rawData.
-  String indexDirectory;
 
   //by default all files under indexDirectory will be uploaded to the controller if its not already present.
   //If the indexes are already uploaded, nothing
@@ -178,10 +176,6 @@ public class PerfBenchmarkDriverConf {
     return regenerateIndex;
   }
 
-  public String getIndexDirectory() {
-    return indexDirectory;
-  }
-
   public boolean isForceReloadIndex() {
     return forceReloadIndex;
   }
@@ -270,10 +264,6 @@ public class PerfBenchmarkDriverConf {
     this.regenerateIndex = regenerateIndex;
   }
 
-  public void setIndexDirectory(String indexDirectory) {
-    this.indexDirectory = indexDirectory;
-  }
-
   public void setForceReloadIndex(boolean forceReloadIndex) {
     this.forceReloadIndex = forceReloadIndex;
   }
@@ -316,14 +306,5 @@ public class PerfBenchmarkDriverConf {
 
   public void setSchemaFileNamePath(String schemaFileNamePath) {
     this.schemaFileNamePath = schemaFileNamePath;
-  }
-
-  public static void main(String[] args) {
-    DumperOptions options = new DumperOptions();
-    options.setIndent(4);
-    options.setDefaultFlowStyle(FlowStyle.BLOCK);
-    Yaml yaml = new Yaml(options);
-    String dump = yaml.dump(new PerfBenchmarkDriverConf());
-    System.out.println(dump);
   }
 }


### PR DESCRIPTION
1. Add table name parameter for hadoop tar and uri push job
2. Add table name parameter for minion segment conversion executor
3. Make upload segment api to derive the table name from the
   parameter and then from the segment metadata
4. Remove precondition table name check for SegmentCreationMapper

Next step will be deprecating table.name from segment metadata