### PR TITLE
Rename metric to reflect what's being counted: segments-processed vs segments-queried

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -35,7 +35,7 @@ public interface DataTable {
   String NUM_SEGMENTS_QUERIED = "numSegmentsQueried";
   String NUM_SEGMENTS_PROCESSED = "numSegmentsProcessed";
   String NUM_SEGMENTS_MATCHED = "numSegmentsMatched";
-  String NUM_CONSUMING_SEGMENTS_QUERIED = "numConsumingSegmentsQueried";
+  String NUM_CONSUMING_SEGMENTS_PROCESSED = "numConsumingSegmentsProcessed";
   String MIN_CONSUMING_FRESHNESS_TIME_MS = "minConsumingFreshnessTimeMs";
   String TOTAL_DOCS_METADATA_KEY = "totalDocs";
   String NUM_GROUPS_LIMIT_REACHED_KEY = "numGroupsLimitReached";

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -151,13 +151,13 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       TraceContext.register(requestId);
     }
 
-    int numConsumingSegmentsQueried = 0;
+    int numConsumingSegmentsProcessed = 0;
     long minIndexTimeMs = Long.MAX_VALUE;
     long minIngestionTimeMs = Long.MAX_VALUE;
     // gather stats for realtime consuming segments
     for (SegmentDataManager segmentMgr : segmentDataManagers) {
       if (segmentMgr.getSegment() instanceof MutableSegment) {
-        numConsumingSegmentsQueried += 1;
+        numConsumingSegmentsProcessed += 1;
         SegmentMetadata metadata = segmentMgr.getSegment().getSegmentMetadata();
         long indexedTime = metadata.getLastIndexedTimestamp();
         if (indexedTime != Long.MIN_VALUE && indexedTime < minIndexTimeMs) {
@@ -171,12 +171,12 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
 
     long minConsumingFreshnessTimeMs = minIngestionTimeMs;
-    if (numConsumingSegmentsQueried > 0) {
+    if (numConsumingSegmentsProcessed > 0) {
       if (minIngestionTimeMs == Long.MAX_VALUE) {
         LOGGER.debug("Did not find valid ingestionTimestamp across consuming segments! Using indexTime instead");
         minConsumingFreshnessTimeMs = minIndexTimeMs;
       }
-      LOGGER.debug("Querying {} consuming segments with min minConsumingFreshnessTimeMs {}", numConsumingSegmentsQueried, minConsumingFreshnessTimeMs);
+      LOGGER.debug("Querying {} consuming segments with min minConsumingFreshnessTimeMs {}", numConsumingSegmentsProcessed, minConsumingFreshnessTimeMs);
     }
 
     DataTable dataTable = null;
@@ -256,8 +256,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_MISSING_SEGMENTS, missingSegments);
     }
 
-    if (numConsumingSegmentsQueried > 0) {
-      dataTable.getMetadata().put(DataTable.NUM_CONSUMING_SEGMENTS_QUERIED, Integer.toString(numConsumingSegmentsQueried));
+    if (numConsumingSegmentsProcessed > 0) {
+      dataTable.getMetadata().put(DataTable.NUM_CONSUMING_SEGMENTS_PROCESSED, Integer.toString(numConsumingSegmentsProcessed));
       dataTable.getMetadata().put(DataTable.MIN_CONSUMING_FRESHNESS_TIME_MS, Long.toString(minConsumingFreshnessTimeMs));
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -84,7 +84,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     long numSegmentsQueried = 0L;
     long numSegmentsProcessed = 0L;
     long numSegmentsMatched = 0L;
-    long numConsumingSegmentsQueried = 0L;
+    long numConsumingSegmentsProcessed = 0L;
     long minConsumingFreshnessTimeMs = Long.MAX_VALUE;
     long numTotalRawDocs = 0L;
     boolean numGroupsLimitReached = false;
@@ -140,9 +140,9 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
         numSegmentsMatched += Long.parseLong(numSegmentsMatchedString);
       }
 
-      String numConsumingString = metadata.get(DataTable.NUM_CONSUMING_SEGMENTS_QUERIED);
+      String numConsumingString = metadata.get(DataTable.NUM_CONSUMING_SEGMENTS_PROCESSED);
       if (numConsumingString != null) {
-        numConsumingSegmentsQueried += Long.parseLong(numConsumingString);
+        numConsumingSegmentsProcessed += Long.parseLong(numConsumingString);
       }
 
       String minConsumingFreshnessTimeMsString = metadata.get(DataTable.MIN_CONSUMING_FRESHNESS_TIME_MS);
@@ -182,8 +182,8 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     brokerResponseNative.setNumSegmentsMatched(numSegmentsMatched);
     brokerResponseNative.setTotalDocs(numTotalRawDocs);
     brokerResponseNative.setNumGroupsLimitReached(numGroupsLimitReached);
-    if (numConsumingSegmentsQueried > 0) {
-      brokerResponseNative.setNumConsumingSegmentsQueried(numConsumingSegmentsQueried);
+    if (numConsumingSegmentsProcessed > 0) {
+      brokerResponseNative.setNumConsumingSegmentsQueried(numConsumingSegmentsProcessed);
       brokerResponseNative.setMinConsumingFreshnessTimeMs(minConsumingFreshnessTimeMs);
     }
 
@@ -197,7 +197,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       brokerMetrics
           .addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_POST_FILTER, numEntriesScannedPostFilter);
 
-      if (numConsumingSegmentsQueried > 0 && minConsumingFreshnessTimeMs > 0) {
+      if (numConsumingSegmentsProcessed > 0 && minConsumingFreshnessTimeMs > 0) {
         brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.FRESHNESS_LAG_MS,
             System.currentTimeMillis() - minConsumingFreshnessTimeMs, TimeUnit.MILLISECONDS);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -177,7 +177,7 @@ public abstract class QueryScheduler {
     long numSegmentsMatched =
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_SEGMENTS_MATCHED, INVALID_SEGMENTS_COUNT));
     long numSegmentsConsuming =
-        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_CONSUMING_SEGMENTS_QUERIED, INVALID_SEGMENTS_COUNT));
+        Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_CONSUMING_SEGMENTS_PROCESSED, INVALID_SEGMENTS_COUNT));
     long minConsumingFreshnessMs =
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.MIN_CONSUMING_FRESHNESS_TIME_MS, INVALID_FRESHNESS_MS));
 


### PR DESCRIPTION
Metric was incorrectly named before.

Testing done: None
Rollout: If broker/server rollouts are staggered, then the log line and metric value emitted will be off temporarily. Since this is not a critical/widely-used metric currently, we should be ok doing this.