### PR TITLE
Support serialized BYTES data with non-default factor

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -80,16 +80,19 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
 
   /**
    * Extracts the intermediate result from the aggregation result holder (aggregation only).
+   * TODO: Support serializing/deserializing null values in DataTable and use null as the empty intermediate result
    */
   IntermediateResult extractAggregationResult(AggregationResultHolder aggregationResultHolder);
 
   /**
    * Extracts the intermediate result from the group-by result holder for the given group key (aggregation group-by).
+   * TODO: Support serializing/deserializing null values in DataTable and use null as the empty intermediate result
    */
   IntermediateResult extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey);
 
   /**
    * Merges two intermediate results.
+   * TODO: Support serializing/deserializing null values in DataTable and use null as the empty intermediate result
    */
   IntermediateResult merge(IntermediateResult intermediateResult1, IntermediateResult intermediateResult2);
 
@@ -106,6 +109,7 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
 
   /**
    * Extracts the final result used in the broker response from the given intermediate result.
+   * TODO: Support serializing/deserializing null values in DataTable and use null as the empty intermediate result
    */
   FinalResult extractFinalResult(IntermediateResult intermediateResult);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -60,33 +60,24 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
-    switch (valueType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        double[] valueArray = blockValSets[0].getDoubleValuesSV();
-        double sum = 0.0;
-        for (int i = 0; i < length; i++) {
-          sum += valueArray[i];
-        }
-        setAggregationResult(aggregationResultHolder, sum, (long) length);
-        break;
-      case BYTES:
-        // Serialized AvgPair
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
-        sum = 0.0;
-        long count = 0L;
-        for (int i = 0; i < length; i++) {
-          AvgPair value = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
-          sum += value.getSum();
-          count += value.getCount();
-        }
-        setAggregationResult(aggregationResultHolder, sum, count);
-        break;
-      default:
-        throw new IllegalStateException("Illegal data type for AVG aggregation function: " + valueType);
+    if (blockValSets[0].getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      double sum = 0.0;
+      for (int i = 0; i < length; i++) {
+        sum += doubleValues[i];
+      }
+      setAggregationResult(aggregationResultHolder, sum, (long) length);
+    } else {
+      // Serialized AvgPair
+      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      double sum = 0.0;
+      long count = 0L;
+      for (int i = 0; i < length; i++) {
+        AvgPair value = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
+        sum += value.getSum();
+        count += value.getCount();
+      }
+      setAggregationResult(aggregationResultHolder, sum, count);
     }
   }
 
@@ -102,61 +93,43 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
-    switch (valueType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        double[] valueArray = blockValSets[0].getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          setGroupByResult(groupKeyArray[i], groupByResultHolder, valueArray[i], 1L);
-        }
-        break;
-      case BYTES:
-        // Serialized AvgPair
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          AvgPair value = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
-          setGroupByResult(groupKeyArray[i], groupByResultHolder, value.getSum(), value.getCount());
-        }
-        break;
-      default:
-        throw new IllegalStateException("Illegal data type for AVG aggregation function: " + valueType);
+    if (blockValSets[0].getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      for (int i = 0; i < length; i++) {
+        setGroupByResult(groupKeyArray[i], groupByResultHolder, doubleValues[i], 1L);
+      }
+    } else {
+      // Serialized AvgPair
+      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        AvgPair avgPair = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
+        setGroupByResult(groupKeyArray[i], groupByResultHolder, avgPair.getSum(), avgPair.getCount());
+      }
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
-    switch (valueType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        double[] valueArray = blockValSets[0].getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          double value = valueArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            setGroupByResult(groupKey, groupByResultHolder, value, 1L);
-          }
+    if (blockValSets[0].getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      for (int i = 0; i < length; i++) {
+        double value = doubleValues[i];
+        for (int groupKey : groupKeysArray[i]) {
+          setGroupByResult(groupKey, groupByResultHolder, value, 1L);
         }
-        break;
-      case BYTES:
-        // Serialized AvgPair
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          AvgPair value = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
-          double sum = value.getSum();
-          long count = value.getCount();
-          for (int groupKey : groupKeysArray[i]) {
-            setGroupByResult(groupKey, groupByResultHolder, sum, count);
-          }
+      }
+    } else {
+      // Serialized AvgPair
+      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        AvgPair avgPair = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
+        double sum = avgPair.getSum();
+        long count = avgPair.getCount();
+        for (int groupKey : groupKeysArray[i]) {
+          setGroupByResult(groupKey, groupByResultHolder, sum, count);
         }
-        break;
-      default:
-        throw new IllegalStateException("Illegal data type for AVG aggregation function: " + valueType);
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
-import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -45,46 +45,46 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+    HyperLogLog hyperLogLog = getDefaultHyperLogLog(aggregationResultHolder);
 
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    DataType valueType = blockValSets[0].getValueType();
     switch (valueType) {
       case INT:
-        int[][] intValues = blockValSets[0].getIntValuesMV();
+        int[][] intValuesArray = blockValSets[0].getIntValuesMV();
         for (int i = 0; i < length; i++) {
-          for (int value : intValues[i]) {
+          for (int value : intValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
         break;
       case LONG:
-        long[][] longValues = blockValSets[0].getLongValuesMV();
+        long[][] longValuesArray = blockValSets[0].getLongValuesMV();
         for (int i = 0; i < length; i++) {
-          for (long value : longValues[i]) {
+          for (long value : longValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
         break;
       case FLOAT:
-        float[][] floatValues = blockValSets[0].getFloatValuesMV();
+        float[][] floatValuesArray = blockValSets[0].getFloatValuesMV();
         for (int i = 0; i < length; i++) {
-          for (float value : floatValues[i]) {
+          for (float value : floatValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
         break;
       case DOUBLE:
-        double[][] doubleValues = blockValSets[0].getDoubleValuesMV();
+        double[][] doubleValuesArray = blockValSets[0].getDoubleValuesMV();
         for (int i = 0; i < length; i++) {
-          for (double value : doubleValues[i]) {
+          for (double value : doubleValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
         break;
       case STRING:
-        String[][] stringValues = blockValSets[0].getStringValuesMV();
+        String[][] stringValuesArray = blockValSets[0].getStringValuesMV();
         for (int i = 0; i < length; i++) {
-          for (String value : stringValues[i]) {
+          for (String value : stringValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
@@ -98,49 +98,49 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    DataType valueType = blockValSets[0].getValueType();
     switch (valueType) {
       case INT:
-        int[][] intValues = blockValSets[0].getIntValuesMV();
+        int[][] intValuesArray = blockValSets[0].getIntValuesMV();
         for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (int value : intValues[i]) {
+          HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+          for (int value : intValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
         break;
       case LONG:
-        long[][] longValues = blockValSets[0].getLongValuesMV();
+        long[][] longValuesArray = blockValSets[0].getLongValuesMV();
         for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (long value : longValues[i]) {
+          HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+          for (long value : longValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
         break;
       case FLOAT:
-        float[][] floatValues = blockValSets[0].getFloatValuesMV();
+        float[][] floatValuesArray = blockValSets[0].getFloatValuesMV();
         for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (float value : floatValues[i]) {
+          HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+          for (float value : floatValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
         break;
       case DOUBLE:
-        double[][] doubleValues = blockValSets[0].getDoubleValuesMV();
+        double[][] doubleValuesArray = blockValSets[0].getDoubleValuesMV();
         for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (double value : doubleValues[i]) {
+          HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+          for (double value : doubleValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
         break;
       case STRING:
-        String[][] stringValues = blockValSets[0].getStringValuesMV();
+        String[][] stringValuesArray = blockValSets[0].getStringValuesMV();
         for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (String value : stringValues[i]) {
+          HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+          for (String value : stringValuesArray[i]) {
             hyperLogLog.offer(value);
           }
         }
@@ -154,47 +154,50 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    DataType valueType = blockValSets[0].getValueType();
     switch (valueType) {
       case INT:
-        int[][] intValues = blockValSets[0].getIntValuesMV();
+        int[][] intValuesArray = blockValSets[0].getIntValuesMV();
         for (int i = 0; i < length; i++) {
+          int[] intValues = intValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
-            for (int value : intValues[i]) {
+            HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKey);
+            for (int value : intValues) {
               hyperLogLog.offer(value);
             }
           }
         }
         break;
       case LONG:
-        long[][] longValues = blockValSets[0].getLongValuesMV();
+        long[][] longValuesArray = blockValSets[0].getLongValuesMV();
         for (int i = 0; i < length; i++) {
+          long[] longValues = longValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
-            for (long value : longValues[i]) {
+            HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKey);
+            for (long value : longValues) {
               hyperLogLog.offer(value);
             }
           }
         }
         break;
       case FLOAT:
-        float[][] floatValues = blockValSets[0].getFloatValuesMV();
+        float[][] floatValuesArray = blockValSets[0].getFloatValuesMV();
         for (int i = 0; i < length; i++) {
+          float[] floatValues = floatValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
-            for (float value : floatValues[i]) {
+            HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKey);
+            for (float value : floatValues) {
               hyperLogLog.offer(value);
             }
           }
         }
         break;
       case DOUBLE:
-        double[][] doubleMVValues = blockValSets[0].getDoubleValuesMV();
+        double[][] doubleValuesArray = blockValSets[0].getDoubleValuesMV();
         for (int i = 0; i < length; i++) {
-          double[] doubleValues = doubleMVValues[i];
+          double[] doubleValues = doubleValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
+            HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKey);
             for (double value : doubleValues) {
               hyperLogLog.offer(value);
             }
@@ -202,11 +205,11 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case STRING:
-        String[][] stringMVValues = blockValSets[0].getStringValuesMV();
+        String[][] stringValuesArray = blockValSets[0].getStringValuesMV();
         for (int i = 0; i < length; i++) {
-          String[] stringValues = stringMVValues[i];
+          String[] stringValues = stringValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
+            HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKey);
             for (String value : stringValues) {
               hyperLogLog.offer(value);
             }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -59,45 +59,35 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
-    switch (valueType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        double[] valueArray = blockValSets[0].getDoubleValuesSV();
-        double min = Double.POSITIVE_INFINITY;
-        double max = Double.NEGATIVE_INFINITY;
-        for (int i = 0; i < length; i++) {
-          double value = valueArray[i];
-          if (value < min) {
-            min = value;
-          }
-          if (value > max) {
-            max = value;
-          }
+    double min = Double.POSITIVE_INFINITY;
+    double max = Double.NEGATIVE_INFINITY;
+    if (blockValSets[0].getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      for (int i = 0; i < length; i++) {
+        double value = doubleValues[i];
+        if (value < min) {
+          min = value;
         }
-        setAggregationResult(aggregationResultHolder, min, max);
-        break;
-      case BYTES:
-        // Serialized MinMaxRangePair
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
-        min = Double.POSITIVE_INFINITY;
-        max = Double.NEGATIVE_INFINITY;
-        for (int i = 0; i < length; i++) {
-          MinMaxRangePair value = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
-          if (value.getMin() < min) {
-            min = value.getMin();
-          }
-          if (value.getMax() > max) {
-            max = value.getMax();
-          }
+        if (value > max) {
+          max = value;
         }
-        setAggregationResult(aggregationResultHolder, min, max);
-        break;
-      default:
-        throw new IllegalStateException("Illegal data type for MIN_MAX_RANGE aggregation function: " + valueType);
+      }
+    } else {
+      // Serialized MinMaxRangePair
+      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        MinMaxRangePair minMaxRangePair = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
+        double minValue = minMaxRangePair.getMin();
+        double maxValue = minMaxRangePair.getMax();
+        if (minValue < min) {
+          min = minValue;
+        }
+        if (maxValue > max) {
+          max = maxValue;
+        }
+      }
     }
+    setAggregationResult(aggregationResultHolder, min, max);
   }
 
   protected void setAggregationResult(AggregationResultHolder aggregationResultHolder, double min, double max) {
@@ -112,60 +102,44 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
-    switch (valueType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        double[] valueArray = blockValSets[0].getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          double value = valueArray[i];
-          setGroupByResult(groupKeyArray[i], groupByResultHolder, value, value);
-        }
-        break;
-      case BYTES:
-        // Serialized MinMaxRangePair
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          MinMaxRangePair value = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
-          setGroupByResult(groupKeyArray[i], groupByResultHolder, value.getMin(), value.getMax());
-        }
-        break;
-      default:
-        throw new IllegalStateException("Illegal data type for MIN_MAX_RANGE aggregation function: " + valueType);
+    if (blockValSets[0].getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      for (int i = 0; i < length; i++) {
+        double value = doubleValues[i];
+        setGroupByResult(groupKeyArray[i], groupByResultHolder, value, value);
+      }
+    } else {
+      // Serialized MinMaxRangePair
+      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        MinMaxRangePair minMaxRangePair = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
+        setGroupByResult(groupKeyArray[i], groupByResultHolder, minMaxRangePair.getMin(), minMaxRangePair.getMax());
+      }
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
-    switch (valueType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        double[] valueArray = blockValSets[0].getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          double value = valueArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            setGroupByResult(groupKey, groupByResultHolder, value, value);
-          }
+    if (blockValSets[0].getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      for (int i = 0; i < length; i++) {
+        double value = doubleValues[i];
+        for (int groupKey : groupKeysArray[i]) {
+          setGroupByResult(groupKey, groupByResultHolder, value, value);
         }
-        break;
-      case BYTES:
-        // Serialized MinMaxRangePair
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          MinMaxRangePair value = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
-          for (int groupKey : groupKeysArray[i]) {
-            setGroupByResult(groupKey, groupByResultHolder, value.getMin(), value.getMax());
-          }
+      }
+    } else {
+      // Serialized MinMaxRangePair
+      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        MinMaxRangePair minMaxRangePair = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
+        double min = minMaxRangePair.getMin();
+        double max = minMaxRangePair.getMax();
+        for (int groupKey : groupKeysArray[i]) {
+          setGroupByResult(groupKey, groupByResultHolder, min, max);
         }
-        break;
-      default:
-        throw new IllegalStateException("Illegal data type for MIN_MAX_RANGE aggregation function: " + valueType);
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -48,11 +48,11 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
-    QuantileDigest quantileDigest = getQuantileDigest(aggregationResultHolder);
+    long[][] valuesArray = blockValSets[0].getLongValuesMV();
+    QuantileDigest quantileDigest = getDefaultQuantileDigest(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
-      for (double value : valuesArray[i]) {
-        quantileDigest.add((long) value);
+      for (long value : valuesArray[i]) {
+        quantileDigest.add(value);
       }
     }
   }
@@ -60,11 +60,11 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+    long[][] valuesArray = blockValSets[0].getLongValuesMV();
     for (int i = 0; i < length; i++) {
-      QuantileDigest quantileDigest = getQuantileDigest(groupByResultHolder, groupKeyArray[i]);
-      for (double value : valuesArray[i]) {
-        quantileDigest.add((long) value);
+      QuantileDigest quantileDigest = getDefaultQuantileDigest(groupByResultHolder, groupKeyArray[i]);
+      for (long value : valuesArray[i]) {
+        quantileDigest.add(value);
       }
     }
   }
@@ -72,13 +72,13 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+    long[][] valuesArray = blockValSets[0].getLongValuesMV();
     for (int i = 0; i < length; i++) {
-      double[] values = valuesArray[i];
+      long[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {
-        QuantileDigest quantileDigest = getQuantileDigest(groupByResultHolder, groupKey);
-        for (double value : values) {
-          quantileDigest.add((long) value);
+        QuantileDigest quantileDigest = getDefaultQuantileDigest(groupByResultHolder, groupKey);
+        for (long value : values) {
+          quantileDigest.add(value);
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -19,8 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import com.tdunning.math.stats.TDigest;
-import java.nio.ByteBuffer;
-import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.FieldSpec.DataType;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -70,89 +69,80 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    TDigest tDigest = getTDigest(aggregationResultHolder);
-
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
-    switch (valueType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        double[] valueArray = blockValSets[0].getDoubleValuesSV();
+    if (blockValSets[0].getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      TDigest tDigest = getDefaultTDigest(aggregationResultHolder);
+      for (int i = 0; i < length; i++) {
+        tDigest.add(doubleValues[i]);
+      }
+    } else {
+      // Serialized TDigest
+      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      TDigest tDigest = aggregationResultHolder.getResult();
+      if (tDigest != null) {
         for (int i = 0; i < length; i++) {
-          tDigest.add(valueArray[i]);
+          tDigest.add(ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(bytesValues[i]));
         }
-        break;
-      case BYTES:
-        // Serialized TDigest
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          tDigest.add(ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ByteBuffer.wrap(bytesValues[i])));
+      } else {
+        tDigest = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(bytesValues[0]);
+        aggregationResultHolder.setValue(tDigest);
+        for (int i = 1; i < length; i++) {
+          tDigest.add(ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(bytesValues[i]));
         }
-        break;
-      default:
-        throw new IllegalStateException("Illegal data type for PERCENTILE_TDIGEST aggregation function: " + valueType);
+      }
     }
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
-    switch (valueType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        double[] valueArray = blockValSets[0].getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          TDigest tDigest = getTDigest(groupByResultHolder, groupKeyArray[i]);
-          tDigest.add(valueArray[i]);
+    if (blockValSets[0].getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      for (int i = 0; i < length; i++) {
+        getDefaultTDigest(groupByResultHolder, groupKeyArray[i]).add(doubleValues[i]);
+      }
+    } else {
+      // Serialized TDigest
+      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        TDigest value = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(bytesValues[i]);
+        int groupKey = groupKeyArray[i];
+        TDigest tDigest = groupByResultHolder.getResult(groupKey);
+        if (tDigest != null) {
+          tDigest.add(value);
+        } else {
+          groupByResultHolder.setValueForKey(groupKey, value);
         }
-        break;
-      case BYTES:
-        // Serialized TDigest
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          TDigest tDigest = getTDigest(groupByResultHolder, groupKeyArray[i]);
-          tDigest.add(ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ByteBuffer.wrap(bytesValues[i])));
-        }
-        break;
-      default:
-        throw new IllegalStateException("Illegal data type for PERCENTILE_TDIGEST aggregation function: " + valueType);
+      }
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
-    switch (valueType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        double[] valueArray = blockValSets[0].getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          double value = valueArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            TDigest tDigest = getTDigest(groupByResultHolder, groupKey);
+    if (blockValSets[0].getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      for (int i = 0; i < length; i++) {
+        double value = doubleValues[i];
+        for (int groupKey : groupKeysArray[i]) {
+          getDefaultTDigest(groupByResultHolder, groupKey).add(value);
+        }
+      }
+    } else {
+      // Serialized QuantileDigest
+      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        TDigest value = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(bytesValues[i]);
+        for (int groupKey : groupKeysArray[i]) {
+          TDigest tDigest = groupByResultHolder.getResult(groupKey);
+          if (tDigest != null) {
             tDigest.add(value);
+          } else {
+            // Create a new TDigest for the group
+            groupByResultHolder.setValueForKey(groupKey, ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(bytesValues[i]));
           }
         }
-      case BYTES:
-        // Serialized QuantileDigest
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          TDigest value = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ByteBuffer.wrap(bytesValues[i]));
-          for (int groupKey : groupKeysArray[i]) {
-            TDigest tDigest = getTDigest(groupByResultHolder, groupKey);
-            tDigest.add(value);
-          }
-        }
-        break;
-      default:
-        throw new IllegalStateException("Illegal data type for PERCENTILE_TDIGEST aggregation function: " + valueType);
+      }
     }
   }
 
@@ -178,6 +168,12 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
 
   @Override
   public TDigest merge(TDigest intermediateResult1, TDigest intermediateResult2) {
+    if (intermediateResult1.size() == 0L) {
+      return intermediateResult2;
+    }
+    if (intermediateResult2.size() == 0L) {
+      return intermediateResult1;
+    }
     intermediateResult1.add(intermediateResult2);
     return intermediateResult1;
   }
@@ -194,29 +190,16 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
 
   @Override
   public Double extractFinalResult(TDigest intermediateResult) {
-    return calculatePercentile(intermediateResult, _percentile);
+    return intermediateResult.quantile(_percentile / 100.0);
   }
 
   /**
-   * Calculates percentile from {@link TDigest}.
-   * <p>Handles cases where only one value in TDigest object.
-   */
-  public static double calculatePercentile(TDigest tDigest, int percentile) {
-    if (tDigest.size() == 1) {
-      // Specialize cases where only one value in TDigest (cannot use quantile method)
-      return tDigest.centroids().iterator().next().mean();
-    } else {
-      return tDigest.quantile(percentile / 100.0);
-    }
-  }
-
-  /**
-   * Returns the TDigest from the result holder or creates a new one if it does not exist.
+   * Returns the TDigest from the result holder or creates a new one with default compression if it does not exist.
    *
    * @param aggregationResultHolder Result holder
    * @return TDigest from the result holder
    */
-  protected static TDigest getTDigest(AggregationResultHolder aggregationResultHolder) {
+  protected static TDigest getDefaultTDigest(AggregationResultHolder aggregationResultHolder) {
     TDigest tDigest = aggregationResultHolder.getResult();
     if (tDigest == null) {
       tDigest = TDigest.createMergingDigest(DEFAULT_TDIGEST_COMPRESSION);
@@ -226,13 +209,13 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
   }
 
   /**
-   * Returns the TDigest for the given group key. If one does not exist, creates a new one and returns that.
+   * Returns the TDigest for the given group key if exists, or creates a new one with default compression.
    *
    * @param groupByResultHolder Result holder
    * @param groupKey Group key for which to return the TDigest
    * @return TDigest for the group key
    */
-  protected static TDigest getTDigest(GroupByResultHolder groupByResultHolder, int groupKey) {
+  protected static TDigest getDefaultTDigest(GroupByResultHolder groupByResultHolder, int groupKey) {
     TDigest tDigest = groupByResultHolder.getResult(groupKey);
     if (tDigest == null) {
       tDigest = TDigest.createMergingDigest(DEFAULT_TDIGEST_COMPRESSION);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -49,7 +49,7 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
     double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
-    TDigest tDigest = getTDigest(aggregationResultHolder);
+    TDigest tDigest = getDefaultTDigest(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
         tDigest.add(value);
@@ -62,7 +62,7 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
       BlockValSet... blockValSets) {
     double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
-      TDigest tDigest = getTDigest(groupByResultHolder, groupKeyArray[i]);
+      TDigest tDigest = getDefaultTDigest(groupByResultHolder, groupKeyArray[i]);
       for (double value : valuesArray[i]) {
         tDigest.add(value);
       }
@@ -76,7 +76,7 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {
-        TDigest tDigest = getTDigest(groupByResultHolder, groupKey);
+        TDigest tDigest = getDefaultTDigest(groupByResultHolder, groupKey);
         for (double value : values) {
           tDigest.add(value);
         }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
@@ -249,9 +249,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
       } else {
         expected = doubleList.getDouble(doubleList.size() * percentile / 100);
       }
-      Assert
-          .assertEquals(PercentileTDigestAggregationFunction.calculatePercentile(tDigest, percentile), expected, DELTA,
-              ERROR_MESSAGE);
+      Assert.assertEquals(tDigest.quantile(percentile / 100.0), expected, DELTA, ERROR_MESSAGE);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
@@ -1,0 +1,794 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.tdunning.math.stats.MergingDigest;
+import com.tdunning.math.stats.TDigest;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.data.FieldSpec.DataType;
+import org.apache.pinot.common.data.Schema;
+import org.apache.pinot.common.response.broker.AggregationResult;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.GroupByResult;
+import org.apache.pinot.common.segment.ReadMode;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.data.GenericRow;
+import org.apache.pinot.core.data.manager.SegmentDataManager;
+import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.data.readers.RecordReader;
+import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
+import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
+import org.apache.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
+import org.apache.pinot.core.query.aggregation.function.customobject.QuantileDigest;
+import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
+import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+/**
+ * Tests for serialized bytes values.
+ *
+ * <p>Aggregation function that supports serialized bytes values:
+ * <ul>
+ *   <li>AVG</li>
+ *   <li>DISTINCTCOUNTHLL</li>
+ *   <li>MINMAXRANGE</li>
+ *   <li>PERCENTILEEST</li>
+ *   <li>PERCENTILETDIGEST</li>
+ * </ul>
+ */
+public class SerializedBytesQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "SerializedBytesQueriesTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  private static final int NUM_ROWS = 1000;
+  private static final int MAX_NUM_VALUES_TO_PRE_AGGREGATE = 10;
+  private static final String AVG_COLUMN = "avgColumn";
+  private static final String DISTINCT_COUNT_HLL_COLUMN = "distinctCountHLLColumn";
+  // Use non-default log2m
+  private static final int DISTINCT_COUNT_HLL_LOG2M = 9;
+  private static final String MIN_MAX_RANGE_COLUMN = "minMaxRangeColumn";
+  private static final String PERCENTILE_EST_COLUMN = "percentileEstColumn";
+  // Use non-default max error
+  private static final double PERCENTILE_EST_MAX_ERROR = 0.025;
+  private static final String PERCENTILE_TDIGEST_COLUMN = "percentileTDigestColumn";
+  // Use non-default compression
+  private static final double PERCENTILE_TDIGEST_COMPRESSION = 200;
+  // Allow 5% quantile error due to the randomness of TDigest merge
+  private static final double PERCENTILE_TDIGEST_DELTA = 0.05 * Integer.MAX_VALUE;
+  private static final String GROUP_BY_SV_COLUMN = "groupBySVColumn";
+  private static final String GROUP_BY_MV_COLUMN = "groupByMVColumn";
+  private static final String[] GROUPS = new String[]{"G0", "G1", "G2"};
+  private static final int NUM_GROUPS = GROUPS.length;
+  private static final long RANDOM_SEED = System.nanoTime();
+  private static final Random RANDOM = new Random(RANDOM_SEED);
+
+  private final int[][] _valuesArray = new int[NUM_ROWS][MAX_NUM_VALUES_TO_PRE_AGGREGATE];
+  private final AvgPair[] _avgPairs = new AvgPair[NUM_ROWS];
+  private final HyperLogLog[] _hyperLogLogs = new HyperLogLog[NUM_ROWS];
+  private final MinMaxRangePair[] _minMaxRangePairs = new MinMaxRangePair[NUM_ROWS];
+  private final QuantileDigest[] _quantileDigests = new QuantileDigest[NUM_ROWS];
+  private final TDigest[] _tDigests = new TDigest[NUM_ROWS];
+
+  private ImmutableSegment _indexSegment;
+  private List<SegmentDataManager> _segmentDataManagers;
+
+  @Override
+  protected String getFilter() {
+    return ""; // No filtering required for this test.
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<SegmentDataManager> getSegmentDataManagers() {
+    return _segmentDataManagers;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+
+    buildSegment();
+    _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _segmentDataManagers =
+        Arrays.asList(new ImmutableSegmentDataManager(_indexSegment), new ImmutableSegmentDataManager(_indexSegment));
+  }
+
+  private void buildSegment()
+      throws Exception {
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      int numValues = RANDOM.nextInt(MAX_NUM_VALUES_TO_PRE_AGGREGATE) + 1;
+      int[] values = new int[numValues];
+      for (int j = 0; j < numValues; j++) {
+        values[j] = RANDOM.nextInt();
+      }
+      _valuesArray[i] = values;
+      int groupId = i % NUM_GROUPS;
+
+      HashMap<String, Object> valueMap = new HashMap<>();
+      valueMap.put(GROUP_BY_SV_COLUMN, GROUPS[groupId]);
+      valueMap.put(GROUP_BY_MV_COLUMN, GROUPS);
+
+      double sum = 0.0;
+      for (int value : values) {
+        sum += value;
+      }
+      AvgPair avgPair = new AvgPair(sum, numValues);
+      _avgPairs[i] = avgPair;
+      valueMap.put(AVG_COLUMN, ObjectSerDeUtils.AVG_PAIR_SER_DE.serialize(avgPair));
+
+      HyperLogLog hyperLogLog = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+      for (int value : values) {
+        hyperLogLog.offer(value);
+      }
+      _hyperLogLogs[i] = hyperLogLog;
+      valueMap.put(DISTINCT_COUNT_HLL_COLUMN, ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hyperLogLog));
+
+      double min = Double.POSITIVE_INFINITY;
+      double max = Double.NEGATIVE_INFINITY;
+      for (int value : values) {
+        if (value < min) {
+          min = value;
+        }
+        if (value > max) {
+          max = value;
+        }
+      }
+      MinMaxRangePair minMaxRangePair = new MinMaxRangePair(min, max);
+      _minMaxRangePairs[i] = minMaxRangePair;
+      valueMap.put(MIN_MAX_RANGE_COLUMN, ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.serialize(minMaxRangePair));
+
+      QuantileDigest quantileDigest = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+      for (int value : values) {
+        quantileDigest.add(value);
+      }
+      _quantileDigests[i] = quantileDigest;
+      valueMap.put(PERCENTILE_EST_COLUMN, ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.serialize(quantileDigest));
+
+      TDigest tDigest = MergingDigest.createDigest(PERCENTILE_TDIGEST_COMPRESSION);
+      for (int value : values) {
+        tDigest.add(value);
+      }
+      _tDigests[i] = tDigest;
+      valueMap.put(PERCENTILE_TDIGEST_COLUMN, ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest));
+
+      GenericRow genericRow = new GenericRow();
+      genericRow.init(valueMap);
+      rows.add(genericRow);
+    }
+
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+        .addSingleValueDimension(GROUP_BY_SV_COLUMN, DataType.STRING)
+        .addMultiValueDimension(GROUP_BY_MV_COLUMN, DataType.STRING).addMetric(AVG_COLUMN, DataType.BYTES)
+        .addMetric(DISTINCT_COUNT_HLL_COLUMN, DataType.BYTES).addMetric(MIN_MAX_RANGE_COLUMN, DataType.BYTES)
+        .addMetric(PERCENTILE_EST_COLUMN, DataType.BYTES).addMetric(PERCENTILE_TDIGEST_COLUMN, DataType.BYTES).build();
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(RAW_TABLE_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    try (RecordReader recordReader = new GenericRowRecordReader(rows, schema)) {
+      driver.init(config, recordReader);
+      driver.build();
+    }
+  }
+
+  @Test
+  public void testInnerSegmentAggregation()
+      throws Exception {
+    AggregationOperator aggregationOperator = getOperatorForQuery(getAggregationQuery());
+    IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
+    List<Object> aggregationResult = resultsBlock.getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(aggregationResult.size(), 5);
+
+    // Avg
+    AvgPair avgPair = (AvgPair) aggregationResult.get(0);
+    AvgPair expectedAvgPair = new AvgPair(_avgPairs[0].getSum(), _avgPairs[0].getCount());
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedAvgPair.apply(_avgPairs[i]);
+    }
+    assertEquals(avgPair.getSum(), expectedAvgPair.getSum());
+    assertEquals(avgPair.getCount(), expectedAvgPair.getCount());
+
+    // DistinctCountHLL
+    HyperLogLog hyperLogLog = (HyperLogLog) aggregationResult.get(1);
+    HyperLogLog expectedHyperLogLog = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+    for (int value : _valuesArray[0]) {
+      expectedHyperLogLog.offer(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedHyperLogLog.addAll(_hyperLogLogs[i]);
+    }
+    assertEquals(hyperLogLog.cardinality(), expectedHyperLogLog.cardinality());
+
+    // MinMaxRange
+    MinMaxRangePair minMaxRangePair = (MinMaxRangePair) aggregationResult.get(2);
+    MinMaxRangePair expectedMinMaxRangePair =
+        new MinMaxRangePair(_minMaxRangePairs[0].getMin(), _minMaxRangePairs[0].getMax());
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedMinMaxRangePair.apply(_minMaxRangePairs[i]);
+    }
+    assertEquals(minMaxRangePair.getMin(), expectedMinMaxRangePair.getMin());
+    assertEquals(minMaxRangePair.getMax(), expectedMinMaxRangePair.getMax());
+
+    // PercentileEst
+    QuantileDigest quantileDigest = (QuantileDigest) aggregationResult.get(3);
+    QuantileDigest expectedQuantileDigest = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+    for (int value : _valuesArray[0]) {
+      expectedQuantileDigest.add(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedQuantileDigest.merge(_quantileDigests[i]);
+    }
+    assertEquals(quantileDigest.getQuantile(0.5), expectedQuantileDigest.getQuantile(0.5));
+
+    // PercentileTDigest
+    TDigest tDigest = (TDigest) aggregationResult.get(4);
+    TDigest expectedTDigest = TDigest.createMergingDigest(PERCENTILE_TDIGEST_COMPRESSION);
+    for (int value : _valuesArray[0]) {
+      expectedTDigest.add(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedTDigest.add(_tDigests[i]);
+    }
+    assertEquals(tDigest.quantile(0.5), expectedTDigest.quantile(0.5), PERCENTILE_TDIGEST_DELTA);
+  }
+
+  @Test
+  public void testInterSegmentAggregation()
+      throws Exception {
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getAggregationQuery());
+    List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+    assertNotNull(aggregationResults);
+    assertEquals(aggregationResults.size(), 5);
+
+    // Simulate the process of server side merge and broker side merge
+
+    // Avg
+    AvgPair avgPair1 = new AvgPair(_avgPairs[0].getSum(), _avgPairs[0].getCount());
+    AvgPair avgPair2 = new AvgPair(_avgPairs[0].getSum(), _avgPairs[0].getCount());
+    for (int i = 1; i < NUM_ROWS; i++) {
+      avgPair1.apply(_avgPairs[i]);
+      avgPair2.apply(_avgPairs[i]);
+    }
+    avgPair1.apply(avgPair2);
+    avgPair1 = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(ObjectSerDeUtils.AVG_PAIR_SER_DE.serialize(avgPair1));
+    avgPair2 = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(ObjectSerDeUtils.AVG_PAIR_SER_DE.serialize(avgPair1));
+    avgPair1.apply(avgPair2);
+    assertEquals(Double.parseDouble((String) aggregationResults.get(0).getValue()),
+        avgPair1.getSum() / avgPair1.getCount(), 1e-5);
+
+    // DistinctCountHLL
+    HyperLogLog hyperLogLog1 = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+    HyperLogLog hyperLogLog2 = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+    for (int value : _valuesArray[0]) {
+      hyperLogLog1.offer(value);
+      hyperLogLog2.offer(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      hyperLogLog1.addAll(_hyperLogLogs[i]);
+      hyperLogLog2.addAll(_hyperLogLogs[i]);
+    }
+    hyperLogLog1.addAll(hyperLogLog2);
+    hyperLogLog1 = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE
+        .deserialize(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hyperLogLog1));
+    hyperLogLog2 = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE
+        .deserialize(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hyperLogLog1));
+    hyperLogLog1.addAll(hyperLogLog2);
+    assertEquals(Long.parseLong((String) aggregationResults.get(1).getValue()), hyperLogLog1.cardinality());
+
+    // MinMaxRange
+    MinMaxRangePair minMaxRangePair1 =
+        new MinMaxRangePair(_minMaxRangePairs[0].getMin(), _minMaxRangePairs[0].getMax());
+    MinMaxRangePair minMaxRangePair2 =
+        new MinMaxRangePair(_minMaxRangePairs[0].getMin(), _minMaxRangePairs[0].getMax());
+    for (int i = 1; i < NUM_ROWS; i++) {
+      minMaxRangePair1.apply(_minMaxRangePairs[i]);
+      minMaxRangePair2.apply(_minMaxRangePairs[i]);
+    }
+    minMaxRangePair1.apply(minMaxRangePair2);
+    minMaxRangePair1 = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE
+        .deserialize(ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.serialize(minMaxRangePair1));
+    minMaxRangePair2 = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE
+        .deserialize(ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.serialize(minMaxRangePair1));
+    minMaxRangePair1.apply(minMaxRangePair2);
+    assertEquals(Double.parseDouble((String) aggregationResults.get(2).getValue()),
+        minMaxRangePair1.getMax() - minMaxRangePair1.getMin(), 1e-5);
+
+    // PercentileEst
+    QuantileDigest quantileDigest1 = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+    QuantileDigest quantileDigest2 = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+    for (int value : _valuesArray[0]) {
+      quantileDigest1.add(value);
+      quantileDigest2.add(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      quantileDigest1.merge(_quantileDigests[i]);
+      quantileDigest2.merge(_quantileDigests[i]);
+    }
+    quantileDigest1.merge(quantileDigest2);
+    quantileDigest1 = ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE
+        .deserialize(ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.serialize(quantileDigest1));
+    quantileDigest2 = ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE
+        .deserialize(ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.serialize(quantileDigest1));
+    quantileDigest1.merge(quantileDigest2);
+    assertEquals(Long.parseLong((String) aggregationResults.get(3).getValue()), quantileDigest1.getQuantile(0.5));
+
+    // PercentileTDigest
+    TDigest tDigest1 = TDigest.createMergingDigest(PERCENTILE_TDIGEST_COMPRESSION);
+    TDigest tDigest2 = TDigest.createMergingDigest(PERCENTILE_TDIGEST_COMPRESSION);
+    for (int value : _valuesArray[0]) {
+      tDigest1.add(value);
+      tDigest2.add(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      tDigest1.add(_tDigests[i]);
+      tDigest2.add(_tDigests[i]);
+    }
+    tDigest1.add(tDigest2);
+    tDigest1 = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest1));
+    tDigest2 = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest1));
+    tDigest1.add(tDigest2);
+    assertEquals(Double.parseDouble((String) aggregationResults.get(4).getValue()), tDigest1.quantile(0.5),
+        PERCENTILE_TDIGEST_DELTA);
+  }
+
+  @Test
+  public void testInnerSegmentSVGroupBy()
+      throws Exception {
+    AggregationGroupByOperator groupByOperator = getOperatorForQuery(getSVGroupByQuery());
+    IntermediateResultsBlock resultsBlock = groupByOperator.nextBlock();
+    AggregationGroupByResult groupByResult = resultsBlock.getAggregationGroupByResult();
+    assertNotNull(groupByResult);
+
+    Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
+    while (groupKeyIterator.hasNext()) {
+      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+      int groupId = Integer.parseInt(groupKey._stringKey.substring(1));
+
+      // Avg
+      AvgPair avgPair = (AvgPair) groupByResult.getResultForKey(groupKey, 0);
+      AvgPair expectedAvgPair = new AvgPair(_avgPairs[groupId].getSum(), _avgPairs[groupId].getCount());
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        expectedAvgPair.apply(_avgPairs[i]);
+      }
+      assertEquals(avgPair.getSum(), expectedAvgPair.getSum());
+      assertEquals(avgPair.getCount(), expectedAvgPair.getCount());
+
+      // DistinctCountHLL
+      HyperLogLog hyperLogLog = (HyperLogLog) groupByResult.getResultForKey(groupKey, 1);
+      HyperLogLog expectedHyperLogLog = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+      for (int value : _valuesArray[groupId]) {
+        expectedHyperLogLog.offer(value);
+      }
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        expectedHyperLogLog.addAll(_hyperLogLogs[i]);
+      }
+      assertEquals(hyperLogLog.cardinality(), expectedHyperLogLog.cardinality());
+
+      // MinMaxRange
+      MinMaxRangePair minMaxRangePair = (MinMaxRangePair) groupByResult.getResultForKey(groupKey, 2);
+      MinMaxRangePair expectedMinMaxRangePair =
+          new MinMaxRangePair(_minMaxRangePairs[groupId].getMin(), _minMaxRangePairs[groupId].getMax());
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        expectedMinMaxRangePair.apply(_minMaxRangePairs[i]);
+      }
+      assertEquals(minMaxRangePair.getMin(), expectedMinMaxRangePair.getMin());
+      assertEquals(minMaxRangePair.getMax(), expectedMinMaxRangePair.getMax());
+
+      // PercentileEst
+      QuantileDigest quantileDigest = (QuantileDigest) groupByResult.getResultForKey(groupKey, 3);
+      QuantileDigest expectedQuantileDigest = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+      for (int value : _valuesArray[groupId]) {
+        expectedQuantileDigest.add(value);
+      }
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        expectedQuantileDigest.merge(_quantileDigests[i]);
+      }
+      assertEquals(quantileDigest.getQuantile(0.5), expectedQuantileDigest.getQuantile(0.5));
+
+      // PercentileTDigest
+      TDigest tDigest = (TDigest) groupByResult.getResultForKey(groupKey, 4);
+      TDigest expectedTDigest = TDigest.createMergingDigest(PERCENTILE_TDIGEST_COMPRESSION);
+      for (int value : _valuesArray[groupId]) {
+        expectedTDigest.add(value);
+      }
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        expectedTDigest.add(_tDigests[i]);
+      }
+      assertEquals(tDigest.quantile(0.5), expectedTDigest.quantile(0.5), PERCENTILE_TDIGEST_DELTA);
+    }
+  }
+
+  @Test
+  public void testInterSegmentSVGroupBy()
+      throws Exception {
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getSVGroupByQuery());
+    List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+    assertNotNull(aggregationResults);
+    assertEquals(aggregationResults.size(), 5);
+
+    // Simulate the process of server side merge and broker side merge
+
+    // Avg
+    List<GroupByResult> groupByResults = aggregationResults.get(0).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      int groupId = Integer.parseInt(groupByResult.getGroup().get(0).substring(1));
+
+      AvgPair avgPair1 = new AvgPair(_avgPairs[groupId].getSum(), _avgPairs[groupId].getCount());
+      AvgPair avgPair2 = new AvgPair(_avgPairs[groupId].getSum(), _avgPairs[groupId].getCount());
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        avgPair1.apply(_avgPairs[i]);
+        avgPair2.apply(_avgPairs[i]);
+      }
+      avgPair1.apply(avgPair2);
+      avgPair1 = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(ObjectSerDeUtils.AVG_PAIR_SER_DE.serialize(avgPair1));
+      avgPair2 = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(ObjectSerDeUtils.AVG_PAIR_SER_DE.serialize(avgPair1));
+      avgPair1.apply(avgPair2);
+      assertEquals(Double.parseDouble((String) groupByResult.getValue()), avgPair1.getSum() / avgPair1.getCount(),
+          1e-5);
+    }
+
+    // DistinctCountHLL
+    groupByResults = aggregationResults.get(1).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      int groupId = Integer.parseInt(groupByResult.getGroup().get(0).substring(1));
+
+      HyperLogLog hyperLogLog1 = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+      HyperLogLog hyperLogLog2 = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+      for (int value : _valuesArray[groupId]) {
+        hyperLogLog1.offer(value);
+        hyperLogLog2.offer(value);
+      }
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        hyperLogLog1.addAll(_hyperLogLogs[i]);
+        hyperLogLog2.addAll(_hyperLogLogs[i]);
+      }
+      hyperLogLog1.addAll(hyperLogLog2);
+      hyperLogLog1 = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE
+          .deserialize(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hyperLogLog1));
+      hyperLogLog2 = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE
+          .deserialize(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hyperLogLog1));
+      hyperLogLog1.addAll(hyperLogLog2);
+      assertEquals(Long.parseLong((String) groupByResult.getValue()), hyperLogLog1.cardinality());
+    }
+
+    // MinMaxRange
+    groupByResults = aggregationResults.get(2).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      int groupId = Integer.parseInt(groupByResult.getGroup().get(0).substring(1));
+
+      MinMaxRangePair minMaxRangePair1 =
+          new MinMaxRangePair(_minMaxRangePairs[groupId].getMin(), _minMaxRangePairs[groupId].getMax());
+      MinMaxRangePair minMaxRangePair2 =
+          new MinMaxRangePair(_minMaxRangePairs[groupId].getMin(), _minMaxRangePairs[groupId].getMax());
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        minMaxRangePair1.apply(_minMaxRangePairs[i]);
+        minMaxRangePair2.apply(_minMaxRangePairs[i]);
+      }
+      minMaxRangePair1.apply(minMaxRangePair2);
+      minMaxRangePair1 = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE
+          .deserialize(ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.serialize(minMaxRangePair1));
+      minMaxRangePair2 = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE
+          .deserialize(ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.serialize(minMaxRangePair1));
+      minMaxRangePair1.apply(minMaxRangePair2);
+      assertEquals(Double.parseDouble((String) groupByResult.getValue()),
+          minMaxRangePair1.getMax() - minMaxRangePair1.getMin(), 1e-5);
+    }
+
+    // PercentileEst
+    groupByResults = aggregationResults.get(3).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      int groupId = Integer.parseInt(groupByResult.getGroup().get(0).substring(1));
+
+      QuantileDigest quantileDigest1 = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+      QuantileDigest quantileDigest2 = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+      for (int value : _valuesArray[groupId]) {
+        quantileDigest1.add(value);
+        quantileDigest2.add(value);
+      }
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        quantileDigest1.merge(_quantileDigests[i]);
+        quantileDigest2.merge(_quantileDigests[i]);
+      }
+      quantileDigest1.merge(quantileDigest2);
+      quantileDigest1 = ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE
+          .deserialize(ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.serialize(quantileDigest1));
+      quantileDigest2 = ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE
+          .deserialize(ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.serialize(quantileDigest1));
+      quantileDigest1.merge(quantileDigest2);
+      assertEquals(Long.parseLong((String) groupByResult.getValue()), quantileDigest1.getQuantile(0.5));
+    }
+
+    // PercentileTDigest
+    groupByResults = aggregationResults.get(4).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      int groupId = Integer.parseInt(groupByResult.getGroup().get(0).substring(1));
+
+      TDigest tDigest1 = TDigest.createMergingDigest(PERCENTILE_TDIGEST_COMPRESSION);
+      TDigest tDigest2 = TDigest.createMergingDigest(PERCENTILE_TDIGEST_COMPRESSION);
+      for (int value : _valuesArray[groupId]) {
+        tDigest1.add(value);
+        tDigest2.add(value);
+      }
+      for (int i = groupId + NUM_GROUPS; i < NUM_ROWS; i += NUM_GROUPS) {
+        tDigest1.add(_tDigests[i]);
+        tDigest2.add(_tDigests[i]);
+      }
+      tDigest1.add(tDigest2);
+      tDigest1 = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest1));
+      tDigest2 = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest1));
+      tDigest1.add(tDigest2);
+      assertEquals(Double.parseDouble((String) groupByResult.getValue()), tDigest1.quantile(0.5),
+          PERCENTILE_TDIGEST_DELTA);
+    }
+  }
+
+  @Test
+  public void testInnerSegmentMVGroupBy()
+      throws Exception {
+    AggregationGroupByOperator groupByOperator = getOperatorForQuery(getMVGroupByQuery());
+    IntermediateResultsBlock resultsBlock = groupByOperator.nextBlock();
+    AggregationGroupByResult groupByResult = resultsBlock.getAggregationGroupByResult();
+    assertNotNull(groupByResult);
+
+    // Avg
+    AvgPair expectedAvgPair = new AvgPair(_avgPairs[0].getSum(), _avgPairs[0].getCount());
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedAvgPair.apply(_avgPairs[i]);
+    }
+
+    // DistinctCountHLL
+    HyperLogLog expectedHyperLogLog = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+    for (int value : _valuesArray[0]) {
+      expectedHyperLogLog.offer(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedHyperLogLog.addAll(_hyperLogLogs[i]);
+    }
+
+    // MinMaxRange
+    MinMaxRangePair expectedMinMaxRangePair =
+        new MinMaxRangePair(_minMaxRangePairs[0].getMin(), _minMaxRangePairs[0].getMax());
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedMinMaxRangePair.apply(_minMaxRangePairs[i]);
+    }
+
+    // PercentileEst
+    QuantileDigest expectedQuantileDigest = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+    for (int value : _valuesArray[0]) {
+      expectedQuantileDigest.add(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedQuantileDigest.merge(_quantileDigests[i]);
+    }
+
+    // PercentileTDigest
+    TDigest expectedTDigest = TDigest.createMergingDigest(PERCENTILE_TDIGEST_COMPRESSION);
+    for (int value : _valuesArray[0]) {
+      expectedTDigest.add(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      expectedTDigest.add(_tDigests[i]);
+    }
+
+    Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
+    while (groupKeyIterator.hasNext()) {
+      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+
+      // Avg
+      AvgPair avgPair = (AvgPair) groupByResult.getResultForKey(groupKey, 0);
+      assertEquals(avgPair.getSum(), expectedAvgPair.getSum());
+      assertEquals(avgPair.getCount(), expectedAvgPair.getCount());
+
+      // DistinctCountHLL
+      HyperLogLog hyperLogLog = (HyperLogLog) groupByResult.getResultForKey(groupKey, 1);
+      assertEquals(hyperLogLog.cardinality(), expectedHyperLogLog.cardinality());
+
+      // MinMaxRange
+      MinMaxRangePair minMaxRangePair = (MinMaxRangePair) groupByResult.getResultForKey(groupKey, 2);
+      assertEquals(minMaxRangePair.getMin(), expectedMinMaxRangePair.getMin());
+      assertEquals(minMaxRangePair.getMax(), expectedMinMaxRangePair.getMax());
+
+      // PercentileEst
+      QuantileDigest quantileDigest = (QuantileDigest) groupByResult.getResultForKey(groupKey, 3);
+      assertEquals(quantileDigest.getQuantile(0.5), expectedQuantileDigest.getQuantile(0.5));
+
+      // PercentileTDigest
+      TDigest tDigest = (TDigest) groupByResult.getResultForKey(groupKey, 4);
+      assertEquals(tDigest.quantile(0.5), expectedTDigest.quantile(0.5), PERCENTILE_TDIGEST_DELTA);
+    }
+  }
+
+  @Test
+  public void testInterSegmentMVGroupBy()
+      throws Exception {
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getMVGroupByQuery());
+    List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+    assertNotNull(aggregationResults);
+    assertEquals(aggregationResults.size(), 5);
+
+    // Simulate the process of server side merge and broker side merge
+
+    // Avg
+    AvgPair avgPair1 = new AvgPair(_avgPairs[0].getSum(), _avgPairs[0].getCount());
+    AvgPair avgPair2 = new AvgPair(_avgPairs[0].getSum(), _avgPairs[0].getCount());
+    for (int i = 1; i < NUM_ROWS; i++) {
+      avgPair1.apply(_avgPairs[i]);
+      avgPair2.apply(_avgPairs[i]);
+    }
+    avgPair1.apply(avgPair2);
+    avgPair1 = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(ObjectSerDeUtils.AVG_PAIR_SER_DE.serialize(avgPair1));
+    avgPair2 = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(ObjectSerDeUtils.AVG_PAIR_SER_DE.serialize(avgPair1));
+    avgPair1.apply(avgPair2);
+    List<GroupByResult> groupByResults = aggregationResults.get(0).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      assertEquals(Double.parseDouble((String) groupByResult.getValue()), avgPair1.getSum() / avgPair1.getCount(),
+          1e-5);
+    }
+
+    // DistinctCountHLL
+    HyperLogLog hyperLogLog1 = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+    HyperLogLog hyperLogLog2 = new HyperLogLog(DISTINCT_COUNT_HLL_LOG2M);
+    for (int value : _valuesArray[0]) {
+      hyperLogLog1.offer(value);
+      hyperLogLog2.offer(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      hyperLogLog1.addAll(_hyperLogLogs[i]);
+      hyperLogLog2.addAll(_hyperLogLogs[i]);
+    }
+    hyperLogLog1.addAll(hyperLogLog2);
+    hyperLogLog1 = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE
+        .deserialize(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hyperLogLog1));
+    hyperLogLog2 = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE
+        .deserialize(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hyperLogLog1));
+    hyperLogLog1.addAll(hyperLogLog2);
+    groupByResults = aggregationResults.get(1).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      assertEquals(Long.parseLong((String) groupByResult.getValue()), hyperLogLog1.cardinality());
+    }
+
+    // MinMaxRange
+    MinMaxRangePair minMaxRangePair1 =
+        new MinMaxRangePair(_minMaxRangePairs[0].getMin(), _minMaxRangePairs[0].getMax());
+    MinMaxRangePair minMaxRangePair2 =
+        new MinMaxRangePair(_minMaxRangePairs[0].getMin(), _minMaxRangePairs[0].getMax());
+    for (int i = 1; i < NUM_ROWS; i++) {
+      minMaxRangePair1.apply(_minMaxRangePairs[i]);
+      minMaxRangePair2.apply(_minMaxRangePairs[i]);
+    }
+    minMaxRangePair1.apply(minMaxRangePair2);
+    minMaxRangePair1 = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE
+        .deserialize(ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.serialize(minMaxRangePair1));
+    minMaxRangePair2 = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE
+        .deserialize(ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.serialize(minMaxRangePair1));
+    minMaxRangePair1.apply(minMaxRangePair2);
+    groupByResults = aggregationResults.get(2).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      assertEquals(Double.parseDouble((String) groupByResult.getValue()),
+          minMaxRangePair1.getMax() - minMaxRangePair1.getMin(), 1e-5);
+    }
+
+    // PercentileEst
+    QuantileDigest quantileDigest1 = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+    QuantileDigest quantileDigest2 = new QuantileDigest(PERCENTILE_EST_MAX_ERROR);
+    for (int value : _valuesArray[0]) {
+      quantileDigest1.add(value);
+      quantileDigest2.add(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      quantileDigest1.merge(_quantileDigests[i]);
+      quantileDigest2.merge(_quantileDigests[i]);
+    }
+    quantileDigest1.merge(quantileDigest2);
+    quantileDigest1 = ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE
+        .deserialize(ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.serialize(quantileDigest1));
+    quantileDigest2 = ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE
+        .deserialize(ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.serialize(quantileDigest1));
+    quantileDigest1.merge(quantileDigest2);
+    groupByResults = aggregationResults.get(3).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      assertEquals(Long.parseLong((String) groupByResult.getValue()), quantileDigest1.getQuantile(0.5));
+    }
+
+    // PercentileTDigest
+    TDigest tDigest1 = TDigest.createMergingDigest(PERCENTILE_TDIGEST_COMPRESSION);
+    TDigest tDigest2 = TDigest.createMergingDigest(PERCENTILE_TDIGEST_COMPRESSION);
+    for (int value : _valuesArray[0]) {
+      tDigest1.add(value);
+      tDigest2.add(value);
+    }
+    for (int i = 1; i < NUM_ROWS; i++) {
+      tDigest1.add(_tDigests[i]);
+      tDigest2.add(_tDigests[i]);
+    }
+    tDigest1.add(tDigest2);
+    tDigest1 = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest1));
+    tDigest2 = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest1));
+    tDigest1.add(tDigest2);
+    groupByResults = aggregationResults.get(4).getGroupByResult();
+    assertEquals(groupByResults.size(), 3);
+    for (GroupByResult groupByResult : groupByResults) {
+      assertEquals(Double.parseDouble((String) groupByResult.getValue()), tDigest1.quantile(0.5),
+          PERCENTILE_TDIGEST_DELTA);
+    }
+  }
+
+  private String getAggregationQuery() {
+    return String.format(
+        "SELECT AVG(%s), DISTINCTCOUNTHLL(%s), MINMAXRANGE(%s), PERCENTILEEST50(%s), PERCENTILETDIGEST50(%s) FROM %s",
+        AVG_COLUMN, DISTINCT_COUNT_HLL_COLUMN, MIN_MAX_RANGE_COLUMN, PERCENTILE_EST_COLUMN, PERCENTILE_TDIGEST_COLUMN,
+        RAW_TABLE_NAME);
+  }
+
+  private String getSVGroupByQuery() {
+    return String.format("%s GROUP BY %s", getAggregationQuery(), GROUP_BY_SV_COLUMN);
+  }
+
+  private String getMVGroupByQuery() {
+    return String.format("%s GROUP BY %s", getAggregationQuery(), GROUP_BY_MV_COLUMN);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _indexSegment.destroy();
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+}


### PR DESCRIPTION
For the following approximate aggregation functions, the function allows a factor to tune the result size and accuracy:
- DistinctCountHLL - log2m for HyperLogLog
- PercentileEst - max error for QuantileDigest
- PercentileTDigest - compression for TDigest

When user provides serialized Object via BYTES, this factor is embedded inside the serialized bytes.
In that case, we should pick the one inside the serialized Object instead of using the default one.

Added SerializedBytesQueriesTest to test the behavior