### PR TITLE
Revert "Set processingException when all queried segments cannot be a…

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -41,7 +41,6 @@ public class QueryException {
   public static final int SEGMENT_PLAN_EXECUTION_ERROR_CODE = 160;
   public static final int COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR_CODE = 170;
   public static final int ACCESS_DENIED_ERROR_CODE = 180;
-  public static final int SEGMENTS_MISSING_ERROR_CODE = 190;
   public static final int QUERY_EXECUTION_ERROR_CODE = 200;
   // TODO: Handle these errors in broker
   public static final int SERVER_SHUTTING_DOWN_ERROR_CODE = 210;
@@ -98,7 +97,6 @@ public class QueryException {
   public static final ProcessingException QUERY_VALIDATION_ERROR = new ProcessingException(QUERY_VALIDATION_ERROR_CODE);
   public static final ProcessingException UNKNOWN_ERROR = new ProcessingException(UNKNOWN_ERROR_CODE);
   public static final ProcessingException QUOTA_EXCEEDED_ERROR = new ProcessingException(TOO_MANY_REQUESTS_ERROR_CODE);
-  public static final ProcessingException SEGMENTS_MISSING_ERROR = new ProcessingException(SEGMENTS_MISSING_ERROR_CODE);
 
   static {
     JSON_PARSING_ERROR.setMessage("JsonParsingError");

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -79,20 +79,6 @@ public interface InstanceDataManager {
       throws Exception;
 
   /**
-   * Handles addition of a segment from the table.
-   *
-   * This method performs book keeping of added segments, especially if the deleted-cache needs to be invalidated
-   */
-  void notifySegmentAdded(@Nonnull String tableNameWithType, @Nonnull String segmentName);
-
-  /**
-   * Handles deletion of a segment from the table.
-   *
-   * This method performs book keeping of deleted segments.
-   */
-  void notifySegmentDeleted(@Nonnull String tableNameWithType, @Nonnull String segmentName);
-
-  /**
    * Reloads a segment in a table.
    */
   void reloadSegment(@Nonnull String tableNameWithType, @Nonnull String segmentName)

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
@@ -80,21 +80,6 @@ public interface TableDataManager {
   void removeSegment(@Nonnull String segmentName);
 
   /**
-   * Track a deleted segment.
-   */
-  void notifySegmentDeleted(@Nonnull String segmentName);
-
-  /**
-   * Track addition of a segment
-   */
-  void notifySegmentAdded(@Nonnull String segmentName);
-
-  /**
-   * Check if a segment is recently deleted.
-   */
-  boolean isRecentlyDeleted(@Nonnull String segmentName);
-
-  /**
    * Acquires all segments of the table.
    * <p>It is the caller's responsibility to return the segments by calling {@link #releaseSegment(SegmentDataManager)}.
    *

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.executor;
 
 import com.google.common.base.Preconditions;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -127,24 +126,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
     TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(tableNameWithType);
     Preconditions.checkState(tableDataManager != null, "Failed to find data manager for table: " + tableNameWithType);
-
-    // acquire the segments
-    int missingSegments = 0;
-    List<String> segmentsToQuery = queryRequest.getSegmentsToQuery();
-    List<SegmentDataManager> segmentDataManagers = new ArrayList<>();
-    for (String segmentName : segmentsToQuery) {
-      SegmentDataManager segmentDataManager = tableDataManager.acquireSegment(segmentName);
-      if (segmentDataManager != null) {
-        segmentDataManagers.add(segmentDataManager);
-      } else {
-        if (!tableDataManager.isRecentlyDeleted(segmentName)) {
-          LOGGER.error("Could not find segment {} for table {} for requestId {}", segmentName, tableNameWithType,
-              requestId);
-          missingSegments++;
-        }
-      }
-    }
-
+    List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireSegments(queryRequest.getSegmentsToQuery());
     int numSegmentsQueried = segmentDataManagers.size();
     boolean enableTrace = queryRequest.isEnableTrace();
     if (enableTrace) {
@@ -243,18 +225,6 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     long queryProcessingTime = queryProcessingTimer.getDurationMs();
     dataTable.getMetadata().put(DataTable.NUM_SEGMENTS_QUERIED, Integer.toString(numSegmentsQueried));
     dataTable.getMetadata().put(DataTable.TIME_USED_MS_METADATA_KEY, Long.toString(queryProcessingTime));
-
-    if (missingSegments > 0) {
-      // TODO: add this exception to the datatable after verfying the metrics
-      // Currently, given the deleted segments cache is in-memory only, a server restart will reset it
-      // We might end up sending partial-response metadata in such cases. It appears that the likelihood of
-      // this occurence is low; ie, segment has to be retained out and the server must be restarted while the
-      // broker view is still behind. We would however like to validate that and/or conf control this based on
-      // data.
-      /*dataTable.addException(QueryException.getException(QueryException.SEGMENTS_MISSING_ERROR,
-          "Could not find " + missingSegments + " segments on the server"));*/
-      _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_MISSING_SEGMENTS, missingSegments);
-    }
 
     if (numConsumingSegmentsProcessed > 0) {
       dataTable.getMetadata().put(DataTable.NUM_CONSUMING_SEGMENTS_PROCESSED, Integer.toString(numConsumingSegmentsProcessed));

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -158,11 +158,6 @@ public class BaseTableDataManagerTest {
     // Removing the segment again is fine.
     tableDataManager.removeSegment(segmentName);
 
-    // Delete the segment
-    tableDataManager.notifySegmentDeleted(segmentName);
-    // check that it is recorded as deleted
-    Assert.assertTrue(tableDataManager.isRecentlyDeleted(segmentName));
-
     // Add a new segment and remove it in order this time.
     final String anotherSeg = "AnotherSegment";
     ImmutableSegment ix1 = makeImmutableSegment(anotherSeg, totalDocs);

--- a/pinot-core/src/test/java/org/apache/pinot/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/executor/QueryExecutorTest.java
@@ -68,7 +68,6 @@ public class QueryExecutorTest {
   private final List<ImmutableSegment> _indexSegments = new ArrayList<>(NUM_SEGMENTS_TO_GENERATE);
   private final List<String> _segmentNames = new ArrayList<>(NUM_SEGMENTS_TO_GENERATE);
 
-  private InstanceDataManager _instanceDataManager;
   private ServerMetrics _serverMetrics;
   private QueryExecutor _queryExecutor;
 
@@ -106,8 +105,8 @@ public class QueryExecutorTest {
     for (ImmutableSegment indexSegment : _indexSegments) {
       tableDataManager.addSegment(indexSegment);
     }
-    _instanceDataManager = mock(InstanceDataManager.class);
-    when(_instanceDataManager.getTableDataManager(TABLE_NAME)).thenReturn(tableDataManager);
+    InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
+    when(instanceDataManager.getTableDataManager(TABLE_NAME)).thenReturn(tableDataManager);
 
     // Set up the query executor
     resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
@@ -116,7 +115,7 @@ public class QueryExecutorTest {
     queryExecutorConfig.setDelimiterParsingDisabled(false);
     queryExecutorConfig.load(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
-    _queryExecutor.init(queryExecutorConfig, _instanceDataManager, _serverMetrics);
+    _queryExecutor.init(queryExecutorConfig, instanceDataManager, _serverMetrics);
   }
 
   @Test
@@ -154,49 +153,6 @@ public class QueryExecutorTest {
     DataTable instanceResponse = _queryExecutor.processQuery(getQueryRequest(instanceRequest), QUERY_RUNNERS);
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 0.0);
   }
-
-  @Test
-  public void testDeletedSegmentQuery() {
-    String query = "SELECT count(*) FROM " + TABLE_NAME;
-    _instanceDataManager.notifySegmentDeleted(TABLE_NAME, _segmentNames.get(0));
-
-    InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
-    instanceRequest.setSearchSegments(_segmentNames);
-    DataTable instanceResponse = _queryExecutor.processQuery(getQueryRequest(instanceRequest), QUERY_RUNNERS);
-    Assert.assertEquals(instanceResponse.getLong(0, 0), 400002L);
-
-    for (String key : instanceResponse.getMetadata().keySet()) {
-      if (key.startsWith(DataTable.EXCEPTION_METADATA_KEY)) {
-        Assert.fail("Response should not contain exceptions");
-      }
-    }
-  }
-
-  // TODO: enable this when the code is updated to set the exception
-  @Test(enabled=false)
-  public void testMissingSegmentQuery() {
-    String query = "SELECT count(*) FROM " + TABLE_NAME;
-
-    List<String> searchSegments = new ArrayList<>(NUM_SEGMENTS_TO_GENERATE + 1);
-    searchSegments.addAll(_segmentNames);
-    searchSegments.add("NON_EXISTENT_SEGMENT");
-
-    InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
-    instanceRequest.setSearchSegments(searchSegments);
-    DataTable instanceResponse = _queryExecutor.processQuery(getQueryRequest(instanceRequest), QUERY_RUNNERS);
-    Assert.assertEquals(instanceResponse.getLong(0, 0), 400002L);
-
-    boolean exception = false;
-    for (String key : instanceResponse.getMetadata().keySet()) {
-      if (key.startsWith(DataTable.EXCEPTION_METADATA_KEY)) {
-        // "null" below stems from a quirk around how the processing exception is built
-        Assert.assertEquals("null:\nCould not find 1 segments on the server", instanceResponse.getMetadata().get(key));
-        exception = true;
-      }
-    }
-    Assert.assertTrue(exception, "Expected missing segment exception");
-  }
-
 
   @AfterClass
   public void tearDown() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -152,22 +152,6 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   }
 
   @Override
-  public void notifySegmentAdded(@Nonnull String tableNameWithType, @Nonnull String segmentName) {
-    TableDataManager tableDataManager = _tableDataManagerMap.get(tableNameWithType);
-    if (tableDataManager != null) {
-      tableDataManager.notifySegmentAdded(segmentName);
-    }
-  }
-
-  @Override
-  public void notifySegmentDeleted(@Nonnull String tableNameWithType, @Nonnull String segmentName) {
-    TableDataManager tableDataManager = _tableDataManagerMap.get(tableNameWithType);
-    if (tableDataManager != null) {
-      tableDataManager.notifySegmentDeleted(segmentName);
-    }
-  }
-
-  @Override
   public void reloadSegment(@Nonnull String tableNameWithType, @Nonnull String segmentName)
       throws Exception {
     LOGGER.info("Reloading single segment: {} in table: {}", segmentName, tableNameWithType);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -166,8 +166,6 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
         } else {
           _instanceDataManager.addRealtimeSegment(tableNameWithType, segmentName);
         }
-        // handle any book-keeping after a segment is added
-        _instanceDataManager.notifySegmentAdded(tableNameWithType, segmentName);
       } catch (Exception e) {
         _logger.error("Caught exception in state transition from OFFLINE -> ONLINE for resource: {}, partition: {}",
             tableNameWithType, segmentName, e);
@@ -197,9 +195,6 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromOffline() : " + message);
       String tableNameWithType = message.getResourceName();
       String segmentName = message.getPartitionName();
-
-      // handle any additional book-keeping that needs to be done when a segment is dropped
-      _instanceDataManager.notifySegmentDeleted(tableNameWithType, segmentName);
 
       // This method might modify the file on disk. Use segment lock to prevent race condition
       Lock segmentLock = SegmentLocks.getSegmentLock(tableNameWithType, segmentName);


### PR DESCRIPTION
…cquired (#3942)"

This reverts commit d4f2ecef660ab1d4efa9696a53b0623aac867c3f.

Spoke with Sunitha offline regarding this commit. This PR currently hinges on the state transition OFFLINE -> DROPPED in order to determine segments that were retained out. However, by the time  this message is received, the broker has already determined that the server had an error. Retained segments first undergo ONLINE -> OFFLINE then OFFLINE -> DROPPED transition states. Therefore, backing out this PR because it doesn't properly handle retained out segments. In the future, we can change this check to be on the broker side, where we can enforce retention among segments queried.