### PR TITLE
Revert the binary-search change for MapValue transform function

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/AvroRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/AvroRecordReader.java
@@ -82,7 +82,7 @@ public class AvroRecordReader implements RecordReader {
       Object value = _reusableAvroRecord.get(fieldName);
       // Allow default value for non-time columns
       if (value != null || fieldSpec.getFieldType() != FieldSpec.FieldType.TIME) {
-        AvroUtils.extractField(_schema, fieldSpec, _reusableAvroRecord, reuse);
+        AvroUtils.extractField(fieldSpec, _reusableAvroRecord, reuse);
       }
     }
     return reuse;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.common.DataSource;
@@ -103,13 +102,17 @@ public class MapValueTransformFunction extends BaseTransformFunction {
     int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       int[] keyDictIds = keyDictIdsMV[i];
-      int index = Arrays.binarySearch(keyDictIds, _keyDictId);
-      if (index >= 0) {
-        _dictIds[i] = valueDictIdsMV[i][index];
-      } else {
-        // Allow NULL_VALUE_INDEX for filter
-        _dictIds[i] = Dictionary.NULL_VALUE_INDEX;
+
+      // Allow NULL_VALUE_INDEX for filter
+      int valueDictId = Dictionary.NULL_VALUE_INDEX;
+      int numValues = keyDictIds.length;
+      for (int j = 0; j < numValues; j++) {
+        if (keyDictIds[j] == _keyDictId) {
+          valueDictId = valueDictIdsMV[i][j];
+          break;
+        }
       }
+      _dictIds[i] = valueDictId;
     }
     return _dictIds;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/AvroRecordToPinotRowGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/AvroRecordToPinotRowGenerator.java
@@ -44,7 +44,7 @@ public class AvroRecordToPinotRowGenerator {
     for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
       FieldSpec incomingFieldSpec =
           fieldSpec.getFieldType() == FieldSpec.FieldType.TIME ? _incomingTimeFieldSpec : fieldSpec;
-      AvroUtils.extractField(_schema, incomingFieldSpec, from, to);
+      AvroUtils.extractField(incomingFieldSpec, from, to);
     }
     return to;
   }


### PR DESCRIPTION
Binary-search assumes ordered dictIds for key column, which will break for real-time case
Use linear-search for MapValue transform function