### PR TITLE
The external view check in rebalancer should also check for no extra servers

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/TableRebalancer.java
@@ -622,9 +622,9 @@ public class TableRebalancer {
           LOGGER.info("Waiting for externalView to match idealstate for table:" + resourceName);
           Thread.sleep(EXTERNAL_VIEW_CHECK_INTERVAL_MS);
           wait += EXTERNAL_VIEW_CHECK_INTERVAL_MS;
-          }
         }
-      } catch (InterruptedException e) {
+      }
+    } catch (InterruptedException e) {
       LOGGER.error("Rebalancer got interrupted while waiting for external view to converge");
       Thread.currentThread().interrupt();
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/TableRebalancer.java
@@ -564,19 +564,13 @@ public class TableRebalancer {
 
       // now do the reverse comparison
       // if a server had lost a segment as part of rebalancing (implying ideal state no
-      // longer has that server for the particular segment) then one of the following should
-      // be true in external view
-      // (1) either the server is no longer present for that segment in external view as well OR
-      // (2) the server has state DROPPED for that segment in external view
-      // if none of the above conditions is true, it implies that external view still hasn't converged.
+      // longer has that server for the particular segment) then the server should
+      // no longer present for that segment in external view as well
       for (String server : hostAndStatesInExternalView.keySet()) {
         if (!hostAndStatesInIdealState.containsKey(server)) {
-          if (hostAndStatesInExternalView.containsKey(server) &&
-              !hostAndStatesInExternalView.get(server).equalsIgnoreCase("dropped")) {
             stable = false;
-            LOGGER.info("Server {} has not yet dropped segment {} in external view", server, segment);
+            LOGGER.info("Server {} for segment {} should not be present in external view", server, segment);
           }
-        }
       }
     }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancerAdminToolClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancerAdminToolClusterIntegrationTest.java
@@ -200,8 +200,9 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // as part of rebalancing, host2 lost segment1 and host3
       // lost segment2 -- so 2 transitions from ON to OFF and
       // OFF to DROP
-      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 2);
-      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 2);
+      // HELIX-818: https://issues.apache.org/jira/browse/HELIX-818
+      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 2);
+      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 2);
     } finally {
       stopFakeServers();
     }
@@ -318,8 +319,9 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // as part of rebalancing, host2 lost segment1 and segment3,
       // host1 and host3 lost segment2 and segment4 -- so 6
       // transitions from ON to OFF and OFF to DROP
-      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 6);
-      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 6);
+      // HELIX-818: https://issues.apache.org/jira/browse/HELIX-818
+      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 6);
+      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 6);
     } finally {
       stopFakeServers();
     }
@@ -453,8 +455,9 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // and segment4. similarly, host4 lost segment1, segment3
       // and segment4 -- total 6 transitions from ONLINE to OFFLINE
       // and OFFLINE to DROPPED
-      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 6);
-      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 6);
+      // HELIX-818: https://issues.apache.org/jira/browse/HELIX-818
+      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 6);
+      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 6);
     } finally {
       stopFakeServers();
     }
@@ -587,8 +590,9 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // as part of rebalancing, host2 lost segment1 and segment3,
       // host1 and host3 lost segment2 and segment4 -- so 6
       // transitions from ON to OFF and OFF to DROP
-      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 3);
-      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 3);
+      // HELIX-818: https://issues.apache.org/jira/browse/HELIX-818
+      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 3);
+      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 3);
     } finally {
       stopFakeServers();
     }
@@ -662,8 +666,9 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // as part of rebalancing, host2 lost segment1 and segment3,
       // host1 and host3 lost segment2 and segment4 -- so 6
       // transitions from ON to OFF and OFF to DROP
-      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 3);
-      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 3);
+      // HELIX-818: https://issues.apache.org/jira/browse/HELIX-818
+      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 3);
+      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 3);
     } finally {
       stopFakeServers();
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancerAdminToolClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancerAdminToolClusterIntegrationTest.java
@@ -845,9 +845,6 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
 
       @Transition(from = "ONLINE", to = "DROPPED")
       public void onBecomeDroppedFromOnline(Message message, NotificationContext context) {
-        if (_segmentStateTransitionStats != null) {
-          System.out.println("online to dropped");
-        }
       }
     }
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancerAdminToolClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancerAdminToolClusterIntegrationTest.java
@@ -19,11 +19,9 @@
 package org.apache.pinot.integration.tests;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import jdk.nashorn.internal.ir.annotations.Ignore;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
@@ -47,7 +45,6 @@ import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.helix.core.TableRebalancer;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
-import org.apache.pinot.server.realtime.ControllerLeaderLocator;
 import org.apache.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory;
 import org.apache.pinot.tools.PinotTableRebalancer;
 import org.testng.Assert;
@@ -203,9 +200,8 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // as part of rebalancing, host2 lost segment1 and host3
       // lost segment2 -- so 2 transitions from ON to OFF and
       // OFF to DROP
-      // TODO: fix the flakey test behavior and re-enable these assertions
-      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn, 2);
-      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff, 2);
+      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 2);
+      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 2);
     } finally {
       stopFakeServers();
     }
@@ -322,9 +318,8 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // as part of rebalancing, host2 lost segment1 and segment3,
       // host1 and host3 lost segment2 and segment4 -- so 6
       // transitions from ON to OFF and OFF to DROP
-      // TODO: fix the flakey test behavior and re-enable these assertions
-      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn, 6);
-      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff, 6);
+      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 6);
+      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 6);
     } finally {
       stopFakeServers();
     }
@@ -458,9 +453,8 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // and segment4. similarly, host4 lost segment1, segment3
       // and segment4 -- total 6 transitions from ONLINE to OFFLINE
       // and OFFLINE to DROPPED
-      // TODO: fix the flakey test behavior and re-enable these assertions
-      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn, 6);
-      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff, 6);
+      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 6);
+      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 6);
     } finally {
       stopFakeServers();
     }
@@ -593,9 +587,8 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // as part of rebalancing, host2 lost segment1 and segment3,
       // host1 and host3 lost segment2 and segment4 -- so 6
       // transitions from ON to OFF and OFF to DROP
-      // TODO: fix the flakey test behavior and re-enable these assertions
-      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn, 3);
-      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff, 3);
+      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 3);
+      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 3);
     } finally {
       stopFakeServers();
     }
@@ -669,9 +662,8 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       // as part of rebalancing, host2 lost segment1 and segment3,
       // host1 and host3 lost segment2 and segment4 -- so 6
       // transitions from ON to OFF and OFF to DROP
-      // TODO: fix the flakey test behavior and re-enable these assertions
-      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn, 3);
-      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff, 3);
+      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 3);
+      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 3);
     } finally {
       stopFakeServers();
     }
@@ -730,9 +722,8 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       Assert.assertEquals(stats.getIncrementalUpdatesToSegmentInstanceMap(), 0);
       Assert.assertEquals(stats.getNumSegmentMoves(), 0);
 
-      // TODO: fix the flakey test behavior and re-enable these assertions
-      // Assert.assertEquals(_segmentStateTransitionStats.offFromOn, 0);
-      // Assert.assertEquals(_segmentStateTransitionStats.dropFromOff, 0);
+      Assert.assertEquals(_segmentStateTransitionStats.offFromOn.get(), 0);
+      Assert.assertEquals(_segmentStateTransitionStats.dropFromOff.get(), 0);
     } finally {
       stopFakeServers();
     }
@@ -841,26 +832,29 @@ public class TableRebalancerAdminToolClusterIntegrationTest extends BaseClusterI
       @Transition(from = "ONLINE", to = "OFFLINE")
       public void onBecomeOfflineFromOnline(Message message, NotificationContext context) {
         if (_segmentStateTransitionStats != null) {
-          ++_segmentStateTransitionStats.offFromOn;
+          _segmentStateTransitionStats.offFromOn.incrementAndGet();
         }
       }
 
       @Transition(from = "OFFLINE", to = "DROPPED")
       public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
         if (_segmentStateTransitionStats != null) {
-          ++_segmentStateTransitionStats.dropFromOff;
+          _segmentStateTransitionStats.dropFromOff.incrementAndGet();
         }
       }
 
       @Transition(from = "ONLINE", to = "DROPPED")
       public void onBecomeDroppedFromOnline(Message message, NotificationContext context) {
+        if (_segmentStateTransitionStats != null) {
+          System.out.println("online to dropped");
+        }
       }
     }
   }
 
   private static class SegmentStateTransitionStats {
-    private int offFromOn = 0;
-    private int dropFromOff = 0;
+    private AtomicInteger offFromOn = new AtomicInteger();
+    private AtomicInteger dropFromOff = new AtomicInteger();
   }
 
   @Override


### PR DESCRIPTION
The function to check if external view has converged now also ensures that servers that lost segments as part of rebalancing are not present in external view (for that segment).