### PR TITLE
Remove validation for config controller.host

### DIFF
--- a/kubernetes/examples/gke/skaffold/pinot-broker.yml
+++ b/kubernetes/examples/gke/skaffold/pinot-broker.yml
@@ -52,7 +52,7 @@ items:
         spec:
           terminationGracePeriodSeconds: 30
           containers:
-          - image: winedepot/pinot:kafka2
+          - image: winedepot/pinot:0.1.13-SNAPSHOT
             imagePullPolicy: Always
             name: pinot-broker
             args: [

--- a/kubernetes/examples/gke/skaffold/pinot-controller.yml
+++ b/kubernetes/examples/gke/skaffold/pinot-controller.yml
@@ -28,7 +28,6 @@ items:
     data:
       pinot-controller.conf: |-
         controller.helix.cluster.name=pinot-quickstart
-        controller.host=pinot-controller-0.pinot-controller
         controller.port=9000
         controller.vip.host=pinot-controller
         controller.vip.port=9000
@@ -56,7 +55,7 @@ items:
         spec:
           terminationGracePeriodSeconds: 30
           containers:
-          - image: winedepot/pinot:kafka2
+          - image: winedepot/pinot:0.1.13-SNAPSHOT
             imagePullPolicy: Always
             name: pinot-controller
             args: [

--- a/kubernetes/examples/gke/skaffold/pinot-server.yml
+++ b/kubernetes/examples/gke/skaffold/pinot-server.yml
@@ -53,7 +53,7 @@ items:
         spec:
           terminationGracePeriodSeconds: 30
           containers:
-          - image: winedepot/pinot:kafka2
+          - image: winedepot/pinot:0.1.13-SNAPSHOT
             imagePullPolicy: Always
             name: pinot-server
             args: [

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -197,11 +197,6 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
       return false;
     }
 
-    if (conf.getControllerHost() == null) {
-      LOGGER.error("Error: missing hostname, please specify 'controller.host' property in config file.");
-      return false;
-    }
-
     if (conf.getControllerPort() == null) {
       LOGGER.error("Error: missing controller port, please specify 'controller.port' property in config file.");
       return false;


### PR DESCRIPTION
Currently controller requires to set `controller.host` explicitly in config file, which complicates k8s setup.
ControllerStarter itself already has the ability(https://github.com/apache/incubator-pinot/pull/4517) to infer hostname if not set this config.
Just we haven't updated StartControllerCommand script to reflect this change.