### PR TITLE
Fix segmentMetadata for MutableSegment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -115,29 +115,7 @@ public class MutableSegmentImpl implements MutableSegment {
     _segmentName = config.getSegmentName();
     _schema = config.getSchema();
     _capacity = config.getCapacity();
-    _segmentMetadata = new SegmentMetadataImpl(config.getRealtimeSegmentZKMetadata(), _schema) {
-      @Override
-      public int getTotalDocs() {
-        return _numDocsIndexed;
-      }
-
-      @Override
-      public int getTotalRawDocs() {
-        // In realtime total docs and total raw docs are the same currently.
-        return _numDocsIndexed;
-      }
-
-      @Override
-      public long getLastIndexedTimestamp() {
-        return _lastIndexedTimeMs;
-      }
-
-      @Override
-      public long getLatestIngestionTimestamp() {
-        return _latestIngestionTimeMs;
-      }
-    };
-
+    _segmentMetadata = new SegmentMetadataImpl(config.getRealtimeSegmentZKMetadata(), _schema);
     _offHeap = config.isOffHeap();
     _memoryManager = config.getMemoryManager();
     _statsHistory = config.getStatsHistory();
@@ -277,6 +255,13 @@ public class MutableSegmentImpl implements MutableSegment {
     if (rowMetadata != null && rowMetadata.getIngestionTimeMs() != Long.MIN_VALUE) {
       _latestIngestionTimeMs = Math.max(_latestIngestionTimeMs, rowMetadata.getIngestionTimeMs());
     }
+
+    // Update segmentMetadata
+    ((SegmentMetadataImpl) _segmentMetadata).setTotalDocs(_numDocsIndexed);
+    // In realtime total docs and total raw docs are the same currently.
+    ((SegmentMetadataImpl) _segmentMetadata).setTotalRawDocs(_numDocsIndexed);
+    ((SegmentMetadataImpl) _segmentMetadata).setLastIndexedTimestamp(_lastIndexedTimeMs);
+    ((SegmentMetadataImpl) _segmentMetadata).setLatestIngestionTimestamp(_latestIngestionTimeMs);
     return canTakeMore;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -558,6 +558,22 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     }
   }
 
+  public void setTotalDocs (int totalDocs) {
+    _totalDocs = totalDocs;
+  }
+
+  public void setTotalRawDocs (int totalRawDocs) {
+    _totalRawDocs = totalRawDocs;
+  }
+
+  public void setLastIndexedTimestamp (long lastIndexedTime) {
+    _lastIndexedTime = lastIndexedTime;
+  }
+
+  public void setLatestIngestionTimestamp (long latestIngestionTime) {
+    _latestIngestionTime = latestIngestionTime;
+  }
+
   /**
    * Converts segment metadata to json
    * @param columnFilter list only  the columns in the set. Lists all the columns if

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.realtime.stream.StreamMessageMetadata;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.segments.v1.creator.SegmentTestUtils;
 import org.testng.Assert;
@@ -94,6 +95,7 @@ public class MutableSegmentImplTest {
   public void testMetadata() {
     SegmentMetadata actualSegmentMetadata = _mutableSegmentImpl.getSegmentMetadata();
     SegmentMetadata expectedSegmentMetadata = _immutableSegment.getSegmentMetadata();
+    Assert.assertEquals(actualSegmentMetadata.getClass(), SegmentMetadataImpl.class);
     Assert.assertEquals(actualSegmentMetadata.getTotalDocs(), expectedSegmentMetadata.getTotalDocs());
 
     // assert that the last indexed timestamp is close to what we expect


### PR DESCRIPTION
The current way of initializing `_segmentMetadata` would make its type to be `MutableSegmentImpl` instead of `SegmentMetadataImpl`.

Fixing it and adding a test.