### PR TITLE
[TE] fix the last time stamp filter out the generated anomalies 

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyDetectorWrapper.java
@@ -216,10 +216,8 @@ public class AnomalyDetectorWrapper extends DetectionPipeline {
       anomaly.getProperties().put(PROP_SUB_ENTITY_NAME, this.entityName);
     }
     long lastTimeStamp = this.getLastTimeStamp();
-    List<MergedAnomalyResultDTO> anomalyResults = anomalies.stream().filter(anomaly -> anomaly.getEndTime() <= lastTimeStamp).collect(
-        Collectors.toList());
     PredictionResult predictedTimeSeries = new PredictionResult(this.detectorName, this.metricUrn, predictedResult.getDataFrame());
-    return new DetectionPipelineResult(anomalyResults, lastTimeStamp, Collections.singletonList(predictedTimeSeries));
+    return new DetectionPipelineResult(anomalies, lastTimeStamp, Collections.singletonList(predictedTimeSeries));
   }
 
   /**


### PR DESCRIPTION
- Remove the check that to filter out generated anomalies based on the last timestamp. This may filter out useful anomalies.
- In the replay endpoint, add the option to turn on email sending for the generated anomalies.