### PR TITLE
[TE][RCA] Fix the broken RCA algorithm tab

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-algorithm/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-algorithm/component.js
@@ -414,6 +414,7 @@ export default Component.extend({
       const metricId = metricUrn.match(/^thirdeye:metric:(\d+)/)[1];
       const baselineRange = toBaselineRange(range, mode); // start/end is dependent on 'compareMode' (WoW, Wo2W, etc)
       const requestObj = {
+        metricUrn: metricUrn,
         metric: parsedMetric[1],
         dataset: parsedMetric[0],
         currentStart: range[0],

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/cube/summary/SummaryResponse.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/cube/summary/SummaryResponse.java
@@ -44,6 +44,9 @@ public class SummaryResponse {
   static final String NOT_ALL = "(ALL)-";
   static final String NOT_AVAILABLE = "-na-";
 
+  @JsonProperty("metricUrn")
+  private String metricUrn;
+
   @JsonProperty("dataset")
   private String dataset;
 
@@ -88,6 +91,14 @@ public class SummaryResponse {
     globalRatio = roundUp(currentTotal / baselineTotal);
   }
 
+  public String getMetricUrn() {
+    return metricUrn;
+  }
+
+  public void setMetricUrn(String metricUrn) {
+    this.metricUrn = metricUrn;
+  }
+
   public String getDataset() {
     return dataset;
   }
@@ -122,6 +133,13 @@ public class SummaryResponse {
 
   public void setDimensionCosts(List<Cube.DimensionCost> dimensionCosts) {
     this.dimensionCosts = dimensionCosts;
+  }
+
+  public static SummaryResponse buildNotAvailableResponse(String metricUrn) {
+    SummaryResponse response = new SummaryResponse(0d, 0d, 0d, 0d);
+    response.setMetricUrn(metricUrn);
+    response.dimensions.add(NOT_AVAILABLE);
+    return response;
   }
 
   public static SummaryResponse buildNotAvailableResponse(String dataset, String metricName) {


### PR DESCRIPTION
After the dataset display name changes, the RCA page was passing the display name to the backend in its api call instead of the original dataset table name. Modified the api call to pass the metricUrn instead of metric and dataset. 