### PR TITLE
Make MAX_PLAN_THREADS >= 1

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -39,7 +39,8 @@ import org.slf4j.LoggerFactory;
 public class CombinePlanNode implements PlanNode {
   private static final Logger LOGGER = LoggerFactory.getLogger(CombinePlanNode.class);
 
-  private static final int MAX_PLAN_THREADS = Math.min(10, (int) (Runtime.getRuntime().availableProcessors() * .5));
+  private static final int MAX_PLAN_THREADS =
+      Math.max(1, Math.min(10, (int) (Runtime.getRuntime().availableProcessors() * .5)));
   private static final int MIN_TASKS_PER_THREAD = 10;
   private static final int TIME_OUT_IN_MILLISECONDS_FOR_PARALLEL_RUN = 10_000;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -39,6 +39,10 @@ import org.slf4j.LoggerFactory;
 public class CombinePlanNode implements PlanNode {
   private static final Logger LOGGER = LoggerFactory.getLogger(CombinePlanNode.class);
 
+  /**
+   * MAX_PLAN_THREADS should be >= 1.
+   * Runtime.getRuntime().availableProcessors() may return value < 2 in container based environment, e.g. Kubernetes.
+   */
   private static final int MAX_PLAN_THREADS =
       Math.max(1, Math.min(10, (int) (Runtime.getRuntime().availableProcessors() * .5)));
   private static final int MIN_TASKS_PER_THREAD = 10;


### PR DESCRIPTION
Current computation of MAX_PLAN_THREADS could be 0 in k8s environment if cpu resource is < 2. (https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu)
