### PR TITLE
Down-grade Helix to version 0.8.4

### DIFF
--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -90,6 +90,8 @@
                 <exclude>**/RealtimeClusterIntegrationTest.java</exclude>
                 <!-- Covered by ConvertToRawIndexMinionClusterIntegrationTest -->
                 <exclude>**/HybridClusterIntegrationTest.java</exclude>
+                <!-- TODO: re-enable the Minion tests when upgrading to Helix 0.9.1 -->
+                <exclude>**/*MinionClusterIntegrationTest.java</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.7.6</avro.version>
     <parquet.version>1.8.0</parquet.version>
-    <helix.version>0.9.0</helix.version>
+    <helix.version>0.8.4</helix.version>
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.9.8</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
@@ -386,7 +386,7 @@
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
-	<version>8.2.3</version>
+        <version>8.2.3</version>
       </dependency>
       <dependency>
         <groupId>joda-time</groupId>
@@ -1164,6 +1164,8 @@
           <!-- Excludes integration tests when unit tests are run. -->
           <excludes>
             <exclude>**/*IT.java</exclude>
+            <!-- TODO: re-enable the Minion tests when upgrading to Helix 0.9.1 -->
+            <exclude>**/*MinionClusterIntegrationTest.java</exclude>
           </excludes>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>


### PR DESCRIPTION
We found some issues in Helix 0.9.0: apache/helix#377

NOTE: Helix version 0.8.4 has issues in Task Framework. Disabled the Minion tests for now. Don't use this version for Minion tasks.