### PR TITLE
[TE] frontend - harleyjj/alert-details - add comparison to preview

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-details/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-details/template.hbs
@@ -134,9 +134,9 @@
 
           <div class="te-content-block">
             {{#if showRules}}
-              <h4 class="te-self-serve__block-title">{{selectedRule.name}} {{#if alertHasDimensions}}/ {{selectedDimension}}{{/if}} anomalies over time ({{numCurrentAnomalies}})</h4>
+              <h4 class="te-self-serve__block-title">{{selectedRule.name}} {{#if alertHasDimensions}}/ {{selectedDimension}}{{/if}} anomalies over time ({{numFilteredAnomalies}})</h4>
             {{else}}
-              <h4 class="te-self-serve__block-title">{{#if alertHasDimensions}}{{selectedDimension}} a{{else}}A{{/if}}nomalies over time ({{numCurrentAnomalies}})</h4>
+              <h4 class="te-self-serve__block-title">{{#if alertHasDimensions}}{{selectedDimension}} a{{else}}A{{/if}}nomalies over time ({{numFilteredAnomalies}})</h4>
             {{/if}}
 
             {{#unless isPreviewMode}}
@@ -246,6 +246,7 @@
                 zoom=zoom
                 legend=legend
                 point=point
+                order=order
               }}
               {{#unless isPreviewMode}}
                 <div class="te-form__note">
@@ -259,190 +260,14 @@
             timeRangeOptions=baselineOptions
             selectAction=(action "onBaselineOptionClick")
           }}
-            {{#if anomalies}}
-
-              {{!-- Alert anomaly table --}}
-              <div class="te-block-container">
-                <table class="te-anomaly-table">
-                  {{#if anomalies}}
-                    <thead>
-                      <tr class="te-anomaly-table__row te-anomaly-table__head">
-                        <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--left">
-                          <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
-                            Start/Duration (PDT)
-                            <i class="te-anomaly-table__icon glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                          </a>
-                        </th>
-                        {{#if alertHasDimensions}}
-                          <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--fixed">Dimensions</th>
-                        {{/if}}
-                        <th class="te-anomaly-table__cell-head">
-                          <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
-                            Current / Predicted
-                            <i class="te-anomaly-table__icon glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                          </a>
-                        </th>
-                        <th class="te-anomaly-table__cell-head">
-                          <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "rule"}}>
-                            Rule
-                            <i class="te-anomaly-table__icon glyphicon {{if sortColumnRuleUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                          </a>
-                        </th>
-                        {{#unless isPreviewMode}}
-                          <th class="te-anomaly-table__cell-head">
-                            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "feedback"}}>
-                              Feedback
-                              <i class="te-anomaly-table__icon glyphicon {{if sortColumnFeedbackUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                            </a>
-                          </th>
-                          <th class="te-anomaly-table__cell-head">
-                            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "modifiedBy"}}>
-                              Modified
-                              <i class="te-anomaly-table__icon glyphicon {{if sortColumnModifiedByUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                            </a>
-                          </th>
-                          <th class="te-anomaly-table__cell-head"></th>
-                        {{/unless}}
-                      </tr>
-                    </thead>
-                  {{/if}}
-                  <tbody>
-                    {{#each paginatedFilteredAnomalies as |anomaly|}}
-                      <tr class="te-anomaly-table__row">
-                         <td class="te-anomaly-table__cell">
-                          <ul class="te-anomaly-table__list te-anomaly-table__list--left">
-                            <li class="te-anomaly-table__list-item te-anomaly-table__list-item--stronger">
-                              {{#if isPreviewMode}}
-                                {{anomaly.startDateStr}}
-                              {{else}}
-                                <a target="_blank" class="te-anomaly-table__link" href="/app/#/rootcause?anomalyId={{anomaly.anomalyId}}">
-                                  {{anomaly.startDateStr}}
-                                </a>
-                              {{/if}}
-                            </li>
-                            <li class="te-anomaly-table__list-item te-anomaly-table__list-item--lighter">{{anomaly.durationStr}}</li>
-                          </ul>
-                         </td>
-                         {{#if alertHasDimensions}}
-                           <td class="te-anomaly-table__cell">
-                            <ul class="te-anomaly-table__list">
-                             {{#each anomaly.dimensionList as |dimension|}}
-                                <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller" title="{{dimension.dimensionVal}}">
-                                  {{dimension}}: <span class="stronger">{{get anomaly.dimensions dimension}}</span>
-                                </li>
-                             {{else}}
-                                -
-                             {{/each}}
-                            </ul>
-                           </td>
-                         {{/if}}
-                         <td class="te-anomaly-table__cell">
-                          <ul class="te-anomaly-table__list">
-                            <li>{{anomaly.shownCurrent}} / {{anomaly.shownBaseline}}</li>
-                            <li class="te-anomaly-table__value-label te-anomaly-table__value-label--{{calculate-direction anomaly.shownChangeRate}}">
-                              {{#if (not anomaly.isNullChangeRate)}}
-                                ({{anomaly.shownChangeRate}}%)
-                              {{else}}
-                                (N/A)
-                              {{/if}}
-                            </li>
-                          </ul>
-                         </td>
-                         <td class="te-anomaly-table__cell">
-                          <ul class="te-anomaly-table__list">
-                           <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller">
-                              <span class="stronger">{{anomaly.rule}}</span>
-                            </li>
-                          </ul>
-                         </td>
-                         {{#unless isPreviewMode}}
-                           <td class="te-anomaly-table__cell">
-                              {{#if renderStatusIcon}}
-                                {{#if anomaly.showResponseSaved}}
-                                  <i class="te-anomaly-table__icon--status glyphicon glyphicon-ok-circle"></i>
-                                {{/if}}
-                                {{#if anomaly.showResponseFailed}}
-                                  <i class="te-anomaly-table__icon--status te-anomaly-table__icon--error glyphicon glyphicon-remove-circle"></i>
-                                {{/if}}
-                              {{/if}}
-
-                              {{#if anomaly.isUserReported}}
-                                <div class="te-anomaly-table__text te-anomaly-table__text--explore">User Reported</div>
-                                <div class="te-anomaly-table__comment">
-                                  <i class="glyphicon glyphicon-th-list"></i>
-                                  {{#tooltip-on-element class="te-anomaly-table__tooltip"}}
-                                    {{anomaly.anomalyFeedbackComments}}
-                                  {{/tooltip-on-element}}
-                                </div>
-                              {{else}}
-                                {{#power-select
-                                  triggerId=anomaly.anomalyId
-                                  triggerClass="te-anomaly-table__select"
-                                  options=feedbackOptions
-                                  searchEnabled=false
-                                  selected=(get labelMap anomaly.anomalyFeedback)
-                                  onchange=(action "onChangeAnomalyFeedback" anomaly)
-                                  as |response|
-                                }}
-                                  {{response}}
-                                {{/power-select}}
-                              {{/if}}
-                           </td>
-                           <td class="te-anomaly-table__cell">
-                            <ul class="te-anomaly-table__list">
-                             <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller">
-                                <span class="stronger">{{anomaly.modifiedBy}}</span>
-                              </li>
-                            </ul>
-                           </td>
-                           <td class="te-anomaly-table__cell te-anomaly-table__cell--feedback">
-                              <div class="te-anomaly-table__link-wrapper">
-                                {{#link-to 'rootcause' (query-params anomalyId=anomaly.anomalyId) target="_blank" class="te-anomaly-table__link"}}
-                                  Investigate
-                                {{/link-to}}
-                              </div>
-                           </td>
-                         {{/unless}}
-                      </tr>
-                    {{/each}}
-                  </tbody>
-                </table>
-              </div>
-
-              {{!--pagination--}}
-              {{#if (gt pagesNum 1)}}
-                <nav class="text-center" aria-label="Page navigation">
-                  <ul class="pagination">
-                    <li class={{if (eq currentPage 1) 'active disabled'}} >
-                      <a href="#" {{action "onPaginationClick" 1}} aria-label="First">
-                        <span aria-hidden="true">First</span>
-                      </a>
-                    </li>
-                    <li class={{if (eq currentPage 1) 'active disabled'}}>
-                      <a href="#" {{action "onPaginationClick" "previous"}} aria-label="Previous">
-                        <span aria-hidden="true">Previous</span>
-                      </a>
-                    </li>
-                    {{#each viewPages as |page|}}
-                      <li class={{if (eq page currentPage) 'active'}}><a href="#" {{action "onPaginationClick" page}}>{{page}}</a></li>
-                    {{/each}}
-                    <li class={{if (eq currentPage pagesNum) 'disabled'}} >
-                      <a href="#" {{action "onPaginationClick" "next"}} aria-label="Next">
-                        <span aria-hidden="true">Next</span>
-                      </a>
-                    </li>
-                    <li class={{if (eq currentPage pagesNum) 'disabled'}} >
-                      <a href="#" {{action "onPaginationClick" pagesNum}} aria-label="Last">
-                        <span aria-hidden="true">Last</span>
-                      </a>
-                    </li>
-                  </ul>
-                </nav>
-              {{/if}}
+            {{#if anomaliesOld}}
+              {{models-table
+                data=tableAnomalies
+                columns=columns
+                columnsDropdownTemplate="dropdown"
+              }}
             {{/if}}
-
-
-                </div>
+        </div>
         {{else}}
         <div class="yaml-editor-msg">Alert configuration has changed.</div>
           {{range-pill-selectors

--- a/thirdeye/thirdeye-frontend/app/pods/components/timeseries-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/timeseries-chart/component.js
@@ -53,7 +53,7 @@ export default Component.extend({
   },
 
   legend: {
-    hide: 'lowerBound'
+    hide: ['lowerBound', 'old-anomaly-edges', 'new-anomaly-edges']
   },
 
   axis: {
@@ -153,7 +153,7 @@ export default Component.extend({
     const axes = {};
     loadKeys.filter(sid => 'axis' in series[sid]).forEach(sid => axes[sid] = series[sid].axis);
     // keep the lower bound line in graph but remove in from the legend
-    legend.hide = 'lowerBound';
+    legend.hide = ['lowerBound', 'old-anomaly-edges', 'new-anomaly-edges'];
     const config = { unload, xs, columns, types, regions, tooltip, focusedIds, colors, axis, axes, legend };
     return config;
   },

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/dimensions-only/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/dimensions-only/template.hbs
@@ -1,0 +1,7 @@
+<ul class="te-anomaly-table__list">
+  {{#each-in record.anomaly.dimensions as |dimName dimList|}}
+     <li class="te-anomaly-table__list-item">
+       {{dimName}}:<span class="te-anomaly-table__list-value">{{dimList}}</span>
+     </li>
+  {{/each-in}}
+</ul>

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/investigation-link/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/investigation-link/template.hbs
@@ -1,4 +1,4 @@
 {{!-- TODO: Replace css classes below with te-anomaly-table styles --}}
 {{#link-to "rootcause" (query-params anomalyId=record.id) class="te-anomaly-table__link"}}
-  Investigate
+  Investigate {{record.id}}
 {{/link-to}}

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
@@ -15,17 +15,15 @@
 import Component from "@ember/component";
 import * as anomalyUtil from 'thirdeye-frontend/utils/anomaly';
 import { getAnomalyDataUrl } from 'thirdeye-frontend/utils/api/anomaly';
-import { inject as service } from '@ember/service';
 import {
   set,
   get,
-  computed,
   setProperties,
   getWithDefault
 } from '@ember/object';
 
 export default Component.extend({
-  tagName: '',//using tagless so i can add my own in hbs
+  tagName: '', //using tagless so i can add my own in hbs
   anomalyResponseNames: anomalyUtil.anomalyResponseObj.mapBy('name'),
   anomalyDataUrl: getAnomalyDataUrl(),
   showResponseSaved: false,
@@ -52,7 +50,7 @@ export default Component.extend({
      * @param {String} selectedResponse - user-selected anomaly feedback option
      * @param {Object} inputObj - the selection object
      */
-     onChangeAnomalyResponse: async function(humanizedAnomaly, selectedResponse, inputObj) {
+    onChangeAnomalyResponse: async function(humanizedAnomaly, selectedResponse, inputObj) {
       const responseObj = anomalyUtil.anomalyResponseObj.find(res => res.name === selectedResponse);
       set(inputObj, 'selected', selectedResponse);
       // Reset icon display props
@@ -69,9 +67,9 @@ export default Component.extend({
         const savedAnomaly = await anomalyUtil.verifyAnomalyFeedback(id);
         // TODO: right now we will update the union wrapper cached record for this anomaly
         humanizedAnomaly.set('anomaly.feedback', responseObj.value);
-        const filterMap = getWithDefault(savedAnomaly, 'searchFilters.statusFilterMap', null);
+        const filterMap = getWithDefault(savedAnomaly, 'feedback.feedbackType', null);
         // This verifies that the status change got saved as key in the anomaly statusFilterMap property
-        const keyPresent = filterMap && Object.keys(filterMap).find(key => responseObj.status.includes(key));
+        const keyPresent = filterMap && (filterMap === responseObj.value);
         if (keyPresent) {
           humanizedAnomaly.set('anomalyFeedback', selectedResponse);
           set(this, 'showResponseSaved', true);

--- a/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
@@ -171,7 +171,7 @@ export default Controller.extend({
       let falseNegatives = 0;
       Object.keys(anomalyMapping).forEach(function (key) {
         anomalyMapping[key].forEach(function (attr) {
-          const classification = attr.anomaly.data.classification;
+          const classification = ((attr.anomaly || {}).data || {}).classification;
           if (classification != 'NONE') {
             respondedAnomaliesCount++;
             if (classification == 'TRUE_POSITIVE') {

--- a/thirdeye/thirdeye-frontend/app/pods/manage/yaml/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/yaml/template.hbs
@@ -44,9 +44,11 @@
               {{/aitem.title}}
               {{#aitem.body}}
                 {{#alert-details
+                  isEditMode=true
                   isPreviewMode=true
                   alertId=model.alertId
                   alertYaml=detectionYaml
+                  originalYaml=model.detectionYaml
                   dataIsCurrent=alertDataIsCurrent
                   detectionHealth=model.detectionHealth
                   timeWindowSize=model.timeWindowSize

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -445,6 +445,7 @@
             {{/aitem.title}}
             {{#aitem.body}}
               {{#alert-details
+                isEditMode=false
                 isPreviewMode=true
                 alertYaml=detectionYaml
                 dataIsCurrent=alertDataIsCurrent

--- a/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
@@ -31,12 +31,18 @@ const HumanizedAnomaly = EmberObject.extend({// ex: record.humanizedChangeDispla
   baseline: computed('anomaly.baseline', function() {
     return humanizeFloat(get(this, 'anomaly.baseline'));
   }),
+  modifiedBy: computed.alias('anomaly.modifiedBy'),
+  rule: computed.alias('anomaly.rule'),
+  dimensionStr: computed.alias('anomaly.dimensionStr'),
   severity: computed('anomaly.severity', function() {
     return humanizeFloat(get(this, 'anomaly.severity'));
   }),
   source: computed('anomaly.source', function() {
     return humanizeFloat(get(this, 'anomaly.source'));
   }),
+  startDateStr: computed.alias('anomaly.startDateStr'),
+  start: computed.alias('anomaly.start'),
+  settings: computed.alias('anomaly.settings'),
   anomalyFeedback: computed('anomaly.feedback', function() {
     return get(this, 'anomaly.feedback') ? anomalyResponseObj.find(res => res.value === get(this, 'anomaly.feedback')).name : '';
   }),

--- a/thirdeye/thirdeye-frontend/app/styles/components/timeseries-chart.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/timeseries-chart.scss
@@ -8,10 +8,36 @@
     stroke-dasharray: 2,2;
   }
   .c3-target-Upper-and-lower-bound{
-    opacity: 0.5 !important;
+    // opacity: 0.5 !important;
+    visibility: hidden !important;
   }
   .c3-target-lowerBound {
-    opacity: 0.5 !important;
+    // opacity: 0.5 !important;
+    visibility: hidden !important;
+  }
+  .c3-circles-old-anomaly-edges > .c3-circle {
+    opacity: 1.0 !important;
+  }
+  .c3-circles-new-anomaly-edges > .c3-circle {
+    opacity: 1.0 !important;
+  }
+  .c3-tooltip-name--old-anomaly-edges {
+    display: none !important;
+  }
+  .c3-tooltip-name--new-anomaly-edges {
+    display: none !important;
+  }
+  .c3-tooltip-name--New-Settings-Anomalies {
+    display: none !important;
+  }
+  .c3-tooltip-name--Current-Anomalies {
+    display: none !important;
+  }
+  .c3-tooltip-name--Current-Settings-Anomalies {
+    display: none !important;
+  }
+  .c3-tooltip-name--Old-Settings-Anomalies {
+    display: none !important;
   }
   path.confidence-bounds {
     stroke: #1CAFED;

--- a/thirdeye/thirdeye-frontend/app/templates/dropdown.hbs
+++ b/thirdeye/thirdeye-frontend/app/templates/dropdown.hbs
@@ -1,0 +1,29 @@
+<div class="{{classes.columnsDropdownWrapper}}">
+  <div class="{{classes.columnsDropdownButtonWrapper}}">
+    {{#bs-dropdown as |dd|}}
+      {{#dd.button}}
+        {{messages.columns-title}}<span class="caret"></span>
+      {{/dd.button}}
+      {{#dd.menu as |ddm|}}
+        {{#ddm.item}}
+          <a {{action "showAllColumns" column bubbles=false}} href="#">{{messages.columns-showAll}}</a>
+        {{/ddm.item}}
+        {{#ddm.item}}
+          <a {{action "hideAllColumns" column bubbles=false}} href="#">{{messages.columns-hideAll}}</a>
+        {{/ddm.item}}
+        {{#ddm.item}}
+          <a {{action "restoreDefaultVisibility" column bubbles=false}} href="#">{{messages.columns-restoreDefaults}}</a>
+        {{/ddm.item}}
+        {{#each processedColumns as |column|}}
+          {{#if column.mayBeHidden}}
+            {{#ddm.item}}
+              <a {{action "toggleHidden" column bubbles=false}} href="#">
+                  <span class="{{if column.isVisible icons.column-visible icons.column-hidden}}"></span> {{column.title}}
+              </a>
+            {{/ddm.item}}
+          {{/if}}
+        {{/each}}
+      {{/dd.menu}}
+    {{/bs-dropdown}}
+  </div>
+</div>

--- a/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
@@ -14,7 +14,7 @@ export const colorMapping = {
   red: '#FF2C33',
   green: '#469A1F',
   pink: '#FF1B90',
-  grey: '#878787',
+  grey: '#B4B4B4',
   'light-blue': '#98D8F4', // 2/10
   'light-green': '#B5D99F',
   'light-red': '#FFBCBA',


### PR DESCRIPTION
1) Adds comparison for anomalies between 2 different detection configuration settings in Preview.  In Edit Alert, the previewed configuration is compared to the saved configuration.  In Create Alert, it compares with the last previewed detection configuration, if there is one.  
2) Changes how anomalies are displayed to make distinguishing between sets of anomalies intuitive
3) Draws anomalies in graph in intuitive manner (Anomaly endTime-1 time granularity is where the anomaly plot finishes).  Anomalies are also limited to the same timestamps that are provided for current time series.
4) Leverages ember-models-table to add filtering, column add/remove, and global search for anomaly table
5) Makes anomalies table searchable, filterable, and sortable by dimensions and other columns.