### PR TITLE
[Issue #4551] Remove memory allocation for virtual columns in consumi…

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/IndexSegment.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/IndexSegment.java
@@ -71,16 +71,6 @@ public interface IndexSegment {
   List<StarTreeV2> getStarTrees();
 
   /**
-   * Returns the record for the given document Id.
-   * <p>NOTE: don't use this method for high performance code.
-   *
-   * @param docId Document Id
-   * @param reuse Reusable buffer for the record
-   * @return Record for the given document Id
-   */
-  GenericRow getRecord(int docId, GenericRow reuse);
-
-  /**
    * Destroys segment in memory and closes file handlers if in MMAP mode.
    */
   void destroy();

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/IndexSegment.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/IndexSegment.java
@@ -71,6 +71,16 @@ public interface IndexSegment {
   List<StarTreeV2> getStarTrees();
 
   /**
+   * Returns the record for the given document Id. Virtual column values are not returned.
+   * <p>NOTE: don't use this method for high performance code.
+   *
+   * @param docId Document Id
+   * @param reuse Reusable buffer for the record
+   * @return Record for the given document Id
+   */
+  GenericRow getRecord(int docId, GenericRow reuse);
+
+  /**
    * Destroys segment in memory and closes file handlers if in MMAP mode.
    */
   void destroy();

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -158,16 +158,4 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   public List<StarTreeV2> getStarTrees() {
     return _starTreeIndexContainer != null ? _starTreeIndexContainer.getStarTrees() : null;
   }
-
-  @Override
-  public GenericRow getRecord(int docId, GenericRow reuse) {
-    for (FieldSpec fieldSpec : _segmentMetadata.getSchema().getAllFieldSpecs()) {
-      String column = fieldSpec.getName();
-      ColumnIndexContainer indexContainer = _indexContainerMap.get(column);
-      reuse.putField(column, IndexSegmentUtils
-          .getValue(docId, fieldSpec, indexContainer.getForwardIndex(), indexContainer.getDictionary(),
-              _segmentMetadata.getColumnMetadataFor(column).getMaxNumberOfMultiValues()));
-    }
-    return reuse;
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -479,13 +479,11 @@ public class MutableSegmentImpl implements MutableSegment {
    * @return Generic row with physical columns of the specified row.
    */
   public GenericRow getRecord(int docId, GenericRow reuse) {
-    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+    for (FieldSpec fieldSpec : _physicalColumnFieldSpecs) {
       String column = fieldSpec.getName();
-      if (!_schema.isVirtualColumn(column)) {
-        reuse.putField(column,
-            IndexSegmentUtils.getValue(docId, fieldSpec, _indexReaderWriterMap.get(column), _dictionaryMap.get(column),
-                _maxNumValuesMap.getOrDefault(column, 0)));
-      }
+      reuse.putField(column,
+          IndexSegmentUtils.getValue(docId, fieldSpec, _indexReaderWriterMap.get(column), _dictionaryMap.get(column),
+              _maxNumValuesMap.getOrDefault(column, 0)));
     }
     return reuse;
   }
@@ -680,7 +678,7 @@ public class MutableSegmentImpl implements MutableSegment {
         _aggregateMetrics = false;
         break;
       }
-      
+
       if (!_schema.getDimensionSpec(dimension).isSingleValueField()) {
         _logger.warn("Metrics aggregation cannot be turned ON in presence of multi-value dimension columns, eg: {}",
             dimension);

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -630,6 +630,7 @@ public class MutableSegmentImpl implements MutableSegment {
    *   <li> All dimensions and time are dictionary encoded. This is because an integer array containing dictionary id's
    *        is used as key for dimensions to record Id map. </li>
    *   <li> None of the metrics are dictionary encoded. </li>
+   *   <li> All columns should be single-valued (see https://github.com/apache/incubator-pinot/issues/3867)</li>
    * </ul>
    *
    * TODO: Eliminate the requirement on dictionary encoding for dimension and metric columns.
@@ -658,7 +659,7 @@ public class MutableSegmentImpl implements MutableSegment {
         _aggregateMetrics = false;
         break;
       }
-      // https://github.com/apache/incubator-pinot/issues/3867
+
       if (!_schema.getMetricSpec(metric).isSingleValueField()) {
         _logger
             .warn("Metrics aggregation cannot be turned ON in presence of multi-value metric columns, eg: {}", metric);
@@ -679,7 +680,7 @@ public class MutableSegmentImpl implements MutableSegment {
         _aggregateMetrics = false;
         break;
       }
-      // https://github.com/apache/incubator-pinot/issues/3867
+      
       if (!_schema.getDimensionSpec(dimension).isSingleValueField()) {
         _logger.warn("Metrics aggregation cannot be turned ON in presence of multi-value dimension columns, eg: {}",
             dimension);


### PR DESCRIPTION
…ng segments

Removed allocation of memory for virtual columns in consuming segments.

Removed the getRecord() interface from IndexSegment since it is not used anywhere.
Restricted it to a method within MutableSegmentImpl (needed to build completed
segments from consuming segments).

Verified that segment metadata did not have virtual columns before and after my change.

Verified that we can still execute the following queries:

        SELECT distinctcount($segmentName) from mytable
        SELECT count(*) from mytable group by $segmentName top 50
        SELECT somefield, $docId, $segmentName, $hostName from mytable
        SELECT count(*) from mytable where $segmentName = "mytable__1__23__20190823T0142Z"

and they work fine