### PR TITLE
Enable full stack trace when there is an exception during tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1092,6 +1092,7 @@
             <systemPropertyVariables>
               <zookeeper.forceSync>no</zookeeper.forceSync>
             </systemPropertyVariables>
+            <trimStackTrace>false</trimStackTrace>
             <reportFormat>plain</reportFormat>
           </configuration>
         </plugin>


### PR DESCRIPTION
By default maven does not print the full stack when exceptions are encountered during tests.
Enabled surefire plugin to print the full stack for easy debugging.  In some cases we may not
have access to the full surefire report to get the stack trace.