### PR TITLE
Make Kafka offset out of range as an transient exception.

### DIFF
--- a/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -388,7 +388,6 @@ public class KafkaConnectionHandler {
     final Errors kafkaError = Errors.forCode(kafkaErrorCode);
     switch (kafkaError) {
       case UNKNOWN:
-      case OFFSET_OUT_OF_RANGE:
       case CORRUPT_MESSAGE:
       case MESSAGE_TOO_LARGE:
       case OFFSET_METADATA_TOO_LARGE:
@@ -402,6 +401,7 @@ public class KafkaConnectionHandler {
       case INVALID_SESSION_TIMEOUT:
       case INVALID_COMMIT_OFFSET_SIZE:
         return new PermanentConsumerException(new KafkaPermanentConsumerException(kafkaError));
+      case OFFSET_OUT_OF_RANGE:
       case UNKNOWN_TOPIC_OR_PARTITION:
       case LEADER_NOT_AVAILABLE:
       case NOT_LEADER_FOR_PARTITION:

--- a/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -86,7 +86,7 @@ public class KafkaConnectionHandler {
 
   /**
    * A Kafka protocol error that indicates a situation that is not likely to clear up by retrying the request (for
-   * example, no such topic or offset out of range).
+   * example, no such topic).
    */
   private class KafkaPermanentConsumerException extends RuntimeException {
     public KafkaPermanentConsumerException(Errors error) {


### PR DESCRIPTION
During LLC migration in Uber, we found LLC consumer often stopped consumption because it is assigned a bad Kafka broker (and resulted in OFFSET_OUT_OF_RANGE error). The current way of assigning OFFSET_OUT_OF_RANGE as permanent error causes the realtime consumption to completely stop -- until a background fixer thread to revive the consumption in ~10mins. 

In a company with large number of Kafka brokers, faulty brokers occur pretty frequently. A stop of realtime ingestion for 10 mins is not acceptable due to high SLA. We rather mark the error as a transient one and let the retry to kick in to select a different broker. It works well after the error code reassignment. 