### PR TITLE
Fetch new schema when loading committed real-time segments

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -34,7 +34,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.config.IndexingConfig;
 import org.apache.pinot.common.config.TableConfig;
-import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
@@ -48,13 +47,11 @@ import org.apache.pinot.common.utils.SegmentName;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.data.manager.BaseTableDataManager;
 import org.apache.pinot.core.data.manager.SegmentDataManager;
-import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.core.segment.index.loader.LoaderUtils;
-
-import static org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSchema;
+import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory;
 
 
 @ThreadSafe
@@ -180,12 +177,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     return consumerDir.getAbsolutePath();
   }
 
-  public void notifySegmentCommitted(String tableNameWithType, RealtimeSegmentZKMetadata metadata,
-      ImmutableSegment segment) {
-    ZKMetadataProvider.setRealtimeSegmentZKMetadata(_propertyStore, tableNameWithType, metadata);
-    addSegment(segment);
-  }
-
   /*
    * This call comes in one of two ways:
    * For HL Segments:
@@ -205,9 +196,18 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   public void addSegment(@Nonnull String segmentName, @Nonnull TableConfig tableConfig,
       @Nonnull IndexLoadingConfig indexLoadingConfig)
       throws Exception {
+    SegmentDataManager segmentDataManager = _segmentDataManagerMap.get(segmentName);
+    if (segmentDataManager != null) {
+      _logger.warn("Skipping adding existing segment: {} for table: {} with data manager class: {}", segmentName,
+          _tableNameWithType, segmentDataManager.getClass().getSimpleName());
+      return;
+    }
+
     RealtimeSegmentZKMetadata realtimeSegmentZKMetadata =
         ZKMetadataProvider.getRealtimeSegmentZKMetadata(_propertyStore, _tableNameWithType, segmentName);
     Preconditions.checkNotNull(realtimeSegmentZKMetadata);
+    Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
+    Preconditions.checkNotNull(schema);
 
     File indexDir = new File(_indexDir, segmentName);
     // Restart during segment reload might leave segment in inconsistent state (index directory might not exist but
@@ -216,35 +216,19 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     LoaderUtils.reloadFailureRecovery(indexDir);
 
     if (indexDir.exists() && (realtimeSegmentZKMetadata.getStatus() == Status.DONE)) {
-      // segment already exists on file, and we have committed the realtime segment in ZK. Treat it like an offline segment
-      SegmentDataManager segmentDataManager = _segmentDataManagerMap.get(segmentName);
-      if (segmentDataManager != null) {
-        _logger.warn("Got reload for segment already on disk {} table {}, have {}", segmentName, _tableNameWithType,
-            segmentDataManager.getClass().getSimpleName());
-        return;
-      }
+      // Segment already exists on disk, and metadata has been committed. Treat it like an offline segment
 
-      ImmutableSegment segment = ImmutableSegmentLoader.load(indexDir, indexLoadingConfig);
-      addSegment(segment);
+      addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
     } else {
       // Either we don't have the segment on disk or we have not committed in ZK. We should be starting the consumer
       // for realtime segment here. If we wrote it on disk but could not get to commit to zk yet, we should replace the
       // on-disk segment next time
-      SegmentDataManager segmentDataManager = _segmentDataManagerMap.get(segmentName);
-      if (segmentDataManager != null) {
-        _logger.warn("Got reload for segment not on disk {} table {}, have {}", segmentName, _tableNameWithType,
-            segmentDataManager.getClass().getSimpleName());
-        return;
-      }
 
-      Schema schema = ZKMetadataProvider
-          .getTableSchema(_propertyStore, TableNameBuilder.REALTIME.tableNameWithType(_tableNameWithType));
-      Preconditions.checkNotNull(schema);
       if (!isValid(schema, tableConfig.getIndexingConfig())) {
         _logger.error("Not adding segment {}", segmentName);
         throw new RuntimeException("Mismatching schema/table config for " + _tableNameWithType);
       }
-      addBuiltInVirtualColumnsToSchema(schema);
+      VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSchema(schema);
 
       InstanceZKMetadata instanceZKMetadata = ZKMetadataProvider.getInstanceZKMetadata(_propertyStore, _instanceId);
 
@@ -270,8 +254,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   public void downloadAndReplaceSegment(@Nonnull String segmentName,
       @Nonnull LLCRealtimeSegmentZKMetadata llcSegmentMetadata, @Nonnull IndexLoadingConfig indexLoadingConfig) {
     final String uri = llcSegmentMetadata.getDownloadUrl();
-    File tempSegmentFolder =
-        new File(_indexDir, "tmp-" + segmentName + "." + String.valueOf(System.currentTimeMillis()));
+    File tempSegmentFolder = new File(_indexDir, "tmp-" + segmentName + "." + System.currentTimeMillis());
     File tempFile = new File(_indexDir, segmentName + ".tar.gz");
     final File segmentFolder = new File(_indexDir, segmentName);
     FileUtils.deleteQuietly(segmentFolder);
@@ -291,11 +274,25 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     }
   }
 
-  // Replace a committed segment.
-  public void replaceLLSegment(@Nonnull String segmentName, @Nonnull IndexLoadingConfig indexLoadingConfig) {
+  /**
+   * Replaces a committed HLC REALTIME segment.
+   */
+  public void replaceHLSegment(RealtimeSegmentZKMetadata segmentZKMetadata, IndexLoadingConfig indexLoadingConfig)
+      throws Exception {
+    ZKMetadataProvider.setRealtimeSegmentZKMetadata(_propertyStore, _tableNameWithType, segmentZKMetadata);
+    File indexDir = new File(_indexDir, segmentZKMetadata.getSegmentName());
+    Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
+    addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
+  }
+
+  /**
+   * Replaces a committed LLC REALTIME segment.
+   */
+  public void replaceLLSegment(String segmentName, IndexLoadingConfig indexLoadingConfig) {
     try {
-      ImmutableSegment indexSegment = ImmutableSegmentLoader.load(new File(_indexDir, segmentName), indexLoadingConfig);
-      addSegment(indexSegment);
+      File indexDir = new File(_indexDir, segmentName);
+      Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
+      addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -56,7 +56,7 @@ public class ImmutableSegmentLoader {
   /**
    * For tests only.
    */
-  public static ImmutableSegment load(@Nonnull File indexDir, @Nonnull ReadMode readMode)
+  public static ImmutableSegment load(File indexDir, ReadMode readMode)
       throws Exception {
     IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig();
     defaultIndexLoadingConfig.setReadMode(readMode);
@@ -64,22 +64,14 @@ public class ImmutableSegmentLoader {
   }
 
   /**
-   * For segments from REALTIME table.
-   * <p>
-   * NOTE: Currently REALTIME data manager does not have mechanism to download a new segment copy from controller and
-   * reload the segment when encountering exception during segment load (HLC maintains segment on server side only),
-   * so REALTIME table should always use this method without passing schema.
+   * For tests only.
    */
-  public static ImmutableSegment load(@Nonnull File indexDir, @Nonnull IndexLoadingConfig indexLoadingConfig)
+  public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
     return load(indexDir, indexLoadingConfig, null);
   }
 
-  /**
-   * For segments from OFFLINE table.
-   */
-  public static ImmutableSegment load(@Nonnull File indexDir, @Nonnull IndexLoadingConfig indexLoadingConfig,
-      @Nullable Schema schema)
+  public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig, @Nullable Schema schema)
       throws Exception {
     Preconditions
         .checkArgument(indexDir.isDirectory(), "Index directory: {} does not exist or is not a directory", indexDir);


### PR DESCRIPTION
We added real-time reload support in #4335 and #4349 to generate
default columns for committed segments. But the consuming segments
won't have default columns generated. In order to support default
columns for real-time segments, when loading the committed real-time
segments, we need to fetch the latest schema from the cluster.

With this fix, after applying the new schema, new committed segments
will have the default columns generated for the new added columns.