### PR TITLE
Add column types info to the selection and aggregation query results.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/AggregationResult.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/AggregationResult.java
@@ -23,12 +23,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 
 /**
  * This class models the aggregation and aggregationGroupBy sections of query response.
  */
-@JsonPropertyOrder({"groupByResult", "function", "groupByColumns"})
+@JsonPropertyOrder({"groupByResult", "function", "groupByColumns", "valueType"})
 public class AggregationResult {
 
   private Serializable _value;
@@ -36,6 +37,7 @@ public class AggregationResult {
 
   List<GroupByResult> _groupByResults;
   List<String> _groupByColumns;
+  private String _valueType;
 
   /**
    * Default constructor, required by JSON de-serializer.
@@ -134,12 +136,13 @@ public class AggregationResult {
     return _groupByColumns;
   }
 
-  /**
-   * Set groupByColumns for the aggregation function.
-   * @param groupByColumns
-   */
-  @JsonProperty("groupByColumns")
-  public void setGroupByColumns(List<String> groupByColumns) {
-    _groupByColumns = groupByColumns;
+  @JsonProperty("valueType")
+  public String getValueType() {
+    return _valueType;
+  }
+
+  @JsonProperty("valueType")
+  public void setValueType(String valueType) {
+    _valueType = valueType;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/SelectionResults.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/SelectionResults.java
@@ -23,18 +23,28 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 
-@JsonPropertyOrder({"columns", "results"})
+@JsonPropertyOrder({"columns", "results", "columnTypes"})
 public class SelectionResults {
   private List<String> _columns;
   private List<Serializable[]> _rows;
+  private Map<String, String> _columnTypes;
+
+  /* Deprecated */
+  public SelectionResults(@JsonProperty("columns") List<String> columns,
+      @JsonProperty("results") List<Serializable[]> results) {
+    this(columns, results, null);
+  }
 
   @JsonCreator
   public SelectionResults(@JsonProperty("columns") List<String> columns,
-      @JsonProperty("results") List<Serializable[]> results) {
+      @JsonProperty("results") List<Serializable[]> rows,
+      @JsonProperty("columnTypes") Map<String, String> columnTypes) {
     _columns = columns;
-    _rows = results;
+    _rows = rows;
+    _columnTypes = columnTypes;
   }
 
   @JsonProperty("columns")
@@ -55,5 +65,15 @@ public class SelectionResults {
   @JsonProperty("results")
   public void setRows(List<Serializable[]> rows) {
     _rows = rows;
+  }
+
+  @JsonProperty("columnTypes")
+  public Map<String, String> getColumnTypes() {
+    return _columnTypes;
+  }
+
+  @JsonProperty("columnTypes")
+  public void setColumnTypes(Map<String, String> columnTypes) {
+    _columnTypes = columnTypes;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pinot.common.utils;
 
+import com.google.common.base.Preconditions;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.data.FieldSpec;
 
@@ -34,10 +37,21 @@ import org.apache.pinot.common.data.FieldSpec;
 public class DataSchema {
   private String[] _columnNames;
   private ColumnDataType[] _columnDataTypes;
+  private Map<String, String> _columnTypeMap;
 
   public DataSchema(@Nonnull String[] columnNames, @Nonnull ColumnDataType[] columnDataTypes) {
     _columnNames = columnNames;
     _columnDataTypes = columnDataTypes;
+    makeColumnType(_columnNames, _columnDataTypes);
+  }
+
+  private void makeColumnType(String[] columnNames, ColumnDataType[] columnDataTypes) {
+    _columnTypeMap = new HashMap<>();
+    Preconditions.checkState(columnNames.length == columnDataTypes.length, "columnName array has"
+        + "different length as column types");
+    for(int i = 0; i < columnNames.length; i++) {
+      _columnTypeMap.put(columnNames[i], columnDataTypes[i].toString());
+    }
   }
 
   public int size() {
@@ -52,6 +66,11 @@ public class DataSchema {
   @Nonnull
   public ColumnDataType getColumnDataType(int index) {
     return _columnDataTypes[index];
+  }
+
+  @Nonnull
+  public Map<String, String> getColumnTypes() {
+    return  _columnTypeMap;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
@@ -75,7 +75,7 @@ public class SelectionOperatorService {
   private final int _selectionOffset;
   private final int _maxNumRows;
   private final PriorityQueue<Serializable[]> _rows;
-
+  private final Map<String, String> _selectionColumnTypes;
   private long _numDocsScanned = 0;
 
   /**
@@ -94,6 +94,7 @@ public class SelectionOperatorService {
     _selectionOffset = selection.getOffset();
     _maxNumRows = _selectionOffset + selection.getSize();
     _rows = new PriorityQueue<>(_maxNumRows, getStrictComparator());
+    _selectionColumnTypes = _dataSchema.getColumnTypes();
   }
 
   /**
@@ -112,6 +113,7 @@ public class SelectionOperatorService {
     _selectionOffset = selection.getOffset();
     _maxNumRows = _selectionOffset + selection.getSize();
     _rows = new PriorityQueue<>(_maxNumRows, getTypeCompatibleComparator());
+    _selectionColumnTypes = _dataSchema.getColumnTypes();
   }
 
   /**
@@ -330,6 +332,6 @@ public class SelectionOperatorService {
       rowsInSelectionResults.addFirst(SelectionOperatorUtils.extractColumns(_rows.poll(), columnIndices));
     }
 
-    return new SelectionResults(_selectionColumns, rowsInSelectionResults);
+    return new SelectionResults(_selectionColumns, rowsInSelectionResults, _selectionColumnTypes);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -428,7 +428,7 @@ public class SelectionOperatorUtils {
     for (int i = 0; i < numRows; i++) {
       rows.set(i, extractColumns(rows.get(i), columnIndices));
     }
-    return new SelectionResults(selectionColumns, rows);
+    return new SelectionResults(selectionColumns, rows, dataSchema.getColumnTypes());
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -138,15 +138,17 @@ public class FastHllQueriesTest extends BaseQueriesTest {
 
     // Test inter segments base query
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(BASE_QUERY);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 4L, 0L, 8L, 120000L, new String[]{"21", "1762"});
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 4L, 0L, 8L, 120000L, new String[]{"21", "1762"},
+        new String[]{"OBJECT", "OBJECT"});
     // Test inter segments query with filter
     brokerResponse = getBrokerResponseForQueryWithFilter(BASE_QUERY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 449916L, 49032L, 120000L,
-        new String[]{"17", "1197"});
+        new String[]{"17", "1197"}, new String[]{"OBJECT", "OBJECT"});
     // Test inter segments query with group-by
     brokerResponse = getBrokerResponseForQuery(BASE_QUERY + GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 18452L, 0L, 55356L, 120000L, new String[]{"21", "1762"});
+        .testInterSegmentAggregationResult(brokerResponse, 18452L, 0L, 55356L, 120000L, new String[]{"21", "1762"},
+            new String[]{"OBJECT", "OBJECT"});
 
     deleteSegment();
   }
@@ -187,15 +189,17 @@ public class FastHllQueriesTest extends BaseQueriesTest {
     // Test inter segments base query
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(BASE_QUERY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L, new String[]{"21", "1762"});
+        .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L, new String[]{"21", "1762"},
+            new String[]{"OBJECT", "OBJECT"});
     // Test inter segments query with filter
     brokerResponse = getBrokerResponseForQueryWithFilter(BASE_QUERY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"17", "1197"});
+        new String[]{"17", "1197"}, new String[]{"OBJECT", "OBJECT"});
     // Test inter segments query with group-by
     brokerResponse = getBrokerResponseForQuery(BASE_QUERY + GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L, new String[]{"21", "1762"});
+        .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L, new String[]{"21", "1762"},
+            new String[]{"OBJECT", "OBJECT"});
 
     deleteSegment();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
@@ -39,19 +39,23 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"426752"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"426752"},
+            new String[]{"LONG"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"62480"});
+    QueriesTestUtils
+        .testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L, new String[]{"62480"},
+            new String[]{"LONG"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"231056"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"231056"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"199896"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"199896"},
+            new String[]{"OBJECT"});
   }
 
   @Test
@@ -60,19 +64,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"DOUBLE"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"DOUBLE"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
   }
 
   @Test
@@ -81,19 +85,22 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"1001.00000"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"1001.00000"},
+            new String[]{"DOUBLE"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"1009.00000"});
+        new String[]{"1009.00000"}, new String[]{"DOUBLE"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"1001.00000"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"1001.00000"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"1001.00000"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"1001.00000"},
+            new String[]{"OBJECT"});
   }
 
   @Test
@@ -102,19 +109,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
-        new String[]{"484324601810280.00000"});
+        new String[]{"484324601810280.00000"}, new String[]{"DOUBLE"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"114652613591912.00000"});
+        new String[]{"114652613591912.00000"}, new String[]{"DOUBLE"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"402591409613620.00000"});
+        new String[]{"402591409613620.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"393483780531788.00000"});
+        new String[]{"393483780531788.00000"}, new String[]{"OBJECT"});
   }
 
   @Test
@@ -123,19 +130,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
-        new String[]{"1134908803.73210"});
+        new String[]{"1134908803.73210"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"1835029026.75916"});
+        new String[]{"1835029026.75916"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
   }
 
   @Test
@@ -144,19 +151,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
-        new String[]{"2147482646.00000"});
+        new String[]{"2147482646.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147482638.00000"});
+        new String[]{"2147482638.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147482646.00000"});
+        new String[]{"2147482646.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147482646.00000"});
+        new String[]{"2147482646.00000"}, new String[]{"OBJECT"});
   }
 
   @Test
@@ -165,19 +172,23 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"18499"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"18499"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"1186"});
+    QueriesTestUtils
+        .testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L, new String[]{"1186"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"4784"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"4784"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"3434"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"3434"},
+            new String[]{"OBJECT"});
   }
 
   @Test
@@ -186,19 +197,23 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"20039"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"20039"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"1296"});
+    QueriesTestUtils
+        .testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L, new String[]{"1296"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"4715"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"4715"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"3490"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"3490"},
+            new String[]{"OBJECT"});
   }
 
   @Test
@@ -208,19 +223,23 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, cardinalityExtractor, new String[]{"20039"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, cardinalityExtractor, new String[]{"20039"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        cardinalityExtractor, new String[]{"1296"});
+    QueriesTestUtils
+        .testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L, cardinalityExtractor, new String[]{"1296"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, cardinalityExtractor, new String[]{"4715"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, cardinalityExtractor, new String[]{"4715"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, cardinalityExtractor, new String[]{"3490"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, cardinalityExtractor, new String[]{"3490"},
+            new String[]{"OBJECT"});
   }
 
   @Test
@@ -229,19 +248,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
   }
 
   @Test
@@ -250,19 +269,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
   }
 
   @Test
@@ -271,19 +290,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
   }
 
   @Test
@@ -292,19 +311,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
-        new String[]{"2147483647.00000"});
+        new String[]{"2147483647.00000"}, new String[]{"OBJECT"});
   }
 
   @Test
@@ -313,19 +332,22 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147483647"});
+        new String[]{"2147483647"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
   }
 
   @Test
@@ -334,19 +356,22 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147483647"});
+        new String[]{"2147483647"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
   }
 
   @Test
@@ -355,19 +380,22 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147483647"});
+        new String[]{"2147483647"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
   }
 
   @Test
@@ -376,19 +404,22 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
-        new String[]{"2147483647"});
+        new String[]{"2147483647"}, new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
+        .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"},
+            new String[]{"OBJECT"});
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
@@ -38,19 +38,25 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L, new String[]{"120000"});
+        .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L, new String[]{"120000"},
+            new String[]{"LONG"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 0L, 120000L, new String[]{"24516"});
+        .testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 0L, 120000L, new String[]{"24516"},
+            new String[]{"LONG"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    // Note the difference about result column type of a group by query and a non-group by query. It is due to the loss
+    // of type info about the aggregation function in the schema for a group-by query currently.
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 120000L, 120000L, new String[]{"64420"});
+        .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 120000L, 120000L, new String[]{"64420"},
+            new String[]{"OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 24516L, 120000L, new String[]{"17080"});
+        .testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 24516L, 120000L, new String[]{"17080"},
+            new String[]{"OBJECT"});
   }
 
   @Test
@@ -61,19 +67,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     // numEntriesScannedPostFilter are 0
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L,
-        new String[]{"2146952047.00000", "2147419555.00000"});
+        new String[]{"2146952047.00000", "2147419555.00000"}, new String[]{"DOUBLE", "DOUBLE"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"2146952047.00000", "999813884.00000"});
+        new String[]{"2146952047.00000", "999813884.00000"}, new String[]{"DOUBLE", "DOUBLE"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146952047.00000", "2147419555.00000"});
+        new String[]{"2146952047.00000", "2147419555.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2146952047.00000", "999813884.00000"});
+        new String[]{"2146952047.00000", "999813884.00000"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -84,19 +90,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     // numEntriesScannedPostFilter are 0
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L,
-        new String[]{"240528.00000", "17891.00000"});
+        new String[]{"240528.00000", "17891.00000"}, new String[]{"DOUBLE", "DOUBLE"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"101116473.00000", "20396372.00000"});
+        new String[]{"101116473.00000", "20396372.00000"}, new String[]{"DOUBLE", "DOUBLE"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"240528.00000", "17891.00000"});
+        new String[]{"240528.00000", "17891.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"101116473.00000", "20396372.00000"});
+        new String[]{"101116473.00000", "20396372.00000"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -105,19 +111,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"129268741751388.00000", "129156636756600.00000"});
+        new String[]{"129268741751388.00000", "129156636756600.00000"}, new String[]{"DOUBLE", "DOUBLE"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"27503790384288.00000", "12429178874916.00000"});
+        new String[]{"27503790384288.00000", "12429178874916.00000"}, new String[]{"DOUBLE", "DOUBLE"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"69526727335224.00000", "69225631719808.00000"});
+        new String[]{"69526727335224.00000", "69225631719808.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"19058003631876.00000", "8606725456500.00000"});
+        new String[]{"19058003631876.00000", "8606725456500.00000"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -126,19 +132,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"1077239514.59490", "1076305306.30500"});
+        new String[]{"1077239514.59490", "1076305306.30500"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"1121871038.68037", "506982332.96280"});
+        new String[]{"1121871038.68037", "506982332.96280"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2142595699.00000", "2141451242.00000"});
+        new String[]{"2142595699.00000", "2141451242.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2142595699.00000", "999309554.00000"});
+        new String[]{"2142595699.00000", "999309554.00000"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -149,19 +155,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     // numEntriesScannedPostFilter are 0
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L,
-        new String[]{"2146711519.00000", "2147401664.00000"});
+        new String[]{"2146711519.00000", "2147401664.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"2045835574.00000", "979417512.00000"});
+        new String[]{"2045835574.00000", "979417512.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146711519.00000", "2146612605.00000"});
+        new String[]{"2146711519.00000", "2146612605.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2044094181.00000", "979417512.00000"});
+        new String[]{"2044094181.00000", "979417512.00000"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -170,19 +176,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"6582", "21910"});
+        new String[]{"6582", "21910"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"1872", "4556"});
+        new String[]{"1872", "4556"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"3495", "11961"});
+        new String[]{"3495", "11961"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"1272", "3289"});
+        new String[]{"1272", "3289"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -191,19 +197,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"5977", "23825"});
+        new String[]{"5977", "23825"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"1886", "4492"});
+        new String[]{"1886", "4492"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"3592", "11889"});
+        new String[]{"3592", "11889"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"1324", "3197"});
+        new String[]{"1324", "3197"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -214,22 +220,22 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         cardinalityExtractor,
-        new String[]{"5977", "23825"});
+        new String[]{"5977", "23825"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         cardinalityExtractor,
-        new String[]{"1886", "4492"});
+        new String[]{"1886", "4492"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         cardinalityExtractor,
-        new String[]{"3592", "11889"});
+        new String[]{"3592", "11889"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         cardinalityExtractor,
-        new String[]{"1324", "3197"});
+        new String[]{"1324", "3197"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -238,19 +244,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"1107310944.00000", "1080136306.00000"});
+        new String[]{"1107310944.00000", "1080136306.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"1139674505.00000", "505053732.00000"});
+        new String[]{"1139674505.00000", "505053732.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146791843.00000", "2141451242.00000"});
+        new String[]{"2146791843.00000", "2141451242.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2142595699.00000", "999309554.00000"});
+        new String[]{"2142595699.00000", "999309554.00000"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -259,19 +265,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"1943040511.00000", "1936611145.00000"});
+        new String[]{"1943040511.00000", "1936611145.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"1936730975.00000", "899534534.00000"});
+        new String[]{"1936730975.00000", "899534534.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146791843.00000", "2147278341.00000"});
+        new String[]{"2146791843.00000", "2147278341.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2142595699.00000", "999309554.00000"});
+        new String[]{"2142595699.00000", "999309554.00000"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -280,19 +286,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"2071559385.00000", "2042409652.00000"});
+        new String[]{"2071559385.00000", "2042409652.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"2096857943.00000", "947763150.00000"});
+        new String[]{"2096857943.00000", "947763150.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146791843.00000", "2147419555.00000"});
+        new String[]{"2146791843.00000", "2147419555.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2142595699.00000", "999309554.00000"});
+        new String[]{"2142595699.00000", "999309554.00000"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -301,19 +307,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"2139354437.00000", "2125299552.00000"});
+        new String[]{"2139354437.00000", "2125299552.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"2146232405.00000", "990669195.00000"});
+        new String[]{"2146232405.00000", "990669195.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146791843.00000", "2147419555.00000"});
+        new String[]{"2146791843.00000", "2147419555.00000"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2146232405.00000", "999309554.00000"});
+        new String[]{"2146232405.00000", "999309554.00000"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -322,19 +328,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"1107310944", "1082130431"});
+        new String[]{"1107310944", "1082130431"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"1139674505", "509607935"});
+        new String[]{"1139674505", "509607935"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146791843", "2141451242"});
+        new String[]{"2146791843", "2141451242"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2142595699", "999309554"});
+        new String[]{"2142595699", "999309554"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -343,19 +349,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"1946157055", "1946157055"});
+        new String[]{"1946157055", "1946157055"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"1939865599", "902299647"});
+        new String[]{"1939865599", "902299647"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146791843", "2147278341"});
+        new String[]{"2146791843", "2147278341"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2142595699", "999309554"});
+        new String[]{"2142595699", "999309554"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -364,19 +370,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"2080374783", "2051014655"});
+        new String[]{"2080374783", "2051014655"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"2109734911", "950009855"});
+        new String[]{"2109734911", "950009855"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146791843", "2147419555"});
+        new String[]{"2146791843", "2147419555"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2142595699", "999309554"});
+        new String[]{"2142595699", "999309554"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test
@@ -385,19 +391,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
-        new String[]{"2143289343", "2143289343"});
+        new String[]{"2143289343", "2143289343"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
-        new String[]{"2146232405", "991952895"});
+        new String[]{"2146232405", "991952895"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
-        new String[]{"2146791843", "2147419555"});
+        new String[]{"2146791843", "2147419555"}, new String[]{"OBJECT", "OBJECT"});
 
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
-        new String[]{"2146232405", "999309554"});
+        new String[]{"2146232405", "999309554"}, new String[]{"OBJECT", "OBJECT"});
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentSelectionSingleValueQueriesTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.queries;
 
 import java.util.ArrayList;
@@ -28,7 +46,7 @@ public class InterSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     expectedColumnTypes.put("column18", "INT");
     expectedColumnTypes.put("daysSinceEpoch", "INT");
 
-    List<String> expectedColumns  = new ArrayList<>();
+    List<String> expectedColumns = new ArrayList<>();
     expectedColumns.add("column1");
     expectedColumns.add("column3");
     expectedColumns.add("column5");
@@ -50,18 +68,18 @@ public class InterSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Map<String, String> expectedColumnTypes = new HashMap<>();
     expectedColumnTypes.put("column1", "INT");
     expectedColumnTypes.put("column5", "STRING");
-    List<String> expectedColumns  = new ArrayList<>();
+    List<String> expectedColumns = new ArrayList<>();
     expectedColumns.add("column1");
     expectedColumns.add("column5");
     verifyBrokerResponse(brokerResponse, 40L, 120000L, expectedColumns, expectedColumnTypes);
   }
 
-  private void verifyBrokerResponse(BrokerResponseNative brokerResponse, long expectedNumDocsScanned, long expectedTotalDocNum, List<String> expectedColumns,
-      Map<String, String> expectedColumnTypes) {
+  private void verifyBrokerResponse(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,
+      long expectedTotalDocNum, List<String> expectedColumns, Map<String, String> expectedColumnTypes) {
     Assert.assertEquals(brokerResponse.getNumDocsScanned(), expectedNumDocsScanned);
     Assert.assertEquals(brokerResponse.getTotalDocs(), expectedTotalDocNum);
     Assert.assertEquals(brokerResponse.getSelectionResults().getColumns().size(), expectedColumns.size());
-    for(String column : expectedColumns) {
+    for (String column : expectedColumns) {
       Assert.assertTrue(brokerResponse.getSelectionResults().getColumns().contains(column));
     }
     Assert.assertEquals(brokerResponse.getSelectionResults().getColumnTypes(), expectedColumnTypes);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentSelectionSingleValueQueriesTest.java
@@ -1,0 +1,69 @@
+package org.apache.pinot.queries;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class InterSegmentSelectionSingleValueQueriesTest extends BaseSingleValueQueriesTest {
+  @Test
+  public void testSelectStar() {
+    String query = "SELECT * FROM testTable";
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    Map<String, String> expectedColumnTypes = new HashMap<>();
+    expectedColumnTypes.put("column1", "INT");
+    expectedColumnTypes.put("column3", "INT");
+    expectedColumnTypes.put("column5", "STRING");
+    expectedColumnTypes.put("column6", "INT");
+    expectedColumnTypes.put("column7", "INT");
+    expectedColumnTypes.put("column9", "INT");
+    expectedColumnTypes.put("column11", "STRING");
+    expectedColumnTypes.put("column12", "STRING");
+    expectedColumnTypes.put("column17", "INT");
+    expectedColumnTypes.put("column18", "INT");
+    expectedColumnTypes.put("daysSinceEpoch", "INT");
+
+    List<String> expectedColumns  = new ArrayList<>();
+    expectedColumns.add("column1");
+    expectedColumns.add("column3");
+    expectedColumns.add("column5");
+    expectedColumns.add("column6");
+    expectedColumns.add("column7");
+    expectedColumns.add("column9");
+    expectedColumns.add("column11");
+    expectedColumns.add("column12");
+    expectedColumns.add("column17");
+    expectedColumns.add("column18");
+    expectedColumns.add("daysSinceEpoch");
+    verifyBrokerResponse(brokerResponse, 40L, 120000L, expectedColumns, expectedColumnTypes);
+  }
+
+  @Test
+  public void testSelectColumns() {
+    String query = "SELECT column1, column5 FROM testTable";
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    Map<String, String> expectedColumnTypes = new HashMap<>();
+    expectedColumnTypes.put("column1", "INT");
+    expectedColumnTypes.put("column5", "STRING");
+    List<String> expectedColumns  = new ArrayList<>();
+    expectedColumns.add("column1");
+    expectedColumns.add("column5");
+    verifyBrokerResponse(brokerResponse, 40L, 120000L, expectedColumns, expectedColumnTypes);
+  }
+
+  private void verifyBrokerResponse(BrokerResponseNative brokerResponse, long expectedNumDocsScanned, long expectedTotalDocNum, List<String> expectedColumns,
+      Map<String, String> expectedColumnTypes) {
+    Assert.assertEquals(brokerResponse.getNumDocsScanned(), expectedNumDocsScanned);
+    Assert.assertEquals(brokerResponse.getTotalDocs(), expectedTotalDocNum);
+    Assert.assertEquals(brokerResponse.getSelectionResults().getColumns().size(), expectedColumns.size());
+    for(String column : expectedColumns) {
+      Assert.assertTrue(brokerResponse.getSelectionResults().getColumns().contains(column));
+    }
+    Assert.assertEquals(brokerResponse.getSelectionResults().getColumnTypes(), expectedColumnTypes);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -82,7 +82,7 @@ public class QueriesTestUtils {
 
   public static void testInterSegmentAggregationResult(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,
       long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter, long expectedNumTotalDocs,
-      String[] expectedAggregationResults) {
+      String[] expectedAggregationResults, String[] expectedAggregationColumnTypes) {
     testInterSegmentAggregationResult(
         brokerResponse,
         expectedNumDocsScanned,
@@ -90,12 +90,13 @@ public class QueriesTestUtils {
         expectedNumEntriesScannedPostFilter,
         expectedNumTotalDocs,
         Serializable::toString,
-        expectedAggregationResults);
+        expectedAggregationResults, expectedAggregationColumnTypes);
   }
 
   public static void testInterSegmentAggregationResult(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,
       long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter, long expectedNumTotalDocs,
-      Function<Serializable, String> responseMapper, String[] expectedAggregationResults) {
+      Function<Serializable, String> responseMapper, String[] expectedAggregationResults,
+      String[] expectedAggregationColumnTypes) {
     Assert.assertEquals(brokerResponse.getNumDocsScanned(), expectedNumDocsScanned);
     Assert.assertEquals(brokerResponse.getNumEntriesScannedInFilter(), expectedNumEntriesScannedInFilter);
     Assert.assertEquals(brokerResponse.getNumEntriesScannedPostFilter(), expectedNumEntriesScannedPostFilter);
@@ -103,10 +104,12 @@ public class QueriesTestUtils {
     List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
     int length = expectedAggregationResults.length;
     Assert.assertEquals(aggregationResults.size(), length);
+    Assert.assertEquals(expectedAggregationColumnTypes.length, length);
     for (int i = 0; i < length; i++) {
       AggregationResult aggregationResult = aggregationResults.get(i);
       String expectedAggregationResult = expectedAggregationResults[i];
       Serializable value = aggregationResult.getValue();
+      Assert.assertEquals(aggregationResult.getValueType(), expectedAggregationColumnTypes[i]);
       if (value != null) {
         // Aggregation.
         Assert.assertEquals(responseMapper.apply(value), expectedAggregationResult);


### PR DESCRIPTION
Add column types to the selection and aggregation query results. The column type info for group by columns are not added in this PR because the information right now is not present in the data schema available to the brokerReduceService. 

@kishoreg 