### PR TITLE
Expose table-name via StreamConfig

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTableBuilderFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTableBuilderFactory.java
@@ -131,7 +131,8 @@ public class RoutingTableBuilderFactory {
         break;
       case PartitionAwareRealtime:
         // Check that the table uses LL consumer.
-        StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+        StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(),
+            tableConfig.getIndexingConfig().getStreamConfigs());
 
         if (streamConfig.getConsumerTypes().size() == 1 && streamConfig.hasLowLevelConsumerType()) {
           builder = new PartitionAwareRealtimeRoutingTableBuilder();

--- a/pinot-connectors/pinot-connector-kafka-0.9/src/test/java/org/apache/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfigTest.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/test/java/org/apache/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamConfigTest.java
@@ -66,7 +66,7 @@ public class KafkaLowLevelStreamConfigTest {
     if (fetcherMinBytes != null) {
       streamConfigMap.put("stream.kafka.fetcher.minBytes", fetcherMinBytes);
     }
-    return new KafkaLowLevelStreamConfig(new StreamConfig(streamConfigMap));
+    return new KafkaLowLevelStreamConfig(new StreamConfig("fakeTable_REALTIME", streamConfigMap));
   }
 
   @Test

--- a/pinot-connectors/pinot-connector-kafka-0.9/src/test/java/org/apache/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/test/java/org/apache/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumerTest.java
@@ -222,6 +222,7 @@ public class KafkaPartitionLevelConsumerTest {
     String streamKafkaBrokerList = "abcd:1234,bcde:2345";
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
+    String tableNameWithType = "table_REALTIME";
 
     MockKafkaSimpleConsumerFactory mockKafkaSimpleConsumerFactory =
         new MockKafkaSimpleConsumerFactory(new String[]{"abcd", "bcde"}, new int[]{1234, 2345},
@@ -237,7 +238,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
     streamConfigMap.put("stream.kafka.fetcher.size", "10000");
     streamConfigMap.put("stream.kafka.fetcher.minBytes", "20000");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     KafkaStreamMetadataProvider streamMetadataProvider =
         new KafkaStreamMetadataProvider(clientId, streamConfig, mockKafkaSimpleConsumerFactory);
@@ -259,7 +260,7 @@ public class KafkaPartitionLevelConsumerTest {
     // test user defined values
     streamConfigMap.put("stream.kafka.buffer.size", "100");
     streamConfigMap.put("stream.kafka.socket.timeout", "1000");
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
     kafkaSimpleStreamConsumer =
         new KafkaPartitionLevelConsumer(clientId, streamConfig, 0, mockKafkaSimpleConsumerFactory);
     kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
@@ -274,6 +275,7 @@ public class KafkaPartitionLevelConsumerTest {
     String streamKafkaBrokerList = "abcd:1234,bcde:2345";
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
+    String tableNameWithType = "table_REALTIME";
 
     MockKafkaSimpleConsumerFactory mockKafkaSimpleConsumerFactory =
         new MockKafkaSimpleConsumerFactory(new String[]{"abcd", "bcde"}, new int[]{1234, 2345},
@@ -287,7 +289,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap
         .put("stream.kafka.consumer.factory.class.name", mockKafkaSimpleConsumerFactory.getClass().getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     KafkaStreamMetadataProvider streamMetadataProvider =
         new KafkaStreamMetadataProvider(clientId, streamConfig, mockKafkaSimpleConsumerFactory);
@@ -302,6 +304,7 @@ public class KafkaPartitionLevelConsumerTest {
     String streamKafkaBrokerList = "abcd:1234,bcde:2345";
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
+    String tableNameWithType = "table_REALTIME";
 
     MockKafkaSimpleConsumerFactory mockKafkaSimpleConsumerFactory =
         new MockKafkaSimpleConsumerFactory(new String[]{"abcd", "bcde"}, new int[]{1234, 2345},
@@ -315,7 +318,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap
         .put("stream.kafka.consumer.factory.class.name", mockKafkaSimpleConsumerFactory.getClass().getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     int partition = 0;
     KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer =
@@ -331,6 +334,7 @@ public class KafkaPartitionLevelConsumerTest {
     String streamKafkaBrokerList = "abcd:1234,bcde:2345";
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
+    String tableNameWithType = "table_REALTIME";
 
     MockKafkaSimpleConsumerFactory mockKafkaSimpleConsumerFactory =
         new MockKafkaSimpleConsumerFactory(new String[]{"abcd", "bcde"}, new int[]{1234, 2345},
@@ -344,7 +348,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap
         .put("stream.kafka.consumer.factory.class.name", mockKafkaSimpleConsumerFactory.getClass().getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     int partition = 0;
     KafkaStreamMetadataProvider kafkaStreamMetadataProvider =

--- a/pinot-connectors/pinot-connector-kafka-2.0/src/test/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-connectors/pinot-connector-kafka-2.0/src/test/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaPartitionLevelConsumerTest.java
@@ -105,6 +105,7 @@ public class KafkaPartitionLevelConsumerTest {
     String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
+    String tableNameWithType = "tableName_REALTIME";
 
     Map<String, String> streamConfigMap = new HashMap<>();
     streamConfigMap.put("streamType", streamType);
@@ -115,7 +116,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
     streamConfigMap.put("stream.kafka.fetcher.size", "10000");
     streamConfigMap.put("stream.kafka.fetcher.minBytes", "20000");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     KafkaStreamMetadataProvider streamMetadataProvider =
         new KafkaStreamMetadataProvider(clientId, streamConfig);
@@ -139,7 +140,7 @@ public class KafkaPartitionLevelConsumerTest {
     // test user defined values
     streamConfigMap.put("stream.kafka.buffer.size", "100");
     streamConfigMap.put("stream.kafka.socket.timeout", "1000");
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
     kafkaSimpleStreamConsumer = new KafkaPartitionLevelConsumer(clientId, streamConfig, 0);
     kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
     Assert.assertEquals(100, kafkaSimpleStreamConsumer.getKafkaPartitionLevelStreamConfig().getKafkaBufferSize());
@@ -152,6 +153,7 @@ public class KafkaPartitionLevelConsumerTest {
     String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
+    String tableNameWithType = "tableName_REALTIME";
 
     Map<String, String> streamConfigMap = new HashMap<>();
     streamConfigMap.put("streamType", streamType);
@@ -160,7 +162,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.consumer.type", streamKafkaConsumerType);
     streamConfigMap.put("stream.kafka.consumer.factory.class.name", KafkaConsumerFactory.class.getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     KafkaStreamMetadataProvider streamMetadataProvider =
         new KafkaStreamMetadataProvider(clientId, streamConfig);
@@ -173,7 +175,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.consumer.type", streamKafkaConsumerType);
     streamConfigMap.put("stream.kafka.consumer.factory.class.name", KafkaConsumerFactory.class.getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     streamMetadataProvider = new KafkaStreamMetadataProvider(clientId, streamConfig);
     Assert.assertEquals(streamMetadataProvider.fetchPartitionCount(10000L), 2);
@@ -187,6 +189,7 @@ public class KafkaPartitionLevelConsumerTest {
     String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
+    String tableNameWithType = "tableName_REALTIME";
 
     Map<String, String> streamConfigMap = new HashMap<>();
     streamConfigMap.put("streamType", streamType);
@@ -195,7 +198,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.consumer.type", streamKafkaConsumerType);
     streamConfigMap.put("stream.kafka.consumer.factory.class.name", KafkaConsumerFactory.class.getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     int partition = 0;
     KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer =
@@ -216,6 +219,7 @@ public class KafkaPartitionLevelConsumerTest {
     String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
+    String tableNameWithType = "tableName_REALTIME";
 
     Map<String, String> streamConfigMap = new HashMap<>();
     streamConfigMap.put("streamType", streamType);
@@ -224,7 +228,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.consumer.type", streamKafkaConsumerType);
     streamConfigMap.put("stream.kafka.consumer.factory.class.name", KafkaConsumerFactory.class.getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     int numPartitions =
         new KafkaStreamMetadataProvider(clientId, streamConfig).fetchPartitionCount(10000);
@@ -251,6 +255,7 @@ public class KafkaPartitionLevelConsumerTest {
     String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
+    String tableNameWithType = "tableName_REALTIME";
 
     Map<String, String> streamConfigMap = new HashMap<>();
     streamConfigMap.put("streamType", streamType);
@@ -259,7 +264,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.consumer.type", streamKafkaConsumerType);
     streamConfigMap.put("stream.kafka.consumer.factory.class.name", KafkaConsumerFactory.class.getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     final StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
     int numPartitions =

--- a/pinot-connectors/pinot-connector-kafka-2.0/src/test/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaPartitionLevelStreamConfigTest.java
+++ b/pinot-connectors/pinot-connector-kafka-2.0/src/test/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaPartitionLevelStreamConfigTest.java
@@ -41,6 +41,7 @@ public class KafkaPartitionLevelStreamConfigTest {
     String consumerType = StreamConfig.ConsumerType.LOWLEVEL.toString();
     String consumerFactoryClassName = KafkaConsumerFactory.class.getName();
     String decoderClass = "org.apache.pinot.core.realtime.impl.kafka.KafkaAvroMessageDecoder";
+    String tableNameWithType = "tableName_REALTIME";
     streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
     streamConfigMap
         .put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME),
@@ -67,7 +68,7 @@ public class KafkaPartitionLevelStreamConfigTest {
     if (fetcherMinBytes != null) {
       streamConfigMap.put("stream.kafka.fetcher.minBytes", fetcherMinBytes);
     }
-    return new KafkaPartitionLevelStreamConfig(new StreamConfig(streamConfigMap));
+    return new KafkaPartitionLevelStreamConfig(new StreamConfig(tableNameWithType, streamConfigMap));
   }
 
   @Test

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1169,7 +1169,7 @@ public class PinotHelixResourceManager {
 
   private void verifyIndexingConfig(String tableNameWithType, IndexingConfig indexingConfig) {
     // Check if HLC table is allowed.
-    StreamConfig streamConfig = new StreamConfig(indexingConfig.getStreamConfigs());
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, indexingConfig.getStreamConfigs());
     if (streamConfig.hasHighLevelConsumerType() && !_allowHLCTables) {
       throw new InvalidTableConfigException(
           "Creating HLC realtime table is not allowed for Table: " + tableNameWithType);
@@ -1178,7 +1178,7 @@ public class PinotHelixResourceManager {
 
   private void ensureRealtimeClusterIsSetUp(TableConfig config, String realtimeTableName,
       IndexingConfig indexingConfig) {
-    StreamConfig streamConfig = new StreamConfig(indexingConfig.getStreamConfigs());
+    StreamConfig streamConfig = new StreamConfig(realtimeTableName, indexingConfig.getStreamConfigs());
     IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, realtimeTableName);
 
     if (streamConfig.hasHighLevelConsumerType()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -176,7 +176,7 @@ public class PinotTableIdealStateBuilder {
 
   private static String getGroupIdFromRealtimeDataTable(String realtimeTableName, Map<String, String> streamConfigMap) {
     String groupId = StringUtil.join("_", realtimeTableName, System.currentTimeMillis() + "");
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(realtimeTableName, streamConfigMap);
     String streamConfigGroupId = streamConfig.getGroupId();
     if (streamConfigGroupId != null && !streamConfigGroupId.isEmpty()) {
       groupId = streamConfigGroupId;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -196,7 +196,9 @@ public class PinotLLCRealtimeSegmentManager {
    */
   public void setupNewTable(TableConfig tableConfig, IdealState emptyIdealState)
       throws InvalidConfigException {
-    final StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+    final StreamConfig streamConfig = new StreamConfig(
+        tableConfig.getTableName(),
+        tableConfig.getIndexingConfig().getStreamConfigs());
     int partitionCount = getPartitionCount(streamConfig);
     List<String> currentSegments = getExistingSegments(tableConfig.getTableName());
     // Make sure that there are no low-level segments existing.
@@ -887,7 +889,7 @@ public class PinotLLCRealtimeSegmentManager {
    */
   public void ensureAllPartitionsConsuming(final TableConfig tableConfig) {
     final String tableNameWithType = tableConfig.getTableName();
-    final StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+    final StreamConfig streamConfig = new StreamConfig(tableNameWithType, tableConfig.getIndexingConfig().getStreamConfigs());
     final int partitionCount = getPartitionCount(streamConfig);
     HelixHelper.updateIdealState(_helixManager, tableNameWithType, new Function<IdealState, IdealState>() {
       @Nullable
@@ -945,7 +947,8 @@ public class PinotLLCRealtimeSegmentManager {
       LOGGER.info("Skipping validation for disabled table {}", tableNameWithType);
       return idealState;
     }
-    final StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+    final StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(),
+        tableConfig.getIndexingConfig().getStreamConfigs());
     final long now = getCurrentTimeMs();
 
     PartitionAssignment partitionAssignment =
@@ -1045,7 +1048,7 @@ public class PinotLLCRealtimeSegmentManager {
   protected IdealState ensureAllPartitionsConsuming(final TableConfig tableConfig, IdealState idealState,
       final int partitionCount) {
     final String tableNameWithType = tableConfig.getTableName();
-    final StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+    final StreamConfig streamConfig = new StreamConfig(tableNameWithType, tableConfig.getIndexingConfig().getStreamConfigs());
     if (!idealState.isEnabled()) {
       LOGGER.info("Skipping validation for disabled table {}", tableNameWithType);
       return idealState;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -129,7 +129,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         continue;
       }
 
-      StreamConfig metadata = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+      StreamConfig metadata = new StreamConfig(realtimeTableName, tableConfig.getIndexingConfig().getStreamConfigs());
       if (metadata.hasHighLevelConsumerType()) {
         idealStateMap.put(realtimeTableName, _pinotHelixResourceManager.getHelixAdmin()
             .getResourceIdealState(_pinotHelixResourceManager.getHelixClusterName(), realtimeTableName));
@@ -333,7 +333,8 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         String znRecordId = tableConfigZnRecord.getId();
         if (TableNameBuilder.getTableTypeFromTableName(znRecordId) == TableType.REALTIME) {
           TableConfig tableConfig = TableConfig.fromZnRecord(tableConfigZnRecord);
-          StreamConfig metadata = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+          StreamConfig metadata = new StreamConfig(tableConfig.getTableName(),
+              tableConfig.getIndexingConfig().getStreamConfigs());
           if (metadata.hasHighLevelConsumerType()) {
             String realtimeTable = tableConfig.getTableName();
             String realtimeSegmentsPathForTable = _propertyStorePath + SEGMENTS_PATH + "/" + realtimeTable;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
@@ -43,7 +43,7 @@ public class FlushThresholdUpdateManager {
   public FlushThresholdUpdater getFlushThresholdUpdater(TableConfig realtimeTableConfig) {
     final String tableName = realtimeTableConfig.getTableName();
     PartitionLevelStreamConfig streamConfig =
-        new PartitionLevelStreamConfig(realtimeTableConfig.getIndexingConfig().getStreamConfigs());
+        new PartitionLevelStreamConfig(tableName, realtimeTableConfig.getIndexingConfig().getStreamConfigs());
 
     final int tableFlushSize = streamConfig.getFlushThresholdRows();
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
@@ -90,7 +90,8 @@ public class DefaultRebalanceSegmentStrategy implements RebalanceSegmentStrategy
     PartitionAssignment newPartitionAssignment = new PartitionAssignment(tableNameWithType);
 
     if (tableConfig.getTableType().equals(CommonConstants.Helix.TableType.REALTIME)) {
-      StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+      StreamConfig streamConfig = new StreamConfig(tableNameWithType,
+          tableConfig.getIndexingConfig().getStreamConfigs());
       if (!streamConfig.hasLowLevelConsumerType()) {
         LOGGER.info("Table {} does not have LLC and will have no partition assignment", tableNameWithType);
         return newPartitionAssignment;
@@ -140,7 +141,8 @@ public class DefaultRebalanceSegmentStrategy implements RebalanceSegmentStrategy
     int targetNumReplicas;
     if (tableType.equals(CommonConstants.Helix.TableType.REALTIME)) {
       if (tableConfig.getIndexingConfig().getStreamConfigs() != null) {
-        StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+        StreamConfig streamConfig = new StreamConfig(tableNameWithType,
+            tableConfig.getIndexingConfig().getStreamConfigs());
         if (!streamConfig.hasLowLevelConsumerType()) {
           LOGGER.info("Table {} does not have LLC and therefore no change for rebalanced ideal state", tableNameWithType);
           return idealState;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -96,7 +96,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
       }
 
       Map<String, String> streamConfigMap = tableConfig.getIndexingConfig().getStreamConfigs();
-      StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+      StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
       if (streamConfig.hasLowLevelConsumerType()) {
         _llcRealtimeSegmentManager.ensureAllPartitionsConsuming(tableConfig);
       }
@@ -108,7 +108,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     List<RealtimeSegmentZKMetadata> metadataList =
         _pinotHelixResourceManager.getRealtimeSegmentMetadata(realtimeTableName);
     boolean countHLCSegments = true;  // false if this table has ONLY LLC segments (i.e. fully migrated)
-    StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+    StreamConfig streamConfig = new StreamConfig(realtimeTableName, tableConfig.getIndexingConfig().getStreamConfigs());
     if (streamConfig.hasLowLevelConsumerType() && !streamConfig.hasHighLevelConsumerType()) {
       countHLCSegments = false;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -148,7 +148,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     varLengthDictionaryColumns = new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns());
 
-    _streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+    _streamConfig = new StreamConfig(tableNameWithType, tableConfig.getIndexingConfig().getStreamConfigs());
 
     segmentLogger = LoggerFactory.getLogger(
         HLRealtimeSegmentDataManager.class.getName() + "_" + segmentName + "_" + _streamConfig.getTopicName());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1076,7 +1076,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     // TODO Validate configs
     IndexingConfig indexingConfig = _tableConfig.getIndexingConfig();
-    _partitionLevelStreamConfig = new PartitionLevelStreamConfig(indexingConfig.getStreamConfigs());
+    _partitionLevelStreamConfig = new PartitionLevelStreamConfig(_tableNameWithType, indexingConfig.getStreamConfigs());
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(_partitionLevelStreamConfig);
     _streamTopic = _partitionLevelStreamConfig.getTopicName();
     _segmentNameStr = _segmentZKMetadata.getSegmentName();

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/PartitionLevelStreamConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/PartitionLevelStreamConfig.java
@@ -38,10 +38,9 @@ public class PartitionLevelStreamConfig extends StreamConfig {
   /**
    * Initializes a partition level stream config using the map of stream configs from the table config
    * This overrides some properties for low level consumer
-   * @param streamConfigMap
    */
-  public PartitionLevelStreamConfig(Map<String, String> streamConfigMap) {
-    super(streamConfigMap);
+  public PartitionLevelStreamConfig(String tableNameWithType, Map<String, String> streamConfigMap) {
+    super(tableNameWithType, streamConfigMap);
 
     int flushThresholdRows = super.getFlushThresholdRows();
     String flushThresholdRowsKey =

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConfig.java
@@ -73,12 +73,14 @@ public class StreamConfig {
 
   final private String _groupId;
 
+  final private String _tableNameWithType;
+
   final private Map<String, String> _streamConfigMap = new HashMap<>();
 
   /**
    * Initializes a StreamConfig using the map of stream configs from the table config
    */
-  public StreamConfig(Map<String, String> streamConfigMap) {
+  public StreamConfig(String tableNameWithType, Map<String, String> streamConfigMap) {
 
     _type = streamConfigMap.get(StreamConfigProperties.STREAM_TYPE);
     Preconditions.checkNotNull(_type, "Stream type cannot be null");
@@ -87,6 +89,8 @@ public class StreamConfig {
         StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.STREAM_TOPIC_NAME);
     _topicName = streamConfigMap.get(topicNameKey);
     Preconditions.checkNotNull(_topicName, "Stream topic name " + topicNameKey + " cannot be null");
+
+    _tableNameWithType = tableNameWithType;
 
     String consumerTypesKey =
         StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.STREAM_CONSUMER_TYPES);
@@ -302,6 +306,10 @@ public class StreamConfig {
     return _groupId;
   }
 
+  public String getTableNameWithType() {
+    return _tableNameWithType;
+  }
+
   public Map<String, String> getStreamConfigsMap() {
     return _streamConfigMap;
   }
@@ -314,7 +322,8 @@ public class StreamConfig {
         + _fetchTimeoutMillis + ", _flushThresholdRows=" + _flushThresholdRows + ", _flushThresholdTimeMillis="
         + _flushThresholdTimeMillis + ", _flushSegmentDesiredSizeBytes=" + _flushSegmentDesiredSizeBytes
         + ", _flushAutotuneInitialRows=" + _flushAutotuneInitialRows + ", _decoderClass='" + _decoderClass
-        + '\'' + ", _decoderProperties=" + _decoderProperties + ", _groupId='" + _groupId + '}';
+        + '\'' + ", _decoderProperties=" + _decoderProperties + ", _groupId='" + _groupId
+        + ", _tableNameWithType='" + _tableNameWithType + '}';
   }
 
   @Override
@@ -340,7 +349,8 @@ public class StreamConfig {
         .isEqual(_consumerFactoryClassName, that._consumerFactoryClassName) && EqualityUtils
         .isEqual(_offsetCriteria, that._offsetCriteria) && EqualityUtils.isEqual(_decoderClass, that._decoderClass)
         && EqualityUtils.isEqual(_decoderProperties, that._decoderProperties) && EqualityUtils
-        .isEqual(_groupId, that._groupId) && EqualityUtils.isEqual(_streamConfigMap, that._streamConfigMap);
+        .isEqual(_groupId, that._groupId) && EqualityUtils.isEqual(_tableNameWithType, that._tableNameWithType)
+        && EqualityUtils.isEqual(_streamConfigMap, that._streamConfigMap);
   }
 
   @Override
@@ -360,6 +370,7 @@ public class StreamConfig {
     result = EqualityUtils.hashCodeOf(result, _decoderProperties);
     result = EqualityUtils.hashCodeOf(result, _groupId);
     result = EqualityUtils.hashCodeOf(result, _streamConfigMap);
+    result = EqualityUtils.hashCodeOf(result, _tableNameWithType);
     return result;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ReplicationUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ReplicationUtils.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.util;
 
 import org.apache.pinot.common.config.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 import org.apache.pinot.core.realtime.stream.StreamConfig;
 
@@ -36,7 +37,8 @@ public class ReplicationUtils {
 
     TableType tableType = tableConfig.getTableType();
     if (tableType.equals(TableType.REALTIME)) {
-      StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+      StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(),
+          tableConfig.getIndexingConfig().getStreamConfigs());
       return streamConfig.hasHighLevelConsumerType();
     }
     return true;
@@ -49,7 +51,8 @@ public class ReplicationUtils {
 
     TableType tableType = tableConfig.getTableType();
     if (tableType.equals(TableType.REALTIME)) {
-      StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+      StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(),
+          tableConfig.getIndexingConfig().getStreamConfigs());
       return streamConfig.hasLowLevelConsumerType();
     }
     return false;

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
@@ -38,6 +38,7 @@ import org.testng.Assert;
  * TODO: make input tar file and pinot schema configurable
  */
 public class FakeStreamConfigUtils {
+  private static final String TABLE_NAME_WITH_TYPE = "fake_tableName_REALTIME";
   private static final String AVRO_TAR_FILE = "fake_stream_avro_data.tar.gz";
   // This avro schema file must be in sync with the avro data
   private static final String AVRO_SCHEMA_FILE = "fake_stream_avro_schema.avsc";
@@ -126,7 +127,7 @@ public class FakeStreamConfigUtils {
         StreamConfigProperties.constructStreamProperty(STREAM_TYPE, NUM_PARTITIONS_KEY),
         String.valueOf(numPartitions));
 
-    return new StreamConfig(streamConfigMap);
+    return new StreamConfig(TABLE_NAME_WITH_TYPE, streamConfigMap);
   }
 
   /**
@@ -145,7 +146,7 @@ public class FakeStreamConfigUtils {
         StreamConfigProperties.constructStreamProperty(STREAM_TYPE, StreamConfigProperties.STREAM_CONSUMER_TYPES),
         StreamConfig.ConsumerType.HIGHLEVEL.toString());
 
-    return new StreamConfig(streamConfigMap);
+    return new StreamConfig(TABLE_NAME_WITH_TYPE, streamConfigMap);
   }
 
   private static Map<String, String> getDefaultStreamConfigs() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
@@ -40,6 +40,7 @@ public class StreamConfigTest {
     StreamConfig streamConfig;
     String streamType = "fakeStream";
     String topic = "fakeTopic";
+    String tableName = "fakeTable_REALTIME";
     String consumerType = StreamConfig.ConsumerType.LOWLEVEL.toString();
     String consumerFactoryClass = FakeStreamConsumerFactory.class.getName();
     String decoderClass = FakeStreamMessageDecoder.class.getName();
@@ -47,7 +48,7 @@ public class StreamConfigTest {
     // test with empty map
     try {
       Map<String, String> streamConfigMap = new HashMap<>();
-      streamConfig = new StreamConfig(streamConfigMap);
+      streamConfig = new StreamConfig(tableName, streamConfigMap);
     } catch (NullPointerException e) {
       exception = true;
     }
@@ -66,13 +67,13 @@ public class StreamConfigTest {
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
         decoderClass);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
 
     // Missing streamType
     streamConfigMap.remove(StreamConfigProperties.STREAM_TYPE);
     exception = false;
     try {
-      streamConfig = new StreamConfig(streamConfigMap);
+      streamConfig = new StreamConfig(tableName, streamConfigMap);
     } catch (NullPointerException e) {
       exception = true;
     }
@@ -84,7 +85,7 @@ public class StreamConfigTest {
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME));
     exception = false;
     try {
-      streamConfig = new StreamConfig(streamConfigMap);
+      streamConfig = new StreamConfig(tableName, streamConfigMap);
     } catch (NullPointerException e) {
       exception = true;
     }
@@ -97,7 +98,7 @@ public class StreamConfigTest {
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES));
     exception = false;
     try {
-      streamConfig = new StreamConfig(streamConfigMap);
+      streamConfig = new StreamConfig(tableName, streamConfigMap);
     } catch (NullPointerException e) {
       exception = true;
     }
@@ -111,7 +112,7 @@ public class StreamConfigTest {
         StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS));
     exception = false;
     try {
-      streamConfig = new StreamConfig(streamConfigMap);
+      streamConfig = new StreamConfig(tableName, streamConfigMap);
     } catch (NullPointerException e) {
       exception = true;
     }
@@ -125,7 +126,7 @@ public class StreamConfigTest {
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS));
     exception = false;
     try {
-      streamConfig = new StreamConfig(streamConfigMap);
+      streamConfig = new StreamConfig(tableName, streamConfigMap);
     } catch (NullPointerException e) {
       exception = true;
     }
@@ -134,7 +135,7 @@ public class StreamConfigTest {
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
         decoderClass);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getType(), streamType);
     Assert.assertEquals(streamConfig.getTopicName(), topic);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(0), StreamConfig.ConsumerType.LOWLEVEL);
@@ -150,6 +151,7 @@ public class StreamConfigTest {
     String streamType = "fakeStream";
     String topic = "fakeTopic";
     String consumerType = "simple";
+    String tableName = "fakeTable_REALTIME";
     String consumerFactoryClass = FakeStreamConsumerFactory.class.getName();
     String decoderClass = FakeStreamMessageDecoder.class.getName();
 
@@ -167,7 +169,7 @@ public class StreamConfigTest {
         decoderClass);
 
     // Mandatory values + defaults
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getType(), streamType);
     Assert.assertEquals(streamConfig.getTopicName(), topic);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(0), StreamConfig.ConsumerType.LOWLEVEL);
@@ -210,7 +212,7 @@ public class StreamConfigTest {
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, flushThresholdTime);
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE, flushSegmentSize);
 
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getType(), streamType);
     Assert.assertEquals(streamConfig.getTopicName(), topic);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(0), StreamConfig.ConsumerType.LOWLEVEL);
@@ -230,11 +232,11 @@ public class StreamConfigTest {
     // Backward compatibility check for flushThresholdTime
     flushThresholdTime = "18000000";
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, flushThresholdTime);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFlushThresholdTimeMillis(), Long.parseLong(flushThresholdTime));
     flushThresholdTime = "invalid input";
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, flushThresholdTime);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFlushThresholdTimeMillis(), StreamConfig.getDefaultFlushThresholdTimeMillis());
   }
 
@@ -248,6 +250,7 @@ public class StreamConfigTest {
     String streamType = "fakeStream";
     String topic = "fakeTopic";
     String consumerType = "simple";
+    String tableName = "fakeTable_REALTIME";
     String consumerFactoryClass = FakeStreamConsumerFactory.class.getName();
     String decoderClass = FakeStreamMessageDecoder.class.getName();
 
@@ -264,7 +267,7 @@ public class StreamConfigTest {
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
         decoderClass);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
 
     // Invalid consumer type
     streamConfigMap.put(
@@ -272,7 +275,7 @@ public class StreamConfigTest {
         "invalidConsumerType");
     exception = false;
     try {
-      streamConfig = new StreamConfig(streamConfigMap);
+      streamConfig = new StreamConfig(tableName, streamConfigMap);
     } catch (IllegalArgumentException e) {
       exception = true;
     }
@@ -285,7 +288,7 @@ public class StreamConfigTest {
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_FETCH_TIMEOUT_MILLIS),
         "timeout");
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFetchTimeoutMillis(), StreamConfig.DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS);
 
     // Invalid connection timeout
@@ -293,7 +296,7 @@ public class StreamConfigTest {
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_FETCH_TIMEOUT_MILLIS));
     streamConfigMap.put(StreamConfigProperties.constructStreamProperty(streamType,
         StreamConfigProperties.STREAM_CONNECTION_TIMEOUT_MILLIS), "timeout");
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getConnectionTimeoutMillis(),
         StreamConfig.DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS);
 
@@ -301,19 +304,19 @@ public class StreamConfigTest {
     streamConfigMap.remove(StreamConfigProperties.constructStreamProperty(streamType,
         StreamConfigProperties.STREAM_CONNECTION_TIMEOUT_MILLIS));
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "rows");
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFlushThresholdRows(), StreamConfig.getDefaultFlushThresholdRows());
 
     // Invalid flush threshold time
     streamConfigMap.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS);
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, "time");
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFlushThresholdTimeMillis(), StreamConfig.getDefaultFlushThresholdTimeMillis());
 
     // Invalid flush segment size
     streamConfigMap.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME);
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE, "size");
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFlushSegmentDesiredSizeBytes(),
         StreamConfig.getDefaultDesiredSegmentSizeBytes());
   }
@@ -326,6 +329,7 @@ public class StreamConfigTest {
     StreamConfig streamConfig;
     String streamType = "fakeStream";
     String topic = "fakeTopic";
+    String tableName = "fakeTable_REALTIME";
     String consumerType = "lowlevel";
     String consumerFactoryClass = FakeStreamConsumerFactory.class.getName();
     String decoderClass = FakeStreamMessageDecoder.class.getName();
@@ -348,14 +352,14 @@ public class StreamConfigTest {
         decoderClass);
 
     // use defaults if nothing provided
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFlushThresholdRows(), StreamConfig.getDefaultFlushThresholdRows());
     Assert.assertEquals(streamConfig.getFlushThresholdTimeMillis(), StreamConfig.getDefaultFlushThresholdTimeMillis());
 
     // use base values if provided
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, flushThresholdRows);
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, flushThresholdTime);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFlushThresholdRows(), Integer.parseInt(flushThresholdRows));
     Assert.assertEquals(streamConfig.getFlushThresholdTimeMillis(),
         (long) TimeUtils.convertPeriodToMillis(flushThresholdTime));
@@ -365,7 +369,7 @@ public class StreamConfigTest {
         flushThresholdRowsLLC);
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME + StreamConfigProperties.LLC_SUFFIX,
         flushThresholdTimeLLC);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFlushThresholdRows(), Integer.parseInt(flushThresholdRows));
     Assert.assertEquals(streamConfig.getFlushThresholdTimeMillis(),
         (long) TimeUtils.convertPeriodToMillis(flushThresholdTime));
@@ -373,12 +377,12 @@ public class StreamConfigTest {
     // llc overrides provided, no base values, defaults will be picked
     streamConfigMap.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS);
     streamConfigMap.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getFlushThresholdRows(), StreamConfig.getDefaultFlushThresholdRows());
     Assert.assertEquals(streamConfig.getFlushThresholdTimeMillis(), StreamConfig.getDefaultFlushThresholdTimeMillis());
 
     // PartitionLevel stream config will retrieve the llc overrides
-    PartitionLevelStreamConfig partitionLevelStreamConfig = new PartitionLevelStreamConfig(streamConfigMap);
+    PartitionLevelStreamConfig partitionLevelStreamConfig = new PartitionLevelStreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(partitionLevelStreamConfig.getFlushThresholdRows(), Integer.parseInt(flushThresholdRowsLLC));
     Assert.assertEquals(partitionLevelStreamConfig.getFlushThresholdTimeMillis(),
         (long) TimeUtils.convertPeriodToMillis(flushThresholdTimeLLC));
@@ -388,7 +392,7 @@ public class StreamConfigTest {
     streamConfigMap.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME + StreamConfigProperties.LLC_SUFFIX);
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, flushThresholdRows);
     streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, flushThresholdTime);
-    partitionLevelStreamConfig = new PartitionLevelStreamConfig(streamConfigMap);
+    partitionLevelStreamConfig = new PartitionLevelStreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(partitionLevelStreamConfig.getFlushThresholdRows(), Integer.parseInt(flushThresholdRows));
     Assert.assertEquals(partitionLevelStreamConfig.getFlushThresholdTimeMillis(),
         (long) TimeUtils.convertPeriodToMillis(flushThresholdTime));
@@ -396,7 +400,7 @@ public class StreamConfigTest {
     // PartitionLevelStreamConfig should use defaults if nothing provided
     streamConfigMap.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS);
     streamConfigMap.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME);
-    partitionLevelStreamConfig = new PartitionLevelStreamConfig(streamConfigMap);
+    partitionLevelStreamConfig = new PartitionLevelStreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(partitionLevelStreamConfig.getFlushThresholdRows(),
         StreamConfig.getDefaultFlushThresholdRows());
     Assert.assertEquals(partitionLevelStreamConfig.getFlushThresholdTimeMillis(),
@@ -407,6 +411,7 @@ public class StreamConfigTest {
   public void testConsumerTypes() {
     String streamType = "fakeStream";
     String topic = "fakeTopic";
+    String tableName = "fakeTable_REALTIME";
     String consumerFactoryClass = FakeStreamConsumerFactory.class.getName();
     String decoderClass = FakeStreamMessageDecoder.class.getName();
 
@@ -424,7 +429,7 @@ public class StreamConfigTest {
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
         consumerType);
-    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(0), StreamConfig.ConsumerType.LOWLEVEL);
     Assert.assertTrue(streamConfig.hasLowLevelConsumerType());
     Assert.assertFalse(streamConfig.hasHighLevelConsumerType());
@@ -433,7 +438,7 @@ public class StreamConfigTest {
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
         consumerType);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(0), StreamConfig.ConsumerType.LOWLEVEL);
     Assert.assertTrue(streamConfig.hasLowLevelConsumerType());
     Assert.assertFalse(streamConfig.hasHighLevelConsumerType());
@@ -442,7 +447,7 @@ public class StreamConfigTest {
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
         consumerType);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(0), StreamConfig.ConsumerType.HIGHLEVEL);
     Assert.assertFalse(streamConfig.hasLowLevelConsumerType());
     Assert.assertTrue(streamConfig.hasHighLevelConsumerType());
@@ -451,7 +456,7 @@ public class StreamConfigTest {
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
         consumerType);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(0), StreamConfig.ConsumerType.HIGHLEVEL);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(1), StreamConfig.ConsumerType.LOWLEVEL);
     Assert.assertTrue(streamConfig.hasLowLevelConsumerType());
@@ -461,7 +466,7 @@ public class StreamConfigTest {
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
         consumerType);
-    streamConfig = new StreamConfig(streamConfigMap);
+    streamConfig = new StreamConfig(tableName, streamConfigMap);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(0), StreamConfig.ConsumerType.HIGHLEVEL);
     Assert.assertEquals(streamConfig.getConsumerTypes().get(1), StreamConfig.ConsumerType.LOWLEVEL);
     Assert.assertTrue(streamConfig.hasLowLevelConsumerType());


### PR DESCRIPTION
TableName is required to emit metrics in higher layers and currently the stream-config only has the topic-name. Since topic-name and table-name don't have to be the same, this change provides table-name explicitly.