### PR TITLE
Remove the usage of guava deprecated methods

### DIFF
--- a/pinot-server/src/test/java/org/apache/pinot/server/request/ScheduledRequestHandlerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/request/ScheduledRequestHandlerTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pinot.server.request;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.IOException;
 import java.util.Arrays;
@@ -115,8 +115,7 @@ public class ScheduledRequestHandlerTest {
             // Specifying it for less ambiguity.
             ListenableFuture<DataTable> dataTable = resourceManager.getQueryRunners().submit(new Callable<DataTable>() {
               @Override
-              public DataTable call()
-                  throws Exception {
+              public DataTable call() {
                 throw new RuntimeException("query processing error");
               }
             });
@@ -124,7 +123,7 @@ public class ScheduledRequestHandlerTest {
               DataTable result = new DataTableImplV2();
               result.addException(QueryException.INTERNAL_ERROR);
               return result;
-            });
+            }, MoreExecutors.directExecutor());
             return serializeData(queryResponse);
           }
 
@@ -199,13 +198,13 @@ public class ScheduledRequestHandlerTest {
   }
 
   private ListenableFuture<byte[]> serializeData(ListenableFuture<DataTable> dataTable) {
-    return Futures.transform(dataTable, (Function<DataTable, byte[]>) input -> {
+    return Futures.transform(dataTable, input -> {
       try {
         Preconditions.checkNotNull(input);
         return input.toBytes();
       } catch (IOException e) {
         return new byte[0];
       }
-    });
+    }, MoreExecutors.directExecutor());
   }
 }

--- a/pinot-transport/src/main/java/org/apache/pinot/transport/netty/NettyServer.java
+++ b/pinot-transport/src/main/java/org/apache/pinot/transport/netty/NettyServer.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -290,7 +291,7 @@ public abstract class NettyServer implements Runnable {
           LOGGER.error("Request processing returned unhandled exception, error: ", t);
           sendResponse(new byte[0]);
         }
-      });
+      }, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/pinot-transport/src/test/java/org/apache/pinot/transport/perf/ScatterGatherPerfClient.java
+++ b/pinot-transport/src/test/java/org/apache/pinot/transport/perf/ScatterGatherPerfClient.java
@@ -152,9 +152,8 @@ public class ScatterGatherPerfClient implements Runnable {
 
     NettyClientMetrics clientMetrics = new NettyClientMetrics(registry, "client_");
     PooledNettyClientResourceManager rm = new PooledNettyClientResourceManager(_eventLoopGroup, _timer, clientMetrics);
-    _pool =
-        new KeyedPoolImpl<PooledNettyClientResourceManager.PooledClientConnection>(1, _maxActiveConnections, 300000, 10,
-            rm, _timedExecutor, MoreExecutors.sameThreadExecutor(), registry);
+    _pool = new KeyedPoolImpl<>(1, _maxActiveConnections, 300000, 10, rm, _timedExecutor,
+        MoreExecutors.newDirectExecutorService(), registry);
     rm.setPool(_pool);
     _scatterGather = new ScatterGatherImpl(_pool, _service);
     for (AsyncReader r : _readerThreads) {

--- a/pinot-transport/src/test/java/org/apache/pinot/transport/pool/AsyncPoolResourceManagerAdapterTest.java
+++ b/pinot-transport/src/test/java/org/apache/pinot/transport/pool/AsyncPoolResourceManagerAdapterTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.transport.pool;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import java.util.concurrent.ExecutorService;
 import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.transport.common.Callback;
 import org.testng.Assert;
@@ -26,6 +27,7 @@ import org.testng.annotations.Test;
 
 
 public class AsyncPoolResourceManagerAdapterTest {
+  private static final ExecutorService EXECUTOR_SERVICE = MoreExecutors.newDirectExecutorService();
 
   @Test
   public void testCreate() {
@@ -36,7 +38,7 @@ public class AsyncPoolResourceManagerAdapterTest {
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(true, value);
       AsyncPoolResourceManagerAdapter<String> adapter =
-          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+          new AsyncPoolResourceManagerAdapter<>(key, rm, EXECUTOR_SERVICE, null);
       MyCallback callback = new MyCallback();
 
       adapter.create(callback);
@@ -52,7 +54,7 @@ public class AsyncPoolResourceManagerAdapterTest {
       ServerInstance key = new ServerInstance("localhost:8080");
       MyPooledResourceManager rm = new MyPooledResourceManager(true, null);
       AsyncPoolResourceManagerAdapter<String> adapter =
-          new AsyncPoolResourceManagerAdapter<String>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+          new AsyncPoolResourceManagerAdapter<String>(key, rm, EXECUTOR_SERVICE, null);
       MyCallback callback = new MyCallback();
 
       adapter.create(callback);
@@ -72,7 +74,7 @@ public class AsyncPoolResourceManagerAdapterTest {
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(true, null);
       AsyncPoolResourceManagerAdapter<String> adapter =
-          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+          new AsyncPoolResourceManagerAdapter<>(key, rm, EXECUTOR_SERVICE, null);
 
       boolean ret = adapter.validateGet(value);
       Assert.assertTrue(ret, "Validate Return");
@@ -93,7 +95,7 @@ public class AsyncPoolResourceManagerAdapterTest {
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(false, null);
       AsyncPoolResourceManagerAdapter<String> adapter =
-          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+          new AsyncPoolResourceManagerAdapter<>(key, rm, EXECUTOR_SERVICE, null);
 
       boolean ret = adapter.validateGet(value);
       Assert.assertFalse(ret, "Validate Return");
@@ -119,7 +121,7 @@ public class AsyncPoolResourceManagerAdapterTest {
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(true, null);
       AsyncPoolResourceManagerAdapter<String> adapter =
-          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+          new AsyncPoolResourceManagerAdapter<>(key, rm, EXECUTOR_SERVICE, null);
       MyCallback callback = new MyCallback();
 
       adapter.destroy(value, true, callback);
@@ -137,7 +139,7 @@ public class AsyncPoolResourceManagerAdapterTest {
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(false, null);
       AsyncPoolResourceManagerAdapter<String> adapter =
-          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+          new AsyncPoolResourceManagerAdapter<>(key, rm, EXECUTOR_SERVICE, null);
       MyCallback callback = new MyCallback();
 
       adapter.destroy(value, true, callback);


### PR DESCRIPTION
Remove the usage of the following methods:
- Futures.addCallback(ListenableFuture FutureCallback)
- MoreExecutors.sameThreadExecutor()