### PR TITLE
[TE] fix email alerter throw exception

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -259,7 +259,7 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
       Map<String, Object> notificationSchemeProps = notification.getNotificationSchemeProps();
       if (notificationSchemeProps != null && notificationSchemeProps.get(PROP_EMAIL_SCHEME) != null
           && ConfigUtils.getMap(notificationSchemeProps.get(PROP_EMAIL_SCHEME)).get(PROP_RECIPIENTS) != null) {
-        SetMultimap<String, String> emailRecipients = (SetMultimap<String, String>) ConfigUtils.getMap(notificationSchemeProps.get(PROP_EMAIL_SCHEME)).get(PROP_RECIPIENTS);
+        Map<String, Set<String>> emailRecipients = (Map<String, Set<String>>) ConfigUtils.getMap(notificationSchemeProps.get(PROP_EMAIL_SCHEME)).get(PROP_RECIPIENTS);
         if (emailRecipients.get(PROP_TO) == null || emailRecipients.get(PROP_TO).isEmpty()) {
           LOG.warn("Skipping! No email recipients found for alert {}.", config.getId());
           return;


### PR DESCRIPTION
The email alerter keep throwing a `ClassCastException`, which cause the alerter to fail. This PR fixes the issue.