### PR TITLE
Fix state change when consumption is stopped

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -604,11 +604,12 @@ public class PinotLLCRealtimeSegmentManager {
       HelixHelper.updateIdealState(_helixManager, realtimeTableName, idealState -> {
         assert idealState != null;
         Map<String, String> stateMap = idealState.getInstanceStateMap(segmentName);
-        if (stateMap != null) {
-          String state = stateMap.get(instanceName);
-          if (state != null && state.equals(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
-            stateMap.put(instanceName, RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
-          }
+        String state = stateMap.get(instanceName);
+        if (RealtimeSegmentOnlineOfflineStateModel.CONSUMING.equals(state)) {
+          stateMap.put(instanceName, RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
+        } else {
+          LOGGER.info("Segment {} in state {} when trying to register consumption stop from {}",
+              segmentName, state, instanceName);
         }
         return idealState;
       }, RetryPolicies.exponentialBackoffRetryPolicy(10, 500L, 1.2f), true);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -589,7 +589,7 @@ public class PinotLLCRealtimeSegmentManager {
 
   /**
    * An instance is reporting that it has stopped consuming a topic due to some error.
-   * Mark the state of the segment to be OFFLINE in idealstate.
+   * If the segment is in CONSUMING state, mark the state of the segment to be OFFLINE in idealstate.
    * When all replicas of this segment are marked offline, the {@link org.apache.pinot.controller.validation.RealtimeSegmentValidationManager},
    * in its next run, will auto-create a new segment with the appropriate offset.
    */
@@ -603,9 +603,15 @@ public class PinotLLCRealtimeSegmentManager {
     try {
       HelixHelper.updateIdealState(_helixManager, realtimeTableName, idealState -> {
         assert idealState != null;
-        idealState.getInstanceStateMap(segmentName).put(instanceName, RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
+        Map<String, String> stateMap = idealState.getInstanceStateMap(segmentName);
+        if (stateMap != null) {
+          String state = stateMap.get(instanceName);
+          if (state != null && state.equals(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+            stateMap.put(instanceName, RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
+          }
+        }
         return idealState;
-      }, RetryPolicies.exponentialBackoffRetryPolicy(10, 500L, 1.2f));
+      }, RetryPolicies.exponentialBackoffRetryPolicy(10, 500L, 1.2f), true);
     } catch (Exception e) {
       _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_ZOOKEEPER_UPDATE_FAILURES, 1L);
       throw e;


### PR DESCRIPTION
When a server stops consumption due to any exception or error, it invokes
a controller operation to mark itself as being OFFLINE. It may happen that
this condition takes place right after a segment is marked as ONLINE,
but the consumer thread on the server is still alive and waiting for the
completion response (of KEEP/COMMIT/DISCARD, etc.)

While updating the ideal state, the controller should ensure that the
Helix state of the segment is CONSUMING and not anything else. If it
is not CONSUMING, then we don't want to error out, but just quietly report
back success to the server, and let it do its thing.