### PR TITLE
Fixing minor bug with duplicate column names in the query

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -317,12 +317,12 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       SelectionOperatorService selectionService = new SelectionOperatorService(selection, dataSchema);
       selectionService.reduceWithOrdering(dataTableMap);
       selectionResults = selectionService.renderSelectionResultsWithOrdering();
-      columnIndices = SelectionOperatorUtils.getColumnIndicesWithOrdering(selectionColumns, dataSchema);
+      columnIndices = SelectionOperatorUtils.getColumnIndices(selectionColumns, dataSchema);
     } else {
       // Selection only.
       selectionResults = SelectionOperatorUtils.renderSelectionResultsWithoutOrdering(
           SelectionOperatorUtils.reduceWithoutOrdering(dataTableMap, selectionSize), dataSchema, selectionColumns);
-      columnIndices = SelectionOperatorUtils.getColumnIndicesWithoutOrdering(selectionColumns, dataSchema);
+      columnIndices = SelectionOperatorUtils.getColumnIndices(selectionColumns, dataSchema);
     }
 
     // TODO: use "formatRowsWithoutOrdering", "formatRowsWithOrdering" properly for selection when the server is updated

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
@@ -319,7 +319,7 @@ public class SelectionOperatorService {
   public SelectionResults renderSelectionResultsWithOrdering() {
     LinkedList<Serializable[]> rowsInSelectionResults = new LinkedList<>();
 
-    int[] columnIndices = SelectionOperatorUtils.getColumnIndicesWithOrdering(_selectionColumns, _dataSchema);
+    int[] columnIndices = SelectionOperatorUtils.getColumnIndices(_selectionColumns, _dataSchema);
     while (_rows.size() > _selectionOffset) {
       rowsInSelectionResults.addFirst(SelectionOperatorUtils.extractColumns(_rows.poll(), columnIndices));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -420,7 +420,7 @@ public class SelectionOperatorUtils {
   @Nonnull
   public static SelectionResults renderSelectionResultsWithoutOrdering(@Nonnull List<Serializable[]> rows,
       @Nonnull DataSchema dataSchema, @Nonnull List<String> selectionColumns) {
-    int[] columnIndices = getColumnIndicesWithoutOrdering(selectionColumns, dataSchema);
+    int[] columnIndices = getColumnIndices(selectionColumns, dataSchema);
     int numRows = rows.size();
     for (int i = 0; i < numRows; i++) {
       rows.set(i, extractColumns(rows.get(i), columnIndices));
@@ -429,34 +429,12 @@ public class SelectionOperatorUtils {
   }
 
   /**
-   * Helper method to compute column indices from selection columns and the data schema for selection queries without
-   * <code>ORDER BY</code>.
+   * Helper method to compute column indices from selection columns and the data schema for selection queries
    * @param selectionColumns selection columns.
    * @param dataSchema data schema.
    * @return column indices
    */
-  public static int[] getColumnIndicesWithoutOrdering(@Nonnull List<String> selectionColumns,
-      @Nonnull DataSchema dataSchema) {
-    int numSelectionColumns = selectionColumns.size();
-    int[] columnIndices = new int[numSelectionColumns];
-    Map<String, Integer> dataSchemaIndices = new HashMap<>(numSelectionColumns);
-    for (int i = 0; i < numSelectionColumns; i++) {
-      dataSchemaIndices.put(dataSchema.getColumnName(i), i);
-    }
-    for (int i = 0; i < numSelectionColumns; i++) {
-      columnIndices[i] = dataSchemaIndices.get(selectionColumns.get(i));
-    }
-    return columnIndices;
-  }
-
-  /**
-   * Helper method to compute column indices from selection columns and the data schema for selection queries with
-   * <code>ORDER BY</code>.
-   * @param selectionColumns selection columns.
-   * @param dataSchema data schema.
-   * @return column indices
-   */
-  public static int[] getColumnIndicesWithOrdering(@Nonnull List<String> selectionColumns,
+  public static int[] getColumnIndices(@Nonnull List<String> selectionColumns,
       @Nonnull DataSchema dataSchema) {
     int numSelectionColumns = selectionColumns.size();
     int[] columnIndices = new int[numSelectionColumns];
@@ -470,6 +448,8 @@ public class SelectionOperatorUtils {
     }
     return columnIndices;
   }
+
+
 
   /**
    * Extract columns from the row based on the given column indices.

--- a/pinot-core/src/test/java/org/apache/pinot/query/selection/SelectionOperatorServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/selection/SelectionOperatorServiceTest.java
@@ -159,7 +159,7 @@ public class SelectionOperatorServiceTest {
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(1), expectedRow2));
 
     int[] columnIndices =
-        SelectionOperatorUtils.getColumnIndicesWithoutOrdering(selectionResults.getColumns(), _dataSchema);
+        SelectionOperatorUtils.getColumnIndices(selectionResults.getColumns(), _dataSchema);
 
     // TODO: use "formatRowsWithoutOrdering" after server updated to the latest code.
     resultRows = SelectionOperatorUtils.formatRowsWithOrdering(resultRows, columnIndices, _upgradedDataSchema);
@@ -192,7 +192,7 @@ public class SelectionOperatorServiceTest {
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(1), expectedRow2));
 
     int[] columnIndices =
-        SelectionOperatorUtils.getColumnIndicesWithOrdering(selectionResults.getColumns(), _dataSchema);
+        SelectionOperatorUtils.getColumnIndices(selectionResults.getColumns(), _dataSchema);
     resultRows = SelectionOperatorUtils.formatRowsWithOrdering(resultRows, columnIndices, _upgradedDataSchema);
 
     Serializable[] expectedFormattedRow1 =

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -657,6 +657,30 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     }
   }
 
+  @Test
+  public void testQueryWithRepeatedColumns()
+      throws Exception {
+    //test repeated columns in selection query
+    String query = "SELECT ArrTime, ArrTime FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL'";
+    testQuery(query, Collections.singletonList(query));
+
+    //test repeated columns in selection query with order by
+    query = "SELECT ArrTime, ArrTime FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL' order by ArrTime";
+    testQuery(query, Collections.singletonList(query));
+
+    //test repeated columns in agg query
+    query = "SELECT count(*), count(*) FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL'";
+    testQuery(query, Arrays.asList("SELECT count(*) FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL'",
+        "SELECT count(*) FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL'"));
+
+    //test repeated columns in agg group by query
+    query =
+        "SELECT ArrTime, ArrTime, count(*), count(*) FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL' group by ArrTime, ArrTime";
+    testQuery(query, Arrays.asList(
+        "SELECT ArrTime, ArrTime, count(*) FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL' group by ArrTime, ArrTime",
+        "SELECT ArrTime, ArrTime, count(*) FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL' group by ArrTime, ArrTime"));
+  }
+
   @AfterClass
   public void tearDown()
       throws Exception {


### PR DESCRIPTION
Without this fix ```Select a, a from T limit 10``` fails with indexOutOfBounds exception. 

Also merged two identical methods into one


