### PR TITLE
Fix simple date time column segment generation test

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.pinot.core.segment.index.creator;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.data.DimensionFieldSpec;
@@ -43,6 +43,7 @@ import org.joda.time.LocalDateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -56,12 +57,19 @@ public class SegmentGenerationWithTimeColumnTest {
   private static final String SEGMENT_NAME = "testSegment";
   private static final int NUM_ROWS = 10000;
 
-  private Random _random = new Random(System.nanoTime());
+  private long seed = System.nanoTime();
+  private Random _random = new Random(seed);
 
   private long validMinTime = TimeUtils.getValidMinTimeMillis();
+  private long validMaxTime = TimeUtils.getValidMaxTimeMillis();
   private long minTime;
   private long maxTime;
   private long startTime = System.currentTimeMillis();
+
+  @BeforeClass
+  public void printSeed() {
+    System.out.println("Seed is: "+ seed);
+  }
 
   @BeforeMethod
   public void reset() {
@@ -180,7 +188,8 @@ public class SegmentGenerationWithTimeColumnTest {
   }
 
   private Object getRandomValueForTimeColumn(boolean isSimpleDate, boolean isInvalidDate) {
-    long randomMs = ThreadLocalRandom.current().nextLong(validMinTime, startTime);
+    long randomMs = validMinTime + (long)(_random.nextDouble() * (startTime - validMinTime));
+    Preconditions.checkArgument(TimeUtils.timeValueInValidRange(randomMs), "Value " + randomMs +" out of range");
     long dateColVal = randomMs;
     Object result;
     if (isInvalidDate) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -155,6 +155,30 @@ public class SegmentGenerationWithTimeColumnTest {
     return RawIndexCreatorTest.getRandomValue(_random, fieldSpec.getDataType());
   }
 
+  @Test
+  public void testMinAllowedValue() {
+    long millis = validMinTime; // is in UTC from epoch (19710101)
+
+    // if we don't use timezone, it will use System default or JDK default (PST)
+    DateTime dateTime = new DateTime(millis);
+    LocalDateTime localDateTime = dateTime.toLocalDateTime();
+    int year = localDateTime.getYear();
+    int month = localDateTime.getMonthOfYear();
+    int day = localDateTime.getDayOfMonth();
+    Assert.assertEquals(year, 1970);
+    Assert.assertEquals(month, 12);
+    Assert.assertEquals(day, 31);
+
+    dateTime = new DateTime(millis, DateTimeZone.UTC);
+    localDateTime = dateTime.toLocalDateTime();
+    year = localDateTime.getYear();
+    month = localDateTime.getMonthOfYear();
+    day = localDateTime.getDayOfMonth();
+    Assert.assertEquals(year, 1971);
+    Assert.assertEquals(month, 1);
+    Assert.assertEquals(day, 1);
+  }
+
   private Object getRandomValueForTimeColumn(boolean isSimpleDate, boolean isInvalidDate) {
     long randomMs = ThreadLocalRandom.current().nextLong(validMinTime, startTime);
     long dateColVal = randomMs;
@@ -163,7 +187,7 @@ public class SegmentGenerationWithTimeColumnTest {
       result = new Long(new DateTime(2072, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis());
       return result;
     } else if (isSimpleDate) {
-      DateTime dateTime = new DateTime(randomMs);
+      DateTime dateTime = new DateTime(randomMs, DateTimeZone.UTC);
       LocalDateTime localDateTime = dateTime.toLocalDateTime();
       int year = localDateTime.getYear();
       int month = localDateTime.getMonthOfYear();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -166,22 +166,11 @@ public class SegmentGenerationWithTimeColumnTest {
   @Test
   public void testMinAllowedValue() {
     long millis = validMinTime; // is in UTC from epoch (19710101)
-
-    // if we don't use timezone, it will use System default or JDK default (PST)
-    DateTime dateTime = new DateTime(millis);
+    DateTime dateTime = new DateTime(millis, DateTimeZone.UTC);
     LocalDateTime localDateTime = dateTime.toLocalDateTime();
     int year = localDateTime.getYear();
     int month = localDateTime.getMonthOfYear();
     int day = localDateTime.getDayOfMonth();
-    Assert.assertEquals(year, 1970);
-    Assert.assertEquals(month, 12);
-    Assert.assertEquals(day, 31);
-
-    dateTime = new DateTime(millis, DateTimeZone.UTC);
-    localDateTime = dateTime.toLocalDateTime();
-    year = localDateTime.getYear();
-    month = localDateTime.getMonthOfYear();
-    day = localDateTime.getDayOfMonth();
     Assert.assertEquals(year, 1971);
     Assert.assertEquals(month, 1);
     Assert.assertEquals(day, 1);


### PR DESCRIPTION
TimeUtils (Pinot code) is using UTC time zone to specify 
allowed segment minTime and maxTime for time column values.

For the particular test testSimpleDateSegmentGeneration that sometimes
failed, we were generating random value of milliseconds
between TimeUtils.getValidMinTimeMillis() and System.currentTimeInMillis.

This random value was then used to build a DateTime with
format yyyymmdd since the test is for simple date format.

The problem happens when the random generated value is in fact
equal to TimeUtils.getValidMinTimeMillis() = 31536000000ms.
Converting this to DateTime would lead to 19701231 date since
we didn't specify the time zone and it uses the default (JDK's)
which happens to be PST (behind UTC)

Subsequently during segment generation we get this simple date
(19701231) as the minDate and we convert it back to millis
before we do the validation against allowed min time.

The converted millis will be slightly less than 31536000000ms
since we didn't take care of the timezone originally when
we generated the random value and it defaulted to PST. Thus
the validity check against min/max allowed values will fail.

The fix is to get the DateTime from millis in UTC in the test code.
This would ensure that if we happen to get the random value as
the minimum allowed value 31536000000ms, it would imply 19710101
in DateTime for yyyymmdd format and not 19701231
 
When this date is later used during segment generation code,
the converted millis are within the range and validity check passes

cc @mcvsubbu 