### PR TITLE
First pass of GROUP BY with ORDER BY support

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -60,7 +60,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.pinot.common.utils.CommonConstants.Broker.*;
-import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.*;
 
 
 @ThreadSafe
@@ -220,19 +219,19 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // Set extra settings into broker request
-    if (request.has(TRACE) && request.get(TRACE).asBoolean()) {
+    if (request.has(Request.TRACE) && request.get(Request.TRACE).asBoolean()) {
       LOGGER.debug("Enable trace for request {}: {}", requestId, query);
       brokerRequest.setEnableTrace(true);
     }
 
-    if (request.has(DEBUG_OPTIONS)) {
-      Map<String, String> debugOptions = getOptionsFromRequest(request, DEBUG_OPTIONS);
+    if (request.has(Request.DEBUG_OPTIONS)) {
+      Map<String, String> debugOptions = getOptionsFromRequest(request, Request.DEBUG_OPTIONS);
       LOGGER.debug("Debug options are set to: {} for request {}: {}", debugOptions, requestId, query);
       brokerRequest.setDebugOptions(debugOptions);
     }
 
-    if (request.has(QUERY_OPTIONS)) {
-      Map<String, String> queryOptions = getOptionsFromRequest(request, QUERY_OPTIONS);
+    if (request.has(Request.QUERY_OPTIONS)) {
+      Map<String, String> queryOptions = getOptionsFromRequest(request, Request.QUERY_OPTIONS);
       LOGGER.debug("Query options are set to: {} for request {}: {}", queryOptions, requestId, query);
       brokerRequest.setQueryOptions(queryOptions);
     }
@@ -352,10 +351,10 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   private PinotQueryRequest getPinotQueryRequest(JsonNode request) {
-    if (request.has(SQL)) {
-      return new PinotQueryRequest(SQL, request.get(SQL).asText());
+    if (request.has(Request.SQL)) {
+      return new PinotQueryRequest(Request.SQL, request.get(Request.SQL).asText());
     }
-    return new PinotQueryRequest(PQL, request.get(PQL).asText());
+    return new PinotQueryRequest(Request.PQL, request.get(Request.PQL).asText());
   }
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -55,11 +55,10 @@ import org.apache.pinot.common.request.FilterQueryMap;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Broker;
 import org.apache.pinot.core.query.reduce.BrokerReduceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.pinot.common.utils.CommonConstants.Broker.*;
 
 
 @ThreadSafe
@@ -96,12 +95,13 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     _queryQuotaManager = queryQuotaManager;
     _brokerMetrics = brokerMetrics;
 
-    _brokerId = config.getString(CONFIG_OF_BROKER_ID, getDefaultBrokerId());
-    _brokerTimeoutMs = config.getLong(CONFIG_OF_BROKER_TIMEOUT_MS, DEFAULT_BROKER_TIMEOUT_MS);
-    _queryResponseLimit = config.getInt(CONFIG_OF_BROKER_QUERY_RESPONSE_LIMIT, DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
-    _queryLogLength = config.getInt(CONFIG_OF_BROKER_QUERY_LOG_LENGTH, DEFAULT_BROKER_QUERY_LOG_LENGTH);
-    _queryLogRateLimiter = RateLimiter.create(
-        config.getDouble(CONFIG_OF_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND, DEFAULT_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND));
+    _brokerId = config.getString(Broker.CONFIG_OF_BROKER_ID, getDefaultBrokerId());
+    _brokerTimeoutMs = config.getLong(Broker.CONFIG_OF_BROKER_TIMEOUT_MS, Broker.DEFAULT_BROKER_TIMEOUT_MS);
+    _queryResponseLimit =
+        config.getInt(Broker.CONFIG_OF_BROKER_QUERY_RESPONSE_LIMIT, Broker.DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
+    _queryLogLength = config.getInt(Broker.CONFIG_OF_BROKER_QUERY_LOG_LENGTH, Broker.DEFAULT_BROKER_QUERY_LOG_LENGTH);
+    _queryLogRateLimiter = RateLimiter.create(config.getDouble(Broker.CONFIG_OF_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND,
+        Broker.DEFAULT_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND));
 
     _numDroppedLog = new AtomicInteger(0);
     _numDroppedLogRateLimiter = RateLimiter.create(1.0);
@@ -219,19 +219,19 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // Set extra settings into broker request
-    if (request.has(Request.TRACE) && request.get(Request.TRACE).asBoolean()) {
+    if (request.has(Broker.Request.TRACE) && request.get(Broker.Request.TRACE).asBoolean()) {
       LOGGER.debug("Enable trace for request {}: {}", requestId, query);
       brokerRequest.setEnableTrace(true);
     }
 
-    if (request.has(Request.DEBUG_OPTIONS)) {
-      Map<String, String> debugOptions = getOptionsFromRequest(request, Request.DEBUG_OPTIONS);
+    if (request.has(Broker.Request.DEBUG_OPTIONS)) {
+      Map<String, String> debugOptions = getOptionsFromRequest(request, Broker.Request.DEBUG_OPTIONS);
       LOGGER.debug("Debug options are set to: {} for request {}: {}", debugOptions, requestId, query);
       brokerRequest.setDebugOptions(debugOptions);
     }
 
-    if (request.has(Request.QUERY_OPTIONS)) {
-      Map<String, String> queryOptions = getOptionsFromRequest(request, Request.QUERY_OPTIONS);
+    if (request.has(Broker.Request.QUERY_OPTIONS)) {
+      Map<String, String> queryOptions = getOptionsFromRequest(request, Broker.Request.QUERY_OPTIONS);
       LOGGER.debug("Query options are set to: {} for request {}: {}", queryOptions, requestId, query);
       brokerRequest.setQueryOptions(queryOptions);
     }
@@ -351,10 +351,10 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   private PinotQueryRequest getPinotQueryRequest(JsonNode request) {
-    if (request.has(Request.SQL)) {
-      return new PinotQueryRequest(Request.SQL, request.get(Request.SQL).asText());
+    if (request.has(Broker.Request.SQL)) {
+      return new PinotQueryRequest(Broker.Request.SQL, request.get(Broker.Request.SQL).asText());
     }
-    return new PinotQueryRequest(Request.PQL, request.get(Request.PQL).asText());
+    return new PinotQueryRequest(Broker.Request.PQL, request.get(Broker.Request.PQL).asText());
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -39,7 +39,7 @@ import org.apache.pinot.common.utils.JsonUtils;
  *
  * Supports serialization via JSON.
  */
-@JsonPropertyOrder({"selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded", "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "segmentStatistics", "traceInfo"})
+@JsonPropertyOrder({"selectionResults", "aggregationResults", "resultTable", "exceptions", "numServersQueried", "numServersResponded", "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "segmentStatistics", "traceInfo"})
 public class BrokerResponseNative implements BrokerResponse {
   public static final BrokerResponseNative EMPTY_RESULT = BrokerResponseNative.empty();
   public static final BrokerResponseNative NO_TABLE_RESULT =
@@ -64,6 +64,7 @@ public class BrokerResponseNative implements BrokerResponse {
 
   private SelectionResults _selectionResults;
   private List<AggregationResult> _aggregationResults;
+  private ResultTable _resultTable;
 
   private Map<String, String> _traceInfo = new HashMap<>();
   private List<QueryProcessingException> _processingExceptions = new ArrayList<>();
@@ -98,6 +99,17 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty("selectionResults")
   public void setSelectionResults(SelectionResults selectionResults) {
     _selectionResults = selectionResults;
+  }
+
+  @JsonProperty("resultTable")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public ResultTable getResultTable() {
+    return _resultTable;
+  }
+
+  @JsonProperty("resultTable")
+  public void setResultTable(ResultTable resultTable) {
+    _resultTable = resultTable;
   }
 
   @JsonProperty("aggregationResults")

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -101,17 +101,6 @@ public class BrokerResponseNative implements BrokerResponse {
     _selectionResults = selectionResults;
   }
 
-  @JsonProperty("resultTable")
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  public ResultTable getResultTable() {
-    return _resultTable;
-  }
-
-  @JsonProperty("resultTable")
-  public void setResultTable(ResultTable resultTable) {
-    _resultTable = resultTable;
-  }
-
   @JsonProperty("aggregationResults")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public List<AggregationResult> getAggregationResults() {
@@ -121,6 +110,17 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty("aggregationResults")
   public void setAggregationResults(List<AggregationResult> aggregationResults) {
     _aggregationResults = aggregationResults;
+  }
+
+  @JsonProperty("resultTable")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public ResultTable getResultTable() {
+    return _resultTable;
+  }
+
+  @JsonProperty("resultTable")
+  public void setResultTable(ResultTable resultTable) {
+    _resultTable = resultTable;
   }
 
   @JsonProperty("exceptions")

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
@@ -32,8 +32,8 @@ import java.util.List;
  */
 @JsonPropertyOrder({"columns", "rows"})
 public class ResultTable {
-  final private List<String> _columns;
-  final private List<Serializable[]> _rows;
+  private final List<String> _columns;
+  private final List<Serializable[]> _rows;
 
   @JsonCreator
   public ResultTable(@JsonProperty("columns") List<String> columns,

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.response.broker;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.io.Serializable;
+import java.util.List;
+
+
+/**
+ * Hosts the results in a standard tabular structure
+ */
+@JsonPropertyOrder({"columns", "results"})
+public class ResultTable {
+  private List<String> _columns;
+  private List<Serializable[]> _rows;
+
+  @JsonCreator
+  public ResultTable(@JsonProperty("columns") List<String> columns,
+      @JsonProperty("results") List<Serializable[]> results) {
+    _columns = columns;
+    _rows = results;
+  }
+
+  @JsonProperty("columns")
+  public List<String> getColumns() {
+    return _columns;
+  }
+
+  @JsonProperty("columns")
+  public void setColumns(List<String> columns) {
+    _columns = columns;
+  }
+
+  @JsonProperty("results")
+  public List<Serializable[]> getRows() {
+    return _rows;
+  }
+
+  @JsonProperty("results")
+  public void setRows(List<Serializable[]> rows) {
+    _rows = rows;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
@@ -28,16 +28,16 @@ import java.util.List;
 /**
  * Hosts the results in a standard tabular structure
  */
-@JsonPropertyOrder({"columns", "results"})
+@JsonPropertyOrder({"columns", "rows"})
 public class ResultTable {
   private List<String> _columns;
   private List<Serializable[]> _rows;
 
   @JsonCreator
   public ResultTable(@JsonProperty("columns") List<String> columns,
-      @JsonProperty("results") List<Serializable[]> results) {
+      @JsonProperty("rows") List<Serializable[]> rows) {
     _columns = columns;
-    _rows = results;
+    _rows = rows;
   }
 
   @JsonProperty("columns")

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
@@ -30,8 +30,8 @@ import java.util.List;
  */
 @JsonPropertyOrder({"columns", "rows"})
 public class ResultTable {
-  private List<String> _columns;
-  private List<Serializable[]> _rows;
+  final private List<String> _columns;
+  final private List<Serializable[]> _rows;
 
   @JsonCreator
   public ResultTable(@JsonProperty("columns") List<String> columns,
@@ -45,18 +45,8 @@ public class ResultTable {
     return _columns;
   }
 
-  @JsonProperty("columns")
-  public void setColumns(List<String> columns) {
-    _columns = columns;
-  }
-
   @JsonProperty("results")
   public List<Serializable[]> getRows() {
     return _rows;
-  }
-
-  @JsonProperty("results")
-  public void setRows(List<Serializable[]> rows) {
-    _rows = rows;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
@@ -26,7 +26,9 @@ import java.util.List;
 
 
 /**
- * Hosts the results in a standard tabular structure
+ * Holds the results in a standard tabular structure
+ *
+ * FIXME: Column types and Multi-value support are missing, and deserialize might not work properly
  */
 @JsonPropertyOrder({"columns", "rows"})
 public class ResultTable {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -171,9 +171,12 @@ public class CommonConstants {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";
       public static final String DEBUG_OPTIONS = "debugOptions";
+      public static final String QUERY_OPTIONS = "queryOptions";
 
       public static class QueryOptionKey {
         public static final String PRESERVE_TYPE = "preserveType";
+        public static final String RESPONSE_FORMAT = "responseFormat";
+        public static final String GROUP_BY_MODE = "groupByMode";
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
@@ -165,6 +165,8 @@ public final class OrderByUtils {
       String column = orderByInfo.getColumn();
       boolean ascending = orderByInfo.isIsAsc();
 
+      // TODO: avoid the index computation and index lookup in the comparison.
+      // we can achieve this by making order by operate on Object[], which contains only order by fields
       if (keyIndexMap.containsKey(column)) {
         int index = keyIndexMap.get(column);
         ColumnDataType columnDataType = keyColumnDataTypeMap.get(column);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
@@ -38,6 +38,8 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils
  */
 public final class OrderByUtils {
 
+  public static final int NUM_RESULTS_LOWER_LIMIT = 5000;
+
   private OrderByUtils() {
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
@@ -108,7 +108,13 @@ public final class OrderByUtils {
     return globalComparator;
   }
 
-  public static List<Integer> getAggregationIndexes(List<SelectionSort> orderBy, List<AggregationInfo> aggregationInfos) {
+  /**
+   * Gets the indices from Record which have aggregations that are present in the order by
+   * @param orderBy order by information
+   * @param aggregationInfos aggregation information
+   * @return indices of aggregations in the record
+   */
+  public static int[] getAggregationIndexes(List<SelectionSort> orderBy, List<AggregationInfo> aggregationInfos) {
     Map<String, Integer> aggregationColumnToIndex = new HashMap<>();
     for (int i = 0; i < aggregationInfos.size(); i++) {
       AggregationInfo aggregationInfo = aggregationInfos.get(i);
@@ -116,15 +122,15 @@ public final class OrderByUtils {
       aggregationColumnToIndex.put(aggregationColumn, i);
     }
 
-    List<Integer> aggregationIndexes = new ArrayList<>();
+    List<Integer> indexes = new ArrayList<>();
     for (SelectionSort orderByInfo : orderBy) {
       String column = orderByInfo.getColumn();
 
       if (aggregationColumnToIndex.containsKey(column)) {
-        aggregationIndexes.add(aggregationColumnToIndex.get(column));
+        indexes.add(aggregationColumnToIndex.get(column));
       }
     }
-    return aggregationIndexes;
+    return indexes.stream().mapToInt(i->i).toArray();
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
@@ -109,12 +109,10 @@ public final class OrderByUtils {
   }
 
   public static List<Integer> getAggregationIndexes(List<SelectionSort> orderBy, List<AggregationInfo> aggregationInfos) {
-    Map<String, Integer> aggregationColumnToIndex = new HashMap<>(aggregationInfos.size());
+    Map<String, Integer> aggregationColumnToIndex = new HashMap<>();
     for (int i = 0; i < aggregationInfos.size(); i++) {
       AggregationInfo aggregationInfo = aggregationInfos.get(i);
-      String aggregationColumn =
-          aggregationInfo.getAggregationType().toLowerCase() + "(" + AggregationFunctionUtils.getColumn(aggregationInfo)
-              + ")";
+      String aggregationColumn = AggregationFunctionUtils.getAggregationColumnName(aggregationInfo);
       aggregationColumnToIndex.put(aggregationColumn, i);
     }
 
@@ -148,9 +146,7 @@ public final class OrderByUtils {
     Map<String, AggregationInfo> aggregationColumnToInfo = new HashMap<>(aggregationInfos.size());
     for (int i = 0; i < aggregationInfos.size(); i++) {
       AggregationInfo aggregationInfo = aggregationInfos.get(i);
-      String aggregationColumn =
-          aggregationInfo.getAggregationType().toLowerCase() + "(" + AggregationFunctionUtils.getColumn(aggregationInfo)
-              + ")";
+      String aggregationColumn = AggregationFunctionUtils.getAggregationColumnName(aggregationInfo);
       aggregationColumnToIndex.put(aggregationColumn, i);
       aggregationColumnToInfo.put(aggregationColumn, aggregationInfo);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
@@ -168,7 +168,7 @@ public final class OrderByUtils {
       if (keyIndexMap.containsKey(column)) {
         int index = keyIndexMap.get(column);
         ColumnDataType columnDataType = keyColumnDataTypeMap.get(column);
-        comparator = OrderByUtils.getKeysComparator(ascending, index, columnDataType);
+        comparator = getKeysComparator(ascending, index, columnDataType);
       } else if (aggregationColumnToIndex.containsKey(column)) {
         int index = aggregationColumnToIndex.get(column);
         AggregationFunction aggregationFunction =

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/order/OrderByUtils.java
@@ -38,8 +38,6 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils
  */
 public final class OrderByUtils {
 
-  public static final int NUM_RESULTS_LOWER_LIMIT = 5000;
-
   private OrderByUtils() {
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
@@ -221,7 +221,7 @@ public class ConcurrentIndexedTable extends IndexedTable {
     resize(_maxCapacity);
     int numResizes = _numResizes.get();
     long resizeTime = _resizeTime.get();
-    LOGGER.info("Num resizes : {}, Total time spent in resizing : {}, Avg resize time : {}", numResizes, resizeTime,
+    LOGGER.debug("Num resizes : {}, Total time spent in resizing : {}, Avg resize time : {}", numResizes, resizeTime,
         numResizes == 0 ? 0 : resizeTime / numResizes);
 
     _iterator = _lookupMap.values().iterator();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
@@ -206,7 +206,7 @@ public class ConcurrentIndexedTable extends IndexedTable {
     long numResizes = _numResizes.sum();
     long resizeTime = _resizeTime.get();
     LOGGER.info("Num resizes : {}, Total time spent in resizing : {}, Avg resize time : {}", numResizes, resizeTime,
-        resizeTime / numResizes);
+        numResizes == 0 ? 0 : resizeTime / numResizes);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
@@ -53,7 +53,7 @@ public class ConcurrentIndexedTable extends IndexedTable {
   private boolean _isOrderBy;
   private Comparator<Record> _orderByComparator;
   private Comparator<Record> _finalOrderByComparator;
-  private List<Integer> _aggregationIndexes;
+  private int[] _aggregationIndexes;
 
   private AtomicBoolean _noMoreNewRecords = new AtomicBoolean();
   private final AtomicInteger _numResizes = new AtomicInteger();
@@ -171,9 +171,9 @@ public class ConcurrentIndexedTable extends IndexedTable {
         for (Record record : _lookupMap.values()) {
 
           // extract final results before hand for comparisons on aggregations
-          if (!_aggregationIndexes.isEmpty()) {
+          if (_aggregationIndexes.length > 0) {
             Object[] values = record.getValues();
-            for (Integer index : _aggregationIndexes) {
+            for (int index : _aggregationIndexes) {
               values[index] = _aggregationFunctions.get(index).extractFinalResult(values[index]);
             }
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
@@ -172,6 +172,7 @@ public class ConcurrentIndexedTable extends IndexedTable {
         for (Record record : _lookupMap.values()) {
 
           // extract final results before hand for comparisons on aggregations
+          // FIXME: at instance level, extract final results only if intermediate result is non-comparable
           if (_aggregationIndexes.length > 0) {
             Object[] values = record.getValues();
             for (int index : _aggregationIndexes) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -42,8 +42,6 @@ public abstract class IndexedTable implements Table {
 
   List<AggregationFunction> _aggregationFunctions;
   DataSchema _dataSchema;
-  List<AggregationInfo> _aggregationInfos;
-  List<SelectionSort> _orderBy;
   boolean _sort;
 
   int _maxCapacity;
@@ -54,8 +52,6 @@ public abstract class IndexedTable implements Table {
   public void init(@Nonnull DataSchema dataSchema, List<AggregationInfo> aggregationInfos, List<SelectionSort> orderBy,
       int maxCapacity, boolean sort) {
     _dataSchema = dataSchema;
-    _aggregationInfos = aggregationInfos;
-    _orderBy = orderBy;
     _sort = sort;
 
     _aggregationFunctions = new ArrayList<>(aggregationInfos.size());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -32,20 +32,12 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils
  * Base abstract implementation of Table for indexed lookup
  */
 public abstract class IndexedTable implements Table {
-  // When table reaches max capacity, we will allow 20% more records to get inserted (bufferedCapacity)
-  // If records beyond bufferedCapacity are received, the table will undergo sort and evict upto evictCapacity (10% more than capacity)
-  // This is to ensure that for a small number beyond capacity, a fair chance is given to all records which have the potential to climb up the order
-  /** Factor used to add buffer to maxCapacity of the Collection used **/
-  private static final double BUFFER_FACTOR = 1.2;
-  /** Factor used to decide eviction threshold **/
-  private static final double EVICTION_FACTOR = 1.1;
 
   List<AggregationFunction> _aggregationFunctions;
   DataSchema _dataSchema;
   boolean _sort;
 
   int _maxCapacity;
-  int _evictCapacity;
   int _bufferedCapacity;
 
   @Override
@@ -60,8 +52,24 @@ public abstract class IndexedTable implements Table {
           AggregationFunctionUtils.getAggregationFunctionContext(aggregationInfo).getAggregationFunction());
     }
 
+    /* Factor used to add buffer to maxCapacity of the table **/
+    double bufferFactor;
+    /* Factor used to decide eviction threshold **/
+    /** The true capacity of the table is {@link IndexedTable::_bufferedCapacity},
+     * which is bufferFactor times the {@link IndexedTable::_maxCapacity}
+     *
+     * If records beyond {@link IndexedTable::_bufferedCapacity} are received,
+     * the table resize and evict bottom records, resizing it to {@link IndexedTable::_maxCapacity}
+     * The assumption here is that {@link IndexedTable::_maxCapacity} already has a buffer added by the caller (typically, we do max(top * 5, 5000))
+     */
+    if (maxCapacity > 50000) {
+      // if max capacity is large, buffer capacity is kept smaller, so that we do not accumulate too many records for sorting/resizing
+      bufferFactor = 1.2;
+    } else {
+      // if max capacity is small, buffer capacity is kept larger, so that we avoid frequent resizing
+      bufferFactor = 2.0;
+    }
     _maxCapacity = maxCapacity;
-    _bufferedCapacity = (int) (maxCapacity * BUFFER_FACTOR);
-    _evictCapacity = (int) (maxCapacity * EVICTION_FACTOR);
+    _bufferedCapacity = (int) (maxCapacity * bufferFactor);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -44,6 +44,7 @@ public abstract class IndexedTable implements Table {
   DataSchema _dataSchema;
   List<AggregationInfo> _aggregationInfos;
   List<SelectionSort> _orderBy;
+  boolean _sort;
 
   int _maxCapacity;
   int _evictCapacity;
@@ -51,10 +52,11 @@ public abstract class IndexedTable implements Table {
 
   @Override
   public void init(@Nonnull DataSchema dataSchema, List<AggregationInfo> aggregationInfos, List<SelectionSort> orderBy,
-      int maxCapacity) {
+      int maxCapacity, boolean sort) {
     _dataSchema = dataSchema;
     _aggregationInfos = aggregationInfos;
     _orderBy = orderBy;
+    _sort = sort;
 
     _aggregationFunctions = new ArrayList<>(aggregationInfos.size());
     for (AggregationInfo aggregationInfo : aggregationInfos) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -36,16 +36,14 @@ public abstract class IndexedTable implements Table {
   List<AggregationFunction> _aggregationFunctions;
   int _numAggregations;
   DataSchema _dataSchema;
-  boolean _sort;
 
   int _maxCapacity;
   int _bufferedCapacity;
 
   @Override
   public void init(@Nonnull DataSchema dataSchema, List<AggregationInfo> aggregationInfos, List<SelectionSort> orderBy,
-      int capacity, boolean sort) {
+      int capacity) {
     _dataSchema = dataSchema;
-    _sort = sort;
 
     _numAggregations = aggregationInfos.size();
     _aggregationFunctions = new ArrayList<>(_numAggregations);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
@@ -48,14 +48,7 @@ public class Key {
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("[ ");
-    for (Object s : _columns) {
-      sb.append(s);
-      sb.append(", ");
-    }
-    sb.append("]");
-    return sb.toString();
+    return Arrays.deepToString(_columns);
   }
 
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.data.table;
 
+import java.util.Arrays;
+
+
 /**
  * Defines a single record in Pinot comprising of keys and values
  */
@@ -42,5 +45,10 @@ public class Record {
    */
   public Object[] getValues() {
     return _values;
+  }
+
+  @Override
+  public String toString() {
+    return _key.toString() + " " + Arrays.deepToString(_values);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
@@ -52,7 +52,9 @@ public class SimpleIndexedTable extends IndexedTable {
     _records = new ArrayList<>(maxCapacity);
     _lookupTable = new HashMap<>(maxCapacity);
 
-    _orderByComparator = OrderByUtils.getKeysAndValuesComparator(_dataSchema, _orderBy, _aggregationInfos);
+    if (CollectionUtils.isNotEmpty(_orderBy)) {
+      _orderByComparator = OrderByUtils.getKeysAndValuesComparator(_dataSchema, _orderBy, _aggregationInfos);
+    }
   }
 
   /**
@@ -88,7 +90,7 @@ public class SimpleIndexedTable extends IndexedTable {
       _records.sort(_orderByComparator);
     }
 
-    // evict lowest
+    // evict lowest (or whatever's at the bottom if sort didnt happen)
     if (_records.size() > trimToSize) {
       _records = new ArrayList<>(_records.subList(0, trimToSize));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
@@ -107,7 +107,7 @@ public class SimpleIndexedTable extends IndexedTable {
 
       if (size() >= _bufferedCapacity) {
         if (_isOrderBy) { // capacity reached, order and resize
-          sortAndResize(_evictCapacity);
+          sortAndResize(_maxCapacity);
         } else { // capacity reached, but no order by. Allow no more records
           _noMoreNewRecords = true;
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
@@ -73,7 +73,8 @@ public class SimpleIndexedTable extends IndexedTable {
 
     _isOrderBy = CollectionUtils.isNotEmpty(orderBy);
     if (_isOrderBy) {
-      _orderByComparator = OrderByUtils.getKeysAndValuesComparator(dataSchema, orderBy, aggregationInfos);
+      // final results not extracted upfront
+      _orderByComparator = OrderByUtils.getKeysAndValuesComparator(dataSchema, orderBy, aggregationInfos, true);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
@@ -165,7 +165,7 @@ public class SimpleIndexedTable extends IndexedTable {
   public void finish(boolean sort) {
     // TODO: support resize without sort
     sortAndResize(_maxCapacity);
-    LOGGER.info("Num resizes : {}, Total time spent in resizing : {}, Avg resize time : {}", _numResizes, _resizeTime,
+    LOGGER.debug("Num resizes : {}, Total time spent in resizing : {}, Avg resize time : {}", _numResizes, _resizeTime,
         _numResizes == 0 ? 0 : _resizeTime / _numResizes);
 
     _iterator = _records.iterator();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
@@ -168,7 +168,7 @@ public class SimpleIndexedTable extends IndexedTable {
     long numResizes = _numResizes.sum();
     long resizeTime = _resizeTime.get();
     LOGGER.info("Num resizes : {}, Total time spent in resizing : {}, Avg resize time : {}", numResizes, resizeTime,
-        resizeTime / numResizes);
+        numResizes == 0 ? 0 : resizeTime / numResizes);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
@@ -163,6 +163,7 @@ public class SimpleIndexedTable extends IndexedTable {
 
   @Override
   public void finish(boolean sort) {
+    // TODO: support resize without sort
     sortAndResize(_maxCapacity);
     LOGGER.info("Num resizes : {}, Total time spent in resizing : {}, Avg resize time : {}", _numResizes, _resizeTime,
         _numResizes == 0 ? 0 : _resizeTime / _numResizes);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Table.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Table.java
@@ -37,10 +37,9 @@ public interface Table {
    * @param aggregationInfos the aggregation info for the values if applicable
    * @param orderBy the order by information if applicable
    * @param maxCapacity the max capacity the table should have
-   * @param sort should the results be sorted in finish
    */
   void init(DataSchema dataSchema, List<AggregationInfo> aggregationInfos, List<SelectionSort> orderBy,
-      int maxCapacity, boolean sort);
+      int maxCapacity);
 
   /**
    * Update the table with the given record
@@ -64,8 +63,9 @@ public interface Table {
 
   /**
    * Finish any pre exit processing
+   * @param sort sort the final results if true
    */
-  void finish();
+  void finish(boolean sort);
 
   /**
    * Returns the data schema of the table

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Table.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Table.java
@@ -37,9 +37,10 @@ public interface Table {
    * @param aggregationInfos the aggregation info for the values if applicable
    * @param orderBy the order by information if applicable
    * @param maxCapacity the max capacity the table should have
+   * @param sort should the results be sorted in finish
    */
   void init(@Nonnull DataSchema dataSchema, List<AggregationInfo> aggregationInfos, List<SelectionSort> orderBy,
-      int maxCapacity);
+      int maxCapacity, boolean sort);
 
   /**
    * Update the table with the given record
@@ -65,4 +66,9 @@ public interface Table {
    * Finish any pre exit processing
    */
   void finish();
+
+  /**
+   * Returns the data schema of the table
+   */
+  DataSchema getDataSchema();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Table.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Table.java
@@ -39,7 +39,7 @@ public interface Table {
    * @param maxCapacity the max capacity the table should have
    * @param sort should the results be sorted in finish
    */
-  void init(@Nonnull DataSchema dataSchema, List<AggregationInfo> aggregationInfos, List<SelectionSort> orderBy,
+  void init(DataSchema dataSchema, List<AggregationInfo> aggregationInfos, List<SelectionSort> orderBy,
       int maxCapacity, boolean sort);
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
@@ -1,0 +1,249 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.response.ProcessingException;
+import org.apache.pinot.common.utils.BytesUtils;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
+import org.apache.pinot.core.data.table.Key;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
+import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.core.util.trace.TraceRunnable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The <code>CombineGroupByOrderByOperator</code> class is the operator to combine aggregation results with group-by and order by.
+ */
+// TODO: this class has a lot of duplication with {@link CombineGroupByOperator}.
+// These 2 classes can be combined into one
+// For the first iteration of Order By support, these will be separate
+public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResultsBlock> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CombineGroupByOrderByOperator.class);
+  private static final String OPERATOR_NAME = "CombineGroupByOrderByOperator";
+
+  // Use a higher limit for groups stored across segments. For most cases, most groups from each segment should be the
+  // same, thus the total number of groups across segments should be equal or slightly higher than the number of groups
+  // in each segment. We still put a limit across segments to protect cases where data is very skewed across different
+  // segments.
+  private static final int INTER_SEGMENT_NUM_GROUPS_LIMIT_FACTOR = 2;
+
+  private final List<Operator> _operators;
+  private final BrokerRequest _brokerRequest;
+  private final ExecutorService _executorService;
+  private final long _timeOutMs;
+  private final int _interSegmentNumGroupsLimit;
+  private Lock _initLock;
+  private DataSchema _dataSchema;
+  private ConcurrentIndexedTable _indexedTable;
+
+  public CombineGroupByOrderByOperator(List<Operator> operators, BrokerRequest brokerRequest,
+      ExecutorService executorService, long timeOutMs, int innerSegmentNumGroupsLimit) {
+    Preconditions.checkArgument(
+        brokerRequest.isSetAggregationsInfo() && brokerRequest.isSetGroupBy() && brokerRequest.isSetOrderBy());
+
+    _operators = operators;
+    _brokerRequest = brokerRequest;
+    _executorService = executorService;
+    _timeOutMs = timeOutMs;
+    _interSegmentNumGroupsLimit =
+        (int) Math.min((long) innerSegmentNumGroupsLimit * INTER_SEGMENT_NUM_GROUPS_LIMIT_FACTOR, Integer.MAX_VALUE);
+    _initLock = new ReentrantLock();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Combines the group-by result blocks from underlying operators and returns a merged and trimmed group-by
+   * result block.
+   * <ul>
+   *   <li>
+   *     Concurrently merge group-by results from multiple result blocks into {@link org.apache.pinot.core.data.table.IndexedTable}
+   *   </li>
+   *   <li>
+   *     Set all exceptions encountered during execution into the merged result block
+   *   </li>
+   * </ul>
+   */
+  @Override
+  protected IntermediateResultsBlock getNextBlock() {
+    int numOperators = _operators.size();
+    CountDownLatch operatorLatch = new CountDownLatch(numOperators);
+
+    int numAggregationFunctions = _brokerRequest.getAggregationsInfoSize();
+    int numGroupBy = _brokerRequest.getGroupBy().getExpressionsSize();
+    ConcurrentLinkedQueue<ProcessingException> mergedProcessingExceptions = new ConcurrentLinkedQueue<>();
+
+    Future[] futures = new Future[numOperators];
+    for (int i = 0; i < numOperators; i++) {
+      int index = i;
+      futures[i] = _executorService.submit(new TraceRunnable() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public void runJob() {
+          AggregationGroupByResult aggregationGroupByResult;
+
+          try {
+            IntermediateResultsBlock intermediateResultsBlock =
+                (IntermediateResultsBlock) _operators.get(index).nextBlock();
+
+            _initLock.lock();
+            try {
+              if (_dataSchema == null) {
+                _dataSchema = intermediateResultsBlock.getDataSchema();
+                _indexedTable = new ConcurrentIndexedTable();
+                _indexedTable.init(_dataSchema, _brokerRequest.getAggregationsInfo(), _brokerRequest.getOrderBy(),
+                    _interSegmentNumGroupsLimit, false);
+              }
+            } finally {
+              _initLock.unlock();
+            }
+
+            // Merge processing exceptions.
+            List<ProcessingException> processingExceptionsToMerge = intermediateResultsBlock.getProcessingExceptions();
+            if (processingExceptionsToMerge != null) {
+              mergedProcessingExceptions.addAll(processingExceptionsToMerge);
+            }
+
+            // Merge aggregation group-by result.
+            aggregationGroupByResult = intermediateResultsBlock.getAggregationGroupByResult();
+            if (aggregationGroupByResult != null) {
+              // Iterate over the group-by keys, for each key, update the group-by result in the indexedTable.
+              Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
+              while (groupKeyIterator.hasNext()) {
+                GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+                String[] stringKey = groupKey._stringKey.split(GroupKeyGenerator.DELIMITER);
+                Object[] objectKey = new Object[numGroupBy];
+                for (int i = 0; i < stringKey.length; i++) {
+                  DataSchema.ColumnDataType columnDataType = _dataSchema.getColumnDataType(i);
+                  switch (columnDataType) {
+
+                    case INT:
+                      objectKey[i] = Integer.valueOf(stringKey[i]);
+                      break;
+                    case LONG:
+                      objectKey[i] = Long.valueOf(stringKey[i]);
+                      break;
+                    case FLOAT:
+                      objectKey[i] = Float.valueOf(stringKey[i]);
+                      break;
+                    case DOUBLE:
+                      objectKey[i] = Double.valueOf(stringKey[i]);
+                      break;
+                    case STRING:
+                      objectKey[i] = stringKey[i];
+                      break;
+                    case BYTES:
+                      objectKey[i] = BytesUtils.toBytes(stringKey[i]);
+                      break;
+                  }
+                }
+                Object[] values = new Object[numAggregationFunctions];
+                for (int i = 0; i < numAggregationFunctions; i++) {
+                  values[i] = aggregationGroupByResult.getResultForKey(groupKey, i);
+                }
+
+                Record record = new Record(new Key(objectKey), values);
+                _indexedTable.upsert(record);
+              }
+            }
+          } catch (Exception e) {
+            LOGGER.error("Exception processing CombineGroupByOrderBy for index {}, operator {}", index,
+                _operators.get(index).getClass().getName(), e);
+            mergedProcessingExceptions.add(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+          }
+
+          operatorLatch.countDown();
+        }
+      });
+    }
+
+    try {
+      boolean opCompleted = operatorLatch.await(_timeOutMs, TimeUnit.MILLISECONDS);
+      if (!opCompleted) {
+        // If this happens, the broker side should already timed out, just log the error and return
+        String errorMessage = "Timed out while combining group-by results after " + _timeOutMs + "ms";
+        LOGGER.error(errorMessage);
+        return new IntermediateResultsBlock(new TimeoutException(errorMessage));
+      }
+
+      _indexedTable.finish();
+      IntermediateResultsBlock mergedBlock = new IntermediateResultsBlock(_indexedTable);
+
+      // Set the processing exceptions.
+      if (!mergedProcessingExceptions.isEmpty()) {
+        mergedBlock.setProcessingExceptions(new ArrayList<>(mergedProcessingExceptions));
+      }
+
+      // Set the execution statistics.
+      ExecutionStatistics executionStatistics = new ExecutionStatistics();
+      for (Operator operator : _operators) {
+        ExecutionStatistics executionStatisticsToMerge = operator.getExecutionStatistics();
+        if (executionStatisticsToMerge != null) {
+          executionStatistics.merge(executionStatisticsToMerge);
+        }
+      }
+      mergedBlock.setNumDocsScanned(executionStatistics.getNumDocsScanned());
+      mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
+      mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
+      mergedBlock.setNumSegmentsProcessed(executionStatistics.getNumSegmentsProcessed());
+      mergedBlock.setNumSegmentsMatched(executionStatistics.getNumSegmentsMatched());
+      mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());
+
+      if (_indexedTable.size() >= _interSegmentNumGroupsLimit) {
+        mergedBlock.setNumGroupsLimitReached(true);
+      }
+
+      return mergedBlock;
+    } catch (Exception e) {
+      return new IntermediateResultsBlock(e);
+    } finally {
+      // Cancel all ongoing jobs
+      for (Future future : futures) {
+        if (!future.isDone()) {
+          future.cancel(true);
+        }
+      }
+    }
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
@@ -124,7 +124,7 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
               if (_dataSchema == null) {
                 _dataSchema = intermediateResultsBlock.getDataSchema();
                 _indexedTable.init(_dataSchema, _brokerRequest.getAggregationsInfo(), _brokerRequest.getOrderBy(),
-                    _indexedTableCapacity, false);
+                    _indexedTableCapacity);
               }
             } finally {
               _initLock.unlock();
@@ -183,7 +183,7 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
         return new IntermediateResultsBlock(new TimeoutException(errorMessage));
       }
 
-      _indexedTable.finish();
+      _indexedTable.finish(false);
       IntermediateResultsBlock mergedBlock = new IntermediateResultsBlock(_indexedTable);
 
       // Set the processing exceptions.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
@@ -44,6 +44,7 @@ import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,8 +79,7 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
     _timeOutMs = timeOutMs;
     _initLock = new ReentrantLock();
     _indexedTable = new ConcurrentIndexedTable();
-    _interSegmentNumGroupsLimit =
-        Math.max(((int) brokerRequest.getGroupBy().getTopN()) * 5, OrderByUtils.NUM_RESULTS_LOWER_LIMIT);
+    _interSegmentNumGroupsLimit = GroupByUtils.getTableCapacity((int) brokerRequest.getGroupBy().getTopN());
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
@@ -84,6 +84,7 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
     _interSegmentNumGroupsLimit =
         (int) Math.min((long) innerSegmentNumGroupsLimit * INTER_SEGMENT_NUM_GROUPS_LIMIT_FACTOR, Integer.MAX_VALUE);
     _initLock = new ReentrantLock();
+    _indexedTable = new ConcurrentIndexedTable();
   }
 
   /**
@@ -126,7 +127,6 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
             try {
               if (_dataSchema == null) {
                 _dataSchema = intermediateResultsBlock.getDataSchema();
-                _indexedTable = new ConcurrentIndexedTable();
                 _indexedTable.init(_dataSchema, _brokerRequest.getAggregationsInfo(), _brokerRequest.getOrderBy(),
                     _interSegmentNumGroupsLimit, false);
               }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
@@ -109,8 +109,6 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
 
     int numAggregationFunctions = _brokerRequest.getAggregationsInfoSize();
     int numGroupBy = _brokerRequest.getGroupBy().getExpressionsSize();
-    boolean isOrderBy = _brokerRequest.isSetOrderBy();
-    AtomicInteger numGroups = new AtomicInteger();
     ConcurrentLinkedQueue<ProcessingException> mergedProcessingExceptions = new ConcurrentLinkedQueue<>();
 
     Future[] futures = new Future[numOperators];
@@ -155,9 +153,6 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
               // Iterate over the group-by keys, for each key, update the group-by result in the indexedTable.
               Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
               while (groupKeyIterator.hasNext()) {
-                if (!isOrderBy && numGroups.getAndIncrement() >= _interSegmentNumGroupsLimit) {
-                  break;
-                }
                 GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
                 String[] stringKey = groupKey._stringKey.split(GroupKeyGenerator.DELIMITER);
                 Object[] objectKey = new Object[numGroupBy];

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -29,7 +29,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
-import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
@@ -45,8 +44,6 @@ import org.apache.pinot.core.data.table.Table;
 import org.apache.pinot.core.query.aggregation.AggregationFunctionContext;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
-
-import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.*;
 
 
 /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -96,6 +96,15 @@ public class IntermediateResultsBlock implements Block {
    * Constructor for aggregation group-by result with {@link AggregationGroupByResult}.
    */
   public IntermediateResultsBlock(@Nonnull AggregationFunctionContext[] aggregationFunctionContexts,
+      @Nullable AggregationGroupByResult aggregationGroupByResults) {
+    _aggregationFunctionContexts = aggregationFunctionContexts;
+    _aggregationGroupByResult = aggregationGroupByResults;
+  }
+
+  /**
+   * Constructor for aggregation group-by order-by result with {@link AggregationGroupByResult}.
+   */
+  public IntermediateResultsBlock(@Nonnull AggregationFunctionContext[] aggregationFunctionContexts,
       @Nullable AggregationGroupByResult aggregationGroupByResults, DataSchema dataSchema) {
     _aggregationFunctionContexts = aggregationFunctionContexts;
     _aggregationGroupByResult = aggregationGroupByResults;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -18,16 +18,20 @@
  */
 package org.apache.pinot.core.operator.blocks;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
+import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.common.Block;
 import org.apache.pinot.core.common.BlockDocIdSet;
@@ -36,16 +40,20 @@ import org.apache.pinot.core.common.BlockMetadata;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.common.datatable.DataTableImplV2;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.data.table.Table;
 import org.apache.pinot.core.query.aggregation.AggregationFunctionContext;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.*;
 
 
 /**
  * The <code>IntermediateResultsBlock</code> class is the holder of the server side inter-segment results.
  */
 public class IntermediateResultsBlock implements Block {
-  private DataSchema _selectionDataSchema;
+  private DataSchema _dataSchema;
   private Collection<Serializable[]> _selectionResult;
   private AggregationFunctionContext[] _aggregationFunctionContexts;
   private List<Object> _aggregationResult;
@@ -60,12 +68,14 @@ public class IntermediateResultsBlock implements Block {
   private long _numSegmentsMatched;
   private boolean _numGroupsLimitReached;
 
+  private Table _table;
+
   /**
    * Constructor for selection result.
    */
-  public IntermediateResultsBlock(@Nonnull DataSchema selectionDataSchema,
+  public IntermediateResultsBlock(@Nonnull DataSchema dataSchema,
       @Nonnull Collection<Serializable[]> selectionResult) {
-    _selectionDataSchema = selectionDataSchema;
+    _dataSchema = dataSchema;
     _selectionResult = selectionResult;
   }
 
@@ -89,9 +99,16 @@ public class IntermediateResultsBlock implements Block {
    * Constructor for aggregation group-by result with {@link AggregationGroupByResult}.
    */
   public IntermediateResultsBlock(@Nonnull AggregationFunctionContext[] aggregationFunctionContexts,
-      @Nullable AggregationGroupByResult aggregationGroupByResults) {
+      @Nullable AggregationGroupByResult aggregationGroupByResults, DataSchema dataSchema) {
     _aggregationFunctionContexts = aggregationFunctionContexts;
     _aggregationGroupByResult = aggregationGroupByResults;
+    _dataSchema = dataSchema;
+  }
+
+
+  public IntermediateResultsBlock(@Nonnull Table table) {
+    _table = table;
+    _dataSchema = table.getDataSchema();
   }
 
   /**
@@ -110,12 +127,12 @@ public class IntermediateResultsBlock implements Block {
   }
 
   @Nullable
-  public DataSchema getSelectionDataSchema() {
-    return _selectionDataSchema;
+  public DataSchema getDataSchema() {
+    return _dataSchema;
   }
 
-  public void setSelectionDataSchema(@Nullable DataSchema dataSchema) {
-    _selectionDataSchema = dataSchema;
+  public void setDataSchema(@Nullable DataSchema dataSchema) {
+    _dataSchema = dataSchema;
   }
 
   @Nullable
@@ -205,6 +222,12 @@ public class IntermediateResultsBlock implements Block {
   @Nonnull
   public DataTable getDataTable()
       throws Exception {
+
+    if (_table != null) {
+      return getResultDataTable();
+    }
+
+    // TODO: remove all these ifs once every operator starts using {@link Table}
     if (_selectionResult != null) {
       return getSelectionResultDataTable();
     }
@@ -225,10 +248,61 @@ public class IntermediateResultsBlock implements Block {
   }
 
   @Nonnull
+  private DataTable getResultDataTable() throws IOException {
+
+    DataTableBuilder dataTableBuilder = new DataTableBuilder(_dataSchema);
+
+    Iterator<Record> iterator = _table.iterator();
+    while (iterator.hasNext()) {
+      Record record = iterator.next();
+      dataTableBuilder.startRow();
+      int columnIndex = 0;
+      for (Object keyColumn : record.getKey().getColumns()) {
+        ColumnDataType columnDataType = _dataSchema.getColumnDataType(columnIndex);
+        setDataTableColumn(columnDataType, dataTableBuilder, columnIndex, keyColumn);
+        columnIndex++;
+      }
+      for (Object valueColumn : record.getValues()) {
+        ColumnDataType columnDataType = _dataSchema.getColumnDataType(columnIndex);
+        setDataTableColumn(columnDataType, dataTableBuilder, columnIndex, valueColumn);
+        columnIndex++;
+      }
+      dataTableBuilder.finishRow();
+    }
+    DataTable dataTable = dataTableBuilder.build();
+    return attachMetadataToDataTable(dataTable);
+  }
+
+  private void setDataTableColumn(ColumnDataType columnDataType, DataTableBuilder dataTableBuilder, int columnIndex, Object value)
+      throws IOException {
+    switch (columnDataType) {
+
+      case INT:
+        dataTableBuilder.setColumn(columnIndex, ((Number) value).intValue());
+        break;
+      case LONG:
+        dataTableBuilder.setColumn(columnIndex, ((Number) value).longValue());
+        break;
+      case FLOAT:
+        dataTableBuilder.setColumn(columnIndex, ((Number) value).floatValue());
+        break;
+      case DOUBLE:
+        dataTableBuilder.setColumn(columnIndex, ((Number) value).doubleValue());
+        break;
+      case STRING:
+        dataTableBuilder.setColumn(columnIndex, (String) value);
+        break;
+      default:
+        dataTableBuilder.setColumn(columnIndex, value);
+        break;
+    }
+  }
+
+  @Nonnull
   private DataTable getSelectionResultDataTable()
       throws Exception {
     return attachMetadataToDataTable(
-        SelectionOperatorUtils.getDataTableFromRows(_selectionResult, _selectionDataSchema));
+        SelectionOperatorUtils.getDataTableFromRows(_selectionResult, _dataSchema));
   }
 
   @Nonnull
@@ -237,7 +311,7 @@ public class IntermediateResultsBlock implements Block {
     // Extract each aggregation column name and type from aggregation function context.
     int numAggregationFunctions = _aggregationFunctionContexts.length;
     String[] columnNames = new String[numAggregationFunctions];
-    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numAggregationFunctions];
+    ColumnDataType[] columnDataTypes = new ColumnDataType[numAggregationFunctions];
     for (int i = 0; i < numAggregationFunctions; i++) {
       AggregationFunctionContext aggregationFunctionContext = _aggregationFunctionContexts[i];
       columnNames[i] = aggregationFunctionContext.getAggregationColumnName();
@@ -273,8 +347,8 @@ public class IntermediateResultsBlock implements Block {
   private DataTable getAggregationGroupByResultDataTable()
       throws Exception {
     String[] columnNames = new String[]{"functionName", "GroupByResultMap"};
-    DataSchema.ColumnDataType[] columnDataTypes =
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.OBJECT};
+    ColumnDataType[] columnDataTypes =
+        new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.OBJECT};
 
     // Build the data table.
     DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(columnNames, columnDataTypes));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOperator.java
@@ -18,12 +18,8 @@
  */
 package org.apache.pinot.core.operator.query;
 
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.GroupBy;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
-import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
@@ -18,10 +18,9 @@
  */
 package org.apache.pinot.core.operator.query;
 
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.GroupBy;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -68,17 +67,13 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
     String[] columnNames = new String[numColumns];
     DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numColumns];
 
-    Map<String, DataSchema.ColumnDataType> columnToDataType = new HashMap<>(numColumns);
-    /*for (TransformExpressionTree transformExpression : _transformOperator.getExpressions()) {
-      columnToDataType.put(transformExpression.toString(), DataSchema.ColumnDataType.fromDataType(
-          _transformOperator.getResultMetadata(transformExpression).getDataType(), true));
-    }*/
-
     // extract column names and data types for group by keys
     int index = 0;
     for (String groupByColumn : groupBy.getExpressions()) {
       columnNames[index] = groupByColumn;
-      columnDataTypes[index] = columnToDataType.get(groupByColumn);
+      TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(groupByColumn);
+      columnDataTypes[index] =
+          DataSchema.ColumnDataType.fromDataType(_transformOperator.getResultMetadata(expression).getDataType(), true);
       index++;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.GroupBy;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -39,8 +38,10 @@ import org.apache.pinot.core.startree.executor.StarTreeGroupByExecutor;
 /**
  * The <code>AggregationOperator</code> class provides the operator for aggregation group-by query on a single segment.
  */
-public class AggregationGroupByOperator extends BaseOperator<IntermediateResultsBlock> {
-  private static final String OPERATOR_NAME = "AggregationGroupByOperator";
+public class AggregationGroupByOrderByOperator extends BaseOperator<IntermediateResultsBlock> {
+  private static final String OPERATOR_NAME = "AggregationGroupByOrderByOperator";
+
+  private final DataSchema _dataSchema;
 
   private final AggregationFunctionContext[] _functionContexts;
   private final GroupBy _groupBy;
@@ -52,7 +53,7 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
 
   private ExecutionStatistics _executionStatistics;
 
-  public AggregationGroupByOperator(@Nonnull AggregationFunctionContext[] functionContexts, @Nonnull GroupBy groupBy,
+  public AggregationGroupByOrderByOperator(@Nonnull AggregationFunctionContext[] functionContexts, @Nonnull GroupBy groupBy,
       int maxInitialResultHolderCapacity, int numGroupsLimit, @Nonnull TransformOperator transformOperator,
       long numTotalRawDocs, boolean useStarTree) {
     _functionContexts = functionContexts;
@@ -62,6 +63,34 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
     _transformOperator = transformOperator;
     _numTotalRawDocs = numTotalRawDocs;
     _useStarTree = useStarTree;
+
+    int numColumns = groupBy.getExpressionsSize() + _functionContexts.length;
+    String[] columnNames = new String[numColumns];
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numColumns];
+
+    Map<String, DataSchema.ColumnDataType> columnToDataType = new HashMap<>(numColumns);
+    /*for (TransformExpressionTree transformExpression : _transformOperator.getExpressions()) {
+      columnToDataType.put(transformExpression.toString(), DataSchema.ColumnDataType.fromDataType(
+          _transformOperator.getResultMetadata(transformExpression).getDataType(), true));
+    }*/
+
+    // extract column names and data types for group by keys
+    int index = 0;
+    for (String groupByColumn : groupBy.getExpressions()) {
+      columnNames[index] = groupByColumn;
+      columnDataTypes[index] = columnToDataType.get(groupByColumn);
+      index++;
+    }
+
+    // extract column names and data types for aggregations
+    for (AggregationFunctionContext functionContext : functionContexts) {
+      columnNames[index] = functionContext.getAggregationFunction().getType().toString().toLowerCase() + "("
+          + functionContext.getColumn() + ")";
+      columnDataTypes[index] = functionContext.getAggregationFunction().getIntermediateResultColumnType();
+      index++;
+    }
+
+    _dataSchema = new DataSchema(columnNames, columnDataTypes);
   }
 
   @Override
@@ -94,7 +123,7 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
             _numTotalRawDocs);
 
     // Build intermediate result block based on aggregation group-by result from the executor
-    return new IntermediateResultsBlock(_functionContexts, groupByResult);
+    return new IntermediateResultsBlock(_functionContexts, groupByResult, _dataSchema);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.plan;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.pinot.common.request.AggregationInfo;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.GroupBy;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.common.utils.request.FilterQueryTree;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
+import org.apache.pinot.core.operator.query.AggregationGroupByOrderByOperator;
+import org.apache.pinot.core.query.aggregation.AggregationFunctionContext;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.startree.StarTreeUtils;
+import org.apache.pinot.core.startree.plan.StarTreeTransformPlanNode;
+import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
+import org.apache.pinot.core.startree.v2.StarTreeV2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The <code>AggregationGroupByOrderByPlanNode</code> class provides the execution plan for aggregation group-by order-by query on a
+ * single segment.
+ */
+public class AggregationGroupByOrderByPlanNode implements PlanNode {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AggregationGroupByOrderByPlanNode.class);
+
+  private final IndexSegment _indexSegment;
+  private final int _maxInitialResultHolderCapacity;
+  private final int _numGroupsLimit;
+  private final List<AggregationInfo> _aggregationInfos;
+  private final AggregationFunctionContext[] _functionContexts;
+  private final GroupBy _groupBy;
+  private final TransformPlanNode _transformPlanNode;
+  private final StarTreeTransformPlanNode _starTreeTransformPlanNode;
+
+  public AggregationGroupByOrderByPlanNode(@Nonnull IndexSegment indexSegment, @Nonnull BrokerRequest brokerRequest,
+      int maxInitialResultHolderCapacity, int numGroupsLimit) {
+    _indexSegment = indexSegment;
+    _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
+    _numGroupsLimit = numGroupsLimit;
+    _aggregationInfos = brokerRequest.getAggregationsInfo();
+    _functionContexts =
+        AggregationFunctionUtils.getAggregationFunctionContexts(brokerRequest, indexSegment.getSegmentMetadata());
+    _groupBy = brokerRequest.getGroupBy();
+
+    List<StarTreeV2> starTrees = indexSegment.getStarTrees();
+    if (starTrees != null) {
+      if (!StarTreeUtils.isStarTreeDisabled(brokerRequest)) {
+        Set<AggregationFunctionColumnPair> aggregationFunctionColumnPairs = new HashSet<>();
+        for (AggregationInfo aggregationInfo : _aggregationInfos) {
+          aggregationFunctionColumnPairs.add(AggregationFunctionUtils.getFunctionColumnPair(aggregationInfo));
+        }
+        Set<TransformExpressionTree> groupByExpressions = new HashSet<>();
+        for (String expression : _groupBy.getExpressions()) {
+          groupByExpressions.add(TransformExpressionTree.compileToExpressionTree(expression));
+        }
+        FilterQueryTree rootFilterNode = RequestUtils.generateFilterQueryTree(brokerRequest);
+        for (StarTreeV2 starTreeV2 : starTrees) {
+          if (StarTreeUtils
+              .isFitForStarTree(starTreeV2.getMetadata(), aggregationFunctionColumnPairs, groupByExpressions,
+                  rootFilterNode)) {
+            _transformPlanNode = null;
+            _starTreeTransformPlanNode =
+                new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, groupByExpressions,
+                    rootFilterNode, brokerRequest.getDebugOptions());
+            return;
+          }
+        }
+      }
+    }
+
+    _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest);
+    _starTreeTransformPlanNode = null;
+  }
+
+  @Override
+  public AggregationGroupByOrderByOperator run() {
+    int numTotalRawDocs = _indexSegment.getSegmentMetadata().getTotalRawDocs();
+    if (_transformPlanNode != null) {
+      // Do not use star-tree
+      return new AggregationGroupByOrderByOperator(_functionContexts, _groupBy, _maxInitialResultHolderCapacity,
+          _numGroupsLimit, _transformPlanNode.run(), numTotalRawDocs, false);
+    } else {
+      // Use star-tree
+      return new AggregationGroupByOrderByOperator(_functionContexts, _groupBy, _maxInitialResultHolderCapacity,
+          _numGroupsLimit, _starTreeTransformPlanNode.run(), numTotalRawDocs, true);
+    }
+  }
+
+  @Override
+  public void showTree(String prefix) {
+    LOGGER.debug(prefix + "Aggregation Group-by Plan Node:");
+    LOGGER.debug(prefix + "Operator: AggregationGroupByOperator");
+    LOGGER.debug(prefix + "Argument 0: IndexSegment - " + _indexSegment.getSegmentName());
+    LOGGER.debug(prefix + "Argument 1: Aggregations - " + _aggregationInfos);
+    LOGGER.debug(prefix + "Argument 2: GroupBy - " + _groupBy);
+    if (_transformPlanNode != null) {
+      LOGGER.debug(prefix + "Argument 3: TransformPlanNode -");
+      _transformPlanNode.showTree(prefix + "    ");
+    } else {
+      LOGGER.debug(prefix + "Argument 3: StarTreeTransformPlanNode -");
+      _starTreeTransformPlanNode.showTree(prefix + "    ");
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.CombineGroupByOperator;
 import org.apache.pinot.core.operator.CombineGroupByOrderByOperator;
@@ -34,8 +35,6 @@ import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.core.util.trace.TraceCallable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.*;
 
 
 /**
@@ -148,7 +147,7 @@ public class CombinePlanNode implements PlanNode {
       // Aggregation group-by query
       Map<String, String> queryOptions = _brokerRequest.getQueryOptions();
       // new Combine operator only when GROUP_BY_MODE explicitly set to SQL
-      if (GroupByUtils.isGroupByMode(SQL, queryOptions)) {
+      if (GroupByUtils.isGroupByMode(Request.SQL, queryOptions)) {
         return new CombineGroupByOrderByOperator(operators, _brokerRequest, _executorService, _timeOutMs);
       }
       return new CombineGroupByOperator(operators, _brokerRequest, _executorService, _timeOutMs, _numGroupsLimit);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -25,12 +25,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.CombineGroupByOperator;
 import org.apache.pinot.core.operator.CombineGroupByOrderByOperator;
 import org.apache.pinot.core.operator.CombineOperator;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.core.util.trace.TraceCallable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,7 +148,7 @@ public class CombinePlanNode implements PlanNode {
       // Aggregation group-by query
       Map<String, String> queryOptions = _brokerRequest.getQueryOptions();
       // new Combine operator only when GROUP_BY_MODE explicitly set to SQL
-      if (queryOptions != null && SQL.equalsIgnoreCase(queryOptions.get(QueryOptionKey.GROUP_BY_MODE))) {
+      if (GroupByUtils.isGroupByMode(SQL, queryOptions)) {
         return new CombineGroupByOrderByOperator(operators, _brokerRequest, _executorService, _timeOutMs);
       }
       return new CombineGroupByOperator(operators, _brokerRequest, _executorService, _timeOutMs, _numGroupsLimit);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.CombineGroupByOperator;
+import org.apache.pinot.core.operator.CombineGroupByOrderByOperator;
 import org.apache.pinot.core.operator.CombineOperator;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
 import org.apache.pinot.core.util.trace.TraceCallable;
@@ -141,6 +142,10 @@ public class CombinePlanNode implements PlanNode {
     // TODO: use the same combine operator for both aggregation and selection query.
     if (_brokerRequest.isSetAggregationsInfo() && _brokerRequest.getGroupBy() != null) {
       // Aggregation group-by query
+      if (_brokerRequest.isSetOrderBy()) {
+        return new CombineGroupByOrderByOperator(operators, _brokerRequest, _executorService, _timeOutMs,
+            _numGroupsLimit);
+      }
       return new CombineGroupByOperator(operators, _brokerRequest, _executorService, _timeOutMs, _numGroupsLimit);
     } else {
       // Selection or aggregation only query

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -148,7 +148,7 @@ public class CombinePlanNode implements PlanNode {
       // Aggregation group-by query
       Map<String, String> queryOptions = _brokerRequest.getQueryOptions();
       // new Combine operator only when GROUP_BY_MODE explicitly set to SQL
-      if (queryOptions != null && SQL.equals(queryOptions.get(QueryOptionKey.GROUP_BY_MODE))) {
+      if (queryOptions != null && SQL.equalsIgnoreCase(queryOptions.get(QueryOptionKey.GROUP_BY_MODE))) {
         return new CombineGroupByOrderByOperator(operators, _brokerRequest, _executorService, _timeOutMs,
             _numGroupsLimit);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -147,9 +147,8 @@ public class CombinePlanNode implements PlanNode {
     if (_brokerRequest.isSetAggregationsInfo() && _brokerRequest.getGroupBy() != null) {
       // Aggregation group-by query
       Map<String, String> queryOptions = _brokerRequest.getQueryOptions();
-      // execute order by only if GROUP_BY_MODE explicitly set to SQL
-      if (_brokerRequest.isSetOrderBy() && queryOptions != null && SQL.equals(
-          queryOptions.get(QueryOptionKey.GROUP_BY_MODE))) {
+      // new Combine operator only when GROUP_BY_MODE explicitly set to SQL
+      if (queryOptions != null && SQL.equals(queryOptions.get(QueryOptionKey.GROUP_BY_MODE))) {
         return new CombineGroupByOrderByOperator(operators, _brokerRequest, _executorService, _timeOutMs,
             _numGroupsLimit);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -149,8 +149,7 @@ public class CombinePlanNode implements PlanNode {
       Map<String, String> queryOptions = _brokerRequest.getQueryOptions();
       // new Combine operator only when GROUP_BY_MODE explicitly set to SQL
       if (queryOptions != null && SQL.equalsIgnoreCase(queryOptions.get(QueryOptionKey.GROUP_BY_MODE))) {
-        return new CombineGroupByOrderByOperator(operators, _brokerRequest, _executorService, _timeOutMs,
-            _numGroupsLimit);
+        return new CombineGroupByOrderByOperator(operators, _brokerRequest, _executorService, _timeOutMs);
       }
       return new CombineGroupByOperator(operators, _brokerRequest, _executorService, _timeOutMs, _numGroupsLimit);
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -49,7 +49,7 @@ public class AggregationFunctionUtils {
     return aggregationInfo.getAggregationParams().get(COLUMN_KEY);
   }
 
-  public static String getAggregationColumnName(@Nonnull AggregationInfo aggregationInfo) {
+  public static String getAggregationColumnName(AggregationInfo aggregationInfo) {
     return aggregationInfo.getAggregationType().toLowerCase() + "(" + AggregationFunctionUtils.getColumn(aggregationInfo)
         + ")";
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -49,6 +49,11 @@ public class AggregationFunctionUtils {
     return aggregationInfo.getAggregationParams().get(COLUMN_KEY);
   }
 
+  public static String getAggregationColumnName(@Nonnull AggregationInfo aggregationInfo) {
+    return aggregationInfo.getAggregationType().toLowerCase() + "(" + AggregationFunctionUtils.getColumn(aggregationInfo)
+        + ")";
+  }
+
   /**
    * Creates an {@link AggregationFunctionColumnPair} from the {@link AggregationInfo}.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/AggregationGroupByTrimmingService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/AggregationGroupByTrimmingService.java
@@ -42,7 +42,6 @@ import org.apache.pinot.core.query.aggregation.function.MinAggregationFunction;
  * The <code>AggregationGroupByTrimmingService</code> class provides trimming service for aggregation group-by queries.
  */
 public class AggregationGroupByTrimmingService {
-  public static final String GROUP_KEY_DELIMITER = "\t";
 
   private final AggregationFunction[] _aggregationFunctions;
   private final int _groupByTopN;
@@ -229,7 +228,7 @@ public class AggregationGroupByTrimmingService {
       GroupKeyResultPair groupKeyResultPair;
       while ((groupKeyResultPair = _heap.poll()) != null) {
         // Set limit to -1 to prevent removing trailing empty strings
-        String[] groupKeys = groupKeyResultPair._groupKey.split(GROUP_KEY_DELIMITER, -1);
+        String[] groupKeys = groupKeyResultPair._groupKey.split(GroupKeyGenerator.DELIMITER, -1);
 
         GroupByResult groupByResult = new GroupByResult();
         groupByResult.setGroup(Arrays.asList(groupKeys));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
@@ -427,7 +427,7 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
       StringBuilder groupKeyBuilder = new StringBuilder(_dictionaries[0].getStringValue(rawKey % cardinality));
       rawKey /= cardinality;
       for (int i = 1; i < _numGroupByExpressions; i++) {
-        groupKeyBuilder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
+        groupKeyBuilder.append(GroupKeyGenerator.DELIMITER);
         cardinality = _cardinalities[i];
         groupKeyBuilder.append(_dictionaries[i].getStringValue(rawKey % cardinality));
         rawKey /= cardinality;
@@ -598,7 +598,7 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
     StringBuilder groupKeyBuilder = new StringBuilder(_dictionaries[0].get((int) (rawKey % cardinality)).toString());
     rawKey /= cardinality;
     for (int i = 1; i < _numGroupByExpressions; i++) {
-      groupKeyBuilder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
+      groupKeyBuilder.append(GroupKeyGenerator.DELIMITER);
       cardinality = _cardinalities[i];
       groupKeyBuilder.append(_dictionaries[i].get((int) (rawKey % cardinality)));
       rawKey /= cardinality;
@@ -770,7 +770,7 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
   private String getGroupKey(IntArray rawKey) {
     StringBuilder groupKeyBuilder = new StringBuilder(_dictionaries[0].get(rawKey._elements[0]).toString());
     for (int i = 1; i < _numGroupByExpressions; i++) {
-      groupKeyBuilder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
+      groupKeyBuilder.append(GroupKeyGenerator.DELIMITER);
       groupKeyBuilder.append(_dictionaries[i].get(rawKey._elements[i]));
     }
     return groupKeyBuilder.toString();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.operator.blocks.TransformBlock;
  * Interface for generating group keys.
  */
 public interface GroupKeyGenerator {
+  String DELIMITER = "\t";
   int INVALID_ID = -1;
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
@@ -212,7 +212,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       }
 
       if (i > 0) {
-        builder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
+        builder.append(GroupKeyGenerator.DELIMITER);
       }
       builder.append(key);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -58,16 +57,17 @@ import org.apache.pinot.common.response.broker.GroupByResult;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.response.broker.SelectionResults;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.common.utils.CommonConstants.Broker.Request.*;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
-import org.apache.pinot.core.data.order.OrderByUtils;
-import org.apache.pinot.core.query.aggregation.DistinctTable;
 import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
 import org.apache.pinot.core.data.table.IndexedTable;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.query.aggregation.DistinctTable;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
@@ -76,9 +76,6 @@ import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.core.util.GroupByUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.*;
-
 
 /**
  * The <code>BrokerReduceService</code> class provides service to reduce data tables gathered from multiple servers
@@ -239,8 +236,8 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
               SelectionOperatorUtils.getSelectionColumns(brokerRequest.getSelections().getSelectionColumns(),
                   cachedDataSchema);
           brokerResponseNative.setSelectionResults(new SelectionResults(selectionColumns, new ArrayList<>(0)));
-        } else if (brokerRequest.isSetGroupBy() && GroupByUtils.isGroupByMode(SQL, queryOptions)
-            && GroupByUtils.isResponseFormat(SQL, queryOptions)) {
+        } else if (brokerRequest.isSetGroupBy() && GroupByUtils.isGroupByMode(Request.SQL, queryOptions)
+            && GroupByUtils.isResponseFormat(Request.SQL, queryOptions)) {
           setSQLGroupByOrderByResults(brokerResponseNative, cachedDataSchema, brokerRequest.getAggregationsInfo(),
               brokerRequest.getGroupBy(), brokerRequest.getOrderBy(), dataTableMap, preserveType);
         }
@@ -289,13 +286,13 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
           // Aggregation group-by query.
           // read results as records if  GROUP_BY_MODE is explicitly set to SQL
 
-          if (GroupByUtils.isGroupByMode(SQL, queryOptions)) {
+          if (GroupByUtils.isGroupByMode(Request.SQL, queryOptions)) {
             // sql + order by
 
             int resultSize = 0;
 
             // if RESPONSE_FORMAT is SQL, return results in {@link ResultTable}
-            if (GroupByUtils.isResponseFormat(SQL, queryOptions)) {
+            if (GroupByUtils.isResponseFormat(Request.SQL, queryOptions)) {
               setSQLGroupByOrderByResults(brokerResponseNative, cachedDataSchema, brokerRequest.getAggregationsInfo(),
                   brokerRequest.getGroupBy(), brokerRequest.getOrderBy(), dataTableMap, preserveType);
               resultSize = brokerResponseNative.getResultTable().getRows().size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -73,6 +73,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
 import org.apache.pinot.core.query.selection.SelectionOperatorService;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.core.util.GroupByUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -554,7 +555,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       throws Throwable {
 
     IndexedTable indexedTable = new ConcurrentIndexedTable();
-    int capacity = Math.max(((int) groupBy.getTopN()) * 5, OrderByUtils.NUM_RESULTS_LOWER_LIMIT);
+    int capacity = GroupByUtils.getTableCapacity((int) groupBy.getTopN());
     indexedTable.init(dataSchema, aggregationInfos, orderBy, capacity, true);
 
     for (DataTable dataTable : dataTableMap.values()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -542,7 +542,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     int indexedTableCapacity = 1_000_000;
     // FIXME: indexedTableCapacity should be derived from TOP. Hardcoding this value to a higher number until we can tune the resize
     // int capacity = GroupByUtils.getTableCapacity((int) groupBy.getTopN());
-    indexedTable.init(dataSchema, aggregationInfos, orderBy, indexedTableCapacity, true);
+    indexedTable.init(dataSchema, aggregationInfos, orderBy, indexedTableCapacity);
 
     for (DataTable dataTable : dataTableMap.values()) {
       CheckedFunction2[] functions = new CheckedFunction2[dataSchema.size()];
@@ -588,7 +588,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
         indexedTable.upsert(record);
       }
     }
-    indexedTable.finish();
+    indexedTable.finish(true);
     return indexedTable;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -62,6 +62,7 @@ import org.apache.pinot.common.utils.CommonConstants.Broker.Request.*;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.data.order.OrderByUtils;
 import org.apache.pinot.core.query.aggregation.DistinctTable;
 import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
 import org.apache.pinot.core.data.table.IndexedTable;
@@ -553,8 +554,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       throws Throwable {
 
     IndexedTable indexedTable = new ConcurrentIndexedTable();
-    // setting a higher value to avoid frequent resizing
-    int capacity = (int) Math.max(groupBy.getTopN(), 10000);
+    int capacity = Math.max(((int) groupBy.getTopN()) * 5, OrderByUtils.NUM_RESULTS_LOWER_LIMIT);
     indexedTable.init(dataSchema, aggregationInfos, orderBy, capacity, true);
 
     for (DataTable dataTable : dataTableMap.values()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -211,10 +211,10 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
     if (brokerMetrics != null) {
       brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.DOCUMENTS_SCANNED, numDocsScanned);
-      brokerMetrics
-          .addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_IN_FILTER, numEntriesScannedInFilter);
-      brokerMetrics
-          .addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_POST_FILTER, numEntriesScannedPostFilter);
+      brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_IN_FILTER,
+          numEntriesScannedInFilter);
+      brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_POST_FILTER,
+          numEntriesScannedPostFilter);
 
       if (numConsumingSegmentsProcessed > 0 && minConsumingFreshnessTimeMs > 0) {
         brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.FRESHNESS_LAG_MS,
@@ -233,9 +233,15 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       // For empty data table map, construct empty result using the cached data schema for selection query if exists
       if (cachedDataSchema != null) {
         if (brokerRequest.isSetSelections()) {
-          List<String> selectionColumns = SelectionOperatorUtils.getSelectionColumns(brokerRequest.getSelections().getSelectionColumns(),
-              cachedDataSchema);
+          List<String> selectionColumns =
+              SelectionOperatorUtils.getSelectionColumns(brokerRequest.getSelections().getSelectionColumns(),
+                  cachedDataSchema);
           brokerResponseNative.setSelectionResults(new SelectionResults(selectionColumns, new ArrayList<>(0)));
+        } else if (brokerRequest.isSetOrderBy() && queryOptions != null && SQL.equals(
+            queryOptions.get(QueryOptionKey.GROUP_BY_MODE)) && SQL.equals(
+            queryOptions.get(QueryOptionKey.RESPONSE_FORMAT))) {
+          setSQLGroupByOrderByResults(brokerResponseNative, cachedDataSchema, brokerRequest.getAggregationsInfo(),
+              brokerRequest.getGroupBy(), brokerRequest.getOrderBy(), dataTableMap, preserveType);
         }
       }
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -555,8 +555,10 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       throws Throwable {
 
     IndexedTable indexedTable = new ConcurrentIndexedTable();
-    int capacity = GroupByUtils.getTableCapacity((int) groupBy.getTopN());
-    indexedTable.init(dataSchema, aggregationInfos, orderBy, capacity, true);
+    int indexedTableCapacity = 1_000_000;
+    // FIXME: indexedTableCapacity should be derived from TOP. Hardcoding this value to a higher number until we can tune the resize
+    // int capacity = GroupByUtils.getTableCapacity((int) groupBy.getTopN());
+    indexedTable.init(dataSchema, aggregationInfos, orderBy, indexedTableCapacity, true);
 
     for (DataTable dataTable : dataTableMap.values()) {
       CheckedFunction2[] functions = new CheckedFunction2[dataSchema.size()];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/CombineService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/CombineService.java
@@ -93,8 +93,8 @@ public class CombineService {
 
       // Data schema will be null if exceptions caught during query processing.
       // Result set size will be zero if no row matches the predicate.
-      DataSchema mergedBlockSchema = mergedBlock.getSelectionDataSchema();
-      DataSchema blockToMergeSchema = blockToMerge.getSelectionDataSchema();
+      DataSchema mergedBlockSchema = mergedBlock.getDataSchema();
+      DataSchema blockToMergeSchema = blockToMerge.getDataSchema();
       Collection<Serializable[]> mergedBlockResultSet = mergedBlock.getSelectionResult();
       Collection<Serializable[]> blockToMergeResultSet = blockToMerge.getSelectionResult();
 
@@ -103,7 +103,7 @@ public class CombineService {
 
         // If block to merge schema is not null, set its data schema and result to the merged block.
         if (blockToMergeSchema != null) {
-          mergedBlock.setSelectionDataSchema(blockToMergeSchema);
+          mergedBlock.setDataSchema(blockToMergeSchema);
           mergedBlock.setSelectionResult(blockToMergeResultSet);
         }
       } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.util;
+
+import java.util.Map;
+
+import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.*;
+
+
+public final class GroupByUtils {
+
+  public static final int NUM_RESULTS_LOWER_LIMIT = 5000;
+
+  private GroupByUtils() {
+
+  }
+
+  /**
+   * Returns the higher of topN * 5 or 5k. This is to ensure we better precision in results
+   */
+  public static int getTableCapacity(int topN) {
+    return Math.max(topN * 5, NUM_RESULTS_LOWER_LIMIT);
+  }
+
+  public static boolean isGroupByMode(String groupByMode, Map<String, String> queryOptions) {
+    if (queryOptions != null) {
+      String groupByModeValue = queryOptions.get(QueryOptionKey.GROUP_BY_MODE);
+      return groupByModeValue != null && groupByModeValue.equalsIgnoreCase(groupByMode);
+    }
+    return false;
+  }
+
+  public static boolean isResponseFormat(String responseFormat, Map<String, String> queryOptions) {
+    if (queryOptions != null) {
+      String responseFormatValue = queryOptions.get(QueryOptionKey.RESPONSE_FORMAT);
+      return responseFormatValue != null && responseFormatValue.equalsIgnoreCase(responseFormat);
+    }
+    return false;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/order/OrderByUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/order/OrderByUtilsTest.java
@@ -236,7 +236,7 @@ public class OrderByUtilsTest {
     s4.setColumn("sum(metric0)");
     orderBy = Lists.newArrayList(s0, s4);
     Comparator<Record> keysAndValuesComparator =
-        OrderByUtils.getKeysAndValuesComparator(dataSchema, orderBy, aggregationInfos);
+        OrderByUtils.getKeysAndValuesComparator(dataSchema, orderBy, aggregationInfos, true);
     records.sort(keysAndValuesComparator);
     expected0 = Lists.newArrayList("abc", "abc", "abc", "bcd", "ghi", "mno", "mno");
     actual0 = records.stream().map(k -> k.getKey().getColumns()[0]).collect(Collectors.toList());

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -210,8 +210,6 @@ public class IndexedTableTest {
 
     // resized to 5
     Assert.assertEquals(indexedTable.size(), 5);
-    checkEvicted(indexedTable, "a", "b", "c", "d", "e");
-    checkAggregations(indexedTable, 30d, 20d);
 
     // filling up again
     indexedTable.upsert(getRecord(new Object[]{"k", 11, 110d}, new Object[]{10d, 1100d}));
@@ -234,30 +232,20 @@ public class IndexedTableTest {
     // insert new record n
     mergeTable.upsert(getRecord(new Object[]{"n", 14, 140d}, new Object[]{10d, 1400d}));
     Assert.assertEquals(mergeTable.size(), 4);
+    mergeTable.finish(false);
 
     // merge with table
     indexedTable.merge(mergeTable);
     Assert.assertEquals(indexedTable.size(), 5);
-    checkEvicted(indexedTable, "b", "j", "k", "f", "g");
 
     indexedTable.upsert(getRecord(new Object[]{"h", 8, 80d}, new Object[]{100d, 800d}));
     indexedTable.upsert(getRecord(new Object[]{"i", 9, 90d}, new Object[]{50d, 900d}));
-    mergeTable.upsert(getRecord(new Object[]{"n", 14, 140d}, new Object[]{600d, 1400d}));
+    indexedTable.upsert(getRecord(new Object[]{"n", 14, 140d}, new Object[]{600d, 1400d}));
 
     // finish
     indexedTable.finish(false);
+    checkEvicted(indexedTable, "a", "c", "d", "e", "b", "j", "k", "f", "g");
     Assert.assertEquals(indexedTable.size(), 5);
-  }
-
-  private void checkAggregations(Table indexedTable, double... evicted) {
-    Iterator<Record> iterator = indexedTable.iterator();
-    Set<Double> actualAgg = new HashSet<>();
-    while (iterator.hasNext()) {
-      actualAgg.add((double) iterator.next().getValues()[0]);
-    }
-    for (double d : evicted) {
-      Assert.assertFalse(actualAgg.contains(d));
-    }
   }
 
   private void checkEvicted(Table indexedTable, String... evicted) {
@@ -324,12 +312,14 @@ public class IndexedTableTest {
     indexedTable.upsert(getRecord(new Object[]{"k", 11, 110d}, new Object[]{10d, 1100d}));
     indexedTable.upsert(getRecord(new Object[]{"l", 12, 120d}, new Object[]{10d, 1200d}));
     Assert.assertEquals(indexedTable.size(), 10);
-    checkEvicted(indexedTable, "k", "l");
 
     // existing row allowed
     indexedTable.upsert(getRecord(new Object[]{"b", 2, 20d}, new Object[]{10d, 200d}));
     Assert.assertEquals(indexedTable.size(), 10);
 
+    indexedTable.finish(false);
+
+    checkEvicted(indexedTable, "k", "l");
 
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -72,7 +72,7 @@ public class IndexedTableTest {
     List<SelectionSort> orderBy = Lists.newArrayList(sel);
 
     // max capacity 5, buffered capacity at 10
-    indexedTable.init(dataSchema, aggregationInfos, orderBy, 5, false);
+    indexedTable.init(dataSchema, aggregationInfos, orderBy, 5);
 
     // 3 threads upsert together
     // a inserted 6 times (60), b inserted 5 times (50), d inserted 2 times (20)
@@ -123,7 +123,7 @@ public class IndexedTableTest {
         future.get(10, TimeUnit.SECONDS);
       }
 
-      indexedTable.finish();
+      indexedTable.finish(false);
       Assert.assertEquals(indexedTable.size(), 5);
       checkEvicted(indexedTable, "c", "f");
 
@@ -159,17 +159,17 @@ public class IndexedTableTest {
 
     IndexedTable simpleIndexedTable = new SimpleIndexedTable();
     // max capacity 5, buffered capacity 10
-    simpleIndexedTable.init(dataSchema, aggregationInfos, orderBy, 5, false);
+    simpleIndexedTable.init(dataSchema, aggregationInfos, orderBy, 5);
     // merge table
     IndexedTable mergeTable = new SimpleIndexedTable();
-    mergeTable.init(dataSchema, aggregationInfos, orderBy, 10, false);
+    mergeTable.init(dataSchema, aggregationInfos, orderBy, 10);
     testNonConcurrent(simpleIndexedTable, mergeTable);
 
     IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable();
     // max capacity 5, buffered capacity 10
-    concurrentIndexedTable.init(dataSchema, aggregationInfos, orderBy, 5, false);
+    concurrentIndexedTable.init(dataSchema, aggregationInfos, orderBy, 5);
     mergeTable = new SimpleIndexedTable();
-    mergeTable.init(dataSchema, aggregationInfos, orderBy, 10, false);
+    mergeTable.init(dataSchema, aggregationInfos, orderBy, 10);
     testNonConcurrent(concurrentIndexedTable, mergeTable);
 
   }
@@ -245,7 +245,7 @@ public class IndexedTableTest {
     mergeTable.upsert(getRecord(new Object[]{"n", 14, 140d}, new Object[]{600d, 1400d}));
 
     // finish
-    indexedTable.finish();
+    indexedTable.finish(false);
     Assert.assertEquals(indexedTable.size(), 5);
   }
 
@@ -294,11 +294,11 @@ public class IndexedTableTest {
     List<AggregationInfo> aggregationInfos = Lists.newArrayList(agg1, agg2);
 
     IndexedTable indexedTable = new SimpleIndexedTable();
-    indexedTable.init(dataSchema, aggregationInfos, null, 5, false);
+    indexedTable.init(dataSchema, aggregationInfos, null, 5);
     testNoMoreNewRecordsInTable(indexedTable);
 
     indexedTable = new ConcurrentIndexedTable();
-    indexedTable.init(dataSchema, aggregationInfos, null, 5, false);
+    indexedTable.init(dataSchema, aggregationInfos, null, 5);
     testNoMoreNewRecordsInTable(indexedTable);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -72,7 +72,7 @@ public class IndexedTableTest {
     List<SelectionSort> orderBy = Lists.newArrayList(sel);
 
     // max capacity 10, evict at 12, evict until 11
-    indexedTable.init(dataSchema, aggregationInfos, orderBy, 10);
+    indexedTable.init(dataSchema, aggregationInfos, orderBy, 10, false);
 
     // 3 threads upsert together
     // a inserted 6 times (60), b inserted 5 times (50), d inserted 2 times (20)
@@ -160,17 +160,17 @@ public class IndexedTableTest {
 
     IndexedTable simpleIndexedTable = new SimpleIndexedTable();
     // max capacity 10, evict at 12, evict until 11
-    simpleIndexedTable.init(dataSchema, aggregationInfos, orderBy, 10);
+    simpleIndexedTable.init(dataSchema, aggregationInfos, orderBy, 10, false);
     // merge table
     IndexedTable mergeTable = new SimpleIndexedTable();
-    mergeTable.init(dataSchema, aggregationInfos, orderBy, 10);
+    mergeTable.init(dataSchema, aggregationInfos, orderBy, 10, false);
     testNonConcurrent(simpleIndexedTable, mergeTable);
 
     IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable();
     // max capacity 10, evict at 12, evict until 11
-    concurrentIndexedTable.init(dataSchema, aggregationInfos, orderBy, 10);
+    concurrentIndexedTable.init(dataSchema, aggregationInfos, orderBy, 10, false);
     mergeTable = new SimpleIndexedTable();
-    mergeTable.init(dataSchema, aggregationInfos, orderBy, 10);
+    mergeTable.init(dataSchema, aggregationInfos, orderBy, 10, false);
     testNonConcurrent(concurrentIndexedTable, mergeTable);
 
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -84,7 +84,22 @@ public abstract class BaseQueriesTest {
    * @return broker response.
    */
   protected BrokerResponseNative getBrokerResponseForQuery(String query, PlanMaker planMaker) {
+    return getBrokerResponseForQuery(query, planMaker, null);
+  }
+
+  /**
+   * Run query on multiple index segments with custom plan maker and queryOptions.
+   * <p>Use this to test the whole flow from server to broker.
+   * <p>The result should be equivalent to querying 4 identical index segments.
+   *
+   * @param query PQL query.
+   * @param planMaker Plan maker.
+   * @return broker response.
+   */
+  private BrokerResponseNative getBrokerResponseForQuery(String query, PlanMaker planMaker,
+      Map<String, String> queryOptions) {
     BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
+    brokerRequest.setQueryOptions(queryOptions);
 
     // Server side.
     Plan plan = planMaker.makeInterSegmentPlan(getSegmentDataManagers(), brokerRequest, EXECUTOR_SERVICE, 10_000);
@@ -108,6 +123,18 @@ public abstract class BaseQueriesTest {
    */
   protected BrokerResponseNative getBrokerResponseForQuery(String query) {
     return getBrokerResponseForQuery(query, PLAN_MAKER);
+  }
+
+  /**
+   * Run query on multiple index segments.
+   * <p>Use this to test the whole flow from server to broker.
+   * <p>The result should be equivalent to querying 4 identical index segments.
+   *
+   * @param query PQL query.
+   * @return broker response.
+   */
+  protected BrokerResponseNative getBrokerResponseForQuery(String query, Map<String, String> queryOptions) {
+    return getBrokerResponseForQuery(query, PLAN_MAKER, queryOptions);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
@@ -49,7 +49,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
-    DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 10);
@@ -69,7 +69,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
-    selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
     Assert.assertEquals(selectionDataSchema.size(), 10);
     Assert.assertTrue(columnIndexMap.containsKey("column1"));
@@ -93,7 +93,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 100L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
-    DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 10);
@@ -118,7 +118,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 79L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 100L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
-    selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 10);
@@ -148,7 +148,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 30L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
-    DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 3);
@@ -173,7 +173,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 79L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 30L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
-    selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 3);
@@ -203,7 +203,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 400000L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
-    DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 4);
@@ -228,7 +228,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 272276L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 62480L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
-    selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 4);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
@@ -49,7 +49,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
     Assert.assertEquals(selectionDataSchema.size(), 11);
     Assert.assertTrue(columnIndexMap.containsKey("column1"));
@@ -68,7 +68,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 11);
@@ -93,7 +93,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
     Assert.assertEquals(selectionDataSchema.size(), 11);
     Assert.assertEquals(getVirtualColumns(selectionDataSchema), 0);
@@ -118,7 +118,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 48241L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
     Assert.assertEquals(selectionDataSchema.size(), 11);
     Assert.assertEquals(getVirtualColumns(selectionDataSchema), 0);
@@ -148,7 +148,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 30L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 3);
@@ -173,7 +173,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 48241L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 30L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
     Assert.assertEquals(selectionDataSchema.size(), 3);
     Assert.assertTrue(columnIndexMap.containsKey("column1"));
@@ -202,7 +202,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 120000L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 4);
@@ -227,7 +227,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 84134L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 24516L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(selectionDataSchema.size(), 4);
@@ -257,7 +257,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 330000L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(getVirtualColumns(selectionDataSchema), 0);
@@ -283,7 +283,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 84134L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 67419);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
-    selectionDataSchema = resultsBlock.getSelectionDataSchema();
+    selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
 
     Assert.assertEquals(getVirtualColumns(selectionDataSchema), 0);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import com.google.common.collect.Lists;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.common.response.broker.AggregationResult;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests order by queries
+ */
+public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQueriesTest {
+
+  @Test(dataProvider = "orderByDataProvider")
+  public void testAggregationOrderedGroupByResults(String query, List<Serializable[]> expectedResults,
+      long expectedNumEntriesScannedPostFilter) {
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    QueriesTestUtils.testInterSegmentAggregationOrderedGroupByResult(brokerResponse, 400000L, 0,
+        expectedNumEntriesScannedPostFilter, 400000L, expectedResults);
+  }
+
+  /**
+   * Provides various combinations of order by.
+   * In order to calculate the expected results, the results from a group by were taken, and then ordered accordingly.
+   */
+  @DataProvider(name = "orderByDataProvider")
+  public Object[][] orderByDataProvider() {
+
+    List<Object[]> data = new ArrayList<>();
+    String query;
+    List<Serializable[]> results;
+    long numEntriesScannedPostFilter;
+
+    query = "SELECT SUMMV(column7) FROM testTable GROUP BY column3 ORDER BY column3";
+    results = Lists.newArrayList(new Serializable[]{"", 63917703269308.0}, new Serializable[]{"L", 33260235267900.0},
+        new Serializable[]{"P", 212961658305696.0}, new Serializable[]{"PbQd", 2001454759004.0},
+        new Serializable[]{"w", 116831822080776.0});
+    numEntriesScannedPostFilter = 800000;
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+
+    query = "SELECT SUMMV(column7) FROM testTable GROUP BY column5 ORDER BY column5 DESC TOP 4";
+    results = Lists.newArrayList(new Serializable[]{"yQkJTLOQoOqqhkAClgC", 61100215182228.00000},
+        new Serializable[]{"mhoVvrJm", 5806796153884.00000},
+        new Serializable[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 51891832239248.00000},
+        new Serializable[]{"PbQd", 36532997335388.00000});
+    numEntriesScannedPostFilter = 800000;
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+
+    query = "SELECT SUMMV(column7) FROM testTable GROUP BY column5 ORDER BY SUMMV(column7) TOP 5";
+    results = Lists.newArrayList(new Serializable[]{"NCoFku", 489626381288.00000},
+        new Serializable[]{"mhoVvrJm", 5806796153884.00000},
+        new Serializable[]{"JXRmGakTYafZFPm", 18408231081808.00000}, new Serializable[]{"PbQd", 36532997335388.00000},
+        new Serializable[]{"OKyOqU", 51067166589176.00000});
+    numEntriesScannedPostFilter = 800000;
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+
+    // object type aggregations
+    query = "SELECT MINMAXRANGEMV(column7) FROM testTable GROUP BY column5 ORDER BY column5";
+    results = Lists.newArrayList(new Serializable[]{"AKXcXcIqsqOJFsdwxZ", 2147483446.00000},
+        new Serializable[]{"EOFxevm", 2147483446.00000}, new Serializable[]{"JXRmGakTYafZFPm", 2147483443.00000},
+        new Serializable[]{"NCoFku", 2147483436.00000}, new Serializable[]{"OKyOqU", 2147483443.00000},
+        new Serializable[]{"PbQd", 2147483443.00000},
+        new Serializable[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.00000},
+        new Serializable[]{"mhoVvrJm", 2147483438.00000}, new Serializable[]{"yQkJTLOQoOqqhkAClgC", 2147483446.00000});
+    numEntriesScannedPostFilter = 800000;
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+
+    // object type aggregations
+    query =
+        "SELECT MINMAXRANGEMV(column7) FROM testTable GROUP BY column5 ORDER BY MINMAXRANGEMV(column7), column5 desc";
+    results = Lists.newArrayList(new Serializable[]{"NCoFku", 2147483436.00000},
+        new Serializable[]{"mhoVvrJm", 2147483438.00000}, new Serializable[]{"PbQd", 2147483443.00000},
+        new Serializable[]{"OKyOqU", 2147483443.00000}, new Serializable[]{"JXRmGakTYafZFPm", 2147483443.00000},
+        new Serializable[]{"yQkJTLOQoOqqhkAClgC", 2147483446.00000},
+        new Serializable[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.00000},
+        new Serializable[]{"EOFxevm", 2147483446.00000}, new Serializable[]{"AKXcXcIqsqOJFsdwxZ", 2147483446.00000});
+    numEntriesScannedPostFilter = 800000;
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+
+    // object type aggregations - non comparable intermediate results
+    query = "SELECT DISTINCTCOUNTMV(column7) FROM testTable GROUP BY column5 ORDER BY DISTINCTCOUNTMV(column7) top 5";
+    results = Lists.newArrayList(new Serializable[]{"NCoFku", 26}, new Serializable[]{"mhoVvrJm", 65},
+        new Serializable[]{"JXRmGakTYafZFPm", 126}, new Serializable[]{"PbQd", 211}, new Serializable[]{"OKyOqU", 216});
+    numEntriesScannedPostFilter = 800000;
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+
+    return data.toArray(new Object[data.size()][]);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
@@ -22,11 +22,16 @@ import com.google.common.collect.Lists;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.*;
 
 
 /**
@@ -37,8 +42,11 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
   @Test(dataProvider = "orderByDataProvider")
   public void testAggregationOrderedGroupByResults(String query, List<Serializable[]> expectedResults,
       long expectedNumEntriesScannedPostFilter) {
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
-    QueriesTestUtils.testInterSegmentAggregationOrderedGroupByResult(brokerResponse, 400000L, 0,
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.GROUP_BY_MODE, SQL);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, SQL);
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    QueriesTestUtils.testInterSegmentGroupByOrderByResult(brokerResponse, 400000L, 0,
         expectedNumEntriesScannedPostFilter, 400000L, expectedResults);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
@@ -343,4 +343,4 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
 
     return data.toArray(new Object[data.size()][]);
   }
-  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
@@ -1,0 +1,278 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import com.google.common.collect.Lists;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.common.response.broker.AggregationResult;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests order by queries
+ */
+public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQueriesTest {
+
+  @Test(dataProvider = "orderByDataProvider")
+  public void testAggregationOrderedGroupByResults(String query, List<Serializable[]> expectedResults,
+      long expectedNumDocsScanned, long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter,
+      long expectedNumTotalDocs) {
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    QueriesTestUtils.testInterSegmentAggregationOrderedGroupByResult(brokerResponse, expectedNumDocsScanned,
+        expectedNumEntriesScannedInFilter, expectedNumEntriesScannedPostFilter, expectedNumTotalDocs, expectedResults);
+  }
+
+  /**
+   * Provides various combinations of order by.
+   * In order to calculate the expected results, the results from a group by were taken, and then ordered accordingly.
+   */
+  @DataProvider(name = "orderByDataProvider")
+  public Object[][] orderByDataProvider() {
+
+    List<Object[]> data = new ArrayList<>();
+    String query;
+    List<Serializable[]> results;
+    long numDocsScanned = 120000;
+    long numEntriesScannedInFilter = 0;
+    long numEntriesScannedPostFilter;
+    long numTotalDocs = 120000;
+
+    // order by one of the group by columns
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11";
+    results = Lists.newArrayList(new Serializable[]{"", 5935285005452.0}, new Serializable[]{"P", 88832999206836.0},
+        new Serializable[]{"gFuH", 63202785888.0}, new Serializable[]{"o", 18105331533948.0},
+        new Serializable[]{"t", 16331923219264.0});
+    numEntriesScannedPostFilter = 240000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // order by one of the group by columns DESC
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11 DESC";
+    results = Lists.newArrayList(results);
+    Collections.reverse(results);
+    numEntriesScannedPostFilter = 240000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // order by one of the group by columns, TOP less than default
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11 TOP 3";
+    results = Lists.newArrayList(results);
+    Collections.reverse(results);
+    results = results.subList(0, 3);
+    numEntriesScannedPostFilter = 240000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // group by 2 dimensions, order by both, tie breaker
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, column12";
+    results = Lists.newArrayList(new Serializable[]{"", "HEuxNvH", 3789390396216.0},
+        new Serializable[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.00000},
+        new Serializable[]{"", "MaztCmmxxgguBUxPti", 1333941430664.00000},
+        new Serializable[]{"", "dJWwFk", 55470665124.0000},
+        new Serializable[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.00000},
+        new Serializable[]{"P", "HEuxNvH", 21998672845052.00000},
+        new Serializable[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx", 18069909216728.00000},
+        new Serializable[]{"P", "MaztCmmxxgguBUxPti", 27177029040008.00000},
+        new Serializable[]{"P", "TTltMtFiRqUjvOG", 4462670055540.00000},
+        new Serializable[]{"P", "XcBNHe", 120021767504.00000});
+    numEntriesScannedPostFilter = 360000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // group by 2 columns, order by both, TOP more than default
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, column12 TOP 15";
+    results = Lists.newArrayList(results);
+    results.add(new Serializable[]{"P", "dJWwFk", 6224665921376.00000});
+    results.add(new Serializable[]{"P", "fykKFqiw", 1574451324140.00000});
+    results.add(new Serializable[]{"P", "gFuH", 860077643636.00000});
+    results.add(new Serializable[]{"P", "oZgnrlDEtjjVpUoFLol", 8345501392852.00000});
+    results.add(new Serializable[]{"gFuH", "HEuxNvH", 29872400856.00000});
+    numEntriesScannedPostFilter = 360000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // group by 2 columns, order by both, one of them DESC
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, column12 DESC";
+    results = Lists.newArrayList(new Serializable[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.00000},
+        new Serializable[]{"", "dJWwFk", 55470665124.0000},
+        new Serializable[]{"", "MaztCmmxxgguBUxPti", 1333941430664.00000},
+        new Serializable[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.00000},
+        new Serializable[]{"", "HEuxNvH", 3789390396216.00000},
+        new Serializable[]{"P", "oZgnrlDEtjjVpUoFLol", 8345501392852.00000},
+        new Serializable[]{"P", "gFuH", 860077643636.00000}, new Serializable[]{"P", "fykKFqiw", 1574451324140.00000},
+        new Serializable[]{"P", "dJWwFk", 6224665921376.00000}, new Serializable[]{"P", "XcBNHe", 120021767504.00000});
+    numEntriesScannedPostFilter = 360000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // order by group by column and an aggregation
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, SUM(column1)";
+    results = Lists.newArrayList(new Serializable[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.00000},
+        new Serializable[]{"", "dJWwFk", 55470665124.0000},
+        new Serializable[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.00000},
+        new Serializable[]{"", "MaztCmmxxgguBUxPti", 1333941430664.00000},
+        new Serializable[]{"", "HEuxNvH", 3789390396216.00000}, new Serializable[]{"P", "XcBNHe", 120021767504.00000},
+        new Serializable[]{"P", "gFuH", 860077643636.00000}, new Serializable[]{"P", "fykKFqiw", 1574451324140.00000},
+        new Serializable[]{"P", "TTltMtFiRqUjvOG", 4462670055540.00000},
+        new Serializable[]{"P", "dJWwFk", 6224665921376.00000});
+    numEntriesScannedPostFilter = 360000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // order by only aggregation, DESC, TOP
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY SUM(column1) DESC TOP 50";
+    results = Lists.newArrayList(new Serializable[]{"P", "MaztCmmxxgguBUxPti", 27177029040008.00000},
+        new Serializable[]{"P", "HEuxNvH", 21998672845052.00000},
+        new Serializable[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx", 18069909216728.00000},
+        new Serializable[]{"P", "oZgnrlDEtjjVpUoFLol", 8345501392852.00000},
+        new Serializable[]{"o", "MaztCmmxxgguBUxPti", 6905624581072.00000},
+        new Serializable[]{"P", "dJWwFk", 6224665921376.00000}, new Serializable[]{"o", "HEuxNvH", 5026384681784.00000},
+        new Serializable[]{"t", "MaztCmmxxgguBUxPti", 4492405624940.00000},
+        new Serializable[]{"P", "TTltMtFiRqUjvOG", 4462670055540.00000},
+        new Serializable[]{"t", "HEuxNvH", 4424489490364.00000},
+        new Serializable[]{"o", "KrNxpdycSiwoRohEiTIlLqDHnx", 4051812250524.00000},
+        new Serializable[]{"", "HEuxNvH", 3789390396216.00000},
+        new Serializable[]{"t", "KrNxpdycSiwoRohEiTIlLqDHnx", 3529048341192.00000},
+        new Serializable[]{"P", "fykKFqiw", 1574451324140.00000},
+        new Serializable[]{"t", "dJWwFk", 1349058948804.00000},
+        new Serializable[]{"", "MaztCmmxxgguBUxPti", 1333941430664.00000},
+        new Serializable[]{"o", "dJWwFk", 1152689463360.00000},
+        new Serializable[]{"t", "oZgnrlDEtjjVpUoFLol", 1039101333316.00000},
+        new Serializable[]{"P", "gFuH", 860077643636.00000},
+        new Serializable[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.00000},
+        new Serializable[]{"o", "oZgnrlDEtjjVpUoFLol", 699381633640.00000},
+        new Serializable[]{"t", "TTltMtFiRqUjvOG", 675238030848.00000},
+        new Serializable[]{"t", "fykKFqiw", 480973878052.00000}, new Serializable[]{"t", "gFuH", 330331507792.00000},
+        new Serializable[]{"o", "TTltMtFiRqUjvOG", 203835153352.00000},
+        new Serializable[]{"P", "XcBNHe", 120021767504.00000}, new Serializable[]{"o", "fykKFqiw", 62975165296.00000},
+        new Serializable[]{"", "dJWwFk", 55470665124.0000}, new Serializable[]{"gFuH", "HEuxNvH", 29872400856.00000},
+        new Serializable[]{"gFuH", "MaztCmmxxgguBUxPti", 29170832184.00000},
+        new Serializable[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.00000},
+        new Serializable[]{"t", "XcBNHe", 11276063956.00000},
+        new Serializable[]{"gFuH", "KrNxpdycSiwoRohEiTIlLqDHnx", 4159552848.00000},
+        new Serializable[]{"o", "gFuH", 2628604920.00000});
+    numEntriesScannedPostFilter = 360000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // order by aggregation with space/tab in order by
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY SUM  ( column1) DESC TOP 3";
+    results = Lists.newArrayList(new Serializable[]{"P", "MaztCmmxxgguBUxPti", 27177029040008.00000},
+        new Serializable[]{"P", "HEuxNvH", 21998672845052.00000},
+        new Serializable[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx", 18069909216728.00000});
+    numEntriesScannedPostFilter = 360000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // order by an aggregation DESC, and group by column
+    query = "SELECT MIN(column6) FROM testTable GROUP BY column12 ORDER BY MIN(column6) DESC, column12";
+    results = Lists.newArrayList(new Serializable[]{"XcBNHe", 329467557.00000},
+        new Serializable[]{"fykKFqiw", 296467636.00000}, new Serializable[]{"gFuH", 296467636.00000},
+        new Serializable[]{"HEuxNvH", 6043515.00000}, new Serializable[]{"MaztCmmxxgguBUxPti", 6043515.00000},
+        new Serializable[]{"dJWwFk", 6043515.00000}, new Serializable[]{"KrNxpdycSiwoRohEiTIlLqDHnx", 1980174.00000},
+        new Serializable[]{"TTltMtFiRqUjvOG", 1980174.00000}, new Serializable[]{"oZgnrlDEtjjVpUoFLol", 1689277.00000});
+    numEntriesScannedPostFilter = 240000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // numeric dimension should follow numeric ordering
+    query = "select count(*) from testTable group by column17 order by column17 top 15";
+    results = Lists.newArrayList(new Serializable[]{83386499, 2924L}, new Serializable[]{217787432, 3892L},
+        new Serializable[]{227908817, 6564L}, new Serializable[]{402773817, 7304L},
+        new Serializable[]{423049234, 6556L}, new Serializable[]{561673250, 7420L},
+        new Serializable[]{635942547, 3308L}, new Serializable[]{638936844, 3816L},
+        new Serializable[]{939479517, 3116L}, new Serializable[]{984091268, 3824L},
+        new Serializable[]{1230252339, 5620L}, new Serializable[]{1284373442, 7428L},
+        new Serializable[]{1555255521, 2900L}, new Serializable[]{1618904660, 2744L},
+        new Serializable[]{1670085862, 3388L});
+    numEntriesScannedPostFilter = 120000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // group by UDF order by UDF
+    query = "SELECT COUNT(*) FROM testTable GROUP BY sub(column1, 100000) TOP 3 ORDER BY sub(column1, 100000)";
+    results = Lists.newArrayList(new Serializable[]{140528.0, 28L}, new Serializable[]{194355.0, 12L},
+        new Serializable[]{532157.0, 12L});
+    numEntriesScannedPostFilter = 120000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // spaces in UDF
+    query = "SELECT COUNT(*) FROM testTable GROUP BY sub(column1, 100000) TOP 3 ORDER BY SUB(   column1, 100000 )";
+    results = Lists.newArrayList(new Serializable[]{140528.0, 28L}, new Serializable[]{194355.0, 12L},
+        new Serializable[]{532157.0, 12L});
+    numEntriesScannedPostFilter = 120000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // Object type aggregation - comparable intermediate results (AVG, MINMAXRANGE)
+    query = "SELECT AVG(column6) FROM testTable GROUP BY column11  ORDER BY column11";
+    results = Lists.newArrayList(new Serializable[]{"", 296467636.0}, new Serializable[]{"P", 909380310.3521485},
+        new Serializable[]{"gFuH", 296467636.0}, new Serializable[]{"o", 296467636.0},
+        new Serializable[]{"t", 526245333.3900426});
+    numEntriesScannedPostFilter = 240000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    query = "SELECT AVG(column6) FROM testTable GROUP BY column11 ORDER BY AVG(column6), column11 DESC";
+    results = Lists.newArrayList(new Serializable[]{"o", 296467636.0}, new Serializable[]{"gFuH", 296467636.0},
+        new Serializable[]{"", 296467636.0}, new Serializable[]{"t", 526245333.3900426},
+        new Serializable[]{"P", 909380310.3521485});
+    numEntriesScannedPostFilter = 240000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // Object type aggregation - non comparable intermediate results (DISTINCTCOUNT)
+    query = "SELECT DISTINCTCOUNT(column11) FROM testTable GROUP BY column12 ORDER BY column12";
+    results = Lists.newArrayList(new Serializable[]{"HEuxNvH", 5}, new Serializable[]{"KrNxpdycSiwoRohEiTIlLqDHnx", 5},
+        new Serializable[]{"MaztCmmxxgguBUxPti", 5}, new Serializable[]{"TTltMtFiRqUjvOG", 3},
+        new Serializable[]{"XcBNHe", 2}, new Serializable[]{"dJWwFk", 4}, new Serializable[]{"fykKFqiw", 3},
+        new Serializable[]{"gFuH", 3}, new Serializable[]{"oZgnrlDEtjjVpUoFLol", 4});
+    numEntriesScannedPostFilter = 240000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    query =
+        "SELECT DISTINCTCOUNT(column11) FROM testTable GROUP BY column12 ORDER BY DISTINCTCOUNT(column11), column12 DESC";
+    results = Lists.newArrayList(new Serializable[]{"XcBNHe", 2}, new Serializable[]{"gFuH", 3},
+        new Serializable[]{"fykKFqiw", 3}, new Serializable[]{"TTltMtFiRqUjvOG", 3},
+        new Serializable[]{"oZgnrlDEtjjVpUoFLol", 4}, new Serializable[]{"dJWwFk", 4},
+        new Serializable[]{"MaztCmmxxgguBUxPti", 5}, new Serializable[]{"KrNxpdycSiwoRohEiTIlLqDHnx", 5},
+        new Serializable[]{"HEuxNvH", 5});
+    numEntriesScannedPostFilter = 240000;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    // empty results
+    query =
+        "SELECT MIN(column6) FROM testTable where column12='non-existent-value' GROUP BY column11 order by column11";
+    results = new ArrayList<>(0);
+    numDocsScanned = 0;
+    numEntriesScannedPostFilter = 0;
+    data.add(new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        numTotalDocs});
+
+    return data.toArray(new Object[data.size()][]);
+  }
+  }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.function.Function;
 import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.response.broker.SelectionResults;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
@@ -119,7 +120,7 @@ public class QueriesTestUtils {
     }
   }
 
-  public static void testInterSegmentAggregationOrderedGroupByResult(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,
+  public static void testInterSegmentGroupByOrderByResult(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,
       long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter, long expectedNumTotalDocs,
       List<Serializable[]> expectedResults) {
     Assert.assertEquals(brokerResponse.getNumDocsScanned(), expectedNumDocsScanned);
@@ -127,8 +128,8 @@ public class QueriesTestUtils {
     Assert.assertEquals(brokerResponse.getNumEntriesScannedPostFilter(), expectedNumEntriesScannedPostFilter);
     Assert.assertEquals(brokerResponse.getTotalDocs(), expectedNumTotalDocs);
 
-    SelectionResults selectionResults = brokerResponse.getSelectionResults();
-    List<Serializable[]> actualResults = selectionResults.getRows();
+    ResultTable resultTable = brokerResponse.getResultTable();
+    List<Serializable[]> actualResults = resultTable.getRows();
 
     Assert.assertEquals(actualResults.size(), expectedResults.size());
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -19,11 +19,13 @@
 package org.apache.pinot.queries;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.SelectionResults;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
@@ -114,6 +116,24 @@ public class QueriesTestUtils {
         // Group-by.
         Assert.assertEquals(responseMapper.apply(aggregationResult.getGroupByResult().get(0).getValue()), expectedAggregationResult);
       }
+    }
+  }
+
+  public static void testInterSegmentAggregationOrderedGroupByResult(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,
+      long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter, long expectedNumTotalDocs,
+      List<Serializable[]> expectedResults) {
+    Assert.assertEquals(brokerResponse.getNumDocsScanned(), expectedNumDocsScanned);
+    Assert.assertEquals(brokerResponse.getNumEntriesScannedInFilter(), expectedNumEntriesScannedInFilter);
+    Assert.assertEquals(brokerResponse.getNumEntriesScannedPostFilter(), expectedNumEntriesScannedPostFilter);
+    Assert.assertEquals(brokerResponse.getTotalDocs(), expectedNumTotalDocs);
+
+    SelectionResults selectionResults = brokerResponse.getSelectionResults();
+    List<Serializable[]> actualResults = selectionResults.getRows();
+
+    Assert.assertEquals(actualResults.size(), expectedResults.size());
+
+    for (int i = 0; i < actualResults.size(); i++) {
+      Assert.assertEquals(Arrays.asList(actualResults.get(i)), Arrays.asList(expectedResults.get(i)));
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/AggregationGroupByTrimmingServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/AggregationGroupByTrimmingServiceTest.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.response.broker.GroupByResult;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
+import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -64,8 +65,7 @@ public class AggregationGroupByTrimmingServiceTest {
       List<String> group = new ArrayList<>(NUM_GROUP_KEYS);
       for (int i = 0; i < NUM_GROUP_KEYS; i++) {
         // Randomly generate group key without GROUP_KEY_DELIMITER
-        group.add(RandomStringUtils.random(RANDOM.nextInt(10))
-            .replace(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER, ""));
+        group.add(RandomStringUtils.random(RANDOM.nextInt(10)).replace(GroupKeyGenerator.DELIMITER, ""));
       }
       groupSet.add(buildGroupString(group));
     }
@@ -74,7 +74,7 @@ public class AggregationGroupByTrimmingServiceTest {
     // Explicitly set an empty group
     StringBuilder emptyGroupBuilder = new StringBuilder();
     for (int i = 1; i < NUM_GROUP_KEYS; i++) {
-      emptyGroupBuilder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
+      emptyGroupBuilder.append(GroupKeyGenerator.DELIMITER);
     }
     _groups.set(NUM_GROUPS - 1, emptyGroupBuilder.toString());
 
@@ -136,7 +136,7 @@ public class AggregationGroupByTrimmingServiceTest {
     StringBuilder groupStringBuilder = new StringBuilder();
     for (int i = 0; i < NUM_GROUP_KEYS; i++) {
       if (i != 0) {
-        groupStringBuilder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
+        groupStringBuilder.append(GroupKeyGenerator.DELIMITER);
       }
       groupStringBuilder.append(group.get(i));
     }

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -181,7 +181,7 @@ public class NoDictionaryGroupKeyGeneratorTest {
       for (int i = 0; i < groupByColumns.length; i++) {
         stringBuilder.append(row.getValue(groupByColumns[i]));
         if (i < groupByColumns.length - 1) {
-          stringBuilder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
+          stringBuilder.append(GroupKeyGenerator.DELIMITER);
         }
       }
       groupKeys.add(stringBuilder.toString());

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
@@ -1,0 +1,247 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pinot.common.request.AggregationInfo;
+import org.apache.pinot.common.request.SelectionSort;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
+import org.apache.pinot.core.data.table.IndexedTable;
+import org.apache.pinot.core.data.table.Key;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.core.query.utils.Pair;
+import org.apache.pinot.core.util.GroupByUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = {"-server", "-Xmx8G", "-XX:MaxDirectMemorySize=16G"})
+public class BenchmarkCombineGroupBy {
+
+  private static final int TOP_N = 500;
+  private static final int NUM_SEGMENTS = 4;
+  private static final int NUM_RECORDS_PER_SEGMENT = 100_000;
+  private static final int CARDINALITY_D1 = 500;
+  private static final int CARDINALITY_D2 = 500;
+  private Random _random = new Random();
+
+  private DataSchema _dataSchema;
+  private List<AggregationInfo> _aggregationInfos;
+  private AggregationFunction[] _aggregationFunctions;
+  private List<SelectionSort> _orderBy;
+  private int _numAggregationFunctions;
+
+  private List<String> _d1;
+  private List<Integer> _d2;
+
+  private ExecutorService _executorService;
+
+  @Setup
+  public void setup() {
+
+    // create data
+    _d1 = new ArrayList<>(CARDINALITY_D1);
+    for (int i = 0; i < CARDINALITY_D1; i++) {
+      _d1.add(RandomStringUtils.randomAlphabetic(4));
+    }
+
+    _d2 = new ArrayList<>(CARDINALITY_D2);
+    for (int i = 0; i < CARDINALITY_D2; i++) {
+      _d2.add(i);
+    }
+
+    _dataSchema = new DataSchema(new String[]{"d1", "d2", "sum(m1)", "max(m2)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
+            DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+
+    AggregationInfo agg1 = new AggregationInfo();
+    Map<String, String> params1 = new HashMap<>();
+    params1.put("column", "m1");
+    agg1.setAggregationParams(params1);
+    agg1.setAggregationType("sum");
+    AggregationInfo agg2 = new AggregationInfo();
+    Map<String, String> params2 = new HashMap<>();
+    params2.put("column", "m2");
+    agg2.setAggregationParams(params2);
+    agg2.setAggregationType("max");
+    _aggregationInfos = Lists.newArrayList(agg1, agg2);
+
+    _numAggregationFunctions = 2;
+    _aggregationFunctions = new AggregationFunction[_numAggregationFunctions];
+    for (int i = 0; i < _numAggregationFunctions; i++) {
+      AggregationInfo aggregationInfo = _aggregationInfos.get(i);
+      String functionName = aggregationInfo.getAggregationType();
+      _aggregationFunctions[i] = AggregationFunctionFactory.getAggregationFunction(functionName);
+    }
+
+    SelectionSort orderBy = new SelectionSort();
+    orderBy.setColumn("sum(m1)");
+    orderBy.setIsAsc(true);
+    _orderBy = Lists.newArrayList(orderBy);
+
+    _executorService = Executors.newFixedThreadPool(10);
+  }
+
+  @TearDown
+  public void destroy() {
+    _executorService.shutdown();
+  }
+
+  private Record getRecord() {
+    Object[] keys = new Object[]{_d1.get(_random.nextInt(_d1.size())), _d2.get(_random.nextInt(_d2.size()))};
+    Object[] values = new Object[]{(double) _random.nextInt(1000), (double) _random.nextInt(1000)};
+    return new Record(new Key(keys), values);
+  }
+
+  private Pair<String, Object[]> getOriginalRecord() {
+    String stringKey = Joiner.on(GroupKeyGenerator.DELIMITER)
+        .join(_d1.get(_random.nextInt(_d1.size())), _d2.get(_random.nextInt(_d2.size())));
+    Object[] values = new Object[]{(double) _random.nextInt(1000), (double) _random.nextInt(1000)};
+    return new Pair<>(stringKey, values);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void concurrentIndexedTableForCombineGroupBy() throws InterruptedException, ExecutionException, TimeoutException {
+
+    int capacity = GroupByUtils.getTableCapacity(TOP_N);
+
+    // make 1 concurrent table
+    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable();
+    concurrentIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, capacity, false);
+
+    List<Callable<Void>> innerSegmentCallables = new ArrayList<>(NUM_SEGMENTS);
+
+    // 10 parallel threads putting 10k records into the table
+
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+
+      Callable<Void> callable = () -> {
+
+        for (int r = 0; r < NUM_RECORDS_PER_SEGMENT; r++) {
+          concurrentIndexedTable.upsert(getRecord());
+        }
+        return null;
+      };
+      innerSegmentCallables.add(callable);
+    }
+
+    List<Future<Void>> futures = _executorService.invokeAll(innerSegmentCallables);
+    for (Future<Void> future : futures) {
+      future.get(30, TimeUnit.SECONDS);
+    }
+
+    concurrentIndexedTable.finish();
+  }
+
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void originalCombineGroupBy() throws InterruptedException, TimeoutException, ExecutionException {
+
+    AtomicInteger numGroups = new AtomicInteger();
+    int _interSegmentNumGroupsLimit = 200_000;
+
+    ConcurrentMap<String, Object[]> resultsMap = new ConcurrentHashMap<>();
+    List<Callable<Void>> innerSegmentCallables = new ArrayList<>(NUM_SEGMENTS);
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      Callable<Void> callable = () -> {
+        for (int r = 0; r < NUM_RECORDS_PER_SEGMENT; r++) {
+
+          Pair<String, Object[]> newRecordOriginal = getOriginalRecord();
+          String stringKey = newRecordOriginal.getFirst();
+          final Object[] value = newRecordOriginal.getSecond();
+
+          resultsMap.compute(stringKey, (k, v) -> {
+            if (v == null) {
+              if (numGroups.getAndIncrement() < _interSegmentNumGroupsLimit) {
+                v = new Object[_numAggregationFunctions];
+                for (int j = 0; j < _numAggregationFunctions; j++) {
+                  v[j] = value[j];
+                }
+              }
+            } else {
+              for (int j = 0; j < _numAggregationFunctions; j++) {
+                v[j] = _aggregationFunctions[j].merge(v[j], value[j]);
+              }
+            }
+            return v;
+          });
+        }
+        return null;
+      };
+      innerSegmentCallables.add(callable);
+    }
+
+    List<Future<Void>> futures = _executorService.invokeAll(innerSegmentCallables);
+    for (Future<Void> future : futures) {
+      future.get(30, TimeUnit.SECONDS);
+    }
+
+    //AggregationGroupByTrimmingService aggregationGroupByTrimmingService =
+      //  new AggregationGroupByTrimmingService(_aggregationFunctions, TOP_N);
+    //List<Map<String, Object>> trimmedResults = aggregationGroupByTrimmingService.trimIntermediateResultsMap(resultsMap);
+  }
+
+  public static void main(String[] args) throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkCombineGroupBy.class.getSimpleName())
+        .warmupTime(TimeValue.seconds(10))
+        .warmupIterations(1)
+        .measurementTime(TimeValue.seconds(30))
+        .measurementIterations(3)
+        .forks(1);
+
+    new Runner(opt.build()).run();
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
@@ -118,9 +118,7 @@ public class BenchmarkCombineGroupBy {
     _numAggregationFunctions = 2;
     _aggregationFunctions = new AggregationFunction[_numAggregationFunctions];
     for (int i = 0; i < _numAggregationFunctions; i++) {
-      AggregationInfo aggregationInfo = _aggregationInfos.get(i);
-      String functionName = aggregationInfo.getAggregationType();
-      _aggregationFunctions[i] = AggregationFunctionFactory.getAggregationFunction(functionName);
+      _aggregationFunctions[i] = AggregationFunctionFactory.getAggregationFunction(_aggregationInfos.get(i), null);
     }
 
     SelectionSort orderBy = new SelectionSort();
@@ -158,7 +156,7 @@ public class BenchmarkCombineGroupBy {
 
     // make 1 concurrent table
     IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable();
-    concurrentIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, capacity, false);
+    concurrentIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, capacity);
 
     List<Callable<Void>> innerSegmentCallables = new ArrayList<>(NUM_SEGMENTS);
 
@@ -181,7 +179,7 @@ public class BenchmarkCombineGroupBy {
       future.get(30, TimeUnit.SECONDS);
     }
 
-    concurrentIndexedTable.finish();
+    concurrentIndexedTable.finish(false);
   }
 
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -21,9 +21,11 @@ package org.apache.pinot.perf;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -77,10 +79,12 @@ public class BenchmarkIndexedTable {
   public void setup() {
     // create data
     int cardinalityD1 = 100;
-    _d1 = new ArrayList<>(cardinalityD1);
-    for (int i = 0; i < cardinalityD1; i++) {
-      _d1.add(RandomStringUtils.randomAlphabetic(3));
+    Set<String> d1 = new HashSet<>(cardinalityD1);
+    while (d1.size() < cardinalityD1) {
+      d1.add(RandomStringUtils.randomAlphabetic(3));
     }
+    _d1 = new ArrayList<>(cardinalityD1);
+    _d1.addAll(d1);
 
     int cardinalityD2 = 100;
     _d2 = new ArrayList<>(cardinalityD2);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -134,7 +134,7 @@ public class BenchmarkIndexedTable {
 
     // make 1 concurrent table
     IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable();
-    concurrentIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, CAPACITY);
+    concurrentIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, CAPACITY, false);
 
     List<Callable<Void>> innerSegmentCallables = new ArrayList<>(numSegments);
 
@@ -174,7 +174,7 @@ public class BenchmarkIndexedTable {
 
       // make 10 indexed tables
       IndexedTable simpleIndexedTable = new SimpleIndexedTable();
-      simpleIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, CAPACITY);
+      simpleIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, CAPACITY, false);
       simpleIndexedTables.add(simpleIndexedTable);
 
       // put 10k records in each indexed table, in parallel

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -132,7 +132,7 @@ public class BenchmarkIndexedTable {
 
     // make 1 concurrent table
     IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable();
-    concurrentIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, CAPACITY, false);
+    concurrentIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, CAPACITY);
 
     // 10 parallel threads putting 10k records into the table
 
@@ -156,7 +156,7 @@ public class BenchmarkIndexedTable {
       if (!opCompleted) {
         System.out.println("Timed out............");
       }
-      concurrentIndexedTable.finish();
+      concurrentIndexedTable.finish(false);
     } catch (Exception e) {
       throw e;
     } finally {
@@ -184,7 +184,7 @@ public class BenchmarkIndexedTable {
 
       // make 10 indexed tables
       IndexedTable simpleIndexedTable = new SimpleIndexedTable();
-      simpleIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, CAPACITY, false);
+      simpleIndexedTable.init(_dataSchema, _aggregationInfos, _orderBy, CAPACITY);
       simpleIndexedTables.add(simpleIndexedTable);
 
       // put 10k records in each indexed table, in parallel
@@ -192,7 +192,7 @@ public class BenchmarkIndexedTable {
         for (int r = 0; r < NUM_RECORDS; r++) {
           simpleIndexedTable.upsert(getNewRecord());
         }
-        simpleIndexedTable.finish();
+        simpleIndexedTable.finish(false);
         return null;
       };
       innerSegmentCallables.add(callable);
@@ -212,7 +212,7 @@ public class BenchmarkIndexedTable {
         mergedTable.merge(indexedTable);
       }
     }
-    mergedTable.finish();
+    mergedTable.finish(false);
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
This PR contains the implementation of ORDER BY support in group by.

In this first pass, the changes have been done from `CombineGroupByOrderByOperator` upwards. The AggregationGroupByOperator hasn't been changed.

`IndexedTable` is used wherever possible (to merge results in CombineGroupByOrderByOperator, and then to reduce results across servers in the BrokerReduceService)

`ResultTable` has been introduced, as a standard way to return results to the client.

2 `queryOptions` have been introduced:
1. groupByMode - pql/sql - whether to execute the group by in PQL style (split all aggregations and ignore order by) or standard SQL style
2. responseFormat - pql/sql - whether to present results using List<AggregationResults> (the PQL way), or use ResultTable which is closer to the SQL way.
By default, the modes are PQL, PQL
In order to get the order by results in ResultTable, modes should be SQL,SQL
In order to get the order by results, but in List<AggregationResult>, modes should be SQL,PQL
These modes can be added to the JSON payload:
`curl -H "Content-Type: application/json" -X POST -d '{"sql":"select count(*) from table group by dim1 order by dim1","queryOptions":"groupByMode=sql;responseFormat=sql"}' http://localhost:8099/query`

Pending: Benchmarking.
A comparison should be done of `SELECT agg1 FROM table GROUP BY group1, group2 ORDER by agg1 DESC` with the performance of the original `SELECT agg1 FROM table GROUP BY group1, group2` as the results are expected to be identical.
We can also compare `SELECT agg1,agg2... FROM table GROUP BY group1, group2 ORDER by agg1 DESC` with the performance of the original `SELECT agg1,agg2... FROM table GROUP BY group1, group2`. The groups will be different in the latter, but it is comparable in terms of result size.

Next steps: Push IndexedTable down into the AggregationGroupByOperator. We can introduce new operators, for each strategy we're trying out (1 ConcurrentIndexedTable, multiple SimpleIndexedTable, etc)