### PR TITLE
Adding option to load a Pinot segment as post creation verification

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -200,9 +200,9 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
       ColumnIndexType indexType)
       throws IOException {
     PinotDataBuffer oldBuffer = reader.getIndexFor(column, indexType);
-    PinotDataBuffer newBuffer = writer.newIndexFor(column, indexType, oldBuffer.size());
-    oldBuffer.copyTo(0, newBuffer, 0, oldBuffer.size());
-    newBuffer.flush();
+    long oldBufferSize = oldBuffer.size();
+    PinotDataBuffer newBuffer = writer.newIndexFor(column, indexType, oldBufferSize);
+    oldBuffer.copyTo(0, newBuffer, 0, oldBufferSize);
   }
 
   private void createMetadataFile(File currentDir, File v3Dir)

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -200,8 +200,9 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
       ColumnIndexType indexType)
       throws IOException {
     PinotDataBuffer oldBuffer = reader.getIndexFor(column, indexType);
-    PinotDataBuffer newDictBuffer = writer.newIndexFor(column, indexType, oldBuffer.size());
-    oldBuffer.copyTo(0, newDictBuffer, 0, oldBuffer.size());
+    PinotDataBuffer newBuffer = writer.newIndexFor(column, indexType, oldBuffer.size());
+    oldBuffer.copyTo(0, newBuffer, 0, oldBuffer.size());
+    newBuffer.flush();
   }
 
   private void createMetadataFile(File currentDir, File v3Dir)

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/CrcUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/CrcUtils.java
@@ -31,11 +31,15 @@ import java.util.List;
 import java.util.zip.Adler32;
 import java.util.zip.Checksum;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @SuppressWarnings("Duplicates")
 public class CrcUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CrcUtils.class);
   private static final int BUFFER_SIZE = 65536;
+  private static final String CRC_FILE_EXTENSTION = ".crc";
 
   private final List<File> _files;
 
@@ -59,7 +63,8 @@ public class CrcUtils {
     Preconditions.checkNotNull(files);
     for (File file : files) {
       if (file.isFile()) {
-        if (!file.getName().equals(V1Constants.SEGMENT_CREATION_META)) {
+        // We should ignore both SEGMENT_CREATION_META and generated '.crc' files.
+        if (!file.getName().equals(V1Constants.SEGMENT_CREATION_META) && !file.getName().endsWith(CRC_FILE_EXTENSTION)) {
           normalFiles.add(file);
         }
       } else {
@@ -80,6 +85,7 @@ public class CrcUtils {
           checksum.update(buffer, 0, len);
         }
       }
+      LOGGER.info("Current file = {}, computed crc = {}", file, checksum.getValue());
     }
 
     return checksum.getValue();

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/CrcUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/CrcUtils.java
@@ -85,10 +85,10 @@ public class CrcUtils {
           checksum.update(buffer, 0, len);
         }
       }
-      LOGGER.info("Current file = {}, computed crc = {}", file, checksum.getValue());
     }
-
-    return checksum.getValue();
+    long crc = checksum.getValue();
+    LOGGER.info("Computed crc = {}", crc);
+    return crc;
   }
 
   public String computeMD5()
@@ -104,8 +104,9 @@ public class CrcUtils {
         }
       }
     }
-
-    return toHexaDecimal(digest.digest());
+    String md5Value = toHexaDecimal(digest.digest());
+    LOGGER.info("Computed MD5 = {}", md5Value);
+    return md5Value;
   }
 
   public static String toHexaDecimal(byte[] bytesToConvert) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/CrcUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/CrcUtils.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.zip.Adler32;
@@ -63,6 +64,7 @@ public class CrcUtils {
     Preconditions.checkNotNull(files);
     for (File file : files) {
       if (file.isFile()) {
+        // Certain file systems, e.g. HDFS will create .crc files when perform data copy.
         // We should ignore both SEGMENT_CREATION_META and generated '.crc' files.
         if (!file.getName().equals(V1Constants.SEGMENT_CREATION_META) && !file.getName().endsWith(CRC_FILE_EXTENSTION)) {
           normalFiles.add(file);
@@ -87,7 +89,7 @@ public class CrcUtils {
       }
     }
     long crc = checksum.getValue();
-    LOGGER.info("Computed crc = {}", crc);
+    LOGGER.info("Computed crc = {}, based on files {}", crc, Arrays.toString(_files.toArray()));
     return crc;
   }
 
@@ -105,7 +107,7 @@ public class CrcUtils {
       }
     }
     String md5Value = toHexaDecimal(digest.digest());
-    LOGGER.info("Computed MD5 = {}", md5Value);
+    LOGGER.info("Computed MD5 = {}, based on files {}", md5Value, Arrays.toString(_files.toArray()));
     return md5Value;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/CrcUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/CrcUtils.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.zip.Adler32;
@@ -89,7 +88,7 @@ public class CrcUtils {
       }
     }
     long crc = checksum.getValue();
-    LOGGER.info("Computed crc = {}, based on files {}", crc, Arrays.toString(_files.toArray()));
+    LOGGER.info("Computed crc = {}, based on files {}", crc, _files);
     return crc;
   }
 
@@ -107,7 +106,7 @@ public class CrcUtils {
       }
     }
     String md5Value = toHexaDecimal(digest.digest());
-    LOGGER.info("Computed MD5 = {}, based on files {}", md5Value, Arrays.toString(_files.toArray()));
+    LOGGER.info("Computed MD5 = {}, based on files {}", md5Value, _files);
     return md5Value;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -35,10 +35,13 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.pinot.common.data.StarTreeIndexSpec;
+import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.JsonUtils;
 import org.apache.pinot.core.data.readers.FileFormat;
 import org.apache.pinot.core.data.readers.RecordReader;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.orc.data.readers.ORCRecordReader;
 import org.apache.pinot.parquet.data.readers.ParquetRecordReader;
@@ -105,6 +108,12 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   @Option(name = "-numThreads", metaVar = "<int>", usage = "Parallelism while generating segments, default is 1.")
   private int _numThreads = 1;
 
+  @Option(name = "-postCreationVerification", usage = "Verify segment data file after segment creation. Please ensure you have enough local disk to hold data for verification")
+  private boolean _postCreationVerification = false;
+
+  @Option(name = "-retry", metaVar = "<int>", usage = "Number of retries if encountered any segment creation failure, default is 0.")
+  private int _retry = 0;
+
   @SuppressWarnings("FieldCanBeLocal")
   @Option(name = "-help", help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
@@ -166,6 +175,16 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
 
   public CreateSegmentCommand setStarTreeIndexSpecFile(String starTreeIndexSpecFile) {
     _starTreeIndexSpecFile = starTreeIndexSpecFile;
+    return this;
+  }
+
+  public CreateSegmentCommand setRetry(int retry) {
+    _retry = retry;
+    return this;
+  }
+
+  public CreateSegmentCommand setPostCreationVerification(boolean postCreationVerification) {
+    _postCreationVerification = postCreationVerification;
     return this;
   }
 
@@ -375,34 +394,49 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
       executor.execute(new Runnable() {
         @Override
         public void run() {
-          try {
-            SegmentGeneratorConfig config = new SegmentGeneratorConfig(segmentGeneratorConfig);
+          for (int curr = 0; curr <= _retry; curr++) {
+            try {
+              SegmentGeneratorConfig config = new SegmentGeneratorConfig(segmentGeneratorConfig);
 
-            String localFile = dataFilePath.getName();
-            Path localFilePath = new Path(localFile);
-            dataDirPath.getFileSystem(new Configuration()).copyToLocalFile(dataFilePath, localFilePath);
-            config.setInputFilePath(localFile);
-            config.setSegmentName(_segmentName + "_" + segCnt);
-            config.loadConfigFiles();
+              String localFile = dataFilePath.getName();
+              Path localFilePath = new Path(localFile);
+              dataDirPath.getFileSystem(new Configuration()).copyToLocalFile(dataFilePath, localFilePath);
+              config.setInputFilePath(localFile);
+              config.setSegmentName(_segmentName + "_" + segCnt);
+              config.loadConfigFiles();
 
-            final SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-            switch (config.getFormat()) {
-              case PARQUET:
-                RecordReader parquetRecordReader = new ParquetRecordReader();
-                parquetRecordReader.init(config);
-                driver.init(config, parquetRecordReader);
-                break;
-              case ORC:
-                RecordReader orcRecordReader = new ORCRecordReader();
-                orcRecordReader.init(config);
-                driver.init(config, orcRecordReader);
-                break;
-              default:
-                driver.init(config);
+              final SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+              switch (config.getFormat()) {
+                case PARQUET:
+                  RecordReader parquetRecordReader = new ParquetRecordReader();
+                  parquetRecordReader.init(config);
+                  driver.init(config, parquetRecordReader);
+                  break;
+                case ORC:
+                  RecordReader orcRecordReader = new ORCRecordReader();
+                  orcRecordReader.init(config);
+                  driver.init(config, orcRecordReader);
+                  break;
+                default:
+                  driver.init(config);
+              }
+              driver.build();
+              if (_postCreationVerification) {
+                if (!verifySegment(new File(config.getOutDir(), driver.getSegmentName()))) {
+                  throw new RuntimeException("Pinot segment is corrupted, please try to recreate it.");
+                } else {
+                  LOGGER.info("Post segment creation verification is succeed for segment {}.", driver.getSegmentName());
+                }
+              }
+              break;
+            } catch (Exception e) {
+              LOGGER.error("Got exception during segment creation.", e);
+              if (curr == _retry) {
+                throw new RuntimeException(e);
+              } else {
+                LOGGER.error("Failed to create Pinot segment, retry: {}/{}", curr + 1, _retry);
+              }
             }
-            driver.build();
-          } catch (Exception e) {
-            throw new RuntimeException(e);
           }
         }
       });
@@ -411,6 +445,32 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
 
     executor.shutdown();
     return executor.awaitTermination(1, TimeUnit.HOURS);
+  }
+
+  private boolean verifySegment(File indexDir) {
+    File localTempDir = null;
+    try {
+      try {
+        localTempDir = new File("segmentVerification", org.apache.pinot.common.utils.FileUtils.getRandomFileName());
+        localTempDir.getParentFile().mkdirs();
+        FileSystem.get(URI.create(indexDir.toString()), new Configuration())
+            .copyToLocalFile(new Path(indexDir.toString()), new Path(localTempDir.toString()));
+      } catch (IOException e) {
+        LOGGER.error("Failed to copy segment {} to local directory for verification.", indexDir, e);
+        return false;
+      }
+      try {
+        ImmutableSegment segment = ImmutableSegmentLoader.load(localTempDir, ReadMode.mmap);
+        LOGGER.info("Successfully loaded Pinot segment {} (size: {} Bytes).", segment.getSegmentName(),
+            segment.getSegmentSizeBytes());
+      } catch (Exception e) {
+        LOGGER.error("Failed to load segment from {}.", localTempDir, e);
+        return false;
+      }
+      return true;
+    } finally {
+      FileUtils.deleteQuietly(localTempDir);
+    }
   }
 
   protected List<Path> getDataFilePaths(Path pathPattern)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -448,20 +448,20 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   }
 
   private boolean verifySegment(File indexDir) {
-    File localTempDir = FileUtils.getTempDirectory();
+    File localTempDir = new File(FileUtils.getTempDirectory(), org.apache.pinot.common.utils.FileUtils.getRandomFileName());
     try {
       try {
         localTempDir.getParentFile().mkdirs();
         FileSystem.get(URI.create(indexDir.toString()), new Configuration())
             .copyToLocalFile(new Path(indexDir.toString()), new Path(localTempDir.toString()));
       } catch (IOException e) {
-        LOGGER.error("Failed to copy segment {} to local directory for verification.", indexDir, e);
+        LOGGER.error("Failed to copy segment {} to local directory {} for verification.", indexDir, localTempDir, e);
         return false;
       }
       try {
         ImmutableSegment segment = ImmutableSegmentLoader.load(localTempDir, ReadMode.mmap);
-        LOGGER.info("Successfully loaded Pinot segment {} (size: {} Bytes).", segment.getSegmentName(),
-            segment.getSegmentSizeBytes());
+        LOGGER.info("Successfully loaded Pinot segment {} (size: {} Bytes) from {}.", segment.getSegmentName(),
+            segment.getSegmentSizeBytes(), localTempDir);
         segment.destroy();
       } catch (Exception e) {
         LOGGER.error("Failed to load segment from {}.", localTempDir, e);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -448,10 +448,9 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   }
 
   private boolean verifySegment(File indexDir) {
-    File localTempDir = null;
+    File localTempDir = FileUtils.getTempDirectory();
     try {
       try {
-        localTempDir = new File("segmentVerification", org.apache.pinot.common.utils.FileUtils.getRandomFileName());
         localTempDir.getParentFile().mkdirs();
         FileSystem.get(URI.create(indexDir.toString()), new Configuration())
             .copyToLocalFile(new Path(indexDir.toString()), new Path(localTempDir.toString()));
@@ -463,6 +462,7 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
         ImmutableSegment segment = ImmutableSegmentLoader.load(localTempDir, ReadMode.mmap);
         LOGGER.info("Successfully loaded Pinot segment {} (size: {} Bytes).", segment.getSegmentName(),
             segment.getSegmentSizeBytes());
+        segment.destroy();
       } catch (Exception e) {
         LOGGER.error("Failed to load segment from {}.", localTempDir, e);
         return false;


### PR DESCRIPTION
Per https://github.com/apache/incubator-pinot/issues/4705, this PR

1. adds a flag `-postCreationVerification` to turn on segment verification to ensure we could load segment metadata and column data file as well did a crc check. Segment verification process will copy data from `-outDir` to local then load it using `MMAP` mode.
2. add a `-retry` flag to re-generate segment for any exception thrown during segment creation or verification phase.