### PR TITLE
Remove "refresh" usecase check in RoutingTableBuilderFactory

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTableBuilderFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTableBuilderFactory.java
@@ -117,13 +117,7 @@ public class RoutingTableBuilderFactory {
 
         // Check that replica group strategy config is correctly set
         boolean hasReplicaGroupStrategyConfig = (validationConfig.getReplicaGroupStrategyConfig() != null);
-
-        // Check that the table push type is not 'refresh'.
-        boolean isNotRefreshPush =
-            (validationConfig.getSegmentPushType() != null) && !validationConfig.getSegmentPushType()
-                .equalsIgnoreCase("REFRESH");
-
-        if (isSegmentAssignmentStrategyCorrect && hasReplicaGroupStrategyConfig && isNotRefreshPush) {
+        if (isSegmentAssignmentStrategyCorrect && hasReplicaGroupStrategyConfig) {
           builder = new PartitionAwareOfflineRoutingTableBuilder();
         } else {
           builder = new DefaultOfflineRoutingTableBuilder();


### PR DESCRIPTION
We have created "DefaultOfflineRoutingTableBuilder" when the
use case is a refresh use case. Since PartitionAwareOffline
should work with the refresh table, we are removing the check.