### PR TITLE
Reduce the number of calls to ZK to fetch the current ideal state in rebalancer

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancerAdminToolClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancerAdminToolClusterIntegrationTest.java
@@ -19,11 +19,8 @@
 package org.apache.pinot.integration.tests;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
@@ -47,7 +44,6 @@ import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.helix.core.TableRebalancer;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
-import org.apache.pinot.server.realtime.ControllerLeaderLocator;
 import org.apache.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory;
 import org.apache.pinot.tools.PinotTableRebalancer;
 import org.testng.Assert;


### PR DESCRIPTION
In TableRebalancer, after updating the ideal state (after moving segments), if we successfully persisted this in ZK, we were still going back and fetching the current ideal state from ZK again.

The changes here fetch the ideal state from ZK and re-compute target ideal state only if we failed to persist updated ideal state in ZK earlier due to version error. If there is no version error, we simply start the next iteration (if there are more segments to be moved to get to target) by taking ideal state we just wrote in ZK as the current ideal state.