### PR TITLE
[TE] Remove hard-coded AdLibAnomalyDetector and AdLibAlertFilter

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionRegistry.java
@@ -91,6 +91,13 @@ public class DetectionRegistry {
           }
         }
       }
+      // todo: get rid of MIGRATED_ALGORITHM and MIGRATED_ALGORITHM_FILTER after the migration is completed
+      if (REGISTRY_MAP.containsKey("ALGORITHM")) {
+        REGISTRY_MAP.put("MIGRATED_ALGORITHM", REGISTRY_MAP.get("ALGORITHM"));
+      }
+      if (REGISTRY_MAP.containsKey("ALGORITHM_FILTER")) {
+        REGISTRY_MAP.put("MIGRATED_ALGORITHM_FILTER", REGISTRY_MAP.get("ALGORITHM_FILTER"));
+      }
     } catch (Exception e) {
       LOG.warn("initialize detection registry error", e);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/DetectionConfigTuner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/DetectionConfigTuner.java
@@ -59,14 +59,6 @@ public class DetectionConfigTuner {
   private static final String DEFAULT_TIMEZONE = "America/Los_Angeles";
 
   private static final DetectionRegistry DETECTION_REGISTRY = DetectionRegistry.getInstance();
-  static {
-    // do not tune for alerts migrated from legacy anomaly function.
-    DetectionRegistry.registerComponent("com.linkedin.thirdeye.detection.components.AdLibAlertFilter",
-        "MIGRATED_ALGORITHM_FILTER");
-    DetectionRegistry.registerComponent("com.linkedin.thirdeye.detection.components.AdLibAnomalyDetector",
-        "MIGRATED_ALGORITHM");
-  }
-
   public static final String PROP_YAML_PARAMS = "yamlParams";
   public static final Set<String> TURNOFF_TUNING_COMPONENTS =
       ImmutableSet.of("MIGRATED_ALGORITHM_FILTER", "MIGRATED_ALGORITHM", "MIGRATED_ALGORITHM_BASELINE");

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/translator/DetectionConfigTranslator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/translator/DetectionConfigTranslator.java
@@ -165,13 +165,6 @@ public class DetectionConfigTranslator extends ConfigTranslator<DetectionConfigD
 
 
   private static final DetectionRegistry DETECTION_REGISTRY = DetectionRegistry.getInstance();
-  static {
-    // do not tune for alerts migrated from legacy anomaly function.
-    DetectionRegistry.registerComponent("com.linkedin.thirdeye.detection.components.AdLibAlertFilter",
-        "MIGRATED_ALGORITHM_FILTER");
-    DetectionRegistry.registerComponent("com.linkedin.thirdeye.detection.components.AdLibAnomalyDetector",
-        "MIGRATED_ALGORITHM");
-  }
   private static final Set<String> MOVING_WINDOW_DETECTOR_TYPES = ImmutableSet.of("ALGORITHM", "MIGRATED_ALGORITHM");
 
   private final Map<String, Object> components = new HashMap<>();


### PR DESCRIPTION
Hard-code these class names will results exception for open source version. This fixed it.