### PR TITLE
[#4667] Fix auto-tuning algorithm to update when parameters are changed

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -78,6 +78,7 @@ import org.apache.pinot.controller.util.SegmentCompletionUtils;
 import org.apache.pinot.core.realtime.segment.ConsumingSegmentAssignmentStrategy;
 import org.apache.pinot.core.realtime.segment.RealtimeSegmentAssignmentStrategy;
 import org.apache.pinot.core.realtime.stream.OffsetCriteria;
+import org.apache.pinot.core.realtime.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.core.realtime.stream.PartitionOffsetFetcher;
 import org.apache.pinot.core.realtime.stream.StreamConfig;
 import org.apache.pinot.core.realtime.stream.StreamConfigProperties;
@@ -585,10 +586,12 @@ public class PinotLLCRealtimeSegmentManager {
             newLLCSegmentName, partitionAssignment.getNumPartitions());
     final LLCRealtimeSegmentZKMetadata newSegmentZKMetadata = new LLCRealtimeSegmentZKMetadata(newZnRecord);
 
+    PartitionLevelStreamConfig streamConfig =
+        new PartitionLevelStreamConfig(realtimeTableName, realtimeTableConfig.getIndexingConfig().getStreamConfigs());
     FlushThresholdUpdater flushThresholdUpdater =
-        _flushThresholdUpdateManager.getFlushThresholdUpdater(realtimeTableConfig);
+        _flushThresholdUpdateManager.getFlushThresholdUpdater(streamConfig);
     flushThresholdUpdater
-        .updateFlushThreshold(newSegmentZKMetadata, committingSegmentZKMetadata, committingSegmentDescriptor,
+        .updateFlushThreshold(newSegmentZKMetadata, streamConfig, committingSegmentZKMetadata, committingSegmentDescriptor,
             partitionAssignment);
 
     newZnRecord = newSegmentZKMetadata.toZNRecord();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.partition.PartitionAssignment;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.realtime.stream.StreamConfig;
 
 
 /**
@@ -42,7 +43,7 @@ public class DefaultFlushThresholdUpdater implements FlushThresholdUpdater {
 
   @Override
   public void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
-      LLCRealtimeSegmentZKMetadata committingSegmentZKMetadata, CommittingSegmentDescriptor committingSegmentDescriptor,
+      StreamConfig streamConfig, LLCRealtimeSegmentZKMetadata committingSegmentZKMetadata, CommittingSegmentDescriptor committingSegmentDescriptor,
       @Nonnull PartitionAssignment partitionAssignment) {
 
     // Gather list of instances for this partition

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
@@ -21,9 +21,7 @@ package org.apache.pinot.controller.helix.core.realtime.segment;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.pinot.common.config.TableConfig;
-import org.apache.pinot.core.realtime.stream.PartitionLevelStreamConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.pinot.core.realtime.stream.StreamConfig;
 
 
 /**
@@ -40,18 +38,15 @@ public class FlushThresholdUpdateManager {
    * If flush size > 0, create a new DefaultFlushThresholdUpdater with given flush size.
    * If flush size == 0, create new SegmentSizeBasedFlushThresholdUpdater if not already created. Create only 1 per table, because we want to maintain tuning information for the table in the updater
    */
-  public FlushThresholdUpdater getFlushThresholdUpdater(TableConfig realtimeTableConfig) {
-    final String tableName = realtimeTableConfig.getTableName();
-    PartitionLevelStreamConfig streamConfig =
-        new PartitionLevelStreamConfig(tableName, realtimeTableConfig.getIndexingConfig().getStreamConfigs());
-
+  public FlushThresholdUpdater getFlushThresholdUpdater(StreamConfig streamConfig) {
+    final String tableName = streamConfig.getTableNameWithType();
     final int tableFlushSize = streamConfig.getFlushThresholdRows();
 
     if (tableFlushSize == 0) {
-      final long desiredSegmentSize = streamConfig.getFlushSegmentDesiredSizeBytes();
-      final int flushAutotuneInitialRows = streamConfig.getFlushAutotuneInitialRows();
-      return _flushThresholdUpdaterMap.computeIfAbsent(tableName,
-          k -> new SegmentSizeBasedFlushThresholdUpdater(desiredSegmentSize, flushAutotuneInitialRows));
+      FlushThresholdUpdater updater =  _flushThresholdUpdaterMap.computeIfAbsent(tableName,
+          k -> new SegmentSizeBasedFlushThresholdUpdater());
+      // In case the table config has changed, update it
+      return updater;
     } else {
       _flushThresholdUpdaterMap.remove(tableName);
       return new DefaultFlushThresholdUpdater(tableFlushSize);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.helix.core.realtime.segment;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.partition.PartitionAssignment;
+import org.apache.pinot.core.realtime.stream.StreamConfig;
 
 
 /**
@@ -32,11 +33,12 @@ public interface FlushThresholdUpdater {
   /**
    * Updated the flush threshold of the segment metadata
    * @param newSegmentZKMetadata - new segment metadata for which the thresholds need to be set
+   * @param streamConfig - the StreamConfig object from the tableConfig
    * @param committingSegmentZKMetadata - metadata of the committing segment
    * @param committingSegmentDescriptor
    * @param partitionAssignment - partition assignment for the table
    */
-  void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
+  void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata, StreamConfig streamConfig,
       LLCRealtimeSegmentZKMetadata committingSegmentZKMetadata, CommittingSegmentDescriptor committingSegmentDescriptor,
       PartitionAssignment partitionAssignment);
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -29,13 +29,26 @@ import org.apache.pinot.common.partition.PartitionAssignment;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
+import org.apache.pinot.core.realtime.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.core.realtime.stream.StreamConfig;
 import org.apache.pinot.core.realtime.stream.StreamConfigProperties;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-
+/*
+ * TODO: FIXME
+ * - Consider changing the test to use mock streamConfig than the one generated via real configurations.
+ *   Makes things a lot easier. Or, have a class that inherits from StreamConfig and has setters/getters
+ *   to return the values that we care about.
+ * - Change the SegmentSizeBasedFlushThresholdUpdater class to use a method to get time, and fake it
+ *   in this class to set time to arbitrary value. Calling System.currentTime() in the class under
+ *   test can cause this test to be flaky. We need to use the current time to generate segment start
+ *   times, and if for any reason threads get slower, the test will fail.
+ * - Some tests in testFlushThresholdUpdater() seem to test StreamConfig more than the threshold updater.
+ *   The lines are commented out so that we don't lose the tests, but we need to move those lines
+ *   to a different class that does not use use flush threshold updater.
+ */
 public class FlushThresholdUpdaterTest {
   private static final long DESIRED_SEGMENT_SIZE = StreamConfig.getDefaultDesiredSegmentSizeBytes();
   private static final int DEFAULT_INITIAL_ROWS_THRESHOLD = StreamConfig.getDefaultFlushAutotuneInitialRows();
@@ -60,12 +73,42 @@ public class FlushThresholdUpdaterTest {
     datasetGraph.put("steps", steps);
   }
 
+  StreamConfig convertToAutoTune(StreamConfig streamConfig) {
+    Map<String, String> streamConfigsMap = streamConfig.getStreamConfigsMap();
+    streamConfigsMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "0");
+    return new StreamConfig(streamConfig.getTableNameWithType(), streamConfigsMap);
+  }
+
+  StreamConfig updateDesiredSegmentSize(StreamConfig streamConfig, long desiredSegmentSize) {
+    Map<String, String> streamConfigsMap = streamConfig.getStreamConfigsMap();
+    streamConfigsMap.put(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE, String.valueOf(desiredSegmentSize));
+    return new StreamConfig(streamConfig.getTableNameWithType(), streamConfigsMap);
+  }
+
+  StreamConfig updateTimeThreshold(StreamConfig streamConfig, long timeThresholdMillis) {
+    Map<String, String> streamConfigsMap = streamConfig.getStreamConfigsMap();
+    streamConfigsMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, String.valueOf(timeThresholdMillis));
+    return new StreamConfig(streamConfig.getTableNameWithType(), streamConfigsMap);
+  }
+
+  StreamConfig updateInitialRowsForAutoTune(StreamConfig streamConfig, long initialRowsForAutoTune) {
+    Map<String, String> streamConfigsMap = streamConfig.getStreamConfigsMap();
+    streamConfigsMap.put(StreamConfigProperties.SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS, String.valueOf(initialRowsForAutoTune));
+    return new StreamConfig(streamConfig.getTableNameWithType(), streamConfigsMap);
+  }
+
+  StreamConfig updateRowThreshold(StreamConfig streamConfig, int rowThreshold) {
+    Map<String, String> streamConfigsMap = streamConfig.getStreamConfigsMap();
+    streamConfigsMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, String.valueOf(rowThreshold));
+    return new StreamConfig(streamConfig.getTableNameWithType(), streamConfigsMap);
+  }
   /**
    * Tests that we have the right flush threshold set in the segment metadata given the various combinations of servers, partitions and replicas
    */
   @Test
   public void testDefaultUpdateFlushThreshold() {
 
+    final StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
     PartitionAssignment partitionAssignment = new PartitionAssignment("fakeTable_REALTIME");
     // 4 partitions assigned to 4 servers, 4 replicas => the segments should have 250k rows each (1M / 4)
     for (int segmentId = 1; segmentId <= 4; ++segmentId) {
@@ -83,7 +126,7 @@ public class FlushThresholdUpdaterTest {
     for (int segmentId = 1; segmentId <= 4; ++segmentId) {
       LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
       metadata.setSegmentName(makeFakeSegmentName(segmentId));
-      flushThresholdUpdater.updateFlushThreshold(metadata, null, null, partitionAssignment);
+      flushThresholdUpdater.updateFlushThreshold(metadata, streamConfig, null, null, partitionAssignment);
       Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 250000);
     }
 
@@ -103,7 +146,7 @@ public class FlushThresholdUpdaterTest {
     for (int segmentId = 1; segmentId <= 4; ++segmentId) {
       LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
       metadata.setSegmentName(makeFakeSegmentName(segmentId));
-      flushThresholdUpdater.updateFlushThreshold(metadata, null, null, partitionAssignment);
+      flushThresholdUpdater.updateFlushThreshold(metadata, streamConfig, null, null, partitionAssignment);
       Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 500000);
     }
 
@@ -119,7 +162,7 @@ public class FlushThresholdUpdaterTest {
     for (int segmentId = 1; segmentId <= 4; ++segmentId) {
       LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
       metadata.setSegmentName(makeFakeSegmentName(segmentId));
-      flushThresholdUpdater.updateFlushThreshold(metadata, null, null, partitionAssignment);
+      flushThresholdUpdater.updateFlushThreshold(metadata, streamConfig, null, null, partitionAssignment);
       Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 1000000);
     }
 
@@ -134,13 +177,116 @@ public class FlushThresholdUpdaterTest {
     for (int segmentId = 1; segmentId <= 4; ++segmentId) {
       LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
       metadata.setSegmentName(makeFakeSegmentName(segmentId));
-      flushThresholdUpdater.updateFlushThreshold(metadata, null, null, partitionAssignment);
+      flushThresholdUpdater.updateFlushThreshold(metadata, streamConfig, null, null, partitionAssignment);
       Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 500000);
     }
   }
 
   private String makeFakeSegmentName(int id) {
     return new LLCSegmentName("fakeTable_REALTIME", id, 0, 1234L).getSegmentName();
+  }
+
+  @Test
+  public void testSegmentSizeBasedUpdaterWithModifications() {
+    final String tableName = "xyz_REALTIME";
+    final int initialDefaultRows = 100_000;
+    final int partitionId = 0;
+    final long startOffset = 0L;
+
+    int segmentSeqNum = 17;
+    final long now = System.currentTimeMillis();
+
+    StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
+    streamConfig = convertToAutoTune(streamConfig);
+
+    int consumedRows;
+    long consumptionDuration;
+    int nextThreshold;
+    LLCRealtimeSegmentZKMetadata committingSegmentMetadata;
+    LLCRealtimeSegmentZKMetadata newSegmentMetadata;
+    long committingSegmentSize;
+
+    // Create an updater
+    SegmentSizeBasedFlushThresholdUpdater updater = new SegmentSizeBasedFlushThresholdUpdater();
+
+    CommittingSegmentDescriptor committingSegmentDescriptor;
+
+    // Assume that we were asked to consume 5M rows, and we did so in 90% of the time, producing a 180M segment
+    consumedRows = 5_000_000;
+    consumptionDuration = streamConfig.getFlushThresholdTimeMillis() * 90/100;
+    committingSegmentSize = 180_000_000;
+
+    committingSegmentMetadata = getNextSegmentMetadata(tableName, startOffset, partitionId, segmentSeqNum, now - consumptionDuration);
+    committingSegmentMetadata.setSizeThresholdToFlushSegment(consumedRows);
+    committingSegmentMetadata.setTotalRawDocs(consumedRows);
+    committingSegmentDescriptor = new CommittingSegmentDescriptor(committingSegmentMetadata.getSegmentName(), startOffset,
+        committingSegmentSize);
+
+    newSegmentMetadata = getNextSegmentMetadata(tableName, startOffset, partitionId, segmentSeqNum +1, now);
+    updater.updateFlushThreshold(newSegmentMetadata, streamConfig, committingSegmentMetadata, committingSegmentDescriptor, null);
+    nextThreshold = newSegmentMetadata.getSizeThresholdToFlushSegment();
+
+    // Since we hit the row threshold, and have not reached desired segment size, we should see higher number of rows.
+    Assert.assertTrue(nextThreshold > consumedRows);
+    // We should have set the ratio now.
+    double ratio = updater.getLatestSegmentRowsToSizeRatio();
+
+    // Now we reach the time threshold for the next segment, consuming 50% of the number we were asked to do, and
+    // generate half the size of the segment we last did.
+    consumedRows = nextThreshold * 5/10;
+    consumptionDuration = streamConfig.getFlushThresholdTimeMillis() * 9/10;  // We cannot mock time in the class!
+    committingSegmentSize /= 2;
+
+    committingSegmentMetadata = getNextSegmentMetadata(tableName, startOffset, partitionId, segmentSeqNum, now - consumptionDuration);
+    committingSegmentMetadata.setSizeThresholdToFlushSegment(nextThreshold);
+    committingSegmentMetadata.setTotalRawDocs(consumedRows);
+    committingSegmentDescriptor = new CommittingSegmentDescriptor( committingSegmentMetadata.getSegmentName(), startOffset,
+        committingSegmentSize);
+
+    newSegmentMetadata = getNextSegmentMetadata(tableName, startOffset, partitionId, segmentSeqNum +1, now);
+    updater.updateFlushThreshold(newSegmentMetadata, streamConfig, committingSegmentMetadata, committingSegmentDescriptor, null);
+    nextThreshold = newSegmentMetadata.getSizeThresholdToFlushSegment();
+
+    // The new threshold should be slightly above the number of rows we consumed
+    Assert.assertEquals(nextThreshold, (int) (consumedRows * updater.getRowsMultiplierWhenTimeThresholdHit()));
+
+    // Now let us assume that the admin has reduced the segment size threshold to be lower than the size of segment we produced last time,
+    // and we hit the time threshold again, but we made a bigger segment than the new desired segment size. We should reduce the
+    // number of rows to consume next time.
+    streamConfig = updateDesiredSegmentSize(streamConfig, committingSegmentSize * 9/10);
+    consumedRows = nextThreshold * 9/10;
+
+    committingSegmentMetadata = getNextSegmentMetadata(tableName, startOffset, partitionId, segmentSeqNum, now - consumptionDuration);
+    committingSegmentMetadata.setSizeThresholdToFlushSegment(nextThreshold);
+    committingSegmentMetadata.setTotalRawDocs(consumedRows);
+    committingSegmentDescriptor = new CommittingSegmentDescriptor( committingSegmentMetadata.getSegmentName(), startOffset,
+        committingSegmentSize);
+
+    newSegmentMetadata = getNextSegmentMetadata(tableName, startOffset, partitionId, segmentSeqNum +1, now);
+    updater.updateFlushThreshold(newSegmentMetadata, streamConfig, committingSegmentMetadata, committingSegmentDescriptor, null);
+    nextThreshold = newSegmentMetadata.getSizeThresholdToFlushSegment();
+
+    Assert.assertTrue(nextThreshold < consumedRows);
+
+    // Now the admin adjusts the time threshold to be lower. We reach the time limit on the current segment, consuming at a much
+    // smaller rate of consumption
+    streamConfig = updateTimeThreshold(streamConfig, streamConfig.getFlushThresholdTimeMillis() * 6/10);
+    consumedRows = nextThreshold * 5/10;
+
+    committingSegmentSize = streamConfig.getFlushSegmentDesiredSizeBytes() * 9/10;
+    committingSegmentMetadata = getNextSegmentMetadata(tableName, startOffset, partitionId, segmentSeqNum, now - consumptionDuration);
+    committingSegmentMetadata.setSizeThresholdToFlushSegment(nextThreshold);
+    committingSegmentMetadata.setTotalRawDocs(consumedRows);
+    committingSegmentDescriptor = new CommittingSegmentDescriptor( committingSegmentMetadata.getSegmentName(), startOffset,
+        committingSegmentSize);
+
+    newSegmentMetadata = getNextSegmentMetadata(tableName, startOffset, partitionId, segmentSeqNum +1, now);
+    updater.updateFlushThreshold(newSegmentMetadata, streamConfig, committingSegmentMetadata, committingSegmentDescriptor, null);
+    nextThreshold = newSegmentMetadata.getSizeThresholdToFlushSegment();
+
+    // Once again, the next threshold should reduce to about half of the threshold we set for the previous segment
+    // (since we consumed half the number of rows in 60% of the time allotted to us)
+    Assert.assertTrue(nextThreshold < consumedRows, "nextThreshold=" + nextThreshold +",consumedRows=" + consumedRows);
   }
 
   /**
@@ -152,17 +298,19 @@ public class FlushThresholdUpdaterTest {
   @Test
   public void testSegmentSizeBasedFlushThreshold() {
     String tableName = "aRealtimeTable_REALTIME";
+    StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
+    streamConfig = convertToAutoTune(streamConfig);
 
     for (Map.Entry<String, double[][]> entry : datasetGraph.entrySet()) {
 
       SegmentSizeBasedFlushThresholdUpdater segmentSizeBasedFlushThresholdUpdater =
-          new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE, DEFAULT_INITIAL_ROWS_THRESHOLD);
+          new SegmentSizeBasedFlushThresholdUpdater();
 
       double[][] numRowsToSegmentSize = entry.getValue();
 
       int numRuns = 500;
       double checkRunsAfter = 400;
-      long idealSegmentSize = segmentSizeBasedFlushThresholdUpdater.getDesiredSegmentSizeBytes();
+      long idealSegmentSize = DESIRED_SEGMENT_SIZE;
       long segmentSizeSwivel = (long) (idealSegmentSize * 0.5);
       int numRowsLowerLimit = 0;
       int numRowsUpperLimit = 0;
@@ -184,9 +332,9 @@ public class FlushThresholdUpdaterTest {
       newSegmentMetadata = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
       committingSegmentDescriptor = new CommittingSegmentDescriptor(null, startOffset, segmentSizeBytes);
       segmentSizeBasedFlushThresholdUpdater
-          .updateFlushThreshold(newSegmentMetadata, null, committingSegmentDescriptor, null);
+          .updateFlushThreshold(newSegmentMetadata, streamConfig, null, committingSegmentDescriptor, null);
       Assert.assertEquals(newSegmentMetadata.getSizeThresholdToFlushSegment(),
-          segmentSizeBasedFlushThresholdUpdater.getAutotuneInitialRows());
+          DEFAULT_INITIAL_ROWS_THRESHOLD);
 
       System.out.println("NumRowsThreshold, SegmentSize");
       for (int run = 0; run < numRuns; run++) {
@@ -203,7 +351,8 @@ public class FlushThresholdUpdaterTest {
         committingSegmentDescriptor =
             new CommittingSegmentDescriptor(committingSegmentMetadata.getSegmentName(), startOffset, segmentSizeBytes);
         segmentSizeBasedFlushThresholdUpdater
-            .updateFlushThreshold(newSegmentMetadata, committingSegmentMetadata, committingSegmentDescriptor, null);
+            .updateFlushThreshold(newSegmentMetadata, streamConfig,
+                committingSegmentMetadata, committingSegmentDescriptor, null);
 
         // Assert that segment size is in limits
         if (run > checkRunsAfter) {
@@ -237,17 +386,22 @@ public class FlushThresholdUpdaterTest {
   }
 
   private LLCRealtimeSegmentZKMetadata getNextSegmentMetadata(String realtimeTableName, long startOffset,
-      int partitionId, int seqNum) {
-    LLCSegmentName newSegmentName =
-        new LLCSegmentName(realtimeTableName, partitionId, seqNum, System.currentTimeMillis());
+      int partitionId, int seqNum, long creationTime) {
+
+    LLCSegmentName newSegmentName = new LLCSegmentName(realtimeTableName, partitionId, seqNum, creationTime);
     LLCRealtimeSegmentZKMetadata newSegMetadata = new LLCRealtimeSegmentZKMetadata();
-    newSegMetadata.setCreationTime(System.currentTimeMillis());
+    newSegMetadata.setCreationTime(creationTime);
     newSegMetadata.setStartOffset(startOffset);
     newSegMetadata.setEndOffset(Long.MAX_VALUE);
     newSegMetadata.setNumReplicas(3);
     newSegMetadata.setSegmentName(newSegmentName.getSegmentName());
     newSegMetadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
     return newSegMetadata;
+  }
+
+  private LLCRealtimeSegmentZKMetadata getNextSegmentMetadata(String realtimeTableName, long startOffset,
+      int partitionId, int seqNum) {
+    return getNextSegmentMetadata(realtimeTableName, startOffset, partitionId, seqNum, System.currentTimeMillis());
   }
 
   private void updateCommittingSegmentMetadata(LLCRealtimeSegmentZKMetadata committingSegmentMetadata, long endOffset,
@@ -270,79 +424,93 @@ public class FlushThresholdUpdaterTest {
     TableConfig realtimeTableConfig;
 
     FlushThresholdUpdater flushThresholdUpdater;
-    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
-    tableConfigBuilder.setStreamConfigs(streamConfigs);
+    StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
 
     // flush size set
-    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "10000");
+//    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "10000");
+    streamConfig = updateRowThreshold(streamConfig, 10000);
     realtimeTableConfig = tableConfigBuilder.build();
-    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(streamConfig);
     Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
     Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 10000);
 
     // llc flush size set
-    streamConfigs.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS);
-    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS + StreamConfigProperties.LLC_SUFFIX, "5000");
+//    streamConfigs.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS);
+//    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS + StreamConfigProperties.LLC_SUFFIX, "5000");
+    streamConfig = updateRowThreshold(streamConfig, 5000);
     realtimeTableConfig = tableConfigBuilder.build();
-    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(streamConfig);
     Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
     Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 5000);
 
     // 0 flush size set
-    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS + StreamConfigProperties.LLC_SUFFIX, "0");
+//    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS + StreamConfigProperties.LLC_SUFFIX, "0");
+    streamConfig = convertToAutoTune(streamConfig);
     realtimeTableConfig = tableConfigBuilder.build();
-    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(streamConfig);
     Assert.assertEquals(flushThresholdUpdater.getClass(), SegmentSizeBasedFlushThresholdUpdater.class);
 
     // called again with 0 flush size - same object as above
-    streamConfigs.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS + StreamConfigProperties.LLC_SUFFIX);
-    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "0");
+    streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
+    streamConfig = convertToAutoTune(streamConfig);
     realtimeTableConfig = tableConfigBuilder.build();
-    FlushThresholdUpdater flushThresholdUpdaterSame = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    FlushThresholdUpdater flushThresholdUpdaterSame = manager.getFlushThresholdUpdater(streamConfig);
     Assert.assertEquals(flushThresholdUpdaterSame.getClass(), SegmentSizeBasedFlushThresholdUpdater.class);
     Assert.assertEquals(flushThresholdUpdater, flushThresholdUpdaterSame);
-    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getDesiredSegmentSizeBytes(),
-        StreamConfig.getDefaultDesiredSegmentSizeBytes());
+//    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getDesiredSegmentSizeBytes(),
+//        StreamConfig.getDefaultDesiredSegmentSizeBytes());
 
     // flush size reset to some number - default received, map cleared of segmentsize based
-    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "20000");
+    streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
+    streamConfig = updateRowThreshold(streamConfig, 20000);
+//    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "20000");
     realtimeTableConfig = tableConfigBuilder.build();
-    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(streamConfig);
     Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
     Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 20000);
 
     // optimal segment size set to invalid value. Default remains the same.
+    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
+    tableConfigBuilder.setStreamConfigs(streamConfigs);
     streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "0");
     streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE, "Invalid");
     realtimeTableConfig = tableConfigBuilder.build();
-    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    streamConfig =
+        new PartitionLevelStreamConfig(realtimeTableConfig.getTableName(), realtimeTableConfig.getIndexingConfig().getStreamConfigs());
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(streamConfig);
     Assert.assertEquals(flushThresholdUpdater.getClass(), SegmentSizeBasedFlushThresholdUpdater.class);
-    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getDesiredSegmentSizeBytes(),
-        StreamConfig.getDefaultDesiredSegmentSizeBytes());
+//    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getDesiredSegmentSizeBytes(),
+//        StreamConfig.getDefaultDesiredSegmentSizeBytes());
 
     // Clear the flush threshold updater for this table.
     streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "20000");
     realtimeTableConfig = tableConfigBuilder.build();
-    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    streamConfig =
+        new PartitionLevelStreamConfig(realtimeTableConfig.getTableName(), realtimeTableConfig.getIndexingConfig().getStreamConfigs());
+    realtimeTableConfig = tableConfigBuilder.build();
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(streamConfig);
+    Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
 
     // optimal segment size set to 500M
-    long desiredSegSize = 500 * 1024 * 1024;
-    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "0");
-    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE, Long.toString(desiredSegSize));
+//    long desiredSegSize = 500 * 1024 * 1024;
+//    streamConfig = convertToAutoTune(streamConfig);
+//    streamConfig = updateDesiredSegmentSize(streamConfig, desiredSegSize);
+//    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "0");
+//    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE, Long.toString(desiredSegSize));
     realtimeTableConfig = tableConfigBuilder.build();
-    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
-    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getDesiredSegmentSizeBytes(),
-        desiredSegSize);
-    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getAutotuneInitialRows(),
-        DEFAULT_INITIAL_ROWS_THRESHOLD);
+//    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig, null);
+//    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getDesiredSegmentSizeBytes(),
+//        desiredSegSize);
+//    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getAutotuneInitialRows(),
+//        DEFAULT_INITIAL_ROWS_THRESHOLD);
 
     // initial rows threshold
-    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS, "500000");
-    realtimeTableConfig = tableConfigBuilder.build();
-    FlushThresholdUpdateManager newManager = new FlushThresholdUpdateManager();
-    flushThresholdUpdater = newManager.getFlushThresholdUpdater(realtimeTableConfig);
-    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getAutotuneInitialRows(),
-        500_000);
+//    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS, "500000");
+//    realtimeTableConfig = tableConfigBuilder.build();
+//    FlushThresholdUpdateManager newManager = new FlushThresholdUpdateManager();
+//    flushThresholdUpdater = newManager.getFlushThresholdUpdater(realtimeTableConfig, null);
+//    Assert.assertEquals(((SegmentSizeBasedFlushThresholdUpdater) (flushThresholdUpdater)).getAutotuneInitialRows(),
+//        500_000);
   }
 
   /**
@@ -356,6 +524,7 @@ public class FlushThresholdUpdaterTest {
     int seqNum = 0;
     long startOffset = 0;
     long committingSegmentSizeBytes = 0;
+    StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs(4);
 
     PartitionAssignment partitionAssignment = new PartitionAssignment(tableName);
     // 4 partitions assigned to 4 servers, 4 replicas => the segments should have 250k rows each (1M / 4)
@@ -373,14 +542,14 @@ public class FlushThresholdUpdaterTest {
     LLCRealtimeSegmentZKMetadata metadata0 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
 
     FlushThresholdUpdater flushThresholdUpdater = new DefaultFlushThresholdUpdater(tableFlushSize);
-    flushThresholdUpdater.updateFlushThreshold(metadata0, null, null, partitionAssignment);
+    flushThresholdUpdater.updateFlushThreshold(metadata0, streamConfig, null, null, partitionAssignment);
 
     Assert.assertEquals(metadata0.getSizeThresholdToFlushSegment(), 250_000);
     Assert.assertNull(metadata0.getTimeThresholdToFlushSegment());
 
     // before committing segment, we switched to size based updation - verify that new thresholds are set as per size based strategy
-    flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE,
-        DEFAULT_INITIAL_ROWS_THRESHOLD);
+    streamConfig = convertToAutoTune(streamConfig);
+    flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
 
     startOffset += 1000;
     updateCommittingSegmentMetadata(metadata0, startOffset, 250_000);
@@ -388,11 +557,12 @@ public class FlushThresholdUpdaterTest {
     CommittingSegmentDescriptor committingSegmentDescriptor =
         new CommittingSegmentDescriptor(metadata0.getSegmentName(), startOffset, committingSegmentSizeBytes);
     LLCRealtimeSegmentZKMetadata metadata1 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
-    flushThresholdUpdater.updateFlushThreshold(metadata1, metadata0, committingSegmentDescriptor, partitionAssignment);
+    flushThresholdUpdater.updateFlushThreshold(metadata1, streamConfig, metadata0, committingSegmentDescriptor, partitionAssignment);
     Assert.assertTrue(
         metadata1.getSizeThresholdToFlushSegment() != 0 && metadata1.getSizeThresholdToFlushSegment() != 250_000);
 
     // before committing we switched back to default strategy, verify that thresholds are set according to default logic
+    streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs(4);
     flushThresholdUpdater = new DefaultFlushThresholdUpdater(tableFlushSize);
 
     startOffset += 1000;
@@ -401,7 +571,7 @@ public class FlushThresholdUpdaterTest {
     committingSegmentDescriptor =
         new CommittingSegmentDescriptor(metadata1.getSegmentName(), startOffset, committingSegmentSizeBytes);
     LLCRealtimeSegmentZKMetadata metadata2 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
-    flushThresholdUpdater.updateFlushThreshold(metadata2, metadata1, committingSegmentDescriptor, partitionAssignment);
+    flushThresholdUpdater.updateFlushThreshold(metadata2, streamConfig, metadata1, committingSegmentDescriptor, partitionAssignment);
 
     Assert.assertEquals(metadata2.getSizeThresholdToFlushSegment(), 250_000);
     Assert.assertNull(metadata2.getTimeThresholdToFlushSegment());
@@ -409,20 +579,23 @@ public class FlushThresholdUpdaterTest {
 
   @Test
   public void testTimeThresholdInSegmentSizeBased() {
-    String tableName = "fakeTable_REALTIME";
     int partitionId = 0;
     int seqNum = 0;
     long startOffset = 0;
     long committingSegmentSizeBytes;
     CommittingSegmentDescriptor committingSegmentDescriptor;
+    StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
+    streamConfig = convertToAutoTune(streamConfig);
+    final String tableName = streamConfig.getTableNameWithType();
+
 
     // initial segment
     LLCRealtimeSegmentZKMetadata metadata0 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
     SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
-        new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE, DEFAULT_INITIAL_ROWS_THRESHOLD);
+        new SegmentSizeBasedFlushThresholdUpdater();
     committingSegmentDescriptor = new CommittingSegmentDescriptor(metadata0.getSegmentName(), startOffset, 0);
-    flushThresholdUpdater.updateFlushThreshold(metadata0, null, committingSegmentDescriptor, null);
-    Assert.assertEquals(metadata0.getSizeThresholdToFlushSegment(), flushThresholdUpdater.getAutotuneInitialRows());
+    flushThresholdUpdater.updateFlushThreshold(metadata0, streamConfig, null, committingSegmentDescriptor, null);
+    Assert.assertEquals(metadata0.getSizeThresholdToFlushSegment(), DEFAULT_INITIAL_ROWS_THRESHOLD);
 
     // next segment hit time threshold
     startOffset += 1000;
@@ -431,7 +604,7 @@ public class FlushThresholdUpdaterTest {
     committingSegmentDescriptor =
         new CommittingSegmentDescriptor(metadata0.getSegmentName(), startOffset, committingSegmentSizeBytes);
     LLCRealtimeSegmentZKMetadata metadata1 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
-    flushThresholdUpdater.updateFlushThreshold(metadata1, metadata0, committingSegmentDescriptor, null);
+    flushThresholdUpdater.updateFlushThreshold(metadata1, streamConfig, metadata0, committingSegmentDescriptor, null);
     Assert.assertEquals(metadata1.getSizeThresholdToFlushSegment(),
         (int) (metadata0.getTotalRawDocs() * flushThresholdUpdater.getRowsMultiplierWhenTimeThresholdHit()));
 
@@ -442,13 +615,12 @@ public class FlushThresholdUpdaterTest {
     committingSegmentDescriptor =
         new CommittingSegmentDescriptor(metadata1.getSegmentName(), startOffset, committingSegmentSizeBytes);
     LLCRealtimeSegmentZKMetadata metadata2 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
-    flushThresholdUpdater.updateFlushThreshold(metadata2, metadata1, committingSegmentDescriptor, null);
+    flushThresholdUpdater.updateFlushThreshold(metadata2, streamConfig, metadata1, committingSegmentDescriptor, null);
     Assert.assertTrue(metadata2.getSizeThresholdToFlushSegment() != metadata1.getSizeThresholdToFlushSegment());
   }
 
   @Test
   public void testMinThreshold() {
-    String tableName = "fakeTable_REALTIME";
     final int partitionId = 0;
     int seqNum = 0;
     long startOffset = 0;
@@ -458,12 +630,15 @@ public class FlushThresholdUpdaterTest {
     long seg0time = now - 1334_650;
     long seg1time = seg0time + 14_000;
 
+    final StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
+    final String tableName = streamConfig.getTableNameWithType();
+
     // initial segment consumes only 15 rows, so next segment has 10k rows min.
     LLCSegmentName seg0SegmentName = new LLCSegmentName(tableName, partitionId, seqNum, seg0time);
     LLCRealtimeSegmentZKMetadata metadata0 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
     metadata0.setSegmentName(seg0SegmentName.getSegmentName());
     SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
-        new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE, DEFAULT_INITIAL_ROWS_THRESHOLD);
+        new SegmentSizeBasedFlushThresholdUpdater();
     committingSegmentDescriptor =
         new CommittingSegmentDescriptor(seg0SegmentName.getSegmentName(), startOffset, 10_000);
     metadata0.setTotalRawDocs(15);
@@ -473,7 +648,7 @@ public class FlushThresholdUpdaterTest {
     LLCRealtimeSegmentZKMetadata metadata1 = new LLCRealtimeSegmentZKMetadata();
     metadata1.setSegmentName(seg1SegmentName.getSegmentName());
     metadata1.setCreationTime(seg1time);
-    flushThresholdUpdater.updateFlushThreshold(metadata1, metadata0, committingSegmentDescriptor, null);
+    flushThresholdUpdater.updateFlushThreshold(metadata1, streamConfig, metadata0, committingSegmentDescriptor, null);
     Assert.assertEquals(metadata1.getSizeThresholdToFlushSegment(), flushThresholdUpdater.getMinimumNumRowsThreshold());
 
     // seg1 also consumes 20 rows, so seg2 also gets 10k as threshold.
@@ -484,21 +659,23 @@ public class FlushThresholdUpdaterTest {
     committingSegmentDescriptor =
         new CommittingSegmentDescriptor(seg1SegmentName.getSegmentName(), startOffset + 1000, 14_000);
     metadata1.setTotalRawDocs(25);
-    flushThresholdUpdater.updateFlushThreshold(metadata2, metadata1, committingSegmentDescriptor, null);
+    flushThresholdUpdater.updateFlushThreshold(metadata2, streamConfig, metadata1, committingSegmentDescriptor, null);
     Assert.assertEquals(metadata2.getSizeThresholdToFlushSegment(), flushThresholdUpdater.getMinimumNumRowsThreshold());
   }
 
   @Test
   public void testNonZeroPartitionUpdates() {
-    String tableName = "fakeTable_REALTIME";
     int seqNum = 0;
     long startOffset = 0;
     CommittingSegmentDescriptor committingSegmentDescriptor;
     long now = System.currentTimeMillis();
     long seg0time = now - 1334_650;
     long seg1time = seg0time + 14_000;
+    final StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
+    final String tableName = streamConfig.getTableNameWithType();
+
     SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
-        new SegmentSizeBasedFlushThresholdUpdater(DESIRED_SEGMENT_SIZE, DEFAULT_INITIAL_ROWS_THRESHOLD);
+        new SegmentSizeBasedFlushThresholdUpdater();
 
     // Initial update is from partition 1
     LLCSegmentName seg0SegmentName = new LLCSegmentName(tableName, 1, seqNum, seg0time);
@@ -514,7 +691,7 @@ public class FlushThresholdUpdaterTest {
     metadata1.setSegmentName(seg1SegmentName.getSegmentName());
     metadata1.setCreationTime(seg1time);
     Assert.assertEquals(flushThresholdUpdater.getLatestSegmentRowsToSizeRatio(), 0.0);
-    flushThresholdUpdater.updateFlushThreshold(metadata1, metadata0, committingSegmentDescriptor, null);
+    flushThresholdUpdater.updateFlushThreshold(metadata1, streamConfig, metadata0, committingSegmentDescriptor, null);
     final double currentRatio = flushThresholdUpdater.getLatestSegmentRowsToSizeRatio();
     Assert.assertTrue(currentRatio > 0.0);
 
@@ -527,13 +704,13 @@ public class FlushThresholdUpdaterTest {
     committingSegmentDescriptor =
         new CommittingSegmentDescriptor(seg1SegmentName.getSegmentName(), startOffset + 1000, 256_000_000);
     metadata1.setTotalRawDocs(2_980_880);
-    flushThresholdUpdater.updateFlushThreshold(metadata2, metadata1, committingSegmentDescriptor, null);
+    flushThresholdUpdater.updateFlushThreshold(metadata2, streamConfig, metadata1, committingSegmentDescriptor, null);
     Assert.assertEquals(flushThresholdUpdater.getLatestSegmentRowsToSizeRatio(), currentRatio);
 
     // But if seg1 is from partition 0, the ratio is changed.
     seg1SegmentName = new LLCSegmentName(tableName, 0, seqNum + 1, seg1time);
     metadata1.setSegmentName(seg1SegmentName.getSegmentName());
-    flushThresholdUpdater.updateFlushThreshold(metadata2, metadata1, committingSegmentDescriptor, null);
+    flushThresholdUpdater.updateFlushThreshold(metadata2, streamConfig, metadata1, committingSegmentDescriptor, null);
     Assert.assertTrue(flushThresholdUpdater.getLatestSegmentRowsToSizeRatio() != currentRatio);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
@@ -137,6 +137,16 @@ public class FakeStreamConfigUtils {
     return getDefaultLowLevelStreamConfigs(DEFAULT_NUM_PARTITIONS);
   }
 
+  public static StreamConfig replaceProperties(StreamConfig streamConfig, long desiredSegmentSize,
+      int initialAutoTuneRows, long timeThresholdMillis, int rowThreshold) {
+    Map<String, String> streamConfigsMap = streamConfig.getStreamConfigsMap();
+    streamConfigsMap.put(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE, String.valueOf(desiredSegmentSize));
+    streamConfigsMap.put(StreamConfigProperties.SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS, String.valueOf(initialAutoTuneRows));
+    streamConfigsMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, String.valueOf(timeThresholdMillis));
+    streamConfigsMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, String.valueOf(rowThreshold));
+    return new StreamConfig(streamConfig.getTableNameWithType(), streamConfigsMap);
+  }
+
   /**
    * Generate fake stream configs for high level stream
    */


### PR DESCRIPTION
When any of the parameters of segment auto-tuning are changed, we currently
miss picking them up, since we cache the FlushThreshodUpdater in
memory in the controller. A controller restart will pick up the
new parameters, but we can do better.

Changed the auto-tuning mechanism to take parameters on every call, so
that we can recognize chantges and act accordingly.

Extra logic added:
We used to consider that we hit the time limit any time when the
number of rows in committing segment is lower than the target
we set for it. Now, we also check that the target segment size
must be lower than the desired size. If the target segment size
is higher (most likely because the operator set it higher),
we need to fall through to the computation based on ratio.

Further,

When we hit the time limit in the committing segment, it may
be the case that the new time limit is even lower than the time we
spend consuming the segment being committed.
In that case, we should reduce the number of rows consumed by
the committing segment (as per the average consumption rate)
before applying the standard multiplier when we hit the time limit.

Some examples are useful, since the logic is a bit involved:

Assume segment size was set to 200M, and time limit was 3h, and we
set the number of rows to 4M, and let a segment start consuming.

Case-1:
While it is consuming, the operator  changes the optimal segment
size to 180 M.
The segment comes back with a 190M size after hitting the time limit.
and consumes 3.8M rows.

Previously, we would have increased the number of rows as 3.8M * 1.1

After this change, we will fall through to computing the rows using the
ratio (and effectively reduce the number of rows).

Case 2:
The operator changes the time limit to 1 hr.
The segment comes back the same way as before, 190M size, 3.8M rows
consumed in 3 hrs.

Previously, we would have treated this as a time limit hit, and
increased the number of rows to 3.8M * 1.1

After this change, we will assume that the segment actually consumed
(3.8M * 1 hr)/3hrs (i.e. approx 1.3M rows, and then apply the multiplier,
getting a value of about 1.4M rows target.