### PR TITLE
check start time in range when deciding if needs notification

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -60,6 +60,8 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   List<MergedAnomalyResultDTO> findByStartTimeInRangeAndFunctionId(long startTime, long endTime, long functionId);
 
+  List<MergedAnomalyResultDTO> findByStartEndTimeInRangeAndDetectionConfigId(long startTime, long endTime, long detectionConfigId);
+
   List<MergedAnomalyResultDTO> findByStartTimeInRangeAndDetectionConfigId(long startTime, long endTime, long detectionConfigId);
 
   List<MergedAnomalyResultDTO> findByTime(long startTime, long endTime);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -259,7 +259,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findByStartTimeInRangeAndDetectionConfigId(long startTime, long endTime,
+  public List<MergedAnomalyResultDTO> findByStartEndTimeInRangeAndDetectionConfigId(long startTime, long endTime,
       long detectionConfigId) {
     Predicate predicate =
         Predicate.AND(Predicate.LT("startTime", endTime), Predicate.GT("endTime", startTime),
@@ -267,6 +267,16 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
     return convertMergedAnomalyBean2DTO(list);
   }
+
+  @Override
+  public List<MergedAnomalyResultDTO> findByStartTimeInRangeAndDetectionConfigId(long startTime, long endTime, long detectionConfigId) {
+    Predicate predicate =
+        Predicate.AND(Predicate.GE("startTime", startTime), Predicate.LT("startTime", endTime),
+            Predicate.EQ("detectionConfigId", detectionConfigId));
+    List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
+    return convertMergedAnomalyBean2DTO(list);
+  }
+
 
   @Override
   public List<MergedAnomalyResultDTO> findByCollectionMetricDimensionsTime(String collection, String metric,

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertJob.java
@@ -106,7 +106,13 @@ public class DetectionAlertJob implements Job {
 
   /**
    * Check if we need to create a notification task.
-   * If there is no anomaly generated between last notification time till now then no need to create this task.
+   * If there is no anomaly generated (by looking at anomaly start_time) between last notification time
+   * till now (left inclusive, right exclusive) then no need to create this task.
+   *
+   * The reason we use start_time is end_time is not accurate due to anomaly merge.
+   * The timestamp stored in vectorLock is anomaly end_time, which should be fine.
+   * For example, if previous anomaly is from t1 to t2, then the timestamp in vectorLock is t2.
+   * If there is a new anomaly generated from t2 to t3 then we can still get this anomaly.
    *
    * @param configDTO The DetectionAlert Configuration.
    * @return true if it needs notification task. false otherwise.

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
@@ -142,6 +142,34 @@ public class TestMergedAnomalyResultManager{
   }
 
   @Test
+  public void testFindByStartEndTimeInRangeAndDetectionConfigId() {
+    long detectionConfigId = detectionConfigDAO.save(mockDetectionConfig());
+    List<MergedAnomalyResultDTO> anomalies = mockAnomalies(detectionConfigId);
+    for (MergedAnomalyResultDTO anomaly : anomalies) {
+      this.mergedAnomalyResultDAO.save(anomaly);
+    }
+    List<MergedAnomalyResultDTO> fetchedAnomalies = mergedAnomalyResultDAO
+        .findByStartEndTimeInRangeAndDetectionConfigId(
+            new DateTime(2019, 1, 1, 0, 0).getMillis(),
+            new DateTime(2019, 1, 3, 0, 0).getMillis(),
+            detectionConfigId);
+    Assert.assertEquals(fetchedAnomalies.size(), anomalies.size());
+    for (int i = 0; i < anomalies.size(); i ++) {
+      MergedAnomalyResultDTO actual = fetchedAnomalies.get(i);
+      MergedAnomalyResultDTO expected = anomalies.get(i);
+      Assert.assertNotNull(actual.getId());
+      Assert.assertEquals(actual.getDetectionConfigId(), expected.getDetectionConfigId());
+      Assert.assertEquals(actual.getDimensions(), expected.getDimensions());
+    }
+    // Clean up
+    for (int i = 0; i < anomalies.size(); i++) {
+      this.mergedAnomalyResultDAO.delete(fetchedAnomalies.get(i));
+    }
+    this.detectionConfigDAO.deleteById(detectionConfigId);
+  }
+
+
+  @Test
   public void testFindByStartTimeInRangeAndDetectionConfigId() {
     long detectionConfigId = detectionConfigDAO.save(mockDetectionConfig());
     List<MergedAnomalyResultDTO> anomalies = mockAnomalies(detectionConfigId);
@@ -149,7 +177,7 @@ public class TestMergedAnomalyResultManager{
       this.mergedAnomalyResultDAO.save(anomaly);
     }
     List<MergedAnomalyResultDTO> fetchedAnomalies = mergedAnomalyResultDAO
-        .findByStartTimeInRangeAndDetectionConfigId(
+        .findByStartEndTimeInRangeAndDetectionConfigId(
             new DateTime(2019, 1, 1, 0, 0).getMillis(),
             new DateTime(2019, 1, 3, 0, 0).getMillis(),
             detectionConfigId);


### PR DESCRIPTION
Currently we still see lots of notification tasks created with no anomaly to notify.
The reason is in the vectorClock of the notification task it stores the end_time of the last notified anomaly.
However the end_time may change due to merge. If merge happens then the last notified anomaly will have a newer end_time, and alert task scheduler thought it is a new anomaly.

We can fix it by only check start_time.
If there is new anomaly generated, then there should be anomaly with start_time larger than the  last notified anomaly's end_time (when notified).