### PR TITLE
Fix potential NPE from HelixDataAccessor

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -272,14 +272,22 @@ public class HelixBrokerStarter {
   private void addInstanceTagIfNeeded() {
     InstanceConfig instanceConfig =
         _helixDataAccessor.getProperty(_helixDataAccessor.keyBuilder().instanceConfig(_brokerId));
-    List<String> instanceTags = instanceConfig.getTags();
-    if (instanceTags == null || instanceTags.isEmpty()) {
-      if (ZKMetadataProvider.getClusterTenantIsolationEnabled(_propertyStore)) {
-        _helixAdmin.addInstanceTag(_clusterName, _brokerId,
-            TagNameUtils.getBrokerTagForTenant(TagNameUtils.DEFAULT_TENANT_NAME));
-      } else {
-        _helixAdmin.addInstanceTag(_clusterName, _brokerId, Helix.UNTAGGED_BROKER_INSTANCE);
+    if (instanceConfig == null) {
+      addInstanceConfig();
+    } else {
+      List<String> instanceTags = instanceConfig.getTags();
+      if (instanceTags == null || instanceTags.isEmpty()) {
+        addInstanceConfig();
       }
+    }
+  }
+
+  private void addInstanceConfig() {
+    if (ZKMetadataProvider.getClusterTenantIsolationEnabled(_propertyStore)) {
+      _helixAdmin.addInstanceTag(_clusterName, _brokerId,
+          TagNameUtils.getBrokerTagForTenant(TagNameUtils.DEFAULT_TENANT_NAME));
+    } else {
+      _helixAdmin.addInstanceTag(_clusterName, _brokerId, Helix.UNTAGGED_BROKER_INSTANCE);
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -385,8 +385,12 @@ public class ServiceStatus {
     protected CurrentState getState(String resourceName) {
       PropertyKey.Builder keyBuilder = _helixDataAccessor.keyBuilder();
       LiveInstance liveInstance = _helixDataAccessor.getProperty(keyBuilder.liveInstance(_instanceName));
-      String sessionId = liveInstance.getSessionId();
-      return _helixDataAccessor.getProperty(keyBuilder.currentState(_instanceName, sessionId, resourceName));
+      if (liveInstance == null) {
+        return null;
+      } else {
+        String sessionId = liveInstance.getSessionId();
+        return _helixDataAccessor.getProperty(keyBuilder.currentState(_instanceName, sessionId, resourceName));
+      }
     }
 
     @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -838,6 +838,9 @@ public class PinotHelixResourceManager {
     List<String> instancesInCluster = _helixAdmin.getInstancesInCluster(_helixClusterName);
     for (String instanceName : instancesInCluster) {
       InstanceConfig config = _helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
+      if (config == null) {
+        continue;
+      }
       for (String tag : config.getTags()) {
         if (TagNameUtils.isBrokerTag(tag)) {
           tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
@@ -852,6 +855,9 @@ public class PinotHelixResourceManager {
     List<String> instancesInCluster = _helixAdmin.getInstancesInCluster(_helixClusterName);
     for (String instanceName : instancesInCluster) {
       InstanceConfig config = _helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
+      if (config == null) {
+        continue;
+      }
       for (String tag : config.getTags()) {
         if (TagNameUtils.isServerTag(tag)) {
           tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
@@ -863,7 +869,11 @@ public class PinotHelixResourceManager {
 
   private List<String> getTagsForInstance(String instanceName) {
     InstanceConfig config = _helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
-    return config.getTags();
+    if (config == null) {
+      return new ArrayList<>(0);
+    } else {
+      return config.getTags();
+    }
   }
 
   public PinotResourceManagerResponse createServerTenant(Tenant serverTenant) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -223,17 +223,19 @@ public class PinotLLCRealtimeSegmentManager {
     // If there are any completions in the pipeline we let them commit.
     Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
 
-    IdealState idealState = HelixHelper.getTableIdealState(_helixManager, realtimeTableName);
     final List<String> segmentsToRemove = new ArrayList<String>();
-    Set<String> allSegments = idealState.getPartitionSet();
-    int removeCount = 0;
-    for (String segmentName : allSegments) {
-      if (SegmentName.isLowLevelConsumerSegmentName(segmentName)) {
-        segmentsToRemove.add(segmentName);
-        removeCount++;
+    IdealState idealState = HelixHelper.getTableIdealState(_helixManager, realtimeTableName);
+    if (idealState != null) {
+      Set<String> allSegments = idealState.getPartitionSet();
+      int removeCount = 0;
+      for (String segmentName : allSegments) {
+        if (SegmentName.isLowLevelConsumerSegmentName(segmentName)) {
+          segmentsToRemove.add(segmentName);
+          removeCount++;
+        }
       }
+      LOGGER.info("Attempting to remove {} LLC segments of table {}", removeCount, realtimeTableName);
     }
-    LOGGER.info("Attempting to remove {} LLC segments of table {}", removeCount, realtimeTableName);
 
     _helixResourceManager.deleteSegments(realtimeTableName, segmentsToRemove);
   }


### PR DESCRIPTION
When calling `getProperty` method from `HelixDataAccessor`, it could return null.
This PR handles potential NPE for that method in Pinot codebase.