### PR TITLE
[#4626] Fix a thread race condition during LLC realtime ingestion.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -677,7 +677,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         segmentLogger.info("Waiting to acquire semaphore for building segment");
         _segBuildSemaphore.acquire();
       }
-      // This method can be called in either the consumerThread or the main server thread. In case of the former
+      // This method can be called in either the consumerThread or the main server thread. In the case of the former,
       // the thread should double check the _shouldStop value before proceeding further.
       if (_shouldStop && Thread.currentThread() == _consumerThread) {
         segmentLogger.info("The consumer thread was asked to stop build segments.");
@@ -707,7 +707,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       final long waitTimeMillis = lockAquireTimeMillis - startTimeMillis;
       segmentLogger
           .info("Successfully built segment in {} ms, after lockWaitTime {} ms", buildTimeMillis, waitTimeMillis);
-      // This method can be called in either the consumerThread or the main server thread. In case of the former
+      // This method can be called in either the consumerThread or the main server thread. In the case of the former,
       // the thread should double check the _shouldStop value before proceeding further.
       if (_shouldStop && Thread.currentThread() == _consumerThread) {
         segmentLogger.info("The consumer thread was asked to stop build segments.");


### PR DESCRIPTION
Fix a thread race condition by double check the _shouldStop value in the consumer thread after any lengthy blocking ops like build() and semaphore acquasition.

@mcvsubbu 