### PR TITLE
Use guava cache for instance admin endpoints

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -187,13 +187,11 @@ public class PinotHelixResourceManager {
     _helixAdmin = _helixZkManager.getClusterManagmentTool();
     _propertyStore = _helixZkManager.getHelixPropertyStore();
     _helixDataAccessor = _helixZkManager.getHelixDataAccessor();
-    // Cache instance zk paths.
-    BaseDataAccessor<ZNRecord> baseDataAccessor = _helixDataAccessor.getBaseDataAccessor();
+    _keyBuilder = _helixDataAccessor.keyBuilder();
 
     // Add instance group tag for controller
     addInstanceGroupTagIfNeeded();
 
-    _keyBuilder = _helixDataAccessor.keyBuilder();
     _segmentDeletionManager = new SegmentDeletionManager(_dataDir, _helixAdmin, _helixClusterName, _propertyStore);
     ZKMetadataProvider.setClusterTenantIsolationEnabled(_propertyStore, _isSingleTenantCluster);
   }
@@ -302,7 +300,7 @@ public class PinotHelixResourceManager {
    * @return Helix instance config
    */
   public InstanceConfig getHelixInstanceConfig(@Nonnull String instanceId) {
-    return _helixAdmin.getInstanceConfig(_helixClusterName, instanceId);
+    return _helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceId));
   }
 
   /**
@@ -2220,9 +2218,7 @@ public class PinotHelixResourceManager {
    * @return True if instance exists in the Helix cluster, False otherwise.
    */
   public boolean instanceExists(String instanceName) {
-    HelixDataAccessor helixDataAccessor = _helixZkManager.getHelixDataAccessor();
-    InstanceConfig config = helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
-    return (config != null);
+    return getHelixInstanceConfig(instanceName) != null;
   }
 
   public boolean isSingleTenantCluster() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -21,7 +21,9 @@ package org.apache.pinot.controller.helix.core;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Lists;
@@ -36,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -51,10 +54,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkCacheBaseDataAccessor;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -92,6 +92,7 @@ import org.apache.pinot.common.utils.CommonConstants.Helix;
 import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.BrokerOnlineOfflineStateModel;
 import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
+import org.apache.pinot.common.utils.CommonConstants.Server;
 import org.apache.pinot.common.utils.SchemaUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.common.utils.helix.PinotHelixPropertyStoreZnRecordProvider;
@@ -117,11 +118,13 @@ import org.slf4j.LoggerFactory;
 public class PinotHelixResourceManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotHelixResourceManager.class);
   private static final long DEFAULT_EXTERNAL_VIEW_UPDATE_RETRY_INTERVAL_MILLIS = 500L;
+  private static final long CACHE_TIMEOUT_HR = 6L;
   private static final RetryPolicy DEFAULT_RETRY_POLICY = RetryPolicies.exponentialBackoffRetryPolicy(5, 1000L, 2.0f);
   public static final String APPEND = "APPEND";
 
   private final Map<String, Map<String, Long>> _segmentCrcMap = new HashMap<>();
   private final Map<String, Map<String, Integer>> _lastKnownSegmentMetadataVersionMap = new HashMap<>();
+  private final LoadingCache<String, String> _instanceAdminEndpointCache;
 
   private final String _helixZkURL;
   private final String _helixClusterName;
@@ -136,7 +139,6 @@ public class PinotHelixResourceManager {
   private HelixAdmin _helixAdmin;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private HelixDataAccessor _helixDataAccessor;
-  private ZkCacheBaseDataAccessor<ZNRecord> _cacheInstanceConfigsDataAccessor;
   private Builder _keyBuilder;
   private SegmentDeletionManager _segmentDeletionManager;
   private PinotLLCRealtimeSegmentManager _pinotLLCRealtimeSegmentManager;
@@ -151,6 +153,19 @@ public class PinotHelixResourceManager {
     _isSingleTenantCluster = isSingleTenantCluster;
     _enableBatchMessageMode = enableBatchMessageMode;
     _allowHLCTables = allowHLCTables;
+    _instanceAdminEndpointCache = CacheBuilder.newBuilder().expireAfterWrite(CACHE_TIMEOUT_HR, TimeUnit.HOURS)
+        .build(new CacheLoader<String, String>() {
+          @Override
+          public String load(@Nonnull String instanceId) {
+            InstanceConfig helixInstanceConfig = getHelixInstanceConfig(instanceId);
+            ZNRecord record = helixInstanceConfig.getRecord();
+            String[] hostnameSplit = helixInstanceConfig.getHostName().split("_");
+            Preconditions.checkState(hostnameSplit.length >= 2);
+            String adminPort =
+                record.getStringField(Helix.Instance.ADMIN_PORT_KEY, Integer.toString(Server.DEFAULT_ADMIN_API_PORT));
+            return hostnameSplit[1] + ":" + adminPort;
+          }
+        });
   }
 
   public PinotHelixResourceManager(@Nonnull ControllerConf controllerConf) {
@@ -173,11 +188,6 @@ public class PinotHelixResourceManager {
     _helixDataAccessor = _helixZkManager.getHelixDataAccessor();
     // Cache instance zk paths.
     BaseDataAccessor<ZNRecord> baseDataAccessor = _helixDataAccessor.getBaseDataAccessor();
-
-    String instanceConfigs = PropertyPathBuilder.instanceConfig(_helixClusterName);
-    _cacheInstanceConfigsDataAccessor =
-        new ZkCacheBaseDataAccessor<>((ZkBaseDataAccessor<ZNRecord>) baseDataAccessor, instanceConfigs, null,
-            Collections.singletonList(instanceConfigs));
 
     // Add instance group tag for controller
     addInstanceGroupTagIfNeeded();
@@ -274,27 +284,14 @@ public class PinotHelixResourceManager {
    */
   @Nonnull
   public List<String> getAllInstances() {
-    return _cacheInstanceConfigsDataAccessor.getChildNames("/", AccessOption.PERSISTENT);
+    return _helixAdmin.getInstancesInCluster(_helixClusterName);
   }
 
   /**
    * Returns the config for all the Helix instances in the cluster.
    */
   public List<InstanceConfig> getAllHelixInstanceConfigs() {
-    List<ZNRecord> znRecords = _cacheInstanceConfigsDataAccessor.getChildren("/", null, AccessOption.PERSISTENT);
-    int numZNRecords = znRecords.size();
-    List<InstanceConfig> instanceConfigs = new ArrayList<>(numZNRecords);
-    for (ZNRecord znRecord : znRecords) {
-      // NOTE: it is possible that znRecord is null if the record gets removed while calling this method
-      if (znRecord != null) {
-        instanceConfigs.add(new InstanceConfig(znRecord));
-      }
-    }
-    int numNullZNRecords = numZNRecords - instanceConfigs.size();
-    if (numNullZNRecords > 0) {
-      LOGGER.warn("Failed to read {}/{} instance configs", numZNRecords - numNullZNRecords, numZNRecords);
-    }
-    return instanceConfigs;
+    return HelixHelper.getInstanceConfigs(_helixZkManager);
   }
 
   /**
@@ -304,8 +301,7 @@ public class PinotHelixResourceManager {
    * @return Helix instance config
    */
   public InstanceConfig getHelixInstanceConfig(@Nonnull String instanceId) {
-    ZNRecord znRecord = _cacheInstanceConfigsDataAccessor.get("/" + instanceId, null, AccessOption.PERSISTENT);
-    return znRecord != null ? new InstanceConfig(znRecord) : null;
+    return _helixAdmin.getInstanceConfig(_helixClusterName, instanceId);
   }
 
   /**
@@ -2223,8 +2219,9 @@ public class PinotHelixResourceManager {
    * @return True if instance exists in the Helix cluster, False otherwise.
    */
   public boolean instanceExists(String instanceName) {
-    ZNRecord znRecord = _cacheInstanceConfigsDataAccessor.get("/" + instanceName, null, AccessOption.PERSISTENT);
-    return (znRecord != null);
+    HelixDataAccessor helixDataAccessor = _helixZkManager.getHelixDataAccessor();
+    InstanceConfig config = helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
+    return (config != null);
   }
 
   public boolean isSingleTenantCluster() {
@@ -2262,7 +2259,7 @@ public class PinotHelixResourceManager {
    * Provides admin endpoints for the provided data instances
    * @param instances instances for which to read endpoints
    * @return returns map of instances to their admin endpoints.
-   * The return value is a bimap because admin instances are typically used for
+   * The return value is a biMap because admin instances are typically used for
    * http requests. So, on response, we need mapping from the endpoint to the
    * server instances. With BiMap, both mappings are easily available
    */
@@ -2272,23 +2269,17 @@ public class PinotHelixResourceManager {
     Preconditions.checkNotNull(instances);
     BiMap<String, String> endpointToInstance = HashBiMap.create(instances.size());
     for (String instance : instances) {
-      InstanceConfig helixInstanceConfig = getHelixInstanceConfig(instance);
-      if (helixInstanceConfig == null) {
-        LOGGER.warn("Instance {} not found", instance);
-        continue;
+      String instanceAdminEndpoint;
+      try {
+        instanceAdminEndpoint = _instanceAdminEndpointCache.get(instance);
+      } catch (ExecutionException e) {
+        String errorMessage = String
+            .format("ExecutionException when getting instance admin endpoint for instance: %s. Error message: %s",
+                instance, e.getMessage());
+        LOGGER.error(errorMessage, e);
+        throw new InvalidConfigException(errorMessage);
       }
-      ZNRecord record = helixInstanceConfig.getRecord();
-      String[] hostnameSplit = helixInstanceConfig.getHostName().split("_");
-      Preconditions.checkState(hostnameSplit.length >= 2);
-      String adminPort = record.getSimpleField(Helix.Instance.ADMIN_PORT_KEY);
-      // If admin port is missing, there's no point to calculate the remaining table size.
-      // Thus, throwing an exception will be good here.
-      if (Strings.isNullOrEmpty(adminPort)) {
-        String message = String.format("Admin port is missing for host: %s", helixInstanceConfig.getHostName());
-        LOGGER.error(message);
-        throw new InvalidConfigException(message);
-      }
-      endpointToInstance.put(instance, hostnameSplit[1] + ":" + adminPort);
+      endpointToInstance.put(instance, instanceAdminEndpoint);
     }
     return endpointToInstance;
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -44,6 +44,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
@@ -105,6 +106,7 @@ public abstract class ControllerTest {
   protected PinotHelixResourceManager _helixResourceManager;
   protected HelixManager _helixManager;
   protected HelixAdmin _helixAdmin;
+  protected HelixDataAccessor _helixDataAccessor;
   protected ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
   private ZkStarter.ZookeeperInstance _zookeeperInstance;
@@ -156,6 +158,7 @@ public abstract class ControllerTest {
     _controllerStarter.start();
     _helixResourceManager = _controllerStarter.getHelixResourceManager();
     _helixManager = _controllerStarter.getHelixControllerManager();
+    _helixDataAccessor = _helixManager.getHelixDataAccessor();
 
     // HelixResourceManager is null in Helix only mode, while HelixManager is null in Pinot only mode.
     switch (_controllerStarter.getControllerMode()) {


### PR DESCRIPTION
This PR:
* uses guava cache for instance admin endpoints.
* removes cached data accessor, which comes from Helix code.

Current usage of cached based data accessor has the issue described in this link: #4665
And the cached data accessor was to solve the problem of frequent zk access to get the instance admin endpoints when there's segment upload. Plus, we've seen some flaky tests in our build, which are also related to this cached data accessor.
This issue can be solved by just introducing a guava cache to cache the instance admin endpoint. So no need to maintain a cached data accessor any more.