### PR TITLE
[TE] Make the dashboard report summary to show the correct values

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/home/share-dashboard/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/share-dashboard/route.js
@@ -19,6 +19,8 @@ const queryParamsConfig = {
   refreshModel: true
 };
 
+const REPORT_DISPLAY_DATE_FORMAT = 'MM/DD/YYYY HH:mm A (z)';
+
 export default Route.extend(AuthenticatedRouteMixin, {
   anomaliesApiService: service('services/api/anomalies'),
   shareDashboardApiService: service('services/api/share-dashboard'),
@@ -239,8 +241,8 @@ export default Route.extend(AuthenticatedRouteMixin, {
       columns,
       start: get(this, 'startDate'),
       end: get(this, 'endDate'),
-      startDateDisplay:  moment(get(this, 'startDate')).format('MM/DD/YYYY'),
-      endDateDisplay: moment(get(this, 'endDate')).format('MM/DD/YYYY'),
+      startDateDisplay:  moment(get(this, 'startDate')).tz(moment.tz.guess()).format(REPORT_DISPLAY_DATE_FORMAT),
+      endDateDisplay: moment(get(this, 'endDate')).tz(moment.tz.guess()).format(REPORT_DISPLAY_DATE_FORMAT),
       appNameDisplay: get(this, 'appName'),
       subGroupDisplay: get(this, 'subGroup'),
       anomaliesCount: get(this, 'anomalies.content') ? get(this, 'anomalies.content').length : 0

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -158,25 +158,38 @@ export function setUpTimeRangeOptions(datesKeys, duration) {
       [ '2w', ['Last 2 Weeks', 2, 'week'] ],
       [ '1w', ['Last Week', 1, 'week'] ],
       [ '2d', ['Yesterday', 2, 'day'] ],
-      [ '1d', ['Last 24 Hours', 1, 'day'] ],
-      [ '48h', ['Last 48 Hours', 2, 'day'] ],
+      [ '1d', ['Last 24 Hours', 24, 'hour'] ],
+      [ '48h', ['Last 48 Hours', 48, 'hour'] ],
       [ 'today', ['Today'] ]
     ]);
 
   datesKeys.forEach((value) => {
     const currVal = dateKeyMap.get(value);
     const label = currVal[0];
-    let start = moment().subtract(currVal[1], currVal[2]).startOf('day');
+    let start;
+    let end;
     // overrides map above
     switch(label) {
       case 'Today':
         start = moment().startOf('day');
+        end = start.add(1, 'days');
         break;
       case 'Yesterday':
         start = moment().subtract(1, 'day').startOf('day');
+        end = moment().startOf('day');
         break;
+      case 'Last 24 Hours':
+        start = moment().subtract(24, 'hour').startOf('hour');
+        end = moment().startOf('hour');
+        break;
+      case 'Last 48 Hours':
+        start = moment().subtract(48, 'hour').startOf('hour');
+        end = moment().startOf('hour');
+        break;
+      default:
+        start = moment().subtract(currVal[1], currVal[2]).startOf('day');
+        end = moment().startOf('day').add(1, 'days');
     }
-    const end = (label === 'Yesterday') ? moment().startOf('day') : moment().startOf('day').add(1, 'days');
     const isActive = duration === value;
     newRangeArr.push({ name: label, value, start, end, isActive });
   });

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
@@ -648,8 +648,8 @@ public class RootCauseMetricResource {
     // align to time buckets and request time zone
     long offset = DateTimeZone.forID(timezone).getOffset(slice.getStart());
     long timeGranularity = granularity.toMillis();
-    long start = ((slice.getStart() + offset) / timeGranularity) * timeGranularity - offset;
-    long end = ((slice.getEnd() + offset + timeGranularity - 1) / timeGranularity) * timeGranularity - offset;
+    long start = ((slice.getStart() + offset + timeGranularity - 1) / timeGranularity) * timeGranularity - offset; // round up the start time to time granularity boundary of the requested time zone
+    long end = start + (slice.getEnd() - slice.getStart());
 
     return slice.withStart(start).withEnd(end).withGranularity(granularity);
   }


### PR DESCRIPTION
This PR makes the dashboard report summary to show the correct values. 
- Fix the time range selector to return correct timestamps
- Make the report summary to show the full-time range and time zone information to avoid confusions.
- Fix the time range rounding/alignments.