### PR TITLE
Fixing metrics aggregation logic for Float and Double

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -371,10 +371,10 @@ public class MutableSegmentImpl implements MutableSegment {
           indexReaderWriter.setLong(docId, (Long) value + indexReaderWriter.getLong(docId));
           break;
         case FLOAT:
-          indexReaderWriter.setFloat(docId, indexReaderWriter.getFloat(docId) + indexReaderWriter.getFloat(docId));
+          indexReaderWriter.setFloat(docId, (Float) value + indexReaderWriter.getFloat(docId));
           break;
         case DOUBLE:
-          indexReaderWriter.setDouble(docId, indexReaderWriter.getDouble(docId) + indexReaderWriter.getDouble(docId));
+          indexReaderWriter.setDouble(docId, (Double) value + indexReaderWriter.getDouble(docId));
           break;
         default:
           throw new UnsupportedOperationException(

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
@@ -39,6 +39,7 @@ public class MutableSegmentImplAggregateMetricsTest {
   private static final String DIMENSION_1 = "dim1";
   private static final String DIMENSION_2 = "dim2";
   private static final String METRIC = "metric";
+  private static final String METRIC_2 = "metric2";
   private static final String KEY_SEPARATOR = "\t\t";
   private static final int NUM_ROWS = 10001;
 
@@ -48,10 +49,12 @@ public class MutableSegmentImplAggregateMetricsTest {
   public void setUp() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName("testSchema")
         .addSingleValueDimension(DIMENSION_1, FieldSpec.DataType.INT)
-        .addSingleValueDimension(DIMENSION_2, FieldSpec.DataType.STRING).addMetric(METRIC, FieldSpec.DataType.LONG)
-        .build();
+            .addSingleValueDimension(DIMENSION_2, FieldSpec.DataType.STRING)
+            .addMetric(METRIC, FieldSpec.DataType.LONG)
+            .addMetric(METRIC_2, FieldSpec.DataType.FLOAT)
+            .build();
     _mutableSegmentImpl = MutableSegmentImplTestUtils
-        .createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(DIMENSION_1, METRIC)),
+        .createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(DIMENSION_1, METRIC, METRIC_2)),
             new HashSet<>(Arrays.asList(DIMENSION_1)),
             Collections.singleton(DIMENSION_1), true);
   }
@@ -59,13 +62,16 @@ public class MutableSegmentImplAggregateMetricsTest {
   @Test
   public void testAggregateMetrics() {
     String[] stringValues = new String[10];
+    Float[] floatValues = new Float[10];
+    Random random = new Random();
     for (int i = 0; i < stringValues.length; i++) {
       stringValues[i] = RandomStringUtils.random(10);
+      floatValues[i] = random.nextFloat() * 10f;
     }
 
     Map<String, Long> expectedValues = new HashMap<>();
+    Map<String, Float> expectedValuesFloat = new HashMap<>();
     StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis());
-    Random random = new Random();
     for (int i = 0; i < NUM_ROWS; i++) {
       GenericRow row = new GenericRow();
       row.putField(DIMENSION_1, random.nextInt(10));
@@ -73,12 +79,15 @@ public class MutableSegmentImplAggregateMetricsTest {
       // Generate random int to prevent overflow
       long metricValue = random.nextInt();
       row.putField(METRIC, metricValue);
+      float metricValueFloat = floatValues[random.nextInt(floatValues.length)];
+      row.putField(METRIC_2, metricValueFloat);
 
       _mutableSegmentImpl.index(row, defaultMetadata);
 
       // Update expected values
       String key = buildKey(row);
       expectedValues.put(key, expectedValues.getOrDefault(key, 0L) + metricValue);
+      expectedValuesFloat.put(key, expectedValuesFloat.getOrDefault(key, 0f) + metricValueFloat);
     }
 
     int numDocsIndexed = _mutableSegmentImpl.getNumDocsIndexed();
@@ -92,6 +101,7 @@ public class MutableSegmentImplAggregateMetricsTest {
       GenericRow row = _mutableSegmentImpl.getRecord(docId, reuse);
       String key = buildKey(row);
       Assert.assertEquals(row.getValue(METRIC), expectedValues.get(key));
+      Assert.assertEquals(row.getValue(METRIC_2), expectedValuesFloat.get(key));
     }
   }
 


### PR DESCRIPTION
There seems to an issue with metrics aggregation for float and double type columns. The current code seems to ignore the value of the row being ingested (and simply add the existing cumulative total). This PR fixes this minor bug.