### PR TITLE
Hotfix for Selection Comparator (triggering the Travis tests)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.query;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -88,51 +89,49 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
   }
 
   private Comparator<Serializable[]> getComparator() {
-    return (o1, o2) -> {
-      int numOrderByExpressions = _sortSequence.size();
-      for (int i = 0; i < numOrderByExpressions; i++) {
-        // Only compare single-value columns
-        if (!_expressionMetadata[i].isSingleValue()) {
-          continue;
-        }
-
-        Serializable v1 = o1[i];
-        Serializable v2 = o2[i];
-
-        int result;
-        switch (_expressionMetadata[i].getDataType()) {
-          case INT:
-            result = ((Integer) v1).compareTo((Integer) v2);
-            break;
-          case LONG:
-            result = ((Long) v1).compareTo((Long) v2);
-            break;
-          case FLOAT:
-            result = ((Float) v1).compareTo((Float) v2);
-            break;
-          case DOUBLE:
-            result = ((Double) v1).compareTo((Double) v2);
-            break;
-          case STRING:
-            result = ((String) v1).compareTo((String) v2);
-            break;
-          case BYTES:
-            result = ByteArray.compare((byte[]) v1, (byte[]) v2);
-            break;
-          default:
-            throw new IllegalStateException();
-        }
-
-        if (result != 0) {
-          if (_sortSequence.get(i).isIsAsc()) {
-            return -result;
-          } else {
-            return result;
-          }
-        }
+    // Compare all single-value columns
+    int numOrderByExpressions = _sortSequence.size();
+    List<Integer> valueIndexList = new ArrayList<>(numOrderByExpressions);
+    for (int i = 0; i < numOrderByExpressions; i++) {
+      if (_expressionMetadata[i].isSingleValue()) {
+        valueIndexList.add(i);
       }
-      return 0;
-    };
+    }
+
+    int numValuesToCompare = valueIndexList.size();
+    int[] valueIndices = new int[numValuesToCompare];
+    Comparator[] valueComparators = new Comparator[numValuesToCompare];
+    for (int i = 0; i < numValuesToCompare; i++) {
+      int valueIndex = valueIndexList.get(i);
+      valueIndices[i] = valueIndex;
+      switch (_expressionMetadata[valueIndex].getDataType()) {
+        case INT:
+          valueComparators[i] = (Comparator<Integer>) Integer::compare;
+          break;
+        case LONG:
+          valueComparators[i] = (Comparator<Long>) Long::compare;
+          break;
+        case FLOAT:
+          valueComparators[i] = (Comparator<Float>) Float::compare;
+          break;
+        case DOUBLE:
+          valueComparators[i] = (Comparator<Double>) Double::compare;
+          break;
+        case STRING:
+          valueComparators[i] = Comparator.naturalOrder();
+          break;
+        case BYTES:
+          valueComparators[i] = (Comparator<byte[]>) ByteArray::compare;
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+      if (_sortSequence.get(valueIndex).isIsAsc()) {
+        valueComparators[i] = valueComparators[i].reversed();
+      }
+    }
+
+    return new SelectionOperatorUtils.RowComparator(valueIndices, valueComparators);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.plan;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,6 +30,7 @@ import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,46 +59,58 @@ public class TransformPlanNode implements PlanNode {
    */
   private void extractColumnsAndTransforms(BrokerRequest brokerRequest, IndexSegment indexSegment) {
     if (brokerRequest.isSetAggregationsInfo()) {
+      // Extract aggregation expressions
       for (AggregationInfo aggregationInfo : brokerRequest.getAggregationsInfo()) {
         if (!aggregationInfo.getAggregationType().equalsIgnoreCase(AggregationFunctionType.COUNT.getName())) {
-          String expression = AggregationFunctionUtils.getColumn(aggregationInfo);
-          TransformExpressionTree transformExpressionTree = TransformExpressionTree.compileToExpressionTree(expression);
-          transformExpressionTree.getColumns(_projectionColumns);
-          _expressions.add(transformExpressionTree);
+          addExpressionColumn(AggregationFunctionUtils.getColumn(aggregationInfo));
         }
       }
 
-      // Process all group-by expressions
+      // Extract group-by expressions
       if (brokerRequest.isSetGroupBy()) {
-        for (String expression : brokerRequest.getGroupBy().getExpressions()) {
-          TransformExpressionTree transformExpressionTree = TransformExpressionTree.compileToExpressionTree(expression);
-          transformExpressionTree.getColumns(_projectionColumns);
-          _expressions.add(transformExpressionTree);
+        for (String column : brokerRequest.getGroupBy().getExpressions()) {
+          addExpressionColumn(column);
         }
       }
     } else {
       Selection selection = brokerRequest.getSelections();
-      List<String> columns = selection.getSelectionColumns();
-      if (columns.size() == 1 && columns.get(0).equals("*")) {
-        columns = new ArrayList<>(indexSegment.getPhysicalColumnNames());
-      }
-      List<SelectionSort> sortSequence = selection.getSelectionSortSequence();
-      if (sortSequence == null) {
-        // For selection only queries, select minimum number of documents. Fetch at least 1 document per
-        // DocIdSetPlanNode's requirement.
-        // TODO: Skip the filtering phase and document fetching for LIMIT 0 case
-        _maxDocPerNextCall = Math.max(Math.min(selection.getSize(), _maxDocPerNextCall), 1);
+
+      // Extract selection expressions
+      List<String> selectionColumns = selection.getSelectionColumns();
+      if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
+        for (String column : indexSegment.getPhysicalColumnNames()) {
+          _projectionColumns.add(column);
+          _expressions.add(new TransformExpressionTree(new IdentifierAstNode(column)));
+        }
       } else {
-        for (SelectionSort selectionSort : sortSequence) {
-          columns.add(selectionSort.getColumn());
+        for (String column : selectionColumns) {
+          addExpressionColumn(column);
         }
       }
-      for (String column : columns) {
-        TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(column);
-        expression.getColumns(_projectionColumns);
-        _expressions.add(expression);
+
+      // Extract order-by expressions and update maxDocPerNextCall
+      if (selection.getSize() > 0) {
+        List<SelectionSort> sortSequence = selection.getSelectionSortSequence();
+        if (sortSequence == null) {
+          // For selection only queries, select minimum number of documents
+          _maxDocPerNextCall = Math.min(selection.getSize(), _maxDocPerNextCall);
+        } else {
+          for (SelectionSort selectionSort : sortSequence) {
+            addExpressionColumn(selectionSort.getColumn());
+          }
+        }
+      } else {
+        // For LIMIT 0 queries, fetch at least 1 document per DocIdSetPlanNode's requirement
+        // TODO: Skip the filtering phase and document fetching for LIMIT 0 case
+        _maxDocPerNextCall = 1;
       }
     }
+  }
+
+  private void addExpressionColumn(String column) {
+    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(column);
+    expression.getColumns(_projectionColumns);
+    _expressions.add(expression);
   }
 
   @Override


### PR DESCRIPTION
- Enhance the comparator for selection order-by queries to avoid doing row based switch
- Enhance the 'SELECT *' to not compile the expression
- Do not project order-by columns for 'LIMIT 0' (EmptySelection) case