### PR TITLE
Enable DISTINCT and throw exceptions for not-supported cases

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.broker.requesthandler;
+
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class QueryValidationTest {
+  @Test
+  public void testUnsupportedDistinctQueries() {
+    Pql2Compiler compiler = new Pql2Compiler();
+
+    String pql = "SELECT DISTINCT(col1, col2) FROM foo ORDER BY col1, col2";
+    testUnsupportedQueriesHelper(compiler, pql, "DISTINCT with ORDER BY is currently not supported");
+
+    pql = "SELECT DISTINCT(col1, col2) FROM foo GROUP BY col1";
+    testUnsupportedQueriesHelper(compiler, pql, "DISTINCT with GROUP BY is currently not supported");
+
+    pql = "SELECT sum(col1), min(col2), DISTINCT(col3, col4) FROM foo";
+    testUnsupportedQueriesHelper(compiler, pql, "Aggregation functions cannot be used with DISTINCT");
+
+    pql = "SELECT sum(col1), DISTINCT(col2, col3), min(col4) FROM foo";
+    testUnsupportedQueriesHelper(compiler, pql, "Aggregation functions cannot be used with DISTINCT");
+
+    pql = "SELECT DISTINCT(col1, col2), DISTINCT(col3) FROM foo";
+    testUnsupportedQueriesHelper(compiler, pql, "Aggregation functions cannot be used with DISTINCT");
+
+    pql = "SELECT DISTINCT(col1, col2), sum(col3), min(col4) FROM foo";
+    testUnsupportedQueriesHelper(compiler, pql, "Aggregation functions cannot be used with DISTINCT");
+  }
+
+  private void testUnsupportedQueriesHelper(Pql2Compiler compiler, String query, String errorMessage) {
+    try {
+      BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
+      BaseBrokerRequestHandler.validateRequest(brokerRequest, 1000);
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains(errorMessage));
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/Pql2Compiler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/Pql2Compiler.java
@@ -71,7 +71,7 @@ public class Pql2Compiler implements AbstractCompiler {
   public static boolean FAIL_ON_CONVERSION_ERROR =
       Boolean.valueOf(System.getProperty("pinot.query.converter.fail_on_error", "false"));
   public static String ENABLE_DISTINCT_KEY = "pinot.distinct.enabled";
-  public static boolean ENABLE_DISTINCT = Boolean.valueOf(System.getProperty(ENABLE_DISTINCT_KEY, "false"));
+  public static boolean ENABLE_DISTINCT = Boolean.valueOf(System.getProperty(ENABLE_DISTINCT_KEY, "true"));
 
   private static class ErrorListener extends BaseErrorListener {
 

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnListAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnListAstNode.java
@@ -18,10 +18,8 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
-import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.PinotQuery;
-import org.apache.pinot.pql.parsers.Pql2CompilationException;
 
 
 /**
@@ -43,97 +41,8 @@ public class OutputColumnListAstNode extends BaseAstNode {
     }
   }
 
-  /**
-   * Check for following style PQLs and raise syntax error
-   *
-   * These 4 queries are not valid SQL queries as well so PQL won't support them too
-   * (1) SELECT sum(col1), min(col2), DISTINCT(col3, col4)
-   * (2) SELECT col1, col2, DISTINCT(col3) FROM foo
-   * (3) SELECT DISTINCT(col1, col2), DISTINCT(col3) FROM foo
-   * (4) SELECT timeConvert(DaysSinceEpoch,'DAYS','SECONDS'), DISTINCT(DaysSinceEpoch) FROM foo
-   *
-   * These 3 queries are either both selection and aggregation query
-   * or the query does not make sense from result point of view (like 6)
-   * (5) SELECT DISTINCT(col1), col2, col3 FROM foo
-   * (6) SELECT DISTINCT(col1), sum(col3), min(col4) FROM foo
-   * (7) SELECT DISTINCT(DaysSinceEpoch), timeConvert(DaysSinceEpoch,'DAYS','SECONDS') FROM foo
-   *
-   * SQL versions of the above queries:
-   *
-   * (1) SELECT sum(col1), min(col2), DISTINCT col3, col4
-   * (2) SELECT col1, col2, DISTINCT col3 FROM foo
-   * (3) SELECT DISTINCT col1, col2, DISTINCT col3 FROM foo
-   * (4) SELECT timeConvert(DaysSinceEpoch,'DAYS','SECONDS'), DISTINCT DaysSinceEpoch FROM foo
-   *
-   * 1, 2, 3 and 4 will still not be supported in compliance with SQL
-   *
-   * (5) SELECT DISTINCT col1, col2, col3 FROM foo
-   * will be supported as it effectively becomes a multi column distinct
-   *
-   * (6) SELECT DISTINCT col1, sum(col3), min(col4) FROM foo
-   * although a valid SQL syntax for multi column distinct, if we decide to support
-   * them, we will have to do sum and min as transform functions which is not the case today.
-   * In any case, not a helpful query.
-   *
-   * (7) SELECT DISTINCT DaysSinceEpoch, timeConvert(DaysSinceEpoch,'DAYS','SECONDS') FROM foo
-   * again a valid SQL syntax for multi column distinct, we can support this since timeConvert
-   * is a valid supported transform function.
-   */
-  private void validate() {
-    boolean identifierPresent = false;
-    boolean distinctPresent = false;
-    boolean functionPresent = false;
-    if (hasChildren()) {
-      for (AstNode child : getChildren()) {
-        // OutputColumnListAstNode can have a child of
-        // OutputColumnAstNode type where each OutputColumnAstNode
-        // represents an individually selected column in the select list.
-        // The individually selected column can either be standalone column
-        // represented by IdentifierAstNode or a function (agg or transform)
-        // represented by FunctionCallAstNode.
-        // Also, for star queries, the child of SelectAstNode will
-        // be StarColumnListAstNode and not OutputColumnListAstNode
-        // so we will not end up here for star queries.
-        if (child instanceof OutputColumnAstNode) {
-            for (AstNode selectChild : child.getChildren()) {
-            if (selectChild instanceof IdentifierAstNode) {
-              if (distinctPresent) {
-                throw new Pql2CompilationException(
-                    "Syntax error: SELECT list columns should be part of DISTINCT clause");
-              } else {
-                identifierPresent = true;
-              }
-            } else if (selectChild instanceof FunctionCallAstNode) {
-              FunctionCallAstNode function = (FunctionCallAstNode) selectChild;
-              if (function.getName().equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
-                if (identifierPresent) {
-                  throw new Pql2CompilationException(
-                      "Syntax error: SELECT list columns should be part of DISTINCT clause");
-                } else if (functionPresent) {
-                  throw new Pql2CompilationException("Syntax error: Functions cannot be used with DISTINCT clause");
-                } else if (distinctPresent) {
-                  throw new Pql2CompilationException(
-                      "Syntax error: DISTINCT clause can be used only once in a query");
-                } else {
-                  distinctPresent = true;
-                }
-              } else {
-                if (distinctPresent) {
-                  throw new Pql2CompilationException("Syntax error: Functions cannot be used with DISTINCT clause");
-                } else {
-                  functionPresent = true;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
   @Override
   public void updateBrokerRequest(BrokerRequest brokerRequest) {
-    validate();
     sendBrokerRequestUpdateToChildren(brokerRequest);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -126,6 +126,14 @@ public class CalciteSqlParser {
     switch (sqlNode.getKind()) {
       case ORDER_BY:
         selectOrderBySqlNode = (SqlOrderBy) sqlNode;
+        SqlNode sqlSelectNode = selectOrderBySqlNode.query;
+        if (sqlSelectNode instanceof SqlSelect) {
+          SqlSelect sqlSelect = (SqlSelect) sqlSelectNode;
+          if (sqlSelect.getModifierNode(SqlSelectKeyword.DISTINCT) != null) {
+            // TODO: add support for ORDER BY with DISTINCT
+            throw new SqlCompilationException("DISTINCT with ORDER BY is not supported");
+          }
+        }
         if (selectOrderBySqlNode.orderList != null) {
           pinotQuery.setOrderByList(convertOrderByList(selectOrderBySqlNode.orderList));
         }
@@ -152,6 +160,10 @@ public class CalciteSqlParser {
         dataSource.setTableName(selectSqlNode.getFrom().toString());
         pinotQuery.setDataSource(dataSource);
         if (selectSqlNode.getModifierNode(SqlSelectKeyword.DISTINCT) != null) {
+          if (selectSqlNode.getGroup() != null) {
+            // TODO: explore support for GROUP BY with DISTINCT
+            throw new SqlCompilationException("DISTINCT with GROUP BY is not supported");
+          }
           pinotQuery.setSelectList(convertDistinctSelectList(selectSqlNode.getSelectList()));
         } else {
           pinotQuery.setSelectList(convertSelectList(selectSqlNode.getSelectList()));

--- a/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
@@ -476,42 +476,4 @@ public class Pql2CompilerTest {
       Assert.assertEquals(orderBy.isIsAsc(), isAscs.get(i).booleanValue());
     }
   }
-
-  @Test
-  public void testBadQueries() {
-    Pql2Compiler.ENABLE_DISTINCT = true;
-    String pql = "SELECT sum(col1), min(col2), DISTINCT(col3, col4) FROM foo";
-    runBadQuery(pql, "Syntax error: Functions cannot be used with DISTINCT clause");
-
-    pql = "SELECT col1, col2, DISTINCT(col3) FROM foo";
-    runBadQuery(pql, "Syntax error: SELECT list columns should be part of DISTINCT clause");
-
-    pql = "SELECT DISTINCT(col1, col2), DISTINCT(col3) FROM foo";
-    runBadQuery(pql, "Syntax error: DISTINCT clause can be used only once in a query");
-
-    pql = "SELECT timeConvert(DaysSinceEpoch,'DAYS','SECONDS'), DISTINCT(DaysSinceEpoch) FROM foo";
-    runBadQuery(pql, "Syntax error: Functions cannot be used with DISTINCT clause");
-
-    pql = "SELECT DISTINCT(col1), col2, col3 FROM foo";
-    runBadQuery(pql, "Syntax error: SELECT list columns should be part of DISTINCT clause");
-
-    pql = "SELECT DISTINCT(col1, col2), sum(col3), min(col4) FROM foo";
-    runBadQuery(pql, "Syntax error: Functions cannot be used with DISTINCT clause");
-
-    pql = "SELECT DISTINCT(DaysSinceEpoch), timeConvert(DaysSinceEpoch,'DAYS','SECONDS') FROM foo";
-    runBadQuery(pql, "Syntax error: Functions cannot be used with DISTINCT clause");
-
-    pql = "SELECT DISTINCT(*) FROM foo";
-    runBadQuery(pql,
-        "Syntax error: Pinot currently does not support DISTINCT with *. Please specify each column name as argument to DISTINCT function");
-  }
-
-  private void runBadQuery(final String pql, final String message) {
-    try {
-      COMPILER.compileToBrokerRequest(pql);
-      Assert.fail("Query should not have compiled successfully");
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof Pql2CompilationException && e.getMessage().contains(message));
-    }
-  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -602,6 +602,26 @@ public class CalciteSqlCompilerTest {
           "Syntax error: Pinot currently does not support DISTINCT with *. Please specify each column name after DISTINCT keyword"));
     }
 
+    // Pinot currently does not support ORDER BY with DISTINCT
+    try {
+      sql = "SELECT DISTINCT C1, C2 FROM foo ORDER BY C1, C2";
+      CalciteSqlParser.compileToPinotQuery(sql);
+      Assert.fail("Query should have failed compilation");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof SqlCompilationException);
+      Assert.assertTrue(e.getMessage().contains("DISTINCT with ORDER BY is not supported"));
+    }
+
+    // Pinot currently does not support GROUP BY with DISTINCT
+    try {
+      sql = "SELECT DISTINCT C1, C2 FROM foo GROUP BY C1";
+      CalciteSqlParser.compileToPinotQuery(sql);
+      Assert.fail("Query should have failed compilation");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof SqlCompilationException);
+      Assert.assertTrue(e.getMessage().contains("DISTINCT with GROUP BY is not supported"));
+    }
+
     // distinct with transform is supported since the output of
     // transform can be piped into distinct function
 


### PR DESCRIPTION
Enable DISTINCT and raise errors for queries currently not supported

(1) Throw parse exception (after building AST) if DISTINCT query
has ORDER BY. Done for both PQL compilation and Calcite SQL
compilation paths

(2) Throw runtime exception if DISTINCT query has one or more
multi-value columns.

Added unit tests for both cases. When the support is implemented,
we can remove the tests and exceptions.

Also, don't take star-tree path in AggregationPlanNode for DISTINCT
query.

cc @Jackie-Jiang , @mayankshriv 