### PR TITLE
Delete extra refreshed segments after segment push

### DIFF
--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/JobConfigConstants.java
@@ -58,5 +58,5 @@ public class JobConfigConstants {
   public static final String ENABLE_SORTING = "enable.sorting";
   public static final String ENABLE_RESIZING = "enable.resizing";
 
-  public static final String DELETE_EXTRA_REFRESHED_SEGMENTS = "delete.extra.refreshed.segments";
+  public static final String IS_DELETE_EXTRA_SEGMENTS = "is.delete.extra.segments";
 }

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/JobConfigConstants.java
@@ -57,4 +57,6 @@ public class JobConfigConstants {
   public static final String ENABLE_PARTITIONING = "enable.partitioning";
   public static final String ENABLE_SORTING = "enable.sorting";
   public static final String ENABLE_RESIZING = "enable.resizing";
+
+  public static final String DELETE_EXTRA_REFRESHED_SEGMENTS = "delete.extra.refreshed.segments";
 }

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/JobConfigConstants.java
@@ -58,5 +58,7 @@ public class JobConfigConstants {
   public static final String ENABLE_SORTING = "enable.sorting";
   public static final String ENABLE_RESIZING = "enable.resizing";
 
+  // This setting should be used if you will generate less # of segments after
+  // push. In preprocessing, this is likely because we resize segments. 
   public static final String IS_DELETE_EXTRA_SEGMENTS = "is.delete.extra.segments";
 }

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/JobConfigConstants.java
@@ -59,6 +59,6 @@ public class JobConfigConstants {
   public static final String ENABLE_RESIZING = "enable.resizing";
 
   // This setting should be used if you will generate less # of segments after
-  // push. In preprocessing, this is likely because we resize segments. 
-  public static final String IS_DELETE_EXTRA_SEGMENTS = "is.delete.extra.segments";
+  // push. In preprocessing, this is likely because we resize segments.
+  public static final String DELETE_EXTRA_SEGMENTS = "delete.extra.segments";
 }

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentTarPushJob.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentTarPushJob.java
@@ -60,12 +60,12 @@ public class SegmentTarPushJob extends BaseSegmentJob {
     try (ControllerRestApi controllerRestApi = getControllerRestApi()) {
       // TODO: Deal with invalid prefixes in the future
 
-      List<String> allSegments = controllerRestApi.getAllSegments("OFFLINE");
+      List<String> currentSegments = controllerRestApi.getAllSegments("OFFLINE");
 
       controllerRestApi.pushSegments(fileSystem, segmentsToPush);
 
       if (_deleteExtraSegments) {
-        controllerRestApi.deleteSegmentUris(getSegmentsToDelete(allSegments, segmentsToPush));
+        controllerRestApi.deleteSegmentUris(getSegmentsToDelete(currentSegments, segmentsToPush));
       }
     }
   }
@@ -80,8 +80,8 @@ public class SegmentTarPushJob extends BaseSegmentJob {
     Set<String> uniqueSegmentPrefixes = new HashSet<>();
 
     // Get all relevant segment prefixes that we are planning on pushing
-    List<String> segmentsToPushNames = segmentsToPush.stream().map(s -> s.getName()).collect(Collectors.toList());
-    for (String segmentName : segmentsToPushNames) {
+    List<String> segmentNamesToPush = segmentsToPush.stream().map(s -> s.getName()).collect(Collectors.toList());
+    for (String segmentName : segmentNamesToPush) {
       String segmentNamePrefix = removeSequenceId(segmentName);
       uniqueSegmentPrefixes.add(segmentNamePrefix);
     }
@@ -94,7 +94,7 @@ public class SegmentTarPushJob extends BaseSegmentJob {
       }
     }
 
-    relevantSegments.removeAll(segmentsToPushNames);
+    relevantSegments.removeAll(segmentNamesToPush);
     return relevantSegments;
   }
 

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentTarPushJob.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentTarPushJob.java
@@ -19,8 +19,12 @@
 package org.apache.pinot.hadoop.job;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -31,6 +35,7 @@ public class SegmentTarPushJob extends BaseSegmentJob {
   private final Path _segmentPattern;
   private final List<PushLocation> _pushLocations;
   private final String _rawTableName;
+  private final boolean _deleteExtraSegments;
 
   public SegmentTarPushJob(Properties properties) {
     super(properties);
@@ -39,6 +44,7 @@ public class SegmentTarPushJob extends BaseSegmentJob {
     int port = Integer.parseInt(properties.getProperty(JobConfigConstants.PUSH_TO_PORT));
     _pushLocations = PushLocation.getPushLocations(hosts, port);
     _rawTableName = Preconditions.checkNotNull(_properties.getProperty(JobConfigConstants.SEGMENT_TABLE_NAME));
+    _deleteExtraSegments = Boolean.parseBoolean(properties.getProperty(JobConfigConstants.DELETE_EXTRA_REFRESHED_SEGMENTS, "false"));
   }
 
   @Override
@@ -50,8 +56,43 @@ public class SegmentTarPushJob extends BaseSegmentJob {
       throws Exception {
     FileSystem fileSystem = FileSystem.get(_conf);
     try (ControllerRestApi controllerRestApi = getControllerRestApi()) {
-      controllerRestApi.pushSegments(fileSystem, getDataFilePaths(_segmentPattern));
+      // TODO: Deal with invalid prefixes in the future
+      if (_deleteExtraSegments) {
+        List<String> allSegments = controllerRestApi.getAllSegments("OFFLINE");
+        Set<String> uniqueSegmentPrefixes = new HashSet<>();
+
+        // Get all relevant segment prefixes that we are planning on pushing
+        List<Path> segmentsToPushPaths = getDataFilePaths(_segmentPattern);
+        List<String> segmentsToPushNames = segmentsToPushPaths.stream().map(s -> s.getName()).collect(Collectors.toList());
+        for (String segmentName : segmentsToPushNames) {
+          String segmentNamePrefix = removeSequenceId(segmentName);
+          uniqueSegmentPrefixes.add(segmentNamePrefix);
+        }
+
+        List<String> relevantSegments = new ArrayList<>();
+        // Get relevant segments already pushed that we are planning on refreshing
+        for (String segmentName : allSegments) {
+          if (uniqueSegmentPrefixes.contains(removeSequenceId(segmentName))) {
+            relevantSegments.add(segmentName);
+          }
+        }
+
+        relevantSegments.removeAll(segmentsToPushNames);
+        controllerRestApi.pushSegments(fileSystem, getDataFilePaths(_segmentPattern));
+        controllerRestApi.deleteSegmentUris(relevantSegments);
+      } else {
+        controllerRestApi.pushSegments(fileSystem, getDataFilePaths(_segmentPattern));
+      }
     }
+  }
+
+  /**
+   * Remove trailing sequence id
+   * @param segmentName
+   * @return
+   */
+  private String removeSequenceId(String segmentName) {
+    return segmentName.replaceAll("\\d*$", "");
   }
 
   protected ControllerRestApi getControllerRestApi() {

--- a/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentTarPushJob.java
+++ b/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/SegmentTarPushJob.java
@@ -45,7 +45,7 @@ public class SegmentTarPushJob extends BaseSegmentJob {
     int port = Integer.parseInt(properties.getProperty(JobConfigConstants.PUSH_TO_PORT));
     _pushLocations = PushLocation.getPushLocations(hosts, port);
     _rawTableName = Preconditions.checkNotNull(_properties.getProperty(JobConfigConstants.SEGMENT_TABLE_NAME));
-    _deleteExtraSegments = Boolean.parseBoolean(properties.getProperty(JobConfigConstants.IS_DELETE_EXTRA_SEGMENTS, "false"));
+    _deleteExtraSegments = Boolean.parseBoolean(properties.getProperty(JobConfigConstants.DELETE_EXTRA_SEGMENTS, "false"));
   }
 
   @Override

--- a/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/DeleteExtraPushedSegmentsTest.java
+++ b/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/DeleteExtraPushedSegmentsTest.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.hadoop.io;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.apache.hadoop.fs.Path;
+import org.apache.pinot.hadoop.job.JobConfigConstants;
+import org.apache.pinot.hadoop.job.SegmentTarPushJob;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests logic to delete extra segments within the same time unit for APPEND or extra segments during REFRESH cases.
+ */
+public class DeleteExtraPushedSegmentsTest {
+  Properties _defaultProperties = new Properties();
+
+  @BeforeClass
+  private void setup() {
+    _defaultProperties.setProperty(JobConfigConstants.PUSH_TO_HOSTS, "sample_host");
+    _defaultProperties.setProperty(JobConfigConstants.PUSH_TO_PORT, "1234");
+    _defaultProperties.setProperty(JobConfigConstants.PATH_TO_OUTPUT, "sample_output_path");
+  }
+
+  @Test
+  public void checkDelete() {
+    List<String> allSegments = new ArrayList<>();
+    allSegments.add("mytable_2018-09-10_2018-09-10_0");
+    allSegments.add("mytable_2018-09-10_2018-09-10_1");
+    allSegments.add("mytable_2018-09-10_2018-09-10_2");
+
+    List<Path> currentSegments = new ArrayList<>();
+    currentSegments.add(new Path("mytable_2018-09-10_2018-09-10_0"));
+    SegmentTarPushJob segmentTarPushJob = new SegmentTarPushJob(_defaultProperties);
+    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegments, currentSegments);
+    Assert.assertEquals(segmentsToDelete.size(), 2);
+    Assert.assertEquals(segmentsToDelete.contains("mytable_2018-09-10_2018-09-10_0"), false);
+  }
+
+  @Test
+  public void checkDeleteWithRefresh() {
+    List<String> allSegments = new ArrayList<>();
+    allSegments.add("mytable_0");
+    allSegments.add("mytable_1");
+    allSegments.add("mytable_2");
+
+    List<Path> currentSegments = new ArrayList<>();
+    currentSegments.add(new Path("mytable_0"));
+    SegmentTarPushJob segmentTarPushJob = new SegmentTarPushJob(_defaultProperties);
+    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegments, currentSegments);
+    Assert.assertEquals(segmentsToDelete.size(), 2);
+    Assert.assertEquals(segmentsToDelete.contains("mytable_0"), false);
+  }
+
+  @Test
+  public void checkDeleteWithDoubleDigitSequenceIds() {
+    List<String> allSegments = new ArrayList<>();
+    allSegments.add("mytable_02");
+    allSegments.add("mytable_12");
+    allSegments.add("mytable_23");
+
+    List<Path> currentSegments = new ArrayList<>();
+    currentSegments.add(new Path("mytable_02"));
+    SegmentTarPushJob segmentTarPushJob = new SegmentTarPushJob(_defaultProperties);
+    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegments, currentSegments);
+    Assert.assertEquals(segmentsToDelete.size(), 2);
+    Assert.assertEquals(segmentsToDelete.contains("mytable_02"), false);
+  }
+
+  @AfterClass
+  private void shutdown() {
+
+  }
+}

--- a/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/DeleteExtraPushedSegmentsTest.java
+++ b/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/DeleteExtraPushedSegmentsTest.java
@@ -40,6 +40,7 @@ public class DeleteExtraPushedSegmentsTest {
     _defaultProperties.setProperty(JobConfigConstants.PUSH_TO_HOSTS, "sample_host");
     _defaultProperties.setProperty(JobConfigConstants.PUSH_TO_PORT, "1234");
     _defaultProperties.setProperty(JobConfigConstants.PATH_TO_OUTPUT, "sample_output_path");
+    _defaultProperties.setProperty(JobConfigConstants.SEGMENT_TABLE_NAME, "myTable");
   }
 
   @Test
@@ -85,5 +86,17 @@ public class DeleteExtraPushedSegmentsTest {
     List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegmentsInCluster, currentSegments);
     Assert.assertEquals(segmentsToDelete.size(), 2);
     Assert.assertFalse(segmentsToDelete.contains("mytable_02"));
+  }
+
+  @Test
+  public void checkDeleteWithoutSequenceIds() {
+    List<String> allSegmentsInCluster = new ArrayList<>();
+    allSegmentsInCluster.add("mytable");
+
+    List<Path> currentSegments = new ArrayList<>();
+    currentSegments.add(new Path("mytable"));
+    SegmentTarPushJob segmentTarPushJob = new SegmentTarPushJob(_defaultProperties);
+    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegmentsInCluster, currentSegments);
+    Assert.assertEquals(segmentsToDelete.size(), 0);
   }
 }

--- a/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/DeleteExtraPushedSegmentsTest.java
+++ b/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/DeleteExtraPushedSegmentsTest.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.pinot.hadoop.job.JobConfigConstants;
 import org.apache.pinot.hadoop.job.SegmentTarPushJob;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -45,51 +44,46 @@ public class DeleteExtraPushedSegmentsTest {
 
   @Test
   public void checkDelete() {
-    List<String> allSegments = new ArrayList<>();
-    allSegments.add("mytable_2018-09-10_2018-09-10_0");
-    allSegments.add("mytable_2018-09-10_2018-09-10_1");
-    allSegments.add("mytable_2018-09-10_2018-09-10_2");
+    List<String> allSegmentsInCluster = new ArrayList<>();
+    allSegmentsInCluster.add("mytable_2018-09-10_2018-09-10_0");
+    allSegmentsInCluster.add("mytable_2018-09-10_2018-09-10_1");
+    allSegmentsInCluster.add("mytable_2018-09-10_2018-09-10_2");
 
     List<Path> currentSegments = new ArrayList<>();
     currentSegments.add(new Path("mytable_2018-09-10_2018-09-10_0"));
     SegmentTarPushJob segmentTarPushJob = new SegmentTarPushJob(_defaultProperties);
-    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegments, currentSegments);
+    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegmentsInCluster, currentSegments);
     Assert.assertEquals(segmentsToDelete.size(), 2);
-    Assert.assertEquals(segmentsToDelete.contains("mytable_2018-09-10_2018-09-10_0"), false);
+    Assert.assertFalse(segmentsToDelete.contains("mytable_2018-09-10_2018-09-10_0"));
   }
 
   @Test
   public void checkDeleteWithRefresh() {
-    List<String> allSegments = new ArrayList<>();
-    allSegments.add("mytable_0");
-    allSegments.add("mytable_1");
-    allSegments.add("mytable_2");
+    List<String> allSegmentsInCluster = new ArrayList<>();
+    allSegmentsInCluster.add("mytable_0");
+    allSegmentsInCluster.add("mytable_1");
+    allSegmentsInCluster.add("mytable_2");
 
     List<Path> currentSegments = new ArrayList<>();
     currentSegments.add(new Path("mytable_0"));
     SegmentTarPushJob segmentTarPushJob = new SegmentTarPushJob(_defaultProperties);
-    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegments, currentSegments);
+    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegmentsInCluster, currentSegments);
     Assert.assertEquals(segmentsToDelete.size(), 2);
-    Assert.assertEquals(segmentsToDelete.contains("mytable_0"), false);
+    Assert.assertFalse(segmentsToDelete.contains("mytable_0"));
   }
 
   @Test
   public void checkDeleteWithDoubleDigitSequenceIds() {
-    List<String> allSegments = new ArrayList<>();
-    allSegments.add("mytable_02");
-    allSegments.add("mytable_12");
-    allSegments.add("mytable_23");
+    List<String> allSegmentsInCluster = new ArrayList<>();
+    allSegmentsInCluster.add("mytable_02");
+    allSegmentsInCluster.add("mytable_12");
+    allSegmentsInCluster.add("mytable_23");
 
     List<Path> currentSegments = new ArrayList<>();
     currentSegments.add(new Path("mytable_02"));
     SegmentTarPushJob segmentTarPushJob = new SegmentTarPushJob(_defaultProperties);
-    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegments, currentSegments);
+    List<String> segmentsToDelete = segmentTarPushJob.getSegmentsToDelete(allSegmentsInCluster, currentSegments);
     Assert.assertEquals(segmentsToDelete.size(), 2);
-    Assert.assertEquals(segmentsToDelete.contains("mytable_02"), false);
-  }
-
-  @AfterClass
-  private void shutdown() {
-
+    Assert.assertFalse(segmentsToDelete.contains("mytable_02"));
   }
 }


### PR DESCRIPTION
* Adds a config to make possible deleting extra segments that are pushed within the same configured time segment or refreshed
* Future work: deal with invalid prefixes (when people accidentally change their prefix, when they keep a huge amount of time in the same segment for append segments, etc)
* #4353 