### PR TITLE
Add metrics for the number of partitions for which controller becomes leader

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -55,7 +55,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   PINOT_LEAD_CONTROLLER_RESOURCE_ENABLED("PinotLeadControllerResourceEnabled", true),
 
   // Number of partitions for which current controller becomes the leader
-  NUMBER_PARTITIONS_CONTROLLER_BECOMES_LEADER("NumberPartitionsControllerBecomesLeader", true),
+  CONTROLLER_LEADER_PARTITION_COUNT("ControllerLeaderPartitionCount", true),
 
   // Number of extra live instances needed
   SHORT_OF_LIVE_INSTANCES("ShortOfLiveInstances", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -54,6 +54,9 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // Pinot controller resource enabled
   PINOT_LEAD_CONTROLLER_RESOURCE_ENABLED("PinotLeadControllerResourceEnabled", true),
 
+  // Number of partitions for which current controller becomes the leader
+  NUMBER_PARTITIONS_CONTROLLER_BECOMES_LEADER("NumberPartitionsControllerBecomesLeader", true),
+
   // Number of extra live instances needed
   SHORT_OF_LIVE_INSTANCES("ShortOfLiveInstances", false),
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
@@ -123,6 +123,8 @@ public class LeadControllerManager {
     int partitionId = LeadControllerUtils.extractPartitionId(partitionName);
     _leadForPartitions.add(partitionId);
     _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PINOT_CONTROLLER_PARTITION_LEADER, partitionName, 1L);
+    _controllerMetrics
+        .setValueOfGlobalGauge(ControllerGauge.NUMBER_PARTITIONS_CONTROLLER_BECOMES_LEADER, _leadForPartitions.size());
   }
 
   /**
@@ -134,6 +136,8 @@ public class LeadControllerManager {
     int partitionId = LeadControllerUtils.extractPartitionId(partitionName);
     _leadForPartitions.remove(partitionId);
     _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PINOT_CONTROLLER_PARTITION_LEADER, partitionName, 0L);
+    _controllerMetrics
+        .setValueOfGlobalGauge(ControllerGauge.NUMBER_PARTITIONS_CONTROLLER_BECOMES_LEADER, _leadForPartitions.size());
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
@@ -124,7 +124,7 @@ public class LeadControllerManager {
     _leadForPartitions.add(partitionId);
     _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PINOT_CONTROLLER_PARTITION_LEADER, partitionName, 1L);
     _controllerMetrics
-        .setValueOfGlobalGauge(ControllerGauge.NUMBER_PARTITIONS_CONTROLLER_BECOMES_LEADER, _leadForPartitions.size());
+        .setValueOfGlobalGauge(ControllerGauge.CONTROLLER_LEADER_PARTITION_COUNT, _leadForPartitions.size());
   }
 
   /**
@@ -137,7 +137,7 @@ public class LeadControllerManager {
     _leadForPartitions.remove(partitionId);
     _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PINOT_CONTROLLER_PARTITION_LEADER, partitionName, 0L);
     _controllerMetrics
-        .setValueOfGlobalGauge(ControllerGauge.NUMBER_PARTITIONS_CONTROLLER_BECOMES_LEADER, _leadForPartitions.size());
+        .setValueOfGlobalGauge(ControllerGauge.CONTROLLER_LEADER_PARTITION_COUNT, _leadForPartitions.size());
   }
 
   /**


### PR DESCRIPTION
This PR adds metrics to track the number of partitions for which controller becomes leader, so that 
when the total number of this metric is aggregated from multiple controllers, we know every partitions have their own leader.