### PR TITLE
Remove import of sun.misc.Cleaner to make code compatible with jdk11

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
@@ -328,9 +328,8 @@ public class PinotByteBuffer extends PinotDataBuffer {
 
   @Override
   protected void release() {
-    Cleaner cleaner = ((DirectBuffer) _buffer).cleaner();
-    if (cleaner != null) {
-      cleaner.clean();
+    if ( ((DirectBuffer) _buffer).cleaner() != null) {
+      ((DirectBuffer) _buffer).cleaner().clean();
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
@@ -328,7 +328,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
 
   @Override
   protected void release() {
-    if ( ((DirectBuffer) _buffer).cleaner() != null) {
+    if (((DirectBuffer) _buffer).cleaner() != null) {
       ((DirectBuffer) _buffer).cleaner().clean();
     }
   }


### PR DESCRIPTION
sun.misc.Cleaner is deprecated since jdk9 and replaced with jdk.internal.ref.Cleaner.
This change aims to make Pinot compilable in higher jdk version.

Ref: https://bugs.openjdk.java.net/browse/JDK-8148117