### PR TITLE
Updating license and notice binary files for aea8fca7e

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -246,13 +246,18 @@ io.swagger:swagger-jersey2-jaxrs:1.5.16
 io.swagger:swagger-models:1.5.16
 io.vavr:vavr:0.9.2
 io.vavr:vavr-match:0.9.2
-it.unimi.dsi:fastutil:6.5.16
+it.unimi.dsi:fastutil:8.2.3
 javax.inject:javax.inject:1
 javax.validation:validation-api:2.0.1.Final
 joda-time:joda-time:2.0
 me.lemire.integercompression:JavaFastPFOR:0.0.13
 net.jpountz.lz4:lz4:1.2.0
 org.apache.avro:avro:1.7.6
+org.apache.avro:avro-ipc:1.7.4
+org.apache.avro:avro-mapred:1.7.4
+org.apache.calcite.avatica:avatica-core:1.13.0
+org.apache.calcite:calcite-core:1.19.0
+org.apache.calcite:calcite-linq4j:1.19.0
 org.apache.commons:commons-compress:1.9
 org.apache.commons:commons-csv:1.0
 org.apache.commons:commons-lang3:3.5
@@ -270,7 +275,7 @@ org.apache.hadoop:hadoop-auth:2.7.0
 org.apache.hadoop:hadoop-common:2.7.0
 org.apache.hadoop:hadoop-hdfs:2.2.0
 org.apache.hadoop:hadoop-mapreduce-client-core:2.2.0
-org.apache.helix:helix-core:0.8.2
+org.apache.helix:helix-core:0.8.4
 org.apache.hive:hive-storage-api:2.6.0
 org.apache.htrace:htrace-core:3.1.0-incubating
 org.apache.httpcomponents:httpclient:4.5.3
@@ -285,12 +290,16 @@ org.apache.logging.log4j:log4j-slf4j-impl:2.11.2
 org.apache.orc:orc-core:1.5.2
 org.apache.orc:orc-mapreduce:1.5.2
 org.apache.orc:orc-shims:1.5.2
-org.apache.thrift:libthrift:0.9.1
+org.apache.thrift:libthrift:0.12.0
+org.apache.velocity:velocity:1.7
 org.apache.yetus:audience-annotations:0.5.0
 org.apache.zookeeper:zookeeper:3.4.11
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.javassist:javassist:3.19.0-GA
+org.mortbay.jetty:jetty:6.1.26
+org.mortbay.jetty:jetty-util:6.1.26
+org.mortbay.jetty:servlet-api:2.5-20081211
 org.objenesis:objenesis:2.1
 org.roaringbitmap:RoaringBitmap:0.8.0
 org.roaringbitmap:shims:0.8.0
@@ -315,8 +324,7 @@ MIT License
 args4j:args4j:2.32
 com.microsoft.azure:azure-data-lake-store-sdk:2.1.5
 net.sf.jopt-simple:jopt-simple:4.6
-org.slf4j:slf4j-api:1.7.7
-org.slf4j:slf4j-log4j12:1.7.7
+org.slf4j:slf4j-api:1.7.25
 
 pinot-controller/src/main/resources/*/js/lib/codemirror/*
 pinot-controller/src/main/resources/*/js/lib/foundation/*

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -10,8 +10,11 @@ The Apache Software Foundation (http://www.apache.org/).
 // Version 2.0, in this case for 
 // ------------------------------------------------------------------
 
-Apache Log4j Core
-Copyright 1999-2012 Apache Software Foundation
+The HermiteInterpolator class and its corresponding test have been imported from
+the orekit library distributed under the terms of the Apache 2 licence. Original
+source copyright:
+Copyright 2010-2012 CS Systèmes d'Information
+===============================================================================
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -41,14 +44,23 @@ provided this notice is preserved.
 Apache HttpCore
 Copyright 2005-2017 The Apache Software Foundation
 
-Apache Thrift
-Copyright 2006-2010 The Apache Software Foundation.
+Calcite Core
+Copyright 2012-2019 The Apache Software Foundation
+
+Apache Calcite Avatica
+Copyright 2012-2018 The Apache Software Foundation
+
+Calcite Linq4j
+Copyright 2012-2019 The Apache Software Foundation
 
 Apache Commons Lang
 Copyright 2001-2016 The Apache Software Foundation
 
 This product includes software from the Spring Framework,
 under the Apache License 2.0 (see: StringUtils.containsWhitespace())
+
+Apache Thrift
+Copyright 2006-2017 The Apache Software Foundation.
 
 Apache Avro
 Copyright 2009-2014 The Apache Software Foundation
@@ -107,7 +119,7 @@ which has been placed in the public domain:
 "LZMA SDK is placed in the public domain." (http://www.7-zip.org/sdk.html)
 
 Apache Helix :: Core
-Copyright 2018 The Apache Software Foundation
+Copyright 2019 The Apache Software Foundation
 
                             The Netty Project
                             =================
@@ -329,11 +341,66 @@ To find the details that apply to this artifact see the accompanying LICENSE fil
 For more information, including possible other licensing options, contact
 FasterXML.com (http://fasterxml.com).
 
+Apache Log4j Core
+Copyright 1999-2012 Apache Software Foundation
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Apache Avro Mapred API
+Copyright 2009-2013 The Apache Software Foundation
+
+Apache Avro IPC
+Copyright 2009-2013 The Apache Software Foundation
+
+Apache Velocity
+
+Copyright (C) 2000-2007 The Apache Software Foundation
+
 ORC Core
 Copyright 2013-2018 The Apache Software Foundation
 
 ORC Shims
 Copyright 2013-2018 The Apache Software Foundation
+
+Apache Commons Net
+Copyright 2001-2012 The Apache Software Foundation
+
+ApacheDS Protocol Kerberos Codec
+Copyright 2003-2013 The Apache Software Foundation
+
+ApacheDS I18n
+Copyright 2003-2013 The Apache Software Foundation
+
+Apache Directory API ASN.1 API
+Copyright 2003-2013 The Apache Software Foundation
+
+Apache Directory LDAP API Utilities
+Copyright 2003-2013 The Apache Software Foundation
+
+Curator Framework
+Copyright 2011-2015 The Apache Software Foundation
+
+Curator Client
+Copyright 2011-2015 The Apache Software Foundation
+
+htrace-core
+Copyright 2015 The Apache Software Foundation
+
+Hive Storage API
+Copyright 2018 The Apache Software Foundation
+
+ORC MapReduce
+Copyright 2013-2018 The Apache Software Foundation
+
+Objenesis
+Copyright 2006-2013 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+Google Guice - Extensions - Servlet
+Copyright 2006-2011 Google, Inc.
+
+Google Guice - Core Library
+Copyright 2006-2011 Google, Inc.
 
 Apache Commons Math
 Copyright 2001-2013 The Apache Software Foundation
@@ -396,55 +463,7 @@ terms of the Apache 2 licence. Original source copyright:
 Copyright 2010 CS Systèmes d'Information
 ===============================================================================
 
-The HermiteInterpolator class and its corresponding test have been imported from
-the orekit library distributed under the terms of the Apache 2 licence. Original
-source copyright:
-Copyright 2010-2012 CS Systèmes d'Information
-===============================================================================
-
 The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
 by an original code donated by Sébastien Brisard.
 ===============================================================================
-
-Apache Commons Net
-Copyright 2001-2012 The Apache Software Foundation
-
-ApacheDS Protocol Kerberos Codec
-Copyright 2003-2013 The Apache Software Foundation
-
-ApacheDS I18n
-Copyright 2003-2013 The Apache Software Foundation
-
-Apache Directory API ASN.1 API
-Copyright 2003-2013 The Apache Software Foundation
-
-Apache Directory LDAP API Utilities
-Copyright 2003-2013 The Apache Software Foundation
-
-Curator Framework
-Copyright 2011-2015 The Apache Software Foundation
-
-Curator Client
-Copyright 2011-2015 The Apache Software Foundation
-
-htrace-core
-Copyright 2015 The Apache Software Foundation
-
-Hive Storage API
-Copyright 2018 The Apache Software Foundation
-
-ORC MapReduce
-Copyright 2013-2018 The Apache Software Foundation
-
-Objenesis
-Copyright 2006-2013 Joe Walnes, Henri Tremblay, Leonardo Mesquita
-
-Google Guice - Extensions - Servlet
-Copyright 2006-2011 Google, Inc.
-
-Google Guice - Core Library
-Copyright 2006-2011 Google, Inc.
-
-ResolverUtil.java
-Copyright 2005-2006 Tim Fennell
 


### PR DESCRIPTION

Updated the license and notice binaries as per instructions in
https://cwiki.apache.org/confluence/display/PINOT/Creating+an+Apache+Release
These files are as of commit aea8fca7e from which we expect to cut
pinot-0.2.0 release