### PR TITLE
Support HTTP POST/PUT JSON schema

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -120,14 +121,36 @@ public class PinotSchemaRestletResource {
     return addOrUpdateSchema(schemaName, multiPart);
   }
 
+  @PUT
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Path("/schemas/{schemaName}")
+  @ApiOperation(value = "Update a schema", notes = "Updates a schema")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully updated schema"), @ApiResponse(code = 404, message = "Schema not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
+  public SuccessResponse updateSchema(@ApiParam(value = "Name of the schema", required = true) @PathParam("schemaName") String schemaName,
+      Schema schema) {
+    return addOrUpdateSchema(schemaName, schema);
+  }
+
   // TODO: This should not update if the schema already exists
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/schemas")
   @ApiOperation(value = "Add a new schema", notes = "Adds a new schema")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully deleted schema"), @ApiResponse(code = 404, message = "Schema not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully created schema"), @ApiResponse(code = 404, message = "Schema not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
   public SuccessResponse addSchema(FormDataMultiPart multiPart) {
     return addOrUpdateSchema(null, multiPart);
+  }
+
+  // TODO: This should not update if the schema already exists
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Path("/schemas")
+  @ApiOperation(value = "Add a new schema", notes = "Adds a new schema")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully created schema"), @ApiResponse(code = 404, message = "Schema not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
+  public SuccessResponse addSchema(Schema schema) {
+    return addOrUpdateSchema(null, schema);
   }
 
   @POST
@@ -145,6 +168,21 @@ public class PinotSchemaRestletResource {
     return schema.toPrettyJsonString();
   }
 
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Path("/schemas/validate")
+  @ApiOperation(value = "Validate schema", notes = "This API returns the schema that matches the one you get "
+      + "from 'GET /schema/{schemaName}'. This allows us to validate schema before apply.")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully validated schema"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")})
+  public String validateSchema(Schema schema) {
+    if (!schema.validate(LOGGER)) {
+      throw new ControllerApplicationException(LOGGER, "Invalid schema. Check controller logs",
+          Response.Status.BAD_REQUEST);
+    }
+    return schema.toPrettyJsonString();
+  }
+
   /**
    * Internal method to add or update schema
    * @param schemaName null value indicates new schema (POST request) where schemaName is
@@ -152,8 +190,17 @@ public class PinotSchemaRestletResource {
    * @return
    */
   private SuccessResponse addOrUpdateSchema(@Nullable String schemaName, FormDataMultiPart multiPart) {
+    return addOrUpdateSchema(schemaName, getSchemaFromMultiPart(multiPart));
+  }
+
+  /**
+   * Internal method to add or update schema
+   * @param schemaName null value indicates new schema (POST request) where schemaName is
+   *                   not part of URI
+   * @return
+   */
+  private SuccessResponse addOrUpdateSchema(@Nullable String schemaName, Schema schema) {
     final String schemaNameForLogging = (schemaName == null) ? "new schema" : schemaName + " schema";
-    Schema schema = getSchemaFromMultiPart(multiPart);
     if (!schema.validate(LOGGER)) {
       LOGGER.info("Invalid schema during create/update of {}", schemaNameForLogging);
       throw new ControllerApplicationException(LOGGER, "Invalid schema", Response.Status.BAD_REQUEST);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.controller.api;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.pinot.common.data.DimensionFieldSpec;
@@ -51,6 +53,36 @@ public class PinotSchemaRestletResourceTest extends ControllerTest {
     }
     // should not reach here
     Assert.fail("Should have caught an exception");
+  }
+
+  @Test
+  public void testPostJson() {
+    String schemaString = "{\n" + "  \"schemaName\" : \"transcript\",\n" + "  \"dimensionFieldSpecs\" : [ {\n"
+        + "    \"name\" : \"studentID\",\n" + "    \"dataType\" : \"STRING\"\n" + "  }, {\n"
+        + "    \"name\" : \"firstName\",\n" + "    \"dataType\" : \"STRING\"\n" + "  }, {\n"
+        + "    \"name\" : \"lastName\",\n" + "    \"dataType\" : \"STRING\"\n" + "  }, {\n"
+        + "    \"name\" : \"gender\",\n" + "    \"dataType\" : \"STRING\"\n" + "  }, {\n"
+        + "    \"name\" : \"subject\",\n" + "    \"dataType\" : \"STRING\"\n" + "  } ],\n"
+        + "  \"metricFieldSpecs\" : [ {\n" + "    \"name\" : \"score\",\n" + "    \"dataType\" : \"FLOAT\"\n"
+        + "  } ]}";
+    try {
+      Map<String, String> header = new HashMap<>();
+      sendPostRequest(_controllerRequestURLBuilder.forSchemaCreate(), schemaString, header);
+    } catch (IOException e) {
+      e.printStackTrace();
+      Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 415"), e.getMessage());
+    }
+
+    try {
+      Map<String, String> header = new HashMap<>();
+      header.put("Content-Type", "application/json");
+      final String response = sendPostRequest(_controllerRequestURLBuilder.forSchemaCreate(), schemaString, header);
+      Assert.assertEquals(response, "{\"status\":\"transcript successfully added\"}");
+    } catch (IOException e) {
+      e.printStackTrace();
+      // should not reach here
+      Assert.fail("Shouldn't have caught an exception");
+    }
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -69,7 +69,6 @@ public class PinotSchemaRestletResourceTest extends ControllerTest {
       Map<String, String> header = new HashMap<>();
       sendPostRequest(_controllerRequestURLBuilder.forSchemaCreate(), schemaString, header);
     } catch (IOException e) {
-      e.printStackTrace();
       Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 415"), e.getMessage());
     }
 
@@ -79,7 +78,6 @@ public class PinotSchemaRestletResourceTest extends ControllerTest {
       final String response = sendPostRequest(_controllerRequestURLBuilder.forSchemaCreate(), schemaString, header);
       Assert.assertEquals(response, "{\"status\":\"transcript successfully added\"}");
     } catch (IOException e) {
-      e.printStackTrace();
       // should not reach here
       Assert.fail("Shouldn't have caught an exception");
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
@@ -466,8 +467,18 @@ public abstract class ControllerTest {
 
   public static String sendPostRequest(String urlString, String payload)
       throws IOException {
+    return sendPostRequest(urlString, payload, Collections.EMPTY_MAP);
+  }
+
+  public static String sendPostRequest(String urlString, String payload, Map<String, String> headers)
+      throws IOException {
     HttpURLConnection httpConnection = (HttpURLConnection) new URL(urlString).openConnection();
     httpConnection.setRequestMethod("POST");
+    if (headers != null) {
+      for (String key : headers.keySet()) {
+        httpConnection.setRequestProperty(key, headers.get(key));
+      }
+    }
 
     if (payload != null && !payload.isEmpty()) {
       httpConnection.setDoOutput(true);


### PR DESCRIPTION
Resolution to: https://github.com/apache/incubator-pinot/issues/4603

Sample usage:
```
curl -X POST --header 'Content-Type: application/json'  -d '{
"schemaName": "transcript",
"dimensionFieldSpecs": [
{
"name": "studentID",
"dataType": "STRING"
},
{
"name": "firstName",
"dataType": "STRING"
},
{
"name": "lastName",
"dataType": "STRING"
},
{
"name": "gender",
"dataType": "STRING"
},
{
"name": "subject",
"dataType": "STRING"
}
],
"metricFieldSpecs": [
{
"name": "score",
"dataType": "FLOAT"
}
]
}' 'http://localhost:9000/schemas/validate'
```