### PR TITLE
[Pinot Bench Service] Implement data preparation component

### DIFF
--- a/pinot-benchmark/pom.xml
+++ b/pinot-benchmark/pom.xml
@@ -38,6 +38,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.1</version>

--- a/pinot-benchmark/pom.xml
+++ b/pinot-benchmark/pom.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>pinot</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>0.2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>pinot-benchmark</artifactId>
+  <name>Pinot Benchmark Service</name>
+  <url>https://pinot.apache.org/</url>
+  <properties>
+    <pinot.root>${basedir}/..</pinot.root>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-grizzly2-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jersey2-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>swagger-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-configuration</groupId>
+      <artifactId>commons-configuration</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>true</reuseForks>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+    </plugins>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+  </build>
+</project>

--- a/pinot-benchmark/pom.xml
+++ b/pinot-benchmark/pom.xml
@@ -19,11 +19,9 @@
     under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
@@ -41,27 +39,15 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
-
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jersey2-jaxrs</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-grizzly2-http</artifactId>
@@ -87,14 +73,6 @@
       <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.swagger</groupId>
-      <artifactId>swagger-jersey2-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>swagger-ui</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
@@ -117,20 +95,6 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/BenchmarkConfig.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/BenchmarkConfig.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark;
+
+import org.apache.commons.configuration.PropertiesConfiguration;
+
+
+public class BenchmarkConfig extends PropertiesConfiguration {
+  private static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
+  private static final String CONSOLE_WEBAPP_USE_HTTPS = "controller.query.console.useHttps";
+
+  public String getQueryConsoleWebappPath() {
+    if (containsKey(CONSOLE_WEBAPP_ROOT_PATH)) {
+      return (String) getProperty(CONSOLE_WEBAPP_ROOT_PATH);
+    }
+    return BenchmarkConfig.class.getClassLoader().getResource("webapp").toExternalForm();
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchConf.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchConf.java
@@ -40,6 +40,8 @@ public class PinotBenchConf extends PropertiesConfiguration {
   private static final String TABLE_RETENTION_MANAGER_FREQUENCY_IN_SECONDS =
       "pinot.bench.table.retention.frequencyInSeconds";
 
+  private static final String PINOT_BENCH_BASE_QUERY_DIR = "pinot.bench.base.query.dir";
+
   private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
 
   public void setPinotBenchHost(String pinotBenchHost) {
@@ -120,5 +122,13 @@ public class PinotBenchConf extends PropertiesConfiguration {
 
   public long getTableRetentionManagerFrequencyInSeconds() {
     return getLong(TABLE_RETENTION_MANAGER_FREQUENCY_IN_SECONDS);
+  }
+
+  public void setPinotBenchBaseQueryDir(String pinotBenchBaseQueryDir) {
+    setProperty(PINOT_BENCH_BASE_QUERY_DIR, pinotBenchBaseQueryDir);
+  }
+
+  public String getPinotBenchBaseQueryDir() {
+    return (String) getProperty(PINOT_BENCH_BASE_QUERY_DIR);
   }
 }

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchConf.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchConf.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.benchmark;
 
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -5,13 +23,40 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 
 public class PinotBenchConf extends PropertiesConfiguration {
 
+  private static final String PINOT_BENCH_HOST = "pinot.bench.host";
+  private static final String PINOT_BENCH_PORT = "pinot.bench.port";
+
   private static final String PERF_CONTROLLER_HOST = "perf.controller.host";
   private static final String PERF_CONTROLLER_PORT = "perf.controller.port";
 
   private static final String PROD_CONTROLLER_HOST = "prod.controller.host";
   private static final String PROD_CONTROLLER_PORT = "prod.controller.port";
 
+  private static final String CLUSTER_NAME = "pinot.bench.cluster.name";
+  private static final String ZK_STR = "pinot.bench.zk.str";
+
+  private static final String TABLE_RETENTION_MANAGER_INITIAL_DELAY_IN_SECONDS =
+      "pinot.bench.table.retention.initialDelayInSeconds";
+  private static final String TABLE_RETENTION_MANAGER_FREQUENCY_IN_SECONDS =
+      "pinot.bench.table.retention.frequencyInSeconds";
+
   private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
+
+  public void setPinotBenchHost(String pinotBenchHost) {
+    setProperty(PINOT_BENCH_HOST, pinotBenchHost);
+  }
+
+  public String getPinotBenchHost() {
+    return (String) getProperty(PINOT_BENCH_HOST);
+  }
+
+  public void setPinotBenchPort(int pinotBenchPort) {
+    setProperty(PINOT_BENCH_PORT, pinotBenchPort);
+  }
+
+  public int getPinotBenchPort() {
+    return getInt(PINOT_BENCH_PORT);
+  }
 
   public void setPerfControllerHost(String perfControllerHost) {
     setProperty(PERF_CONTROLLER_HOST, perfControllerHost);
@@ -43,5 +88,37 @@ public class PinotBenchConf extends PropertiesConfiguration {
 
   public int getProdControllerPort() {
     return getInt(PROD_CONTROLLER_PORT, -1);
+  }
+
+  public void setClusterName(String clusterName) {
+    setProperty(CLUSTER_NAME, clusterName);
+  }
+
+  public String getClusterName() {
+    return (String) getProperty(CLUSTER_NAME);
+  }
+
+  public void setZkStr(String zkStr) {
+    setProperty(ZK_STR, zkStr);
+  }
+
+  public String getZkStr() {
+    return (String) getProperty(ZK_STR);
+  }
+
+  public void setTableRetentionManagerInitialDelayInSeconds(long tableRetentionManagerInitialDelayInSeconds) {
+    setProperty(TABLE_RETENTION_MANAGER_INITIAL_DELAY_IN_SECONDS, tableRetentionManagerInitialDelayInSeconds);
+  }
+
+  public long getTableRetentionManagerInitialDelayInSeconds() {
+    return getLong(TABLE_RETENTION_MANAGER_INITIAL_DELAY_IN_SECONDS);
+  }
+
+  public void setTableRetentionManagerFrequencyInSeconds(long tableRetentionManagerFrequencyInSeconds) {
+    setProperty(TABLE_RETENTION_MANAGER_FREQUENCY_IN_SECONDS, tableRetentionManagerFrequencyInSeconds);
+  }
+
+  public long getTableRetentionManagerFrequencyInSeconds() {
+    return getLong(TABLE_RETENTION_MANAGER_FREQUENCY_IN_SECONDS);
   }
 }

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchConf.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchConf.java
@@ -1,0 +1,47 @@
+package org.apache.pinot.benchmark;
+
+import org.apache.commons.configuration.PropertiesConfiguration;
+
+
+public class PinotBenchConf extends PropertiesConfiguration {
+
+  private static final String PERF_CONTROLLER_HOST = "perf.controller.host";
+  private static final String PERF_CONTROLLER_PORT = "perf.controller.port";
+
+  private static final String PROD_CONTROLLER_HOST = "prod.controller.host";
+  private static final String PROD_CONTROLLER_PORT = "prod.controller.port";
+
+  private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
+
+  public void setPerfControllerHost(String perfControllerHost) {
+    setProperty(PERF_CONTROLLER_HOST, perfControllerHost);
+  }
+
+  public String getPerfControllerHost() {
+    return (String) getProperty(PERF_CONTROLLER_HOST);
+  }
+
+  public void setPerfControllerPort(int perfControllerPort) {
+    setProperty(PERF_CONTROLLER_PORT, perfControllerPort);
+  }
+
+  public int getPerfControllerPort() {
+    return getInt(PERF_CONTROLLER_PORT);
+  }
+
+  public void setProdControllerHost(String prodControllerHost) {
+    setProperty(PROD_CONTROLLER_HOST, prodControllerHost);
+  }
+
+  public String getProdControllerHost() {
+    return (String) getProperty(PROD_CONTROLLER_HOST);
+  }
+
+  public void setProdControllerPort(int prodControllerPort) {
+    setProperty(PROD_CONTROLLER_PORT, prodControllerPort);
+  }
+
+  public int getProdControllerPort() {
+    return getInt(PROD_CONTROLLER_PORT, -1);
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchmarkServiceStarter.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchmarkServiceStarter.java
@@ -99,8 +99,7 @@ public class PinotBenchmarkServiceStarter {
     _tableRetentionManager.stop();
   }
 
-  public static void main(String[] args)
-      throws InterruptedException {
+  public static void main(String[] args) {
     PinotBenchConf conf = new PinotBenchConf();
     conf.setPerfControllerHost("localhost");
     conf.setPerfControllerPort(9010);
@@ -108,6 +107,7 @@ public class PinotBenchmarkServiceStarter {
     conf.setPinotBenchPort(9008);
     conf.setClusterName("PinotCluster");
     conf.setZkStr("localhost:2181");
+    conf.setPinotBenchBaseQueryDir("/Users/user1/Desktop/testQueries");
     conf.setTableRetentionManagerInitialDelayInSeconds(30L);
     conf.setTableRetentionManagerFrequencyInSeconds(TimeUnit.HOURS.toSeconds(6L));
 
@@ -117,18 +117,21 @@ public class PinotBenchmarkServiceStarter {
     PinotBenchmarkServiceStarter starter = new PinotBenchmarkServiceStarter(conf);
 
     try {
-      LOGGER.info("Start starter.");
       starter.start();
     } catch (Exception e) {
-      LOGGER.error("Error starting", e);
+      LOGGER.error("Error starting.", e);
+      System.exit(-1);
     }
 
-    int i = 0;
-    while (i++ < 600L) {
-      Thread.sleep(1000L);
+    while (true) {
+      try {
+        Thread.sleep(1000L);
+      } catch (InterruptedException e) {
+        LOGGER.error("Caught InterruptedException. Exiting.");
+        break;
+      }
     }
 
-    LOGGER.info("Stopping");
     starter.stop();
   }
 }

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchmarkServiceStarter.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchmarkServiceStarter.java
@@ -18,29 +18,55 @@
  */
 package org.apache.pinot.benchmark;
 
+import java.util.concurrent.TimeUnit;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
 import org.apache.pinot.benchmark.api.PinotClusterManager;
+import org.apache.pinot.benchmark.api.retentions.TableRetentionManager;
 import org.apache.pinot.benchmark.common.PinotBenchServiceApplication;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-
 public class PinotBenchmarkServiceStarter {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotBenchmarkServiceStarter.class);
 
+  private final String _clusterName;
+  private final String _pinotBenchInstanceId;
+  private final String _zkServers;
   private final PinotBenchConf _config;
-  private final PinotBenchServiceApplication _pinotBenchServiceApplication;
   private final PinotClusterManager _pinotClusterManager;
+  private final TableRetentionManager _tableRetentionManager;
+  private final PinotBenchServiceApplication _pinotBenchServiceApplication;
+
+  private HelixManager _helixManager;
 
   public PinotBenchmarkServiceStarter(PinotBenchConf conf) {
     _config = conf;
-    _pinotBenchServiceApplication = new PinotBenchServiceApplication();
+    String host = _config.getPinotBenchHost();
+    int port = _config.getPinotBenchPort();
+    _clusterName = _config.getClusterName();
+    _pinotBenchInstanceId = host + ":" + port;
+    _zkServers = _config.getZkStr();
+
     _pinotClusterManager = new PinotClusterManager(_config);
+    _tableRetentionManager = new TableRetentionManager(_config, _pinotClusterManager);
+    _pinotBenchServiceApplication = new PinotBenchServiceApplication();
   }
 
-  public void start() {
+  public void start()
+      throws Exception {
+    _helixManager =
+        HelixManagerFactory.getZKHelixManager(_clusterName, _pinotBenchInstanceId, InstanceType.SPECTATOR, _zkServers);
+    _helixManager.connect();
+
     LOGGER.info("Starting Pinot cluster manager");
+    _pinotClusterManager.start(_helixManager);
+
+    LOGGER.info("Starting table retention manager");
+    _tableRetentionManager.start(_helixManager);
 
     _pinotBenchServiceApplication.registerBinder(new AbstractBinder() {
       @Override
@@ -50,26 +76,35 @@ public class PinotBenchmarkServiceStarter {
     });
 
     LOGGER.info("Starting Pinot benchmark service.");
-    _pinotBenchServiceApplication.start(9008);
-
+    _pinotBenchServiceApplication.start(_config.getPinotBenchPort());
   }
 
   public void stop() {
     LOGGER.info("Stopping Pinot benchmark service...");
     _pinotBenchServiceApplication.stop();
+
+    _tableRetentionManager.stop();
   }
 
-  public static void main(String[] args) throws InterruptedException {
+  public static void main(String[] args)
+      throws InterruptedException {
     PinotBenchConf conf = new PinotBenchConf();
     conf.setPerfControllerHost("localhost");
     conf.setPerfControllerPort(9000);
+    conf.setPinotBenchHost("localhost");
+    conf.setPinotBenchPort(9008);
+    conf.setClusterName("QuickStartCluster");
+    conf.setZkStr("localhost:2123");
+    conf.setTableRetentionManagerInitialDelayInSeconds(30L);
+    conf.setTableRetentionManagerFrequencyInSeconds(TimeUnit.HOURS.toSeconds(6L));
+
     PinotBenchmarkServiceStarter starter = new PinotBenchmarkServiceStarter(conf);
 
     try {
       LOGGER.info("Start starter.");
       starter.start();
     } catch (Exception e) {
-      LOGGER.error("Error starting!!!", e);
+      LOGGER.error("Error starting", e);
     }
 
     int i = 0;
@@ -77,10 +112,7 @@ public class PinotBenchmarkServiceStarter {
       Thread.sleep(1000L);
     }
 
-    System.out.println("Stopping!");
-    LOGGER.info("Stopping!!!");
-
+    LOGGER.info("Stopping");
     starter.stop();
   }
-
 }

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchmarkServiceStarter.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/PinotBenchmarkServiceStarter.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark;
+
+import org.apache.pinot.benchmark.common.PinotBenchServiceApplication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PinotBenchmarkServiceStarter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotBenchmarkServiceStarter.class);
+
+  private PinotBenchServiceApplication _pinotBenchServiceApplication;
+
+  public PinotBenchmarkServiceStarter() {
+    _pinotBenchServiceApplication = new PinotBenchServiceApplication();
+  }
+
+  public void start() {
+
+
+    LOGGER.info("Starting Pinot benchmark service.");
+    _pinotBenchServiceApplication.start(9008);
+
+  }
+
+  public void stop() {
+    LOGGER.info("Stopping Pinot benchmark service...");
+    _pinotBenchServiceApplication.stop();
+  }
+
+
+  public static void main(String[] args) throws InterruptedException {
+    PinotBenchmarkServiceStarter starter = new PinotBenchmarkServiceStarter();
+
+    try {
+      LOGGER.info("Start starter.");
+      starter.start();
+    } catch (Exception e) {
+      LOGGER.error("Error starting!!!", e);
+    }
+
+    int i = 0;
+    while (i++ < 600L) {
+      Thread.sleep(1000L);
+    }
+
+    System.out.println("Stopping!");
+    LOGGER.info("Stopping!!!");
+
+    starter.stop();
+  }
+
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/PinotClusterManager.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/PinotClusterManager.java
@@ -1,16 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.benchmark.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.ws.rs.core.Response;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.pinot.benchmark.PinotBenchConf;
+import org.apache.pinot.benchmark.api.resources.CreatePerfTableRequest;
 import org.apache.pinot.benchmark.api.resources.PinotBenchException;
+import org.apache.pinot.benchmark.api.resources.SuccessResponse;
+import org.apache.pinot.benchmark.common.utils.PerfTableMode;
+import org.apache.pinot.benchmark.common.utils.PinotBenchConstants;
+import org.apache.pinot.benchmark.common.utils.PinotBenchConstants.PerfTableCreationParameters;
+import org.apache.pinot.benchmark.common.utils.PinotBenchConstants.PinotServerType;
+import org.apache.pinot.benchmark.common.utils.PinotBenchConstants.TenantTags;
 import org.apache.pinot.benchmark.common.utils.PinotClusterClient;
-import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.benchmark.common.utils.PinotClusterLocator;
+import org.apache.pinot.common.config.IndexingConfig;
+import org.apache.pinot.common.config.SegmentsValidationAndRetentionConfig;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.config.TableCustomConfig;
+import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.config.TenantConfig;
+import org.apache.pinot.common.data.Schema;
+import org.apache.pinot.common.exception.HttpErrorStatusException;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.JsonUtils;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.pql.parsers.utils.Pair;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,39 +64,514 @@ public class PinotClusterManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotClusterManager.class);
 
   private PinotBenchConf _conf;
-  private FileUploadDownloadClient _fileUploadDownloadClient;
   private PinotClusterClient _pinotClusterClient;
-
-  private String _perfHost;
-  private int _perfPort;
-  private String _prodHost;
-  private int _prodPort;
+  private PinotClusterLocator _pinotClusterLocator;
+  private HelixManager _helixZkManager;
+  private HelixAdmin _helixAdmin;
 
   public PinotClusterManager(PinotBenchConf conf) {
     _conf = conf;
-    _perfHost = conf.getPerfControllerHost();
-    _perfPort = conf.getPerfControllerPort();
-    _prodHost = conf.getProdControllerHost();
-    _prodPort = conf.getProdControllerPort();
-    _fileUploadDownloadClient = new FileUploadDownloadClient();
+    _pinotClusterLocator = new PinotClusterLocator(conf);
     _pinotClusterClient = new PinotClusterClient();
   }
 
-  public List<String> listTables() {
+  public void start(HelixManager helixManager) {
+    _helixZkManager = helixManager;
+    _helixAdmin = _helixZkManager.getClusterManagmentTool();
+  }
+
+  public List<String> listTables(String clusterType) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPinotClusterFromType(clusterType);
     List<String> tableNames = new ArrayList<>();
     try {
-      SimpleHttpResponse response =
-          _pinotClusterClient.sendGetRequest(PinotClusterClient.getListAllTablesHttpURI(_perfHost, _perfPort));
-      JsonNode jsonArray = JsonUtils.stringToJsonNode(response.getResponse()).get("tables");
+      SimpleHttpResponse response = _pinotClusterClient
+          .sendGetRequest(PinotClusterClient.getListTablesHttpURI(pair.getFirst(), pair.getSecond()));
+      JsonNode jsonArray = JsonUtils.stringToJsonNode(response.getResponse()).get(PinotBenchConstants.TABLES_PATH);
 
       Iterator<JsonNode> elements = jsonArray.elements();
       while (elements.hasNext()) {
         tableNames.add(elements.next().asText());
       }
       return tableNames;
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
     } catch (Exception e) {
-      e.printStackTrace();
-      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String getTableConfig(String clusterType, String tableName) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPinotClusterFromType(clusterType);
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    try {
+      SimpleHttpResponse response = _pinotClusterClient.sendGetRequest(
+          PinotClusterClient.getRetrieveTableConfigHttpURI(pair.getFirst(), pair.getSecond(), rawTableName));
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String addTableConfig(FormDataMultiPart multiPart) {
+    FormDataBodyPart bodyPart = multiPart.getFields().values().iterator().next().get(0);
+    String tableConfigStr = bodyPart.getValueAs(String.class);
+    return addTableConfig(tableConfigStr);
+  }
+
+  private String addTableConfig(TableConfig tableConfig) {
+    if (tableConfig == null) {
+      return null;
+    }
+    return addTableConfig(tableConfig.toJsonConfigString());
+  }
+
+  private String addTableConfig(String tableConfigStr) {
+    if (tableConfigStr == null) {
+      return null;
+    }
+    Pair<String, Integer> pair = _pinotClusterLocator.getPerfClusterPair();
+    try {
+      SimpleHttpResponse response = _pinotClusterClient.sendRequest(PinotClusterClient
+          .getAddTableConfigRequest(PinotClusterClient.getListTablesHttpURI(pair.getFirst(), pair.getSecond()), "table",
+              tableConfigStr));
+      LOGGER.info("Add table successfully: " + response.getResponse());
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String updateTableConfig(String tableName, String tableConfigStr) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPerfClusterPair();
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    try {
+      SimpleHttpResponse response = _pinotClusterClient.sendRequest(PinotClusterClient.getUpdateTableConfigRequest(
+          PinotClusterClient.getRetrieveTableConfigHttpURI(pair.getFirst(), pair.getSecond(), rawTableName),
+          rawTableName, tableConfigStr));
+      LOGGER.info("Add table successfully: " + response.getResponse());
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String deleteTableConfig(String tableName, String tableTypeStr) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPerfClusterPair();
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    if (tableTypeStr == null) {
+      CommonConstants.Helix.TableType type = TableNameBuilder.getTableTypeFromTableName(tableName);
+      if (type != null) {
+        tableTypeStr = type.name();
+      }
+    }
+    try {
+      SimpleHttpResponse response = _pinotClusterClient.sendRequest(PinotClusterClient.getDeleteTableConfigHttpURI(
+          PinotClusterClient.getRetrieveTableConfigHttpURI(pair.getFirst(), pair.getSecond(), rawTableName),
+          rawTableName, tableTypeStr));
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String listSchemas(String clusterType) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPinotClusterFromType(clusterType);
+    try {
+      SimpleHttpResponse response = _pinotClusterClient
+          .sendGetRequest(PinotClusterClient.getListSchemasHttpURI(pair.getFirst(), pair.getSecond()));
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String getSchema(String clusterType, String schemaName) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPinotClusterFromType(clusterType);
+    try {
+      SimpleHttpResponse response = _pinotClusterClient
+          .sendGetRequest(PinotClusterClient.getSchemaHTTPURI(pair.getFirst(), pair.getSecond(), schemaName));
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String addSchema(Schema schema) {
+    String schemaStr = schema.toPrettyJsonString();
+    InputStream schemaInputStream = new ByteArrayInputStream(schemaStr.getBytes());
+    return addSchema(schemaInputStream);
+  }
+
+  public String addSchema(FormDataMultiPart multiPart) {
+    FormDataBodyPart bodyPart = multiPart.getFields().values().iterator().next().get(0);
+    InputStream schemaInputStream = bodyPart.getValueAs(InputStream.class);
+    return addSchema(schemaInputStream);
+  }
+
+  public String addSchema(InputStream schemaInputStream) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPerfClusterPair();
+    try {
+      SimpleHttpResponse response = _pinotClusterClient.sendRequest(PinotClusterClient
+          .getAddSchemaRequest(PinotClusterClient.getListSchemasHttpURI(pair.getFirst(), pair.getSecond()), "schema",
+              schemaInputStream));
+      LOGGER.info("Add schema successfully: " + response.getResponse());
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String updateSchema(String schemaName, FormDataMultiPart multiPart) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPerfClusterPair();
+    FormDataBodyPart bodyPart = multiPart.getFields().values().iterator().next().get(0);
+    InputStream schemaInputStream = bodyPart.getValueAs(InputStream.class);
+
+    try {
+      SimpleHttpResponse response = _pinotClusterClient.sendRequest(PinotClusterClient
+          .getUpdateSchemaRequest(PinotClusterClient.getSchemaHTTPURI(pair.getFirst(), pair.getSecond(), schemaName),
+              schemaName, schemaInputStream));
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String deleteSchema(String schemaName) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPerfClusterPair();
+    try {
+      SimpleHttpResponse response = _pinotClusterClient
+          .sendDeleteRequest(PinotClusterClient.getSchemaHTTPURI(pair.getFirst(), pair.getSecond(), schemaName));
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public SuccessResponse createBenchmarkTable(FormDataMultiPart multiPart) {
+    CreatePerfTableRequest createPerfTableRequest = parseRequest(multiPart);
+
+    List<String> tableNames = listTables(PinotClusterLocator.PinotClusterType.PERF.getClusterType());
+    if (tableNames.contains(createPerfTableRequest.getRawTableName())) {
+      throw new PinotBenchException(LOGGER, "Table " + createPerfTableRequest.getRawTableName() + " already exists",
+          Response.Status.NOT_ACCEPTABLE);
+    }
+
+    Schema schema = validateSchema(createPerfTableRequest);
+    TableConfig offlineTableConfig = validateOfflineTableConfig(createPerfTableRequest);
+    TableConfig realtimeTableConfig = validateRealtimeTableConfig(createPerfTableRequest);
+
+    // Assign brokers and servers here before adding schema and table configs.
+    prepareInstances(createPerfTableRequest);
+
+    addSchema(schema);
+
+    try {
+      // puts sleeps between two calls.
+      Thread.sleep(50L);
+      addTableConfig(offlineTableConfig);
+      Thread.sleep(50L);
+      addTableConfig(realtimeTableConfig);
+      return new SuccessResponse("Create Table " + schema.getSchemaName() + " successfully");
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER,
+          "Exception when adding table config for Table: " + createPerfTableRequest.getRawTableName(),
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private CreatePerfTableRequest parseRequest(FormDataMultiPart multiPart) {
+    String tableName = null;
+    String tableType = null;
+    String mode = null;
+    String ldap = null;
+    String versionId = null;
+    int tableRetention = -1;
+    String tableConfig = null;
+    String schema = null;
+    int numBrokers = 0;
+    int numOfflineServers = 0;
+    int numRealtimeServers = 0;
+
+    for (Map.Entry<String, List<FormDataBodyPart>> entry : multiPart.getFields().entrySet()) {
+      String entryName = entry.getKey();
+      List<FormDataBodyPart> dataBodyPartList = entry.getValue();
+      throwExceptionIfViolated(dataBodyPartList.size() == 1, "The data body size should be 1");
+      String bodyPartValue = dataBodyPartList.get(0).getValueAs(String.class);
+
+      switch (entryName) {
+        case PerfTableCreationParameters.TABLE_CONFIG_KEY:
+          tableConfig = bodyPartValue;
+          break;
+        case PerfTableCreationParameters.TABLE_SCHEMA_KEY:
+          schema = bodyPartValue;
+          break;
+        case PerfTableCreationParameters.TABLE_NAME_KEY:
+          tableName = bodyPartValue;
+          break;
+        case PerfTableCreationParameters.TABLE_TYPE_KEY:
+          tableType = bodyPartValue;
+          break;
+        case PerfTableCreationParameters.MODE_KEY:
+          mode = bodyPartValue;
+          break;
+        case PerfTableCreationParameters.LDAP_KEY:
+          ldap = bodyPartValue;
+          break;
+        case PerfTableCreationParameters.TABLE_RETENTION_KEY:
+          tableRetention = Integer.parseInt(bodyPartValue);
+          break;
+        case PerfTableCreationParameters.VERSION_ID_KEY:
+          versionId = bodyPartValue;
+          break;
+        case PerfTableCreationParameters.NUM_BROKERS_KEY:
+          numBrokers = Integer.parseInt(bodyPartValue);
+          break;
+        case PerfTableCreationParameters.NUM_OFFLINE_SERVERS_KEY:
+          numOfflineServers = Integer.parseInt(bodyPartValue);
+          break;
+        case PerfTableCreationParameters.NUM_REALTIME_SERVERS_KEY:
+          numRealtimeServers = Integer.parseInt(bodyPartValue);
+          break;
+        default:
+          throw new PinotBenchException(LOGGER, "Invalid name:" + entryName, Response.Status.BAD_REQUEST);
+      }
+    }
+
+    PerfTableMode perfTableMode = PerfTableMode.getPerfTableMode(mode);
+    throwExceptionIfViolated(perfTableMode != null, "Perf table mode should not be null. Current value: " + mode);
+    throwExceptionIfViolated(ldap != null, "Ldap should not be null");
+    throwExceptionIfViolated(tableRetention != -1,
+        "Table retention should not be null. Current value: " + tableRetention);
+    throwExceptionIfViolated(tableType != null, "Perf table type should not be null");
+    throwExceptionIfViolated(tableName != null, "Table name should not be null");
+    throwExceptionIfViolated(numBrokers >= 0, "Number of brokers should be >= 0");
+    throwExceptionIfViolated(numOfflineServers >= 0, "Number of offline servers should be >= 0");
+    throwExceptionIfViolated(numRealtimeServers >= 0, "Number of realtime servers should be >= 0");
+
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    if (!rawTableName.endsWith(PinotBenchConstants.TABLE_TEST_SUFFIX)) {
+      rawTableName = rawTableName + PinotBenchConstants.TABLE_TEST_SUFFIX;
+    }
+    if (versionId != null) {
+      rawTableName = rawTableName + "_" + versionId;
+    }
+
+    if (perfTableMode == PerfTableMode.NON_MIRROR) {
+      throwExceptionIfViolated(tableConfig != null, "Table config should not be null for table in non-mirror mode");
+      throwExceptionIfViolated(schema != null, "Schema should not be null for table in non-mirror mode");
+    } else {
+      // Creates table in mirror mode.
+      if (schema == null) {
+        // Assume the schema name in prod is the same as the table name.
+        schema = getSchema(PinotClusterLocator.PinotClusterType.PROD.getClusterType(), tableName);
+      }
+      if (tableConfig == null) {
+        tableConfig = getTableConfig(PinotClusterLocator.PinotClusterType.PROD.getClusterType(), tableName);
+      }
+    }
+
+    String offlineTableConfigStr = null;
+    String realtimeTableConfigStr = null;
+    JsonNode jsonNode;
+    try {
+      jsonNode = JsonUtils.stringToJsonNode(tableConfig);
+    } catch (IOException e) {
+      throw new PinotBenchException(LOGGER, "IOException when parsing string to json node.",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    if (tableType.equalsIgnoreCase(PinotServerType.HYBRID) || tableType.equalsIgnoreCase(PinotServerType.OFFLINE)) {
+      offlineTableConfigStr = jsonNode.get(PinotServerType.OFFLINE).toString();
+    }
+    if (tableType.equalsIgnoreCase(PinotServerType.HYBRID) || tableType.equalsIgnoreCase(PinotServerType.REALTIME)) {
+      realtimeTableConfigStr = jsonNode.get(PinotServerType.REALTIME).toString();
+    }
+
+    String tenantTag = TenantTags.PINOT_BENCH_TENANT_TAG_PREFIX + ldap + "-" + rawTableName;
+    return new CreatePerfTableRequest(rawTableName, tableName, tableType, perfTableMode, ldap, versionId,
+        tableRetention, schema, offlineTableConfigStr, realtimeTableConfigStr, tenantTag, numBrokers, numOfflineServers,
+        numRealtimeServers);
+  }
+
+  private Schema validateSchema(CreatePerfTableRequest createPerfTableRequest) {
+    String rawTableName = TableNameBuilder.extractRawTableName(createPerfTableRequest.getRawTableName());
+    String schemaStr = createPerfTableRequest.getSchema();
+    Schema schema;
+    try {
+      schema = Schema.fromString(schemaStr);
+    } catch (IOException e) {
+      throw new PinotBenchException(LOGGER, "IOException when parsing schema for Table: " + rawTableName,
+          Response.Status.BAD_REQUEST, e);
+    }
+    schema.setSchemaName(rawTableName);
+    return schema;
+  }
+
+  private TableConfig validateOfflineTableConfig(CreatePerfTableRequest createPerfTableRequest) {
+    return validateTableConfig(createPerfTableRequest, createPerfTableRequest.getOfflineTableConfig());
+  }
+
+  private TableConfig validateRealtimeTableConfig(CreatePerfTableRequest createPerfTableRequest) {
+    return validateTableConfig(createPerfTableRequest, createPerfTableRequest.getRealtimeTableConfig());
+  }
+
+  private TableConfig validateTableConfig(CreatePerfTableRequest createPerfTableRequest, String tableConfigStr) {
+    if (tableConfigStr == null) {
+      return null;
+    }
+    TableConfig tableConfig;
+    try {
+      tableConfig = TableConfig.fromJsonString(tableConfigStr);
+    } catch (IOException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST);
+    }
+
+    SegmentsValidationAndRetentionConfig segmentConfig = tableConfig.getValidationConfig();
+    if (segmentConfig.getReplicationNumber() != 1) {
+      throw new PinotBenchException(LOGGER,
+          "Replication should be 1. Current replication: " + segmentConfig.getReplicationNumber(),
+          Response.Status.BAD_REQUEST);
+    }
+
+    TableCustomConfig customConfig = tableConfig.getCustomConfig();
+    Map<String, String> customConfigMap = customConfig.getCustomConfigs();
+    if (customConfigMap == null) {
+      customConfigMap = new HashMap<>();
+      customConfig.setCustomConfigs(customConfigMap);
+    }
+
+    String ldap = createPerfTableRequest.getLdap();
+    String versionId = createPerfTableRequest.getVersionId();
+    int tableRetention = createPerfTableRequest.getTableRetention();
+    CommonConstants.Helix.TableType tableType = tableConfig.getTableType();
+
+    long creationTimeMs = System.currentTimeMillis();
+    long expirationTimeMs = creationTimeMs + TimeUnit.DAYS.toMillis(tableRetention);
+    customConfigMap.put(PerfTableCreationParameters.CREATION_TIME_MS_KEY, Long.toString(creationTimeMs));
+    customConfigMap.put(PerfTableCreationParameters.EXPIRATION_TIME_MS_KEY, Long.toString(expirationTimeMs));
+    customConfigMap.put(PerfTableCreationParameters.TABLE_RETENTION_KEY, Integer.toString(tableRetention));
+    customConfigMap.put(PerfTableCreationParameters.LDAP_KEY, ldap);
+    customConfigMap.put(PerfTableCreationParameters.VERSION_ID_KEY, versionId);
+    customConfigMap
+        .put(PerfTableCreationParameters.NUM_BROKERS_KEY, Integer.toString(createPerfTableRequest.getNumBrokers()));
+
+    if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
+      int numOfflineServers = createPerfTableRequest.getNumOfflineServers();
+
+      // Set numInstancesPerPartition to the number of hosts specified in the params for offline table
+      String segmentAssignmentStrategy = segmentConfig.getSegmentAssignmentStrategy();
+      if (CommonConstants.Helix.DataSource.SegmentAssignmentStrategyType.valueOf(segmentAssignmentStrategy)
+          == CommonConstants.Helix.DataSource.SegmentAssignmentStrategyType.ReplicaGroupSegmentAssignmentStrategy) {
+        segmentConfig.setReplicasPerPartition(Integer.toString(numOfflineServers));
+      }
+
+      // Add number of hosts to custom config.
+      customConfigMap.put(PerfTableCreationParameters.NUM_OFFLINE_SERVERS_KEY,
+          Integer.toString(createPerfTableRequest.getNumOfflineServers()));
+    } else {
+      // Set replicasPerPartition to 1
+      segmentConfig.setReplicasPerPartition("1");
+
+      IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+      Map<String, String> streamConfigsMap = indexingConfig.getStreamConfigs();
+
+      // Set kafka auto offset to “largest”
+      streamConfigsMap.put("stream.kafka.consumer.prop.auto.offset.reset", "largest");
+
+      // Add number of hosts to custom config.
+      customConfigMap.put(PerfTableCreationParameters.NUM_REALTIME_SERVERS_KEY,
+          Integer.toString(createPerfTableRequest.getNumRealtimeServers()));
+    }
+
+    String rawTableName = createPerfTableRequest.getRawTableName();
+    tableConfig.setTableName(TableNameBuilder.forType(tableType).tableNameWithType(rawTableName));
+
+    TenantConfig tenantConfig = tableConfig.getTenantConfig();
+    String tenantTag = createPerfTableRequest.getTenantTag();
+    tenantConfig.setBroker(tenantTag);
+    tenantConfig.setServer(tenantTag);
+    tableConfig.setTenantConfig(tenantConfig);
+    return tableConfig;
+  }
+
+  private void prepareInstances(CreatePerfTableRequest createPerfTableRequest) {
+    String tenantTag = createPerfTableRequest.getTenantTag();
+    int numBrokers = createPerfTableRequest.getNumBrokers();
+    int numOfflineServers = createPerfTableRequest.getNumOfflineServers();
+    int numRealtimeServers = createPerfTableRequest.getNumRealtimeServers();
+
+    List<String> spareBrokerInstances = _helixAdmin
+        .getInstancesInClusterWithTag(_helixZkManager.getClusterName(), TenantTags.DEFAULT_UNTAGGED_BROKER_TAG);
+    List<String> spareServerInstances = _helixAdmin
+        .getInstancesInClusterWithTag(_helixZkManager.getClusterName(), TenantTags.DEFAULT_UNTAGGED_SERVER_TAG);
+
+    if (spareBrokerInstances.size() < numBrokers) {
+      throw new PinotBenchException(LOGGER,
+          "Not enough spare brokers. Current number of spare brokers: " + spareBrokerInstances.size()
+              + ", requested number of brokers: " + numBrokers, Response.Status.BAD_REQUEST);
+    }
+
+    if (spareServerInstances.size() < (numOfflineServers + numRealtimeServers)) {
+      throw new PinotBenchException(LOGGER,
+          "Not enough spare servers. Current number of spare servers: " + spareServerInstances.size()
+              + ", requested number of offline servers: " + numOfflineServers
+              + ", requested number of realtime servers: " + numRealtimeServers, Response.Status.BAD_REQUEST);
+    }
+
+    // TODO: selects instances randomly
+    List<String> brokersInUse = new ArrayList<>();
+    for (int i = 0; i < numBrokers; i++) {
+      String instanceName = spareBrokerInstances.get(i);
+      _helixAdmin
+          .removeInstanceTag(_helixZkManager.getClusterName(), instanceName, TenantTags.DEFAULT_UNTAGGED_BROKER_TAG);
+      _helixAdmin.addInstanceTag(_helixZkManager.getClusterName(), instanceName, tenantTag + TenantTags.BROKER_SUFFIX);
+      brokersInUse.add(instanceName);
+    }
+
+    List<String> offlineServersInUse = new ArrayList<>();
+    List<String> realtimeServersInUse = new ArrayList<>();
+    int numServers = numOfflineServers + numRealtimeServers;
+    // TODO: selects instances randomly
+    for (int i = 0, j = 0; i < numServers; i++, j++) {
+      String instanceName = spareServerInstances.get(i);
+      String tagSuffix = (j < numOfflineServers) ? TenantTags.OFFLINE_SERVER_SUFFIX : TenantTags.REALTIME_SERVER_SUFFIX;
+      _helixAdmin
+          .removeInstanceTag(_helixZkManager.getClusterName(), instanceName, TenantTags.DEFAULT_UNTAGGED_SERVER_TAG);
+      _helixAdmin.addInstanceTag(_helixZkManager.getClusterName(), instanceName, tenantTag + tagSuffix);
+
+      if (j < numOfflineServers) {
+        offlineServersInUse.add(instanceName);
+      } else {
+        realtimeServersInUse.add(instanceName);
+      }
+    }
+    LOGGER.info("Finish preparing brokers and servers. Brokers: {}, offline servers: {}, realtime servers: {}",
+        brokersInUse, offlineServersInUse, realtimeServersInUse);
+  }
+
+  /**
+   * Similar to Precondition.checkState, but it throws PinotBenchException.
+   */
+  private void throwExceptionIfViolated(boolean expression, String errorMessage) {
+    if (!expression) {
+      throw new PinotBenchException(LOGGER, errorMessage, Response.Status.BAD_REQUEST);
     }
   }
 }

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/PinotClusterManager.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/PinotClusterManager.java
@@ -1,0 +1,57 @@
+package org.apache.pinot.benchmark.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.benchmark.PinotBenchConf;
+import org.apache.pinot.benchmark.api.resources.PinotBenchException;
+import org.apache.pinot.benchmark.common.utils.PinotClusterClient;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.JsonUtils;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PinotClusterManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotClusterManager.class);
+
+  private PinotBenchConf _conf;
+  private FileUploadDownloadClient _fileUploadDownloadClient;
+  private PinotClusterClient _pinotClusterClient;
+
+  private String _perfHost;
+  private int _perfPort;
+  private String _prodHost;
+  private int _prodPort;
+
+  public PinotClusterManager(PinotBenchConf conf) {
+    _conf = conf;
+    _perfHost = conf.getPerfControllerHost();
+    _perfPort = conf.getPerfControllerPort();
+    _prodHost = conf.getProdControllerHost();
+    _prodPort = conf.getProdControllerPort();
+    _fileUploadDownloadClient = new FileUploadDownloadClient();
+    _pinotClusterClient = new PinotClusterClient();
+  }
+
+  public List<String> listTables() {
+    List<String> tableNames = new ArrayList<>();
+    try {
+      SimpleHttpResponse response =
+          _pinotClusterClient.sendGetRequest(PinotClusterClient.getListAllTablesHttpURI(_perfHost, _perfPort));
+      JsonNode jsonArray = JsonUtils.stringToJsonNode(response.getResponse()).get("tables");
+
+      Iterator<JsonNode> elements = jsonArray.elements();
+      while (elements.hasNext()) {
+        tableNames.add(elements.next().asText());
+      }
+      return tableNames;
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/PinotClusterManager.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/PinotClusterManager.java
@@ -69,10 +69,10 @@ public class PinotClusterManager {
   private HelixManager _helixZkManager;
   private HelixAdmin _helixAdmin;
 
-  public PinotClusterManager(PinotBenchConf conf) {
+  public PinotClusterManager(PinotBenchConf conf, PinotClusterClient pinotClusterClient, PinotClusterLocator pinotClusterLocator) {
     _conf = conf;
-    _pinotClusterLocator = new PinotClusterLocator(conf);
-    _pinotClusterClient = new PinotClusterClient();
+    _pinotClusterClient = pinotClusterClient;
+    _pinotClusterLocator = pinotClusterLocator;
   }
 
   public void start(HelixManager helixManager) {
@@ -285,9 +285,9 @@ public class PinotClusterManager {
 
     try {
       // puts sleeps between two calls.
-      Thread.sleep(50L);
+      Thread.sleep(100L);
       addTableConfig(offlineTableConfig);
-      Thread.sleep(50L);
+      Thread.sleep(100L);
       addTableConfig(realtimeTableConfig);
       return new SuccessResponse("Create Table " + schema.getSchemaName() + " successfully");
     } catch (Exception e) {

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/data/DataPreparationManager.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/data/DataPreparationManager.java
@@ -1,0 +1,243 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.api.data;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.core.Response;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.pinot.benchmark.PinotBenchConf;
+import org.apache.pinot.benchmark.api.resources.PinotBenchException;
+import org.apache.pinot.benchmark.api.resources.SuccessResponse;
+import org.apache.pinot.benchmark.common.utils.PinotBenchConstants.PinotServerType;
+import org.apache.pinot.benchmark.common.utils.PinotClusterClient;
+import org.apache.pinot.benchmark.common.utils.PinotClusterLocator;
+import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.exception.HttpErrorStatusException;
+import org.apache.pinot.common.utils.JsonUtils;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.pql.parsers.utils.Pair;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class DataPreparationManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataPreparationManager.class);
+  private static final String TMP_DIR_PREFIX = "tmp-";
+
+  private final PinotBenchConf _conf;
+  private final PinotClusterClient _pinotClusterClient;
+  private final PinotClusterLocator _pinotClusterLocator;
+
+  private HelixManager _helixManager;
+  private HelixAdmin _helixAdmin;
+
+  public DataPreparationManager(PinotBenchConf pinotBenchConf, PinotClusterClient pinotClusterClient,
+      PinotClusterLocator pinotClusterLocator) {
+    _conf = pinotBenchConf;
+    _pinotClusterClient = pinotClusterClient;
+    _pinotClusterLocator = pinotClusterLocator;
+  }
+
+  public void start(HelixManager helixManager) {
+    _helixManager = helixManager;
+    _helixAdmin = _helixManager.getClusterManagmentTool();
+  }
+
+  public String listSegments(String clusterType, String tableName) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPinotClusterFromType(clusterType);
+    try {
+      SimpleHttpResponse response = _pinotClusterClient
+          .sendGetRequest(PinotClusterClient.getListSegmentsHttpURI(pair.getFirst(), pair.getSecond(), tableName));
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER,
+          "Exception when listing segments for Table: " + tableName + " from Cluster: " + clusterType,
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String uploadSegment(FormDataMultiPart multiPart) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getPerfClusterPair();
+    FormDataBodyPart bodyPart = multiPart.getFields().values().iterator().next().get(0);
+    InputStream segmentInputStream = bodyPart.getValueAs(InputStream.class);
+
+    try {
+      SimpleHttpResponse response = _pinotClusterClient.sendRequest(PinotClusterClient
+          .getUploadSegmentRequest(PinotClusterClient.getUploadSegmentHttpURI(pair.getFirst(), pair.getSecond()),
+              "segment", segmentInputStream));
+      LOGGER.info("Added segment successfully: " + response.getResponse());
+      return response.getResponse();
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public String convertAndUploadSegment(String tableName, FormDataMultiPart multiPart, String actionsStr) {
+    if (actionsStr == null || actionsStr.isEmpty()) {
+      return uploadSegment(multiPart);
+    }
+    String[] actions = actionsStr.split(",");
+    int index = 0;
+
+    Pair<String, Integer> pair = _pinotClusterLocator.getPerfClusterPair();
+    FormDataBodyPart bodyPart = multiPart.getFields().values().iterator().next().get(0);
+    InputStream segmentInputStream = bodyPart.getValueAs(InputStream.class);
+
+    List<NameValuePair> nameValuePairs = new ArrayList<>();
+    if ("convert".equalsIgnoreCase(actions[index])) {
+      index++;
+      nameValuePairs.add(new BasicNameValuePair("tableName", tableName));
+    }
+
+    if ("upload".equalsIgnoreCase(actions[index])) {
+      try {
+        SimpleHttpResponse response = _pinotClusterClient.sendRequest(PinotClusterClient
+            .getUploadSegmentRequest(PinotClusterClient.getUploadSegmentHttpURI(pair.getFirst(), pair.getSecond()),
+                "segment", segmentInputStream, null, nameValuePairs));
+        return response.getResponse();
+      } catch (HttpErrorStatusException e) {
+        throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+      } catch (Exception e) {
+        throw new PinotBenchException(LOGGER, "Exception when sending upload segment to perf cluster",
+            Response.Status.INTERNAL_SERVER_ERROR, e);
+      }
+    } else {
+      return "No actions taken for Table: " + tableName;
+    }
+  }
+
+  public SuccessResponse copyConvertAndUploadSegments(String originalTableName, String targetTableName,
+      boolean diffOnly) {
+    if (originalTableName == null || originalTableName.isEmpty()) {
+      throw new PinotBenchException(LOGGER, "Original table name should not be null", Response.Status.BAD_REQUEST);
+    }
+    Pair<String, Integer> pair = _pinotClusterLocator.getPerfClusterPair();
+    List<String> prodOfflineSegmentNames =
+        getOfflineSegmentNames(PinotClusterLocator.PinotClusterType.PROD, originalTableName);
+
+    if (diffOnly) {
+      List<String> perfOfflineSegmentNames =
+          getOfflineSegmentNames(PinotClusterLocator.PinotClusterType.PERF, targetTableName);
+      removeExistingSegments(originalTableName, targetTableName, prodOfflineSegmentNames, perfOfflineSegmentNames);
+    }
+
+    String originalRawTableName = TableNameBuilder.extractRawTableName(originalTableName);
+    int uploadedSegmentCount = 0;
+    for (String offlineSegmentName : prodOfflineSegmentNames) {
+      String url = getSegmentDownloadUrl(originalRawTableName, offlineSegmentName);
+      if (url == null) {
+        throw new PinotBenchException(LOGGER,
+            "Could not find download url for Segment: " + offlineSegmentName + " of Table: " + originalTableName,
+            Response.Status.INTERNAL_SERVER_ERROR);
+      }
+
+      try {
+        SimpleHttpResponse response = _pinotClusterClient.sendRequest(PinotClusterClient
+            .getUploadSegmentRequest(PinotClusterClient.getUploadSegmentHttpURI(pair.getFirst(), pair.getSecond()),
+                targetTableName, "segment", url));
+
+        uploadedSegmentCount++;
+        LOGGER.info(response.getResponse());
+      } catch (HttpErrorStatusException e) {
+        throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+      } catch (Exception e) {
+        throw new PinotBenchException(LOGGER, "Exception when uploading segment to perf cluster",
+            Response.Status.INTERNAL_SERVER_ERROR, e);
+      }
+    }
+    return new SuccessResponse(
+        "Successfully uploaded " + uploadedSegmentCount + " segments from Table: " + originalTableName
+            + " to perf Table: " + targetTableName);
+  }
+
+  private List<String> getOfflineSegmentNames(PinotClusterLocator.PinotClusterType pinotClusterType, String tableName) {
+    String perfSegmentListStr = listSegments(pinotClusterType.name(), tableName);
+    return parseOfflineSegmentNames(tableName, perfSegmentListStr);
+  }
+
+  private List<String> parseOfflineSegmentNames(String originalTableName, String segmentsList) {
+    List<String> segmentNames = new ArrayList<>();
+    try {
+      JsonNode jsonArray = JsonUtils.stringToJsonNode(segmentsList);
+      for (final JsonNode node : jsonArray) {
+        JsonNode offlineJsonNode = node.get(PinotServerType.OFFLINE);
+        if (offlineJsonNode != null) {
+          if (offlineJsonNode.size() != 0) {
+            for (JsonNode segmentNameJsonNode : offlineJsonNode) {
+              segmentNames.add(segmentNameJsonNode.asText());
+            }
+          } else {
+            throw new PinotBenchException(LOGGER, "There is no segment in Table: " + originalTableName,
+                Response.Status.INTERNAL_SERVER_ERROR);
+          }
+        }
+      }
+      return segmentNames;
+    } catch (IOException e) {
+      throw new PinotBenchException(LOGGER, "IOException when parsing segment names for Table: " + originalTableName,
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private void removeExistingSegments(String originalTableName, String targetTableName,
+      List<String> prodOfflineSegmentNames, List<String> perfOfflineSegmentNames) {
+    for (String perfSegmentName : perfOfflineSegmentNames) {
+      String prodSegment = perfSegmentName.replace(targetTableName, originalTableName);
+      prodOfflineSegmentNames.remove(prodSegment);
+    }
+  }
+
+  private String getSegmentDownloadUrl(String rawTableName, String segmentName) {
+    Pair<String, Integer> pair = _pinotClusterLocator.getProdClusterPair();
+    try {
+      SimpleHttpResponse response = _pinotClusterClient.sendGetRequest(PinotClusterClient
+          .getRetrieveSegmentMetadataHttpURI(pair.getFirst(), pair.getSecond(), rawTableName, segmentName));
+      JsonNode jsonArray = JsonUtils.stringToJsonNode(response.getResponse());
+
+      for (final JsonNode jsonNode : jsonArray) {
+        for (JsonNode node : jsonNode) {
+          JsonNode state = node.get("state");
+          if (state != null) {
+            return state.get("segment.offline.download.url").asText();
+          }
+        }
+      }
+      return null;
+    } catch (HttpErrorStatusException e) {
+      throw new PinotBenchException(LOGGER, e.getMessage(), e.getStatusCode(), e);
+    } catch (Exception e) {
+      throw new PinotBenchException(LOGGER,
+          "Exception when getting metadata for Segment: " + segmentName + " of Table: " + rawTableName,
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/BenchmarkExecutionResource.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/BenchmarkExecutionResource.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.api.resources;
+
+import io.swagger.annotations.Api;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+
+@Api(tags = "benchmark")
+@Path("/")
+public class BenchmarkExecutionResource {
+
+  @GET
+  @Path("/test")
+  public String test() {
+    return "Hello world!";
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/ClusterManagementResource.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/ClusterManagementResource.java
@@ -19,18 +19,32 @@
 package org.apache.pinot.benchmark.api.resources;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import java.util.List;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.apache.pinot.benchmark.api.PinotClusterManager;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
-@Api(tags = "benchmark")
+@Api(tags = "Cluster Management")
 @Path("/")
 public class ClusterManagementResource {
+  public static final Logger LOGGER = LoggerFactory.getLogger(ClusterManagementResource.class);
 
   @Inject
   private PinotClusterManager _pinotClusterManager;
@@ -38,7 +52,99 @@ public class ClusterManagementResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/cluster/tables")
-  public List<String> listAllTables() {
-    return _pinotClusterManager.listTables();
+  public List<String> listAllTables(@ApiParam(value = "perf|prod") @QueryParam("cluster") String clusterType) {
+    return _pinotClusterManager.listTables(clusterType);
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/cluster/tables/{tableName}")
+  public String getTableConfig(
+      @ApiParam(value = "Table name", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "perf|prod") @QueryParam("cluster") String clusterType) {
+    return _pinotClusterManager.getTableConfig(clusterType, tableName);
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/cluster/tables")
+  @ApiOperation(value = "Adds a table", notes = "Adds a table")
+  public String addTable(FormDataMultiPart multiPart) {
+    return _pinotClusterManager.addTableConfig(multiPart);
+  }
+
+  @PUT
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/cluster/tables/{tableName}")
+  @ApiOperation(value = "Update a table", notes = "Updates a table")
+  public String updateTable(@ApiParam(value = "Table name", required = true) @PathParam("tableName") String tableName,
+      String tableConfigStr) {
+    return _pinotClusterManager.updateTableConfig(tableName, tableConfigStr);
+  }
+
+  @DELETE
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/cluster/tables/{tableName}")
+  @ApiOperation(value = "Delete a table", notes = "Deletes a table by name")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully deleted table config"), @ApiResponse(code = 404, message = "Table config not found"), @ApiResponse(code = 409, message = "Table config already exists"), @ApiResponse(code = 500, message = "Error deleting table config")})
+  public String deleteTableConfig(
+      @ApiParam(value = "Schema name", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "realtime|offline") @QueryParam("type") String tableTypeStr) {
+    return _pinotClusterManager.deleteTableConfig(tableName, tableTypeStr);
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/cluster/schemas")
+  @ApiOperation(value = "List all schema names", notes = "Lists all schema names")
+  public String listSchemaNames(@ApiParam(value = "perf|prod") @QueryParam("cluster") String clusterType) {
+    return _pinotClusterManager.listSchemas(clusterType);
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/cluster/schemas/{schemaName}")
+  public String getSchema(@ApiParam(value = "Schema name", required = true) @PathParam("schemaName") String schemaName,
+      @ApiParam(value = "perf|prod") @QueryParam("cluster") String clusterType) {
+    return _pinotClusterManager.getSchema(clusterType, schemaName);
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Path("/cluster/schemas")
+  @ApiOperation(value = "Add a new schema", notes = "Adds a new schema")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully added schema"), @ApiResponse(code = 404, message = "Schema not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
+  public String addSchema(FormDataMultiPart multiPart) {
+    return _pinotClusterManager.addSchema(multiPart);
+  }
+
+  @PUT
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Path("/cluster/schemas/{schemaName}")
+  public String updateSchema(
+      @ApiParam(value = "Name of the schema", required = true) @PathParam("schemaName") String schemaName,
+      FormDataMultiPart multiPart) {
+    return _pinotClusterManager.updateSchema(schemaName, multiPart);
+  }
+
+  @DELETE
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/cluster/schemas/{schemaName}")
+  @ApiOperation(value = "Delete a schema", notes = "Deletes a schema by name")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully deleted schema"), @ApiResponse(code = 404, message = "Schema not found"), @ApiResponse(code = 409, message = "Schema is in use"), @ApiResponse(code = 500, message = "Error deleting schema")})
+  public String deleteSchema(
+      @ApiParam(value = "Schema name", required = true) @PathParam("schemaName") String schemaName) {
+    return _pinotClusterManager.deleteSchema(schemaName);
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Path("/cluster/createTable")
+  @ApiOperation(value = "Create a benchmark table in perf cluster", notes = "Creates a benchmark table in perf cluster")
+  public SuccessResponse createBenchmarkTable(FormDataMultiPart multiPart) {
+    return _pinotClusterManager.createBenchmarkTable(multiPart);
   }
 }

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/ClusterManagementResource.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/ClusterManagementResource.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.api.resources;
+
+import io.swagger.annotations.Api;
+import java.util.List;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.apache.pinot.benchmark.api.PinotClusterManager;
+
+
+@Api(tags = "benchmark")
+@Path("/")
+public class ClusterManagementResource {
+
+  @Inject
+  private PinotClusterManager _pinotClusterManager;
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/cluster/tables")
+  public List<String> listAllTables() {
+    return _pinotClusterManager.listTables();
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/CreatePerfTableRequest.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/CreatePerfTableRequest.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.api.resources;
+
+import org.apache.pinot.benchmark.common.utils.PerfTableMode;
+
+
+public class CreatePerfTableRequest {
+  private String _rawTableName = null;
+  private String _tableName = null;
+  private String _tableType = null;
+  private PerfTableMode _mode = null;
+  private String _ldap = null;
+  private String _versionId = null;
+  private int _tableRetention = -1;
+  private String _schema = null;
+  private String _realtimeTableConfig;
+  private String _offlineTableConfig;
+  private String _tenantTag;
+  private int _numBrokers;
+  private int _numOfflineServers;
+  private int _numRealtimeServers;
+
+  public CreatePerfTableRequest() {
+  }
+
+  public CreatePerfTableRequest(String rawTableName, String tableName, String tableType, PerfTableMode mode,
+      String ldap, String versionId, int tableRetention, String schema, String offlineTableConfig,
+      String realtimeTableConfig, String tenantTag, int numBrokers, int numOfflineServers, int numRealtimeServers) {
+    _rawTableName = rawTableName;
+    _tableName = tableName;
+    _tableType = tableType;
+    _mode = mode;
+    _ldap = ldap;
+    _versionId = versionId;
+    _tableRetention = tableRetention;
+    _schema = schema;
+    _offlineTableConfig = offlineTableConfig;
+    _realtimeTableConfig = realtimeTableConfig;
+    _tenantTag = tenantTag;
+    _numBrokers = numBrokers;
+    _numOfflineServers = numOfflineServers;
+    _numRealtimeServers = numRealtimeServers;
+  }
+
+  public String getRawTableName() {
+    return _rawTableName;
+  }
+
+  public void setRawTableName(String rawTableName) {
+    _rawTableName = rawTableName;
+  }
+
+  public String getTableName() {
+    return _tableName;
+  }
+
+  public void setTableName(String tableName) {
+    _tableName = tableName;
+  }
+
+  public String getTableType() {
+    return _tableType;
+  }
+
+  public void setTableType(String tableType) {
+    _tableType = tableType;
+  }
+
+  public PerfTableMode getMode() {
+    return _mode;
+  }
+
+  public void setMode(PerfTableMode mode) {
+    _mode = mode;
+  }
+
+  public String getLdap() {
+    return _ldap;
+  }
+
+  public void setLdap(String ldap) {
+    _ldap = ldap;
+  }
+
+  public String getVersionId() {
+    return _versionId;
+  }
+
+  public void setVersionId(String versionId) {
+    _versionId = versionId;
+  }
+
+  public int getTableRetention() {
+    return _tableRetention;
+  }
+
+  public void setTableRetention(int tableRetention) {
+    _tableRetention = tableRetention;
+  }
+
+  public String getSchema() {
+    return _schema;
+  }
+
+  public void setSchema(String schema) {
+    this._schema = schema;
+  }
+
+  public String getRealtimeTableConfig() {
+    return _realtimeTableConfig;
+  }
+
+  public void setRealtimeTableConfig(String realtimeTableConfig) {
+    _realtimeTableConfig = realtimeTableConfig;
+  }
+
+  public String getOfflineTableConfig() {
+    return _offlineTableConfig;
+  }
+
+  public void setOfflineTableConfig(String offlineTableConfig) {
+    _offlineTableConfig = offlineTableConfig;
+  }
+
+  public String getTenantTag() {
+    return _tenantTag;
+  }
+
+  public void setTenantTag(String tenantTag) {
+    _tenantTag = tenantTag;
+  }
+
+  public int getNumBrokers() {
+    return _numBrokers;
+  }
+
+  public void setNumBrokers(int numBrokers) {
+    _numBrokers = numBrokers;
+  }
+
+  public int getNumOfflineServers() {
+    return _numOfflineServers;
+  }
+
+  public void setNumOfflineServers(int numOfflineServers) {
+    _numOfflineServers = numOfflineServers;
+  }
+
+  public int getNumRealtimeServers() {
+    return _numRealtimeServers;
+  }
+
+  public void setNumRealtimeServers(int numRealtimeServers) {
+    _numRealtimeServers = numRealtimeServers;
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/DataPreparationResource.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/DataPreparationResource.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import org.apache.pinot.benchmark.api.data.DataPreparationManager;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Api(tags = "Data Preparation")
+@Path("/")
+public class DataPreparationResource {
+  public static final Logger LOGGER = LoggerFactory.getLogger(DataPreparationManager.class);
+
+  @Inject
+  private DataPreparationManager _dataPreparationManager;
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/data/tables/{tableName}/segments")
+  public String listSegments(@ApiParam(value = "Table name", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "perf|prod") @QueryParam("cluster") String clusterType) {
+    return _dataPreparationManager.listSegments(clusterType, tableName);
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/data/segments")
+  public String uploadSegments(FormDataMultiPart multiPart) {
+    return _dataPreparationManager.uploadSegment(multiPart);
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/data/tables/{tableName}/segments")
+  public String convertAndUploadSegments(
+      @ApiParam(value = "Table name", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "upload|convert,upload") @QueryParam("actions") String actions, FormDataMultiPart multiPart) {
+    return _dataPreparationManager.convertAndUploadSegment(tableName, multiPart, actions);
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/data/mirror")
+  public SuccessResponse copyConvertAndUploadSegments(
+      @ApiParam(value = "originTableName") @QueryParam("from") String originTableName,
+      @ApiParam(value = "targetTableName") @QueryParam("to") String targetTableName,
+      @ApiParam(value = "diffOnly") @QueryParam("diffOnly") @DefaultValue("false") boolean diffOnly) {
+    return _dataPreparationManager.copyConvertAndUploadSegments(originTableName, targetTableName, diffOnly);
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/DataPreparationResource.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/DataPreparationResource.java
@@ -76,4 +76,12 @@ public class DataPreparationResource {
       @ApiParam(value = "diffOnly") @QueryParam("diffOnly") @DefaultValue("false") boolean diffOnly) {
     return _dataPreparationManager.copyConvertAndUploadSegments(originTableName, targetTableName, diffOnly);
   }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/data/queries")
+  public SuccessResponse uploadQueries(@ApiParam(value = "originTableName") @QueryParam("from") String originTableName,
+      @ApiParam(value = "targetTableName") @QueryParam("to") String targetTableName, FormDataMultiPart multiPart) {
+    return _dataPreparationManager.uploadQueries(originTableName, targetTableName, multiPart);
+  }
 }

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/LandingPageHandler.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/LandingPageHandler.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.api.resources;
+
+import java.io.InputStream;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Path("/")
+public class LandingPageHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LandingPageHandler.class);
+
+  // We configure this static resource as jersey handler because all our APIs are at "/"
+  // So, the framework does not serve base index.html page correctly. See ControllerAdminApiApplication
+  // for more details.
+  @GET
+  @Produces(MediaType.TEXT_HTML)
+  public InputStream getIndexPage() {
+    return getClass().getClassLoader().getResourceAsStream("static/index.html");
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/PinotBenchException.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/PinotBenchException.java
@@ -1,7 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.benchmark.api.resources;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.slf4j.Logger;
 
@@ -20,7 +39,7 @@ public class PinotBenchException extends WebApplicationException {
   }
 
   public PinotBenchException(Logger logger, String message, int status, @Nullable Throwable e) {
-    super(message, status);
+    super(Response.status(status).entity(message).type(MediaType.TEXT_PLAIN).build());
     if (status >= 300 && status < 500) {
       if (e == null) {
         logger.info(message);

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/PinotBenchException.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/PinotBenchException.java
@@ -1,0 +1,38 @@
+package org.apache.pinot.benchmark.api.resources;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.slf4j.Logger;
+
+
+public class PinotBenchException extends WebApplicationException {
+  public PinotBenchException(Logger logger, String message, Response.Status status) {
+    this(logger, message, status.getStatusCode(), null);
+  }
+
+  public PinotBenchException(Logger logger, String message, int status) {
+    this(logger, message, status, null);
+  }
+
+  public PinotBenchException(Logger logger, String message, Response.Status status, @Nullable Throwable e) {
+    this(logger, message, status.getStatusCode(), e);
+  }
+
+  public PinotBenchException(Logger logger, String message, int status, @Nullable Throwable e) {
+    super(message, status);
+    if (status >= 300 && status < 500) {
+      if (e == null) {
+        logger.info(message);
+      } else {
+        logger.info(message + " exception: " + e.getMessage());
+      }
+    } else {
+      if (e == null) {
+        logger.error(message);
+      } else {
+        logger.error(message, e);
+      }
+    }
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/SuccessResponse.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/resources/SuccessResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.api.resources;
+
+public final class SuccessResponse {
+  private final String _status;
+
+  public SuccessResponse(String status) {
+    _status = status;
+  }
+
+  public String getStatus() {
+    return _status;
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/retentions/TableRetentionManager.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/api/retentions/TableRetentionManager.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.api.retentions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import javax.ws.rs.core.Response;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.pinot.benchmark.PinotBenchConf;
+import org.apache.pinot.benchmark.api.PinotClusterManager;
+import org.apache.pinot.benchmark.api.resources.PinotBenchException;
+import org.apache.pinot.benchmark.common.utils.PinotBenchConstants.PerfTableCreationParameters;
+import org.apache.pinot.benchmark.common.utils.PinotBenchConstants.PinotServerType;
+import org.apache.pinot.benchmark.common.utils.PinotClusterLocator;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.config.TenantConfig;
+import org.apache.pinot.common.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class TableRetentionManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableRetentionManager.class);
+  private final PinotClusterManager _pinotClusterManager;
+  private final long _tableRetentionManagerInitialDelayInSeconds;
+  private final long _tableRetentionManagerIntervalInSeconds;
+
+  private ScheduledExecutorService _executorService;
+  private HelixManager _helixManager;
+  private HelixAdmin _helixAdmin;
+
+  public TableRetentionManager(PinotBenchConf pinotBenchConf, PinotClusterManager pinotClusterManager) {
+    _tableRetentionManagerInitialDelayInSeconds = pinotBenchConf.getTableRetentionManagerInitialDelayInSeconds();
+    _tableRetentionManagerIntervalInSeconds = pinotBenchConf.getTableRetentionManagerFrequencyInSeconds();
+    _pinotClusterManager = pinotClusterManager;
+  }
+
+  public void start(HelixManager helixManager) {
+    _helixManager = helixManager;
+    _helixAdmin = _helixManager.getClusterManagmentTool();
+
+    _executorService = Executors.newSingleThreadScheduledExecutor();
+    _executorService.scheduleWithFixedDelay(() -> {
+      try {
+        List<String> perfTables = _pinotClusterManager.listTables(PinotClusterLocator.PinotClusterType.PERF.name());
+        LOGGER.info("Start checking table retentions for {} raw tables", perfTables.size());
+        int deletedTableCount = 0;
+        for (String perfTable : perfTables) {
+          String tableConfigStr =
+              _pinotClusterManager.getTableConfig(PinotClusterLocator.PinotClusterType.PERF.name(), perfTable);
+
+          JsonNode jsonNode;
+          try {
+            jsonNode = JsonUtils.stringToJsonNode(tableConfigStr);
+          } catch (IOException e) {
+            throw new PinotBenchException(LOGGER, "IOException when parsing string to json node.",
+                Response.Status.INTERNAL_SERVER_ERROR);
+          }
+
+          JsonNode offlineTableConfigJsonNode = jsonNode.get(PinotServerType.OFFLINE);
+          TableConfig offlineTableConfig = null;
+          if (offlineTableConfigJsonNode != null) {
+            offlineTableConfig = TableConfig.fromJsonConfig(offlineTableConfigJsonNode);
+          }
+
+          JsonNode realtimeTableConfigJsonNode = jsonNode.get(PinotServerType.REALTIME);
+          TableConfig realtimeTableConfig = null;
+          if (realtimeTableConfigJsonNode != null) {
+            realtimeTableConfig = TableConfig.fromJsonConfig(realtimeTableConfigJsonNode);
+          }
+
+          boolean tableDeleted = false;
+          if (shouldDeleteTable(offlineTableConfig)) {
+            removeTable(offlineTableConfig);
+            tableDeleted = true;
+          }
+          if (shouldDeleteTable(realtimeTableConfig)) {
+            removeTable(realtimeTableConfig);
+            tableDeleted = true;
+          }
+          if (tableDeleted) {
+            deletedTableCount++;
+          }
+        }
+        LOGGER.info("Finish checking table retentions. {}/{} tables deleted.", deletedTableCount, perfTables.size());
+      } catch (Exception e) {
+        throw new PinotBenchException(LOGGER, "Exception when cleaning up perf tables",
+            Response.Status.INTERNAL_SERVER_ERROR, e);
+      }
+    }, _tableRetentionManagerInitialDelayInSeconds, _tableRetentionManagerIntervalInSeconds, TimeUnit.SECONDS);
+  }
+
+  public void stop() {
+    if (_executorService != null) {
+      LOGGER.info("Stopping table retention manager");
+      _executorService.shutdown();
+      _executorService = null;
+    }
+  }
+
+  private boolean shouldDeleteTable(TableConfig perfTableConfig) {
+    if (perfTableConfig == null) {
+      return false;
+    }
+    Map<String, String> customConfigMap = perfTableConfig.getCustomConfig().getCustomConfigs();
+    int tableRetention = Integer.parseInt(customConfigMap.get(PerfTableCreationParameters.TABLE_RETENTION_KEY));
+    long creationTimeMs = Long.parseLong(customConfigMap.get(PerfTableCreationParameters.CREATION_TIME_MS_KEY));
+    long expirationTimeMs = Long.parseLong(customConfigMap.get(PerfTableCreationParameters.EXPIRATION_TIME_MS_KEY));
+    long currentTimeMs = System.currentTimeMillis();
+    return expirationTimeMs <= currentTimeMs;
+  }
+
+  private void removeTable(@Nonnull TableConfig perfTableConfig) {
+    String tableNameWithType = perfTableConfig.getTableName();
+    LOGGER.info("Table: {} has reached its expiration. Dropping the table.", tableNameWithType);
+    _pinotClusterManager.deleteTableConfig(tableNameWithType, perfTableConfig.getTableType().name());
+
+    // TODO: deletes schema if not used by other tables.
+    if (false) {
+      _pinotClusterManager.deleteSchema(perfTableConfig.getTableName());
+    }
+
+    // releases used hosts
+    TenantConfig tenantConfig = perfTableConfig.getTenantConfig();
+    removeInstancesWithTag(tenantConfig.getBroker());
+    removeInstancesWithTag(tenantConfig.getBroker());
+  }
+
+  private void removeInstancesWithTag(String tenantTag) {
+    List<String> instances = _helixAdmin.getInstancesInClusterWithTag(_helixManager.getClusterName(), tenantTag);
+    for (String instance : instances) {
+      _helixAdmin.removeInstanceTag(_helixManager.getClusterName(), instance, tenantTag);
+    }
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/PinotBenchServiceApplication.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/PinotBenchServiceApplication.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.common;
+
+import com.google.common.base.Preconditions;
+import io.swagger.jaxrs.config.BeanConfig;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import javax.ws.rs.container.ContainerResponseFilter;
+import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PinotBenchServiceApplication extends ResourceConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotBenchServiceApplication.class);
+
+  private HttpServer httpServer;
+  private URI baseUri;
+  private boolean _useHttps = false;
+  private volatile boolean started = false;
+  private static final String RESOURCE_PACKAGE = "org.apache.pinot.benchmark.api.resources";
+
+  public PinotBenchServiceApplication() {
+    super();
+    packages(RESOURCE_PACKAGE);
+    register(JacksonFeature.class);
+    registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
+    registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register((ContainerResponseFilter) (containerRequestContext,
+        containerResponseContext) -> containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", "*"));
+  }
+
+  public boolean start(int httpPort) {
+    Preconditions.checkArgument(httpPort > 0);
+    baseUri = URI.create("http://0.0.0.0:" + httpPort + "/");
+    httpServer = GrizzlyHttpServerFactory.createHttpServer(baseUri, this);
+    setupSwagger(httpServer);
+    started = true;
+    LOGGER.info("Start jersey admin API on port: {}", httpPort);
+    return true;
+  }
+
+  public void stop() {
+    if (!started) {
+      return;
+    }
+    httpServer.shutdownNow();
+  }
+
+  private void setupSwagger(HttpServer httpServer) {
+    BeanConfig beanConfig = new BeanConfig();
+    beanConfig.setTitle("Pinot bench service API");
+    beanConfig.setDescription("APIs for running Pinot bench against pinot perf cluster");
+    beanConfig.setContact("Pinot Team");
+    beanConfig.setVersion("1.0");
+    if (_useHttps) {
+      beanConfig.setSchemes(new String[]{"https"});
+    } else {
+      beanConfig.setSchemes(new String[]{"http"});
+    }
+    beanConfig.setBasePath(baseUri.getPath());
+    beanConfig.setResourcePackage(RESOURCE_PACKAGE);
+    beanConfig.setScan(true);
+
+    ClassLoader loader = this.getClass().getClassLoader();
+    CLStaticHttpHandler apiStaticHttpHandler = new CLStaticHttpHandler(loader, "/api/");
+    // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
+    httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/api/");
+
+    URL swaggerDistLocation = loader.getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");
+    CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
+    httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/PinotBenchServiceApplication.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/PinotBenchServiceApplication.java
@@ -26,6 +26,7 @@ import java.net.URLClassLoader;
 import javax.ws.rs.container.ContainerResponseFilter;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -67,6 +68,10 @@ public class PinotBenchServiceApplication extends ResourceConfig {
       return;
     }
     httpServer.shutdownNow();
+  }
+
+  public void registerBinder(AbstractBinder binder) {
+    register(binder);
   }
 
   private void setupSwagger(HttpServer httpServer) {

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/PinotBenchServiceApplication.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/PinotBenchServiceApplication.java
@@ -29,6 +29,7 @@ import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,7 @@ public class PinotBenchServiceApplication extends ResourceConfig {
     super();
     packages(RESOURCE_PACKAGE);
     register(JacksonFeature.class);
+    register(MultiPartFeature.class);
     registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
     registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
     register((ContainerResponseFilter) (containerRequestContext,

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PerfTableMode.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PerfTableMode.java
@@ -16,19 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.benchmark;
+package org.apache.pinot.benchmark.common.utils;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+public enum PerfTableMode {
+  MIRROR("mirror"), NON_MIRROR("non-mirror");
 
+  private String _perfTableType;
 
-public class BenchmarkConfig extends PropertiesConfiguration {
-  private static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
-  private static final String CONSOLE_WEBAPP_USE_HTTPS = "controller.query.console.useHttps";
+  PerfTableMode(String perfTableType) {
+    _perfTableType = perfTableType;
+  }
 
-  public String getQueryConsoleWebappPath() {
-    if (containsKey(CONSOLE_WEBAPP_ROOT_PATH)) {
-      return (String) getProperty(CONSOLE_WEBAPP_ROOT_PATH);
+  public static PerfTableMode getPerfTableMode(String perfTableMode) {
+    for (PerfTableMode tableType : PerfTableMode.values()) {
+      if (tableType._perfTableType.equalsIgnoreCase(perfTableMode)) {
+        return tableType;
+      }
     }
-    return BenchmarkConfig.class.getClassLoader().getResource("webapp").toExternalForm();
+    return null;
   }
 }

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PinotBenchConstants.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PinotBenchConstants.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.common.utils;
+
+public class PinotBenchConstants {
+  public static final String TABLES_PATH = "tables";
+  public static final String TABLE_TEST_SUFFIX = "Test";
+
+  public static class PinotServerType {
+    public static final String HYBRID = "HYBRID";
+    public static final String OFFLINE = "OFFLINE";
+    public static final String REALTIME = "REALTIME";
+  }
+
+  public static class PerfTableCreationParameters {
+    public static final String TABLE_CONFIG_KEY = "tableConfig";
+    public static final String TABLE_SCHEMA_KEY = "schema";
+    public static final String TABLE_NAME_KEY = "tableName";
+    public static final String TABLE_TYPE_KEY = "tableType";
+    public static final String MODE_KEY = "mode";
+    public static final String LDAP_KEY = "ldap";
+    public static final String TABLE_RETENTION_KEY = "tableRetention";
+    public static final String VERSION_ID_KEY = "versionId";
+    public static final String NUM_BROKERS_KEY = "numBrokers";
+    public static final String NUM_OFFLINE_SERVERS_KEY = "numOfflineServers";
+    public static final String NUM_REALTIME_SERVERS_KEY = "numRealtimeServers";
+    public static final String CREATION_TIME_MS_KEY = "creationTimeMs";
+    public static final String EXPIRATION_TIME_MS_KEY = "expirationTimeMs";
+  }
+
+  public static class TenantTags {
+    public static final String DEFAULT_UNTAGGED_BROKER_TAG = "broker_untagged";
+    public static final String DEFAULT_UNTAGGED_SERVER_TAG = "server_untagged";
+
+    public static final String BROKER_SUFFIX = "_BROKER";
+    public static final String OFFLINE_SERVER_SUFFIX = "_OFFLINE";
+    public static final String REALTIME_SERVER_SUFFIX = "_REALTIME";
+
+    public static final String PINOT_BENCH_TENANT_TAG_PREFIX = "pinot-bench-";
+
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PinotClusterClient.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PinotClusterClient.java
@@ -1,0 +1,118 @@
+package org.apache.pinot.benchmark.common.utils;
+
+import com.sun.istack.internal.Nullable;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.net.ssl.SSLContext;
+import org.apache.http.HttpVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.apache.pinot.common.exception.HttpErrorStatusException;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.JsonUtils;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PinotClusterClient {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotClusterClient.class);
+
+  public static final int GET_REQUEST_SOCKET_TIMEOUT_MS = 5 * 1000; // 5 seconds
+
+  private static final String HTTP = "http";
+  private static final String HTTPS = "https";
+  private static final String TABLES_PATH = "/tables";
+  private final CloseableHttpClient _httpClient;
+
+  public PinotClusterClient() {
+    this(null);
+  }
+
+  public PinotClusterClient(@Nullable SSLContext sslContext) {
+    _httpClient = HttpClients.custom().setSSLContext(sslContext).build();
+  }
+
+  private static URI getURI(String scheme, String host, int port, String path)
+      throws URISyntaxException {
+    return new URI(scheme, null, host, port, path, null, null);
+  }
+
+  public static URI getListAllTablesHttpURI(String host, int port)
+      throws URISyntaxException {
+    return getURI(HTTP, host, port, TABLES_PATH);
+  }
+
+  public static URI getRetrieveTableConfigHttpURI(String host, int port, String rawTableName)
+      throws URISyntaxException {
+    return getURI(HTTP, host, port, TABLES_PATH + "/" + rawTableName);
+  }
+
+  public SimpleHttpResponse sendGetRequest(URI uri)
+      throws IOException, HttpErrorStatusException {
+    return sendRequest(constructGetRequest(uri));
+  }
+
+  private static HttpUriRequest constructGetRequest(URI uri) {
+    RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+    setTimeout(requestBuilder, GET_REQUEST_SOCKET_TIMEOUT_MS);
+    return requestBuilder.build();
+  }
+
+  private static void setTimeout(RequestBuilder requestBuilder, int socketTimeoutMs) {
+    RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(socketTimeoutMs).build();
+    requestBuilder.setConfig(requestConfig);
+  }
+
+  private SimpleHttpResponse sendRequest(HttpUriRequest request)
+      throws IOException, HttpErrorStatusException {
+    try (CloseableHttpResponse response = _httpClient.execute(request)) {
+      String controllerHost = null;
+      String controllerVersion = null;
+      if (response.containsHeader(CommonConstants.Controller.HOST_HTTP_HEADER)) {
+        controllerHost = response.getFirstHeader(CommonConstants.Controller.HOST_HTTP_HEADER).getValue();
+        controllerVersion = response.getFirstHeader(CommonConstants.Controller.VERSION_HTTP_HEADER).getValue();
+      }
+      if (controllerHost != null) {
+        LOGGER.info(String
+            .format("Sending request: %s to controller: %s, version: %s", request.getURI(), controllerHost,
+                controllerVersion));
+      }
+      int statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode >= 300) {
+        throw new HttpErrorStatusException(getErrorMessage(request, response), statusCode);
+      }
+      return new SimpleHttpResponse(statusCode, EntityUtils.toString(response.getEntity()));
+    }
+  }
+
+  private static String getErrorMessage(HttpUriRequest request, CloseableHttpResponse response) {
+    String controllerHost = null;
+    String controllerVersion = null;
+    if (response.containsHeader(CommonConstants.Controller.HOST_HTTP_HEADER)) {
+      controllerHost = response.getFirstHeader(CommonConstants.Controller.HOST_HTTP_HEADER).getValue();
+      controllerVersion = response.getFirstHeader(CommonConstants.Controller.VERSION_HTTP_HEADER).getValue();
+    }
+    StatusLine statusLine = response.getStatusLine();
+    String reason;
+    try {
+      reason = JsonUtils.stringToJsonNode(EntityUtils.toString(response.getEntity())).get("error").asText();
+    } catch (Exception e) {
+      reason = "Failed to get reason";
+    }
+    String errorMessage = String.format("Got error status code: %d (%s) with reason: \"%s\" while sending request: %s",
+        statusLine.getStatusCode(), statusLine.getReasonPhrase(), reason, request.getURI());
+    if (controllerHost != null) {
+      errorMessage =
+          String.format("%s to controller: %s, version: %s", errorMessage, controllerHost, controllerVersion);
+    }
+    return errorMessage;
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PinotClusterLocator.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PinotClusterLocator.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.benchmark.common.utils;
+
+import javax.ws.rs.core.Response;
+import org.apache.pinot.benchmark.PinotBenchConf;
+import org.apache.pinot.benchmark.api.resources.PinotBenchException;
+import org.apache.pinot.pql.parsers.utils.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PinotClusterLocator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotClusterLocator.class);
+
+  private Pair<String, Integer> _perfClusterPair;
+  private Pair<String, Integer> _prodClusterPair;
+
+  public PinotClusterLocator(PinotBenchConf conf) {
+    _perfClusterPair = new Pair<>(conf.getPerfControllerHost(), conf.getPerfControllerPort());
+    _prodClusterPair = new Pair<>(conf.getProdControllerHost(), conf.getProdControllerPort());
+  }
+
+  public Pair<String, Integer> getPinotClusterFromType(String clusterType) {
+    if (clusterType == null) {
+      // returns perf cluster pair if cluster type is missing.
+      return _perfClusterPair;
+    }
+    PinotClusterType pinotClusterType = PinotClusterType.getClusterType(clusterType);
+    if (pinotClusterType == null) {
+      throw new PinotBenchException(LOGGER, "Wrong type of cluster type: " + clusterType, Response.Status.BAD_REQUEST);
+    }
+    return pinotClusterType == PinotClusterType.PERF ? _perfClusterPair : _prodClusterPair;
+  }
+
+  public Pair<String, Integer> getPerfClusterPair() {
+    return _perfClusterPair;
+  }
+
+  public enum PinotClusterType {
+    PERF("perf"), PROD("prod");
+
+    private String _clusterType;
+
+    PinotClusterType(String clusterType) {
+      _clusterType = clusterType;
+    }
+
+    public String getClusterType() {
+      return _clusterType;
+    }
+
+    public static PinotClusterType getClusterType(String clusterType) {
+      for (PinotClusterType type : PinotClusterType.values()) {
+        if (type._clusterType.equalsIgnoreCase(clusterType)) {
+          return type;
+        }
+      }
+      return null;
+    }
+  }
+}

--- a/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PinotClusterLocator.java
+++ b/pinot-benchmark/src/main/java/org/apache/pinot/benchmark/common/utils/PinotClusterLocator.java
@@ -53,6 +53,10 @@ public class PinotClusterLocator {
     return _perfClusterPair;
   }
 
+  public Pair<String, Integer> getProdClusterPair() {
+    return _prodClusterPair;
+  }
+
   public enum PinotClusterType {
     PERF("perf"), PROD("prod");
 

--- a/pinot-benchmark/src/main/resources/api/index.html
+++ b/pinot-benchmark/src/main/resources/api/index.html
@@ -1,0 +1,126 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!-- This is directly copied from Swagger repository and modified to change url variable -->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Swagger UI</title>
+  <link rel="icon" type="image/png" href="swaggerui-dist/images/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="swaggerui-dist/images/favicon-16x16.png" sizes="16x16" />
+  <link href='swaggerui-dist/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='swaggerui-dist/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='swaggerui-dist/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='swaggerui-dist/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='swaggerui-dist/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+
+  <script src='swaggerui-dist/lib/object-assign-pollyfill.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/jquery.slideto.min.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/jquery.wiggle.min.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/handlebars-4.0.5.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/lodash.min.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/backbone-min.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/swagger-ui.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/jsoneditor.min.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/marked.js' type='text/javascript'></script>
+  <script src='swaggerui-dist/lib/swagger-oauth.js' type='text/javascript'></script>
+
+  <!-- Some basic translations -->
+  <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
+  <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
+  <!-- <script src='lang/en.js' type='text/javascript'></script> -->
+  <script type="text/javascript">
+    $(function () {
+      var url = window.location.search.match(/url=([^&]+)/);
+      if (url && url.length > 1) {
+        url = decodeURIComponent(url[1]);
+      } else {
+        url = "/swagger.json";
+      }
+
+      hljs.configure({
+        highlightSizeThreshold: 5000
+      });
+
+      // Pre load translate...
+      if(window.SwaggerTranslator) {
+        window.SwaggerTranslator.translate();
+      }
+      window.swaggerUi = new SwaggerUi({
+        url: url,
+        dom_id: "swagger-ui-container",
+        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+        onComplete: function(swaggerApi, swaggerUi){
+          if(typeof initOAuth == "function") {
+            initOAuth({
+              clientId: "your-client-id",
+              clientSecret: "your-client-secret-if-required",
+              realm: "your-realms",
+              appName: "your-app-name",
+              scopeSeparator: " ",
+              additionalQueryStringParams: {}
+            });
+          }
+
+          if(window.SwaggerTranslator) {
+            window.SwaggerTranslator.translate();
+          }
+        },
+        onFailure: function(data) {
+          log("Unable to Load SwaggerUI");
+        },
+        docExpansion: "none",
+        jsonEditor: false,
+        defaultModelRendering: 'schema',
+        showRequestHeaders: false
+      });
+
+      window.swaggerUi.load();
+
+      function log() {
+        if ('console' in window) {
+          console.log.apply(console, arguments);
+        }
+      }
+    });
+  </script>
+</head>
+
+<body class="swagger-section">
+<div id='header'>
+  <div class="swagger-ui-wrap">
+    <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="swaggerui-dist/images/logo_small.png" /><span class="logo__title">swagger</span></a>
+    <form id='api_selector'>
+      <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
+      <div id='auth_container'></div>
+      <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
+    </form>
+  </div>
+</div>
+
+<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
+<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+</body>

--- a/pinot-benchmark/src/main/resources/static/index.html
+++ b/pinot-benchmark/src/main/resources/static/index.html
@@ -1,0 +1,81 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Welcome to Pinot</title>
+  <!-- Latest compiled and minified CSS -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+
+  <!-- Optional theme -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+
+  <!-- Latest compiled and minified JavaScript -->
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+</head>
+<body>
+
+<nav class="navbar navbar-inverse navbar-fixed-top">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="#">Pinot benchmark</a>
+    </div>
+    <div id="navbar" class="navbar-collapse collapse">
+    </div><!--/.navbar-collapse -->
+  </div>
+</nav>
+
+<!-- Main jumbotron for a primary marketing message or call to action -->
+<div class="jumbotron">
+  <div class="container">
+    <h1>Welcome to Pinot bench as a service!</h1>
+    <p>You're currently connected to a Pinot controller, which handles the cluster-wide coordination for all Pinot nodes. Most humans tend to find the following features useful:</p>
+    <p><a class="btn btn-primary btn-lg" href="/api" role="button">Open REST API &raquo;</a></p>
+  </div>
+</div>
+
+<div class="container">
+  <!-- Example row of columns -->
+  <div class="row">
+    <div class="col-md-4">
+      <h2>Pinot REST API</h2>
+      <p>An interactive documentation for the Pinot REST API with a swanky Swagger-generated page. Keep in mind that your actions here will directly affect the cluster, so be mindful of other tenants.</p>
+      <p><a class="btn btn-default" href="/api" role="button">REST API &raquo;</a></p>
+    </div>
+  </div>
+
+  <hr>
+
+  <footer>
+    <p>Apache Pinot (Incubating)</p>
+  </footer>
+</div> <!-- /container -->
+
+</body>
+</html>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -70,7 +70,7 @@ public class QuickstartRunner {
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numServers, int numBrokers,
       int numControllers, File tempDir)
       throws Exception {
-    this(tableRequests, numServers, numBrokers, numControllers, tempDir, false);
+    this(tableRequests, numServers, numBrokers, numControllers, tempDir, true);
   }
 
   private void startZookeeper()

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -70,7 +70,7 @@ public class QuickstartRunner {
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numServers, int numBrokers,
       int numControllers, File tempDir)
       throws Exception {
-    this(tableRequests, numServers, numBrokers, numControllers, tempDir, true);
+    this(tableRequests, numServers, numBrokers, numControllers, tempDir, false);
   }
 
   private void startZookeeper()

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -61,7 +61,7 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
   private boolean _help = false;
 
   // This can be set via the set method, or via config file input.
-  private boolean _tenantIsolation = true;
+  private boolean _tenantIsolation = false;
 
   @Override
   public boolean getHelp() {

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <module>pinot-orc</module>
     <module>pinot-parquet</module>
     <module>pinot-connectors</module>
+    <module>pinot-benchmark</module>
   </modules>
 
   <licenses>


### PR DESCRIPTION
This PR implements cluster management component.

Design doc:
https://cwiki.apache.org/confluence/display/PINOT/Pinot+Benchmark+as+a+Service

APIs:
* Upload segment to perf table:
```
curl -X POST 'localhost:9008/data/segment' -F a=@transcript_0_0.tar.gz
{"status":"Successfully uploaded segment: transcript_0_0 of table: transcriptTest_4"}
```
* Upload segments from prod table:
```
curl -X POST 'localhost:9008/data/mirror?from=baseballStats&to=baseballTest_4'
{"status":"Successfully uploaded segments from mirror table"}
```
* Upload queries:
```
$ curl -X POST 'localhost:9008/data/queries?from=baseballStats&to=baseballTest_4' -F a=@queries.txt
{"status":"Successfully uploaded queries for Table: baseballTest_4"}
```