### PR TITLE
Add wait for condition for toggle test

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -76,7 +76,7 @@ public class PinotInstanceRestletResource {
   @ApiOperation(value = "List all instances")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal error")})
   public Instances getAllInstances() {
-    return new Instances(pinotHelixResourceManager.getAllInstances());
+    return new Instances(pinotHelixResourceManager.getAllInstances(false));
   }
 
   @GET
@@ -86,7 +86,7 @@ public class PinotInstanceRestletResource {
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 404, message = "Instance not found"), @ApiResponse(code = 500, message = "Internal error")})
   public String getInstance(
       @ApiParam(value = "Instance name", required = true, example = "Server_a.b.com_20000 | Broker_my.broker.com_30000") @PathParam("instanceName") String instanceName) {
-    InstanceConfig instanceConfig = pinotHelixResourceManager.getHelixInstanceConfig(instanceName);
+    InstanceConfig instanceConfig = pinotHelixResourceManager.getHelixInstanceConfig(instanceName, false);
     if (instanceConfig == null) {
       throw new ControllerApplicationException(LOGGER, "Instance " + instanceName + " not found",
           Response.Status.NOT_FOUND);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -415,7 +415,7 @@ public class PinotSegmentRestletResource {
     if (segmentName == null) {
       // For enable, allow 5 seconds per segment for an instance as timeout.
       if (state == StateType.ENABLE) {
-        int instanceCount = helixResourceManager.getAllInstances().size();
+        int instanceCount = helixResourceManager.getAllInstances(true).size();
         if (instanceCount != 0) {
           timeOutInSeconds = (_offlineToOnlineTimeoutInseconds * segmentsToToggle.size()) / instanceCount;
         } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PqlQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PqlQueryResource.java
@@ -128,7 +128,7 @@ public class PqlQueryResource {
 
     // Send query to a random broker.
     String instanceId = instanceIds.get(RANDOM.nextInt(instanceIds.size()));
-    InstanceConfig instanceConfig = _pinotHelixResourceManager.getHelixInstanceConfig(instanceId);
+    InstanceConfig instanceConfig = _pinotHelixResourceManager.getHelixInstanceConfig(instanceId, false);
     if (instanceConfig == null) {
       LOGGER.error("Instance {} not found", instanceId);
       return QueryException.INTERNAL_ERROR.toString();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -944,7 +944,7 @@ public class PinotHelixResourceManager {
   }
 
   public Set<String> getAllInstancesForServerTenant(String tenantName) {
-    return getAllInstancesForServerTenant(HelixHelper.getInstanceConfigs(_helixZkManager), tenantName);
+    return getAllInstancesForServerTenant(getAllHelixInstanceConfigs(), tenantName);
   }
 
   /**
@@ -956,7 +956,7 @@ public class PinotHelixResourceManager {
   }
 
   public Set<String> getAllInstancesForBrokerTenant(String tenantName) {
-    return getAllInstancesForBrokerTenant(HelixHelper.getInstanceConfigs(_helixZkManager), tenantName);
+    return getAllInstancesForBrokerTenant(getAllHelixInstanceConfigs(), tenantName);
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -49,6 +49,16 @@ public class ControllerInstanceToggleTest extends ControllerTest {
     startController();
     addFakeBrokerInstancesToAutoJoinHelixCluster(NUM_INSTANCES, true);
     addFakeServerInstancesToAutoJoinHelixCluster(NUM_INSTANCES, true);
+
+    // Wait to make sure cached data accessor has caught up.
+    TestUtils.waitForCondition(aVoid -> {
+      Set<String> brokerInstances = _helixResourceManager.getAllInstancesForBrokerTenant(null);
+      return brokerInstances != null && brokerInstances.size() == NUM_INSTANCES;
+    }, TIMEOUT_MS, "Failed to add " + NUM_INSTANCES + " fake brokers.");
+    TestUtils.waitForCondition(aVoid -> {
+      Set<String> serverInstances = _helixResourceManager.getAllInstancesForServerTenant(null);
+      return serverInstances != null && serverInstances.size() == NUM_INSTANCES;
+    }, TIMEOUT_MS, "Failed to add " + NUM_INSTANCES + " fake servers.");
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -114,7 +114,7 @@ public class PinotHelixResourceManagerTest extends ControllerTest {
       throws Exception {
     Set<String> servers = _helixResourceManager.getAllInstancesForServerTenant(SERVER_TENANT_NAME);
     for (String server : servers) {
-      InstanceConfig cachedInstanceConfig = _helixResourceManager.getHelixInstanceConfig(server);
+      InstanceConfig cachedInstanceConfig = _helixResourceManager.getHelixInstanceConfig(server, false);
       InstanceConfig realInstanceConfig = _helixAdmin.getInstanceConfig(getHelixClusterName(), server);
       Assert.assertEquals(cachedInstanceConfig, realInstanceConfig);
     }
@@ -135,7 +135,7 @@ public class PinotHelixResourceManagerTest extends ControllerTest {
     Assert.assertTrue(zkClient.exists(instanceConfigPath));
     ZNRecord znRecord = zkClient.readData(instanceConfigPath, null);
 
-    InstanceConfig cachedInstanceConfig = _helixResourceManager.getHelixInstanceConfig(instanceName);
+    InstanceConfig cachedInstanceConfig = _helixResourceManager.getHelixInstanceConfig(instanceName, false);
     String originalPort = cachedInstanceConfig.getPort();
     Assert.assertNotNull(originalPort);
     String newPort = Long.toString(System.currentTimeMillis());
@@ -146,11 +146,11 @@ public class PinotHelixResourceManagerTest extends ControllerTest {
     zkClient.writeData(instanceConfigPath, znRecord);
 
     long maxTime = System.currentTimeMillis() + MAX_TIMEOUT_IN_MILLISECOND;
-    InstanceConfig latestCachedInstanceConfig = _helixResourceManager.getHelixInstanceConfig(instanceName);
+    InstanceConfig latestCachedInstanceConfig = _helixResourceManager.getHelixInstanceConfig(instanceName, false);
     String latestPort = latestCachedInstanceConfig.getPort();
     while (!newPort.equals(latestPort) && System.currentTimeMillis() < maxTime) {
       Thread.sleep(100L);
-      latestCachedInstanceConfig = _helixResourceManager.getHelixInstanceConfig(instanceName);
+      latestCachedInstanceConfig = _helixResourceManager.getHelixInstanceConfig(instanceName, false);
       latestPort = latestCachedInstanceConfig.getPort();
     }
     Assert.assertTrue(System.currentTimeMillis() < maxTime, "Timeout when waiting for adding instance config");
@@ -166,29 +166,29 @@ public class PinotHelixResourceManagerTest extends ControllerTest {
     String instanceName = "Server_localhost_" + biggerRandomNumber;
     String instanceConfigPath = PropertyPathBuilder.instanceConfig(getHelixClusterName(), instanceName);
     Assert.assertFalse(zkClient.exists(instanceConfigPath));
-    List<String> instances = _helixResourceManager.getAllInstances();
+    List<String> instances = _helixResourceManager.getAllInstances(false);
     Assert.assertFalse(instances.contains(instanceName));
 
     // Add new ZNode.
     ZNRecord znRecord = new ZNRecord(instanceName);
     zkClient.createPersistent(instanceConfigPath, znRecord);
 
-    List<String> latestAllInstances = _helixResourceManager.getAllInstances();
+    List<String> latestAllInstances = _helixResourceManager.getAllInstances(false);
     long maxTime = System.currentTimeMillis() + MAX_TIMEOUT_IN_MILLISECOND;
     while (!latestAllInstances.contains(instanceName) && System.currentTimeMillis() < maxTime) {
       Thread.sleep(100L);
-      latestAllInstances = _helixResourceManager.getAllInstances();
+      latestAllInstances = _helixResourceManager.getAllInstances(false);
     }
     Assert.assertTrue(System.currentTimeMillis() < maxTime, "Timeout when waiting for adding instance config");
 
     // Remove new ZNode.
     zkClient.delete(instanceConfigPath);
 
-    latestAllInstances = _helixResourceManager.getAllInstances();
+    latestAllInstances = _helixResourceManager.getAllInstances(false);
     maxTime = System.currentTimeMillis() + MAX_TIMEOUT_IN_MILLISECOND;
     while (latestAllInstances.contains(instanceName) && System.currentTimeMillis() < maxTime) {
       Thread.sleep(100L);
-      latestAllInstances = _helixResourceManager.getAllInstances();
+      latestAllInstances = _helixResourceManager.getAllInstances(false);
     }
     Assert.assertTrue(System.currentTimeMillis() < maxTime, "Timeout when waiting for removing instance config");
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
@@ -171,7 +171,7 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
   @Test
   public void testPinotHelixResourceManagerAPIs() {
     // Instance APIs
-    Assert.assertEquals(_helixResourceManager.getAllInstances().size(), 7);
+    Assert.assertEquals(_helixResourceManager.getAllInstances(false).size(), 7);
     Assert.assertEquals(_helixResourceManager.getOnlineInstanceList().size(), 7);
     Assert.assertEquals(_helixResourceManager.getOnlineUnTaggedBrokerInstanceList().size(), 0);
     Assert.assertEquals(_helixResourceManager.getOnlineUnTaggedServerInstanceList().size(), 0);


### PR DESCRIPTION
This PR updates the method of getting instance configs, so that cache data accessor is used for segment operations, and direct data accessor is used for tenant/table operations.

Related issue: https://github.com/apache/incubator-pinot/issues/4665