### PR TITLE
Add a thread in ControllerLeadershipManager to periodically fetch controller leadership info

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -49,6 +49,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   CONTROLLER_TABLE_TENANT_GET_ERROR("TableTenantGetError", true),
   CONTROLLER_REALTIME_TABLE_SEGMENT_ASSIGNMENT_ERROR("errors", true),
   CONTROLLER_NOT_LEADER("notLeader", true),
+  CONTROLLER_LEADERSHIP_CHANGE_WITHOUT_CALLBACK("leadershipChangeWithoutCallback", true),
   LLC_STATE_MACHINE_ABORTS("aborts", false),
   LLC_AUTO_CREATED_PARTITIONS("creates", false),
   LLC_ZOOKEEPER_UPDATE_FAILURES("failures", false),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -258,6 +258,7 @@ public class ControllerStarter {
     LOGGER.info("Registering controller leadership manager");
     // TODO: when Helix separation is completed, leadership only depends on the master in leadControllerResource, remove
     //       ControllerLeadershipManager and this callback.
+    _controllerLeadershipManager.start();
     helixParticipantManager.addControllerListener(
         (ControllerChangeListener) changeContext -> _controllerLeadershipManager.onControllerChange());
 


### PR DESCRIPTION
Add a thread in ControllerLeadershipManager to periodically fetch controller leadership info as a work-around of Helix callback delay
When the thread detects inconsistency between ControllerLeadershipManager and HelixManager, log a warning and emit metrics

The work-around is for the first issue described in: apache/helix#377