### PR TITLE
Refactor toggleInstanceState API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -130,13 +130,17 @@ public class PinotInstanceRestletResource {
     }
 
     if (StateType.ENABLE.name().equalsIgnoreCase(state)) {
-      if (!pinotHelixResourceManager.enableInstance(instanceName).isSuccessful()) {
-        throw new ControllerApplicationException(LOGGER, "Failed to enable instance " + instanceName,
+      PinotResourceManagerResponse response = pinotHelixResourceManager.enableInstance(instanceName);
+      if (!response.isSuccessful()) {
+        throw new ControllerApplicationException(LOGGER,
+            "Failed to enable instance " + instanceName + " - " + response.getMessage(),
             Response.Status.INTERNAL_SERVER_ERROR);
       }
     } else if (StateType.DISABLE.name().equalsIgnoreCase(state)) {
-      if (!pinotHelixResourceManager.disableInstance(instanceName).isSuccessful()) {
-        throw new ControllerApplicationException(LOGGER, "Failed to disable instance " + instanceName,
+      PinotResourceManagerResponse response = pinotHelixResourceManager.disableInstance(instanceName);
+      if (!response.isSuccessful()) {
+        throw new ControllerApplicationException(LOGGER,
+            "Failed to disable instance " + instanceName + " - " + response.getMessage(),
             Response.Status.INTERNAL_SERVER_ERROR);
       }
     } else if (StateType.DROP.name().equalsIgnoreCase(state)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2175,6 +2175,9 @@ public class PinotHelixResourceManager {
             for (String state : currentState.getPartitionStateMap().values()) {
               // If instance is enabled, all the partitions should not eventually be offline.
               // If instance is disabled, all the partitions should eventually be offline.
+              // TODO: Handle the case when realtime segments are in OFFLINE state because there're some problem with realtime segment consumption,
+              //  and realtime segment will mark itself as OFFLINE in ideal state.
+              //  Issue: https://github.com/apache/incubator-pinot/issues/4653
               if ((enableInstance && !offlineState.equals(state)) || (!enableInstance && offlineState.equals(state))) {
                 toggleSucceeded = false;
                 break;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2084,11 +2084,11 @@ public class PinotHelixResourceManager {
   }
 
   public PinotResourceManagerResponse enableInstance(String instanceName) {
-    return toggleInstance(instanceName, true, 10);
+    return enableInstance(instanceName, true, 10_000L);
   }
 
   public PinotResourceManagerResponse disableInstance(String instanceName) {
-    return toggleInstance(instanceName, false, 10);
+    return enableInstance(instanceName, false, 10_000L);
   }
 
   /**
@@ -2140,63 +2140,68 @@ public class PinotHelixResourceManager {
    * Keeps checking until ideal-state is successfully updated or times out.
    *
    * @param instanceName: Name of Instance for which the status needs to be toggled.
-   * @param toggle: 'True' for ONLINE 'False' for OFFLINE.
-   * @param timeOutInSeconds: Time-out for setting ideal-state.
+   * @param enableInstance: 'True' for enabling the instance and 'False' for disabling the instance.
+   * @param timeOutMs: Time-out for setting ideal-state.
    * @return
    */
-  private PinotResourceManagerResponse toggleInstance(String instanceName, boolean toggle, int timeOutInSeconds) {
+  private PinotResourceManagerResponse enableInstance(String instanceName, boolean enableInstance, long timeOutMs) {
     if (!instanceExists(instanceName)) {
       return PinotResourceManagerResponse.failure("Instance " + instanceName + " not found");
     }
 
-    _helixAdmin.enableInstance(_helixClusterName, instanceName, toggle);
-    long deadline = System.currentTimeMillis() + 1000 * timeOutInSeconds;
-    boolean toggleSucceed;
+    _helixAdmin.enableInstance(_helixClusterName, instanceName, enableInstance);
+    long intervalWaitTimeMs = 500L;
+    long deadline = System.currentTimeMillis() + timeOutMs;
     String offlineState = SegmentOnlineOfflineStateModel.OFFLINE;
 
     while (System.currentTimeMillis() < deadline) {
-      toggleSucceed = true;
       PropertyKey liveInstanceKey = _keyBuilder.liveInstance(instanceName);
       LiveInstance liveInstance = _helixDataAccessor.getProperty(liveInstanceKey);
       if (liveInstance == null) {
-        if (!toggle) {
+        if (!enableInstance) {
           // If we disable the instance, we actually don't care whether live instance being null. Thus, returning success should be good.
-          // Otherwise, wait for at most 10 seconds.
+          // Otherwise, wait until timeout.
           return PinotResourceManagerResponse.SUCCESS;
         }
       } else {
+        boolean toggleSucceeded = true;
         // Checks all the current states fall into the target states
         PropertyKey instanceCurrentStatesKey = _keyBuilder.currentStates(instanceName, liveInstance.getSessionId());
         List<CurrentState> instanceCurrentStates = _helixDataAccessor.getChildValues(instanceCurrentStatesKey);
-        if (instanceCurrentStates == null) {
+        if (instanceCurrentStates.isEmpty()) {
           return PinotResourceManagerResponse.SUCCESS;
         } else {
           for (CurrentState currentState : instanceCurrentStates) {
             for (String state : currentState.getPartitionStateMap().values()) {
               // If instance is enabled, all the partitions should not eventually be offline.
               // If instance is disabled, all the partitions should eventually be offline.
-              if ((toggle && !offlineState.equals(state)) || (!toggle && offlineState.equals(state))) {
-                toggleSucceed = false;
+              if ((enableInstance && !offlineState.equals(state)) || (!enableInstance && offlineState.equals(state))) {
+                toggleSucceeded = false;
                 break;
               }
             }
-            if (!toggleSucceed) {
+            if (!toggleSucceeded) {
               break;
             }
           }
         }
-        if (toggleSucceed) {
-          return (toggle) ? PinotResourceManagerResponse.success("Instance " + instanceName + " enabled")
+        if (toggleSucceeded) {
+          return (enableInstance) ? PinotResourceManagerResponse.success("Instance " + instanceName + " enabled")
               : PinotResourceManagerResponse.success("Instance " + instanceName + " disabled");
         }
       }
 
       try {
-        Thread.sleep(500L);
+        Thread.sleep(intervalWaitTimeMs);
       } catch (InterruptedException e) {
+        LOGGER.warn("Got interrupted when sleeping for {}ms to wait until the current state matched for instance: {}",
+            intervalWaitTimeMs, instanceName);
+        return PinotResourceManagerResponse
+            .failure("Got interrupted when waiting for instance to be " + (enableInstance ? "enabled" : "disabled"));
       }
     }
-    return PinotResourceManagerResponse.failure("Instance " + (toggle ? "enable" : "disable") + " failed, timeout");
+    return PinotResourceManagerResponse
+        .failure("Instance " + (enableInstance ? "enable" : "disable") + " failed, timeout");
   }
 
   public RebalanceResult rebalanceTable(String tableNameWithType, Configuration rebalanceConfig)

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix;
 
+import java.io.IOException;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.pinot.common.config.TableConfig;
@@ -26,6 +27,7 @@ import org.apache.pinot.common.config.TagNameUtils;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
+import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -34,6 +36,7 @@ import org.testng.annotations.Test;
 
 public class ControllerInstanceToggleTest extends ControllerTest {
   private static final String RAW_TABLE_NAME = "testTable";
+  private static final long TIMEOUT_MS = 10_000L;
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
   private static final String SERVER_TAG_NAME = TagNameUtils.getOfflineTagForTenant(null);
   private static final String BROKER_TAG_NAME = TagNameUtils.getBrokerTagForTenant(null);
@@ -75,25 +78,25 @@ public class ControllerInstanceToggleTest extends ControllerTest {
     // Disable server instances
     int numEnabledInstances = NUM_INSTANCES;
     for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(getHelixClusterName(), SERVER_TAG_NAME)) {
-      sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), "disable");
+      toggleInstanceState(instanceName, "disable");
       checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, --numEnabledInstances);
     }
 
     // Enable server instances
     for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(getHelixClusterName(), SERVER_TAG_NAME)) {
-      sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), "ENABLE");
+      toggleInstanceState(instanceName, "ENABLE");
       checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, ++numEnabledInstances);
     }
 
     // Disable broker instances
     for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(getHelixClusterName(), BROKER_TAG_NAME)) {
-      sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), "Disable");
+      toggleInstanceState(instanceName, "Disable");
       checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, --numEnabledInstances);
     }
 
     // Enable broker instances
     for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(getHelixClusterName(), BROKER_TAG_NAME)) {
-      sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), "Enable");
+      toggleInstanceState(instanceName, "Enable");
       checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, ++numEnabledInstances);
     }
 
@@ -104,9 +107,21 @@ public class ControllerInstanceToggleTest extends ControllerTest {
             .getPartitionSet().size(), 0);
   }
 
+  private void toggleInstanceState(String instanceName, String state) {
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), state);
+      } catch (IOException ioe) {
+        // receive non-200 status code
+        return false;
+      }
+      return true;
+    }, TIMEOUT_MS, "Failed to toggle instance state: \'" + state + "\' for instance: " + instanceName);
+  }
+
   private void checkNumOnlineInstancesFromExternalView(String resourceName, int expectedNumOnlineInstances)
       throws InterruptedException {
-    long endTime = System.currentTimeMillis() + 10_000L;
+    long endTime = System.currentTimeMillis() + TIMEOUT_MS;
     while (System.currentTimeMillis() < endTime) {
       ExternalView resourceExternalView = _helixAdmin.getResourceExternalView(getHelixClusterName(), resourceName);
       Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -108,6 +108,7 @@ public class ControllerInstanceToggleTest extends ControllerTest {
   }
 
   private void toggleInstanceState(String instanceName, String state) {
+    // It may take time for an instance to toggle the state.
     TestUtils.waitForCondition(aVoid -> {
       try {
         sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), state);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -117,7 +117,7 @@ public class ControllerInstanceToggleTest extends ControllerTest {
         return false;
       }
       return true;
-    }, TIMEOUT_MS, "Failed to toggle instance state: \'" + state + "\' for instance: " + instanceName);
+    }, TIMEOUT_MS, "Failed to toggle instance state: '" + state + "' for instance: " + instanceName);
   }
 
   private void checkNumOnlineInstancesFromExternalView(String resourceName, int expectedNumOnlineInstances)


### PR DESCRIPTION
This PR:
* refactors the inner logic of toggleInstanceState API.
* adds error message in the response message.


Existing error in TravisCI:
```
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 38.034 sec <<< FAILURE! - in org.apache.pinot.controller.helix.ControllerInstanceToggleTest
testInstanceToggle(org.apache.pinot.controller.helix.ControllerInstanceToggleTest)  Time elapsed: 17.424 sec  <<< FAILURE!
java.io.IOException: Server returned HTTP response code: 500 for URL: http://localhost:18998/instances/Server_localhost_0/state
    at org.apache.pinot.controller.helix.ControllerInstanceToggleTest.testInstanceToggle(ControllerInstanceToggleTest.java:78)
```