### PR TITLE
Remove import of sun.misc.Cleaner to make code compatible with jdk11

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
@@ -26,7 +26,6 @@ import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import javax.annotation.concurrent.ThreadSafe;
-import sun.misc.Cleaner;
 import sun.nio.ch.DirectBuffer;
 
 
@@ -328,9 +327,8 @@ public class PinotByteBuffer extends PinotDataBuffer {
 
   @Override
   protected void release() {
-    Cleaner cleaner = ((DirectBuffer) _buffer).cleaner();
-    if (cleaner != null) {
-      cleaner.clean();
+    if (((DirectBuffer) _buffer).cleaner() != null) {
+      ((DirectBuffer) _buffer).cleaner().clean();
     }
   }
 }


### PR DESCRIPTION
`sun.misc.Cleaner` is deprecated since jdk9 and replaced with `jdk.internal.ref.Cleaner`.
This change aims to make Pinot compilable in higher jdk version.

Ref: https://bugs.openjdk.java.net/browse/JDK-8148117