### PR TITLE
Add APIs to get leader for all tables or a given table

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
@@ -73,7 +73,7 @@ public class LeadControllerUtils {
     HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
     PropertyKey propertyKey = helixDataAccessor.keyBuilder().resourceConfig(Helix.LEAD_CONTROLLER_RESOURCE_NAME);
     ResourceConfig resourceConfig = helixDataAccessor.getProperty(propertyKey);
-    String enableResource = resourceConfig.getSimpleConfig(Helix.LEAD_CONTROLLER_RESOURCE_ENABLED_KEY);
-    return Boolean.parseBoolean(enableResource);
+    String resourceEnabled = resourceConfig.getSimpleConfig(Helix.LEAD_CONTROLLER_RESOURCE_ENABLED_KEY);
+    return Boolean.parseBoolean(resourceEnabled);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
@@ -93,7 +93,8 @@ public class LeadControllerUtils {
       ZNRecord znRecord = dataAccessor.get("/" + helixManager.getClusterName() + "/CONTROLLER/LEADER", stat,
           AccessOption.THROW_EXCEPTION_IFNOTEXIST);
       String helixLeader = znRecord.getId();
-      LOGGER.info("Getting Helix leader: {} as per znode version {}, mtime {}", helixLeader, stat.getVersion(),
+      // It's ok to log the info since this method isn't called very often.
+      LOGGER.info("Getting Helix leader: {} as per ZNode version {}, mtime {}", helixLeader, stat.getVersion(),
           stat.getMtime());
       return helixLeader;
     } catch (Exception e) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
@@ -20,9 +20,8 @@ package org.apache.pinot.common.utils.helix;
 
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
-import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixManager;
-import org.apache.helix.PropertyKey;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.pinot.common.utils.CommonConstants.Helix;
@@ -74,18 +73,12 @@ public class LeadControllerUtils {
    * Checks from ZK if resource config of leadControllerResource is enabled.
    * @param helixManager helix manager
    */
-  public static boolean isLeadControllerResourceEnabled(HelixManager helixManager)
-      throws Exception {
-    try {
-      HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
-      PropertyKey propertyKey = helixDataAccessor.keyBuilder().resourceConfig(Helix.LEAD_CONTROLLER_RESOURCE_NAME);
-      ResourceConfig resourceConfig = helixDataAccessor.getProperty(propertyKey);
-      String resourceEnabled = resourceConfig.getSimpleConfig(Helix.LEAD_CONTROLLER_RESOURCE_ENABLED_KEY);
-      return Boolean.parseBoolean(resourceEnabled);
-    } catch (Exception e) {
-      LOGGER.warn("Could not get whether lead controller resource is enabled or not.", e);
-      throw e;
-    }
+  public static boolean isLeadControllerResourceEnabled(HelixManager helixManager) {
+    ConfigAccessor configAccessor = helixManager.getConfigAccessor();
+    ResourceConfig resourceConfig =
+        configAccessor.getResourceConfig(helixManager.getClusterName(), Helix.LEAD_CONTROLLER_RESOURCE_NAME);
+    String resourceEnabled = resourceConfig.getSimpleConfig(Helix.LEAD_CONTROLLER_RESOURCE_ENABLED_KEY);
+    return Boolean.parseBoolean(resourceEnabled);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
@@ -18,12 +18,19 @@
  */
 package org.apache.pinot.common.utils.helix;
 
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.ResourceConfig;
 import org.apache.pinot.common.utils.CommonConstants.Helix;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.common.utils.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class LeadControllerUtils {
+  public static final Logger LOGGER = LoggerFactory.getLogger(LeadControllerUtils.class);
 
   /**
    * Given a raw table name and number of partitions, returns the partition id in lead controller resource.
@@ -57,5 +64,16 @@ public class LeadControllerUtils {
    */
   public static int extractPartitionId(String partitionName) {
     return Integer.parseInt(partitionName.substring(partitionName.lastIndexOf('_') + 1));
+  }
+
+  /**
+   * Checks from ZK if resource config of leadControllerResource is enabled.
+   */
+  public static boolean isLeadControllerResourceEnabled(HelixManager helixManager) {
+    HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
+    PropertyKey propertyKey = helixDataAccessor.keyBuilder().resourceConfig(Helix.LEAD_CONTROLLER_RESOURCE_NAME);
+    ResourceConfig resourceConfig = helixDataAccessor.getProperty(propertyKey);
+    String enableResource = resourceConfig.getSimpleConfig(Helix.LEAD_CONTROLLER_RESOURCE_ENABLED_KEY);
+    return Boolean.parseBoolean(enableResource);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
@@ -74,7 +74,8 @@ public class LeadControllerUtils {
    * Checks from ZK if resource config of leadControllerResource is enabled.
    * @param helixManager helix manager
    */
-  public static boolean isLeadControllerResourceEnabled(HelixManager helixManager) {
+  public static boolean isLeadControllerResourceEnabled(HelixManager helixManager)
+      throws Exception {
     try {
       HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
       PropertyKey propertyKey = helixDataAccessor.keyBuilder().resourceConfig(Helix.LEAD_CONTROLLER_RESOURCE_NAME);
@@ -83,7 +84,7 @@ public class LeadControllerUtils {
       return Boolean.parseBoolean(resourceEnabled);
     } catch (Exception e) {
       LOGGER.warn("Could not get whether lead controller resource is enabled or not.", e);
-      return false;
+      throw e;
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
@@ -154,17 +154,6 @@ public class LeadControllerManager {
   }
 
   /**
-   * Checks from ZK if resource config of leadControllerResource is enabled.
-   */
-  public boolean isLeadControllerResourceEnabled() {
-    HelixDataAccessor helixDataAccessor = _helixManager.getHelixDataAccessor();
-    PropertyKey propertyKey = helixDataAccessor.keyBuilder().resourceConfig(Helix.LEAD_CONTROLLER_RESOURCE_NAME);
-    ResourceConfig resourceConfig = helixDataAccessor.getProperty(propertyKey);
-    String enableResource = resourceConfig.getSimpleConfig(Helix.LEAD_CONTROLLER_RESOURCE_ENABLED_KEY);
-    return Boolean.parseBoolean(enableResource);
-  }
-
-  /**
    * Starts the fetching thread to actively fetch helix leadership and resource config of lead controller resource.
    */
   public synchronized void start() {
@@ -226,7 +215,7 @@ public class LeadControllerManager {
     if (_isShuttingDown) {
       return;
     }
-    if (isLeadControllerResourceEnabled()) {
+    if (LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager)) {
       LOGGER.info("Lead controller resource is enabled.");
       _isLeadControllerResourceEnabled = true;
       _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PINOT_LEAD_CONTROLLER_RESOURCE_ENABLED, 1L);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
@@ -215,7 +215,18 @@ public class LeadControllerManager {
     if (_isShuttingDown) {
       return;
     }
-    if (LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager)) {
+
+    boolean leadControllerResourceEnabled;
+    try {
+      leadControllerResourceEnabled = LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
+    } catch (Exception e) {
+      LOGGER.error("Exception when checking whether lead controller resource is enabled or not.", e);
+      _isLeadControllerResourceEnabled = false;
+      _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PINOT_LEAD_CONTROLLER_RESOURCE_ENABLED, 0L);
+      return;
+    }
+
+    if (leadControllerResourceEnabled) {
       LOGGER.info("Lead controller resource is enabled.");
       _isLeadControllerResourceEnabled = true;
       _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PINOT_LEAD_CONTROLLER_RESOURCE_ENABLED, 1L);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
@@ -140,14 +140,11 @@ public class LeadControllerManager {
    * Checks from ZK if the current controller host is Helix cluster leader.
    */
   private boolean isHelixLeader() {
-    HelixDataAccessor helixDataAccessor = _helixManager.getHelixDataAccessor();
-    PropertyKey propertyKey = helixDataAccessor.keyBuilder().controllerLeader();
-    LiveInstance liveInstance = helixDataAccessor.getProperty(propertyKey);
-    if (liveInstance == null) {
+    String helixLeaderInstanceId = LeadControllerUtils.getHelixClusterLeader(_helixManager);
+    if (helixLeaderInstanceId == null) {
       LOGGER.warn("Helix leader ZNode is missing");
       return false;
     }
-    String helixLeaderInstanceId = liveInstance.getInstanceName();
     // The instance name from Helix leader ZNode is without controller prefix.
     // It is essential to convert to participant id for fair comparison.
     return _instanceId.equals(Helix.PREFIX_OF_CONTROLLER_INSTANCE + helixLeaderInstanceId);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
@@ -35,6 +35,7 @@ public class Constants {
   public static final String TENANT_TAG = "Tenant";
   public static final String SEGMENT_TAG = "Segment";
   public static final String TASK_TAG = "Task";
+  public static final String LEAD_CONTROLLER_TAG = "Leader";
   public static final String TABLE_NAME = "tableName";
 
   public static CommonConstants.Helix.TableType validateTableType(String tableTypeStr) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
@@ -65,7 +65,7 @@ public class PinotLeadControllerRestletResource {
     boolean isLeadControllerResourceEnabled = LeadControllerUtils.isLeadControllerResourceEnabled(helixManager);
 
     String helixLeader = null;
-    // returns an empty map if lead controller resource is disabled.
+    // Returns helix leader if lead controller resource is disabled.
     if (!isLeadControllerResourceEnabled) {
       helixLeader = LeadControllerUtils.getHelixClusterLeader(helixManager);
     }
@@ -86,7 +86,7 @@ public class PinotLeadControllerRestletResource {
       }
     }
 
-    // Assign all the tables to the relevant partitions.
+    // Assigns all the tables to the relevant partitions.
     List<String> tableNames = _pinotHelixResourceManager.getAllTables();
     for (String tableName : tableNames) {
       String rawTableName = TableNameBuilder.extractRawTableName(tableName);
@@ -101,10 +101,9 @@ public class PinotLeadControllerRestletResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableName}")
-  @ApiOperation(value = "Gets leaders for all tables", notes = "Gets leaders for all tables")
-  public LeadControllerResponse getLeadersForTable(
+  @ApiOperation(value = "Gets leader for a given table", notes = "Gets leader for a given table")
+  public LeadControllerResponse getLeaderForTable(
       @ApiParam(value = "Table name", required = true) @PathParam("tableName") String tableName) {
-
     Map<String, LeadControllerEntry> leadControllerEntryMap = new HashMap<>();
     HelixManager helixManager = _pinotHelixResourceManager.getHelixZkManager();
     boolean isLeadControllerResourceEnabled = LeadControllerUtils.isLeadControllerResourceEnabled(helixManager);
@@ -115,6 +114,7 @@ public class PinotLeadControllerRestletResource {
     String partitionName = LeadControllerUtils.generatePartitionName(partitionId);
 
     String leadControllerId;
+    // Returns controller Id from lead controller resource is enabled, otherwise returns helix leader.
     if (!isLeadControllerResourceEnabled) {
       leadControllerId = LeadControllerUtils.getHelixClusterLeader(helixManager);
     } else {
@@ -140,7 +140,7 @@ public class PinotLeadControllerRestletResource {
     }
     Map<String, String> partitionStateMap = leadControllerResourceExternalView.getStateMap(partitionName);
 
-    // Get master host from partition map. Return null if no master found.
+    // Gets master host from partition map. Returns null if no master found.
     for (Map.Entry<String, String> entry : partitionStateMap.entrySet()) {
       if (MasterSlaveSMD.States.MASTER.name().equals(entry.getValue())) {
         // Found the controller in master state.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.apache.helix.HelixManager;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.MasterSlaveSMD;
+import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.utils.CommonConstants.Helix;
+import org.apache.pinot.common.utils.helix.LeadControllerUtils;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Api(tags = Constants.LEAD_CONTROLLER_TAG)
+@Path("/leader")
+public class PinotLeadControllerRestletResource {
+  public static Logger LOGGER = LoggerFactory.getLogger(PinotLeadControllerRestletResource.class);
+
+  @Inject
+  private PinotHelixResourceManager _pinotHelixResourceManager;
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/tables")
+  @ApiOperation(value = "Gets leaders for all tables", notes = "Gets leaders for all tables")
+  public Map<String, LeadControllerResponse> getLeadersForAllTables() {
+    Map<String, LeadControllerResponse> leadControllerResponses = new LinkedHashMap<>();
+    HelixManager helixManager = _pinotHelixResourceManager.getHelixZkManager();
+    // returns an empty map if lead controller resource is disabled.
+    if (!LeadControllerUtils.isLeadControllerResourceEnabled(helixManager)) {
+      return leadControllerResponses;
+    }
+
+    ExternalView leadControllerResourceExternalView = getLeadControllerResourceExternalView(helixManager);
+    for (int partitionId = 0; partitionId < Helix.NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE; partitionId++) {
+      String partitionName = LeadControllerUtils.generatePartitionName(partitionId);
+      String participantInstanceId =
+          getParticipantInstanceIdFromExternalView(leadControllerResourceExternalView, partitionName);
+      if (participantInstanceId == null) {
+        continue;
+      }
+      leadControllerResponses
+          .putIfAbsent(partitionName, new LeadControllerResponse(participantInstanceId, new ArrayList<>()));
+    }
+
+    // Assign all the tables to the relevant partitions.
+    List<String> tableNames = _pinotHelixResourceManager.getAllTables();
+    for (String tableName : tableNames) {
+      String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+      int partitionId = LeadControllerUtils.getPartitionIdForTable(rawTableName);
+      String partitionName = LeadControllerUtils.generatePartitionName(partitionId);
+      LeadControllerResponse leadControllerResponse = leadControllerResponses.get(partitionName);
+      leadControllerResponse.getTableNames().add(tableName);
+    }
+    return leadControllerResponses;
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/tables/{tableName}")
+  @ApiOperation(value = "Gets leaders for all tables", notes = "Gets leaders for all tables")
+  public Map<String, LeadControllerResponse> getLeadersForTable(
+      @ApiParam(value = "Table name", required = true) @PathParam("tableName") String tableName) {
+    Map<String, LeadControllerResponse> leadControllerResponses = new HashMap<>();
+    HelixManager helixManager = _pinotHelixResourceManager.getHelixZkManager();
+    // returns an empty map if lead controller resource is disabled.
+    if (!LeadControllerUtils.isLeadControllerResourceEnabled(helixManager)) {
+      return leadControllerResponses;
+    }
+    ExternalView leadControllerResourceExternalView = getLeadControllerResourceExternalView(helixManager);
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    int partitionId = LeadControllerUtils.getPartitionIdForTable(rawTableName);
+    String partitionName = LeadControllerUtils.generatePartitionName(partitionId);
+    String participantInstanceId =
+        getParticipantInstanceIdFromExternalView(leadControllerResourceExternalView, partitionName);
+
+    LeadControllerResponse leadControllerResponse =
+        new LeadControllerResponse(participantInstanceId, Collections.singletonList(tableName));
+    leadControllerResponses.put(partitionName, leadControllerResponse);
+    return leadControllerResponses;
+  }
+
+  private ExternalView getLeadControllerResourceExternalView(HelixManager helixManager) {
+    return helixManager.getClusterManagmentTool()
+        .getResourceExternalView(helixManager.getClusterName(), Helix.LEAD_CONTROLLER_RESOURCE_NAME);
+  }
+
+  private String getParticipantInstanceIdFromExternalView(ExternalView leadControllerResourceExternalView,
+      String partitionName) {
+    if (leadControllerResourceExternalView == null) {
+      LOGGER.warn("External view of lead controller resource is null!");
+      return null;
+    }
+    Map<String, String> partitionStateMap = leadControllerResourceExternalView.getStateMap(partitionName);
+
+    // Get master host from partition map. Return null if no master found.
+    for (Map.Entry<String, String> entry : partitionStateMap.entrySet()) {
+      if (MasterSlaveSMD.States.MASTER.name().equals(entry.getValue())) {
+        // Found the controller in master state.
+        // Converts participant id (with Prefix "Controller_") to controller id and assigns it as the leader,
+        // since realtime segment completion protocol doesn't need the prefix in controller instance id.
+        return entry.getKey();
+      }
+    }
+    return null;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class LeadControllerResponse {
+    private String _leadControllerId;
+    private List<String> _tableNames;
+
+    @JsonCreator
+    public LeadControllerResponse(String leadControllerId, List<String> tableNames) {
+      _leadControllerId = leadControllerId;
+      _tableNames = tableNames;
+    }
+
+    @JsonProperty
+    public String getLeadControllerId() {
+      return _leadControllerId;
+    }
+
+    @JsonProperty
+    public List<String> getTableNames() {
+      return _tableNames;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
@@ -69,7 +69,7 @@ public class PinotLeadControllerRestletResource {
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           "Exception when checking whether lead controller resource is enabled or not.",
-          Response.Status.INTERNAL_SERVER_ERROR);
+          Response.Status.INTERNAL_SERVER_ERROR, e);
     }
 
     // Returns empty map if lead controller resource is disabled.
@@ -82,9 +82,6 @@ public class PinotLeadControllerRestletResource {
       String partitionName = LeadControllerUtils.generatePartitionName(partitionId);
       String participantInstanceId =
           getParticipantInstanceIdFromExternalView(leadControllerResourceExternalView, partitionName);
-      if (participantInstanceId == null) {
-        continue;
-      }
       leadControllerEntryMap
           .putIfAbsent(partitionName, new LeadControllerEntry(participantInstanceId, new ArrayList<>()));
     }
@@ -115,18 +112,17 @@ public class PinotLeadControllerRestletResource {
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           "Exception when checking whether lead controller resource is enabled or not.",
-          Response.Status.INTERNAL_SERVER_ERROR);
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+    // Returns controller Id from lead controller resource is enabled, otherwise returns empty map.
+    if (!isLeadControllerResourceEnabled) {
+      return new LeadControllerResponse(false, leadControllerEntryMap);
     }
 
     ExternalView leadControllerResourceExternalView = getLeadControllerResourceExternalView(helixManager);
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
     int partitionId = LeadControllerUtils.getPartitionIdForTable(rawTableName);
     String partitionName = LeadControllerUtils.generatePartitionName(partitionId);
-
-    // Returns controller Id from lead controller resource is enabled, otherwise returns empty map.
-    if (!isLeadControllerResourceEnabled) {
-      return new LeadControllerResponse(false, leadControllerEntryMap);
-    }
 
     String leadControllerId =
         getParticipantInstanceIdFromExternalView(leadControllerResourceExternalView, partitionName);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
@@ -47,7 +47,7 @@ public class LeadControllerManagerTest {
 
   @BeforeMethod
   public void setup() {
-    _controllerMetrics =  new ControllerMetrics(new MetricsRegistry());
+    _controllerMetrics = new ControllerMetrics(new MetricsRegistry());
     _helixManager = mock(HelixManager.class);
     HelixDataAccessor helixDataAccessor = mock(HelixDataAccessor.class);
     when(_helixManager.getHelixDataAccessor()).thenReturn(helixDataAccessor);
@@ -70,7 +70,8 @@ public class LeadControllerManagerTest {
   }
 
   @Test
-  public void testLeadControllerManager() {
+  public void testLeadControllerManager()
+      throws Exception {
     LeadControllerManager leadControllerManager = new LeadControllerManager(_helixManager, _controllerMetrics);
     String tableName = "testTable";
     int expectedPartitionIndex = LeadControllerUtils.getPartitionIdForTable(tableName);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller;
 
 import com.yammer.metrics.core.MetricsRegistry;
+import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyKey;
@@ -60,18 +61,17 @@ public class LeadControllerManagerTest {
     _liveInstance = mock(LiveInstance.class);
     when(helixDataAccessor.getProperty(controllerLeader)).thenReturn(_liveInstance);
 
-    PropertyKey resourceConfigPropertyKey = mock(PropertyKey.class);
-    when(keyBuilder.resourceConfig(any())).thenReturn(resourceConfigPropertyKey);
-    _resourceConfig = mock(ResourceConfig.class);
-    when(helixDataAccessor.getProperty(resourceConfigPropertyKey)).thenReturn(_resourceConfig);
-
     String instanceId = LeadControllerUtils.generateParticipantInstanceId(CONTROLLER_HOST, CONTROLLER_PORT);
     when(_helixManager.getInstanceName()).thenReturn(instanceId);
+
+    ConfigAccessor configAccessor = mock(ConfigAccessor.class);
+    when(_helixManager.getConfigAccessor()).thenReturn(configAccessor);
+    _resourceConfig = mock(ResourceConfig.class);
+    when(configAccessor.getResourceConfig(any(), anyString())).thenReturn(_resourceConfig);
   }
 
   @Test
-  public void testLeadControllerManager()
-      throws Exception {
+  public void testLeadControllerManager() {
     LeadControllerManager leadControllerManager = new LeadControllerManager(_helixManager, _controllerMetrics);
     String tableName = "testTable";
     int expectedPartitionIndex = LeadControllerUtils.getPartitionIdForTable(tableName);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
@@ -87,7 +87,7 @@ public class LeadControllerManagerTest {
 
     // Even resource config is enabled, leadControllerManager should return false because no index is cached yet.
     Assert.assertFalse(leadControllerManager.isLeaderForTable(tableName));
-    Assert.assertTrue(leadControllerManager.isLeadControllerResourceEnabled());
+    Assert.assertTrue(LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager));
 
     // After the target partition index is cached, leadControllerManager should return true.
     leadControllerManager.addPartitionLeader(partitionName);
@@ -102,7 +102,7 @@ public class LeadControllerManagerTest {
     enableResourceConfig(false);
     leadControllerManager.onResourceConfigChange();
 
-    Assert.assertFalse(leadControllerManager.isLeadControllerResourceEnabled());
+    Assert.assertFalse(LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager));
     Assert.assertFalse(leadControllerManager.isLeaderForTable(tableName));
     leadControllerManager.addPartitionLeader(partitionName);
     Assert.assertFalse(leadControllerManager.isLeaderForTable(tableName));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
@@ -19,10 +19,12 @@
 package org.apache.pinot.controller;
 
 import com.yammer.metrics.core.MetricsRegistry;
+import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyKey;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.pinot.common.metrics.ControllerMetrics;
@@ -32,6 +34,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -45,6 +48,7 @@ public class LeadControllerManagerTest {
   private ControllerMetrics _controllerMetrics;
   private LiveInstance _liveInstance;
   private ResourceConfig _resourceConfig;
+  private ZNRecord _znRecord;
 
   @BeforeMethod
   public void setup() {
@@ -68,6 +72,11 @@ public class LeadControllerManagerTest {
     when(_helixManager.getConfigAccessor()).thenReturn(configAccessor);
     _resourceConfig = mock(ResourceConfig.class);
     when(configAccessor.getResourceConfig(any(), anyString())).thenReturn(_resourceConfig);
+
+    BaseDataAccessor<ZNRecord> dataAccessor = mock(BaseDataAccessor.class);
+    when(helixDataAccessor.getBaseDataAccessor()).thenReturn(dataAccessor);
+    _znRecord = mock(ZNRecord.class);
+    when(dataAccessor.get(anyString(), any(), anyInt())).thenReturn(_znRecord);
   }
 
   @Test
@@ -116,7 +125,7 @@ public class LeadControllerManagerTest {
 
   private void becomeHelixLeader(boolean becomeHelixLeader) {
     if (becomeHelixLeader) {
-      when(_liveInstance.getInstanceName()).thenReturn(CONTROLLER_HOST + "_" + CONTROLLER_PORT);
+      when(_znRecord.getId()).thenReturn(CONTROLLER_HOST + "_" + CONTROLLER_PORT);
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
@@ -61,8 +61,7 @@ public class PinotControllerModeTest extends ControllerTest {
   }
 
   @Test
-  public void testDualModeController()
-      throws Exception {
+  public void testDualModeController() {
     // Start the first dual-mode controller
     ControllerConf firstDualModeControllerConfig = getDefaultControllerConfiguration();
     firstDualModeControllerConfig.setControllerMode(ControllerConf.ControllerMode.DUAL);
@@ -95,7 +94,7 @@ public class PinotControllerModeTest extends ControllerTest {
       try {
         return LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
       } catch (Exception e) {
-        // Exception caught.
+        Assert.fail("Exception when checking whether lead controller resource is enabled or not.");
         return false;
       }
     }, TIMEOUT_IN_MS, "Failed to mark lead controller resource as enabled");
@@ -173,6 +172,7 @@ public class PinotControllerModeTest extends ControllerTest {
         return !LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
       } catch (Exception e) {
         // Exception caught.
+        Assert.fail("Exception when checking whether lead controller resource is enabled or not.");
         return false;
       }
     }, TIMEOUT_IN_MS, "Lead controller resource should be disabled.");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
@@ -61,7 +61,8 @@ public class PinotControllerModeTest extends ControllerTest {
   }
 
   @Test
-  public void testDualModeController() {
+  public void testDualModeController()
+      throws Exception {
     // Start the first dual-mode controller
     ControllerConf firstDualModeControllerConfig = getDefaultControllerConfiguration();
     firstDualModeControllerConfig.setControllerMode(ControllerConf.ControllerMode.DUAL);
@@ -90,8 +91,14 @@ public class PinotControllerModeTest extends ControllerTest {
     Assert.assertTrue(firstLeadControllerManager.isLeaderForTable(secondTableName));
 
     enableResourceConfigForLeadControllerResource(true);
-    TestUtils.waitForCondition(aVoid -> LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager), TIMEOUT_IN_MS,
-        "Failed to mark lead controller resource as enabled");
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
+      } catch (Exception e) {
+        // Exception caught.
+        return false;
+      }
+    }, TIMEOUT_IN_MS, "Failed to mark lead controller resource as enabled");
     // The first controller should still be the leader for both tables, which is the partition leader, after the resource is enabled.
     Assert.assertTrue(firstLeadControllerManager.isLeaderForTable(firstTableName));
     Assert.assertTrue(firstLeadControllerManager.isLeaderForTable(secondTableName));
@@ -161,8 +168,14 @@ public class PinotControllerModeTest extends ControllerTest {
     enableResourceConfigForLeadControllerResource(false);
     final LeadControllerManager thirdLeadControllerManager = thirdDualModeController.getLeadControllerManager();
 
-    TestUtils.waitForCondition(aVoid -> !LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager), TIMEOUT_IN_MS,
-        "Lead controller resource should be disabled.");
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return !LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
+      } catch (Exception e) {
+        // Exception caught.
+        return false;
+      }
+    }, TIMEOUT_IN_MS, "Lead controller resource should be disabled.");
 
     // After disabling lead controller resource, helix leader should be the leader for both tables.
     TestUtils.waitForCondition(

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
@@ -90,7 +90,7 @@ public class PinotControllerModeTest extends ControllerTest {
     Assert.assertTrue(firstLeadControllerManager.isLeaderForTable(secondTableName));
 
     enableResourceConfigForLeadControllerResource(true);
-    TestUtils.waitForCondition(aVoid -> firstLeadControllerManager.isLeadControllerResourceEnabled(), TIMEOUT_IN_MS,
+    TestUtils.waitForCondition(aVoid -> LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager), TIMEOUT_IN_MS,
         "Failed to mark lead controller resource as enabled");
     // The first controller should still be the leader for both tables, which is the partition leader, after the resource is enabled.
     Assert.assertTrue(firstLeadControllerManager.isLeaderForTable(firstTableName));
@@ -109,7 +109,7 @@ public class PinotControllerModeTest extends ControllerTest {
     checkInstanceState(_helixAdmin);
 
     LeadControllerManager secondLeadControllerManager = secondDualModeController.getLeadControllerManager();
-    Assert.assertTrue(secondLeadControllerManager.isLeadControllerResourceEnabled());
+    Assert.assertTrue(LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager));
 
     // Either one of the controllers is the only leader for a given table name.
     TestUtils.waitForCondition(aVoid -> {
@@ -161,7 +161,7 @@ public class PinotControllerModeTest extends ControllerTest {
     enableResourceConfigForLeadControllerResource(false);
     final LeadControllerManager thirdLeadControllerManager = thirdDualModeController.getLeadControllerManager();
 
-    TestUtils.waitForCondition(aVoid -> !thirdLeadControllerManager.isLeadControllerResourceEnabled(), TIMEOUT_IN_MS,
+    TestUtils.waitForCondition(aVoid -> !LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager), TIMEOUT_IN_MS,
         "Lead controller resource should be disabled.");
 
     // After disabling lead controller resource, helix leader should be the leader for both tables.

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
@@ -191,6 +191,7 @@ public class ControllerLeaderLocator {
    * @param instanceId instance id without any prefix, e.g. localhost_9000
    * */
   private Pair<String, Integer> convertToHostAndPortPair(String instanceId) {
+    // TODO: improve the exception handling.
     if (instanceId == null) {
       return null;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
@@ -20,16 +20,12 @@ package org.apache.pinot.server.realtime;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
-import org.apache.helix.AccessOption;
-import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixManager;
-import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.pql.parsers.utils.Pair;
-import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
@@ -108,7 +108,15 @@ public class ControllerLeaderLocator {
    */
   private Pair<String, Integer> getLeaderForTable(String rawTableName) {
     // Checks whether lead controller resource has been enabled or not.
-    if (LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager)) {
+    boolean leadControllerResourceEnabled;
+    try {
+      leadControllerResourceEnabled = LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
+    } catch (Exception e) {
+      LOGGER.error("Exception when checking whether lead controller resource is enabled or not.", e);
+      return null;
+    }
+
+    if (leadControllerResourceEnabled) {
       // Gets leader from lead controller resource.
       return getLeaderFromLeadControllerResource(rawTableName);
     } else {

--- a/pinot-core/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorTest.java
@@ -26,8 +26,10 @@ import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.ResourceConfig;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.core.query.utils.Pair;
 import org.apache.zookeeper.data.Stat;
@@ -177,6 +179,13 @@ public class ControllerLeaderLocatorTest {
     when(helixManager.getClusterManagmentTool()).thenReturn(helixAdmin);
     when(helixAdmin.getResourceExternalView(anyString(), anyString())).thenReturn(null);
 
+    PropertyKey.Builder keyBuilder = mock(PropertyKey.Builder.class);
+    when(helixDataAccessor.keyBuilder()).thenReturn(keyBuilder);
+    ResourceConfig resourceConfig = mock(ResourceConfig.class);
+    PropertyKey resourceConfigKey = mock(PropertyKey.class);
+    when(keyBuilder.resourceConfig(anyString())).thenReturn(resourceConfigKey);
+    when(helixDataAccessor.getProperty(resourceConfigKey)).thenReturn(resourceConfig);
+
     // Create Controller Leader Locator
     FakeControllerLeaderLocator.create(helixManager);
     ControllerLeaderLocator controllerLeaderLocator = FakeControllerLeaderLocator.getInstance();
@@ -193,7 +202,8 @@ public class ControllerLeaderLocatorTest {
     controllerLeaderLocator.invalidateCachedControllerLeader();
 
     // After enabling lead controller resource config, the leader in lead controller resource should be used.
-    when(znRecord.getSimpleField(anyString())).thenReturn("true");
+    when(resourceConfig.getSimpleConfig(anyString())).thenReturn("true");
+
 
     // External view is null, should return null.
     Assert.assertNull(controllerLeaderLocator.getControllerLeader(testTable));

--- a/pinot-core/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.helix.BaseDataAccessor;
+import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
@@ -59,6 +60,13 @@ public class ControllerLeaderLocatorTest {
     ZNRecord znRecord = mock(ZNRecord.class);
     final String leaderHost = "host";
     final int leaderPort = 12345;
+
+    // Lead controller resource disabled.
+    ConfigAccessor configAccessor = mock(ConfigAccessor.class);
+    ResourceConfig resourceConfig = mock(ResourceConfig.class);
+    when(helixManager.getConfigAccessor()).thenReturn(configAccessor);
+    when(configAccessor.getResourceConfig(anyString(), anyString())).thenReturn(resourceConfig);
+    when(resourceConfig.getSimpleConfig(anyString())).thenReturn("false");
 
     when(helixManager.getHelixDataAccessor()).thenReturn(helixDataAccessor);
     when(helixDataAccessor.getBaseDataAccessor()).thenReturn(baseDataAccessor);
@@ -142,6 +150,13 @@ public class ControllerLeaderLocatorTest {
     final String leaderHost = "host";
     final int leaderPort = 12345;
 
+    // Lead controller resource disabled.
+    ConfigAccessor configAccessor = mock(ConfigAccessor.class);
+    ResourceConfig resourceConfig = mock(ResourceConfig.class);
+    when(helixManager.getConfigAccessor()).thenReturn(configAccessor);
+    when(configAccessor.getResourceConfig(anyString(), anyString())).thenReturn(resourceConfig);
+    when(resourceConfig.getSimpleConfig(anyString())).thenReturn("false");
+
     when(helixManager.getHelixDataAccessor()).thenReturn(helixDataAccessor);
     when(helixDataAccessor.getBaseDataAccessor()).thenReturn(baseDataAccessor);
     when(znRecord.getId()).thenReturn(leaderHost + "_" + leaderPort);
@@ -179,12 +194,12 @@ public class ControllerLeaderLocatorTest {
     when(helixManager.getClusterManagmentTool()).thenReturn(helixAdmin);
     when(helixAdmin.getResourceExternalView(anyString(), anyString())).thenReturn(null);
 
-    PropertyKey.Builder keyBuilder = mock(PropertyKey.Builder.class);
-    when(helixDataAccessor.keyBuilder()).thenReturn(keyBuilder);
+    // Lead controller resource disabled.
+    ConfigAccessor configAccessor = mock(ConfigAccessor.class);
     ResourceConfig resourceConfig = mock(ResourceConfig.class);
-    PropertyKey resourceConfigKey = mock(PropertyKey.class);
-    when(keyBuilder.resourceConfig(anyString())).thenReturn(resourceConfigKey);
-    when(helixDataAccessor.getProperty(resourceConfigKey)).thenReturn(resourceConfig);
+    when(helixManager.getConfigAccessor()).thenReturn(configAccessor);
+    when(configAccessor.getResourceConfig(anyString(), anyString())).thenReturn(resourceConfig);
+    when(resourceConfig.getSimpleConfig(anyString())).thenReturn("false");
 
     // Create Controller Leader Locator
     FakeControllerLeaderLocator.create(helixManager);


### PR DESCRIPTION
This PR adds APIs to get leader for all tables or a given table.

* If lead controller resource is enabled, returns the map of partition name and the relevant lead controller response, including lead controller instanceId and a list of table names that belongs to the same partition. 
* If lead controller resource is disabled, returns an empty response.

### Get leaders for all tables:
API GET /leader/tables
When resource enabled:
```
{
  "leadControllerResourceEnabled": true,
  "leadControllerEntryMap": {
    "leadControllerResource_0": {
      "tableNames": [
        "testTable_OFFLINE"
      ],
      "leadControllerId": "Controller_172.25.124.150_9000"
    },
    ...
    "leadControllerResource_23": {
      "tableNames": [],
      "leadControllerId": "Controller_172.25.124.150_9000"
    }
  }
}
```
When resource disabled:
```
{
  "leadControllerResourceEnabled": false,
  "leadControllerEntryMap": {}
}
``` 
### Get leader for a given table:
API GET /leader/tables/{tableName}
When resource enabled:
```
{
  "leadControllerResourceEnabled": true,
  "leadControllerEntryMap": {
    "leadControllerResource_7": {
      "tableNames": [
        "baseballStats_OFFLINE"
      ],
      "leadControllerId": "Controller_172.25.124.150_9000"
    }
  }
}
```
When resource disabled:
```
{
  "leadControllerResourceEnabled": false,
  "leadControllerEntryMap": {}
}
```