### PR TITLE
Enhance Selection Comparator

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.query;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -80,51 +81,49 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
   }
 
   private Comparator<Serializable[]> getComparator() {
-    return (o1, o2) -> {
-      int numOrderByExpressions = _sortSequence.size();
-      for (int i = 0; i < numOrderByExpressions; i++) {
-        // Only compare single-value columns
-        if (!_expressionMetadata[i].isSingleValue()) {
-          continue;
-        }
-
-        Serializable v1 = o1[i];
-        Serializable v2 = o2[i];
-
-        int result;
-        switch (_expressionMetadata[i].getDataType()) {
-          case INT:
-            result = ((Integer) v1).compareTo((Integer) v2);
-            break;
-          case LONG:
-            result = ((Long) v1).compareTo((Long) v2);
-            break;
-          case FLOAT:
-            result = ((Float) v1).compareTo((Float) v2);
-            break;
-          case DOUBLE:
-            result = ((Double) v1).compareTo((Double) v2);
-            break;
-          case STRING:
-            result = ((String) v1).compareTo((String) v2);
-            break;
-          case BYTES:
-            result = ByteArray.compare((byte[]) v1, (byte[]) v2);
-            break;
-          default:
-            throw new IllegalStateException();
-        }
-
-        if (result != 0) {
-          if (_sortSequence.get(i).isIsAsc()) {
-            return -result;
-          } else {
-            return result;
-          }
-        }
+    // Compare all single-value columns
+    int numOrderByExpressions = _sortSequence.size();
+    List<Integer> valueIndexList = new ArrayList<>(numOrderByExpressions);
+    for (int i = 0; i < numOrderByExpressions; i++) {
+      if (_expressionMetadata[i].isSingleValue()) {
+        valueIndexList.add(i);
       }
-      return 0;
-    };
+    }
+
+    int numValuesToCompare = valueIndexList.size();
+    int[] valueIndices = new int[numValuesToCompare];
+    Comparator[] valueComparators = new Comparator[numValuesToCompare];
+    for (int i = 0; i < numValuesToCompare; i++) {
+      int valueIndex = valueIndexList.get(i);
+      valueIndices[i] = valueIndex;
+      switch (_expressionMetadata[valueIndex].getDataType()) {
+        case INT:
+          valueComparators[i] = (Comparator<Integer>) Integer::compare;
+          break;
+        case LONG:
+          valueComparators[i] = (Comparator<Long>) Long::compare;
+          break;
+        case FLOAT:
+          valueComparators[i] = (Comparator<Float>) Float::compare;
+          break;
+        case DOUBLE:
+          valueComparators[i] = (Comparator<Double>) Double::compare;
+          break;
+        case STRING:
+          valueComparators[i] = Comparator.naturalOrder();
+          break;
+        case BYTES:
+          valueComparators[i] = (Comparator<byte[]>) ByteArray::compare;
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+      if (_sortSequence.get(valueIndex).isIsAsc()) {
+        valueComparators[i] = valueComparators[i].reversed();
+      }
+    }
+
+    return new SelectionOperatorUtils.RowComparator(valueIndices, valueComparators);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -23,6 +23,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -42,6 +43,7 @@ import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.util.ArrayCopyUtils;
+import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
 
 
 /**
@@ -106,15 +108,23 @@ public class SelectionOperatorUtils {
     }
 
     if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
+      // For 'SELECT *', sort all physical columns so that the order is deterministic
       selectionColumns = new ArrayList<>(indexSegment.getPhysicalColumnNames());
-      // Sort the columns so that the order is deterministic
       selectionColumns.sort(null);
-    }
 
-    for (String selectionColumn : selectionColumns) {
-      TransformExpressionTree selectionExpression = TransformExpressionTree.compileToExpressionTree(selectionColumn);
-      if (expressionSet.add(selectionExpression)) {
-        expressions.add(selectionExpression);
+      for (String selectionColumn : selectionColumns) {
+        TransformExpressionTree selectionExpression =
+            new TransformExpressionTree(new IdentifierAstNode(selectionColumn));
+        if (expressionSet.add(selectionExpression)) {
+          expressions.add(selectionExpression);
+        }
+      }
+    } else {
+      for (String selectionColumn : selectionColumns) {
+        TransformExpressionTree selectionExpression = TransformExpressionTree.compileToExpressionTree(selectionColumn);
+        if (expressionSet.add(selectionExpression)) {
+          expressions.add(selectionExpression);
+        }
       }
     }
 
@@ -167,6 +177,7 @@ public class SelectionOperatorUtils {
 
   /**
    * Merge two partial results for selection queries with <code>ORDER BY</code>. (Server side)
+   * TODO: Should use type compatible comparator to compare the rows
    *
    * @param mergedRows partial results 1.
    * @param rowsToMerge partial results 2.
@@ -566,6 +577,44 @@ public class SelectionOperatorUtils {
     } else if (queue.comparator().compare(queue.peek(), value) < 0) {
       queue.poll();
       queue.offer(value);
+    }
+  }
+
+  /**
+   * Helper Comparator class to compare rows.
+   * <p>Two arguments are expected to construct the comparator:
+   * <ul>
+   *   <li>
+   *     Value indices: an array of column indices in each row where the values need to be compared (only the
+   *     single-value order-by columns need to be compared)
+   *   </li>
+   *   <li>
+   *     Value comparators: an array of Comparator, where each element is the Comparator for the corresponding column in
+   *     the value indices array
+   *   </li>
+   * </ul>
+   */
+  public static class RowComparator implements Comparator<Serializable[]> {
+    private final int[] _valueIndices;
+    private final Comparator[] _valueComparators;
+
+    public RowComparator(int[] valueIndices, Comparator[] valueComparators) {
+      _valueIndices = valueIndices;
+      _valueComparators = valueComparators;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public int compare(Serializable[] o1, Serializable[] o2) {
+      int numValuesToCompare = _valueIndices.length;
+      for (int i = 0; i < numValuesToCompare; i++) {
+        int valueIndex = _valueIndices[i];
+        int result = _valueComparators[i].compare(o1[valueIndex], o2[valueIndex]);
+        if (result != 0) {
+          return result;
+        }
+      }
+      return 0;
     }
   }
 }


### PR DESCRIPTION
- Enhance the comparator for selection order-by queries to avoid doing row based switch
- Enhance the 'SELECT *' to not compile the expression
- Do not project order-by columns for 'LIMIT 0' (EmptySelection) case