### PR TITLE
Do not update download URL and crypter when segment is not refreshed

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -195,7 +195,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
         _helixResourceManager.getOfflineSegmentZKMetadata(RAW_TABLE_NAME, segmentToRefresh);
     _helixResourceManager.refreshSegment(OFFLINE_TABLE_NAME,
         SegmentMetadataMockUtils.mockSegmentMetadataWithEndTimeInfo(RAW_TABLE_NAME, segmentToRefresh, newEndTime),
-        segmentZKMetadata);
+        segmentZKMetadata, "downloadUrl", null);
 
     TestUtils.waitForCondition(aVoid -> timeBoundaryService.getTimeBoundaryInfoFor(OFFLINE_TABLE_NAME).getTimeValue()
         .equals(Integer.toString(newEndTime - 1)), 30_000L, "Failed to update the time boundary for refreshed segment");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -45,9 +45,10 @@ import org.slf4j.LoggerFactory;
  */
 public class ZKOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(ZKOperator.class);
-  private PinotHelixResourceManager _pinotHelixResourceManager;
-  private ControllerConf _controllerConf;
-  private ControllerMetrics _controllerMetrics;
+
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private final ControllerConf _controllerConf;
+  private final ControllerMetrics _controllerMetrics;
 
   public ZKOperator(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf controllerConf,
       ControllerMetrics controllerMetrics) {
@@ -88,13 +89,6 @@ public class ZKOperator {
 
     OfflineSegmentZKMetadata existingSegmentZKMetadata = new OfflineSegmentZKMetadata(znRecord);
     long existingCrc = existingSegmentZKMetadata.getCrc();
-
-    // Set the download URL.
-    existingSegmentZKMetadata.setDownloadUrl(zkDownloadURI);
-
-    // Set the crypter name (even if null, so it can be removed from metadata).
-    String crypter = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER);
-    existingSegmentZKMetadata.setCrypterName(crypter);
 
     // Check if CRC match when IF-MATCH header is set
     checkCRC(headers, offlineTableName, segmentName, existingCrc);
@@ -176,7 +170,9 @@ public class ZKOperator {
               zkDownloadURI);
         }
 
-        _pinotHelixResourceManager.refreshSegment(offlineTableName, segmentMetadata, existingSegmentZKMetadata);
+        String crypter = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER);
+        _pinotHelixResourceManager
+            .refreshSegment(offlineTableName, segmentMetadata, existingSegmentZKMetadata, zkDownloadURI, crypter);
       }
     } catch (Exception e) {
       if (!_pinotHelixResourceManager.updateZkMetadata(offlineTableName, existingSegmentZKMetadata)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1574,8 +1574,8 @@ public class PinotHelixResourceManager {
     return ZKMetadataProvider.setOfflineSegmentZKMetadata(_propertyStore, offlineTableName, segmentMetadata);
   }
 
-  public void refreshSegment(@Nonnull String offlineTableName, @Nonnull SegmentMetadata segmentMetadata,
-      @Nonnull OfflineSegmentZKMetadata offlineSegmentZKMetadata) {
+  public void refreshSegment(String offlineTableName, SegmentMetadata segmentMetadata,
+      OfflineSegmentZKMetadata offlineSegmentZKMetadata, String downloadUrl, @Nullable String crypter) {
     String segmentName = segmentMetadata.getName();
 
     // NOTE: must first set the segment ZK metadata before trying to refresh because server will pick up the
@@ -1583,6 +1583,8 @@ public class PinotHelixResourceManager {
     // segment or load from local
     ZKMetadataUtils.updateSegmentMetadata(offlineSegmentZKMetadata, segmentMetadata);
     offlineSegmentZKMetadata.setRefreshTime(System.currentTimeMillis());
+    offlineSegmentZKMetadata.setDownloadUrl(downloadUrl);
+    offlineSegmentZKMetadata.setCrypterName(crypter);
     if (!ZKMetadataProvider.setOfflineSegmentZKMetadata(_propertyStore, offlineTableName, offlineSegmentZKMetadata)) {
       throw new RuntimeException(
           "Failed to update ZK metadata for segment: " + segmentName + " of table: " + offlineTableName);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.upload;
+
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.segment.SegmentMetadata;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+public class ZKOperatorTest extends ControllerTest {
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+    startController();
+
+    addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
+    addFakeServerInstancesToAutoJoinHelixCluster(1, true);
+
+    TableConfig tableConfig =
+        new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    _helixResourceManager.addTable(tableConfig);
+  }
+
+  @Test
+  public void testCompleteSegmentOperations()
+      throws Exception {
+    ZKOperator zkOperator =
+        new ZKOperator(_helixResourceManager, mock(ControllerConf.class), mock(ControllerMetrics.class));
+    SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
+    when(segmentMetadata.getName()).thenReturn(SEGMENT_NAME);
+    when(segmentMetadata.getCrc()).thenReturn("12345");
+    when(segmentMetadata.getIndexCreationTime()).thenReturn(123L);
+    HttpHeaders httpHeaders = mock(HttpHeaders.class);
+    when(httpHeaders.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER)).thenReturn("crypter");
+    zkOperator.completeSegmentOperations(RAW_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders, "downloadUrl",
+        false);
+
+    OfflineSegmentZKMetadata segmentZKMetadata =
+        _helixResourceManager.getOfflineSegmentZKMetadata(RAW_TABLE_NAME, SEGMENT_NAME);
+    assertEquals(segmentZKMetadata.getCrc(), 12345L);
+    assertEquals(segmentZKMetadata.getCreationTime(), 123L);
+    long pushTime = segmentZKMetadata.getPushTime();
+    assertTrue(pushTime > 0);
+    assertEquals(segmentZKMetadata.getRefreshTime(), Long.MIN_VALUE);
+    assertEquals(segmentZKMetadata.getDownloadUrl(), "downloadUrl");
+    assertEquals(segmentZKMetadata.getCrypterName(), "crypter");
+
+    // Refresh the segment with unmatched IF_MATCH field
+    when(httpHeaders.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn("123");
+    try {
+      zkOperator.completeSegmentOperations(RAW_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders,
+          "otherDownloadUrl", false);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+
+    // Refresh the segment with the same segment (same CRC) with matched IF_MATCH field but different creation time,
+    // downloadURL and crypter
+    when(httpHeaders.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn("12345");
+    when(segmentMetadata.getIndexCreationTime()).thenReturn(456L);
+    when(httpHeaders.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER)).thenReturn("otherCrypter");
+    zkOperator
+        .completeSegmentOperations(RAW_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders, "otherDownloadUrl",
+            false);
+    segmentZKMetadata = _helixResourceManager.getOfflineSegmentZKMetadata(RAW_TABLE_NAME, SEGMENT_NAME);
+    assertEquals(segmentZKMetadata.getCrc(), 12345L);
+    // Push time should not change
+    assertEquals(segmentZKMetadata.getPushTime(), pushTime);
+    // Creation time and refresh time should change
+    assertEquals(segmentZKMetadata.getCreationTime(), 456L);
+    long refreshTime = segmentZKMetadata.getRefreshTime();
+    assertTrue(refreshTime > 0);
+    // DownloadURL and crypter should not unchanged
+    assertEquals(segmentZKMetadata.getDownloadUrl(), "downloadUrl");
+    assertEquals(segmentZKMetadata.getCrypterName(), "crypter");
+
+    // Refresh the segment with a different segment (different CRC)
+    when(segmentMetadata.getCrc()).thenReturn("23456");
+    when(segmentMetadata.getIndexCreationTime()).thenReturn(789L);
+    when(httpHeaders.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER)).thenReturn("otherCrypter");
+    // Add a tiny sleep to guarantee that refresh time is different from the previous round
+    Thread.sleep(10L);
+    zkOperator
+        .completeSegmentOperations(RAW_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders, "otherDownloadUrl",
+            false);
+    segmentZKMetadata = _helixResourceManager.getOfflineSegmentZKMetadata(RAW_TABLE_NAME, SEGMENT_NAME);
+    assertEquals(segmentZKMetadata.getCrc(), 23456L);
+    // Push time should not change
+    assertEquals(segmentZKMetadata.getPushTime(), pushTime);
+    // Creation time, refresh time, downloadUrl and crypter should change
+    assertEquals(segmentZKMetadata.getCreationTime(), 789L);
+    assertTrue(segmentZKMetadata.getRefreshTime() > refreshTime);
+    assertEquals(segmentZKMetadata.getDownloadUrl(), "otherDownloadUrl");
+    assertEquals(segmentZKMetadata.getCrypterName(), "otherCrypter");
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
+
+    stopFakeInstances();
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ValidationManagerTest.java
@@ -116,7 +116,7 @@ public class ValidationManagerTest extends ControllerTest {
   public void testPushTimePersistence() {
     SegmentMetadata segmentMetadata = SegmentMetadataMockUtils.mockSegmentMetadata(TEST_TABLE_NAME, TEST_SEGMENT_NAME);
 
-    _helixResourceManager.addNewSegment(TEST_TABLE_NAME, segmentMetadata, "http://dummy/");
+    _helixResourceManager.addNewSegment(TEST_TABLE_NAME, segmentMetadata, "downloadUrl");
     OfflineSegmentZKMetadata offlineSegmentZKMetadata =
         _helixResourceManager.getOfflineSegmentZKMetadata(TEST_TABLE_NAME, TEST_SEGMENT_NAME);
     long pushTime = offlineSegmentZKMetadata.getPushTime();
@@ -133,7 +133,8 @@ public class ValidationManagerTest extends ControllerTest {
       return externalView != null && externalView.getPartitionSet().contains(TEST_SEGMENT_NAME);
     }, 30_000L, "Failed to find the segment in the ExternalView");
     Mockito.when(segmentMetadata.getCrc()).thenReturn(Long.toString(System.nanoTime()));
-    _helixResourceManager.refreshSegment(TEST_TABLE_NAME, segmentMetadata, offlineSegmentZKMetadata);
+    _helixResourceManager
+        .refreshSegment(TEST_TABLE_NAME, segmentMetadata, offlineSegmentZKMetadata, "downloadUrl", null);
 
     offlineSegmentZKMetadata = _helixResourceManager.getOfflineSegmentZKMetadata(TEST_TABLE_NAME, TEST_SEGMENT_NAME);
     // Check that the segment still has the same push time


### PR DESCRIPTION
When segment is not refreshed (same crc so no need to refresh),
segment file won't be persisted, so should not change download URL
and crypter field in ZK metadata