### PR TITLE
[TE] Accelerate loading yaml list

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
@@ -879,6 +879,6 @@ public class YamlResource {
     } else {
       detectionConfigDTOs = Collections.singletonList(this.detectionConfigDAO.findById(id));
     }
-    return detectionConfigDTOs.stream().map(this.detectionConfigFormatter::format).collect(Collectors.toList());
+    return detectionConfigDTOs.parallelStream().map(this.detectionConfigFormatter::format).collect(Collectors.toList());
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/formatter/DetectionConfigFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/formatter/DetectionConfigFormatter.java
@@ -112,8 +112,12 @@ public class DetectionConfigFormatter implements DTOFormatter<DetectionConfigDTO
     for (String metricUrn : metricUrns) {
       metricUrnToMetricDTOs.put(metricUrn, getMetricConfigForMetricUrn(metricUrn));
     }
-    Map<String, Object> yamlObject = ConfigUtils.getMap(this.yaml.load(config.getYaml()));
 
+    Map<String, Object> yamlObject;
+    // synchronize on yaml parser because it is not thread safe
+    synchronized (this.yaml) {
+      yamlObject = ConfigUtils.getMap(this.yaml.load(config.getYaml()));
+    }
     Map<String, DatasetConfigDTO> metricUrnToDatasets = metricUrns.stream().collect(Collectors.toMap(metricUrn -> metricUrn,
       metricUrn -> getDatasetForMetricUrn(metricUrn, metricUrnToMetricDTOs), (d1, d2) -> d1));
 


### PR DESCRIPTION
Accelerate the YAML list by utilizing parallelization. This can speed up the latency of loading the alerts page by 4x in local testing.