### PR TITLE
Add sql +, -, *, / symbol arith

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -44,21 +44,21 @@ import org.apache.pinot.common.utils.request.RequestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableMap;
+
 
 public class CalciteSqlParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CalciteSqlParser.class);
 
-  private static final Map<String, String> FUNC_NAME_MAP;
-
   // Calcite Sqlkind name to pinot operator name map
-  static {
-    FUNC_NAME_MAP = new HashMap<String, String>();
-    FUNC_NAME_MAP.put("PLUS", "ADD");
-    FUNC_NAME_MAP.put("MINUS", "SUB");
-    FUNC_NAME_MAP.put("TIMES", "MULT");
-    FUNC_NAME_MAP.put("DIVIDE", "DIV");
-  }
+  private static final Map<String, String> CALCITE_TO_PINOT_FUNC_NAME_MAP =
+      new ImmutableMap.Builder<String, String>()
+        .put("PLUS", "ADD")
+        .put("MINUS", "SUB")
+        .put("TIMES", "MULT")
+        .put("DIVIDE", "DIV")
+        .build();
 
   /** Lexical policy similar to MySQL with ANSI_QUOTES option enabled. (To be
    * precise: MySQL on Windows; MySQL on Linux uses case-sensitive matching,
@@ -269,7 +269,7 @@ public class CalciteSqlParser {
         if (funcSqlNode.getOperator().getKind() == SqlKind.OTHER_FUNCTION) {
           funcName = funcSqlNode.getOperator().getName();
         }
-        funcName = FUNC_NAME_MAP.getOrDefault(funcName, funcName);
+        funcName = CALCITE_TO_PINOT_FUNC_NAME_MAP.getOrDefault(funcName, funcName);
         final Expression funcExpr = RequestUtils.getFunctionExpression(funcName);
         for (SqlNode child : funcSqlNode.getOperands()) {
           if (child instanceof SqlNodeList) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -422,4 +422,36 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue(), "v1");
   }
+
+  @Test
+  public void testSqlBaseArith() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select k1+2 from baseballStats");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "ADD");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "k1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2L);
+
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select k1-3 from baseballStats");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "SUB");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "k1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 3L);
+
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select k1*4 from baseballStats");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "MULT");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "k1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 4L);
+
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select k1/5 from baseballStats");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DIV");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "k1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5L);
+
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -453,5 +453,19 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5L);
 
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select (a * ((b - c) / d) + e) from baseballStats");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "ADD");
+    Expression leftExpr = pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0);
+    Expression rightExpr = pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1);
+    Assert.assertEquals(rightExpr.getIdentifier().getName(), "e");
+    Assert.assertEquals(leftExpr.getFunctionCall().getOperator(), "MULT");
+    Assert.assertEquals(leftExpr.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+    rightExpr = leftExpr.getFunctionCall().getOperands().get(1);
+    Assert.assertEquals(rightExpr.getFunctionCall().getOperator(), "DIV");
+    Assert.assertEquals(rightExpr.getFunctionCall().getOperands().get(1).getIdentifier().getName(), "d");
+    leftExpr = rightExpr.getFunctionCall().getOperands().get(0);
+    Assert.assertEquals(leftExpr.getFunctionCall().getOperator(), "SUB");
+    Assert.assertEquals(leftExpr.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "b");
+    Assert.assertEquals(leftExpr.getFunctionCall().getOperands().get(1).getIdentifier().getName(), "c");
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -186,6 +186,9 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     query = "SELECT MAX(ArrTime), MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 16312";
     testSqlQuery(query, Arrays.asList("SELECT MAX(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 15312",
         "SELECT MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 15312"));
+    query = "SELECT ((FlightNum+5)*3-1)/2 FROM mytable WHERE DaysSinceEpoch >= 16312 limit 10";
+    testSqlQuery(query,
+        Arrays.asList("SELECT ((FlightNum+5)*3-1)/2 FROM mytable WHERE DaysSinceEpoch >= 16312 limit 10000"));
   }
 
   /**


### PR DESCRIPTION
This PR adds sql +, -, *, / symbol arith based on recent new sql grammar support using calcite. Currently it look only support pql-like ADD, SUB, MULT, DIV function, it would be good to also support common used arith symbol.