### PR TITLE
[TE] [Composite-Alert] Adding Entity GroupKey with Whitelist Template and Formatter

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/alert/content/EntityGroupKeyContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/alert/content/EntityGroupKeyContentFormatter.java
@@ -46,21 +46,28 @@ import static org.apache.pinot.thirdeye.detection.yaml.translator.DetectionConfi
 
 /**
  * This email formatter generates a report/alert from the anomalies having a groupKey
+ * and optionally a whitelist metric which will be listed at the top of the alert report
  */
 public class EntityGroupKeyContentFormatter extends BaseEmailContentFormatter{
   private static final Logger LOG = LoggerFactory.getLogger(EntityGroupKeyContentFormatter.class);
 
-
   private static final String EMAIL_TEMPLATE = "entity-groupkey-anomaly-report.ftl";
 
+  // Give some kind of special status to this metric entity. Anomalies from this whitelisted metric entity
+  // will appear at the top of the alert report. Specify the entity name of the metric alert here.
   static final String PROP_ENTITY_WHITELIST = "entityWhitelist";
+
   static final String PROP_ANOMALY_SCORE = "groupScore";
   static final String PROP_GROUP_KEY = "groupKey";
 
   private DetectionConfigManager configDAO = null;
   private Multimap<String, AnomalyReportEntity> entityToAnomaliesMap = ArrayListMultimap.create();
   private Multimap<String, AnomalyReportEntity> entityToSortedAnomaliesMap = ArrayListMultimap.create();
+
+  // WhitelistMetric is usually a top level metric which should be given special status in the alert report.
+  // This map holds info on all the whitelisted metric anomalies which will appear at the top of the alert report.
   private Multimap<String, AnomalyReportEntity> whitelistMetricToAnomaliesMap = ArrayListMultimap.create();
+
   private Map<AnomalyReportEntity, Double> anomalyToGroupScoreMap = new HashMap<>();
   private Map<String, String> anomalyToChildIdsMap = new HashMap<>();
   private List<String> entityWhitelist = new ArrayList<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/alert/content/HierarchicalAnomaliesEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/alert/content/HierarchicalAnomaliesEmailContentFormatter.java
@@ -55,14 +55,13 @@ import org.slf4j.LoggerFactory;
 public class HierarchicalAnomaliesEmailContentFormatter extends BaseEmailContentFormatter{
   private static final Logger LOG = LoggerFactory.getLogger(HierarchicalAnomaliesEmailContentFormatter.class);
 
-  public static final String EMAIL_TEMPLATE = "emailTemplate";
   public static final String USE_LATEST_ANOMALY_INFORMATION = "useLatestAnomaly";
   public static final String PRESENT_SEASONAL_VALUES = "presentSeasonalValues";
 
   public static final String DEFAULT_USE_LATEST_ANOMALY_INFORMATION = "true";
   public static final String DEFAULT_PRESENT_SEASONAL_VALUES = "false";
 
-  public static final String DEFAULT_EMAIL_TEMPLATE = "hierarchical-anomalies-email-template.ftl";
+  public static final String EMAIL_TEMPLATE = "hierarchical-anomalies-email-template.ftl";
 
   private boolean useLatestAnomaly;
   private boolean presentSeasonalValues;
@@ -74,7 +73,7 @@ public class HierarchicalAnomaliesEmailContentFormatter extends BaseEmailContent
   @Override
   public void init(Properties properties, EmailContentFormatterConfiguration configuration) {
     super.init(properties, configuration);
-    this.emailTemplate = properties.getProperty(EMAIL_TEMPLATE, DEFAULT_EMAIL_TEMPLATE);
+    this.emailTemplate = EMAIL_TEMPLATE;
     useLatestAnomaly = Boolean.valueOf(properties.getProperty(USE_LATEST_ANOMALY_INFORMATION, DEFAULT_USE_LATEST_ANOMALY_INFORMATION));
     presentSeasonalValues = Boolean.valueOf(properties.getProperty(PRESENT_SEASONAL_VALUES, DEFAULT_PRESENT_SEASONAL_VALUES));
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/alert/content/MetricAnomaliesEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/alert/content/MetricAnomaliesEmailContentFormatter.java
@@ -51,10 +51,7 @@ import org.slf4j.LoggerFactory;
 public class MetricAnomaliesEmailContentFormatter extends BaseEmailContentFormatter{
   private static final Logger LOG = LoggerFactory.getLogger(MetricAnomaliesEmailContentFormatter.class);
 
-  public static final String EMAIL_TEMPLATE = "emailTemplate";
-
-  public static final String DEFAULT_EMAIL_TEMPLATE = "metric-anomalies-template.ftl";
-
+  private static final String EMAIL_TEMPLATE = "metric-anomalies-template.ftl";
   private DetectionConfigManager configDAO = null;
 
   public MetricAnomaliesEmailContentFormatter(){
@@ -64,7 +61,7 @@ public class MetricAnomaliesEmailContentFormatter extends BaseEmailContentFormat
   @Override
   public void init(Properties properties, EmailContentFormatterConfiguration configuration) {
     super.init(properties, configuration);
-    this.emailTemplate = properties.getProperty(EMAIL_TEMPLATE, DEFAULT_EMAIL_TEMPLATE);
+    this.emailTemplate = EMAIL_TEMPLATE;
     this.configDAO = DAORegistry.getInstance().getDetectionConfigManager();
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -193,8 +193,9 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
 
     Map<String, Object> emailParams = ConfigUtils.getMap(this.config.getAlertSchemes().get(PROP_EMAIL_SCHEME));
     EmailContentFormatter emailContentFormatter = makeTemplate(emailParams);
-    emailContentFormatter.init(new Properties(),
-        EmailContentFormatterConfiguration.fromThirdEyeAnomalyConfiguration(this.teConfig));
+    Properties props = new Properties();
+    props.putAll(emailParams);
+    emailContentFormatter.init(props, EmailContentFormatterConfiguration.fromThirdEyeAnomalyConfiguration(this.teConfig));
 
     List<AnomalyResult> anomalyResultListOfGroup = new ArrayList<>(anomalies);
     anomalyResultListOfGroup.sort(COMPARATOR_DESC);

--- a/thirdeye/thirdeye-pinot/src/main/resources/org/apache/pinot/thirdeye/detector/entity-groupkey-anomaly-report.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/org/apache/pinot/thirdeye/detector/entity-groupkey-anomaly-report.ftl
@@ -26,7 +26,60 @@
     <td>
       <table border="0" cellpadding="0" cellspacing="0" style="border:1px solid #E9E9E9; border-radius: 2px; width: 100%;">
 
+        <!-- Only if whitelist entity exists -->
+        <#if cid?has_content>
+          <tr>
+            <td style="padding: 12px;" align="center">
+              <a href="${anomalyDetails[0].anomalyURL}${anomalyDetails[0].anomalyId}" target="_blank">
+                <img style="width: 70%;" src="cid:${cid}" />
+              </a>
+            </td>
+          </tr>
+        </#if>
+
         <!-- List all the alerts -->
+        <#list whitelistMetricToAnomaliesMap as metricName, whitelistAnomalies>
+          <@utils.addBlock title="" align="left">
+            <p>
+              <span style="color: #1D1D1D; font-size: 20px; font-weight: bold; display:inline-block; vertical-align: middle;">Metric:&nbsp;</span>
+              <span style="color: #606060; font-size: 20px; text-decoration: none; display:inline-block; vertical-align: middle; width: 70%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">${metricName}</span>
+            </p>
+
+            <!-- List all the anomalies under this detection -->
+            <table border="0" width="100%" align="center" style="width:100%; padding:0; margin:0; border-collapse: collapse;text-align:left;">
+              <#list whitelistAnomalies as anomaly>
+                <#if anomaly.metric==metricName>
+                  <tr style="text-align:center; background-color: #F6F8FA; border-top: 2px solid #C7D1D8; border-bottom: 2px solid #C7D1D8;">
+                    <th style="text-align:left; padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Start / Duration</th>
+                    <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Dimensions</th>
+                    <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Current</th>
+                    <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Predicted</th>
+                  </tr>
+                  <tr style="border-bottom: 1px solid #C7D1D8;">
+                    <td style="padding: 6px 12px;white-space: nowrap;">
+                      <div style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px;">${anomaly.startDateTime} ${anomaly.timezone}</div>
+                      <span style="color: rgba(0,0,0,0.6); font-size:12px; line-height:16px;">${anomaly.duration}</span>
+                      <a style="font-weight: bold; text-decoration: none; font-size:14px; line-height:20px; color: #0073B1;" href="${anomaly.anomalyURL}${anomaly.anomalyId}"
+                         target="_blank">(view)</a>
+                    </td>
+                    <td style="word-break: break-all; width: 200px; padding-right:4px 20px 4px 0">
+                      <#list anomaly.dimensions as dimension>
+                        <span style="color: rgba(0,0,0,0.6); font-size: 12px; line-height: 16px;">${dimension}</span>
+                        </br>
+                      </#list>
+                    </td>
+                    <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">${anomaly.currentVal}</td>
+                    <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">
+                      ${anomaly.baselineVal}
+                      <div style="font-size: 12px; color:${anomaly.positiveLift?string('#3A8C18','#ee1620')};">(${anomaly.positiveLift?string('+','')}${anomaly.lift})</div>
+                    </td>
+                  </tr>
+                </#if>
+              </#list>
+            </table>
+          </@utils.addBlock>
+        </#list>
+
         <#list entityToSortedAnomaliesMap as entityName, groupedAnomalies>
           <@utils.addBlock title="" align="left">
             <!-- Display Entity Name -->

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/alert/content/TestEntityGroupKeyEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/alert/content/TestEntityGroupKeyEmailContentFormatter.java
@@ -46,7 +46,9 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.thirdeye.alert.content.EntityGroupKeyContentFormatter.*;
@@ -63,8 +65,8 @@ public class TestEntityGroupKeyEmailContentFormatter {
   private MergedAnomalyResultManager mergedAnomalyResultDAO;
   private MetricConfigManager metricDAO;
 
-  @BeforeClass
-  public void beforeClass(){
+  @BeforeMethod
+  public void beforeMethod(){
     testDAOProvider = DAOTestBase.getInstance();
     DAORegistry daoRegistry = DAORegistry.getInstance();
     detectionDAO = daoRegistry.getDetectionConfigManager();
@@ -72,8 +74,8 @@ public class TestEntityGroupKeyEmailContentFormatter {
     metricDAO = daoRegistry.getMetricConfigDAO();
   }
 
-  @AfterClass(alwaysRun = true)
-  void afterClass() {
+  @AfterMethod(alwaysRun = true)
+  void afterMethod() {
     testDAOProvider.cleanup();
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/alert/content/TestEntityGroupKeyEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/alert/content/TestEntityGroupKeyEmailContentFormatter.java
@@ -82,7 +82,7 @@ public class TestEntityGroupKeyEmailContentFormatter {
    * Where Sub-Entity-A and Sub-Entity-B anomalies have a groupKey and a groupScore
    */
   @Test
-  public void testGetEmailEntity() throws Exception {
+  public void testEntityGroupKeyAnomalyTemplate() throws Exception {
     MetricConfigDTO metric = new MetricConfigDTO();
     metric.setName(TEST);
     metric.setDataset(TEST);
@@ -162,6 +162,124 @@ public class TestEntityGroupKeyEmailContentFormatter {
         new DetectionAlertFilterRecipients(EmailUtils.getValidEmailAddresses("a@b.com")),
         TEST, null, "", anomalies, null);
     String htmlPath = ClassLoader.getSystemResource("test-entity-groupby-email-content-formatter.html").getPath();
+
+    Assert.assertEquals(
+        ContentFormatterUtils.getEmailHtml(emailEntity).replaceAll("\\s", ""),
+        ContentFormatterUtils.getHtmlContent(htmlPath).replaceAll("\\s", ""));
+  }
+
+  /**
+   * Entity Alert Trigger Condition: Metric A AND (Sub-Entity-A OR Sub-Entity-B)
+   * Where Sub-Entity-A and Sub-Entity-B anomalies have a groupKey and a groupScore
+   * E.g.: Alert on Model Performance Metric Anomalies along with co-occurring with Feature Anomalies
+   */
+  @Test
+  public void testEntityGroupKeyAnomalyTemplateWithWhitelistEntity() throws Exception {
+    MetricConfigDTO metric = new MetricConfigDTO();
+    metric.setName(TEST);
+    metric.setDataset(TEST);
+    metric.setAlias(TEST + "::" + TEST);
+    metricDAO.save(metric);
+
+    ThirdEyeAnomalyConfiguration thirdeyeAnomalyConfig = new ThirdEyeAnomalyConfiguration();
+    thirdeyeAnomalyConfig.setId(id);
+    thirdeyeAnomalyConfig.setDashboardHost(dashboardHost);
+    MonitorConfiguration monitorConfiguration = new MonitorConfiguration();
+    monitorConfiguration.setMonitorFrequency(new TimeGranularity(3, TimeUnit.SECONDS));
+    thirdeyeAnomalyConfig.setMonitorConfiguration(monitorConfiguration);
+    TaskDriverConfiguration taskDriverConfiguration = new TaskDriverConfiguration();
+    taskDriverConfiguration.setNoTaskDelayInMillis(1000);
+    taskDriverConfiguration.setRandomDelayCapInMillis(200);
+    taskDriverConfiguration.setTaskFailureDelayInMillis(500);
+    taskDriverConfiguration.setMaxParallelTasks(2);
+    thirdeyeAnomalyConfig.setTaskDriverConfiguration(taskDriverConfiguration);
+    thirdeyeAnomalyConfig.setRootDir(System.getProperty("dw.rootDir", "NOT_SET(dw.rootDir)"));
+    Map<String, Map<String, Object>> alerters = new HashMap<>();
+    Map<String, Object> smtpProps = new HashMap<>();
+    smtpProps.put(SMTP_HOST_KEY, "host");
+    smtpProps.put(SMTP_PORT_KEY, "9000");
+    alerters.put("smtpConfiguration", smtpProps);
+    thirdeyeAnomalyConfig.setAlerterConfiguration(alerters);
+
+    DetectionConfigDTO detection = new DetectionConfigDTO();
+    detection.setName("test_report");
+    detection.setDescription("test_description");
+    long id = detectionDAO.save(detection);
+
+    DateTimeZone dateTimeZone = DateTimeZone.forID("America/Los_Angeles");
+
+    MergedAnomalyResultDTO metricAnomaly = DaoTestUtils.getTestMergedAnomalyResult(
+        new DateTime(2017, 11, 7, 10, 0, dateTimeZone).getMillis(),
+        new DateTime(2017, 11, 7, 17, 0, dateTimeZone).getMillis(),
+        TEST, TEST, 0, id,
+        new DateTime(2017, 11, 6, 10, 0, dateTimeZone).getMillis());
+    metricAnomaly.setAvgCurrentVal(150);
+    metricAnomaly.setAvgBaselineVal(100);
+    Map<String, String> metricAnomalyProperties = new HashMap<>();
+    metricAnomalyProperties.put(PROP_SUB_ENTITY_NAME, "metric-X");
+    metricAnomaly.setProperties(metricAnomalyProperties);
+    mergedAnomalyResultDAO.save(metricAnomaly);
+
+    MergedAnomalyResultDTO subGroupedAnomaly1 = DaoTestUtils.getTestGroupedAnomalyResult(
+        new DateTime(2017, 11, 7, 10, 0, dateTimeZone).getMillis(),
+        new DateTime(2017, 11, 7, 17, 0, dateTimeZone).getMillis(),
+        new DateTime(2017, 11, 6, 10, 0, dateTimeZone).getMillis(),
+        id);
+    Map<String, String> properties = new HashMap<>();
+    properties.put(PROP_GROUP_KEY, "group-1");
+    properties.put(PROP_SUB_ENTITY_NAME, "sub-entity-A");
+    properties.put(PROP_ANOMALY_SCORE, "10");
+    subGroupedAnomaly1.setProperties(properties);
+    subGroupedAnomaly1.setChildIds(Collections.singleton(1l));
+    mergedAnomalyResultDAO.save(subGroupedAnomaly1);
+
+    MergedAnomalyResultDTO subGroupedAnomaly2 = DaoTestUtils.getTestGroupedAnomalyResult(
+        new DateTime(2017, 11, 7, 10, 0, dateTimeZone).getMillis(),
+        new DateTime(2017, 11, 7, 17, 0, dateTimeZone).getMillis(),
+        new DateTime(2017, 11, 6, 10, 0, dateTimeZone).getMillis(),
+        id);
+    Map<String, String> properties2 = new HashMap<>();
+    properties2.put(PROP_GROUP_KEY, "group-2");
+    properties2.put(PROP_SUB_ENTITY_NAME, "sub-entity-B");
+    properties2.put(PROP_ANOMALY_SCORE, "20");
+    subGroupedAnomaly2.setProperties(properties2);
+    subGroupedAnomaly2.setChildIds(Collections.singleton(2l));
+    mergedAnomalyResultDAO.save(subGroupedAnomaly2);
+
+    MergedAnomalyResultDTO parentGroupedAnomaly = DaoTestUtils.getTestGroupedAnomalyResult(
+        new DateTime(2017, 11, 7, 10, 0, dateTimeZone).getMillis(),
+        new DateTime(2017, 11, 7, 17, 0, dateTimeZone).getMillis(),
+        new DateTime(2017, 11, 6, 10, 0, dateTimeZone).getMillis(),
+        id);
+    Set<MergedAnomalyResultDTO> childrenAnomalies = new HashSet<>();
+    childrenAnomalies.add(subGroupedAnomaly1);
+    childrenAnomalies.add(subGroupedAnomaly2);
+    parentGroupedAnomaly.setChildren(childrenAnomalies);
+    mergedAnomalyResultDAO.save(parentGroupedAnomaly);
+
+    MergedAnomalyResultDTO superParentGroupedAnomaly = DaoTestUtils.getTestGroupedAnomalyResult(
+        new DateTime(2017, 11, 7, 10, 0, dateTimeZone).getMillis(),
+        new DateTime(2017, 11, 7, 17, 0, dateTimeZone).getMillis(),
+        new DateTime(2017, 11, 6, 10, 0, dateTimeZone).getMillis(),
+        id
+    );
+    Set<MergedAnomalyResultDTO> unGroupedParentAnomalies = new HashSet<>();
+    unGroupedParentAnomalies.add(metricAnomaly);
+    unGroupedParentAnomalies.add(parentGroupedAnomaly);
+    superParentGroupedAnomaly.setChildren(unGroupedParentAnomalies);
+
+    List<AnomalyResult> anomalies = new ArrayList<>();
+    anomalies.add(superParentGroupedAnomaly);
+
+    EmailContentFormatter contentFormatter = new EntityGroupKeyContentFormatter();
+    Properties props = new Properties();
+    props.put(PROP_ENTITY_WHITELIST, "metric-X");
+    contentFormatter.init(props, EmailContentFormatterConfiguration.fromThirdEyeAnomalyConfiguration(thirdeyeAnomalyConfig));
+    EmailEntity emailEntity = contentFormatter.getEmailEntity(
+        DaoTestUtils.getTestAlertConfiguration("Test Config"),
+        new DetectionAlertFilterRecipients(EmailUtils.getValidEmailAddresses("a@b.com")),
+        TEST, null, "", anomalies, null);
+    String htmlPath = ClassLoader.getSystemResource("test-entity-groupby-with-whitelist-email-content-formatter.html").getPath();
 
     Assert.assertEquals(
         ContentFormatterUtils.getEmailHtml(emailEntity).replaceAll("\\s", ""),

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
@@ -83,6 +83,7 @@ import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * Run adhoc queries to db
  */

--- a/thirdeye/thirdeye-pinot/src/test/resources/test-entity-groupby-email-content-formatter.html
+++ b/thirdeye/thirdeye-pinot/src/test/resources/test-entity-groupby-email-content-formatter.html
@@ -23,6 +23,8 @@
   <tr>
     <td>
       <table border="0" cellpadding="0" cellspacing="0" style="border:1px solid #E9E9E9; border-radius: 2px; width: 100%;">
+        <!-- Only if whitelist entity exists -->
+
         <!-- List all the alerts -->
         <tr>
           <td style="border-bottom: 1px solid rgba(0,0,0,0.15); padding: 12px 24px; align: left">

--- a/thirdeye/thirdeye-pinot/src/test/resources/test-entity-groupby-with-whitelist-email-content-formatter.html
+++ b/thirdeye/thirdeye-pinot/src/test/resources/test-entity-groupby-with-whitelist-email-content-formatter.html
@@ -1,0 +1,142 @@
+<head>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+</head>
+
+<body style="background-color: #EDF0F3;">
+<table border="0" cellpadding="0" cellspacing="0" style="width:100%; font-family: 'Proxima Nova','Arial','Helvetica Neue',Helvetica,sans-serif; font-size:14px; margin:0 auto; max-width: 50%; min-width:700px; background-color: #F3F6F8;">
+  <!-- White bar on top -->
+  <tr>
+    <td align="center" style="padding: 6px 24px;">
+      <span style="color: red; font-size: 35px; vertical-align: middle;">&nbsp;&#9888;&nbsp;</span>
+      <span style="color: rgba(0,0,0,0.75);font-size: 18px; font-weight: bold; letter-spacing: 2px; vertical-align: middle;">ACTION REQUIRED ON THIRDEYE ALERT</span>
+    </td>
+  </tr>
+
+  <!-- Blue header on top -->
+  <tr>
+    <td style="font-size: 16px; padding: 12px; background-color: #0073B1; color: #FFF; text-align: center;">
+      <span style="font-size: 18px; font-weight: bold; letter-spacing: 2px; vertical-align: middle;">Report: test_report</span>
+      <p>test_description</p>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <table border="0" cellpadding="0" cellspacing="0" style="border:1px solid #E9E9E9; border-radius: 2px; width: 100%;">
+        <!-- Only if whitelist entity exists -->
+
+        <!-- List all the alerts -->
+        <tr>
+          <td style="border-bottom:1px solid rgba(0,0,0,0.15); padding:12px 24px; align:left">
+            <p>
+              <span style="color: #1D1D1D; font-size: 20px; font-weight: bold; display:inline-block; vertical-align: middle;">Metric:&nbsp;</span>
+              <span style="color: #606060; font-size: 20px; text-decoration: none; display:inline-block; vertical-align: middle; width: 70%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">test</span>
+            </p>
+
+            <!-- List all the anomalies under this detection -->
+            <table border="0" width="100%" align="center" style="width:100%; padding:0; margin:0; border-collapse: collapse;text-align:left;">
+              <tr style="text-align:center; background-color: #F6F8FA; border-top: 2px solid #C7D1D8; border-bottom: 2px solid #C7D1D8;">
+                <th style="text-align:left; padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Start / Duration</th>
+                <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Dimensions</th>
+                <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Current</th>
+                <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Predicted</th>
+              </tr>
+              <tr style="border-bottom: 1px solid #C7D1D8;">
+                <td style="padding: 6px 12px;white-space: nowrap;">
+                  <div style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px;">Nov 07, 10:00 PDT</div>
+                  <span style="color: rgba(0,0,0,0.6); font-size:12px; line-height:16px;">7 hours</span>
+                  <a style="font-weight: bold; text-decoration: none; font-size:14px; line-height:20px; color: #0073B1;" href="http://localhost:8080/dashboard/app/#/rootcause?anomalyId=3"
+                     target="_blank">(view)</a>
+                </td>
+                <td style="word-break: break-all; width: 200px; padding-right:4px 20px 4px 0">
+                </td>
+                <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">150</td>
+                <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">100
+                  <div style="font-size: 12px; color:#3A8C18;">(+50.00%)</div>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style="border-bottom: 1px solid rgba(0,0,0,0.15); padding: 12px 24px; align: left">
+            <!-- Display Entity Name -->
+            <p>
+              <span style="color: #1D1D1D; font-size: 20px; font-weight: bold; display:inline-block; vertical-align: middle;">Entity:&nbsp;</span>
+              <span style="color: #606060; font-size: 20px; text-decoration: none; display:inline-block; vertical-align: middle; width: 70%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">sub-entity-A</span>
+            </p>
+            <!-- List all the anomalies under this entity in a table -->
+            <table border="0" width="100%" align="center" style="width:100%; padding:0; margin:0; border-collapse: collapse;text-align:left;">
+              <tr style="text-align:center; background-color: #F6F8FA; border-top: 2px solid #C7D1D8; border-bottom: 2px solid #C7D1D8;">
+                <th style="text-align:left; padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Feature</th>
+                <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Criticality Score*</th>
+                <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Current</th>
+                <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Predicted</th>
+              </tr>
+              <tr style="border-bottom: 1px solid #C7D1D8;">
+                <td style="padding: 6px 12px;white-space: nowrap;">
+                  <a style="font-weight: bold; text-decoration: none; font-size:14px; line-height:20px; color: #0073B1;" href="http://localhost:8080/dashboard/app/#/anomalies?anomalyIds=1"
+                     target="_blank">group-1</a>
+                  <div style="color:rgba(0,0,0,0.9);font-size:14px;line-height:20px;">Nov07,10:00PDT</div>
+                  <span style="color: rgba(0,0,0,0.6); font-size:12px; line-height:16px;">7 hours</span>
+                </td>
+                <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">10</td>
+                <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">0</td>
+                <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">
+                  0
+                  <div style="font-size: 12px; color:#3A8C18;">(+100.00%)</div>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style="border-bottom: 1px solid rgba(0,0,0,0.15); padding: 12px 24px; align: left">
+            <!-- Display Entity Name -->
+            <p>
+              <span style="color: #1D1D1D; font-size: 20px; font-weight: bold; display:inline-block; vertical-align: middle;">Entity:&nbsp;</span>
+              <span style="color: #606060; font-size: 20px; text-decoration: none; display:inline-block; vertical-align: middle; width: 70%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">sub-entity-B</span>
+            </p>
+            <!-- List all the anomalies under this entity in a table -->
+            <table border="0" width="100%" align="center" style="width:100%; padding:0; margin:0; border-collapse: collapse;text-align:left;">
+              <tr style="text-align:center; background-color: #F6F8FA; border-top: 2px solid #C7D1D8; border-bottom: 2px solid #C7D1D8;">
+                <th style="text-align:left; padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Feature</th>
+                <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Criticality Score*</th>
+                <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Current</th>
+                <th style="padding: 6px 12px; font-size: 12px; font-weight: bold; line-height: 20px;">Predicted</th>
+              </tr>
+              <tr style="border-bottom: 1px solid #C7D1D8;">
+                <td style="padding: 6px 12px;white-space: nowrap;">
+                  <a style="font-weight: bold; text-decoration: none; font-size:14px; line-height:20px; color: #0073B1;" href="http://localhost:8080/dashboard/app/#/anomalies?anomalyIds=2"
+                     target="_blank">group-2</a>
+                  <div style="color:rgba(0,0,0,0.9);font-size:14px;line-height:20px;">Nov07,10:00PDT</div>
+                  <span style="color: rgba(0,0,0,0.6); font-size:12px; line-height:16px;">7 hours</span>
+                </td>
+                <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">20</td>
+                <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">0</td>
+                <td style="color: rgba(0,0,0,0.9); font-size:14px; line-height:20px; text-align:center;">
+                  0
+                  <div style="font-size: 12px; color:#3A8C18;">(+100.00%)</div>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+
+        <!-- Reference Links -->
+      </table>
+    </td>
+  </tr>
+
+  <tr>
+    <td style="text-align: center; background-color: #EDF0F3; font-size: 12px; font-family:'Proxima Nova','Arial', 'Helvetica Neue',Helvetica, sans-serif; color: #737373; padding: 12px;">
+      <p style="margin-top:0;"> You are receiving this email because you have subscribed to ThirdEye Alert Service for
+        <strong>Test Config</strong>.</p>
+      <p>
+        If you have any questions regarding this report, please email
+        <a style="color: #33aada;" href="mailto:ask_thirdeye@linkedin.com" target="_top">ask_thirdeye@linkedin.com</a>
+      </p>
+    </td>
+  </tr>
+</table>
+</body>


### PR DESCRIPTION
Idea: "Send alert on a top metric (whitelisted) along with anomalies in other affected modules."

Adding a composite alert template to display grouped anomalies(with groupKey) along with the anomalies from a whitelisted entity. For example: Send alert on the model performance metric along with anomalies co-occurring in the respective features.

* Extended the existing Composite alert template to support this by including a `entityWhitelist` property.
* Locally verified and tested along with unit test