### PR TITLE
Make the download url of a realtime LLC segment as a list of urls.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/LLCRealtimeSegmentZKMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/LLCRealtimeSegmentZKMetadata.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.metadata.segment;
 
 import java.util.Map;
 import org.apache.helix.ZNRecord;
+import org.apache.pinot.common.utils.StringUtil;
 
 import static org.apache.pinot.common.utils.EqualityUtils.hashCodeOf;
 import static org.apache.pinot.common.utils.EqualityUtils.isEqual;
@@ -36,8 +37,8 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
   private long _startOffset;
   private long _endOffset;
   private int _numReplicas;
-
-  private String _downloadUrl = null;
+  // A comma separated list of urls to download the segment.
+  private String _downloadUrls = null;
 
   public LLCRealtimeSegmentZKMetadata() {
     super();
@@ -48,7 +49,7 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
     _startOffset = Long.valueOf(znRecord.getSimpleField(START_OFFSET));
     _numReplicas = Integer.valueOf(znRecord.getSimpleField(NUM_REPLICAS));
     _endOffset = Long.valueOf(znRecord.getSimpleField(END_OFFSET));
-    _downloadUrl = znRecord.getSimpleField(DOWNLOAD_URL);
+    _downloadUrls = znRecord.getSimpleField(DOWNLOAD_URL);
   }
 
   public long getStartOffset() {
@@ -76,11 +77,15 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
   }
 
   public String getDownloadUrl() {
-    return _downloadUrl;
+    return _downloadUrls;
   }
 
-  public void setDownloadUrl(String downloadUrl) {
-    _downloadUrl = downloadUrl;
+  public void appendDownloadUrl(String downloadUrl) {
+    if (_downloadUrls == null) {
+      _downloadUrls = downloadUrl;
+      return;
+    }
+    _downloadUrls = StringUtil.join(",", _downloadUrls, downloadUrl);
   }
 
   @Override
@@ -89,7 +94,7 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
     znRecord.setLongField(START_OFFSET, _startOffset);
     znRecord.setLongField(END_OFFSET, _endOffset);
     znRecord.setIntField(NUM_REPLICAS, _numReplicas);
-    znRecord.setSimpleField(DOWNLOAD_URL, _downloadUrl);
+    znRecord.setSimpleField(DOWNLOAD_URL, _downloadUrls);
     return znRecord;
   }
 
@@ -104,7 +109,7 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
     result.append(newline);
     result.append("  " + START_OFFSET + " : " + _startOffset + ",");
     result.append(newline);
-    result.append("  " + DOWNLOAD_URL + " : " + _downloadUrl + ",");
+    result.append("  " + DOWNLOAD_URL + " : " + _downloadUrls + ",");
     result.append(newline);
     result.append("  " + END_OFFSET + " : " + _endOffset);
     result.append(newline);
@@ -124,7 +129,7 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
 
     LLCRealtimeSegmentZKMetadata metadata = (LLCRealtimeSegmentZKMetadata) segmentMetadata;
     return super.equals(metadata) && isEqual(_startOffset, metadata._startOffset) && isEqual(_endOffset,
-        metadata._endOffset) && isEqual(_downloadUrl, metadata._downloadUrl) && isEqual(_numReplicas,
+        metadata._endOffset) && isEqual(_downloadUrls, metadata._downloadUrls) && isEqual(_numReplicas,
         metadata._numReplicas);
   }
 
@@ -134,7 +139,7 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
     result = hashCodeOf(result, _startOffset);
     result = hashCodeOf(result, _endOffset);
     result = hashCodeOf(result, _numReplicas);
-    result = hashCodeOf(result, _downloadUrl);
+    result = hashCodeOf(result, _downloadUrls);
     return result;
   }
 
@@ -144,7 +149,7 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
     configMap.put(START_OFFSET, Long.toString(_startOffset));
     configMap.put(END_OFFSET, Long.toString(_endOffset));
     configMap.put(NUM_REPLICAS, Integer.toString(_numReplicas));
-    configMap.put(DOWNLOAD_URL, _downloadUrl);
+    configMap.put(DOWNLOAD_URL, _downloadUrls);
 
     return configMap;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -480,7 +480,7 @@ public class PinotLLCRealtimeSegmentManager {
 
     committingSegmentZKMetadata.setEndOffset(committingSegmentDescriptor.getNextOffset());
     committingSegmentZKMetadata.setStatus(Status.DONE);
-    committingSegmentZKMetadata.setDownloadUrl(URIUtils
+    committingSegmentZKMetadata.appendDownloadUrl(URIUtils
         .constructDownloadUrl(_controllerConf.generateVipUrl(), TableNameBuilder.extractRawTableName(realtimeTableName),
             segmentName));
     committingSegmentZKMetadata.setCrc(Long.valueOf(segmentMetadata.getCrc()));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1163,7 +1163,7 @@ public class SegmentCompletionTest {
     public void commitSegmentMetadata(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
       _segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
       _segmentMetadata.setEndOffset(committingSegmentDescriptor.getNextOffset());
-      _segmentMetadata.setDownloadUrl(URIUtils.constructDownloadUrl(CONTROLLER_CONF.generateVipUrl(), rawTableName,
+      _segmentMetadata.appendDownloadUrl(URIUtils.constructDownloadUrl(CONTROLLER_CONF.generateVipUrl(), rawTableName,
           committingSegmentDescriptor.getSegmentName()));
       _segmentMetadata.setEndTime(_segmentCompletionMgr.getCurrentTimeMs());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -251,7 +251,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   public void downloadAndReplaceSegment(String segmentName, LLCRealtimeSegmentZKMetadata llcSegmentMetadata,
       IndexLoadingConfig indexLoadingConfig) {
-    final String uri = llcSegmentMetadata.getDownloadUrl();
+    final String uriLst = llcSegmentMetadata.getDownloadUrl();
+    String uri = getDownloadUriFromList(uriLst);
     File tempSegmentFolder = new File(_indexDir, "tmp-" + segmentName + "." + System.currentTimeMillis());
     File tempFile = new File(_indexDir, segmentName + ".tar.gz");
     final File segmentFolder = new File(_indexDir, segmentName);
@@ -270,6 +271,14 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       FileUtils.deleteQuietly(tempFile);
       FileUtils.deleteQuietly(tempSegmentFolder);
     }
+  }
+
+  private String getDownloadUriFromList(String uriLst) {
+    String[] urls = uriLst.split(",");
+    if (urls != null && urls.length > 0) {
+      return urls[0];
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
As planned in the design in [deep storage by-pass for realtime ingestion](https://cwiki.apache.org/confluence/display/PINOT/By-passing+deep-store+requirement+for+Realtime+segment+completion), the PR makes the download url of a LLC segments as a list of uris instead of one single uris.

The high level rationale is that Pinot servers can then download the segment from a list of candidate uris (deep storage or peer servers). This PR is backward compatible for the existing codes.   