### PR TITLE
Minor fix double close in FixedBitIntReaderWriter

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/io/util/FixedBitIntReaderWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/util/FixedBitIntReaderWriter.java
@@ -65,7 +65,7 @@ public final class FixedBitIntReaderWriter implements Closeable {
       throws IOException {
     if (_dataBitSet != null) {
       _dataBitSet.close();
-      _dataBitSet.close();
+      _dataBitSet = null;
     }
   }
 }


### PR DESCRIPTION
There are double close in `FixedBitIntReaderWriter`, it looks need to set it null..