### PR TITLE
Fix num entries scanned in filter for MultiValue scanner

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -80,9 +80,12 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
       return false;
     }
     valueIterator.skipTo(docId);
-    _numEntriesScanned++;
+    //_numEntriesScanned++;
     int length = valueIterator.nextIntVal(intArray);
-    return evaluator.applyMV(intArray, length);
+    int[] numEntriesScannedInEvaluator={0};
+    boolean ret=evaluator.applyMV(intArray, length,numEntriesScannedInEvaluator);
+    _numEntriesScanned+=numEntriesScannedInEvaluator[0];
+    return ret;
   }
 
   @Override
@@ -110,15 +113,18 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     if (currentDocId == Constants.EOF) {
       return currentDocId;
     }
+    int[] numEntriesScannedInEvaluator={0};
     while (valueIterator.hasNext() && currentDocId < endDocId) {
       currentDocId = currentDocId + 1;
-      _numEntriesScanned++;
+      //_numEntriesScanned++;
       int length = valueIterator.nextIntVal(intArray);
-      if (evaluator.applyMV(intArray, length)) {
+      if (evaluator.applyMV(intArray, length, numEntriesScannedInEvaluator)) {
+        _numEntriesScanned+=numEntriesScannedInEvaluator[0];
         return currentDocId;
       }
     }
     currentDocId = Constants.EOF;
+    _numEntriesScanned+=numEntriesScannedInEvaluator[0];
     return Constants.EOF;
   }
 
@@ -141,17 +147,19 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     }
     IntIterator intIterator = answer.getIntIterator();
     int docId = -1, length;
+    int[] numEntriesScannedInEvaluator={0};
     while (intIterator.hasNext() && docId < endDocId) {
       docId = intIterator.next();
       if (docId >= startDocId) {
         valueIterator.skipTo(docId);
-        _numEntriesScanned++;
+        //_numEntriesScanned++;
         length = valueIterator.nextIntVal(intArray);
-        if (evaluator.applyMV(intArray, length)) {
+        if (evaluator.applyMV(intArray, length, numEntriesScannedInEvaluator)) {
           result.add(docId);
         }
       }
     }
+    _numEntriesScanned+=numEntriesScannedInEvaluator[0];
     return result;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -81,9 +81,9 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     }
     valueIterator.skipTo(docId);
     int length = valueIterator.nextIntVal(intArray);
-    int[] numEntriesScannedInEvaluator={0};
-    boolean ret=evaluator.applyMV(intArray, length,numEntriesScannedInEvaluator);
-    _numEntriesScanned+=numEntriesScannedInEvaluator[0];
+    int[] numEntriesScannedInEvaluator = {0};
+    boolean ret = evaluator.applyMV(intArray, length, numEntriesScannedInEvaluator);
+    _numEntriesScanned += numEntriesScannedInEvaluator[0];
     return ret;
   }
 
@@ -112,17 +112,17 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     if (currentDocId == Constants.EOF) {
       return currentDocId;
     }
-    int[] numEntriesScannedInEvaluator={0};
+    int[] numEntriesScannedInEvaluator = {0};
     while (valueIterator.hasNext() && currentDocId < endDocId) {
       currentDocId = currentDocId + 1;
       int length = valueIterator.nextIntVal(intArray);
       if (evaluator.applyMV(intArray, length, numEntriesScannedInEvaluator)) {
-        _numEntriesScanned+=numEntriesScannedInEvaluator[0];
+        _numEntriesScanned += numEntriesScannedInEvaluator[0];
         return currentDocId;
       }
     }
     currentDocId = Constants.EOF;
-    _numEntriesScanned+=numEntriesScannedInEvaluator[0];
+    _numEntriesScanned += numEntriesScannedInEvaluator[0];
     return Constants.EOF;
   }
 
@@ -145,7 +145,7 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     }
     IntIterator intIterator = answer.getIntIterator();
     int docId = -1, length;
-    int[] numEntriesScannedInEvaluator={0};
+    int[] numEntriesScannedInEvaluator = {0};
     while (intIterator.hasNext() && docId < endDocId) {
       docId = intIterator.next();
       if (docId >= startDocId) {
@@ -156,7 +156,7 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
         }
       }
     }
-    _numEntriesScanned+=numEntriesScannedInEvaluator[0];
+    _numEntriesScanned += numEntriesScannedInEvaluator[0];
     return result;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.dociditerators;
 
 import java.util.Arrays;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pinot.core.common.BlockMetadata;
 import org.apache.pinot.core.common.BlockMultiValIterator;
 import org.apache.pinot.core.common.BlockValSet;
@@ -81,9 +82,9 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     }
     valueIterator.skipTo(docId);
     int length = valueIterator.nextIntVal(intArray);
-    int[] numEntriesScannedInEvaluator = {0};
+    MutableInt numEntriesScannedInEvaluator = new MutableInt(0);
     boolean ret = evaluator.applyMV(intArray, length, numEntriesScannedInEvaluator);
-    _numEntriesScanned += numEntriesScannedInEvaluator[0];
+    _numEntriesScanned += numEntriesScannedInEvaluator.toInteger();
     return ret;
   }
 
@@ -112,17 +113,17 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     if (currentDocId == Constants.EOF) {
       return currentDocId;
     }
-    int[] numEntriesScannedInEvaluator = {0};
+    MutableInt numEntriesScannedInEvaluator = new MutableInt(0);
     while (valueIterator.hasNext() && currentDocId < endDocId) {
       currentDocId = currentDocId + 1;
       int length = valueIterator.nextIntVal(intArray);
       if (evaluator.applyMV(intArray, length, numEntriesScannedInEvaluator)) {
-        _numEntriesScanned += numEntriesScannedInEvaluator[0];
+        _numEntriesScanned += numEntriesScannedInEvaluator.toInteger();
         return currentDocId;
       }
     }
     currentDocId = Constants.EOF;
-    _numEntriesScanned += numEntriesScannedInEvaluator[0];
+    _numEntriesScanned += numEntriesScannedInEvaluator.toInteger();
     return Constants.EOF;
   }
 
@@ -145,7 +146,7 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     }
     IntIterator intIterator = answer.getIntIterator();
     int docId = -1, length;
-    int[] numEntriesScannedInEvaluator = {0};
+    MutableInt numEntriesScannedInEvaluator = new MutableInt(0);
     while (intIterator.hasNext() && docId < endDocId) {
       docId = intIterator.next();
       if (docId >= startDocId) {
@@ -156,7 +157,7 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
         }
       }
     }
-    _numEntriesScanned += numEntriesScannedInEvaluator[0];
+    _numEntriesScanned += numEntriesScannedInEvaluator.toInteger();
     return result;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -80,7 +80,6 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
       return false;
     }
     valueIterator.skipTo(docId);
-    //_numEntriesScanned++;
     int length = valueIterator.nextIntVal(intArray);
     int[] numEntriesScannedInEvaluator={0};
     boolean ret=evaluator.applyMV(intArray, length,numEntriesScannedInEvaluator);
@@ -116,7 +115,6 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     int[] numEntriesScannedInEvaluator={0};
     while (valueIterator.hasNext() && currentDocId < endDocId) {
       currentDocId = currentDocId + 1;
-      //_numEntriesScanned++;
       int length = valueIterator.nextIntVal(intArray);
       if (evaluator.applyMV(intArray, length, numEntriesScannedInEvaluator)) {
         _numEntriesScanned+=numEntriesScannedInEvaluator[0];
@@ -152,7 +150,6 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
       docId = intIterator.next();
       if (docId >= startDocId) {
         valueIterator.skipTo(docId);
-        //_numEntriesScanned++;
         length = valueIterator.nextIntVal(intArray);
         if (evaluator.applyMV(intArray, length, numEntriesScannedInEvaluator)) {
           result.add(docId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictionaryBasedPredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictionaryBasedPredicateEvaluator.java
@@ -105,20 +105,20 @@ public abstract class BaseDictionaryBasedPredicateEvaluator extends BasePredicat
     if (isExclusive()) {
       for (int i = 0; i < length; i++) {
         if (!applySV(dictIds[i])) {
-          numEntriesScanned[0]+=i+1;
+          numEntriesScanned[0] += i + 1;
           return false;
         }
       }
-      numEntriesScanned[0]+=length;
+      numEntriesScanned[0] += length;
       return true;
     } else {
       for (int i = 0; i < length; i++) {
         if (applySV(dictIds[i])) {
-          numEntriesScanned[0]+=i+1;
+          numEntriesScanned[0] += i + 1;
           return true;
         }
       }
-      numEntriesScanned[0]+=length;
+      numEntriesScanned[0] += length;
       return false;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictionaryBasedPredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictionaryBasedPredicateEvaluator.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.operator.filter.predicate;
 
+import org.apache.commons.lang3.mutable.MutableInt;
+
+
 public abstract class BaseDictionaryBasedPredicateEvaluator extends BasePredicateEvaluator {
   protected boolean _alwaysTrue;
   protected boolean _alwaysFalse;
@@ -101,24 +104,24 @@ public abstract class BaseDictionaryBasedPredicateEvaluator extends BasePredicat
    */
   @SuppressWarnings("Duplicates")
   @Override
-  public boolean applyMV(int[] dictIds, int length, int[] numEntriesScanned) {
+  public boolean applyMV(int[] dictIds, int length, MutableInt numEntriesScanned) {
     if (isExclusive()) {
       for (int i = 0; i < length; i++) {
         if (!applySV(dictIds[i])) {
-          numEntriesScanned[0] += i + 1;
+          numEntriesScanned.add(i + 1);
           return false;
         }
       }
-      numEntriesScanned[0] += length;
+      numEntriesScanned.add(length);
       return true;
     } else {
       for (int i = 0; i < length; i++) {
         if (applySV(dictIds[i])) {
-          numEntriesScanned[0] += i + 1;
+          numEntriesScanned.add(i + 1);
           return true;
         }
       }
-      numEntriesScanned[0] += length;
+      numEntriesScanned.add(length);
       return false;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictionaryBasedPredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictionaryBasedPredicateEvaluator.java
@@ -101,20 +101,24 @@ public abstract class BaseDictionaryBasedPredicateEvaluator extends BasePredicat
    */
   @SuppressWarnings("Duplicates")
   @Override
-  public boolean applyMV(int[] dictIds, int length) {
+  public boolean applyMV(int[] dictIds, int length, int[] numEntriesScanned) {
     if (isExclusive()) {
       for (int i = 0; i < length; i++) {
         if (!applySV(dictIds[i])) {
+          numEntriesScanned[0]+=i+1;
           return false;
         }
       }
+      numEntriesScanned[0]+=length;
       return true;
     } else {
       for (int i = 0; i < length; i++) {
         if (applySV(dictIds[i])) {
+          numEntriesScanned[0]+=i+1;
           return true;
         }
       }
+      numEntriesScanned[0]+=length;
       return false;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseRawValueBasedPredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseRawValueBasedPredicateEvaluator.java
@@ -69,20 +69,20 @@ public abstract class BaseRawValueBasedPredicateEvaluator extends BasePredicateE
     if (isExclusive()) {
       for (int i = 0; i < length; i++) {
         if (!applySV(values[i])) {
-          numEntriesScanned[0]+=i+1;
+          numEntriesScanned[0] += i + 1;
           return false;
         }
       }
-      numEntriesScanned[0]+=length;
+      numEntriesScanned[0] += length;
       return true;
     } else {
       for (int i = 0; i < length; i++) {
         if (applySV(values[i])) {
-          numEntriesScanned[0]+=i+1;
+          numEntriesScanned[0] += i + 1;
           return true;
         }
       }
-      numEntriesScanned[0]+=length;
+      numEntriesScanned[0] += length;
       return false;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseRawValueBasedPredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseRawValueBasedPredicateEvaluator.java
@@ -65,20 +65,24 @@ public abstract class BaseRawValueBasedPredicateEvaluator extends BasePredicateE
    */
   @SuppressWarnings("Duplicates")
   @Override
-  public boolean applyMV(int[] values, int length) {
+  public boolean applyMV(int[] values, int length, int[] numEntriesScanned) {
     if (isExclusive()) {
       for (int i = 0; i < length; i++) {
         if (!applySV(values[i])) {
+          numEntriesScanned[0]+=i+1;
           return false;
         }
       }
+      numEntriesScanned[0]+=length;
       return true;
     } else {
       for (int i = 0; i < length; i++) {
         if (applySV(values[i])) {
+          numEntriesScanned[0]+=i+1;
           return true;
         }
       }
+      numEntriesScanned[0]+=length;
       return false;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseRawValueBasedPredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseRawValueBasedPredicateEvaluator.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.operator.filter.predicate;
 
+import org.apache.commons.lang3.mutable.MutableInt;
+
 public abstract class BaseRawValueBasedPredicateEvaluator extends BasePredicateEvaluator {
 
   @Override
@@ -65,24 +67,24 @@ public abstract class BaseRawValueBasedPredicateEvaluator extends BasePredicateE
    */
   @SuppressWarnings("Duplicates")
   @Override
-  public boolean applyMV(int[] values, int length, int[] numEntriesScanned) {
+  public boolean applyMV(int[] values, int length, MutableInt numEntriesScanned) {
     if (isExclusive()) {
       for (int i = 0; i < length; i++) {
         if (!applySV(values[i])) {
-          numEntriesScanned[0] += i + 1;
+          numEntriesScanned.add(i + 1);
           return false;
         }
       }
-      numEntriesScanned[0] += length;
+      numEntriesScanned.add(length);
       return true;
     } else {
       for (int i = 0; i < length; i++) {
         if (applySV(values[i])) {
-          numEntriesScanned[0] += i + 1;
+          numEntriesScanned.add(i + 1);
           return true;
         }
       }
-      numEntriesScanned[0] += length;
+      numEntriesScanned.add(length);
       return false;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
@@ -66,7 +66,7 @@ public interface PredicateEvaluator {
    * @param length Number of values in the entry
    * @return Whether the entry matches the predicate
    */
-  boolean applyMV(int[] values, int length);
+  boolean applyMV(int[] values, int length, int[] numEntriesScanned);
 
   /**
    * APIs for dictionary based predicate evaluator

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.filter.predicate;
 
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pinot.core.common.Predicate;
 
 
@@ -66,7 +67,7 @@ public interface PredicateEvaluator {
    * @param length Number of values in the entry
    * @return Whether the entry matches the predicate
    */
-  boolean applyMV(int[] values, int length, int[] numEntriesScanned);
+  boolean applyMV(int[] values, int length, MutableInt numEntriesScanned);
 
   /**
    * APIs for dictionary based predicate evaluator

--- a/pinot-core/src/test/java/org/apache/pinot/core/predicate/NoDictionaryEqualsPredicateEvaluatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/predicate/NoDictionaryEqualsPredicateEvaluatorsTest.java
@@ -66,8 +66,8 @@ public class NoDictionaryEqualsPredicateEvaluatorsTest {
     PredicateEvaluatorTestUtils.fillRandom(randomInts);
     randomInts[_random.nextInt(NUM_MULTI_VALUES)] = intValue;
 
-    Assert.assertTrue(eqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES));
-    Assert.assertFalse(neqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES));
+    Assert.assertTrue(eqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new int[]{0}));
+    Assert.assertFalse(neqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new int[]{0}));
 
     for (int i = 0; i < 100; i++) {
       int random = _random.nextInt();
@@ -75,9 +75,9 @@ public class NoDictionaryEqualsPredicateEvaluatorsTest {
       Assert.assertEquals(neqPredicateEvaluator.applySV(random), (random != intValue));
 
       PredicateEvaluatorTestUtils.fillRandom(randomInts);
-      Assert.assertEquals(eqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES),
+      Assert.assertEquals(eqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new int[]{0}),
           ArrayUtils.contains(randomInts, intValue));
-      Assert.assertEquals(neqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES),
+      Assert.assertEquals(neqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new int[]{0}),
           !ArrayUtils.contains(randomInts, intValue));
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/predicate/NoDictionaryEqualsPredicateEvaluatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/predicate/NoDictionaryEqualsPredicateEvaluatorsTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Random;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.core.common.predicate.EqPredicate;
 import org.apache.pinot.core.common.predicate.NEqPredicate;
@@ -66,8 +67,8 @@ public class NoDictionaryEqualsPredicateEvaluatorsTest {
     PredicateEvaluatorTestUtils.fillRandom(randomInts);
     randomInts[_random.nextInt(NUM_MULTI_VALUES)] = intValue;
 
-    Assert.assertTrue(eqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new int[]{0}));
-    Assert.assertFalse(neqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new int[]{0}));
+    Assert.assertTrue(eqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new MutableInt(0)));
+    Assert.assertFalse(neqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new MutableInt(0)));
 
     for (int i = 0; i < 100; i++) {
       int random = _random.nextInt();
@@ -75,9 +76,9 @@ public class NoDictionaryEqualsPredicateEvaluatorsTest {
       Assert.assertEquals(neqPredicateEvaluator.applySV(random), (random != intValue));
 
       PredicateEvaluatorTestUtils.fillRandom(randomInts);
-      Assert.assertEquals(eqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new int[]{0}),
+      Assert.assertEquals(eqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new MutableInt(0)),
           ArrayUtils.contains(randomInts, intValue));
-      Assert.assertEquals(neqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new int[]{0}),
+      Assert.assertEquals(neqPredicateEvaluator.applyMV(randomInts, NUM_MULTI_VALUES, new MutableInt(0)),
           !ArrayUtils.contains(randomInts, intValue));
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/predicate/NoDictionaryInPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/predicate/NoDictionaryInPredicateEvaluatorTest.java
@@ -93,8 +93,8 @@ public class NoDictionaryInPredicateEvaluatorTest {
     PredicateEvaluatorTestUtils.fillRandom(multiValues);
     multiValues[_random.nextInt(NUM_MULTI_VALUES)] =
         Integer.parseInt(stringValues.get(_random.nextInt(NUM_PREDICATE_VALUES)));
-    Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
-    Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
+    Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES, new int[]{0}));
+    Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES, new int[]{0}));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/predicate/NoDictionaryInPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/predicate/NoDictionaryInPredicateEvaluatorTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.core.common.predicate.InPredicate;
 import org.apache.pinot.core.common.predicate.NotInPredicate;
@@ -93,8 +94,8 @@ public class NoDictionaryInPredicateEvaluatorTest {
     PredicateEvaluatorTestUtils.fillRandom(multiValues);
     multiValues[_random.nextInt(NUM_MULTI_VALUES)] =
         Integer.parseInt(stringValues.get(_random.nextInt(NUM_PREDICATE_VALUES)));
-    Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES, new int[]{0}));
-    Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES, new int[]{0}));
+    Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES, new MutableInt(0)));
+    Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES, new MutableInt(0)));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/predicate/RangeOfflineDictionaryPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/predicate/RangeOfflineDictionaryPredicateEvaluatorTest.java
@@ -51,8 +51,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{1, 3, 7};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart, rangeEnd);
     }
@@ -72,8 +72,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{1, 3, 7};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart + 1, rangeEnd);
     }
@@ -93,8 +93,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{1, 3, 7};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart, rangeEnd - 1);
     }
@@ -114,8 +114,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{1, 3, 7};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart + 1, rangeEnd - 1);
     }
@@ -146,8 +146,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{5, 7, 9};
-      Assert.assertFalse(evaluator.applyMV(dictIds, dictIds.length));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1));
+      Assert.assertFalse(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart, rangeEnd - 1);
     }
@@ -180,8 +180,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeStart - 1));
 
       int[] dictIds = new int[]{5, 7, 9};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart, rangeEnd);
     }
@@ -233,8 +233,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeStart - 1));
 
       int[] dictIds = new int[]{5, 7, 9};
-      Assert.assertFalse(evaluator.applyMV(dictIds, dictIds.length));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1));
+      Assert.assertFalse(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart + 1, rangeEnd - 1);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/predicate/RangeOfflineDictionaryPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/predicate/RangeOfflineDictionaryPredicateEvaluatorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.predicate;
 
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pinot.core.common.predicate.RangePredicate;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory;
@@ -51,8 +52,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{1, 3, 7};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new MutableInt(0)));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new MutableInt(0)));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart, rangeEnd);
     }
@@ -72,8 +73,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{1, 3, 7};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new MutableInt(0)));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new MutableInt(0)));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart + 1, rangeEnd);
     }
@@ -93,8 +94,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{1, 3, 7};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new MutableInt(0)));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new MutableInt(0)));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart, rangeEnd - 1);
     }
@@ -114,8 +115,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{1, 3, 7};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new MutableInt(0)));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new MutableInt(0)));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart + 1, rangeEnd - 1);
     }
@@ -146,8 +147,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeEnd + 1));
 
       int[] dictIds = new int[]{5, 7, 9};
-      Assert.assertFalse(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
+      Assert.assertFalse(evaluator.applyMV(dictIds, dictIds.length, new MutableInt(0)));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new MutableInt(0)));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart, rangeEnd - 1);
     }
@@ -180,8 +181,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeStart - 1));
 
       int[] dictIds = new int[]{5, 7, 9};
-      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
+      Assert.assertTrue(evaluator.applyMV(dictIds, dictIds.length, new MutableInt(0)));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new MutableInt(0)));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart, rangeEnd);
     }
@@ -233,8 +234,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
       Assert.assertFalse(evaluator.applySV(rangeStart - 1));
 
       int[] dictIds = new int[]{5, 7, 9};
-      Assert.assertFalse(evaluator.applyMV(dictIds, dictIds.length, new int[]{0}));
-      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new int[]{0}));
+      Assert.assertFalse(evaluator.applyMV(dictIds, dictIds.length, new MutableInt(0)));
+      Assert.assertFalse(evaluator.applyMV(dictIds, 1, new MutableInt(0)));
       dictIds = evaluator.getMatchingDictIds();
       verifyDictId(dictIds, rangeStart + 1, rangeEnd - 1);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
@@ -57,8 +57,8 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     // Test query with filter.
     aggregationOperator = getOperatorForQueryWithFilter(query);
     resultsBlock = aggregationOperator.nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 15620L, 263414L, 62480L,
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 15620L, 272276L,
+        62480L,
             100000L);
     QueriesTestUtils
         .testInnerSegmentAggregationResult(resultsBlock.getAggregationResult(), 15620L, 17287754700747L, 999943053,
@@ -82,8 +82,8 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     // Test query with filter.
     aggregationOperator = getOperatorForQueryWithFilter(query);
     resultsBlock = aggregationOperator.nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 15620L, 263414L, 31240L,
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 15620L, 272276L,
+        31240L,
             100000L);
     QueriesTestUtils
         .testInnerSegmentAggregationResult(resultsBlock.getAggregationResult(), 15620L, 28567975886777L, 2147483647,
@@ -107,8 +107,8 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     // Test query with filter.
     aggregationGroupByOperator = getOperatorForQueryWithFilter(query);
     resultsBlock = aggregationGroupByOperator.nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L, 263414L,
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L,
+        272276L,
             78100L, 100000L);
     QueriesTestUtils
         .testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(), "203", 1L, 185436225L,
@@ -132,8 +132,8 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     // Test query with filter.
     aggregationGroupByOperator = getOperatorForQueryWithFilter(query);
     resultsBlock = aggregationGroupByOperator.nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L, 263414L,
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L,
+        272276L,
             109340L, 100000L);
     QueriesTestUtils
         .testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(), "L\t306633\t2147483647",
@@ -156,8 +156,8 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     // Test query with filter.
     aggregationGroupByOperator = getOperatorForQueryWithFilter(query);
     resultsBlock = aggregationGroupByOperator.nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L, 263414L,
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L,
+        272276L,
             109340L, 100000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
         "903461357\tL\t2147483647\t388", 2L, 1806922714L, 652024397, 674022574, 870535054L, 2L);
@@ -180,8 +180,8 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     // Test query with filter.
     aggregationGroupByOperator = getOperatorForQueryWithFilter(query);
     resultsBlock = aggregationGroupByOperator.nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L, 263414L,
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L,
+        272276L,
             109340L, 100000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
         "949960647\t238753654\t2147483647\t2147483647\t674022574\t674022574\t674022574", 2L, 1899921294L, 238753654,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
@@ -109,7 +109,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     resultsBlock = selectionOnlyOperator.nextBlock();
     executionStatistics = selectionOnlyOperator.getExecutionStatistics();
     Assert.assertEquals(executionStatistics.getNumDocsScanned(), 10L);
-    Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 77L);
+    Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 79L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 100L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
     selectionDataSchema = resultsBlock.getSelectionDataSchema();
@@ -160,7 +160,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     resultsBlock = selectionOnlyOperator.nextBlock();
     executionStatistics = selectionOnlyOperator.getExecutionStatistics();
     Assert.assertEquals(executionStatistics.getNumDocsScanned(), 10L);
-    Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 77L);
+    Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 79L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 30L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
     selectionDataSchema = resultsBlock.getSelectionDataSchema();
@@ -211,7 +211,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     resultsBlock = selectionOrderByOperator.nextBlock();
     executionStatistics = selectionOrderByOperator.getExecutionStatistics();
     Assert.assertEquals(executionStatistics.getNumDocsScanned(), 15620L);
-    Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 263414L);
+    Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 272276L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 62480L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
     selectionDataSchema = resultsBlock.getSelectionDataSchema();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
@@ -42,8 +42,8 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"426752"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L, new String[]{"62480"});
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
+        new String[]{"62480"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
@@ -63,7 +63,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -84,7 +84,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"1001.00000"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"1009.00000"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -105,7 +105,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         new String[]{"484324601810280.00000"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"114652613591912.00000"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -126,7 +126,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         new String[]{"1134908803.73210"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"1835029026.75916"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -147,7 +147,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         new String[]{"2147482646.00000"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147482638.00000"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -168,8 +168,8 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"18499"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L, new String[]{"1186"});
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
+        new String[]{"1186"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
@@ -189,8 +189,8 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"20039"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L, new String[]{"1296"});
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
+        new String[]{"1296"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
@@ -211,8 +211,8 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, cardinalityExtractor, new String[]{"20039"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L, cardinalityExtractor, new String[]{"1296"});
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
+        cardinalityExtractor, new String[]{"1296"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
@@ -232,7 +232,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -253,7 +253,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -274,7 +274,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -295,7 +295,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -316,7 +316,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -337,7 +337,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -358,7 +358,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
@@ -379,7 +379,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1053656L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);


### PR DESCRIPTION
The calculation of numEntriesScanned in MVScanDocIdIterator does not correctly reflect the actual number entries in multi-value case. The counter should be increase by the actual entries scanned in a multi-value instead of 1.