### PR TITLE
Modify the logic of getting tenant names APIs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -44,7 +44,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.AccessOption;
-import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.Criteria;
 import org.apache.helix.HelixAdmin;
@@ -801,10 +800,9 @@ public class PinotHelixResourceManager {
 
   public Set<String> getAllBrokerTenantNames() {
     Set<String> tenantSet = new HashSet<>();
-    List<String> instancesInCluster = _helixAdmin.getInstancesInCluster(_helixClusterName);
-    for (String instanceName : instancesInCluster) {
-      InstanceConfig config = _helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
-      for (String tag : config.getTags()) {
+    List<InstanceConfig> instanceConfigs = getAllHelixInstanceConfigs();
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      for (String tag : instanceConfig.getTags()) {
         if (TagNameUtils.isBrokerTag(tag)) {
           tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
         }
@@ -815,10 +813,9 @@ public class PinotHelixResourceManager {
 
   public Set<String> getAllServerTenantNames() {
     Set<String> tenantSet = new HashSet<>();
-    List<String> instancesInCluster = _helixAdmin.getInstancesInCluster(_helixClusterName);
-    for (String instanceName : instancesInCluster) {
-      InstanceConfig config = _helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
-      for (String tag : config.getTags()) {
+    List<InstanceConfig> instanceConfigs = getAllHelixInstanceConfigs();
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      for (String tag : instanceConfig.getTags()) {
         if (TagNameUtils.isServerTag(tag)) {
           tenantSet.add(TagNameUtils.getTenantNameFromTag(tag));
         }


### PR DESCRIPTION
This PR modifies the logic of getting tenant name APIs.

The previous code firstly gets the list of instance names from `/INSTANCES` ZNode and then gets the instance config one by one from `/CONFIG/PARTICIPANT/INSTANCES` ZNode. Whereas these two ZNodes may be inconsistent. 
That's why we sometimes encounter flaky NPE when calling these APIs.

Sample exception:
```
java.lang.NullPointerException
	at org.apache.pinot.controller.helix.core.PinotHelixResourceManager.getAllBrokerTenantNames(PinotHelixResourceManager.java:808)
	at org.apache.pinot.controller.helix.core.PinotHelixResourceManagerTest.testRetrieveTenantNames(PinotHelixResourceManagerTest.java:278)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:108)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:661)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:869)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1193)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:126)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
	at org.testng.TestRunner.privateRun(TestRunner.java:744)
	at org.testng.TestRunner.run(TestRunner.java:602)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:380)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:375)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:340)
	at org.testng.SuiteRunner.run(SuiteRunner.java:289)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1301)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1226)
	at org.testng.TestNG.runSuites(TestNG.java:1144)
	at org.testng.TestNG.run(TestNG.java:1115)
	at org.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:73)
	at org.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:123)
```