### PR TITLE
[TE] [Notification] Refactor email filters to a generalized alert filter

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.alert;
+
+import java.util.Map;
+import java.util.Objects;
+
+
+/**
+ * Container class for notification properties
+ */
+public class DetectionAlertFilterNotification {
+  Map<String, Object> notificationProps;
+
+  public DetectionAlertFilterNotification(Map<String, Object> notificationProps) {
+    this.notificationProps = notificationProps;
+  }
+
+  public Map<String, Object> getNotificationProps() {
+    return notificationProps;
+  }
+
+  public DetectionAlertFilterNotification setNotificationProps(Map<String, Object> notificationProps) {
+    this.notificationProps = notificationProps;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DetectionAlertFilterNotification that = (DetectionAlertFilterNotification) o;
+    return Objects.equals(notificationProps, that.notificationProps);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(notificationProps);
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
@@ -27,18 +27,18 @@ import java.util.Objects;
  * Container class for notification properties
  */
 public class DetectionAlertFilterNotification {
-  Map<String, Object> notificationProps;
+  Map<String, Object> notificationSchemeProps;
 
-  public DetectionAlertFilterNotification(Map<String, Object> notificationProps) {
-    this.notificationProps = notificationProps;
+  public DetectionAlertFilterNotification(Map<String, Object> notificationSchemeProps) {
+    this.notificationSchemeProps = notificationSchemeProps;
   }
 
-  public Map<String, Object> getNotificationProps() {
-    return notificationProps;
+  public Map<String, Object> getNotificationSchemeProps() {
+    return notificationSchemeProps;
   }
 
-  public DetectionAlertFilterNotification setNotificationProps(Map<String, Object> notificationProps) {
-    this.notificationProps = notificationProps;
+  public DetectionAlertFilterNotification setNotificationSchemeProps(Map<String, Object> notificationSchemeProps) {
+    this.notificationSchemeProps = notificationSchemeProps;
     return this;
   }
 
@@ -51,12 +51,12 @@ public class DetectionAlertFilterNotification {
       return false;
     }
     DetectionAlertFilterNotification that = (DetectionAlertFilterNotification) o;
-    return Objects.equals(notificationProps, that.notificationProps);
+    return Objects.equals(notificationSchemeProps, that.notificationSchemeProps);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(notificationProps);
+    return Objects.hash(notificationSchemeProps);
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterResult.java
@@ -36,7 +36,7 @@ public class DetectionAlertFilterResult {
   /**
    * The Result.
    */
-  private Map<DetectionAlertFilterRecipients, Set<MergedAnomalyResultDTO>> result;
+  private Map<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> result;
 
   /**
    * Instantiates a new Detection alert filter result.
@@ -50,7 +50,7 @@ public class DetectionAlertFilterResult {
    *
    * @param result the result
    */
-  public DetectionAlertFilterResult(Map<DetectionAlertFilterRecipients, Set<MergedAnomalyResultDTO>> result) {
+  public DetectionAlertFilterResult(Map<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> result) {
     Preconditions.checkNotNull(result);
     this.result = result;
   }
@@ -60,7 +60,7 @@ public class DetectionAlertFilterResult {
    *
    * @return the result
    */
-  public Map<DetectionAlertFilterRecipients, Set<MergedAnomalyResultDTO>> getResult() {
+  public Map<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> getResult() {
     return result;
   }
 
@@ -80,15 +80,15 @@ public class DetectionAlertFilterResult {
   /**
    * Add a mapping from anomalies to recipients in this detection alert filter result.
    *
-   * @param recipients the recipients
+   * @param alertProp the alert properties
    * @param anomalies the anomalies
    * @return the detection alert filter result
    */
-  public DetectionAlertFilterResult addMapping(DetectionAlertFilterRecipients recipients, Set<MergedAnomalyResultDTO> anomalies) {
-    if (!this.result.containsKey(recipients)) {
-      this.result.put(recipients, new HashSet<MergedAnomalyResultDTO>());
+  public DetectionAlertFilterResult addMapping(DetectionAlertFilterNotification alertProp, Set<MergedAnomalyResultDTO> anomalies) {
+    if (!this.result.containsKey(alertProp)) {
+      this.result.put(alertProp, new HashSet<MergedAnomalyResultDTO>());
     }
-    this.result.get(recipients).addAll(anomalies);
+    this.result.get(alertProp).addAll(anomalies);
     return this;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/StatefulDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/StatefulDetectionAlertFilter.java
@@ -21,6 +21,7 @@ package org.apache.pinot.thirdeye.detection.alert;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
+import java.util.stream.Collectors;
 import org.apache.pinot.thirdeye.constant.AnomalyResultSource;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
@@ -35,8 +36,15 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.MapUtils;
 
+import static org.apache.pinot.thirdeye.detection.alert.scheme.DetectionEmailAlerter.*;
+
 
 public abstract class StatefulDetectionAlertFilter extends DetectionAlertFilter {
+
+  public static final String PROP_TO = "to";
+  public static final String PROP_CC = "cc";
+  public static final String PROP_BCC = "bcc";
+  public static final String PROP_RECIPIENTS = "recipients";
 
   public StatefulDetectionAlertFilter(DataProvider provider, DetectionAlertConfigDTO config, long endTime) {
     super(provider, config, endTime);
@@ -91,5 +99,37 @@ public abstract class StatefulDetectionAlertFilter extends DetectionAlertFilter 
       return this.config.getHighWaterMark();
     }
     return 0;
+  }
+
+  protected Set<String> cleanupRecipients(Set<String> recipient) {
+    Set<String> filteredRecipients = new HashSet<>();
+    if (recipient != null) {
+      filteredRecipients.addAll(recipient);
+      filteredRecipients = filteredRecipients.stream().map(String::trim).collect(Collectors.toSet());
+      filteredRecipients.removeIf(rec -> rec == null || "".equals(rec));
+    }
+    return filteredRecipients;
+  }
+
+  protected Map<String, Object> getNotificationSchemeProps(DetectionAlertConfigDTO config,
+      Set<String> to, Set<String> cc, Set<String> bcc) {
+    Map<String, Set<String>> recipients = new HashMap<>();
+    recipients.put(PROP_TO, cleanupRecipients(to));
+    recipients.put(PROP_CC, cleanupRecipients(cc));
+    recipients.put(PROP_BCC, cleanupRecipients(bcc));
+
+    if (config.getAlertSchemes() == null) {
+      Map<String, Map<String, Object>> alertSchemes = new HashMap<>();
+      alertSchemes.put(PROP_EMAIL_SCHEME, new HashMap<>());
+      config.setAlertSchemes(alertSchemes);
+    }
+
+    Map<String, Object> alertSchemes = new HashMap<>();
+    for (Map.Entry<String, Map<String, Object>> schemeProps : config.getAlertSchemes().entrySet()) {
+      alertSchemes.put(schemeProps.getKey(), new HashMap<>(schemeProps.getValue()));
+    }
+    ((Map<String, Object>) alertSchemes.get(PROP_EMAIL_SCHEME)).put(PROP_RECIPIENTS, recipients);
+
+    return alertSchemes;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/StatefulDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/StatefulDetectionAlertFilter.java
@@ -111,7 +111,7 @@ public abstract class StatefulDetectionAlertFilter extends DetectionAlertFilter 
     return filteredRecipients;
   }
 
-  protected Map<String, Object> getNotificationSchemeProps(DetectionAlertConfigDTO config,
+  protected Map<String, Object> generateNotificationSchemeProps(DetectionAlertConfigDTO config,
       Set<String> to, Set<String> cc, Set<String> bcc) {
     Map<String, Set<String>> recipients = new HashMap<>();
     recipients.put(PROP_TO, cleanupRecipients(to));
@@ -124,12 +124,12 @@ public abstract class StatefulDetectionAlertFilter extends DetectionAlertFilter 
       config.setAlertSchemes(alertSchemes);
     }
 
-    Map<String, Object> alertSchemes = new HashMap<>();
+    Map<String, Object> notificationSchemeProps = new HashMap<>();
     for (Map.Entry<String, Map<String, Object>> schemeProps : config.getAlertSchemes().entrySet()) {
-      alertSchemes.put(schemeProps.getKey(), new HashMap<>(schemeProps.getValue()));
+      notificationSchemeProps.put(schemeProps.getKey(), new HashMap<>(schemeProps.getValue()));
     }
-    ((Map<String, Object>) alertSchemes.get(PROP_EMAIL_SCHEME)).put(PROP_RECIPIENTS, recipients);
+    ((Map<String, Object>) notificationSchemeProps.get(PROP_EMAIL_SCHEME)).put(PROP_RECIPIENTS, recipients);
 
-    return alertSchemes;
+    return notificationSchemeProps;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionDetectionAlertFilter.java
@@ -88,7 +88,7 @@ public class DimensionDetectionAlertFilter extends StatefulDetectionAlertFilter 
     for (Map.Entry<String, Collection<MergedAnomalyResultDTO>> dimAnomalyMapping : grouped.asMap().entrySet()) {
       result.addMapping(
           new DetectionAlertFilterNotification(
-              getNotificationSchemeProps(
+              generateNotificationSchemeProps(
                   this.config,
                   this.makeGroupRecipients(dimAnomalyMapping.getKey()),
                   this.recipients.get(PROP_CC),

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
@@ -55,10 +55,6 @@ import org.apache.pinot.thirdeye.detection.annotation.AlertFilter;
 @AlertFilter(type = "PER_USER_DIMENSION_ALERTER_PIPELINE")
 public class PerUserDimensionAlertFilter extends StatefulDetectionAlertFilter {
   private static final String PROP_DETECTION_CONFIG_IDS = "detectionConfigIds";
-  private static final String PROP_TO = "to";
-  private static final String PROP_CC = "cc";
-  private static final String PROP_BCC = "bcc";
-  private static final String PROP_RECIPIENTS = "recipients";
   private static final String PROP_DIMENSION = "dimension";
   private static final String PROP_DIMENSION_RECIPIENTS = "dimensionRecipients";
   private static final String PROP_SEND_ONCE = "sendOnce";
@@ -110,15 +106,14 @@ public class PerUserDimensionAlertFilter extends StatefulDetectionAlertFilter {
     }
 
     for (Map.Entry<String, List<MergedAnomalyResultDTO>> userAnomalyMapping : perUserAnomalies.entrySet()) {
-      Map<String, Set<String>> recipients = new HashMap<>();
-      recipients.put(PROP_TO, this.makeGroupRecipients(userAnomalyMapping.getKey()));
-      recipients.put(PROP_CC, this.recipients.get(PROP_CC));
-      recipients.put(PROP_BCC, this.recipients.get(PROP_BCC));
-
-      Map<String, Object> alertProps = new HashMap<>();
-      alertProps.put(PROP_RECIPIENTS, recipients);
-
-      result.addMapping(new DetectionAlertFilterNotification(alertProps), new HashSet<>(userAnomalyMapping.getValue()));
+      result.addMapping(
+          new DetectionAlertFilterNotification(
+              getNotificationSchemeProps(
+                  this.config,
+                  this.makeGroupRecipients(userAnomalyMapping.getKey()),
+                  this.recipients.get(PROP_CC),
+                  this.recipients.get(PROP_BCC))),
+          new HashSet<>(userAnomalyMapping.getValue()));
     }
 
     return result;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
@@ -37,7 +37,7 @@ import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.detection.DataProvider;
-import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterRecipients;
+import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
 import org.apache.pinot.thirdeye.detection.alert.StatefulDetectionAlertFilter;
 import org.apache.pinot.thirdeye.detection.annotation.AlertFilter;
@@ -110,13 +110,15 @@ public class PerUserDimensionAlertFilter extends StatefulDetectionAlertFilter {
     }
 
     for (Map.Entry<String, List<MergedAnomalyResultDTO>> userAnomalyMapping : perUserAnomalies.entrySet()) {
-      result.addMapping(
-          new DetectionAlertFilterRecipients(
-              this.makeGroupRecipients(userAnomalyMapping.getKey()),
-              this.recipients.get(PROP_CC),
-              this.recipients.get(PROP_BCC)),
-          new HashSet<>(userAnomalyMapping.getValue())
-      );
+      Map<String, Set<String>> recipients = new HashMap<>();
+      recipients.put(PROP_TO, this.makeGroupRecipients(userAnomalyMapping.getKey()));
+      recipients.put(PROP_CC, this.recipients.get(PROP_CC));
+      recipients.put(PROP_BCC, this.recipients.get(PROP_BCC));
+
+      Map<String, Object> alertProps = new HashMap<>();
+      alertProps.put(PROP_RECIPIENTS, recipients);
+
+      result.addMapping(new DetectionAlertFilterNotification(alertProps), new HashSet<>(userAnomalyMapping.getValue()));
     }
 
     return result;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
@@ -108,7 +108,7 @@ public class PerUserDimensionAlertFilter extends StatefulDetectionAlertFilter {
     for (Map.Entry<String, List<MergedAnomalyResultDTO>> userAnomalyMapping : perUserAnomalies.entrySet()) {
       result.addMapping(
           new DetectionAlertFilterNotification(
-              getNotificationSchemeProps(
+              generateNotificationSchemeProps(
                   this.config,
                   this.makeGroupRecipients(userAnomalyMapping.getKey()),
                   this.recipients.get(PROP_CC),

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilter.java
@@ -71,7 +71,7 @@ public class ToAllRecipientsDetectionAlertFilter extends StatefulDetectionAlertF
 
     return result.addMapping(
         new DetectionAlertFilterNotification(
-            getNotificationSchemeProps(
+            generateNotificationSchemeProps(
                 this.config,
                 this.recipients.get(PROP_TO),
                 this.recipients.get(PROP_CC),

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilter.java
@@ -37,6 +37,9 @@ import java.util.Set;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.pinot.thirdeye.detection.annotation.AlertFilter;
 
+import static org.apache.pinot.thirdeye.detection.alert.scheme.DetectionEmailAlerter.*;
+
+
 /**
  * The detection alert filter that sends the anomaly email to all recipients
  */
@@ -76,9 +79,17 @@ public class ToAllRecipientsDetectionAlertFilter extends StatefulDetectionAlertF
     recipients.put(PROP_CC, cleanupRecipients(this.recipients.get(PROP_CC)));
     recipients.put(PROP_BCC, cleanupRecipients(this.recipients.get(PROP_BCC)));
 
-    Map<String, Object> alertProps = new HashMap<>();
-    alertProps.put(PROP_RECIPIENTS, recipients);
-    return result.addMapping(new DetectionAlertFilterNotification(alertProps), anomalies);
+    Map<String, Object> alertSchemeProps = new HashMap<>();
+    if (this.config.getAlertSchemes() == null) {
+      Map<String, Map<String, Object>> alertSchemes = new HashMap<>();
+      alertSchemes.put(PROP_EMAIL_SCHEME, new HashMap<>());
+      this.config.setAlertSchemes(alertSchemes);
+    }
+
+    this.config.getAlertSchemes().get(PROP_EMAIL_SCHEME).put(PROP_RECIPIENTS, recipients);
+    alertSchemeProps.putAll(this.config.getAlertSchemes());
+
+    return result.addMapping(new DetectionAlertFilterNotification(alertSchemeProps), anomalies);
   }
 
   private Set<String> cleanupRecipients(Set<String> recipient) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -74,7 +74,7 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
   private static final String PROP_EMAIL_WHITELIST = "emailWhitelist";
   private static final String PROP_ADMIN_RECIPIENTS = "adminRecipients";
 
-  private static final String PROP_EMAIL_SCHEME = "emailScheme";
+  public static final String PROP_EMAIL_SCHEME = "emailScheme";
   private static final String PROP_EMAIL_TEMPLATE = "template";
   private static final String PROP_EMAIL_SUBJECT_STYLE = "subject";
 
@@ -256,8 +256,10 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
     Preconditions.checkNotNull(detectionResult.getResult());
     for (Map.Entry<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> entry : detectionResult.getResult().entrySet()) {
       DetectionAlertFilterNotification notification = entry.getKey();
-      if (notification.getNotificationProps() != null && notification.getNotificationProps().get(PROP_RECIPIENTS) != null) {
-        SetMultimap<String, String> emailRecipients = (SetMultimap<String, String>) notification.getNotificationProps().get(PROP_RECIPIENTS);
+      Map<String, Object> notificationSchemeProps = notification.getNotificationSchemeProps();
+      if (notificationSchemeProps != null && notificationSchemeProps.get(PROP_EMAIL_SCHEME) != null
+          && ConfigUtils.getMap(notificationSchemeProps.get(PROP_EMAIL_SCHEME)).get(PROP_RECIPIENTS) != null) {
+        SetMultimap<String, String> emailRecipients = (SetMultimap<String, String>) ConfigUtils.getMap(notificationSchemeProps.get(PROP_EMAIL_SCHEME)).get(PROP_RECIPIENTS);
         if (emailRecipients.get(PROP_TO) == null || emailRecipients.get(PROP_TO).isEmpty()) {
           LOG.warn("Skipping! No email recipients found for alert {}.", config.getId());
           return;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.thirdeye.detection.alert.scheme;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.SetMultimap;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,6 +43,7 @@ import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.datalayer.pojo.AlertConfigBean;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.detection.alert.AlertUtils;
+import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
 import org.apache.pinot.thirdeye.detection.annotation.AlertScheme;
@@ -63,6 +65,11 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
 
   private static final Comparator<AnomalyResult> COMPARATOR_DESC =
       (o1, o2) -> -1 * Long.compare(o1.getStartTime(), o2.getStartTime());
+
+  private static final String PROP_RECIPIENTS = "recipients";
+  private static final String PROP_TO = "to";
+  private static final String PROP_CC = "cc";
+  private static final String PROP_BCC = "bcc";
 
   private static final String PROP_EMAIL_WHITELIST = "emailWhitelist";
   private static final String PROP_ADMIN_RECIPIENTS = "adminRecipients";
@@ -247,15 +254,25 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
   private void generateAndSendEmails(DetectionAlertFilterResult detectionResult) throws Exception {
     LOG.info("Preparing an email alert for subscription group id {}", config.getId());
     Preconditions.checkNotNull(detectionResult.getResult());
-    for (Map.Entry<DetectionAlertFilterRecipients, Set<MergedAnomalyResultDTO>> entry : detectionResult.getResult().entrySet()) {
-      DetectionAlertFilterRecipients recipients = entry.getKey();
-      Set<MergedAnomalyResultDTO> anomalies = entry.getValue();
+    for (Map.Entry<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> entry : detectionResult.getResult().entrySet()) {
+      DetectionAlertFilterNotification notification = entry.getKey();
+      if (notification.getNotificationProps() != null && notification.getNotificationProps().get(PROP_RECIPIENTS) != null) {
+        SetMultimap<String, String> emailRecipients = (SetMultimap<String, String>) notification.getNotificationProps().get(PROP_RECIPIENTS);
+        if (emailRecipients.get(PROP_TO) == null || emailRecipients.get(PROP_TO).isEmpty()) {
+          LOG.warn("Skipping! No email recipients found for alert {}.", config.getId());
+          return;
+        }
 
-      try {
-        sendEmail(recipients, anomalies);
-      } catch (IllegalArgumentException e) {
-        LOG.warn("Skipping! Found illegal arguments while sending {} anomalies to recipient {} for alert {}."
-            + " Exception message: ", anomalies.size(), recipients, config.getId(), e);
+        DetectionAlertFilterRecipients recipients =
+            new DetectionAlertFilterRecipients(emailRecipients.get(PROP_TO), emailRecipients.get(PROP_CC),
+                emailRecipients.get(PROP_BCC));
+        Set<MergedAnomalyResultDTO> anomalies = entry.getValue();
+
+        try {
+          sendEmail(recipients, anomalies);
+        } catch (IllegalArgumentException e) {
+          LOG.warn("Skipping! Found illegal arguments while sending {} anomalies to recipient {} for alert {}." + " Exception message: ", anomalies.size(), recipients, config.getId(), e);
+        }
       }
     }
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/AlertFilterUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/AlertFilterUtils.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.alert.filter;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
+
+
+public class AlertFilterUtils {
+
+  private static final String PROP_RECIPIENTS = "recipients";
+  private static final String PROP_TO = "to";
+  private static final String PROP_CC = "cc";
+  private static final String PROP_BCC = "bcc";
+
+  static final Set<String> PROP_TO_VALUE = new HashSet<>(Arrays.asList("test@example.com", "test@example.org"));
+  static final Set<String> PROP_CC_VALUE = new HashSet<>(Arrays.asList("cctest@example.com", "cctest@example.org"));
+  static final Set<String> PROP_BCC_VALUE = new HashSet<>(Arrays.asList("bcctest@example.com", "bcctest@example.org"));
+
+  private static final Map<String, Object> ALERT_PROPS = new HashMap<>();
+
+  static DetectionAlertFilterNotification makeEmailNotifications() {
+    return makeEmailNotifications(new HashSet<String>());
+  }
+
+  static DetectionAlertFilterNotification makeEmailNotifications(Set<String> toRecipients) {
+    Map<String, Set<String>> recipients = new HashMap<>();
+    recipients.put(PROP_TO, new HashSet<>(PROP_TO_VALUE));
+    recipients.put(PROP_CC, new HashSet<>(PROP_CC_VALUE));
+    recipients.put(PROP_BCC, new HashSet<>(PROP_BCC_VALUE));
+
+    recipients.get(PROP_TO).addAll(toRecipients);
+    ALERT_PROPS.put(PROP_RECIPIENTS, recipients);
+
+    return new DetectionAlertFilterNotification(ALERT_PROPS);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/AlertFilterUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/AlertFilterUtils.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
 
+import static org.apache.pinot.thirdeye.detection.alert.scheme.DetectionEmailAlerter.*;
+
 
 public class AlertFilterUtils {
 
@@ -42,13 +44,21 @@ public class AlertFilterUtils {
   }
 
   static DetectionAlertFilterNotification makeEmailNotifications(Set<String> toRecipients) {
-    Map<String, Set<String>> recipients = new HashMap<>();
-    recipients.put(PROP_TO, new HashSet<>(PROP_TO_VALUE));
-    recipients.put(PROP_CC, new HashSet<>(PROP_CC_VALUE));
-    recipients.put(PROP_BCC, new HashSet<>(PROP_BCC_VALUE));
+    Set<String> recipients = new HashSet<>(toRecipients);
+    recipients.addAll(PROP_TO_VALUE);
+    return makeEmailNotifications(recipients, PROP_CC_VALUE, PROP_BCC_VALUE);
+  }
 
-    recipients.get(PROP_TO).addAll(toRecipients);
-    ALERT_PROPS.put(PROP_RECIPIENTS, recipients);
+  static DetectionAlertFilterNotification makeEmailNotifications(Set<String> toRecipients, Set<String> ccRecipients, Set<String> bccRecipients) {
+    Map<String, Set<String>> recipients = new HashMap<>();
+    recipients.put(PROP_TO, new HashSet<>(toRecipients));
+    recipients.put(PROP_CC, new HashSet<>(ccRecipients));
+    recipients.put(PROP_BCC, new HashSet<>(bccRecipients));
+
+    Map<String, Object> emailRecipients = new HashMap<>();
+    emailRecipients.put(PROP_RECIPIENTS, recipients);
+
+    ALERT_PROPS.put(PROP_EMAIL_SCHEME, emailRecipients);
 
     return new DetectionAlertFilterNotification(ALERT_PROPS);
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionDetectionAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionDetectionAlertFilterTest.java
@@ -22,7 +22,7 @@ import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.detection.MockDataProvider;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilter;
-import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterRecipients;
+import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,6 +70,7 @@ public class DimensionDetectionAlertFilterTest {
 
   @BeforeMethod
   public void beforeMethod() {
+
     this.detectedAnomalies = new ArrayList<>();
     this.detectedAnomalies.add(makeAnomaly(1001L, 1500, 2000, Collections.<String, String>emptyMap()));
     this.detectedAnomalies.add(makeAnomaly(1001L,0, 1000, Collections.singletonMap("key", "value")));
@@ -117,13 +118,15 @@ public class DimensionDetectionAlertFilterTest {
   public void testAlertFilterRecipients() throws Exception {
     this.alertFilter = new DimensionDetectionAlertFilter(provider, alertConfig,2500L);
 
-    DetectionAlertFilterRecipients recDefault = makeRecipients();
-    DetectionAlertFilterRecipients recValue = makeRecipients(PROP_TO_FOR_VALUE);
-    DetectionAlertFilterRecipients recAnotherValue = makeRecipients(PROP_TO_FOR_ANOTHER_VALUE);
-
     DetectionAlertFilterResult result = this.alertFilter.run();
+
+    DetectionAlertFilterNotification recDefault = AlertFilterUtils.makeEmailNotifications();
     Assert.assertEquals(result.getResult().get(recDefault), makeSet(0, 3, 4));
+
+    DetectionAlertFilterNotification recValue = AlertFilterUtils.makeEmailNotifications(PROP_TO_FOR_VALUE);
     Assert.assertEquals(result.getResult().get(recValue), makeSet(1, 5));
+
+    DetectionAlertFilterNotification recAnotherValue = AlertFilterUtils.makeEmailNotifications(PROP_TO_FOR_ANOTHER_VALUE);
     Assert.assertEquals(result.getResult().get(recAnotherValue), makeSet(2));
     // 6, 7 are out of search range
   }
@@ -138,9 +141,10 @@ public class DimensionDetectionAlertFilterTest {
 
     this.detectedAnomalies.add(child);
 
-    DetectionAlertFilterRecipients recValue = makeRecipients(PROP_TO_FOR_VALUE);
+    DetectionAlertFilterNotification recValue = AlertFilterUtils.makeEmailNotifications(PROP_TO_FOR_VALUE);
 
     DetectionAlertFilterResult result = this.alertFilter.run();
+
     Assert.assertEquals(result.getResult().size(), 1);
     Assert.assertTrue(result.getResult().containsKey(recValue));
   }
@@ -169,15 +173,16 @@ public class DimensionDetectionAlertFilterTest {
     this.detectedAnomalies.add(anomalyWithoutFeedback);
     this.detectedAnomalies.add(anomalyWithNull);
 
-    DetectionAlertFilterRecipients recDefault = makeRecipients();
-    DetectionAlertFilterRecipients recValue = makeRecipients(PROP_TO_FOR_VALUE);
-
     DetectionAlertFilterResult result = this.alertFilter.run();
     Assert.assertEquals(result.getResult().size(), 2);
+
+    DetectionAlertFilterNotification recDefault = AlertFilterUtils.makeEmailNotifications();
     Assert.assertTrue(result.getResult().containsKey(recDefault));
     Assert.assertEquals(result.getResult().get(recDefault).size(), 2);
     Assert.assertTrue(result.getResult().get(recDefault).contains(anomalyWithoutFeedback));
     Assert.assertTrue(result.getResult().get(recDefault).contains(anomalyWithNull));
+
+    DetectionAlertFilterNotification recValue = AlertFilterUtils.makeEmailNotifications(PROP_TO_FOR_VALUE);
     Assert.assertTrue(result.getResult().containsKey(recValue));
   }
 
@@ -187,15 +192,5 @@ public class DimensionDetectionAlertFilterTest {
       output.add(this.detectedAnomalies.get(anomalyIndex));
     }
     return output;
-  }
-
-  private static DetectionAlertFilterRecipients makeRecipients() {
-    return makeRecipients(new HashSet<String>());
-  }
-
-  private static DetectionAlertFilterRecipients makeRecipients(Set<String> to) {
-    Set<String> newTo = new HashSet<>(PROP_TO_VALUE);
-    newTo.addAll(to);
-    return new DetectionAlertFilterRecipients(newTo, new HashSet<>(PROP_CC_VALUE), new HashSet<>(PROP_BCC_VALUE));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionDetectionAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionDetectionAlertFilterTest.java
@@ -176,7 +176,7 @@ public class DimensionDetectionAlertFilterTest {
     DetectionAlertFilterResult result = this.alertFilter.run();
     Assert.assertEquals(result.getResult().size(), 2);
 
-    DetectionAlertFilterNotification recDefault = AlertFilterUtils.makeEmailNotifications();
+    DetectionAlertFilterNotification recDefault = AlertFilterUtils.makeEmailNotifications(PROP_TO_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
     Assert.assertTrue(result.getResult().containsKey(recDefault));
     Assert.assertEquals(result.getResult().get(recDefault).size(), 2);
     Assert.assertTrue(result.getResult().get(recDefault).contains(anomalyWithoutFeedback));

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilterTest.java
@@ -108,7 +108,7 @@ public class ToAllRecipientsDetectionAlertFilterTest {
 
     DetectionAlertFilterResult result = this.alertFilter.run();
 
-    DetectionAlertFilterNotification notification = makeEmailNotifications();
+    DetectionAlertFilterNotification notification = AlertFilterUtils.makeEmailNotifications(PROP_TO_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
     Assert.assertEquals(result.getResult().get(notification), new HashSet<>(this.detectedAnomalies.subList(0, 4)));
   }
 
@@ -139,7 +139,7 @@ public class ToAllRecipientsDetectionAlertFilterTest {
     DetectionAlertFilterResult result = this.alertFilter.run();
     Assert.assertEquals(result.getResult().size(), 1);
 
-    DetectionAlertFilterNotification notification = makeEmailNotifications();
+    DetectionAlertFilterNotification notification = AlertFilterUtils.makeEmailNotifications(PROP_TO_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
     Assert.assertTrue(result.getResult().containsKey(notification));
     Assert.assertEquals(result.getResult().get(notification).size(), 3);
     Assert.assertTrue(result.getResult().get(notification).contains(this.detectedAnomalies.get(5)));
@@ -170,7 +170,7 @@ public class ToAllRecipientsDetectionAlertFilterTest {
 
     DetectionAlertFilterResult result = this.alertFilter.run();
 
-    DetectionAlertFilterNotification notification = makeEmailNotifications();
+    DetectionAlertFilterNotification notification = AlertFilterUtils.makeEmailNotifications(PROP_TO_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
     Assert.assertEquals(result.getResult().get(notification).size(), 1);
     Assert.assertTrue(result.getResult().get(notification).contains(existingFuture));
   }
@@ -199,7 +199,7 @@ public class ToAllRecipientsDetectionAlertFilterTest {
 
     DetectionAlertFilterResult result = this.alertFilter.run();
 
-    DetectionAlertFilterNotification notification = makeEmailNotifications();
+    DetectionAlertFilterNotification notification = AlertFilterUtils.makeEmailNotifications(PROP_TO_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
     Assert.assertEquals(result.getResult().get(notification).size(), 2);
     Assert.assertTrue(result.getResult().get(notification).contains(existingNew));
     Assert.assertTrue(result.getResult().get(notification).contains(existingFuture));
@@ -214,25 +214,5 @@ public class ToAllRecipientsDetectionAlertFilterTest {
 
     DetectionAlertFilterResult result = this.alertFilter.run();
     Assert.assertEquals(result.getResult().size(), 1);
-  }
-
-  private static DetectionAlertFilterNotification makeEmailNotifications() {
-    return makeEmailNotifications(new HashSet<String>());
-  }
-
-  private static DetectionAlertFilterNotification makeEmailNotifications(Set<String> toRecipients) {
-    Map<String, Set<String>> recipients = new HashMap<>();
-    recipients.put(PROP_TO, new HashSet<>(PROP_TO_VALUE));
-    recipients.put(PROP_CC, new HashSet<>(PROP_CC_VALUE));
-    recipients.put(PROP_BCC, new HashSet<>(PROP_BCC_VALUE));
-
-    recipients.get(PROP_TO).addAll(toRecipients);
-
-    Map<String, Object> emailRecipients = new HashMap<>();
-    emailRecipients.put(PROP_RECIPIENTS, recipients);
-
-    ALERT_PROPS.put(PROP_EMAIL_SCHEME, emailRecipients);
-
-    return new DetectionAlertFilterNotification(ALERT_PROPS);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilterTest.java
@@ -33,11 +33,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.pinot.thirdeye.detection.alert.scheme.DetectionEmailAlerter;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.thirdeye.detection.DetectionTestUtils.*;
+import static org.apache.pinot.thirdeye.detection.alert.scheme.DetectionEmailAlerter.*;
 
 
 public class ToAllRecipientsDetectionAlertFilterTest {
@@ -91,8 +93,8 @@ public class ToAllRecipientsDetectionAlertFilterTest {
     recipients.put(PROP_BCC, PROP_BCC_VALUE);
     properties.put(PROP_RECIPIENTS, recipients);
     properties.put(PROP_DETECTION_CONFIG_IDS, PROP_ID_VALUE);
-
     alertConfig.setProperties(properties);
+
     Map<Long, Long> vectorClocks = new HashMap<>();
     vectorClocks.put(PROP_ID_VALUE.get(0), 0L);
     alertConfig.setVectorClocks(vectorClocks);
@@ -225,7 +227,11 @@ public class ToAllRecipientsDetectionAlertFilterTest {
     recipients.put(PROP_BCC, new HashSet<>(PROP_BCC_VALUE));
 
     recipients.get(PROP_TO).addAll(toRecipients);
-    ALERT_PROPS.put(PROP_RECIPIENTS, recipients);
+
+    Map<String, Object> emailRecipients = new HashMap<>();
+    emailRecipients.put(PROP_RECIPIENTS, recipients);
+
+    ALERT_PROPS.put(PROP_EMAIL_SCHEME, emailRecipients);
 
     return new DetectionAlertFilterNotification(ALERT_PROPS);
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/suppress/DetectionTimeWindowSuppressorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/suppress/DetectionTimeWindowSuppressorTest.java
@@ -3,6 +3,7 @@ package org.apache.pinot.thirdeye.detection.alert.suppress;
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
 import java.util.ArrayList;
@@ -115,9 +116,13 @@ public class DetectionTimeWindowSuppressorTest {
    */
   @Test
   public void testTimeWindowSuppressorWithThreshold() throws Exception {
+    Map<String, Set<String>> recipients = new HashMap<>();
+    recipients.put("to", Collections.singleton("test@test"));
 
     DetectionAlertFilterResult result = new DetectionAlertFilterResult();
-    result.addMapping(new DetectionAlertFilterRecipients(Collections.singleton("test@test")), anomalies);
+    Map<String, Object> alertProps = new HashMap<>();
+    alertProps.put("recipients", recipients);
+    result.addMapping(new DetectionAlertFilterNotification(alertProps), anomalies);
 
     DetectionAlertTimeWindowSuppressor suppressor = new DetectionAlertTimeWindowSuppressor(config);
     DetectionAlertFilterResult resultsAfterSuppress = suppressor.run(result);
@@ -145,8 +150,13 @@ public class DetectionTimeWindowSuppressorTest {
     alertSuppressors.put(TIME_WINDOW_SUPPRESSOR_KEY, params);
     config.setAlertSuppressors(alertSuppressors);
 
+    Map<String, Set<String>> recipients = new HashMap<>();
+    recipients.put("to", Collections.singleton("test@test"));
+
     DetectionAlertFilterResult result = new DetectionAlertFilterResult();
-    result.addMapping(new DetectionAlertFilterRecipients(Collections.singleton("test@test")), anomalies);
+    Map<String, Object> alertProps = new HashMap<>();
+    alertProps.put("recipients", recipients);
+    result.addMapping(new DetectionAlertFilterNotification(alertProps), anomalies);
 
     DetectionAlertTimeWindowSuppressor suppressor = new DetectionAlertTimeWindowSuppressor(config);
     DetectionAlertFilterResult resultsAfterSuppress = suppressor.run(result);


### PR DESCRIPTION
Alert filter to return a map of (alert-properties, anomalies) rather than just the (recipients, anomalies). This will allow other alerters like jira to pass notification related parameters.