### PR TITLE
Use hit counter to track max QPS per minute for broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
@@ -49,6 +49,7 @@ import static org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHandler, QueryQuotaManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixExternalViewBasedQueryQuotaManager.class);
   private static final int TIME_RANGE_IN_SECOND = 1;
+  private static final int HIT_COUNTER_BUCKETS = 100;
 
   private final AtomicInteger _lastKnownBrokerResourceVersion = new AtomicInteger(-1);
   private final Map<String, QueryQuotaConfig> _rateLimiterMap = new ConcurrentHashMap<>();
@@ -182,7 +183,7 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
 
     double perBrokerRate = overallRate / onlineCount;
     QueryQuotaConfig queryQuotaConfig =
-        new QueryQuotaConfig(RateLimiter.create(perBrokerRate), new HitCounter(TIME_RANGE_IN_SECOND));
+        new QueryQuotaConfig(RateLimiter.create(perBrokerRate), new HitCounter(TIME_RANGE_IN_SECOND, HIT_COUNTER_BUCKETS));
     _rateLimiterMap.put(tableNameWithType, queryQuotaConfig);
     LOGGER.info(
         "Rate limiter for table: {} has been initialized. Overall rate: {}. Per-broker rate: {}. Number of online broker instances: {}",

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HitCounter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HitCounter.java
@@ -24,8 +24,7 @@ import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
  * This hit counter is for counting the number of hits within a range of time.
- * Right now the granularity we use is configured the users. Currently two users
- * are there
+ * Currently two callers are there
  *
  * (1) QueryQuota Manager {@link HelixExternalViewBasedQueryQuotaManager} which
  * uses the hit counter for 1sec range of time and 100 time buckets thus
@@ -100,7 +99,7 @@ public class HitCounter {
 
   /*
    * Explanation of algorithm to keep track of
-   * max QPS per minute:
+   * max QPS within a minute window
    *
    * Hit counter is configured with fixed number buckets
    * and each bucket covers a fixed time window to

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HitCounter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HitCounter.java
@@ -22,23 +22,36 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicLongArray;
 
-
 /**
- * This hit counter is for counting the number of hits within a range of time. Right now the granularity we use is second.
- * In order to save the space and time, we store the number of hits over the last 100 time buckets. When the method hit
- * gets called, we put the timestamp to the specified bucket. When the method getHitCount gets called, we sum all the number
- * of hits within the last 100 time buckets.
+ * This hit counter is for counting the number of hits within a range of time.
+ * Right now the granularity we use is configured the users. Currently two users
+ * are there
+ *
+ * (1) QueryQuota Manager {@link HelixExternalViewBasedQueryQuotaManager} which
+ * uses the hit counter for 1sec range of time and 100 time buckets thus
+ * each bucket covers a time width of 10ms.
+ *
+ * (2) {@link org.apache.pinot.broker.requesthandler.BrokerPeakQPSMetricsHandler}
+ * which uses the hit counter to keep track of peak QPS per minute for broker. The
+ * hit counter is configured for a time range of 60secs with 600 buckets thus
+ * each bucket covers a time width of 100ms
+ *
+ * In order to save the space and time, we store the number of hits over the
+ * last configured number of time buckets. When the method hit gets called,
+ * we put the timestamp to the specified bucket. When the method getHitCount
+ * gets called, we sum all the numberof hits within the last 100 time buckets.
  */
 public class HitCounter {
-  private static int BUCKET_COUNT = 100;
+  private final int _bucketCount;
   private final int _timeBucketWidthMs;
   private final AtomicLongArray _bucketStartTime;
   private final AtomicIntegerArray _bucketHitCount;
 
-  public HitCounter(int timeRangeInSeconds) {
-    _timeBucketWidthMs = timeRangeInSeconds * 1000 / BUCKET_COUNT;
-    _bucketStartTime = new AtomicLongArray(BUCKET_COUNT);
-    _bucketHitCount = new AtomicIntegerArray(BUCKET_COUNT);
+  public HitCounter(final int timeRangeInSeconds, final int bucketCount) {
+    _bucketCount = bucketCount;
+    _timeBucketWidthMs = timeRangeInSeconds * 1000 / _bucketCount;
+    _bucketStartTime = new AtomicLongArray(_bucketCount);
+    _bucketHitCount = new AtomicIntegerArray(_bucketCount);
   }
 
   /**
@@ -51,7 +64,7 @@ public class HitCounter {
   @VisibleForTesting
   void hit(long timestamp) {
     long numTimeUnits = timestamp / _timeBucketWidthMs;
-    int index = (int) (numTimeUnits % BUCKET_COUNT);
+    int index = (int) (numTimeUnits % _bucketCount);
     if (_bucketStartTime.get(index) == numTimeUnits) {
       _bucketHitCount.incrementAndGet(index);
     } else {
@@ -77,11 +90,154 @@ public class HitCounter {
   int getHitCount(long timestamp) {
     long numTimeUnits = timestamp / _timeBucketWidthMs;
     int count = 0;
-    for (int i = 0; i < BUCKET_COUNT; i++) {
-      if (numTimeUnits - _bucketStartTime.get(i) < BUCKET_COUNT) {
+    for (int i = 0; i < _bucketCount; i++) {
+      if (numTimeUnits - _bucketStartTime.get(i) < _bucketCount) {
         count += _bucketHitCount.get(i);
       }
     }
     return count;
+  }
+
+  /*
+   * Explanation of algorithm to keep track of
+   * max QPS per minute:
+   *
+   * Hit counter is configured with fixed number buckets
+   * and each bucket covers a fixed time window to
+   * cover an overall range of 60secs.
+   *
+   * Each bucket stores two values -- start time
+   * and hit counter.
+   *
+   * Example:
+   * T = timestamp
+   * BST = bucket start time
+   * B = bucket index
+   * WIDTH = bucket window width = 10000ms
+   * BUCKETS = 6
+   *
+   * Every time hitAndUpdateLatestTime() is called,
+   * we do the following:
+   *
+   * T = current timestamp
+   * BST = T / WIDTH
+   * B = BST % BUCKETS
+   *
+   * if a timestamp T is ending in a bucket B,
+   * T, T + 0, T + 1, ..... T + 9999ms will all
+   * end up in the same bucket B
+   *
+   * T + WIDTHms will end up in the next bucket
+   * and so on
+   *
+   * T + 60000, T + 60000 + 1 ... T + 60000 + 9999
+   * will also end up in the same bucket B as T but
+   * BST would be T + BUCKETS
+   *
+   * Now this is how bucket update rules work on every
+   * call to hitAndUpdateLatesTime()
+   *
+   * (1) Get T
+   * (2) Compute BST and B
+   * (3) CURR = current BST of B
+   * (4) update B's start time as BST
+   * (5) if BST != CURR, it implies we have gone
+   * over a minute and the current hit counter value of the
+   * bucket along with CURR can be overwritten --
+   * so we set B's hit counter to 1 and B's BST to BST.
+   * else, we increment B's hit counter by 1
+   *
+   * note that BST != CURR also implies that
+   * BST - CURR >= BUCKETS which further indicates we have gone
+   * over a minute.
+   *
+   * getMaxHitCount() -- used to update BrokerGauge with peak
+   * QPS per minute
+   *
+   * (1) go over all buckets
+   * (2) keep track of 2 max values seen so far in the loop
+   * (a) max_BST and (b) max_hits
+   * (3) consider each bucket's BST to see if max_BST
+   * should be updated
+   * (4) consider each bucket's hit counter value
+   * as follows to see if max_hits need to be updated
+   *
+   * if abs(bucket's BST - max_BST) <= BUCKETS, it
+   * tell us that start time of this bucket is within
+   * the window of 1min, so we should consider it's hit
+   * counter value to update max_hits
+   *
+   * else if bucket's BST > max_BST, it implies
+   * that bucket's BST is beyond current max_BST
+   * by more than a minute, so we should simply
+   * set max_hits as bucket's hit counter value
+   *
+   * See the unit test for peakQPS in HitCounterTest
+   */
+
+  /**
+   * Currently invoked by {@link org.apache.pinot.broker.requesthandler.BrokerPeakQPSMetricsHandler}
+   * every time a query comes into {@link org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler}
+   */
+  public void hitAndUpdateLatestTime() {
+    hitAndUpdateLatestTime(System.currentTimeMillis());
+  }
+
+  @VisibleForTesting
+  void hitAndUpdateLatestTime(final long timestamp) {
+    // since we are updating two words, it is not possible
+    // to do them in a single atomic instruction
+    // unless there is a way to do multi-word CAS.
+    // wrapping this under synchronize block will
+    // hurt performance. currently the caller of
+    // this BrokerPeakQPSMetricsHandler creates 600 buckets
+    // so that should avoid extreme contention on a
+    // single bucket. it should be noted that without
+    // the use of synchronize, we should expect some
+    // inconsistency at a bucket level
+    final long numTimeUnits = timestamp / _timeBucketWidthMs;
+    final int bucketIndex = (int) (numTimeUnits % _bucketCount);
+    if (numTimeUnits != _bucketStartTime.get(bucketIndex)) {
+      _bucketHitCount.set(bucketIndex, 1);
+      _bucketStartTime.set(bucketIndex, numTimeUnits);
+    } else {
+      _bucketHitCount.incrementAndGet(bucketIndex);
+    }
+
+    /* potential alternative approach where we can miss
+    some updates by simply returning if CAS fails
+    final long numTimeUnits = timestamp / _timeBucketWidthMs;
+    final int bucketIndex = (int) (numTimeUnits % _bucketCount);
+    final int hitCount = _bucketHitCount.get(bucketIndex);
+    final long startTime = _bucketStartTime.get(bucketIndex);
+    if (numTimeUnits != startTime) {
+      if (_bucketStartTime.compareAndSet(bucketIndex, startTime, numTimeUnits)) {
+        _bucketHitCount.set(bucketIndex, 1);
+      }
+    } else {
+      if (_bucketHitCount.compareAndSet(bucketIndex, hitCount, hitCount + 1)) {
+        _bucketStartTime.set(bucketIndex, numTimeUnits);
+      }
+    }*/
+  }
+
+  /**
+   * Used to update {@link org.apache.pinot.common.metrics.BrokerGauge}
+   * @return max hit count in a minute
+   */
+  public long getMaxHitCount() {
+    long maxWindowStartTime = _bucketStartTime.get(0);
+    int maxHits = _bucketHitCount.get(0);
+    for (int bucket = 1; bucket < _bucketCount; ++bucket) {
+      final long startTime = _bucketStartTime.get(bucket);
+      final int hits = _bucketHitCount.get(bucket);
+      if (Math.abs(startTime - maxWindowStartTime) <= _bucketCount) {
+        maxHits = Math.max(maxHits, hits);
+      } else if (startTime > maxWindowStartTime) {
+        maxHits = hits;
+      }
+      maxWindowStartTime = Math.max(maxWindowStartTime, startTime);
+    }
+    return maxHits;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerPeakQPSMetricsHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerPeakQPSMetricsHandler.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import org.apache.pinot.broker.queryquota.HitCounter;
+import org.apache.pinot.common.metrics.BrokerGauge;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+
+/**
+ * Handles the setting of QPS related metrics to the metrics registry
+ */
+public class BrokerPeakQPSMetricsHandler {
+  private static final int TIME_RANGE_IN_SECONDS = 60;
+  // create 600 buckets of 100milliseconds width each to cover a range of 60secs
+  private static final int HIT_COUNTER_BUCKETS = 600;
+  private final HitCounter _hitCounter;
+
+  BrokerPeakQPSMetricsHandler(final BrokerMetrics brokerMetrics) {
+    _hitCounter = new HitCounter(TIME_RANGE_IN_SECONDS, HIT_COUNTER_BUCKETS);
+    brokerMetrics.addCallbackGauge(BrokerGauge.PEAK_QPS_PER_MINUTE.getGaugeName(),
+        () -> _hitCounter.getMaxHitCount());
+  }
+
+  void incrementQueryCount() {
+    _hitCounter.hitAndUpdateLatestTime();
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HitCounterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HitCounterTest.java
@@ -25,13 +25,14 @@ import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-
 public class HitCounterTest {
+
+  private static final int BUCKETS_100 = 100;
 
   @Test
   public void testHitCounterWithOneSecondRange() {
     int timeInSec = 1;
-    HitCounter hitCounter = new HitCounter(timeInSec);
+    HitCounter hitCounter = new HitCounter(timeInSec, BUCKETS_100);
     for (int i = 0; i < 10; i++) {
       hitCounter.hit(System.currentTimeMillis());
     }
@@ -42,7 +43,7 @@ public class HitCounterTest {
   @Test
   public void testHitCounterWithFiveSecondRange() {
     int timeInSec = 5;
-    HitCounter hitCounter = new HitCounter(timeInSec);
+    HitCounter hitCounter = new HitCounter(timeInSec, BUCKETS_100);
     long currentTimestamp = System.currentTimeMillis();
     for (int i = 0; i < 3; i++) {
       hitCounter.hit(currentTimestamp);
@@ -62,7 +63,7 @@ public class HitCounterTest {
   @Test
   public void testHitCounterWithFiveSecondRangeSleepForMoreThanSixSeconds() {
     int timeInSec = 5;
-    HitCounter hitCounter = new HitCounter(timeInSec);
+    HitCounter hitCounter = new HitCounter(timeInSec, BUCKETS_100);
     long currentTimestamp = System.currentTimeMillis();
     for (int i = 0; i < 3; i++) {
       hitCounter.hit(currentTimestamp);
@@ -90,7 +91,7 @@ public class HitCounterTest {
       int expectedHitCount = numThreads * numHitsPerThread;
       // Randomly set the time range.
       int timeRangeInSecond = random.nextInt(100) + 10;
-      HitCounter hitCounter = new HitCounter(timeRangeInSecond);
+      HitCounter hitCounter = new HitCounter(timeRangeInSecond, BUCKETS_100);
       List<Thread> threadList = new ArrayList<>();
 
       for (int i = 0; i < numThreads; i++) {
@@ -113,5 +114,122 @@ public class HitCounterTest {
       long duration = System.currentTimeMillis() - startTime;
       System.out.println(duration);
     }
+  }
+
+  @Test
+  public void testPeakQPS() {
+    // 6 buckets of 10000ms each covering a range of 60secs
+    final HitCounter hitCounter = new HitCounter(60, 6);
+
+    // use custom start time (in millis)
+    long startTime = 1000000L;
+    for (int i = 0; i < 600; i++) {
+      // all 600 queries fired at an interval of 1ms each
+      // all go to same bucket
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [0, 0, 0, 0, 100, 0]
+    // hit counter array: [0, 0, 0, 0, 600, 0]
+
+    startTime = 1010000L;
+    for (int i = 0; i < 500; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [0, 0, 0, 0, 100, 101]
+    // hit counter array: [0, 0, 0, 0, 600, 500]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 600);
+
+    startTime = 1010500L;
+    for (int i = 0; i < 80; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [0, 0, 0, 0, 100, 101]
+    // hit counter array: [0, 0, 0, 0, 600, 580]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 600);
+
+    startTime = 1060000L;
+    for (int i = 0; i < 300; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [0, 0, 0, 0, 106, 101]
+    // hit counter array: [0, 0, 0, 0, 300, 580]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 580);
+
+    startTime = 1070000L;
+    for (int i = 0; i < 315; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [0, 0, 0, 0, 106, 107]
+    // hit counter array: [0, 0, 0, 0, 300, 315]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 315);
+
+    startTime = 1070315L;
+    for (int i = 0; i < 120; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [0, 0, 0, 0, 106, 107]
+    // hit counter array: [0, 0, 0, 0, 300, 435]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 435);
+
+    startTime = 1080000L;
+    for (int i = 0; i < 450; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [108, 0, 0, 0, 106, 107]
+    // hit counter array: [450, 0, 0, 0, 300, 435]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 450);
+
+    startTime = 1120000L;
+    for (int i = 0; i < 220; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [108, 0, 0, 0, 112, 107]
+    // hit counter array: [450, 0, 0, 0, 220, 435]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 450);
+
+    startTime = 1170000L;
+    for (int i = 0; i < 219; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [108, 0, 0, 117, 112, 107]
+    // hit counter array: [450, 0, 0, 219, 220, 435]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 220);
+
+    startTime = 1180000L;
+    for (int i = 0; i < 105; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [108, 0, 0, 117, 118, 107]
+    // hit counter array: [450, 0, 0, 219, 105, 435]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 219);
+
+    startTime = 1180105L;
+    for (int i = 0; i < 140; i++) {
+      hitCounter.hitAndUpdateLatestTime(startTime++);
+    }
+
+    // bucket start array: [108, 0, 0, 117, 118, 107]
+    // hit counter array: [450, 0, 0, 219, 245, 435]
+
+    Assert.assertEquals(hitCounter.getMaxHitCount(), 245);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -26,7 +26,9 @@ import org.apache.pinot.common.Utils;
  *
  */
 public enum BrokerGauge implements AbstractMetrics.Gauge {
-  QUERY_QUOTA_CAPACITY_UTILIZATION_RATE("tables", false), NETTY_CONNECTION_CONNECT_TIME_MS("nettyConnection", true);
+  QUERY_QUOTA_CAPACITY_UTILIZATION_RATE("tables", false),
+  NETTY_CONNECTION_CONNECT_TIME_MS("nettyConnection", true),
+  PEAK_QPS_PER_MINUTE("peakQPSPerMinute", true);
 
   private final String brokerGaugeName;
   private final String unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -159,6 +159,9 @@ public class CommonConstants {
         "pinot.broker.startup.minResourcePercent";
     public static final double DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START = 100.0;
 
+    public static final String CONFIG_OF_BROKER_EMIT_PEAK_QPS_METRICS = "pinot.broker.emit.peak.qps.metrics";
+    public static final boolean DEFAULT_BROKER_EMIT_PEAK_QPS_METRICS = false;
+
     public static class Request {
       public static final String PQL = "pql";
       public static final String SQL = "sql";


### PR DESCRIPTION
Using the hit counter in a configured manner (600 buckets of 100ms each to cover a time range of 60sec) to keep track of max QPS per minute for broker. 
Detailed explanation of algorithm is there is in HitCounter.java