### PR TITLE
Remove the segment missing error message when acquiring segments

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
@@ -20,7 +20,7 @@ package org.apache.pinot.core.data.manager;
 
 import java.io.File;
 import java.util.List;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -40,8 +40,8 @@ public interface TableDataManager {
   /**
    * Initializes the table data manager. Should be called only once and before calling any other method.
    */
-  void init(@Nonnull TableDataManagerConfig tableDataManagerConfig, @Nonnull String instanceId,
-      @Nonnull ZkHelixPropertyStore<ZNRecord> propertyStore, @Nonnull ServerMetrics serverMetrics);
+  void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
+      ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics);
 
   /**
    * Starts the table data manager. Should be called only once after table data manager gets initialized but before
@@ -58,26 +58,25 @@ public interface TableDataManager {
   /**
    * Adds a loaded immutable segment into the table.
    */
-  void addSegment(@Nonnull ImmutableSegment immutableSegment);
+  void addSegment(ImmutableSegment immutableSegment);
 
   /**
    * Adds a segment from local disk into the OFFLINE table.
    */
-  void addSegment(@Nonnull File indexDir, @Nonnull IndexLoadingConfig indexLoadingConfig)
+  void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception;
 
   /**
    * Adds a segment into the REALTIME table.
    * <p>The segment could be committed or under consuming.
    */
-  void addSegment(@Nonnull String segmentName, @Nonnull TableConfig tableConfig,
-      @Nonnull IndexLoadingConfig indexLoadingConfig)
+  void addSegment(String segmentName, TableConfig tableConfig, IndexLoadingConfig indexLoadingConfig)
       throws Exception;
 
   /**
    * Removes a segment from the table.
    */
-  void removeSegment(@Nonnull String segmentName);
+  void removeSegment(String segmentName);
 
   /**
    * Acquires all segments of the table.
@@ -85,7 +84,6 @@ public interface TableDataManager {
    *
    * @return List of segment data managers
    */
-  @Nonnull
   List<SegmentDataManager> acquireAllSegments();
 
   /**
@@ -95,8 +93,7 @@ public interface TableDataManager {
    * @param segmentNames List of names of the segment to acquire
    * @return List of segment data managers
    */
-  @Nonnull
-  List<SegmentDataManager> acquireSegments(@Nonnull List<String> segmentNames);
+  List<SegmentDataManager> acquireSegments(List<String> segmentNames);
 
   /**
    * Acquires the segments with the given segment name.
@@ -105,18 +102,18 @@ public interface TableDataManager {
    * @param segmentName Name of the segment to acquire
    * @return Segment data manager with the given name, or <code>null</code> if no segment matches the name
    */
-  SegmentDataManager acquireSegment(@Nonnull String segmentName);
+  @Nullable
+  SegmentDataManager acquireSegment(String segmentName);
 
   /**
    * Releases the acquired segment.
    *
    * @param segmentDataManager Segment data manager
    */
-  void releaseSegment(@Nonnull SegmentDataManager segmentDataManager);
+  void releaseSegment(SegmentDataManager segmentDataManager);
 
   /**
    * Returns the table name managed by this instance.
    */
-  @Nonnull
   String getTableName();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.data.manager.offline;
 
 import java.io.File;
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
@@ -47,7 +46,7 @@ public class OfflineTableDataManager extends BaseTableDataManager {
   }
 
   @Override
-  public void addSegment(@Nonnull File indexDir, @Nonnull IndexLoadingConfig indexLoadingConfig)
+  public void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
     addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.Utils;
@@ -193,8 +192,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    *   to start consuming or download the segment.
    */
   @Override
-  public void addSegment(@Nonnull String segmentName, @Nonnull TableConfig tableConfig,
-      @Nonnull IndexLoadingConfig indexLoadingConfig)
+  public void addSegment(String segmentName, TableConfig tableConfig, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
     SegmentDataManager segmentDataManager = _segmentDataManagerMap.get(segmentName);
     if (segmentDataManager != null) {
@@ -251,8 +249,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     }
   }
 
-  public void downloadAndReplaceSegment(@Nonnull String segmentName,
-      @Nonnull LLCRealtimeSegmentZKMetadata llcSegmentMetadata, @Nonnull IndexLoadingConfig indexLoadingConfig) {
+  public void downloadAndReplaceSegment(String segmentName, LLCRealtimeSegmentZKMetadata llcSegmentMetadata,
+      IndexLoadingConfig indexLoadingConfig) {
     final String uri = llcSegmentMetadata.getDownloadUrl();
     File tempSegmentFolder = new File(_indexDir, "tmp-" + segmentName + "." + System.currentTimeMillis());
     File tempFile = new File(_indexDir, segmentName + ".tar.gz");


### PR DESCRIPTION
In query execution path, we should not log error message on a per-query per-missing-segment basis, which can easily flood the log
When checking segment metadata, segment can be missing for normal case, and we should not log error as well

Move the NUM_MISSING_SEGMENTS metric into QueryExecutor to only track the missing segments during query execution
Code convention: remove nonnull and add nullable annotations