### PR TITLE
[TE] only store evaluations for top dimensions

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskRunner.java
@@ -166,6 +166,14 @@ public class MonitorTaskRunner implements TaskRunner {
     } catch (Exception e) {
       LOG.error("Exception when expiring raw anomalies.", e);
     }
+
+    // Delete old evaluations (30 days by default)
+    try {
+      int deletedEvaluations = DAO_REGISTRY.getEvaluationManager().deleteRecordsOlderThanDays(monitorTaskInfo.getDefaultRetentionDays());
+      LOG.info("Deleted {} evaluations that are older than {} days.", deletedEvaluations, monitorTaskInfo.getDefaultRetentionDays());
+    } catch (Exception e) {
+      LOG.error("Exception when deleting old evaluations.", e);
+    }
   }
 
   private Map<Long, JobDTO> findScheduledJobsWithinDays(int days) {

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapperTest.java
@@ -117,8 +117,8 @@ public class DimensionWrapperTest {
     this.wrapper.run();
 
     Assert.assertEquals(this.runs.size(), 3);
-    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:b%3D1", 14, 15));
-    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:b%3D2", 14, 15));
+    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:b%3D1", 14, 15));
+    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:b%3D2", 14, 15));
     assertEquals(this.runs.get(2), makePipeline("thirdeye:metric:2:b%3D3", 14, 15));
   }
 
@@ -130,8 +130,8 @@ public class DimensionWrapperTest {
     this.wrapper.run();
 
     Assert.assertEquals(this.runs.size(), 3);
-    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:b%3D1"));
-    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:b%3D2"));
+    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:b%3D1"));
+    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:b%3D2"));
     assertEquals(this.runs.get(2), makePipeline("thirdeye:metric:2:b%3D3"));
   }
 
@@ -143,12 +143,12 @@ public class DimensionWrapperTest {
     this.wrapper.run();
 
     Assert.assertEquals(this.runs.size(), 6);
-    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:a%3D1:b%3D1"));
-    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:a%3D1:b%3D2"));
-    assertEquals(this.runs.get(2), makePipeline("thirdeye:metric:2:a%3D1:b%3D3"));
-    assertEquals(this.runs.get(3), makePipeline("thirdeye:metric:2:a%3D2:b%3D1"));
-    assertEquals(this.runs.get(4), makePipeline("thirdeye:metric:2:a%3D2:b%3D2"));
-    assertEquals(this.runs.get(5), makePipeline("thirdeye:metric:2:a%3D2:b%3D3"));
+    assertEquals(this.runs.get(5), makePipeline("thirdeye:metric:2:a%3D1:b%3D1"));
+    assertEquals(this.runs.get(3), makePipeline("thirdeye:metric:2:a%3D1:b%3D2"));
+    assertEquals(this.runs.get(4), makePipeline("thirdeye:metric:2:a%3D1:b%3D3"));
+    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:a%3D2:b%3D1"));
+    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:a%3D2:b%3D2"));
+    assertEquals(this.runs.get(2), makePipeline("thirdeye:metric:2:a%3D2:b%3D3"));
   }
 
   @Test
@@ -160,8 +160,8 @@ public class DimensionWrapperTest {
     this.wrapper.run();
 
     Assert.assertEquals(this.runs.size(), 2);
-    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:b%3D1"));
-    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:b%3D2"));
+    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:b%3D2"));
+    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:b%3D1"));
   }
 
   @Test
@@ -216,10 +216,10 @@ public class DimensionWrapperTest {
     this.wrapper.run();
 
     Assert.assertEquals(this.runs.size(), 4);
-    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:10:b%3D1"));
-    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:10:b%3D2"));
-    assertEquals(this.runs.get(2), makePipeline("thirdeye:metric:11:b%3D1"));
-    assertEquals(this.runs.get(3), makePipeline("thirdeye:metric:11:b%3D2"));
+    assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:10:b%3D1"));
+    assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:10:b%3D2"));
+    assertEquals(this.runs.get(3), makePipeline("thirdeye:metric:11:b%3D1"));
+    assertEquals(this.runs.get(2), makePipeline("thirdeye:metric:11:b%3D2"));
   }
 
   private DetectionConfigDTO makeConfig(String metricUrn) {

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/algorithm/LegacyDimensionWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/algorithm/LegacyDimensionWrapperTest.java
@@ -122,12 +122,12 @@ public class LegacyDimensionWrapperTest {
     this.dimensionWrapper.run();
 
     Assert.assertEquals(this.runs.size(), 6);
-    Assert.assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:a%3D1:b%3D1"));
-    Assert.assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:a%3D1:b%3D2"));
-    Assert.assertEquals(this.runs.get(2), makePipeline("thirdeye:metric:2:a%3D1:b%3D3"));
-    Assert.assertEquals(this.runs.get(3), makePipeline("thirdeye:metric:2:a%3D2:b%3D1"));
-    Assert.assertEquals(this.runs.get(4), makePipeline("thirdeye:metric:2:a%3D2:b%3D2"));
-    Assert.assertEquals(this.runs.get(5), makePipeline("thirdeye:metric:2:a%3D2:b%3D3"));
+    Assert.assertEquals(this.runs.get(5), makePipeline("thirdeye:metric:2:a%3D1:b%3D1"));
+    Assert.assertEquals(this.runs.get(3), makePipeline("thirdeye:metric:2:a%3D1:b%3D2"));
+    Assert.assertEquals(this.runs.get(4), makePipeline("thirdeye:metric:2:a%3D1:b%3D3"));
+    Assert.assertEquals(this.runs.get(1), makePipeline("thirdeye:metric:2:a%3D2:b%3D1"));
+    Assert.assertEquals(this.runs.get(0), makePipeline("thirdeye:metric:2:a%3D2:b%3D2"));
+    Assert.assertEquals(this.runs.get(2), makePipeline("thirdeye:metric:2:a%3D2:b%3D3"));
   }
 
   private DetectionConfigDTO makeConfig(String metricUrn) {


### PR DESCRIPTION
Previously, we store one evaluation per detection task per metric urn, this may overload the database and creates too many evaluations. This PR fixes the issue by adding the following:
- Only store the evaluations for top 5 dimensions. This is usually enough information to evaluate the regression error.
- Clean up old evaluations (more than 30 days) in the monitoring task.