### PR TITLE
 Support transform functions with AVG aggregation function

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/TransformBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/TransformBlockValSet.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.docvalsets;
 
+import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.core.common.BaseBlockValSet;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -39,6 +40,11 @@ public class TransformBlockValSet extends BaseBlockValSet {
   public TransformBlockValSet(ProjectionBlock projectionBlock, TransformFunction transformFunction) {
     _projectionBlock = projectionBlock;
     _transformFunction = transformFunction;
+  }
+
+  @Override
+  public FieldSpec.DataType getValueType() {
+    return _transformFunction.getResultMetadata().getDataType();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
@@ -49,10 +49,10 @@ public class AdditionTransformFunction extends BaseTransformFunction {
       throw new IllegalArgumentException("At least 2 arguments are required for ADD transform function");
     }
 
-    checkOperands(arguments);
+    processOperands(arguments);
   }
 
-  private void checkOperands(List<TransformFunction> operands) {
+  private void processOperands(List<TransformFunction> operands) {
     for (TransformFunction operand : operands) {
       if (operand instanceof LiteralTransformFunction) {
         String literal = ((LiteralTransformFunction) operand).getLiteral();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
@@ -54,18 +54,15 @@ public class AdditionTransformFunction extends BaseTransformFunction {
 
   private void checkOperands(List<TransformFunction> operands) {
     for (TransformFunction operand : operands) {
-      if (operand instanceof MapValueTransformFunction) {
-        throw new IllegalArgumentException("ADD transform function not supported to work with MAP as inner transform function");
-      }
-
       if (operand instanceof LiteralTransformFunction) {
+        String literal = ((LiteralTransformFunction) operand).getLiteral();
         try {
-          _literalSum += Double.parseDouble(((LiteralTransformFunction) operand).getLiteral());
+          _literalSum += Double.parseDouble(literal);
         } catch (NumberFormatException ne) {
-          throw new IllegalArgumentException("ADD transform function not supported on non-numeric literals");
+          throw new IllegalStateException("ADD transform function not supported on non-numeric literal: " + literal);
         }
       } else {
-        final TransformResultMetadata resultMetadata = operand.getResultMetadata();
+        TransformResultMetadata resultMetadata = operand.getResultMetadata();
 
         if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
           throw new IllegalArgumentException("ADD transform function not supported on non-numeric types");

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
@@ -51,10 +51,10 @@ public class DivisionTransformFunction extends BaseTransformFunction {
       throw new IllegalArgumentException("Exactly 2 arguments are required for DIV transform function");
     }
 
-    checkOperands(arguments.get(0), arguments.get(1));
+    processOperands(arguments.get(0), arguments.get(1));
   }
 
-  private void checkOperands(TransformFunction operand1, TransformFunction operand2) {
+  private void processOperands(TransformFunction operand1, TransformFunction operand2) {
     if (operand1 instanceof LiteralTransformFunction) {
       String literal = ((LiteralTransformFunction) operand1).getLiteral();
       try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
@@ -55,18 +55,15 @@ public class DivisionTransformFunction extends BaseTransformFunction {
   }
 
   private void checkOperands(TransformFunction operand1, TransformFunction operand2) {
-    if (operand1 instanceof MapValueTransformFunction || operand2 instanceof MapValueTransformFunction) {
-      throw new IllegalArgumentException("DIV transform function not supported to work with MAP as inner transform function");
-    }
-
     if (operand1 instanceof LiteralTransformFunction) {
+      String literal = ((LiteralTransformFunction) operand1).getLiteral();
       try {
-        _firstLiteral = Double.parseDouble(((LiteralTransformFunction) operand1).getLiteral());
+        _firstLiteral = Double.parseDouble(literal);
       } catch (NumberFormatException ne) {
-        throw new IllegalArgumentException("DIV transform function not supported on non-numeric literals");
+        throw new IllegalArgumentException("DIV transform function not supported on non-numeric literal: " + literal);
       }
     } else {
-      final TransformResultMetadata resultMetadata = operand1.getResultMetadata();
+      TransformResultMetadata resultMetadata = operand1.getResultMetadata();
 
       if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
         throw new IllegalArgumentException("DIV transform function not supported on non-numeric types");
@@ -80,13 +77,14 @@ public class DivisionTransformFunction extends BaseTransformFunction {
     }
 
     if (operand2 instanceof LiteralTransformFunction) {
+      String literal = ((LiteralTransformFunction) operand2).getLiteral();
       try {
-        _secondLiteral = Double.parseDouble(((LiteralTransformFunction) operand2).getLiteral());
+        _secondLiteral = Double.parseDouble(literal);
       } catch (NumberFormatException ne) {
-        throw new RuntimeException("DIV transform function not supported on non-numeric literals");
+        throw new RuntimeException("DIV transform function not supported on non-numeric literal: " + literal);
       }
     } else {
-      final TransformResultMetadata resultMetadata = operand2.getResultMetadata();
+      TransformResultMetadata resultMetadata = operand2.getResultMetadata();
 
       if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
         throw new IllegalArgumentException("SUB transform function not supported on non-numeric types");

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
@@ -49,10 +49,10 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
       throw new IllegalArgumentException("At least 2 arguments are required for MULT transform function");
     }
 
-    checkOperands(arguments);
+    processOperands(arguments);
   }
 
-  private void checkOperands(List<TransformFunction> operands) {
+  private void processOperands(List<TransformFunction> operands) {
     for (TransformFunction operand : operands) {
       if (operand instanceof LiteralTransformFunction) {
         String literal = ((LiteralTransformFunction) operand).getLiteral();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
@@ -54,18 +54,15 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
 
   private void checkOperands(List<TransformFunction> operands) {
     for (TransformFunction operand : operands) {
-      if (operand instanceof MapValueTransformFunction) {
-        throw new IllegalArgumentException("MUL transform function not supported to work with MAP as inner transform function");
-      }
-
       if (operand instanceof LiteralTransformFunction) {
+        String literal = ((LiteralTransformFunction) operand).getLiteral();
         try {
-          _literalProduct *= Double.parseDouble(((LiteralTransformFunction) operand).getLiteral());
+          _literalProduct *= Double.parseDouble(literal);
         } catch (NumberFormatException ne) {
-          throw new IllegalArgumentException("MUL transform function not supported on non-numeric literals");
+          throw new IllegalArgumentException("MUL transform function not supported on non-numeric literal: " + literal);
         }
       } else {
-        final TransformResultMetadata resultMetadata = operand.getResultMetadata();
+        TransformResultMetadata resultMetadata = operand.getResultMetadata();
 
         if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
           throw new IllegalArgumentException("MUL transform function not supported on non-numeric types");

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -48,14 +49,33 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
       throw new IllegalArgumentException("At least 2 arguments are required for MULT transform function");
     }
 
-    for (TransformFunction argument : arguments) {
-      if (argument instanceof LiteralTransformFunction) {
-        _literalProduct *= Double.parseDouble(((LiteralTransformFunction) argument).getLiteral());
-      } else {
-        if (!argument.getResultMetadata().isSingleValue()) {
-          throw new IllegalArgumentException("All the arguments of MULT transform function must be single-valued");
+    checkOperands(arguments);
+  }
+
+  private void checkOperands(List<TransformFunction> operands) {
+    for (TransformFunction operand : operands) {
+      if (operand instanceof MapValueTransformFunction) {
+        throw new IllegalArgumentException("MUL transform function not supported to work with MAP as inner transform function");
+      }
+
+      if (operand instanceof LiteralTransformFunction) {
+        try {
+          _literalProduct *= Double.parseDouble(((LiteralTransformFunction) operand).getLiteral());
+        } catch (NumberFormatException ne) {
+          throw new IllegalArgumentException("MUL transform function not supported on non-numeric literals");
         }
-        _transformFunctions.add(argument);
+      } else {
+        final TransformResultMetadata resultMetadata = operand.getResultMetadata();
+
+        if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
+          throw new IllegalArgumentException("MUL transform function not supported on non-numeric types");
+        }
+
+        if (!resultMetadata.isSingleValue()) {
+          throw new IllegalArgumentException("MUL transform function must have single-valued arguments");
+        }
+
+        _transformFunctions.add(operand);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -54,14 +54,10 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
   }
 
   private void checkOperands(TransformFunction operand) {
-    if (operand instanceof MapValueTransformFunction) {
-      throw new IllegalArgumentException(getName() + " transform function not supported to work with MAP as inner transform function");
-    }
-
     if (operand instanceof LiteralTransformFunction) {
       throw new IllegalArgumentException("Argument of " + getName() + " should not be literal");
     } else {
-      final TransformResultMetadata resultMetadata = operand.getResultMetadata();
+      TransformResultMetadata resultMetadata = operand.getResultMetadata();
 
       if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
         throw new IllegalArgumentException(getName() + " transform function not supported on non-numeric types");

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -50,10 +50,10 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
       throw new IllegalArgumentException("Exactly 1 arguments are required for " + getName() + " transform function");
     }
 
-    checkOperands(arguments.get(0));
+    processOperands(arguments.get(0));
   }
 
-  private void checkOperands(TransformFunction operand) {
+  private void processOperands(TransformFunction operand) {
     if (operand instanceof LiteralTransformFunction) {
       throw new IllegalArgumentException("Argument of " + getName() + " should not be literal");
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
@@ -57,18 +57,15 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   }
 
   private void checkOperands(TransformFunction operand1, TransformFunction operand2) {
-    if (operand1 instanceof MapValueTransformFunction || operand2 instanceof MapValueTransformFunction) {
-      throw new IllegalArgumentException("SUB transform function not supported to work with MAP as inner transform function");
-    }
-
     if (operand1 instanceof LiteralTransformFunction) {
+      String literal = ((LiteralTransformFunction) operand1).getLiteral();
       try {
-        _firstLiteral = Double.parseDouble(((LiteralTransformFunction) operand1).getLiteral());
+        _firstLiteral = Double.parseDouble(literal);
       } catch (NumberFormatException ne) {
-        throw new IllegalArgumentException("SUB transform function not supported on non-numeric literals");
+        throw new IllegalArgumentException("SUB transform function not supported on non-numeric literal: " + literal);
       }
     } else {
-      final TransformResultMetadata resultMetadata = operand1.getResultMetadata();
+      TransformResultMetadata resultMetadata = operand1.getResultMetadata();
 
       if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
         throw new IllegalArgumentException("SUB transform function not supported on non-numeric types");
@@ -82,13 +79,14 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
     }
 
     if (operand2 instanceof LiteralTransformFunction) {
+      String literal = ((LiteralTransformFunction) operand2).getLiteral();
       try {
-        _secondLiteral = Double.parseDouble(((LiteralTransformFunction) operand2).getLiteral());
+        _secondLiteral = Double.parseDouble(literal);
       } catch (NumberFormatException ne) {
-        throw new RuntimeException("SUB transform function not supported on non-numeric literals");
+        throw new RuntimeException("SUB transform function not supported on non-numeric literal: " + literal);
       }
     } else {
-      final TransformResultMetadata resultMetadata = operand2.getResultMetadata();
+      TransformResultMetadata resultMetadata = operand2.getResultMetadata();
 
       if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
         throw new IllegalArgumentException("SUB transform function not supported on non-numeric types");

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -37,6 +39,7 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   private double _secondLiteral;
   private TransformFunction _secondTransformFunction;
   private double[] _differences;
+  private FieldSpec.DataType returnType;
 
   @Override
   public String getName() {
@@ -50,24 +53,52 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
       throw new IllegalArgumentException("Exactly 2 arguments are required for SUB transform function");
     }
 
-    TransformFunction firstArgument = arguments.get(0);
-    if (firstArgument instanceof LiteralTransformFunction) {
-      _firstLiteral = Double.parseDouble(((LiteralTransformFunction) firstArgument).getLiteral());
-    } else {
-      if (!firstArgument.getResultMetadata().isSingleValue()) {
-        throw new IllegalArgumentException("First argument of SUB transform function must be single-valued");
-      }
-      _firstTransformFunction = firstArgument;
+    checkOperands(arguments.get(0), arguments.get(1));
+  }
+
+  private void checkOperands(TransformFunction operand1, TransformFunction operand2) {
+    if (operand1 instanceof MapValueTransformFunction || operand2 instanceof MapValueTransformFunction) {
+      throw new IllegalArgumentException("SUB transform function not supported to work with MAP as inner transform function");
     }
 
-    TransformFunction secondArgument = arguments.get(1);
-    if (secondArgument instanceof LiteralTransformFunction) {
-      _secondLiteral = Double.parseDouble(((LiteralTransformFunction) secondArgument).getLiteral());
-    } else {
-      if (!secondArgument.getResultMetadata().isSingleValue()) {
-        throw new IllegalArgumentException("Second argument of SUB transform function must be single-valued");
+    if (operand1 instanceof LiteralTransformFunction) {
+      try {
+        _firstLiteral = Double.parseDouble(((LiteralTransformFunction) operand1).getLiteral());
+      } catch (NumberFormatException ne) {
+        throw new IllegalArgumentException("SUB transform function not supported on non-numeric literals");
       }
-      _secondTransformFunction = secondArgument;
+    } else {
+      final TransformResultMetadata resultMetadata = operand1.getResultMetadata();
+
+      if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
+        throw new IllegalArgumentException("SUB transform function not supported on non-numeric types");
+      }
+
+      if (!resultMetadata.isSingleValue()) {
+        throw new IllegalArgumentException("SUB transform function must have single-valued arguments");
+      }
+
+      _firstTransformFunction = operand1;
+    }
+
+    if (operand2 instanceof LiteralTransformFunction) {
+      try {
+        _secondLiteral = Double.parseDouble(((LiteralTransformFunction) operand2).getLiteral());
+      } catch (NumberFormatException ne) {
+        throw new RuntimeException("SUB transform function not supported on non-numeric literals");
+      }
+    } else {
+      final TransformResultMetadata resultMetadata = operand2.getResultMetadata();
+
+      if (resultMetadata.getDataType() == FieldSpec.DataType.STRING) {
+        throw new IllegalArgumentException("SUB transform function not supported on non-numeric types");
+      }
+
+      if (!resultMetadata.isSingleValue()) {
+        throw new IllegalArgumentException("SUB transform function must have single-valued arguments");
+      }
+
+      _secondTransformFunction = operand2;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
@@ -39,7 +39,6 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   private double _secondLiteral;
   private TransformFunction _secondTransformFunction;
   private double[] _differences;
-  private FieldSpec.DataType returnType;
 
   @Override
   public String getName() {
@@ -53,10 +52,10 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
       throw new IllegalArgumentException("Exactly 2 arguments are required for SUB transform function");
     }
 
-    checkOperands(arguments.get(0), arguments.get(1));
+    processOperands(arguments.get(0), arguments.get(1));
   }
 
-  private void checkOperands(TransformFunction operand1, TransformFunction operand2) {
+  private void processOperands(TransformFunction operand1, TransformFunction operand2) {
     if (operand1 instanceof LiteralTransformFunction) {
       String literal = ((LiteralTransformFunction) operand1).getLiteral();
       try {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
@@ -30,26 +30,24 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
   @Test
   public void testAdditionTransformFunction() {
     TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(String
-        .format("add(%s,%s,%s,%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN, FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN,
-            STRING_SV_COLUMN));
+        .format("add(%s,%s,%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN, FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AdditionTransformFunction);
     Assert.assertEquals(transformFunction.getName(), AdditionTransformFunction.FUNCTION_NAME);
     double[] expectedValues = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] =
-          (double) _intSVValues[i] + (double) _longSVValues[i] + (double) _floatSVValues[i] + _doubleSVValues[i]
-              + Double.parseDouble(_stringSVValues[i]);
+          (double) _intSVValues[i] + (double) _longSVValues[i] + (double) _floatSVValues[i] + _doubleSVValues[i];
     }
     testTransformFunction(transformFunction, expectedValues);
 
     expression = TransformExpressionTree.compileToExpressionTree(String
-        .format("add(add(12,%s),%s,add(add(%s,%s),0.34,%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN, FLOAT_SV_COLUMN,
+        .format("add(add(12,%s),%s,add(add(%s,%s),0.34,%s),%s)", INT_SV_COLUMN, DOUBLE_SV_COLUMN, FLOAT_SV_COLUMN,
             LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AdditionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = ((12d + Double.parseDouble(_stringSVValues[i])) + _doubleSVValues[i] + (
+      expectedValues[i] = ((12d + (double)_intSVValues[i]) + _doubleSVValues[i] + (
           ((double) _floatSVValues[i] + (double) _longSVValues[i]) + 0.34 + (double) _intSVValues[i])
           + _doubleSVValues[i]);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
@@ -59,30 +59,30 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedValues);
 
     expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("div(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+        .compileToExpressionTree(String.format("div(%s,%s)", DOUBLE_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = _doubleSVValues[i] / Double.parseDouble(_stringSVValues[i]);
+      expectedValues[i] = _doubleSVValues[i] / (double)_intSVValues[i];
     }
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("div(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+        TransformExpressionTree.compileToExpressionTree(String.format("div(%s,%s)", LONG_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Double.parseDouble(_stringSVValues[i]) / (double) _intSVValues[i];
+      expectedValues[i] = (double)_longSVValues[i] / (double) _intSVValues[i];
     }
     testTransformFunction(transformFunction, expectedValues);
 
     expression = TransformExpressionTree.compileToExpressionTree(String
-        .format("div(div(div(div(div(12,%s),%s),div(div(%s,%s),0.34)),%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
+        .format("div(div(div(div(div(12,%s),%s),div(div(%s,%s),0.34)),%s),%s)", LONG_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = (((((12d / Double.parseDouble(_stringSVValues[i])) / _doubleSVValues[i]) / (
+      expectedValues[i] = (((((12d / (double)_longSVValues[i]) / _doubleSVValues[i]) / (
           ((double) _floatSVValues[i] / (double) _longSVValues[i]) / 0.34)) / (double) _intSVValues[i])
           / _doubleSVValues[i]);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunctionTest.java
@@ -30,26 +30,24 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
   @Test
   public void testMultiplicationTransformFunction() {
     TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(String
-        .format("mult(%s,%s,%s,%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN, FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN,
-            STRING_SV_COLUMN));
+        .format("mult(%s,%s,%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN, FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof MultiplicationTransformFunction);
     Assert.assertEquals(transformFunction.getName(), MultiplicationTransformFunction.FUNCTION_NAME);
     double[] expectedValues = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] =
-          (double) _intSVValues[i] * (double) _longSVValues[i] * (double) _floatSVValues[i] * _doubleSVValues[i]
-              * Double.parseDouble(_stringSVValues[i]);
+          (double) _intSVValues[i] * (double) _longSVValues[i] * (double) _floatSVValues[i] * _doubleSVValues[i];
     }
     testTransformFunction(transformFunction, expectedValues);
 
     expression = TransformExpressionTree.compileToExpressionTree(String
-        .format("mult(mult(12,%s),%s,mult(mult(%s,%s),0.34,%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
+        .format("mult(mult(12,%s),%s,mult(mult(%s,%s),0.34,%s),%s)", LONG_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof MultiplicationTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = ((12d * Double.parseDouble(_stringSVValues[i])) * _doubleSVValues[i] * (
+      expectedValues[i] = ((12d * (double)_longSVValues[i]) * _doubleSVValues[i] * (
           ((double) _floatSVValues[i] * (double) _longSVValues[i]) * 0.34 * (double) _intSVValues[i])
           * _doubleSVValues[i]);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
@@ -67,15 +67,6 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
       expectedValues[i] = Math.abs(_doubleSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
-
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("abs(%s)", STRING_SV_COLUMN));
-    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
-    for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.abs(Double.parseDouble(_stringSVValues[i]));
-    }
-    testTransformFunction(transformFunction, expectedValues);
   }
 
   @Test
@@ -115,15 +106,6 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = Math.ceil(_doubleSVValues[i]);
-    }
-    testTransformFunction(transformFunction, expectedValues);
-
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ceil(%s)", STRING_SV_COLUMN));
-    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
-    for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.ceil(Double.parseDouble(_stringSVValues[i]));
     }
     testTransformFunction(transformFunction, expectedValues);
   }
@@ -167,17 +149,8 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
       expectedValues[i] = Math.exp(_doubleSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
-
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("exp(%s)", STRING_SV_COLUMN));
-    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
-    for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.exp(Double.parseDouble(_stringSVValues[i]));
-    }
-    testTransformFunction(transformFunction, expectedValues);
   }
-  
+
   @Test
   public void testFloorTransformFunction() {
     TransformExpressionTree expression =
@@ -215,15 +188,6 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = Math.floor(_doubleSVValues[i]);
-    }
-    testTransformFunction(transformFunction, expectedValues);
-
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("floor(%s)", STRING_SV_COLUMN));
-    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
-    for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.floor(Double.parseDouble(_stringSVValues[i]));
     }
     testTransformFunction(transformFunction, expectedValues);
   }
@@ -267,15 +231,6 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
       expectedValues[i] = Math.log(_doubleSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
-
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ln(%s)", STRING_SV_COLUMN));
-    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof LnTransformFunction);
-    for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.log(Double.parseDouble(_stringSVValues[i]));
-    }
-    testTransformFunction(transformFunction, expectedValues);
   }
 
   @Test
@@ -315,15 +270,6 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = Math.sqrt(_doubleSVValues[i]);
-    }
-    testTransformFunction(transformFunction, expectedValues);
-
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sqrt(%s)", STRING_SV_COLUMN));
-    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
-    for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.sqrt(Double.parseDouble(_stringSVValues[i]));
     }
     testTransformFunction(transformFunction, expectedValues);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunctionTest.java
@@ -59,30 +59,30 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     testTransformFunction(transformFunction, expectedValues);
 
     expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("sub(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+        .compileToExpressionTree(String.format("sub(%s,%s)", DOUBLE_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = _doubleSVValues[i] - Double.parseDouble(_stringSVValues[i]);
+      expectedValues[i] = _doubleSVValues[i] - (double)_intSVValues[i];
     }
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sub(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+        TransformExpressionTree.compileToExpressionTree(String.format("sub(%s,%s)", LONG_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Double.parseDouble(_stringSVValues[i]) - (double) _intSVValues[i];
+      expectedValues[i] = (double)_longSVValues[i] - (double) _intSVValues[i];
     }
     testTransformFunction(transformFunction, expectedValues);
 
     expression = TransformExpressionTree.compileToExpressionTree(String
-        .format("sub(sub(sub(sub(sub(12,%s),%s),sub(sub(%s,%s),0.34)),%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
+        .format("sub(sub(sub(sub(sub(12,%s),%s),sub(sub(%s,%s),0.34)),%s),%s)", INT_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = (((((12d - Double.parseDouble(_stringSVValues[i])) - _doubleSVValues[i]) - (
+      expectedValues[i] = (((((12d - (double)_intSVValues[i]) - _doubleSVValues[i]) - (
           ((double) _floatSVValues[i] - (double) _longSVValues[i]) - 0.34)) - (double) _intSVValues[i])
           - _doubleSVValues[i]);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
@@ -1,0 +1,286 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.data.DimensionFieldSpec;
+import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.MetricFieldSpec;
+import org.apache.pinot.common.data.Schema;
+import org.apache.pinot.common.data.TimeFieldSpec;
+import org.apache.pinot.common.data.TimeGranularitySpec;
+import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.broker.AggregationResult;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.segment.ReadMode;
+import org.apache.pinot.common.utils.time.TimeUtils;
+import org.apache.pinot.core.data.GenericRow;
+import org.apache.pinot.core.data.manager.SegmentDataManager;
+import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.data.readers.RecordReader;
+import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TransformQueriesTest extends BaseQueriesTest {
+
+  private static final String D1 = "STRING_COL";
+  private static final String M1 = "INT_COL1";
+  private static final String M2 = "INT_COL2";
+  private static final String M3 = "LONG_COL1";
+  private static final String M4 = "LONG_COL2";
+  private static final String TIME = "T";
+  private static final String TABLE_NAME = "FOO";
+  private static final String SEGMENT_NAME_1 = "FOO_SEGMENT_1";
+  private static final String SEGMENT_NAME_2 = "FOO_SEGMENT_2";
+
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "TransformQueriesTest");
+
+  private Schema _schema;
+  private List<IndexSegment> _indexSegments = new ArrayList<>();
+  private List<SegmentDataManager> _segmentDataManagers;
+
+  @BeforeClass
+  public void setup() {
+    _schema = new Schema();
+
+    _schema.setSchemaName(TABLE_NAME);
+
+    final DimensionFieldSpec d1Spec = new DimensionFieldSpec(D1, FieldSpec.DataType.STRING, true);
+    _schema.addField(d1Spec);
+
+    final MetricFieldSpec m1Spec = new MetricFieldSpec(M1, FieldSpec.DataType.INT);
+    _schema.addField(m1Spec);
+
+    final MetricFieldSpec m2Spec = new MetricFieldSpec(M2, FieldSpec.DataType.INT);
+    _schema.addField(m2Spec);
+
+    final MetricFieldSpec m3Spec = new MetricFieldSpec(M3, FieldSpec.DataType.LONG);
+    _schema.addField(m3Spec);
+
+    final MetricFieldSpec m4Spec = new MetricFieldSpec(M4, FieldSpec.DataType.LONG);
+    _schema.addField(m4Spec);
+
+    final TimeFieldSpec tSpec = new TimeFieldSpec(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, TIME));
+    _schema.addField(tSpec);
+  }
+
+  @AfterClass
+  public void destroy() {
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  private void delete() {
+    for (IndexSegment indexSegment : _indexSegments) {
+      if (indexSegment != null) {
+        indexSegment.destroy();
+      }
+    }
+    _indexSegments.clear();
+  }
+
+  @Test
+  public void testTransformWithAvgInnerSegment() throws Exception {
+    try {
+      final List<GenericRow> rows = createDataSet(10);
+
+      final RecordReader recordReader = new GenericRowRecordReader(rows, _schema);
+      createSegment(_schema, recordReader, SEGMENT_NAME_1, TABLE_NAME);
+      final ImmutableSegment segment = loadSegment(SEGMENT_NAME_1);
+      _indexSegments.add(segment);
+
+      String query = "SELECT AVG(SUB(INT_COL1, INT_COL2)) FROM foo";
+      runAndVerifyInnerSegmentQuery(query, -10000.00, 10);
+
+      query = "SELECT AVG(SUB(LONG_COL1, INT_COL1)) FROM foo";
+      runAndVerifyInnerSegmentQuery(query, 4990000.00, 10);
+
+      query = "SELECT AVG(SUB(LONG_COL2, LONG_COL1)) FROM foo";
+      runAndVerifyInnerSegmentQuery(query, 5000000.00, 10);
+
+      query = "SELECT AVG(ADD(INT_COL1, INT_COL2)) FROM foo";
+      runAndVerifyInnerSegmentQuery(query, 30000.00,10);
+
+      query = "SELECT AVG(ADD(INT_COL1, LONG_COL1)) FROM foo";
+      runAndVerifyInnerSegmentQuery(query, 5010000.00,10);
+
+      query = "SELECT AVG(ADD(LONG_COL1, LONG_COL2)) FROM foo";
+      runAndVerifyInnerSegmentQuery(query, 15000000.00,10);
+
+      query = "SELECT AVG(ADD(DIV(INT_COL1, INT_COL2), DIV(LONG_COL1, LONG_COL2))) FROM foo";
+      runAndVerifyInnerSegmentQuery(query, 10.00, 10);
+
+      try {
+        query = "SELECT AVG(SUB(INT_COL1, STRING_COL)) FROM foo";
+        runAndVerifyInnerSegmentQuery(query, -10000.00, 10);
+        Assert.fail("Query should have failed");
+      } catch (Exception e) { }
+
+      try {
+        query = "SELECT AVG(ADD(DIV(INT_COL1, INT_COL2), DIV(LONG_COL1, STRING_COL))) FROM foo";
+        runAndVerifyInnerSegmentQuery(query, 10.00, 10);
+        Assert.fail("Query should have failed");
+      } catch (Exception e) { }
+    } finally {
+      delete();
+    }
+  }
+
+  @Test
+  public void testTransformWithAvgInterSegmentInterServer() throws Exception {
+    try {
+      final List<GenericRow> segmentOneRows = createDataSet(10);
+      final List<GenericRow> segmentTwoRows = createDataSet(10);
+
+      final RecordReader recordReaderOne = new GenericRowRecordReader(segmentOneRows, _schema);
+      final RecordReader recordReaderTwo = new GenericRowRecordReader(segmentTwoRows, _schema);
+
+      createSegment(_schema, recordReaderOne, SEGMENT_NAME_1, TABLE_NAME);
+      createSegment(_schema, recordReaderTwo, SEGMENT_NAME_2, TABLE_NAME);
+
+      final ImmutableSegment segmentOne = loadSegment(SEGMENT_NAME_1);
+      final ImmutableSegment segmentTwo = loadSegment(SEGMENT_NAME_2);
+
+      _indexSegments.add(segmentOne);
+      _indexSegments.add(segmentTwo);
+
+      _segmentDataManagers = Arrays.asList(new ImmutableSegmentDataManager(segmentOne),
+          new ImmutableSegmentDataManager(segmentTwo));
+
+      String query = "SELECT AVG(SUB(INT_COL1, INT_COL2)) FROM foo";
+      runAndVerifyInterSegmentQuery(query, "-1000.00000");
+
+      query = "SELECT AVG(SUB(LONG_COL1, INT_COL1)) FROM foo";
+      runAndVerifyInterSegmentQuery(query, "499000.00000");
+
+      query = "SELECT AVG(SUB(LONG_COL2, LONG_COL1)) FROM foo";
+      runAndVerifyInterSegmentQuery(query, "500000.00000");
+
+      query = "SELECT AVG(ADD(INT_COL1, INT_COL2)) FROM foo";
+      runAndVerifyInterSegmentQuery(query, "3000.00000");
+
+      query = "SELECT AVG(ADD(INT_COL1, LONG_COL1)) FROM foo";
+      runAndVerifyInterSegmentQuery(query, "501000.00000");
+
+      query = "SELECT AVG(ADD(LONG_COL1, LONG_COL2)) FROM foo";
+      runAndVerifyInterSegmentQuery(query, "1500000.00000");
+
+      query = "SELECT AVG(ADD(DIV(INT_COL1, INT_COL2), DIV(LONG_COL1, LONG_COL2))) FROM foo";
+      runAndVerifyInterSegmentQuery(query, "1.00000");
+    } finally {
+      delete();
+    }
+  }
+
+  private List<GenericRow> createDataSet(final int numRows) {
+    final ThreadLocalRandom random = ThreadLocalRandom.current();
+    final List<GenericRow> rows = new ArrayList<>(numRows);
+    Object[] columns;
+
+    // ROW
+    GenericRow row = new GenericRow();
+    columns = new Object[]{"Pinot", 1000, 2000, 500000, 1000000};
+    row.putField(D1, columns[0]);
+    row.putField(M1, columns[1]);
+    row.putField(M2, columns[2]);
+    row.putField(M3, columns[3]);
+    row.putField(M4, columns[4]);
+    row.putField(TIME, random.nextLong(TimeUtils.getValidMinTimeMillis(), TimeUtils.getValidMaxTimeMillis()));
+
+    for (int i = 0; i < numRows; i++) {
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  private void runAndVerifyInnerSegmentQuery(String query, double sum, long count) {
+    AggregationOperator aggregationOperator = getOperatorForQuery(query);
+    IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
+    final List<Object> aggregationResult = resultsBlock.getAggregationResult();
+    AvgPair avgPair = (AvgPair)aggregationResult.get(0);
+    Assert.assertEquals(avgPair.getSum(), sum);
+    Assert.assertEquals(avgPair.getCount(), count);
+  }
+
+  private void runAndVerifyInterSegmentQuery(String query, String serialized) {
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+    Assert.assertEquals(aggregationResults.size(), 1);
+    Serializable value = aggregationResults.get(0).getValue();
+    Assert.assertEquals(value.toString(), serialized);
+  }
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegments.get(0);
+  }
+
+  @Override
+  protected List<SegmentDataManager> getSegmentDataManagers() {
+    return _segmentDataManagers;
+  }
+
+  private void createSegment(
+      Schema schema,
+      RecordReader recordReader,
+      String segmentName,
+      String tableName)
+      throws Exception {
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    segmentGeneratorConfig.setTableName(tableName);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    segmentGeneratorConfig.setSegmentName(segmentName);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, recordReader);
+    driver.build();
+
+    File segmentIndexDir = new File(INDEX_DIR.getAbsolutePath(), segmentName);
+    if (!segmentIndexDir.exists()) {
+      throw new IllegalStateException("Segment generation failed");
+    }
+  }
+
+  private ImmutableSegment loadSegment(String segmentName)
+      throws Exception {
+    return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName), ReadMode.heap);
+  }
+}


### PR DESCRIPTION
Support queries like:

SELECT AVG(SUB(col1, col2) FROM foo
SELECT AVG(SUB(DIV(col1, col2), DIV(col3, col4))) FROM foo

They were failing in AvgAggregationFunction as TransformBlockValSet() did not implement getValueType() method

Also added operand checks for transform functions for acceptable data types

Testing:

Added TransformQueriesTest to test both inner-segment and inter-segment, inter-server queries with custom data