### PR TITLE
Expose a method to determine if a QueryExceptionErrorCode represents a client-side error

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
@@ -28,9 +28,12 @@ import org.apache.pinot.common.response.BrokerResponse;
  * post-processing at a finer level than metrics.
  */
 public class RequestStatistics {
+
+  public static final String DEFAULT_TABLE_NAME = "NotYetParsed";
+
   private int _errorCode = 0;
   private String _pql;
-  private String _tableName = "NotYetParsed";
+  private String _tableName = DEFAULT_TABLE_NAME;
   private long _processingTimeMillis = -1;
 
   private long _totalDocs;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
@@ -29,7 +29,7 @@ import org.apache.pinot.common.response.BrokerResponse;
  */
 public class RequestStatistics {
 
-  public static final String DEFAULT_TABLE_NAME = "NotYetParsed";
+  private static final String DEFAULT_TABLE_NAME = "NotYetParsed";
 
   private int _errorCode = 0;
   private String _pql;
@@ -191,5 +191,9 @@ public class RequestStatistics {
 
   public int getNumExceptions() {
     return _numExceptions;
+  }
+
+  public boolean hasValidTableName() {
+    return ! DEFAULT_TABLE_NAME.equals(_tableName);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -61,6 +61,7 @@ public class QueryException {
   public static final int COMBINE_GROUP_BY_EXCEPTION_ERROR_CODE = 600;
   public static final int QUERY_VALIDATION_ERROR_CODE = 700;
   public static final int UNKNOWN_ERROR_CODE = 1000;
+  // NOTE: update isClientError() method appropriately when new codes are added
 
   public static final ProcessingException JSON_PARSING_ERROR = new ProcessingException(JSON_PARSING_ERROR_CODE);
   public static final ProcessingException JSON_COMPILATION_ERROR = new ProcessingException(JSON_COMPILATION_ERROR_CODE);
@@ -146,5 +147,25 @@ public class QueryException {
     ProcessingException copiedProcessingException = processingException.deepCopy();
     copiedProcessingException.setMessage(errorType + ":\n" + errorMessage);
     return copiedProcessingException;
+  }
+
+  /**
+   * Determines if a query-exception-error-code represents an error on the client side.
+   * @param errorCode  the error code from processing the query
+   * @return whether the code indicates client error or not
+   */
+  public static boolean isClientError(int errorCode) {
+    switch (errorCode) {
+      case QueryException.ACCESS_DENIED_ERROR_CODE:
+      case QueryException.JSON_COMPILATION_ERROR_CODE:
+      case QueryException.JSON_PARSING_ERROR_CODE:
+      case QueryException.QUERY_VALIDATION_ERROR_CODE:
+      case QueryException.PQL_PARSING_ERROR_CODE:
+      case QueryException.TOO_MANY_REQUESTS_ERROR_CODE: {
+        return true;
+      }
+      default:
+        return false;
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -156,14 +156,17 @@ public class QueryException {
    */
   public static boolean isClientError(int errorCode) {
     switch (errorCode) {
+      // NOTE: QueryException.BROKER_RESOURCE_MISSING_ERROR can be triggered either due to
+      // client error (incorrect table name) or due to issues with EV updates. For cases where
+      // access to tables is controlled via ACLs, for an incorrect table name we expect ACCESS_DENIED_ERROR to be
+      // thrown. Hence, we currently don't treat BROKER_RESOURCE_MISSING_ERROR as client error.
       case QueryException.ACCESS_DENIED_ERROR_CODE:
       case QueryException.JSON_COMPILATION_ERROR_CODE:
       case QueryException.JSON_PARSING_ERROR_CODE:
       case QueryException.QUERY_VALIDATION_ERROR_CODE:
       case QueryException.PQL_PARSING_ERROR_CODE:
-      case QueryException.TOO_MANY_REQUESTS_ERROR_CODE: {
+      case QueryException.TOO_MANY_REQUESTS_ERROR_CODE:
         return true;
-      }
       default:
         return false;
     }


### PR DESCRIPTION
Add a method in the QueryException class to determine if an error code represents a client-side error. Adding it in the class directly helps keep the method up-to-date when new codes are added.

Also, expose the value used by RequestStatistics object to indicate the default value set for tables so higher layers can use it appropriately to determine whether the table name was parsed correctly or not.