### PR TITLE
Make TransformFunction.getDictionary() API consistent with DataSource.getDictionary()

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataSource.java
@@ -26,11 +26,23 @@ import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
 
 public abstract class DataSource extends BaseOperator {
 
+  /**
+   * Returns the metadata for the data source.
+   */
   public abstract DataSourceMetadata getDataSourceMetadata();
 
-  public abstract InvertedIndexReader getInvertedIndex();
-
+  /**
+   * Returns the dictionary for the data source if the data is dictionary-encoded, or {@code null} if not.
+   */
   public abstract Dictionary getDictionary();
 
+  /**
+   * Returns the inverted index for the data source if exists, or {@code null} if not.
+   */
+  public abstract InvertedIndexReader getInvertedIndex();
+
+  /**
+   * Returns the bloom filter for the data source if exists, or {@code null} if not.
+   */
   public abstract BloomFilterReader getBloomFilter();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
@@ -78,9 +78,8 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
   }
 
   /**
-   * Returns the dictionary associated with the given expression.
-   * <p>Should be called only if {@link #getResultMetadata(TransformExpressionTree)} indicates that the transform result
-   * has dictionary.
+   * Returns the dictionary associated with the given expression if the transform result is dictionary-encoded, or
+   * {@code null} if not.
    *
    * @return Dictionary
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -52,7 +52,7 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public Dictionary getDictionary() {
-    throw new UnsupportedOperationException();
+    return null;
   }
 
   @Override
@@ -72,12 +72,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
-      getDictionary().readIntValues(dictIds, length, _intValuesSV);
+      dictionary.readIntValues(dictIds, length, _intValuesSV);
     } else {
-      switch (resultMetadata.getDataType()) {
+      switch (getResultMetadata().getDataType()) {
         case LONG:
           long[] longValues = transformToLongValuesSV(projectionBlock);
           ArrayCopyUtils.copy(longValues, _intValuesSV, length);
@@ -108,12 +108,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
-      getDictionary().readLongValues(dictIds, length, _longValuesSV);
+      dictionary.readLongValues(dictIds, length, _longValuesSV);
     } else {
-      switch (resultMetadata.getDataType()) {
+      switch (getResultMetadata().getDataType()) {
         case INT:
           int[] intValues = transformToIntValuesSV(projectionBlock);
           ArrayCopyUtils.copy(intValues, _longValuesSV, length);
@@ -144,12 +144,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
-      getDictionary().readFloatValues(dictIds, length, _floatValuesSV);
+      dictionary.readFloatValues(dictIds, length, _floatValuesSV);
     } else {
-      switch (resultMetadata.getDataType()) {
+      switch (getResultMetadata().getDataType()) {
         case INT:
           int[] intValues = transformToIntValuesSV(projectionBlock);
           ArrayCopyUtils.copy(intValues, _floatValuesSV, length);
@@ -180,12 +180,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
-      getDictionary().readDoubleValues(dictIds, length, _doubleValuesSV);
+      dictionary.readDoubleValues(dictIds, length, _doubleValuesSV);
     } else {
-      switch (resultMetadata.getDataType()) {
+      switch (getResultMetadata().getDataType()) {
         case INT:
           int[] intValues = transformToIntValuesSV(projectionBlock);
           ArrayCopyUtils.copy(intValues, _doubleValuesSV, length);
@@ -216,12 +216,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
-      getDictionary().readStringValues(dictIds, length, _stringValuesSV);
+      dictionary.readStringValues(dictIds, length, _stringValuesSV);
     } else {
-      switch (resultMetadata.getDataType()) {
+      switch (getResultMetadata().getDataType()) {
         case INT:
           int[] intValues = transformToIntValuesSV(projectionBlock);
           ArrayCopyUtils.copy(intValues, _stringValuesSV, length);
@@ -255,12 +255,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
-      getDictionary().readBytesValues(dictIds, length, _byteValuesSV);
+      dictionary.readIntValues(dictIds, length, _intValuesSV);
     } else {
-      Preconditions.checkState(resultMetadata.getDataType() == DataType.STRING);
+      Preconditions.checkState(getResultMetadata().getDataType() == DataType.STRING);
       String[] stringValues = transformToStringValuesSV(projectionBlock);
       ArrayCopyUtils.copy(stringValues, _byteValuesSV, length);
     }
@@ -274,10 +274,9 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
-      Dictionary dictionary = getDictionary();
       for (int i = 0; i < length; i++) {
         int[] dictIds = dictIdsMV[i];
         int numValues = dictIds.length;
@@ -341,10 +340,9 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
-      Dictionary dictionary = getDictionary();
       for (int i = 0; i < length; i++) {
         int[] dictIds = dictIdsMV[i];
         int numValues = dictIds.length;
@@ -408,10 +406,9 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
-      Dictionary dictionary = getDictionary();
       for (int i = 0; i < length; i++) {
         int[] dictIds = dictIdsMV[i];
         int numValues = dictIds.length;
@@ -475,10 +472,9 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
-      Dictionary dictionary = getDictionary();
       for (int i = 0; i < length; i++) {
         int[] dictIds = dictIdsMV[i];
         int numValues = dictIds.length;
@@ -542,10 +538,9 @@ public abstract class BaseTransformFunction implements TransformFunction {
     }
 
     int length = projectionBlock.getNumDocs();
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary()) {
+    Dictionary dictionary = getDictionary();
+    if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
-      Dictionary dictionary = getDictionary();
       for (int i = 0; i < length; i++) {
         int[] dictIds = dictIdsMV[i];
         int numValues = dictIds.length;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
@@ -49,6 +49,7 @@ public class MapValueTransformFunction extends BaseTransformFunction {
   private TransformFunction _keyColumnFunction;
   private int _keyDictId;
   private TransformFunction _valueColumnFunction;
+  private Dictionary _valueColumnDictionary;
   private TransformResultMetadata _resultMetadata;
 
   private int[] _dictIds;
@@ -65,18 +66,20 @@ public class MapValueTransformFunction extends BaseTransformFunction {
 
     _keyColumnFunction = arguments.get(0);
     TransformResultMetadata keyColumnMetadata = _keyColumnFunction.getResultMetadata();
-    Preconditions.checkState(!keyColumnMetadata.isSingleValue() && keyColumnMetadata.hasDictionary(),
+    Dictionary keyColumnDictionary = _keyColumnFunction.getDictionary();
+    Preconditions.checkState(!keyColumnMetadata.isSingleValue() && keyColumnDictionary != null,
         "Key column must be dictionary-encoded multi-value column");
 
     TransformFunction keyValueFunction = arguments.get(1);
     Preconditions.checkState(keyValueFunction instanceof LiteralTransformFunction,
         "Key value must be a literal (number or string)");
     String keyValue = ((LiteralTransformFunction) keyValueFunction).getLiteral();
-    _keyDictId = _keyColumnFunction.getDictionary().indexOf(keyValue);
+    _keyDictId = keyColumnDictionary.indexOf(keyValue);
 
     _valueColumnFunction = arguments.get(2);
     TransformResultMetadata valueColumnMetadata = _valueColumnFunction.getResultMetadata();
-    Preconditions.checkState(!valueColumnMetadata.isSingleValue() && valueColumnMetadata.hasDictionary(),
+    _valueColumnDictionary = _valueColumnFunction.getDictionary();
+    Preconditions.checkState(!valueColumnMetadata.isSingleValue() && _valueColumnDictionary != null,
         "Value column must be dictionary-encoded multi-value column");
     _resultMetadata = new TransformResultMetadata(valueColumnMetadata.getDataType(), true, true);
   }
@@ -88,7 +91,7 @@ public class MapValueTransformFunction extends BaseTransformFunction {
 
   @Override
   public Dictionary getDictionary() {
-    return _valueColumnFunction.getDictionary();
+    return _valueColumnDictionary;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.transform.function;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -59,7 +60,7 @@ public interface TransformFunction {
    */
 
   /**
-   * Returns the dictionary that the dictionary Ids based on.
+   * Returns the dictionary for the transform result if the result is dictionary-encoded, or {@code null} if not.
    *
    * @return Dictionary
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
@@ -51,6 +51,9 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "valueIn";
 
   private TransformFunction _mainTransformFunction;
+  private TransformResultMetadata _resultMetadata;
+  private Dictionary _dictionary;
+
   private IntSet _dictIdSet;
   private int[][] _dictIds;
   private IntSet _intValueSet;
@@ -84,6 +87,8 @@ public class ValueInTransformFunction extends BaseTransformFunction {
           "The first argument of VALUE_IN transform function must be a multi-valued column or a transform function");
     }
     _mainTransformFunction = firstArgument;
+    _resultMetadata = _mainTransformFunction.getResultMetadata();
+    _dictionary = _mainTransformFunction.getDictionary();
 
     // Collect all values for the VALUE_IN transform function
     _stringValueSet = new HashSet<>(numArguments - 1);
@@ -94,21 +99,21 @@ public class ValueInTransformFunction extends BaseTransformFunction {
 
   @Override
   public TransformResultMetadata getResultMetadata() {
-    return _mainTransformFunction.getResultMetadata();
+    return _resultMetadata;
   }
 
   @Override
   public Dictionary getDictionary() {
-    return _mainTransformFunction.getDictionary();
+    return _dictionary;
   }
 
   @Override
   public int[][] transformToDictIdsMV(ProjectionBlock projectionBlock) {
     if (_dictIdSet == null) {
       _dictIdSet = new IntOpenHashSet();
-      Dictionary dictionary = _mainTransformFunction.getDictionary();
+      assert _dictionary != null;
       for (String inValue : _stringValueSet) {
-        int dictId = dictionary.indexOf(inValue);
+        int dictId = _dictionary.indexOf(inValue);
         if (dictId >= 0) {
           _dictIdSet.add(dictId);
         }
@@ -125,8 +130,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.INT) {
+    if (_dictionary != null || _resultMetadata.getDataType() != FieldSpec.DataType.INT) {
       return super.transformToIntValuesMV(projectionBlock);
     }
 
@@ -147,8 +151,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
 
   @Override
   public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.LONG) {
+    if (_dictionary != null || _resultMetadata.getDataType() != FieldSpec.DataType.LONG) {
       return super.transformToLongValuesMV(projectionBlock);
     }
 
@@ -169,8 +172,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
 
   @Override
   public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.FLOAT) {
+    if (_dictionary != null || _resultMetadata.getDataType() != FieldSpec.DataType.FLOAT) {
       return super.transformToFloatValuesMV(projectionBlock);
     }
 
@@ -191,8 +193,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.DOUBLE) {
+    if (_dictionary != null || _resultMetadata.getDataType() != FieldSpec.DataType.DOUBLE) {
       return super.transformToDoubleValuesMV(projectionBlock);
     }
 
@@ -213,8 +214,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
 
   @Override
   public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
-    TransformResultMetadata resultMetadata = getResultMetadata();
-    if (resultMetadata.hasDictionary() || resultMetadata.getDataType() != FieldSpec.DataType.STRING) {
+    if (_dictionary != null || _resultMetadata.getDataType() != FieldSpec.DataType.STRING) {
       return super.transformToStringValuesMV(projectionBlock);
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/data/source/ColumnDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/data/source/ColumnDataSource.java
@@ -151,13 +151,13 @@ public final class ColumnDataSource extends DataSource {
   }
 
   @Override
-  public InvertedIndexReader getInvertedIndex() {
-    return _invertedIndex;
+  public Dictionary getDictionary() {
+    return _dictionary;
   }
 
   @Override
-  public Dictionary getDictionary() {
-    return _dictionary;
+  public InvertedIndexReader getInvertedIndex() {
+    return _invertedIndex;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/store/StarTreeDimensionDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/store/StarTreeDimensionDataSource.java
@@ -99,6 +99,11 @@ public class StarTreeDimensionDataSource extends DataSource {
   }
 
   @Override
+  public Dictionary getDictionary() {
+    return _dictionary;
+  }
+
+  @Override
   public InvertedIndexReader getInvertedIndex() {
     return null;
   }
@@ -106,11 +111,6 @@ public class StarTreeDimensionDataSource extends DataSource {
   @Override
   public BloomFilterReader getBloomFilter() {
     return null;
-  }
-
-  @Override
-  public Dictionary getDictionary() {
-    return _dictionary;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/store/StarTreeMetricDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/store/StarTreeMetricDataSource.java
@@ -104,12 +104,12 @@ public class StarTreeMetricDataSource extends DataSource {
   }
 
   @Override
-  public InvertedIndexReader getInvertedIndex() {
+  public Dictionary getDictionary() {
     return null;
   }
 
   @Override
-  public Dictionary getDictionary() {
+  public InvertedIndexReader getInvertedIndex() {
     return null;
   }
 


### PR DESCRIPTION
If dictionary does not exist, return null instead of throw exception.
Add javadoc to the TransformFunction and DataSource interface for the behavior.