### PR TITLE
Add support sql query http api

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -164,6 +164,8 @@ public class CommonConstants {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";
       public static final String DEBUG_OPTIONS = "debugOptions";
+      public static final String QUERY = "query";
+      public static final String QUERY_FORMAT = "queryFormat";
 
       public static class QueryOptionKey {
         public static final String PRESERVE_TYPE = "preserveType";

--- a/pinot-controller/src/main/resources/static/js/init.js
+++ b/pinot-controller/src/main/resources/static/js/init.js
@@ -202,10 +202,11 @@ var HELPERS = {
   },
 
   executeQuery: function(query, traceEnabled, callback) {
-    var url = "/pql";
+    var url = "/queryByFormat";
     var params = JSON.stringify({
-      "pql": query,
-      "trace": traceEnabled
+      "query": query,
+      "trace": traceEnabled,
+      "queryFormat": "pql"
     });
     $.ajax({
       type: 'POST',


### PR DESCRIPTION
This PR adds support calcite sql query http api, the updates are:
1. Rename PqlQueryResource to PinotQueryResource
2. Adds http post api `/queryByFormat` to support both pql and sql query based on parameter `queryFormat`.
3. Deprecated post api `/pql`.
4. Updates query console query api.