### PR TITLE
Updating maven-surefire-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1081,7 +1081,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19</version>
+          <version>2.22.0</version>
           <configuration>
             <!-- Do not set argLine here, it will break the code coverage plugin. Set it in the properties section. -->
             <forkCount>1</forkCount>


### PR DESCRIPTION
* Attempt to fix [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.19:test (default-test) on project pinot-integration-tests: There was a timeout or other error in the fork -> [Help 1]

* https://github.com/cbeust/testng/issues/1693 
* https://stackoverflow.com/questions/36427868/failed-to-execute-goal-org-apache-maven-pluginsmaven-surefire-plugin2-12test