### PR TITLE
Fixing bytes data type merge logic

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformBlockDataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformBlockDataFetcher.java
@@ -199,9 +199,6 @@ class DictionaryBasedSVValueFetcher implements Fetcher {
   }
 
   public Serializable getValue(int docId) {
-    if (_dataType.equals(FieldSpec.DataType.BYTES)) {
-      return BytesUtils.toHexString(_dictionary.getBytesValue(_dictionaryIds[docId]));
-    }
     return (Serializable) _dictionary.get(_dictionaryIds[docId]);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionFetcher.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.selection;
 import java.io.Serializable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Block;
+import org.apache.pinot.core.query.selection.iterator.BytesSelectionColumnIterator;
 import org.apache.pinot.core.query.selection.iterator.DoubleArraySelectionColumnIterator;
 import org.apache.pinot.core.query.selection.iterator.DoubleSelectionColumnIterator;
 import org.apache.pinot.core.query.selection.iterator.FloatArraySelectionColumnIterator;
@@ -101,8 +102,10 @@ public class SelectionFetcher {
             _selectionColumnIterators[i] = new DoubleSelectionColumnIterator(block);
             break;
           case STRING:
-          case BYTES:
             _selectionColumnIterators[i] = new StringSelectionColumnIterator(block);
+            break;
+          case BYTES:
+            _selectionColumnIterators[i] = new BytesSelectionColumnIterator(block);
             break;
           // TODO: add multi value support
           default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.response.broker.SelectionResults;
+import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.common.DataSourceMetadata;
@@ -248,8 +249,10 @@ public class SelectionOperatorUtils {
             dataTableBuilder.setColumn(i, ((Number) columnValue).doubleValue());
             break;
           case STRING:
-          case BYTES: // BYTES are already converted to String for Selection, before reaching this layer.
             dataTableBuilder.setColumn(i, ((String) columnValue));
+            break;
+          case BYTES:
+            dataTableBuilder.setColumn(i, BytesUtils.toHexString((byte[]) columnValue));
             break;
 
           // Multi-value column.
@@ -649,6 +652,10 @@ public class SelectionOperatorUtils {
             formattedValue[i] = doubleFormat(doubles[i]);
           }
           return formattedValue;
+        }
+      case BYTES:
+        if (value instanceof byte[]) {
+          return BytesUtils.toHexString((byte[]) value);
         }
       default:
         // For STRING and STRING_ARRAY, no need to format.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/iterator/BytesSelectionColumnIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/iterator/BytesSelectionColumnIterator.java
@@ -18,32 +18,33 @@
  */
 package org.apache.pinot.core.query.selection.iterator;
 
+import com.clearspring.analytics.util.Preconditions;
 import java.io.Serializable;
 import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.core.common.Block;
 import org.apache.pinot.core.common.BlockSingleValIterator;
-import org.apache.pinot.core.segment.index.readers.Dictionary;
-import org.apache.pinot.common.utils.BytesUtils;
 
 
 /**
- * Iterator on single-value column with dictionary for selection query.
+ * Iterator on bytes no dictionary column selection query.
  *
  */
-public class SelectionSingleValueColumnWithDictIterator implements SelectionColumnIterator {
-  protected BlockSingleValIterator _blockSingleValIterator;
-  protected Dictionary _dictionary;
+public class BytesSelectionColumnIterator implements SelectionColumnIterator {
   private final FieldSpec.DataType _dataType;
+  protected BlockSingleValIterator bvIter;
 
-  public SelectionSingleValueColumnWithDictIterator(Block block) {
-    _blockSingleValIterator = (BlockSingleValIterator) block.getBlockValueSet().iterator();
+  public BytesSelectionColumnIterator(Block block) {
     _dataType = block.getMetadata().getDataType();
-    _dictionary = block.getMetadata().getDictionary();
+    Preconditions
+        .checkArgument(_dataType.equals(FieldSpec.DataType.BYTES),
+            "Illegal data type for BytesSelectionColumnIterator: " + _dataType);
+    bvIter = (BlockSingleValIterator) block.getBlockValueSet().iterator();
   }
 
   @Override
   public Serializable getValue(int docId) {
-    _blockSingleValIterator.skipTo(docId);
-    return (Serializable) _dictionary.get(_blockSingleValIterator.nextIntVal());
+    bvIter.skipTo(docId);
+    return bvIter.nextBytesVal();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/iterator/StringSelectionColumnIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/iterator/StringSelectionColumnIterator.java
@@ -37,7 +37,7 @@ public class StringSelectionColumnIterator implements SelectionColumnIterator {
   public StringSelectionColumnIterator(Block block) {
     _dataType = block.getMetadata().getDataType();
     Preconditions
-        .checkArgument(_dataType.equals(FieldSpec.DataType.STRING) || _dataType.equals(FieldSpec.DataType.BYTES),
+        .checkArgument(_dataType.equals(FieldSpec.DataType.STRING),
             "Illegal data type for StringSelectionColumnIterator: " + _dataType);
     bvIter = (BlockSingleValIterator) block.getBlockValueSet().iterator();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/iterator/StringSelectionColumnIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/iterator/StringSelectionColumnIterator.java
@@ -45,12 +45,6 @@ public class StringSelectionColumnIterator implements SelectionColumnIterator {
   @Override
   public Serializable getValue(int docId) {
     bvIter.skipTo(docId);
-
-    if (_dataType.equals(FieldSpec.DataType.BYTES)) {
-      // byte[] is converted to equivalent Hex String for selection queries.
-      return BytesUtils.toHexString(bvIter.nextBytesVal());
-    } else {
-      return bvIter.nextStringVal();
-    }
+    return bvIter.nextStringVal();
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/query/selection/SelectionOperatorServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/selection/SelectionOperatorServiceTest.java
@@ -43,24 +43,24 @@ import org.testng.annotations.Test;
  */
 public class SelectionOperatorServiceTest {
   private final String[] _columnNames =
-      {"int", "long", "float", "double", "string", "int_array", "long_array", "float_array", "double_array", "string_array"};
+      {"int", "long", "float", "double", "string", "int_array", "long_array", "float_array", "double_array", "string_array", "bytes"};
   private final DataSchema.ColumnDataType[] _columnDataTypes =
-      {DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.FLOAT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY};
+      {DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.FLOAT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.BYTES};
   private final DataSchema _dataSchema = new DataSchema(_columnNames, _columnDataTypes);
   private final DataSchema.ColumnDataType[] _compatibleColumnDataTypes =
-      {DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.FLOAT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY};
+      {DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.FLOAT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.BYTES};
   private final DataSchema _compatibleDataSchema = new DataSchema(_columnNames, _compatibleColumnDataTypes);
   private final DataSchema.ColumnDataType[] _upgradedColumnDataTypes =
-      new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY};
+      new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.BYTES};
   private final DataSchema _upgradedDataSchema = new DataSchema(_columnNames, _upgradedColumnDataTypes);
   private final Serializable[] _row1 =
-      {0, 1L, 2.0F, 3.0, "4", new int[]{5}, new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new String[]{"9"}};
+      {0, 1L, 2.0F, 3.0, "4", new int[]{5}, new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new String[]{"9"}, new byte[]{0x10, 0x20}};
   private final Serializable[] _row2 =
-      {10, 11L, 12.0F, 13.0, "14", new int[]{15}, new long[]{16L}, new float[]{17.0F}, new double[]{18.0}, new String[]{"19"}};
+      {10, 11L, 12.0F, 13.0, "14", new int[]{15}, new long[]{16L}, new float[]{17.0F}, new double[]{18.0}, new String[]{"19"}, new byte[]{0x30, 0x40}};
   private final Serializable[] _compatibleRow1 =
-      {1L, 2.0F, 3.0, 4, "5", new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new int[]{9}, new String[]{"10"}};
+      {1L, 2.0F, 3.0, 4, "5", new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new int[]{9}, new String[]{"10"}, new byte[]{0x50, 0x60}};
   private final Serializable[] _compatibleRow2 =
-      {11L, 12.0F, 13.0, 14, "15", new long[]{16L}, new float[]{17.0F}, new double[]{18.0}, new int[]{19}, new String[]{"20"}};
+      {11L, 12.0F, 13.0, 14, "15", new long[]{16L}, new float[]{17.0F}, new double[]{18.0}, new int[]{19}, new String[]{"20"}, new byte[]{0x70, 0x00}};
   private final Selection _selectionOrderBy = new Selection();
 
   @BeforeClass
@@ -81,8 +81,8 @@ public class SelectionOperatorServiceTest {
         SelectionOperatorUtils.getSelectionColumns(Collections.singletonList("*"), _dataSchema);
     // Alphabetical.
     List<String> expectedSelectionColumns = Arrays
-        .asList("double", "double_array", "float", "float_array", "int", "int_array", "long", "long_array", "string",
-            "string_array");
+        .asList("bytes", "double", "double_array", "float", "float_array", "int", "int_array", "long", "long_array",
+            "string", "string_array");
     Assert.assertEquals(selectionColumns, expectedSelectionColumns);
   }
 
@@ -132,9 +132,9 @@ public class SelectionOperatorServiceTest {
     Assert.assertEquals(dataSchema, _upgradedDataSchema);
     DataTable dataTable = SelectionOperatorUtils.getDataTableFromRows(rows, dataSchema);
     Serializable[] expectedRow1 =
-        {0L, 1.0, 2.0, 3.0, "4", new long[]{5L}, new double[]{6.0}, new double[]{7.0}, new double[]{8.0}, new String[]{"9"}};
+        {0L, 1.0, 2.0, 3.0, "4", new long[]{5L}, new double[]{6.0}, new double[]{7.0}, new double[]{8.0}, new String[]{"9"}, "1020"};
     Serializable[] expectedCompatibleRow1 =
-        {1L, 2.0, 3.0, 4.0, "5", new long[]{6L}, new double[]{7.0}, new double[]{8.0}, new double[]{9.0}, new String[]{"10"}};
+        {1L, 2.0, 3.0, 4.0, "5", new long[]{6L}, new double[]{7.0}, new double[]{8.0}, new double[]{9.0}, new String[]{"10"}, "5060"};
     Assert.assertTrue(Arrays.deepEquals(SelectionOperatorUtils.extractRowFromDataTable(dataTable, 0), expectedRow1));
     Assert.assertTrue(
         Arrays.deepEquals(SelectionOperatorUtils.extractRowFromDataTable(dataTable, 1), expectedCompatibleRow1));
@@ -151,23 +151,22 @@ public class SelectionOperatorServiceTest {
     List<Serializable[]> resultRows = selectionResults.getRows();
 
     Serializable[] expectedRow1 =
-        {0, 1L, 2.0F, 3.0, "4", new int[]{5}, new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new String[]{"9"}};
+        {0, 1L, 2.0F, 3.0, "4", new int[]{5}, new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new String[]{"9"}, new byte[]{0x10, 0x20}};
     Serializable[] expectedRow2 =
-        {1L, 2.0F, 3.0, 4, "5", new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new int[]{9}, new String[]{"10"}};
+        {1L, 2.0F, 3.0, 4, "5", new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new int[]{9}, new String[]{"10"}, new byte[]{0x50, 0x60}};
 
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(0), expectedRow1));
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(1), expectedRow2));
 
-    int[] columnIndices =
-        SelectionOperatorUtils.getColumnIndices(selectionResults.getColumns(), _dataSchema);
+    int[] columnIndices = SelectionOperatorUtils.getColumnIndices(selectionResults.getColumns(), _dataSchema);
 
     // TODO: use "formatRowsWithoutOrdering" after server updated to the latest code.
     resultRows = SelectionOperatorUtils.formatRowsWithOrdering(resultRows, columnIndices, _upgradedDataSchema);
 
     Serializable[] expectedFormattedRow1 =
-        {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}};
+        {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}, "1020"};
     Serializable[] expectedFormattedRow2 =
-        {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}};
+        {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}, "5060"};
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(0), expectedFormattedRow1));
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(1), expectedFormattedRow2));
   }
@@ -185,20 +184,19 @@ public class SelectionOperatorServiceTest {
     List<Serializable[]> resultRows = selectionResults.getRows();
 
     Serializable[] expectedRow1 =
-        {1L, 2.0F, 3.0, 4, "5", new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new int[]{9}, new String[]{"10"}};
+        {1L, 2.0F, 3.0, 4, "5", new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new int[]{9}, new String[]{"10"}, new byte[]{0x50, 0x60}};
     Serializable[] expectedRow2 =
-        {0, 1L, 2.0F, 3.0, "4", new int[]{5}, new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new String[]{"9"}};
+        {0, 1L, 2.0F, 3.0, "4", new int[]{5}, new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new String[]{"9"}, new byte[]{0x10, 0x20}};
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(0), expectedRow1));
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(1), expectedRow2));
 
-    int[] columnIndices =
-        SelectionOperatorUtils.getColumnIndices(selectionResults.getColumns(), _dataSchema);
+    int[] columnIndices = SelectionOperatorUtils.getColumnIndices(selectionResults.getColumns(), _dataSchema);
     resultRows = SelectionOperatorUtils.formatRowsWithOrdering(resultRows, columnIndices, _upgradedDataSchema);
 
     Serializable[] expectedFormattedRow1 =
-        {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}};
+        {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}, "5060"};
     Serializable[] expectedFormattedRow2 =
-        {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}};
+        {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}, "1020"};
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(0), expectedFormattedRow1));
     Assert.assertTrue(Arrays.deepEquals(resultRows.get(1), expectedFormattedRow2));
   }


### PR DESCRIPTION
The old implementation convert bytes to string, for dictionary based column, but not for non-dictionary based.

Move this logic to merging part.