### PR TITLE
Implement all transform function APIs for MapValueTransformFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/AvroRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/AvroRecordReader.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import org.apache.avro.file.DataFileStream;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
@@ -83,7 +82,7 @@ public class AvroRecordReader implements RecordReader {
       Object value = _reusableAvroRecord.get(fieldName);
       // Allow default value for non-time columns
       if (value != null || fieldSpec.getFieldType() != FieldSpec.FieldType.TIME) {
-        AvroUtils.extractField(fieldSpec, _reusableAvroRecord, reuse);
+        AvroUtils.extractField(_schema, fieldSpec, _reusableAvroRecord, reuse);
       }
     }
     return reuse;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReaderUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReaderUtils.java
@@ -40,6 +40,7 @@ import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.data.TimeFieldSpec;
+import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.core.data.GenericRow;
 
 
@@ -177,6 +178,8 @@ public class RecordReaderUtils {
         return Double.parseDouble(stringValue);
       case STRING:
         return stringValue;
+      case BYTES:
+        return BytesUtils.toBytes(stringValue);
       default:
         throw new IllegalStateException("Illegal data type: " + dataType);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -42,7 +41,7 @@ public class AdditionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are more than 1 arguments
     if (arguments.size() < 2) {
       throw new IllegalArgumentException("At least 2 arguments are required for ADD transform function");
@@ -66,7 +65,7 @@ public class AdditionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public double[] transformToDoubleValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     if (_sums == null) {
       _sums = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
@@ -74,39 +73,9 @@ public class AdditionTransformFunction extends BaseTransformFunction {
     int length = projectionBlock.getNumDocs();
     Arrays.fill(_sums, 0, length, _literalSum);
     for (TransformFunction transformFunction : _transformFunctions) {
-      switch (transformFunction.getResultMetadata().getDataType()) {
-        case INT:
-          int[] intValues = transformFunction.transformToIntValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _sums[i] += intValues[i];
-          }
-          break;
-        case LONG:
-          long[] longValues = transformFunction.transformToLongValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _sums[i] += longValues[i];
-          }
-          break;
-        case FLOAT:
-          float[] floatValues = transformFunction.transformToFloatValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _sums[i] += floatValues[i];
-          }
-          break;
-        case DOUBLE:
-          double[] doubleValues = transformFunction.transformToDoubleValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _sums[i] += doubleValues[i];
-          }
-          break;
-        case STRING:
-          String[] stringValues = transformFunction.transformToStringValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _sums[i] += Double.parseDouble(stringValues[i]);
-          }
-          break;
-        default:
-          throw new UnsupportedOperationException();
+      double[] values = transformFunction.transformToDoubleValuesSV(projectionBlock);
+      for (int i = 0; i < length; i++) {
+        _sums[i] += values[i];
       }
     }
     return _sums;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import javax.annotation.Nonnull;
-import org.apache.pinot.common.data.FieldSpec;
+import com.google.common.base.Preconditions;
+import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
@@ -32,17 +32,18 @@ import org.apache.pinot.core.util.ArrayCopyUtils;
  */
 public abstract class BaseTransformFunction implements TransformFunction {
   protected static final TransformResultMetadata LONG_SV_NO_DICTIONARY_METADATA =
-      new TransformResultMetadata(FieldSpec.DataType.LONG, true, false);
+      new TransformResultMetadata(DataType.LONG, true, false);
   protected static final TransformResultMetadata DOUBLE_SV_NO_DICTIONARY_METADATA =
-      new TransformResultMetadata(FieldSpec.DataType.DOUBLE, true, false);
+      new TransformResultMetadata(DataType.DOUBLE, true, false);
   protected static final TransformResultMetadata STRING_SV_NO_DICTIONARY_METADATA =
-      new TransformResultMetadata(FieldSpec.DataType.STRING, true, false);
+      new TransformResultMetadata(DataType.STRING, true, false);
 
   private int[] _intValuesSV;
   private long[] _longValuesSV;
   private float[] _floatValuesSV;
   private double[] _doubleValuesSV;
   private String[] _stringValuesSV;
+  private byte[][] _byteValuesSV;
   private int[][] _intValuesMV;
   private long[][] _longValuesMV;
   private float[][] _floatValuesMV;
@@ -55,372 +56,549 @@ public abstract class BaseTransformFunction implements TransformFunction {
   }
 
   @Override
-  public int[] transformToDictIdsSV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[] transformToDictIdsSV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public int[][] transformToDictIdsMV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[][] transformToDictIdsMV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public int[] transformToIntValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     if (_intValuesSV == null) {
       _intValuesSV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case LONG:
-        long[] longValues = transformToLongValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(longValues, _intValuesSV, length);
-        return _intValuesSV;
-      case FLOAT:
-        float[] floatValues = transformToFloatValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(floatValues, _intValuesSV, length);
-        return _intValuesSV;
-      case DOUBLE:
-        double[] doubleValues = transformToDoubleValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(doubleValues, _intValuesSV, length);
-        return _intValuesSV;
-      case STRING:
-        String[] stringValues = transformToStringValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(stringValues, _intValuesSV, length);
-        return _intValuesSV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[] dictIds = transformToDictIdsSV(projectionBlock);
+      getDictionary().readIntValues(dictIds, length, _intValuesSV);
+    } else {
+      switch (resultMetadata.getDataType()) {
+        case LONG:
+          long[] longValues = transformToLongValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(longValues, _intValuesSV, length);
+          break;
+        case FLOAT:
+          float[] floatValues = transformToFloatValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(floatValues, _intValuesSV, length);
+          break;
+        case DOUBLE:
+          double[] doubleValues = transformToDoubleValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(doubleValues, _intValuesSV, length);
+          break;
+        case STRING:
+          String[] stringValues = transformToStringValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(stringValues, _intValuesSV, length);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _intValuesSV;
   }
 
   @Override
-  public long[] transformToLongValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     if (_longValuesSV == null) {
       _longValuesSV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case INT:
-        int[] intValues = transformToIntValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(intValues, _longValuesSV, length);
-        return _longValuesSV;
-      case FLOAT:
-        float[] floatValues = transformToFloatValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(floatValues, _longValuesSV, length);
-        return _longValuesSV;
-      case DOUBLE:
-        double[] doubleValues = transformToDoubleValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(doubleValues, _longValuesSV, length);
-        return _longValuesSV;
-      case STRING:
-        String[] stringValues = transformToStringValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(stringValues, _longValuesSV, length);
-        return _longValuesSV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[] dictIds = transformToDictIdsSV(projectionBlock);
+      getDictionary().readLongValues(dictIds, length, _longValuesSV);
+    } else {
+      switch (resultMetadata.getDataType()) {
+        case INT:
+          int[] intValues = transformToIntValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(intValues, _longValuesSV, length);
+          break;
+        case FLOAT:
+          float[] floatValues = transformToFloatValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(floatValues, _longValuesSV, length);
+          break;
+        case DOUBLE:
+          double[] doubleValues = transformToDoubleValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(doubleValues, _longValuesSV, length);
+          break;
+        case STRING:
+          String[] stringValues = transformToStringValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(stringValues, _longValuesSV, length);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _longValuesSV;
   }
 
   @Override
-  public float[] transformToFloatValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
     if (_floatValuesSV == null) {
       _floatValuesSV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case INT:
-        int[] intValues = transformToIntValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(intValues, _floatValuesSV, length);
-        return _floatValuesSV;
-      case LONG:
-        long[] longValues = transformToLongValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(longValues, _floatValuesSV, length);
-        return _floatValuesSV;
-      case DOUBLE:
-        double[] doubleValues = transformToDoubleValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(doubleValues, _floatValuesSV, length);
-        return _floatValuesSV;
-      case STRING:
-        String[] stringValues = transformToStringValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(stringValues, _floatValuesSV, length);
-        return _floatValuesSV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[] dictIds = transformToDictIdsSV(projectionBlock);
+      getDictionary().readFloatValues(dictIds, length, _floatValuesSV);
+    } else {
+      switch (resultMetadata.getDataType()) {
+        case INT:
+          int[] intValues = transformToIntValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(intValues, _floatValuesSV, length);
+          break;
+        case LONG:
+          long[] longValues = transformToLongValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(longValues, _floatValuesSV, length);
+          break;
+        case DOUBLE:
+          double[] doubleValues = transformToDoubleValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(doubleValues, _floatValuesSV, length);
+          break;
+        case STRING:
+          String[] stringValues = transformToStringValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(stringValues, _floatValuesSV, length);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _floatValuesSV;
   }
 
   @Override
-  public double[] transformToDoubleValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     if (_doubleValuesSV == null) {
       _doubleValuesSV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case INT:
-        int[] intValues = transformToIntValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(intValues, _doubleValuesSV, length);
-        return _doubleValuesSV;
-      case LONG:
-        long[] longValues = transformToLongValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(longValues, _doubleValuesSV, length);
-        return _doubleValuesSV;
-      case FLOAT:
-        float[] floatValues = transformToFloatValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(floatValues, _doubleValuesSV, length);
-        return _doubleValuesSV;
-      case STRING:
-        String[] stringValues = transformToStringValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(stringValues, _doubleValuesSV, length);
-        return _doubleValuesSV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[] dictIds = transformToDictIdsSV(projectionBlock);
+      getDictionary().readDoubleValues(dictIds, length, _doubleValuesSV);
+    } else {
+      switch (resultMetadata.getDataType()) {
+        case INT:
+          int[] intValues = transformToIntValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(intValues, _doubleValuesSV, length);
+          break;
+        case LONG:
+          long[] longValues = transformToLongValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(longValues, _doubleValuesSV, length);
+          break;
+        case FLOAT:
+          float[] floatValues = transformToFloatValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(floatValues, _doubleValuesSV, length);
+          break;
+        case STRING:
+          String[] stringValues = transformToStringValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(stringValues, _doubleValuesSV, length);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _doubleValuesSV;
   }
 
   @Override
-  public String[] transformToStringValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
     if (_stringValuesSV == null) {
       _stringValuesSV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case INT:
-        int[] intValues = transformToIntValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(intValues, _stringValuesSV, length);
-        return _stringValuesSV;
-      case LONG:
-        long[] longValues = transformToLongValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(longValues, _stringValuesSV, length);
-        return _stringValuesSV;
-      case FLOAT:
-        float[] floatValues = transformToFloatValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(floatValues, _stringValuesSV, length);
-        return _stringValuesSV;
-      case DOUBLE:
-        double[] doubleValues = transformToDoubleValuesSV(projectionBlock);
-        ArrayCopyUtils.copy(doubleValues, _stringValuesSV, length);
-        return _stringValuesSV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[] dictIds = transformToDictIdsSV(projectionBlock);
+      getDictionary().readStringValues(dictIds, length, _stringValuesSV);
+    } else {
+      switch (resultMetadata.getDataType()) {
+        case INT:
+          int[] intValues = transformToIntValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(intValues, _stringValuesSV, length);
+          break;
+        case LONG:
+          long[] longValues = transformToLongValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(longValues, _stringValuesSV, length);
+          break;
+        case FLOAT:
+          float[] floatValues = transformToFloatValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(floatValues, _stringValuesSV, length);
+          break;
+        case DOUBLE:
+          double[] doubleValues = transformToDoubleValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(doubleValues, _stringValuesSV, length);
+          break;
+        case BYTES:
+          byte[][] bytesValues = transformToBytesValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(bytesValues, _stringValuesSV, length);
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _stringValuesSV;
   }
 
   @Override
-  public int[][] transformToIntValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
+    if (_byteValuesSV == null) {
+      _byteValuesSV = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+    }
+
+    int length = projectionBlock.getNumDocs();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[] dictIds = transformToDictIdsSV(projectionBlock);
+      getDictionary().readBytesValues(dictIds, length, _byteValuesSV);
+    } else {
+      Preconditions.checkState(resultMetadata.getDataType() == DataType.STRING);
+      String[] stringValues = transformToStringValuesSV(projectionBlock);
+      ArrayCopyUtils.copy(stringValues, _byteValuesSV, length);
+    }
+    return _byteValuesSV;
+  }
+
+  @Override
+  public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
     if (_intValuesMV == null) {
       _intValuesMV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case LONG:
-        long[][] longValues = transformToLongValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = longValues[i].length;
-          _intValuesMV[i] = new int[numValues];
-          ArrayCopyUtils.copy(longValues[i], _intValuesMV[i], numValues);
-        }
-        return _intValuesMV;
-      case FLOAT:
-        float[][] floatValues = transformToFloatValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = floatValues[i].length;
-          _intValuesMV[i] = new int[numValues];
-          ArrayCopyUtils.copy(floatValues[i], _intValuesMV[i], numValues);
-        }
-        return _intValuesMV;
-      case DOUBLE:
-        double[][] doubleValues = transformToDoubleValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = doubleValues[i].length;
-          _intValuesMV[i] = new int[numValues];
-          ArrayCopyUtils.copy(doubleValues[i], _intValuesMV[i], numValues);
-        }
-        return _intValuesMV;
-      case STRING:
-        String[][] stringValues = transformToStringValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = stringValues[i].length;
-          _intValuesMV[i] = new int[numValues];
-          ArrayCopyUtils.copy(stringValues[i], _intValuesMV[i], numValues);
-        }
-        return _intValuesMV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
+      Dictionary dictionary = getDictionary();
+      for (int i = 0; i < length; i++) {
+        int[] dictIds = dictIdsMV[i];
+        int numValues = dictIds.length;
+        int[] intValues = new int[numValues];
+        dictionary.readIntValues(dictIds, numValues, intValues);
+        _intValuesMV[i] = intValues;
+      }
+    } else {
+      switch (getResultMetadata().getDataType()) {
+        case LONG:
+          long[][] longValuesMV = transformToLongValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            long[] longValues = longValuesMV[i];
+            int numValues = longValues.length;
+            int[] intValues = new int[numValues];
+            ArrayCopyUtils.copy(longValues, intValues, numValues);
+            _intValuesMV[i] = intValues;
+          }
+          break;
+        case FLOAT:
+          float[][] floatValuesMV = transformToFloatValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            float[] floatValues = floatValuesMV[i];
+            int numValues = floatValues.length;
+            int[] intValues = new int[numValues];
+            ArrayCopyUtils.copy(floatValues, intValues, numValues);
+            _intValuesMV[i] = intValues;
+          }
+          break;
+        case DOUBLE:
+          double[][] doubleValuesMV = transformToDoubleValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            double[] doubleValues = doubleValuesMV[i];
+            int numValues = doubleValues.length;
+            int[] intValues = new int[numValues];
+            ArrayCopyUtils.copy(doubleValues, intValues, numValues);
+            _intValuesMV[i] = intValues;
+          }
+          break;
+        case STRING:
+          String[][] stringValuesMV = transformToStringValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            String[] stringValues = stringValuesMV[i];
+            int numValues = stringValues.length;
+            int[] intValues = new int[numValues];
+            ArrayCopyUtils.copy(stringValues, intValues, numValues);
+            _intValuesMV[i] = intValues;
+          }
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _intValuesMV;
   }
 
   @Override
-  public long[][] transformToLongValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
     if (_longValuesMV == null) {
       _longValuesMV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case INT:
-        int[][] intValues = transformToIntValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = intValues[i].length;
-          _longValuesMV[i] = new long[numValues];
-          ArrayCopyUtils.copy(intValues[i], _longValuesMV[i], numValues);
-        }
-        return _longValuesMV;
-      case FLOAT:
-        float[][] floatValues = transformToFloatValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = floatValues[i].length;
-          _longValuesMV[i] = new long[numValues];
-          ArrayCopyUtils.copy(floatValues[i], _longValuesMV[i], numValues);
-        }
-        return _longValuesMV;
-      case DOUBLE:
-        double[][] doubleValues = transformToDoubleValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = doubleValues[i].length;
-          _longValuesMV[i] = new long[numValues];
-          ArrayCopyUtils.copy(doubleValues[i], _longValuesMV[i], numValues);
-        }
-        return _longValuesMV;
-      case STRING:
-        String[][] stringValues = transformToStringValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = stringValues[i].length;
-          _longValuesMV[i] = new long[numValues];
-          ArrayCopyUtils.copy(stringValues[i], _longValuesMV[i], numValues);
-        }
-        return _longValuesMV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
+      Dictionary dictionary = getDictionary();
+      for (int i = 0; i < length; i++) {
+        int[] dictIds = dictIdsMV[i];
+        int numValues = dictIds.length;
+        long[] longValues = new long[numValues];
+        dictionary.readLongValues(dictIds, numValues, longValues);
+        _longValuesMV[i] = longValues;
+      }
+    } else {
+      switch (getResultMetadata().getDataType()) {
+        case INT:
+          int[][] intValuesMV = transformToIntValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            int[] intValues = intValuesMV[i];
+            int numValues = intValues.length;
+            long[] longValues = new long[numValues];
+            ArrayCopyUtils.copy(intValues, longValues, numValues);
+            _longValuesMV[i] = longValues;
+          }
+          break;
+        case FLOAT:
+          float[][] floatValuesMV = transformToFloatValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            float[] floatValues = floatValuesMV[i];
+            int numValues = floatValues.length;
+            long[] longValues = new long[numValues];
+            ArrayCopyUtils.copy(floatValues, longValues, numValues);
+            _longValuesMV[i] = longValues;
+          }
+          break;
+        case DOUBLE:
+          double[][] doubleValuesMV = transformToDoubleValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            double[] doubleValues = doubleValuesMV[i];
+            int numValues = doubleValues.length;
+            long[] longValues = new long[numValues];
+            ArrayCopyUtils.copy(doubleValues, longValues, numValues);
+            _longValuesMV[i] = longValues;
+          }
+          break;
+        case STRING:
+          String[][] stringValuesMV = transformToStringValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            String[] stringValues = stringValuesMV[i];
+            int numValues = stringValues.length;
+            long[] longValues = new long[numValues];
+            ArrayCopyUtils.copy(stringValues, longValues, numValues);
+            _longValuesMV[i] = longValues;
+          }
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _longValuesMV;
   }
 
   @Override
-  public float[][] transformToFloatValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
     if (_floatValuesMV == null) {
       _floatValuesMV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case INT:
-        int[][] intValues = transformToIntValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = intValues[i].length;
-          _floatValuesMV[i] = new float[numValues];
-          ArrayCopyUtils.copy(intValues[i], _floatValuesMV[i], numValues);
-        }
-        return _floatValuesMV;
-      case LONG:
-        long[][] longValues = transformToLongValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = longValues[i].length;
-          _floatValuesMV[i] = new float[numValues];
-          ArrayCopyUtils.copy(longValues[i], _floatValuesMV[i], numValues);
-        }
-        return _floatValuesMV;
-      case DOUBLE:
-        double[][] doubleValues = transformToDoubleValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = doubleValues[i].length;
-          _floatValuesMV[i] = new float[numValues];
-          ArrayCopyUtils.copy(doubleValues[i], _floatValuesMV[i], numValues);
-        }
-        return _floatValuesMV;
-      case STRING:
-        String[][] stringValues = transformToStringValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = stringValues[i].length;
-          _floatValuesMV[i] = new float[numValues];
-          ArrayCopyUtils.copy(stringValues[i], _floatValuesMV[i], numValues);
-        }
-        return _floatValuesMV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
+      Dictionary dictionary = getDictionary();
+      for (int i = 0; i < length; i++) {
+        int[] dictIds = dictIdsMV[i];
+        int numValues = dictIds.length;
+        float[] floatValues = new float[numValues];
+        dictionary.readFloatValues(dictIds, numValues, floatValues);
+        _floatValuesMV[i] = floatValues;
+      }
+    } else {
+      switch (getResultMetadata().getDataType()) {
+        case INT:
+          int[][] intValuesMV = transformToIntValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            int[] intValues = intValuesMV[i];
+            int numValues = intValues.length;
+            float[] floatValues = new float[numValues];
+            ArrayCopyUtils.copy(intValues, floatValues, numValues);
+            _floatValuesMV[i] = floatValues;
+          }
+          break;
+        case LONG:
+          long[][] longValuesMV = transformToLongValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            long[] longValues = longValuesMV[i];
+            int numValues = longValues.length;
+            float[] floatValues = new float[numValues];
+            ArrayCopyUtils.copy(longValues, floatValues, numValues);
+            _floatValuesMV[i] = floatValues;
+          }
+          break;
+        case DOUBLE:
+          double[][] doubleValuesMV = transformToDoubleValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            double[] doubleValues = doubleValuesMV[i];
+            int numValues = doubleValues.length;
+            float[] floatValues = new float[numValues];
+            ArrayCopyUtils.copy(doubleValues, floatValues, numValues);
+            _floatValuesMV[i] = floatValues;
+          }
+          break;
+        case STRING:
+          String[][] stringValuesMV = transformToStringValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            String[] stringValues = stringValuesMV[i];
+            int numValues = stringValues.length;
+            float[] floatValues = new float[numValues];
+            ArrayCopyUtils.copy(stringValues, floatValues, numValues);
+            _floatValuesMV[i] = floatValues;
+          }
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _floatValuesMV;
   }
 
   @Override
-  public double[][] transformToDoubleValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
     if (_doubleValuesMV == null) {
       _doubleValuesMV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case INT:
-        int[][] intValues = transformToIntValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = intValues[i].length;
-          _doubleValuesMV[i] = new double[numValues];
-          ArrayCopyUtils.copy(intValues[i], _doubleValuesMV[i], numValues);
-        }
-        return _doubleValuesMV;
-      case LONG:
-        long[][] longValues = transformToLongValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = longValues[i].length;
-          _doubleValuesMV[i] = new double[numValues];
-          ArrayCopyUtils.copy(longValues[i], _doubleValuesMV[i], numValues);
-        }
-        return _doubleValuesMV;
-      case FLOAT:
-        float[][] floatValues = transformToFloatValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = floatValues[i].length;
-          _doubleValuesMV[i] = new double[numValues];
-          ArrayCopyUtils.copy(floatValues[i], _doubleValuesMV[i], numValues);
-        }
-        return _doubleValuesMV;
-      case STRING:
-        String[][] stringValues = transformToStringValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = stringValues[i].length;
-          _doubleValuesMV[i] = new double[numValues];
-          ArrayCopyUtils.copy(stringValues[i], _doubleValuesMV[i], numValues);
-        }
-        return _doubleValuesMV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
+      Dictionary dictionary = getDictionary();
+      for (int i = 0; i < length; i++) {
+        int[] dictIds = dictIdsMV[i];
+        int numValues = dictIds.length;
+        double[] doubleValues = new double[numValues];
+        dictionary.readDoubleValues(dictIds, numValues, doubleValues);
+        _doubleValuesMV[i] = doubleValues;
+      }
+    } else {
+      switch (getResultMetadata().getDataType()) {
+        case INT:
+          int[][] intValuesMV = transformToIntValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            int[] intValues = intValuesMV[i];
+            int numValues = intValues.length;
+            double[] doubleValues = new double[numValues];
+            ArrayCopyUtils.copy(intValues, doubleValues, numValues);
+            _doubleValuesMV[i] = doubleValues;
+          }
+          break;
+        case LONG:
+          long[][] longValuesMV = transformToLongValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            long[] longValues = longValuesMV[i];
+            int numValues = longValues.length;
+            double[] doubleValues = new double[numValues];
+            ArrayCopyUtils.copy(longValues, doubleValues, numValues);
+            _doubleValuesMV[i] = doubleValues;
+          }
+          break;
+        case FLOAT:
+          float[][] floatValuesMV = transformToFloatValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            float[] floatValues = floatValuesMV[i];
+            int numValues = floatValues.length;
+            double[] doubleValues = new double[numValues];
+            ArrayCopyUtils.copy(floatValues, doubleValues, numValues);
+            _doubleValuesMV[i] = doubleValues;
+          }
+          break;
+        case STRING:
+          String[][] stringValuesMV = transformToStringValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            String[] stringValues = stringValuesMV[i];
+            int numValues = stringValues.length;
+            double[] doubleValues = new double[numValues];
+            ArrayCopyUtils.copy(stringValues, doubleValues, numValues);
+            _doubleValuesMV[i] = doubleValues;
+          }
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _doubleValuesMV;
   }
 
   @Override
-  public String[][] transformToStringValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
     if (_stringValuesMV == null) {
       _stringValuesMV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
     }
+
     int length = projectionBlock.getNumDocs();
-    switch (getResultMetadata().getDataType()) {
-      case INT:
-        int[][] intValues = transformToIntValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = intValues[i].length;
-          _stringValuesMV[i] = new String[numValues];
-          ArrayCopyUtils.copy(intValues[i], _stringValuesMV[i], numValues);
-        }
-        return _stringValuesMV;
-      case LONG:
-        long[][] longValues = transformToLongValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = longValues[i].length;
-          _stringValuesMV[i] = new String[numValues];
-          ArrayCopyUtils.copy(longValues[i], _stringValuesMV[i], numValues);
-        }
-        return _stringValuesMV;
-      case FLOAT:
-        float[][] floatValues = transformToFloatValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = floatValues[i].length;
-          _stringValuesMV[i] = new String[numValues];
-          ArrayCopyUtils.copy(floatValues[i], _stringValuesMV[i], numValues);
-        }
-        return _stringValuesMV;
-      case DOUBLE:
-        double[][] doubleValues = transformToDoubleValuesMV(projectionBlock);
-        for (int i = 0; i < length; i++) {
-          int numValues = doubleValues[i].length;
-          _stringValuesMV[i] = new String[numValues];
-          ArrayCopyUtils.copy(doubleValues[i], _stringValuesMV[i], numValues);
-        }
-        return _stringValuesMV;
-      default:
-        throw new UnsupportedOperationException();
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
+      int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
+      Dictionary dictionary = getDictionary();
+      for (int i = 0; i < length; i++) {
+        int[] dictIds = dictIdsMV[i];
+        int numValues = dictIds.length;
+        String[] stringValues = new String[numValues];
+        dictionary.readStringValues(dictIds, numValues, stringValues);
+        _stringValuesMV[i] = stringValues;
+      }
+    } else {
+      switch (getResultMetadata().getDataType()) {
+        case INT:
+          int[][] intValuesMV = transformToIntValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            int[] intValues = intValuesMV[i];
+            int numValues = intValues.length;
+            String[] stringValues = new String[numValues];
+            ArrayCopyUtils.copy(intValues, stringValues, numValues);
+            _stringValuesMV[i] = stringValues;
+          }
+          break;
+        case LONG:
+          long[][] longValuesMV = transformToLongValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            long[] longValues = longValuesMV[i];
+            int numValues = longValues.length;
+            String[] stringValues = new String[numValues];
+            ArrayCopyUtils.copy(longValues, stringValues, numValues);
+            _stringValuesMV[i] = stringValues;
+          }
+          break;
+        case FLOAT:
+          float[][] floatValuesMV = transformToFloatValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            float[] floatValues = floatValuesMV[i];
+            int numValues = floatValues.length;
+            String[] stringValues = new String[numValues];
+            ArrayCopyUtils.copy(floatValues, stringValues, numValues);
+            _stringValuesMV[i] = stringValues;
+          }
+          break;
+        case DOUBLE:
+          double[][] doubleValuesMV = transformToDoubleValuesMV(projectionBlock);
+          for (int i = 0; i < length; i++) {
+            double[] doubleValues = doubleValuesMV[i];
+            int numValues = doubleValues.length;
+            String[] stringValues = new String[numValues];
+            ArrayCopyUtils.copy(doubleValues, stringValues, numValues);
+            _stringValuesMV[i] = stringValues;
+          }
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
+    return _stringValuesMV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.transform.function;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.data.DateTimeFieldSpec;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
@@ -94,7 +93,7 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are exactly 4 arguments
     if (arguments.size() != 4) {
       throw new IllegalArgumentException("Exactly 4 arguments are required for DATE_TIME_CONVERT transform function");
@@ -125,7 +124,7 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public long[] transformToLongValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     if (_resultMetadata == LONG_SV_NO_DICTIONARY_METADATA) {
       if (_longOutputTimes == null) {
         _longOutputTimes = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
@@ -133,10 +132,12 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
 
       int length = projectionBlock.getNumDocs();
       if (_dateTimeTransformer instanceof EpochToEpochTransformer) {
-        ((EpochToEpochTransformer) _dateTimeTransformer)
+        EpochToEpochTransformer dateTimeTransformer = (EpochToEpochTransformer) _dateTimeTransformer;
+        dateTimeTransformer
             .transform(_mainTransformFunction.transformToLongValuesSV(projectionBlock), _longOutputTimes, length);
       } else {
-        ((SDFToEpochTransformer) _dateTimeTransformer)
+        SDFToEpochTransformer dateTimeTransformer = (SDFToEpochTransformer) _dateTimeTransformer;
+        dateTimeTransformer
             .transform(_mainTransformFunction.transformToStringValuesSV(projectionBlock), _longOutputTimes, length);
       }
       return _longOutputTimes;
@@ -146,7 +147,7 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public String[] transformToStringValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
     if (_resultMetadata == STRING_SV_NO_DICTIONARY_METADATA) {
       if (_stringOutputTimes == null) {
         _stringOutputTimes = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
@@ -154,10 +155,12 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
 
       int length = projectionBlock.getNumDocs();
       if (_dateTimeTransformer instanceof EpochToSDFTransformer) {
-        ((EpochToSDFTransformer) _dateTimeTransformer)
+        EpochToSDFTransformer dateTimeTransformer = (EpochToSDFTransformer) _dateTimeTransformer;
+        dateTimeTransformer
             .transform(_mainTransformFunction.transformToLongValuesSV(projectionBlock), _stringOutputTimes, length);
       } else {
-        ((SDFToSDFTransformer) _dateTimeTransformer)
+        SDFToSDFTransformer dateTimeTransformer = (SDFToSDFTransformer) _dateTimeTransformer;
+        dateTimeTransformer
             .transform(_mainTransformFunction.transformToStringValuesSV(projectionBlock), _stringOutputTimes, length);
       }
       return _stringOutputTimes;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
@@ -21,12 +21,10 @@ package org.apache.pinot.core.operator.transform.function;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
-import org.apache.pinot.core.util.ArrayCopyUtils;
 
 
 public class DivisionTransformFunction extends BaseTransformFunction {
@@ -44,7 +42,7 @@ public class DivisionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are exactly 2 arguments
     if (arguments.size() != 2) {
       throw new IllegalArgumentException("Exactly 2 arguments are required for DIV transform function");
@@ -78,7 +76,7 @@ public class DivisionTransformFunction extends BaseTransformFunction {
 
   @SuppressWarnings("Duplicates")
   @Override
-  public double[] transformToDoubleValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     if (_quotients == null) {
       _quotients = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
@@ -88,30 +86,8 @@ public class DivisionTransformFunction extends BaseTransformFunction {
     if (_firstTransformFunction == null) {
       Arrays.fill(_quotients, 0, length, _firstLiteral);
     } else {
-      switch (_firstTransformFunction.getResultMetadata().getDataType()) {
-        case INT:
-          int[] intValues = _firstTransformFunction.transformToIntValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(intValues, _quotients, length);
-          break;
-        case LONG:
-          long[] longValues = _firstTransformFunction.transformToLongValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(longValues, _quotients, length);
-          break;
-        case FLOAT:
-          float[] floatValues = _firstTransformFunction.transformToFloatValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(floatValues, _quotients, length);
-          break;
-        case DOUBLE:
-          double[] doubleValues = _firstTransformFunction.transformToDoubleValuesSV(projectionBlock);
-          System.arraycopy(doubleValues, 0, _quotients, 0, length);
-          break;
-        case STRING:
-          String[] stringValues = _firstTransformFunction.transformToStringValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(stringValues, _quotients, length);
-          break;
-        default:
-          throw new UnsupportedOperationException();
-      }
+      double[] values = _firstTransformFunction.transformToDoubleValuesSV(projectionBlock);
+      System.arraycopy(values, 0, _quotients, 0, length);
     }
 
     if (_secondTransformFunction == null) {
@@ -119,43 +95,12 @@ public class DivisionTransformFunction extends BaseTransformFunction {
         _quotients[i] /= _secondLiteral;
       }
     } else {
-      switch (_secondTransformFunction.getResultMetadata().getDataType()) {
-        case INT:
-          int[] intValues = _secondTransformFunction.transformToIntValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _quotients[i] /= intValues[i];
-          }
-          break;
-        case LONG:
-          long[] longValues = _secondTransformFunction.transformToLongValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _quotients[i] /= longValues[i];
-          }
-          break;
-        case FLOAT:
-          float[] floatValues = _secondTransformFunction.transformToFloatValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _quotients[i] /= floatValues[i];
-          }
-          break;
-        case DOUBLE:
-          double[] doubleValues = _secondTransformFunction.transformToDoubleValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _quotients[i] /= doubleValues[i];
-          }
-          break;
-        case STRING:
-          String[] stringValues = _secondTransformFunction.transformToStringValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _quotients[i] /= Double.parseDouble(stringValues[i]);
-          }
-          break;
-        default:
-          throw new UnsupportedOperationException();
+      double[] values = _secondTransformFunction.transformToDoubleValuesSV(projectionBlock);
+      for (int i = 0; i < length; i++) {
+        _quotients[i] /= values[i];
       }
     }
 
     return _quotients;
   }
 }
-

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.transform.function;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.common.DataSourceMetadata;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
@@ -37,7 +36,7 @@ public class IdentifierTransformFunction implements TransformFunction {
   private final DataSource _dataSource;
   private final TransformResultMetadata _resultMetadata;
 
-  public IdentifierTransformFunction(@Nonnull String columnName, @Nonnull DataSource dataSource) {
+  public IdentifierTransformFunction(String columnName, DataSource dataSource) {
     _columnName = columnName;
     _dataSource = dataSource;
     DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
@@ -51,7 +50,7 @@ public class IdentifierTransformFunction implements TransformFunction {
   }
 
   @Override
-  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     throw new UnsupportedOperationException();
   }
 
@@ -66,62 +65,67 @@ public class IdentifierTransformFunction implements TransformFunction {
   }
 
   @Override
-  public int[] transformToDictIdsSV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[] transformToDictIdsSV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getDictionaryIdsSV();
   }
 
   @Override
-  public int[][] transformToDictIdsMV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[][] transformToDictIdsMV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getDictionaryIdsMV();
   }
 
   @Override
-  public int[] transformToIntValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getIntValuesSV();
   }
 
   @Override
-  public long[] transformToLongValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getLongValuesSV();
   }
 
   @Override
-  public float[] transformToFloatValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getFloatValuesSV();
   }
 
   @Override
-  public double[] transformToDoubleValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getDoubleValuesSV();
   }
 
   @Override
-  public String[] transformToStringValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getStringValuesSV();
   }
 
   @Override
-  public int[][] transformToIntValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
+    return projectionBlock.getBlockValueSet(_columnName).getBytesValuesSV();
+  }
+
+  @Override
+  public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getIntValuesMV();
   }
 
   @Override
-  public long[][] transformToLongValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getLongValuesMV();
   }
 
   @Override
-  public float[][] transformToFloatValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getFloatValuesMV();
   }
 
   @Override
-  public double[][] transformToDoubleValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getDoubleValuesMV();
   }
 
   @Override
-  public String[][] transformToStringValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
     return projectionBlock.getBlockValueSet(_columnName).getStringValuesMV();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.transform.function;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -34,7 +33,7 @@ import org.apache.pinot.core.segment.index.readers.Dictionary;
 public class LiteralTransformFunction implements TransformFunction {
   private final String _literal;
 
-  public LiteralTransformFunction(@Nonnull String literal) {
+  public LiteralTransformFunction(String literal) {
     _literal = literal;
   }
 
@@ -48,7 +47,7 @@ public class LiteralTransformFunction implements TransformFunction {
   }
 
   @Override
-  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     throw new UnsupportedOperationException();
   }
 
@@ -63,62 +62,67 @@ public class LiteralTransformFunction implements TransformFunction {
   }
 
   @Override
-  public int[] transformToDictIdsSV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[] transformToDictIdsSV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public int[][] transformToDictIdsMV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[][] transformToDictIdsMV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public int[] transformToIntValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public long[] transformToLongValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public float[] transformToFloatValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public double[] transformToDoubleValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public String[] transformToStringValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public int[][] transformToIntValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public long[][] transformToLongValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public float[][] transformToFloatValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public double[][] transformToDoubleValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public String[][] transformToStringValuesMV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
     throw new UnsupportedOperationException();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -42,7 +41,7 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are more than 1 arguments
     if (arguments.size() < 2) {
       throw new IllegalArgumentException("At least 2 arguments are required for MULT transform function");
@@ -66,7 +65,7 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public double[] transformToDoubleValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     if (_products == null) {
       _products = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
@@ -74,39 +73,9 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
     int length = projectionBlock.getNumDocs();
     Arrays.fill(_products, 0, length, _literalProduct);
     for (TransformFunction transformFunction : _transformFunctions) {
-      switch (transformFunction.getResultMetadata().getDataType()) {
-        case INT:
-          int[] intValues = transformFunction.transformToIntValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _products[i] *= intValues[i];
-          }
-          break;
-        case LONG:
-          long[] longValues = transformFunction.transformToLongValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _products[i] *= longValues[i];
-          }
-          break;
-        case FLOAT:
-          float[] floatValues = transformFunction.transformToFloatValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _products[i] *= floatValues[i];
-          }
-          break;
-        case DOUBLE:
-          double[] doubleValues = transformFunction.transformToDoubleValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _products[i] *= doubleValues[i];
-          }
-          break;
-        case STRING:
-          String[] stringValues = transformFunction.transformToStringValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _products[i] *= Double.parseDouble(stringValues[i]);
-          }
-          break;
-        default:
-          throw new UnsupportedOperationException();
+      double[] values = transformFunction.transformToDoubleValuesSV(projectionBlock);
+      for (int i = 0; i < length; i++) {
+        _products[i] *= values[i];
       }
     }
     return _products;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -18,15 +18,14 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
-import org.apache.pinot.core.util.ArrayCopyUtils;
+
 
 /**
  * A group of commonly used math transformation which has only one single parameter,
@@ -37,24 +36,16 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
   protected double[] _results;
 
   @Override
-  public abstract String getName();
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    Preconditions
+        .checkArgument(arguments.size() == 1, "Exactly 1 argument is required for transform function: %s", getName());
+    TransformFunction transformFunction = arguments.get(0);
+    Preconditions.checkArgument(!(transformFunction instanceof LiteralTransformFunction),
+        "Argument cannot be literal for transform function: %s", getName());
+    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
+        "Argument must be single-valued for transform function: %s", getName());
 
-  @Override
-  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
-    // Check that there are exactly 1 argument
-    if (arguments.size() != 1) {
-      throw new IllegalArgumentException("Exactly 1 arguments are required for " + getName() + " transform function");
-    }
-
-    TransformFunction firstArgument = arguments.get(0);
-    if (firstArgument instanceof LiteralTransformFunction) {
-      throw new IllegalArgumentException("Argument of " + getName() + " should not be literal");
-    } else {
-      if (!firstArgument.getResultMetadata().isSingleValue()) {
-        throw new IllegalArgumentException("First argument of " + getName() + " transform function must be single-valued");
-      }
-      _transformFunction = firstArgument;
-    }
+    _transformFunction = transformFunction;
   }
 
   @Override
@@ -63,22 +54,13 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
   }
 
   @Override
-  public double[] transformToDoubleValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     if (_results == null) {
       _results = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
 
-    int length = projectionBlock.getNumDocs();
-
-    if (_transformFunction.getResultMetadata().getDataType() == DataType.STRING) {
-      String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
-      ArrayCopyUtils.copy(stringValues, _results, length);
-      applyMathOperator(_results, length);
-    } else {
-      double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
-      applyMathOperator(doubleValues, length);
-    }
-
+    double[] values = _transformFunction.transformToDoubleValuesSV(projectionBlock);
+    applyMathOperator(values, projectionBlock.getNumDocs());
     return _results;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.operator.transform.function;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -43,7 +42,7 @@ public class TimeConversionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are exactly 3 arguments
     if (arguments.size() != 3) {
       throw new IllegalArgumentException("Exactly 3 arguments are required for TIME_CONVERT transform function");
@@ -67,7 +66,7 @@ public class TimeConversionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public long[] transformToLongValuesSV(@Nonnull ProjectionBlock projectionBlock) {
+  public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     if (_outputTimes == null) {
       _outputTimes = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.transform.function;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -46,7 +45,7 @@ public interface TransformFunction {
    * @param arguments Arguments for the transform function
    * @param dataSourceMap Map from column to data source
    */
-  void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap);
+  void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap);
 
   /**
    * Returns the metadata for the result of the transform function.
@@ -72,7 +71,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection block
    * @return Transformation result
    */
-  int[] transformToDictIdsSV(@Nonnull ProjectionBlock projectionBlock);
+  int[] transformToDictIdsSV(ProjectionBlock projectionBlock);
 
   /**
    * Transforms the data from the given projection block to multi-valued dictionary Ids.
@@ -80,7 +79,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection block
    * @return Transformation result
    */
-  int[][] transformToDictIdsMV(@Nonnull ProjectionBlock projectionBlock);
+  int[][] transformToDictIdsMV(ProjectionBlock projectionBlock);
 
   /**
    * SINGLE-VALUED APIs
@@ -92,7 +91,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  int[] transformToIntValuesSV(@Nonnull ProjectionBlock projectionBlock);
+  int[] transformToIntValuesSV(ProjectionBlock projectionBlock);
 
   /**
    * Transforms the data from the given projection block to single-valued long values.
@@ -100,7 +99,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  long[] transformToLongValuesSV(@Nonnull ProjectionBlock projectionBlock);
+  long[] transformToLongValuesSV(ProjectionBlock projectionBlock);
 
   /**
    * Transforms the data from the given projection block to single-valued float values.
@@ -108,7 +107,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  float[] transformToFloatValuesSV(@Nonnull ProjectionBlock projectionBlock);
+  float[] transformToFloatValuesSV(ProjectionBlock projectionBlock);
 
   /**
    * Transforms the data from the given projection block to single-valued double values.
@@ -116,7 +115,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  double[] transformToDoubleValuesSV(@Nonnull ProjectionBlock projectionBlock);
+  double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock);
 
   /**
    * Transforms the data from the given projection block to single-valued string values.
@@ -124,7 +123,15 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  String[] transformToStringValuesSV(@Nonnull ProjectionBlock projectionBlock);
+  String[] transformToStringValuesSV(ProjectionBlock projectionBlock);
+
+  /**
+   * Transforms the data from the given projection block to single-valued bytes values.
+   *
+   * @param projectionBlock Projection result
+   * @return Transformation result
+   */
+  byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock);
 
   /**
    * MULTI-VALUED APIs
@@ -136,7 +143,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  int[][] transformToIntValuesMV(@Nonnull ProjectionBlock projectionBlock);
+  int[][] transformToIntValuesMV(ProjectionBlock projectionBlock);
 
   /**
    * Transforms the data from the given projection block to multi-valued long values.
@@ -144,7 +151,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  long[][] transformToLongValuesMV(@Nonnull ProjectionBlock projectionBlock);
+  long[][] transformToLongValuesMV(ProjectionBlock projectionBlock);
 
   /**
    * Transforms the data from the given projection block to multi-valued float values.
@@ -152,7 +159,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  float[][] transformToFloatValuesMV(@Nonnull ProjectionBlock projectionBlock);
+  float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock);
 
   /**
    * Transforms the data from the given projection block to multi-valued double values.
@@ -160,7 +167,7 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  double[][] transformToDoubleValuesMV(@Nonnull ProjectionBlock projectionBlock);
+  double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock);
 
   /**
    * Transforms the data from the given projection block to multi-valued string values.
@@ -168,5 +175,5 @@ public interface TransformFunction {
    * @param projectionBlock Projection result
    * @return Transformation result
    */
-  String[][] transformToStringValuesMV(@Nonnull ProjectionBlock projectionBlock);
+  String[][] transformToStringValuesMV(ProjectionBlock projectionBlock);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.AbsTransformFunction;
@@ -50,16 +49,16 @@ public class TransformFunctionFactory {
           put(SubtractionTransformFunction.FUNCTION_NAME.toLowerCase(), SubtractionTransformFunction.class);
           put(MultiplicationTransformFunction.FUNCTION_NAME.toLowerCase(), MultiplicationTransformFunction.class);
           put(DivisionTransformFunction.FUNCTION_NAME.toLowerCase(), DivisionTransformFunction.class);
-          put(TimeConversionTransformFunction.FUNCTION_NAME.toLowerCase(), TimeConversionTransformFunction.class);
-          put(DateTimeConversionTransformFunction.FUNCTION_NAME.toLowerCase(),
-              DateTimeConversionTransformFunction.class);
-          put(ValueInTransformFunction.FUNCTION_NAME.toLowerCase(), ValueInTransformFunction.class);
           put(AbsTransformFunction.FUNCTION_NAME.toLowerCase(), AbsTransformFunction.class);
           put(CeilTransformFunction.FUNCTION_NAME.toLowerCase(), CeilTransformFunction.class);
           put(ExpTransformFunction.FUNCTION_NAME.toLowerCase(), ExpTransformFunction.class);
           put(FloorTransformFunction.FUNCTION_NAME.toLowerCase(), FloorTransformFunction.class);
           put(LnTransformFunction.FUNCTION_NAME.toLowerCase(), LnTransformFunction.class);
           put(SqrtTransformFunction.FUNCTION_NAME.toLowerCase(), SqrtTransformFunction.class);
+          put(TimeConversionTransformFunction.FUNCTION_NAME.toLowerCase(), TimeConversionTransformFunction.class);
+          put(DateTimeConversionTransformFunction.FUNCTION_NAME.toLowerCase(),
+              DateTimeConversionTransformFunction.class);
+          put(ValueInTransformFunction.FUNCTION_NAME.toLowerCase(), ValueInTransformFunction.class);
           put(MapValueTransformFunction.FUNCTION_NAME.toLowerCase(), MapValueTransformFunction.class);
         }
       };
@@ -70,7 +69,7 @@ public class TransformFunctionFactory {
    *
    * @param transformFunctionClasses Set of transform function classes
    */
-  public static void init(@Nonnull Set<Class<TransformFunction>> transformFunctionClasses) {
+  public static void init(Set<Class<TransformFunction>> transformFunctionClasses) {
     for (Class<TransformFunction> transformFunctionClass : transformFunctionClasses) {
       TransformFunction transformFunction;
       try {
@@ -95,8 +94,7 @@ public class TransformFunctionFactory {
    * @param dataSourceMap Map from column name to column data source
    * @return Transform function
    */
-  public static TransformFunction get(@Nonnull TransformExpressionTree expression,
-      @Nonnull Map<String, DataSource> dataSourceMap) {
+  public static TransformFunction get(TransformExpressionTree expression, Map<String, DataSource> dataSourceMap) {
     TransformFunction transformFunction;
     switch (expression.getExpressionType()) {
       case FUNCTION:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
@@ -39,7 +39,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
@@ -71,7 +70,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are more than 1 arguments
     int numArguments = arguments.size();
     if (numArguments < 2) {
@@ -104,7 +103,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public int[][] transformToDictIdsMV(@Nonnull ProjectionBlock projectionBlock) {
+  public int[][] transformToDictIdsMV(ProjectionBlock projectionBlock) {
     if (_dictIdSet == null) {
       _dictIdSet = new IntOpenHashSet();
       Dictionary dictionary = _mainTransformFunction.getDictionary();
@@ -125,8 +124,9 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public int[][] transformToIntValuesMV(@Nonnull ProjectionBlock projectionBlock) {
-    if (getResultMetadata().getDataType() != FieldSpec.DataType.INT) {
+  public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.INT) {
       return super.transformToIntValuesMV(projectionBlock);
     }
 
@@ -146,8 +146,9 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public long[][] transformToLongValuesMV(@Nonnull ProjectionBlock projectionBlock) {
-    if (getResultMetadata().getDataType() != FieldSpec.DataType.LONG) {
+  public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.LONG) {
       return super.transformToLongValuesMV(projectionBlock);
     }
 
@@ -167,8 +168,9 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public float[][] transformToFloatValuesMV(@Nonnull ProjectionBlock projectionBlock) {
-    if (getResultMetadata().getDataType() != FieldSpec.DataType.FLOAT) {
+  public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.FLOAT) {
       return super.transformToFloatValuesMV(projectionBlock);
     }
 
@@ -188,8 +190,9 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public double[][] transformToDoubleValuesMV(@Nonnull ProjectionBlock projectionBlock) {
-    if (getResultMetadata().getDataType() != FieldSpec.DataType.DOUBLE) {
+  public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.DOUBLE) {
       return super.transformToDoubleValuesMV(projectionBlock);
     }
 
@@ -209,8 +212,9 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public String[][] transformToStringValuesMV(@Nonnull ProjectionBlock projectionBlock) {
-    if (getResultMetadata().getDataType() != FieldSpec.DataType.STRING) {
+  public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
+    TransformResultMetadata resultMetadata = getResultMetadata();
+    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.STRING) {
       return super.transformToStringValuesMV(projectionBlock);
     }
 
@@ -291,7 +295,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
     if (stringList.size() == source.length) {
       return source;
     } else {
-      return stringList.toArray(new String[stringList.size()]);
+      return stringList.toArray(new String[0]);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/AvroRecordToPinotRowGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/AvroRecordToPinotRowGenerator.java
@@ -28,7 +28,6 @@ import org.apache.pinot.core.util.AvroUtils;
 
 
 public class AvroRecordToPinotRowGenerator {
-
   private final Schema _schema;
   private final FieldSpec _incomingTimeFieldSpec;
 
@@ -45,7 +44,7 @@ public class AvroRecordToPinotRowGenerator {
     for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
       FieldSpec incomingFieldSpec =
           fieldSpec.getFieldType() == FieldSpec.FieldType.TIME ? _incomingTimeFieldSpec : fieldSpec;
-      AvroUtils.extractField(incomingFieldSpec, from, to);
+      AvroUtils.extractField(_schema, incomingFieldSpec, from, to);
     }
     return to;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ArrayCopyUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ArrayCopyUtils.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.util;
 
+import org.apache.pinot.common.utils.BytesUtils;
+
+
 /**
  * The class <code>ArrayCopyUtils</code> provides methods to copy values across arrays of different types.
  */
@@ -142,6 +145,18 @@ public class ArrayCopyUtils {
   public static void copy(String[] src, double[] dest, int length) {
     for (int i = 0; i < length; i++) {
       dest[i] = Double.parseDouble(src[i]);
+    }
+  }
+
+  public static void copy(String[] src, byte[][] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      dest[i] = BytesUtils.toBytes(src[i]);
+    }
+  }
+
+  public static void copy(byte[][] src, String[] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      dest[i] = BytesUtils.toHexString(src[i]);
     }
   }
 }


### PR DESCRIPTION
- Enhance BaseTransformFunction to support bytes type and fetching values from dictionary
- Enhance MapValueTransformFunction to support filter with non-existing key, and use binary search
- Fix AvroUtils Map handling to sort keys based on the key data type
- Change MapValue function name to "mapValue" to follow the convention
- Add documentation for MapValue transform function
- Add more checks on the arguments for MapValue transform function
- Enhance the mapValue transform function test
- Simplify the logic for some transform functions (no need to check data type)
- Remove @nonnull annotation for transform functions