### PR TITLE
Replace Hashmap to Object2IntOpenHashMap in OnHeapStringDictionary

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapStringDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapStringDictionary.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class OnHeapStringDictionary extends OnHeapDictionary {
     _paddingByte = paddingByte;
     byte[] buffer = new byte[numBytesPerValue];
     _unpaddedStrings = new String[length];
-    _unPaddedStringToIdMap = new HashMap<>(length);
+    _unPaddedStringToIdMap = new Object2IntOpenHashMap<>(length);
 
     for (int i = 0; i < length; i++) {
       _unpaddedStrings[i] = getUnpaddedString(i, buffer);
@@ -58,7 +59,7 @@ public class OnHeapStringDictionary extends OnHeapDictionary {
       _paddedStringToIdMap = null;
     } else {
       _paddedStrings = new String[length];
-      _paddedStringToIdMap = new HashMap<>(length);
+      _paddedStringToIdMap = new Object2IntOpenHashMap<>(length);
 
       for (int i = 0; i < length; i++) {
         _paddedStrings[i] = getPaddedString(i, buffer);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapStringDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapStringDictionary.java
@@ -20,8 +20,6 @@ package org.apache.pinot.core.segment.index.readers;
 
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 
 
@@ -38,8 +36,8 @@ public class OnHeapStringDictionary extends OnHeapDictionary {
   private final byte _paddingByte;
   private final String[] _unpaddedStrings;
   private final String[] _paddedStrings;
-  private final Map<String, Integer> _paddedStringToIdMap;
-  private final Map<String, Integer> _unPaddedStringToIdMap;
+  private final Object2IntOpenHashMap<String> _paddedStringToIdMap;
+  private final Object2IntOpenHashMap<String> _unPaddedStringToIdMap;
 
   public OnHeapStringDictionary(PinotDataBuffer dataBuffer, int length, int numBytesPerValue, byte paddingByte) {
     super(dataBuffer, length, numBytesPerValue, paddingByte);
@@ -48,6 +46,7 @@ public class OnHeapStringDictionary extends OnHeapDictionary {
     byte[] buffer = new byte[numBytesPerValue];
     _unpaddedStrings = new String[length];
     _unPaddedStringToIdMap = new Object2IntOpenHashMap<>(length);
+    _unPaddedStringToIdMap.defaultReturnValue(-1);
 
     for (int i = 0; i < length; i++) {
       _unpaddedStrings[i] = getUnpaddedString(i, buffer);
@@ -60,6 +59,7 @@ public class OnHeapStringDictionary extends OnHeapDictionary {
     } else {
       _paddedStrings = new String[length];
       _paddedStringToIdMap = new Object2IntOpenHashMap<>(length);
+      _paddedStringToIdMap.defaultReturnValue(-1);
 
       for (int i = 0; i < length; i++) {
         _paddedStrings[i] = getPaddedString(i, buffer);
@@ -70,16 +70,15 @@ public class OnHeapStringDictionary extends OnHeapDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
-    Map<String, Integer> stringToIdMap = (_paddingByte == 0) ? _unPaddedStringToIdMap : _paddedStringToIdMap;
-    Integer index = stringToIdMap.get(rawValue);
-    return (index != null) ? index : -1;
+    Object2IntOpenHashMap<String> stringToIdMap = (_paddingByte == 0) ? _unPaddedStringToIdMap : _paddedStringToIdMap;
+    return stringToIdMap.getInt(rawValue);
   }
 
   @Override
   public int insertionIndexOf(Object rawValue) {
     if (_paddingByte == 0) {
-      Integer id = _unPaddedStringToIdMap.get(rawValue);
-      return (id != null) ? id : Arrays.binarySearch(_unpaddedStrings, rawValue);
+      int id = _unPaddedStringToIdMap.getInt(rawValue);
+      return (id != -1) ? id : Arrays.binarySearch(_unpaddedStrings, rawValue);
     } else {
       String paddedValue = padString((String) rawValue);
       return Arrays.binarySearch(_paddedStrings, paddedValue);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.perf;
 
 import com.google.common.base.Joiner;
 import java.io.File;
+import java.lang.instrument.Instrumentation;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,7 +41,9 @@ import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
+import sun.instrument.InstrumentationImpl;
 
 
 /**
@@ -115,9 +118,11 @@ public class StringDictionaryPerfTest {
       rows.add(genericRow);
     }
 
+    long start = System.currentTimeMillis();
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, new GenericRowRecordReader(rows, schema));
     driver.build();
+    System.out.println("Total time for building segment: " + (System.currentTimeMillis() - start));
   }
 
   /**
@@ -153,7 +158,13 @@ public class StringDictionaryPerfTest {
    * @throws Exception
    */
   private String[] perfTestGetValues(int numGetValues) throws Exception {
-    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(_indexDir, ReadMode.heap);
+    IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig();
+    defaultIndexLoadingConfig.setReadMode(ReadMode.heap);
+    Set<String> columnNames = new HashSet<>();
+    columnNames.add(COLUMN_NAME);
+    defaultIndexLoadingConfig.setOnHeapDictionaryColumns(columnNames);
+
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(_indexDir, defaultIndexLoadingConfig);
     Dictionary dictionary = immutableSegment.getDictionary(COLUMN_NAME);
 
     Random random = new Random(System.nanoTime());
@@ -168,6 +179,7 @@ public class StringDictionaryPerfTest {
     FileUtils.deleteQuietly(_indexDir);
     long time = System.currentTimeMillis() - start;
     System.out.println("Total time for " + numGetValues + " lookups: " + time + "ms");
+    System.out.println("Memory usage: " + (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()));
     return new String[] {String.valueOf(_statistics.getN()), String.valueOf(time),
         String.valueOf(segmentSize), String.valueOf(numGetValues),
         String.valueOf(_statistics.getMin()), String.valueOf(_statistics.getMax()),

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
@@ -158,6 +158,9 @@ public class StringDictionaryPerfTest {
    * @throws Exception
    */
   private String[] perfTestGetValues(int numGetValues) throws Exception {
+    Runtime r = Runtime.getRuntime();
+    System.gc();
+    long oldMemory = r.totalMemory() - r.freeMemory();
     IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig();
     defaultIndexLoadingConfig.setReadMode(ReadMode.heap);
     Set<String> columnNames = new HashSet<>();
@@ -169,17 +172,19 @@ public class StringDictionaryPerfTest {
 
     Random random = new Random(System.nanoTime());
     long start = System.currentTimeMillis();
-
     for (int i = 0; i < numGetValues; i++) {
       int index = random.nextInt(_dictLength);
       dictionary.get(index);
     }
+    long time = System.currentTimeMillis() - start;
 
+    System.gc();
+    long newMemory = r.totalMemory() - r.freeMemory();
     long segmentSize = immutableSegment.getSegmentSizeBytes();
     FileUtils.deleteQuietly(_indexDir);
-    long time = System.currentTimeMillis() - start;
+
     System.out.println("Total time for " + numGetValues + " lookups: " + time + "ms");
-    System.out.println("Memory usage: " + (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()));
+    System.out.println("Memory usage: " + (newMemory - oldMemory));
     return new String[] {String.valueOf(_statistics.getN()), String.valueOf(time),
         String.valueOf(segmentSize), String.valueOf(numGetValues),
         String.valueOf(_statistics.getMin()), String.valueOf(_statistics.getMax()),

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
@@ -174,7 +174,7 @@ public class StringDictionaryPerfTest {
     long start = System.currentTimeMillis();
     for (int i = 0; i < numGetValues; i++) {
       int index = random.nextInt(_dictLength);
-      dictionary.get(index);
+      dictionary.indexOf(dictionary.get(index));
     }
     long time = System.currentTimeMillis() - start;
 


### PR DESCRIPTION
This PR replaces `Hashmap` to `Object2IntOpenHashMap` in OnHeapStringDictionary. 

https://issues.apache.org/jira/browse/PINOT-8
