### PR TITLE
[TE] support row count metric for Pinot

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
@@ -68,6 +68,10 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
 
   private static final Set<String> DIMENSION_SUFFIX_BLACKLIST = new HashSet<>(Arrays.asList("_topk", "_approximate", "_tDigest"));
 
+  /**
+   * Use "ROW_COUNT" as the special token for the count(*) metric for a pinot table
+   */
+  private static final String ROW_COUNT = "ROW_COUNT";
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
   private final AlertConfigManager alertDAO;
   private final DatasetConfigManager datasetDAO;
@@ -154,7 +158,7 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
       List<MetricConfigDTO> metrics = metricDAO.findByDataset(datasetConfigDTO.getDataset());
       int metricCount = metrics.size();
       for (MetricConfigDTO metric : metrics) {
-        if (!metric.isDerived()) {
+        if (!metric.isDerived() && !metric.getName().equals(ROW_COUNT)) {
           metricDAO.delete(metric);
           metricCount--;
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetUtils.java
@@ -188,9 +188,7 @@ public class ThirdEyeResultSetUtils {
       return (aggregate * prevCount + value) / (prevCount + 1);
     } else if (aggFunction.equals(MetricAggFunction.MAX)) {
       return Math.max(aggregate, value);
-    } else if (aggFunction.equals(MetricAggFunction.COUNT) && sourceName.equals(PINOT)) {
-      return aggregate + 1;
-    } else if (aggFunction.equals(MetricAggFunction.COUNT)) { // For all other COUNT cases
+    } else if (aggFunction.equals(MetricAggFunction.COUNT)) { // For all COUNT cases
       return aggregate + value;
     } else {
       throw new IllegalArgumentException(String.format("Unknown aggregation function '%s'", aggFunction));

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSourceTest.java
@@ -61,7 +61,7 @@ public class PinotThirdEyeDataSourceTest {
 
   @Test
   public void testReduceCount() {
-    Assert.assertEquals(ThirdEyeResultSetUtils.reduce(4, 3, 4, MetricAggFunction.COUNT, "Pinot"), 5.0);
+    Assert.assertEquals(ThirdEyeResultSetUtils.reduce(4, 3, 4, MetricAggFunction.COUNT, "Pinot"), 7.0);
   }
 
   @Test


### PR DESCRIPTION
This PR adds the support for the ROW_COUNT metric for Pinot. It requires two changes:
- Don't remove the ROW_COUNT metric during Pinot metric auto-onboarding.
- Remove the special condition for the "COUNT" aggregation function when parsing the Pinot response.