### PR TITLE
Refactor TransformBlockDataFetcher so that DISTINCT and reuse it

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/BaseBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/BaseBlockValSet.java
@@ -18,20 +18,13 @@
  */
 package org.apache.pinot.core.common;
 
-import org.apache.pinot.common.data.FieldSpec;
-
-
 /**
  * Abstract base class implementation for BlockValSet
  */
 public abstract class BaseBlockValSet implements BlockValSet {
-  @Override
-  public BlockValIterator iterator() {
-    throw new UnsupportedOperationException();
-  }
 
   @Override
-  public FieldSpec.DataType getValueType() {
+  public BlockValIterator iterator() {
     throw new UnsupportedOperationException();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/BlockValSet.java
@@ -27,6 +27,8 @@ public interface BlockValSet {
 
   DataType getValueType();
 
+  boolean isSingleValue();
+
   /**
    * DOCUMENT ID BASED APIs
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
@@ -63,13 +63,10 @@ public class ProjectionBlock implements Block {
     throw new UnsupportedOperationException();
   }
 
-  // TODO: let selection operator use DataBlockCache as well
-  public Block getBlock(String column) {
-    return _blockMap.get(column);
-  }
-
   public BlockValSet getBlockValueSet(String column) {
-    return new ProjectionBlockValSet(_dataBlockCache, column, _blockMap.get(column).getMetadata().getDataType());
+    BlockMetadata blockMetadata = _blockMap.get(column).getMetadata();
+    return new ProjectionBlockValSet(_dataBlockCache, column, blockMetadata.getDataType(),
+        blockMetadata.isSingleValue());
   }
 
   public DocIdSetBlock getDocIdSetBlock() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/MultiValueSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/MultiValueSet.java
@@ -45,4 +45,9 @@ public final class MultiValueSet extends BaseBlockValSet {
   public DataType getValueType() {
     return _dataType;
   }
+
+  @Override
+  public boolean isSingleValue() {
+    return false;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.operator.docvalsets;
 
-import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.core.common.BaseBlockValSet;
 import org.apache.pinot.core.common.DataBlockCache;
 import org.apache.pinot.core.operator.ProjectionOperator;
@@ -32,7 +32,8 @@ import org.apache.pinot.core.operator.ProjectionOperator;
 public class ProjectionBlockValSet extends BaseBlockValSet {
   private final DataBlockCache _dataBlockCache;
   private final String _column;
-  private final FieldSpec.DataType _dataType;
+  private final DataType _dataType;
+  private final boolean _singleValue;
 
   /**
    * Constructor for the class.
@@ -42,10 +43,21 @@ public class ProjectionBlockValSet extends BaseBlockValSet {
    * @param dataBlockCache data block cache
    * @param column Projection column.
    */
-  public ProjectionBlockValSet(DataBlockCache dataBlockCache, String column, FieldSpec.DataType dataType) {
+  public ProjectionBlockValSet(DataBlockCache dataBlockCache, String column, DataType dataType, boolean singleValue) {
     _dataBlockCache = dataBlockCache;
     _column = column;
     _dataType = dataType;
+    _singleValue = singleValue;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return _dataType;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return _singleValue;
   }
 
   @Override
@@ -113,11 +125,6 @@ public class ProjectionBlockValSet extends BaseBlockValSet {
   @Override
   public String[][] getStringValuesMV() {
     return _dataBlockCache.getStringValuesForMVColumn(_column);
-  }
-
-  @Override
-  public FieldSpec.DataType getValueType() {
-    return _dataType;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/SingleValueSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/SingleValueSet.java
@@ -49,6 +49,11 @@ public final class SingleValueSet extends BaseBlockValSet {
   }
 
   @Override
+  public boolean isSingleValue() {
+    return true;
+  }
+
+  @Override
   public void getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos) {
     int inEndPos = inStartPos + inDocIdsSize;
     ReaderContext context = _reader.createContext();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/TransformBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/TransformBlockValSet.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.operator.docvalsets;
 
-import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.core.common.BaseBlockValSet;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -43,8 +43,13 @@ public class TransformBlockValSet extends BaseBlockValSet {
   }
 
   @Override
-  public FieldSpec.DataType getValueType() {
+  public DataType getValueType() {
     return _transformFunction.getResultMetadata().getDataType();
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return _transformFunction.getResultMetadata().isSingleValue();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
@@ -19,19 +19,16 @@
 package org.apache.pinot.core.operator.query;
 
 import java.io.Serializable;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
-import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.primitive.ByteArray;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.indexsegment.IndexSegment;
@@ -42,204 +39,160 @@ import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.TransformBlockDataFetcher;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.segment.index.readers.Dictionary;
 
 
-/**
- * This SelectionOnlyOperator will take care of applying a selection query to one IndexSegment.
- * nextBlock() will return an IntermediateResultBlock for the given IndexSegment.
- */
 public class SelectionOperator extends BaseOperator<IntermediateResultsBlock> {
-
-  private static final String OPERATOR_NAME = "SelectionOnlyOperator";
+  private static final String OPERATOR_NAME = "SelectionOperator";
 
   private final IndexSegment _indexSegment;
   private final TransformOperator _transformOperator;
-  private final DataSchema _dataSchema;
-  private final BlockValSet[] _blockValSets;
-  private final int _limit;
-  private Selection _selection;
-  private final int _offset;
-  private final int _maxRows;
+  private final List<SelectionSort> _sortSequence;
   private final List<TransformExpressionTree> _expressions;
-  private final List<TransformExpressionTree> _selectExpressions;
-  private final List<TransformExpressionTree> _orderByExpressions;
-  private final List<Integer> _orderByIndices;
-  private final TransformResultMetadata[] _expressionResultMetadata;
-  private final Dictionary[] _dictionaries;
-  private Collection<Serializable[]> _rowEvents;
-  private PriorityQueue<Serializable[]> _priorityQueue;
+  private final int _limit;
+  private final int _maxRows;
+  private final Collection<Serializable[]> _rows;
+  private final PriorityQueue<Serializable[]> _priorityQueue;
+  private final BlockValSet[] _blockValSets;
+  private final DataSchema _dataSchema;
 
   private ExecutionStatistics _executionStatistics;
 
-  public SelectionOperator(IndexSegment indexSegment, Selection selection, TransformOperator transformOperator) {
+  /**
+   * NOTE: The expressions in the transform operator has the sort expressions at the front. The sort sequence is the
+   * deduplicated sort expressions.
+   */
+  public SelectionOperator(IndexSegment indexSegment, Selection selection, TransformOperator transformOperator,
+      List<SelectionSort> sortSequence) {
     _indexSegment = indexSegment;
-    _offset = selection.getOffset();
-    _limit = selection.getSize();
-    _selection = selection;
-    _maxRows = _offset + _limit;
     _transformOperator = transformOperator;
+    _sortSequence = sortSequence;
     _expressions = _transformOperator.getExpressions();
+    _limit = selection.getSize();
 
-    List<String> selectColumns = selection.getSelectionColumns();
-    if (selectColumns.size() == 1 && selectColumns.get(0).equals("*")) {
-      selectColumns = new LinkedList<>(indexSegment.getPhysicalColumnNames());
+    boolean selectionOnly = sortSequence.isEmpty();
+    if (selectionOnly) {
+      // Selection only
+      _maxRows = _limit;
+      _rows = new ArrayList<>(_maxRows);
+      _priorityQueue = null;
+    } else {
+      // Selection order-by
+      _maxRows = selection.getOffset() + _limit;
+      _rows = null;
+      _priorityQueue = new PriorityQueue<>(_maxRows, getComparator());
     }
 
-    List<String> orderByColumns = new ArrayList<>();
-    if (selection.getSelectionSortSequence() != null) {
-      for (SelectionSort selectionSort : selection.getSelectionSortSequence()) {
-        String expression = selectionSort.getColumn();
-        orderByColumns.add(expression);
-      }
-    }
-    _selectExpressions = new ArrayList<>();
-    _orderByExpressions = new ArrayList<>();
-    _orderByIndices = new ArrayList<>();
-    for (int i = 0; i < _expressions.size(); i++) {
+    int numExpressions = _expressions.size();
+    _blockValSets = new BlockValSet[numExpressions];
+    String[] columnNames = new String[numExpressions];
+    ColumnDataType[] columnDataTypes = new ColumnDataType[numExpressions];
+    for (int i = 0; i < numExpressions; i++) {
       TransformExpressionTree expression = _expressions.get(i);
-      if (selectColumns.contains(expression.toString())) {
-        _selectExpressions.add(expression);
-      }
-    }
-
-    for (String orderByColumn : orderByColumns) {
-      for (int i = 0; i < _expressions.size(); i++) {
-        TransformExpressionTree expression = _expressions.get(i);
-        if (orderByColumn.equalsIgnoreCase(expression.toString())) {
-          _orderByExpressions.add(expression);
-          _orderByIndices.add(i);
-        }
-      }
-    }
-
-    _blockValSets = new BlockValSet[_expressions.size()];
-    _expressionResultMetadata = new TransformResultMetadata[_expressions.size()];
-    _dictionaries = new Dictionary[_expressions.size()];
-    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[_expressions.size()];
-    String[] columnNames = new String[_expressions.size()];
-    for (int i = 0; i < _expressions.size(); i++) {
-      TransformExpressionTree expression = _expressions.get(i);
-      _expressionResultMetadata[i] = _transformOperator.getResultMetadata(expression);
-      columnDataTypes[i] = DataSchema.ColumnDataType
-          .fromDataType(_expressionResultMetadata[i].getDataType(), _expressionResultMetadata[i].isSingleValue());
       columnNames[i] = expression.toString();
-      if (_expressionResultMetadata[i].hasDictionary()) {
-        _dictionaries[i] = _transformOperator.getDictionary(expression);
-      }
+      TransformResultMetadata resultMetadata = _transformOperator.getResultMetadata(expression);
+      columnDataTypes[i] = ColumnDataType.fromDataType(resultMetadata.getDataType(), resultMetadata.isSingleValue());
     }
     _dataSchema = new DataSchema(columnNames, columnDataTypes);
-    if (_orderByExpressions.isEmpty()) {
-      _rowEvents = new ArrayList<>();
-    } else {
-      Comparator<Serializable[]> comparator = getStrictComparator();
-      _priorityQueue = new PriorityQueue<>(_maxRows, comparator);
-    }
   }
 
-  private Comparator<Serializable[]> getStrictComparator() {
-    return new Comparator<Serializable[]>() {
-      @Override
-      public int compare(Serializable[] o1, Serializable[] o2) {
-        List<SelectionSort> sortSequence = _selection.getSelectionSortSequence();
-        int numSortColumns = sortSequence.size();
-        for (int i = 0; i < numSortColumns; i++) {
-          int ret = 0;
-          SelectionSort selectionSort = sortSequence.get(i);
-          int index = _orderByIndices.get(i);
-          // Only compare single-value columns.
-          if (!_expressionResultMetadata[index].isSingleValue()) {
-            continue;
-          }
-
-          Serializable v1 = o1[index];
-          Serializable v2 = o2[index];
-
-          DataType dataType = _expressionResultMetadata[index].getDataType();
-          switch (dataType) {
-            case INT:
-              if (!selectionSort.isIsAsc()) {
-                ret = ((Integer) v1).compareTo((Integer) v2);
-              } else {
-                ret = ((Integer) v2).compareTo((Integer) v1);
-              }
-              break;
-            case LONG:
-              if (!selectionSort.isIsAsc()) {
-                ret = ((Long) v1).compareTo((Long) v2);
-              } else {
-                ret = ((Long) v2).compareTo((Long) v1);
-              }
-              break;
-            case FLOAT:
-              if (!selectionSort.isIsAsc()) {
-                ret = ((Float) v1).compareTo((Float) v2);
-              } else {
-                ret = ((Float) v2).compareTo((Float) v1);
-              }
-              break;
-            case DOUBLE:
-              if (!selectionSort.isIsAsc()) {
-                ret = ((Double) v1).compareTo((Double) v2);
-              } else {
-                ret = ((Double) v2).compareTo((Double) v1);
-              }
-              break;
-            case BOOLEAN:
-            case STRING:
-              if (!selectionSort.isIsAsc()) {
-                ret = ((String) v1).compareTo((String) v2);
-              } else {
-                ret = ((String) v2).compareTo((String) v1);
-              }
-              break;
-            case BYTES:
-              if (!selectionSort.isIsAsc()) {
-                ret = ByteArray.compare((byte[]) v1, (byte[]) v2);
-              } else {
-                ret = ByteArray.compare((byte[]) v2, (byte[]) v1);
-              }
-            default:
-              break;
-          }
-
-          if (ret != 0) {
-            return ret;
-          }
+  // TODO: Optimize the comparator by comparing dictionary ids
+  private Comparator<Serializable[]> getComparator() {
+    return (o1, o2) -> {
+      int numSortExpressions = _sortSequence.size();
+      for (int i = 0; i < numSortExpressions; i++) {
+        // Only compare single-value columns
+        if (!_blockValSets[i].isSingleValue()) {
+          continue;
         }
-        return 0;
+
+        Serializable v1 = o1[i];
+        Serializable v2 = o2[i];
+
+        int ret = 0;
+        SelectionSort selectionSort = _sortSequence.get(i);
+        switch (_blockValSets[i].getValueType()) {
+          case INT:
+            if (!selectionSort.isIsAsc()) {
+              ret = ((Integer) v1).compareTo((Integer) v2);
+            } else {
+              ret = ((Integer) v2).compareTo((Integer) v1);
+            }
+            break;
+          case LONG:
+            if (!selectionSort.isIsAsc()) {
+              ret = ((Long) v1).compareTo((Long) v2);
+            } else {
+              ret = ((Long) v2).compareTo((Long) v1);
+            }
+            break;
+          case FLOAT:
+            if (!selectionSort.isIsAsc()) {
+              ret = ((Float) v1).compareTo((Float) v2);
+            } else {
+              ret = ((Float) v2).compareTo((Float) v1);
+            }
+            break;
+          case DOUBLE:
+            if (!selectionSort.isIsAsc()) {
+              ret = ((Double) v1).compareTo((Double) v2);
+            } else {
+              ret = ((Double) v2).compareTo((Double) v1);
+            }
+            break;
+          case STRING:
+            if (!selectionSort.isIsAsc()) {
+              ret = ((String) v1).compareTo((String) v2);
+            } else {
+              ret = ((String) v2).compareTo((String) v1);
+            }
+            break;
+          case BYTES:
+            if (!selectionSort.isIsAsc()) {
+              ret = ByteArray.compare((byte[]) v1, (byte[]) v2);
+            } else {
+              ret = ByteArray.compare((byte[]) v2, (byte[]) v1);
+            }
+          default:
+            break;
+        }
+        if (ret != 0) {
+          return ret;
+        }
       }
+
+      return 0;
     };
   }
 
   @Override
   protected IntermediateResultsBlock getNextBlock() {
     int numDocsScanned = 0;
+    int numExpressions = _expressions.size();
+    boolean selectionOnly = _sortSequence.isEmpty();
 
     TransformBlock transformBlock;
-    boolean selectionOnly = _orderByExpressions.isEmpty();
     while ((transformBlock = _transformOperator.nextBlock()) != null) {
-      for (int i = 0; i < _expressions.size(); i++) {
+      for (int i = 0; i < numExpressions; i++) {
         TransformExpressionTree expression = _expressions.get(i);
         _blockValSets[i] = transformBlock.getBlockValueSet(expression);
       }
-      TransformBlockDataFetcher dataFetcher;
-      dataFetcher = new TransformBlockDataFetcher(_blockValSets, _dictionaries, _expressionResultMetadata);
+      TransformBlockDataFetcher dataFetcher = new TransformBlockDataFetcher(_blockValSets);
+      int numDocs = transformBlock.getNumDocs();
+      int docId = 0;
       if (selectionOnly) {
-        int docId = 0;
-        while (_rowEvents.size() < _limit && docId < transformBlock.getNumDocs()) {
+        // Selection only
+        while (_rows.size() < _limit && docId < numDocs) {
           Serializable[] row = dataFetcher.getRow(docId);
-          _rowEvents.add(row);
-          docId = docId + 1;
+          _rows.add(row);
+          docId++;
         }
-        if (_rowEvents.size() >= _limit) {
-          numDocsScanned += docId;
+        numDocsScanned += docId;
+        if (_rows.size() == _limit) {
           break;
         }
       } else {
-        //Selection + orderby
-        int docId = 0;
-        while (docId < transformBlock.getNumDocs()) {
+        // Selection order-by
+        while (docId < numDocs) {
           Serializable[] row = dataFetcher.getRow(docId);
           if (_priorityQueue.size() < _maxRows) {
             _priorityQueue.add(row);
@@ -247,7 +200,7 @@ public class SelectionOperator extends BaseOperator<IntermediateResultsBlock> {
             _priorityQueue.poll();
             _priorityQueue.offer(row);
           }
-          docId = docId + 1;
+          docId++;
         }
         numDocsScanned += docId;
       }
@@ -260,9 +213,12 @@ public class SelectionOperator extends BaseOperator<IntermediateResultsBlock> {
     _executionStatistics =
         new ExecutionStatistics(numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
             numTotalRawDocs);
+
     if (selectionOnly) {
-      return new IntermediateResultsBlock(_dataSchema, _rowEvents);
+      // Selection only
+      return new IntermediateResultsBlock(_dataSchema, _rows);
     } else {
+      // Selection order-by
       return new IntermediateResultsBlock(_dataSchema, _priorityQueue);
     }
   }
@@ -277,6 +233,3 @@ public class SelectionOperator extends BaseOperator<IntermediateResultsBlock> {
     return _executionStatistics;
   }
 }
-
-
-

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
@@ -21,8 +21,6 @@ package org.apache.pinot.core.operator.transform;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -39,7 +37,6 @@ import org.apache.pinot.core.segment.index.readers.Dictionary;
  * Class for evaluating transform expressions.
  */
 public class TransformOperator extends BaseOperator<TransformBlock> {
-
   private static final String OPERATOR_NAME = "TransformOperator";
 
   private final ProjectionOperator _projectionOperator;
@@ -48,21 +45,19 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
   private final List<TransformExpressionTree> _expressions;
 
   /**
-   * Constructor for the class
+   * Constructor for the class.
    *
    * @param projectionOperator Projection operator
    * @param expressions Set of expressions to evaluate
    */
-  public TransformOperator(@Nonnull ProjectionOperator projectionOperator,
-      @Nonnull List<TransformExpressionTree> expressions) {
+  public TransformOperator(ProjectionOperator projectionOperator, List<TransformExpressionTree> expressions) {
     _projectionOperator = projectionOperator;
-    _expressions = expressions;
     _dataSourceMap = projectionOperator.getDataSourceMap();
     for (TransformExpressionTree expression : expressions) {
-      TransformFunction transformFunction = TransformFunctionFactory
-          .get(expression, _dataSourceMap);
+      TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
       _transformFunctionMap.put(expression, transformFunction);
     }
+    _expressions = expressions;
   }
 
   /**
@@ -80,7 +75,7 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
    * @param expression Expression
    * @return Transform result metadata
    */
-  public TransformResultMetadata getResultMetadata(@Nonnull TransformExpressionTree expression) {
+  public TransformResultMetadata getResultMetadata(TransformExpressionTree expression) {
     return _transformFunctionMap.get(expression).getResultMetadata();
   }
 
@@ -91,7 +86,7 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
    *
    * @return Dictionary
    */
-  public Dictionary getDictionary(@Nonnull TransformExpressionTree expression) {
+  public Dictionary getDictionary(TransformExpressionTree expression) {
     return _transformFunctionMap.get(expression).getDictionary();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -18,12 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nonnull;
-
 import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -26,7 +26,12 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.DataSource;
-import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.*;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.AbsTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.CeilTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.ExpTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.FloorTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.LnTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SqrtTransformFunction;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
 
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -54,7 +54,8 @@ public class SelectionPlanNode implements PlanNode {
     if (_selection.getSize() <= 0) {
       return new EmptySelectionOperator(_indexSegment, _selection);
     }
-    return new SelectionOperator(_indexSegment, _selection, _transformPlanNode.run());
+    return new SelectionOperator(_indexSegment, _selection, _transformPlanNode.run(),
+        _transformPlanNode.getSortSequence());
   }
 
   @Override


### PR DESCRIPTION
1. Refactor TransformBlockDataFetcher to take only the BlockValSets
2. Remove the redundant dictionary handling logic (already handled in DataFetcher)
3. Refactor SelectionOperator to simplify the logic, and only parse selection columns once
4. Move the sort columns (expressions) into the front of the data schema
5. Make MapValueTransformFunction able to transform values