### PR TITLE
Catch exception when checking lead controller resource is enabled

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
@@ -216,8 +216,6 @@ public class LeadControllerManager {
       leadControllerResourceEnabled = LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
     } catch (Exception e) {
       LOGGER.error("Exception when checking whether lead controller resource is enabled or not.", e);
-      _isLeadControllerResourceEnabled = false;
-      _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PINOT_LEAD_CONTROLLER_RESOURCE_ENABLED, 0L);
       return;
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/LeadControllerManager.java
@@ -138,14 +138,19 @@ public class LeadControllerManager {
    * Checks from ZK if the current controller host is Helix cluster leader.
    */
   private boolean isHelixLeader() {
-    String helixLeaderInstanceId = LeadControllerUtils.getHelixClusterLeader(_helixManager);
-    if (helixLeaderInstanceId == null) {
-      LOGGER.warn("Helix leader ZNode is missing");
+    try {
+      String helixLeaderInstanceId = LeadControllerUtils.getHelixClusterLeader(_helixManager);
+      if (helixLeaderInstanceId == null) {
+        LOGGER.warn("Helix leader ZNode is missing");
+        return false;
+      }
+      // The instance name from Helix leader ZNode is without controller prefix.
+      // It is essential to convert to participant id for fair comparison.
+      return _instanceId.equals(Helix.PREFIX_OF_CONTROLLER_INSTANCE + helixLeaderInstanceId);
+    } catch (Exception e) {
+      LOGGER.error("Exception when getting Helix leader", e);
       return false;
     }
-    // The instance name from Helix leader ZNode is without controller prefix.
-    // It is essential to convert to participant id for fair comparison.
-    return _instanceId.equals(Helix.PREFIX_OF_CONTROLLER_INSTANCE + helixLeaderInstanceId);
   }
 
   /**
@@ -215,6 +220,10 @@ public class LeadControllerManager {
     try {
       leadControllerResourceEnabled = LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
     } catch (Exception e) {
+      // Do not change the state if any exception happened.
+      // Enabling the resource is always one-off. If administrator wants to enable it he will check the log.
+      // Plus, it's quite common to have resource config changes because every time there's a Helix task generated,
+      // the task will be written to resource config, which will trigger this notification as well.
       LOGGER.error("Exception when checking whether lead controller resource is enabled or not.", e);
       return;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
@@ -106,19 +106,15 @@ public class ControllerLeaderLocator {
    * Thus, simply exiting the method should be enough. Retry will be done in the next request.
    */
   private void refreshControllerLeaderMap() {
-    // Checks whether lead controller resource has been enabled or not.
-    boolean leadControllerResourceEnabled;
     try {
-      leadControllerResourceEnabled = LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
+      // Checks whether lead controller resource has been enabled or not.
+      if (LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager)) {
+        refreshControllerLeaderMapFromLeadControllerResource();
+      } else {
+        refreshControllerLeaderMapFromHelixClusterLeader();
+      }
     } catch (Exception e) {
       LOGGER.error("Exception when checking whether lead controller resource is enable or not.", e);
-      return;
-    }
-
-    if (leadControllerResourceEnabled) {
-      refreshControllerLeaderMapFromLeadControllerResource();
-    } else {
-      refreshControllerLeaderMapFromHelixClusterLeader();
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
@@ -102,10 +102,20 @@ public class ControllerLeaderLocator {
    * Checks whether lead controller resource has been enabled or not.
    * If yes, updates lead controller pairs from the external view of lead controller resource.
    * Otherwise, updates lead controller pairs from Helix cluster leader.
+   * Note: Exception may happen due to Helix/ZK disconnect. If so, we should NOT regress the behavior back to false.
+   * Thus, simply exiting the method should be enough. Retry will be done in the next request.
    */
   private void refreshControllerLeaderMap() {
     // Checks whether lead controller resource has been enabled or not.
-    if (LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager)) {
+    boolean leadControllerResourceEnabled;
+    try {
+      leadControllerResourceEnabled = LeadControllerUtils.isLeadControllerResourceEnabled(_helixManager);
+    } catch (Exception e) {
+      LOGGER.error("Exception when checking whether lead controller resource is enable or not.", e);
+      return;
+    }
+
+    if (leadControllerResourceEnabled) {
       refreshControllerLeaderMapFromLeadControllerResource();
     } else {
       refreshControllerLeaderMapFromHelixClusterLeader();


### PR DESCRIPTION
This PR catches exception when checking lead controller resource is enabled.

Exception may happen due to Helix/ZK disconnect. If so, we should **NOT** regress the behavior back to false.
Thus, simply exiting the method should be enough. Retry will be done in the next request.

Sample exception log:
```
org.apache.helix.HelixException: HelixManager is not connected within retry timeout for cluster pinot
        at org.apache.helix.manager.zk.ZKHelixManager.checkConnected(ZKHelixManager.java:378) ~[helix-core-0.8.4.905.jar:0.8.4.905]
        at org.apache.helix.manager.zk.ZKHelixManager.getHelixDataAccessor(ZKHelixManager.java:593) ~[helix-core-0.8.4.905.jar:0.8.4.905]
        at org.apache.pinot.server.realtime.ControllerLeaderLocator.isLeadControllerResourceEnabled(ControllerLeaderLocator.java:128) ~[pinot-core-0.2.1129.jar:0.2.0-SNAPSHOT-dbcbd2eae2430050c003de86c605a7ed8f0e1b9e]
        at org.apache.pinot.server.realtime.ControllerLeaderLocator.getLeaderForTable(ControllerLeaderLocator.java:115) ~[pinot-core-0.2.1129.jar:0.2.0-SNAPSHOT-dbcbd2eae2430050c003de86c605a7ed8f0e1b9e]
        at org.apache.pinot.server.realtime.ControllerLeaderLocator.getControllerLeader(ControllerLeaderLocator.java:92) ~[pinot-core-0.2.1129.jar:0.2.0-SNAPSHOT-dbcbd2eae2430050c003de86c605a7ed8f0e1b9e]
        at org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler.createSegmentCompletionUrl(ServerSegmentCompletionProtocolHandler.java:166) ~[pinot-core-0.2.1129.jar:0.2.0-SNAPSHOT-dbcbd2eae2430050c003de86c605a7ed8f0e1b9e]
        at org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler.segmentConsumed(ServerSegmentCompletionProtocolHandler.java:147) ~[pinot-core-0.2.1129.jar:0.2.0-SNAPSHOT-dbcbd2eae2430050c003de86c605a7ed8f0e1b9e]
        at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager.postSegmentConsumedMsg(LLRealtimeSegmentDataManager.java:901) ~[pinot-core-0.2.1129.jar:0.2.0-SNAPSHOT-dbcbd2eae2430050c003de86c605a7ed8f0e1b9e]
        at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager$PartitionConsumer.run(LLRealtimeSegmentDataManager.java:524) ~[pinot-core-0.2.1129.jar:0.2.0-SNAPSHOT-dbcbd2eae2430050c003de86c605a7ed8f0e1b9e]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_172]
```