### PR TITLE
[TE] handle data insufficient exceptions in the detection pipeline

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
@@ -267,8 +267,8 @@ public class DimensionWrapper extends DetectionPipeline {
         diagnostics.put(metric.getUrn(), intermediate.getDiagnostics());
         predictionResults.addAll(intermediate.getPredictions());
       }
-      // if either one detector run successfully, mark the dimension as successful
-      if (exceptionsForNestedMetric.size() != this.nestedProperties.size()) {
+      // for one dimension, if all detectors run successfully, mark the dimension as successful
+      if (exceptionsForNestedMetric.isEmpty()) {
         successNestedMetrics++;
       }
       exceptions.addAll(exceptionsForNestedMetric);
@@ -307,7 +307,7 @@ public class DimensionWrapper extends DetectionPipeline {
    * thrown by one detector should not block other detectors's result.
    *
    * @param totalNestedMetrics the total number of nested metrics
-   * @param successNestedMetrics the successfully generated nested metrics
+   * @param successNestedMetrics the successfully run nested metrics
    * @param exceptions the list of all exceptions
    * @param predictions the prediction results generated, which can tell us whether there are detectors run successfully.
    * @throws DetectionPipelineException the exception to throw

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
@@ -318,8 +318,12 @@ public class DimensionWrapper extends DetectionPipeline {
     if (successNestedMetrics == 0 && totalNestedMetrics > 0) {
       // if all exceptions are caused by DetectorDataInsufficientException and
       // there are other detectors run successfully, keep the detection running
-      if (!exceptions.stream().allMatch(e -> e.getCause() instanceof DetectorDataInsufficientException)
-          || predictions.size() == 0) {
+      if (exceptions.stream().allMatch(e -> e.getCause() instanceof DetectorDataInsufficientException)
+          && predictions.size() != 0) {
+        LOG.warn(
+            "The detection pipeline {} for monitoring window {} to {} is having detectors throwing the DataInsufficientException, "
+                + "but the result for other successful detectors are preserved", this.config.getId(), this.getStartTime(), this.getEndTime());
+      } else {
         throw new DetectionPipelineException(String.format(
             "Detection failed for all nested dimensions for detection config id %d for monitoring window %d to %d.",
             this.config.getId(), this.getStartTime(), this.getEndTime()), Iterables.getLast(exceptions));


### PR DESCRIPTION
When new metrics are on-boarded into ThirdEye, we expect the detector to throw a checked exception on the case that the data is insufficient to make a decision on whether it is an anomaly. 

This RB makes that if such a case happens, instead of failing the detection pipeline, it will check if there are any other detectors successfully executes and keep the result.