### PR TITLE
[SegmentGeneratorConfig Cleanup] Replace checkTimeColumnValidityDuringGeneration with skipTimeValueCheck

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/SegmentsValidationAndRetentionConfig.java
@@ -83,6 +83,8 @@ public class SegmentsValidationAndRetentionConfig {
     this.segmentAssignmentStrategy = segmentAssignmentStrategy;
   }
 
+  // TODO: Use TimeFieldSpec in Schema
+  @Deprecated
   public String getTimeColumnName() {
     return timeColumnName;
   }
@@ -91,6 +93,8 @@ public class SegmentsValidationAndRetentionConfig {
     this.timeColumnName = timeColumnName;
   }
 
+  // TODO: Use TimeFieldSpec in Schema
+  @Deprecated
   public TimeUnit getTimeType() {
     return _timeType;
   }
@@ -233,15 +237,16 @@ public class SegmentsValidationAndRetentionConfig {
 
     SegmentsValidationAndRetentionConfig that = (SegmentsValidationAndRetentionConfig) o;
 
-    return EqualityUtils.isEqual(retentionTimeUnit, that.retentionTimeUnit) && EqualityUtils.isEqual(retentionTimeValue,
-        that.retentionTimeValue) && EqualityUtils.isEqual(segmentPushFrequency, that.segmentPushFrequency)
-        && EqualityUtils.isEqual(segmentPushType, that.segmentPushType) && EqualityUtils.isEqual(replication,
-        that.replication) && EqualityUtils.isEqual(schemaName, that.schemaName) && EqualityUtils.isEqual(timeColumnName,
-        that.timeColumnName) && EqualityUtils.isEqual(_timeType, that._timeType) && EqualityUtils.isEqual(
-        segmentAssignmentStrategy, that.segmentAssignmentStrategy) && EqualityUtils.isEqual(replicaGroupStrategyConfig,
-        that.replicaGroupStrategyConfig) && EqualityUtils.isEqual(_completionConfig, that._completionConfig)
-        && EqualityUtils.isEqual(hllConfig, that.hllConfig) && EqualityUtils.isEqual(replicasPerPartition,
-        that.replicasPerPartition);
+    return EqualityUtils.isEqual(retentionTimeUnit, that.retentionTimeUnit) && EqualityUtils
+        .isEqual(retentionTimeValue, that.retentionTimeValue) && EqualityUtils
+        .isEqual(segmentPushFrequency, that.segmentPushFrequency) && EqualityUtils
+        .isEqual(segmentPushType, that.segmentPushType) && EqualityUtils.isEqual(replication, that.replication)
+        && EqualityUtils.isEqual(schemaName, that.schemaName) && EqualityUtils
+        .isEqual(timeColumnName, that.timeColumnName) && EqualityUtils.isEqual(_timeType, that._timeType)
+        && EqualityUtils.isEqual(segmentAssignmentStrategy, that.segmentAssignmentStrategy) && EqualityUtils
+        .isEqual(replicaGroupStrategyConfig, that.replicaGroupStrategyConfig) && EqualityUtils
+        .isEqual(_completionConfig, that._completionConfig) && EqualityUtils.isEqual(hllConfig, that.hllConfig)
+        && EqualityUtils.isEqual(replicasPerPartition, that.replicasPerPartition);
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/time/TimeUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/time/TimeUtils.java
@@ -23,12 +23,18 @@ import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
+import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
 
 
 public class TimeUtils {
+  public static final long VALID_MIN_TIME_MILLIS = new DateTime(1971, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
+  public static final long VALID_MAX_TIME_MILLIS = new DateTime(2071, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
+  public static final Interval VALID_TIME_INTERVAL =
+      new Interval(VALID_MIN_TIME_MILLIS, VALID_MAX_TIME_MILLIS, DateTimeZone.UTC);
+
   private static final String UPPER_CASE_DAYS = "DAYS";
   private static final String UPPER_CASE_DAYS_SINCE_EPOCH = "DAYSSINCEEPOCH";
   private static final String UPPER_CASE_HOURS = "HOURS";
@@ -46,9 +52,6 @@ public class TimeUtils {
   private static final String UPPER_CASE_NANOSECONDS = "NANOSECONDS";
   private static final String UPPER_CASE_NANOS_SINCE_EPOCH = "NANOSSINCEEPOCH";
   private static final String UPPER_CASE_NANOSECONDS_SINCE_EPOCH = "NANOSECONDSSINCEEPOCH";
-
-  private static final long VALID_MIN_TIME_MILLIS = new DateTime(1971, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
-  private static final long VALID_MAX_TIME_MILLIS = new DateTime(2071, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
 
   /**
    * Converts a time unit string into {@link TimeUnit}, ignoring case. For {@code null} or empty time unit string,
@@ -108,7 +111,16 @@ public class TimeUtils {
    * <p>The current valid range used is between beginning of 1971 and beginning of 2071.
    */
   public static boolean timeValueInValidRange(long timeValueInMillis) {
-    return (VALID_MIN_TIME_MILLIS <= timeValueInMillis && timeValueInMillis <= VALID_MAX_TIME_MILLIS);
+    return timeValueInMillis >= VALID_MIN_TIME_MILLIS && timeValueInMillis <= VALID_MAX_TIME_MILLIS;
+  }
+
+  /**
+   * Given a time interval, returns true if the interval is between a valid range, false otherwise.
+   * <p>The current valid range used is between beginning of 1971 and beginning of 2071.
+   */
+  public static boolean isValidTimeInterval(Interval timeInterval) {
+    return timeInterval.getStartMillis() >= VALID_MIN_TIME_MILLIS
+        && timeInterval.getEndMillis() <= VALID_MAX_TIME_MILLIS;
   }
 
   /**
@@ -166,20 +178,5 @@ public class TimeUtils {
       periodStr = PERIOD_FORMATTER.print(p);
     }
     return periodStr;
-  }
-
-  /**
-   * Verify that start and end time (should be in milliseconds from epoch) of the segment
-   * are in valid range.
-   * @param startMillis start time (in milliseconds)
-   * @param endMillis end time (in milliseconds)
-   * @return true if start and end time are in range, false otherwise
-   *
-   * Note: this function assumes that given times are in milliseconds. The
-   * caller should take care of converting to millis from epoch before
-   * trying to validate the times.
-   */
-  public static boolean checkSegmentTimeValidity(final long startMillis, final long endMillis) {
-    return timeValueInValidRange(startMillis) && timeValueInValidRange(endMillis);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/SegmentIntervalUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/SegmentIntervalUtils.java
@@ -20,9 +20,7 @@ package org.apache.pinot.controller.util;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.config.SegmentsValidationAndRetentionConfig;
-import org.apache.pinot.common.utils.time.TimeUtils;
 import org.joda.time.Duration;
-import org.joda.time.Interval;
 
 
 /**
@@ -31,15 +29,8 @@ import org.joda.time.Interval;
 public class SegmentIntervalUtils {
 
   /**
-   * Checks if the given segment metadata time interval is valid
-   */
-  public static boolean isValidInterval(Interval timeInterval) {
-    return timeInterval != null && TimeUtils.timeValueInValidRange(timeInterval.getStartMillis()) && TimeUtils
-        .timeValueInValidRange(timeInterval.getEndMillis());
-  }
-
-  /**
    * We only want to check missing segments if the table has at least 2 segments and a time column
+   * TODO: Use TimeFieldSpec in Schema
    */
   public static boolean eligibleForMissingSegmentCheck(int numSegments,
       SegmentsValidationAndRetentionConfig validationConfig) {
@@ -48,6 +39,7 @@ public class SegmentIntervalUtils {
 
   /**
    * We only want to check intervals if the table has a time column
+   * TODO: Use TimeFieldSpec in Schema
    */
   public static boolean eligibleForSegmentIntervalCheck(SegmentsValidationAndRetentionConfig validationConfig) {
     return StringUtils.isNotEmpty(validationConfig.getTimeColumnName());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ValidationMetrics;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.time.TimeUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -88,7 +89,7 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask<Void> 
       int numSegmentsWithInvalidIntervals = 0;
       for (OfflineSegmentZKMetadata offlineSegmentZKMetadata : offlineSegmentZKMetadataList) {
         Interval timeInterval = offlineSegmentZKMetadata.getTimeInterval();
-        if (SegmentIntervalUtils.isValidInterval(timeInterval)) {
+        if (timeInterval != null && TimeUtils.isValidTimeInterval(timeInterval)) {
           segmentIntervals.add(timeInterval);
         } else {
           numSegmentsWithInvalidIntervals++;

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -112,7 +112,7 @@ public class SegmentGeneratorConfig {
   private String _simpleDateFormat = null;
   // Use on-heap or off-heap memory to generate index (currently only affect inverted index and star-tree v2)
   private boolean _onHeap = false;
-  private boolean _checkTimeColumnValidityDuringGeneration = true;
+  private boolean _skipTimeValueCheck = false;
   private boolean _nullHandlingEnabled = false;
 
   public SegmentGeneratorConfig() {
@@ -162,7 +162,7 @@ public class SegmentGeneratorConfig {
     _simpleDateFormat = config._simpleDateFormat;
     _onHeap = config._onHeap;
     _recordReaderPath = config._recordReaderPath;
-    _checkTimeColumnValidityDuringGeneration = config._checkTimeColumnValidityDuringGeneration;
+    _skipTimeValueCheck = config._skipTimeValueCheck;
     _nullHandlingEnabled = config._nullHandlingEnabled;
   }
 
@@ -599,12 +599,12 @@ public class SegmentGeneratorConfig {
     _onHeap = onHeap;
   }
 
-  public boolean isCheckTimeColumnValidityDuringGeneration() {
-    return _checkTimeColumnValidityDuringGeneration;
+  public boolean isSkipTimeValueCheck() {
+    return _skipTimeValueCheck;
   }
 
-  public void setCheckTimeColumnValidityDuringGeneration(boolean checkTimeColumnValidityDuringGeneration) {
-    _checkTimeColumnValidityDuringGeneration = checkTimeColumnValidityDuringGeneration;
+  public void setSkipTimeValueCheck(boolean skipTimeValueCheck) {
+    _skipTimeValueCheck = skipTimeValueCheck;
   }
 
   public Map<String, ChunkCompressorFactory.CompressionType> getRawIndexCompressionType() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -102,7 +102,7 @@ public class RealtimeSegmentConverter {
     // range. We don't want the realtime consumption to stop (if an exception
     // is thrown) and thus the time validity check is explicitly disabled for
     // realtime segment generation
-    genConfig.setCheckTimeColumnValidityDuringGeneration(false);
+    genConfig.setSkipTimeValueCheck(true);
     if (invertedIndexColumns != null && !invertedIndexColumns.isEmpty()) {
       for (String column : invertedIndexColumns) {
         genConfig.createInvertedIndexForColumn(column);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -57,6 +57,7 @@ import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.core.startree.v2.StarTreeV2Constants;
 import org.apache.pinot.core.startree.v2.StarTreeV2Metadata;
 import org.apache.pinot.startree.hll.HllConstants;
+import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.slf4j.Logger;
@@ -190,7 +191,8 @@ public class SegmentMetadataImpl implements SegmentMetadata {
         String endTimeString = segmentMetadataPropertiesConfiguration.getString(SEGMENT_END_TIME);
         _segmentStartTime = Long.parseLong(startTimeString);
         _segmentEndTime = Long.parseLong(endTimeString);
-        _timeInterval = new Interval(_timeUnit.toMillis(_segmentStartTime), _timeUnit.toMillis(_segmentEndTime));
+        _timeInterval =
+            new Interval(_timeUnit.toMillis(_segmentStartTime), _timeUnit.toMillis(_segmentEndTime), DateTimeZone.UTC);
       } catch (Exception e) {
         LOGGER.warn("Caught exception while setting time interval and granularity", e);
         _timeInterval = null;

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
@@ -29,19 +29,18 @@ import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.MetricFieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.data.TimeFieldSpec;
-import org.apache.pinot.common.utils.time.TimeUtils;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.data.readers.RecordReader;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
-import org.apache.pinot.core.operator.transform.transformer.datetime.BaseDateTimeTransformer;
-import org.apache.pinot.core.operator.transform.transformer.datetime.DateTimeTransformerFactory;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
-import org.testng.Assert;
+import org.joda.time.DateTime;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 
 public class SegmentConverterTest {
@@ -57,9 +56,9 @@ public class SegmentConverterTest {
   private static final String D2 = "d2";
   private static final String M1 = "m1";
   private static final String T = "t";
+  private static final long BASE_TIMESTAMP = new DateTime(2018, 9, 5, 0, 0).getMillis();
 
   private List<File> _segmentIndexDirList;
-  private final long _referenceTimestamp = TimeUtils.getValidMinTimeMillis();
 
   @BeforeClass
   public void setUp()
@@ -74,14 +73,13 @@ public class SegmentConverterTest {
     schema.addField(new TimeFieldSpec(T, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
-    long timestamp = _referenceTimestamp;
     for (int i = 0; i < NUM_ROWS; i++) {
       int dimensionValue = i % (NUM_ROWS / REPEAT_ROWS);
       GenericRow row = new GenericRow();
-      row.putField(D1, dimensionValue);
-      row.putField(D2, Integer.toString(dimensionValue));
-      row.putField(M1, dimensionValue);
-      row.putField(T, timestamp++);
+      row.putValue(D1, dimensionValue);
+      row.putValue(D2, Integer.toString(dimensionValue));
+      row.putValue(M1, dimensionValue);
+      row.putValue(T, BASE_TIMESTAMP + i);
       rows.add(row);
     }
 
@@ -111,7 +109,7 @@ public class SegmentConverterTest {
 
     List<File> result = segmentConverter.convertSegment();
 
-    Assert.assertEquals(result.size(), 1);
+    assertEquals(result.size(), 1);
     List<GenericRow> outputRows = new ArrayList<>();
     try (PinotSegmentRecordReader pinotSegmentRecordReader = new PinotSegmentRecordReader(result.get(0))) {
       while (pinotSegmentRecordReader.hasNext()) {
@@ -119,20 +117,18 @@ public class SegmentConverterTest {
       }
     }
     // Check that the segment is correctly rolled up on the time column
-    Assert.assertEquals(outputRows.size(), NUM_ROWS * NUM_SEGMENTS,
+    assertEquals(outputRows.size(), NUM_ROWS * NUM_SEGMENTS,
         "Number of rows returned by segment converter is incorrect");
 
     // Check the value
     for (int i = 0; i < NUM_SEGMENTS; i++) {
-      int rowCount = 0;
-      long timestamp = _referenceTimestamp;
       for (int j = 0; j < NUM_ROWS; j++) {
-        int expectedValue = rowCount % (NUM_ROWS / REPEAT_ROWS);
-        Assert.assertEquals(outputRows.get(rowCount).getValue(D1), expectedValue);
-        Assert.assertEquals(outputRows.get(rowCount).getValue(D2), Integer.toString(expectedValue));
-        Assert.assertEquals(outputRows.get(rowCount).getValue(M1), expectedValue);
-        Assert.assertEquals(outputRows.get(rowCount).getValue(T), timestamp++);
-        rowCount++;
+        GenericRow row = outputRows.get(i * NUM_ROWS + j);
+        int expectedValue = j % (NUM_ROWS / REPEAT_ROWS);
+        assertEquals(row.getValue(D1), expectedValue);
+        assertEquals(row.getValue(D2), Integer.toString(expectedValue));
+        assertEquals(row.getValue(M1), expectedValue);
+        assertEquals(row.getValue(T), BASE_TIMESTAMP + j);
       }
     }
   }
@@ -140,43 +136,26 @@ public class SegmentConverterTest {
   @Test
   public void testSegmentRollupWithTimeConversion()
       throws Exception {
-    final BaseDateTimeTransformer dateTimeTransformer =
-        DateTimeTransformerFactory.getDateTimeTransformer("1:MILLISECONDS:EPOCH", "1:DAYS:EPOCH", "1:DAYS");
-
-    // The segment generation code in SegmentColumnarIndexCreator will throw
-    // exception if start and end time in time column are not in acceptable
-    // range. For this test, we have explicitly disabled the check since the segment
-    // conversion is happening along with transforming each input record by converting
-    // the time column value (from millis since epoch) into days since epoch. While the
-    // source data is under range, the transformed data (days since epoch) goes out of range
-    // since segment conversion follows the same schema -- it does not create new schema. This
-    // means that time column spec doesn't change and still carries the time unit as milliseconds
-    // for the converted segment even though values we are writing are "days since epoch" and
-    // not "millis since epoch". Thus SegmentColumnarIndexCreator throws exception.
     SegmentConverter segmentConverter =
         new SegmentConverter.Builder().setTableName(TABLE_NAME).setSegmentName("segmentRollupWithTimeConversion")
-            .setInputIndexDirs(_segmentIndexDirList).setWorkingDir(WORKING_DIR).setCheckTimeValidityDuringGeneration(false)
+            .setInputIndexDirs(_segmentIndexDirList).setWorkingDir(WORKING_DIR).setSkipTimeValueCheck(false)
             .setRecordTransformer((row) -> {
-          long[] input = new long[1];
-          long[] output = new long[1];
-          input[0] = (Long) row.getValue(T);
-          dateTimeTransformer.transform(input, output, 1);
-          row.putField(T, output[0]);
-          return row;
-        }).setGroupByColumns(Arrays.asList(new String[]{D1, D2, T})).setRecordAggregator((rows) -> {
+              row.putValue(T, BASE_TIMESTAMP);
+              return row;
+            }).setGroupByColumns(Arrays.asList(D1, D2, T)).setRecordAggregator((rows) -> {
           GenericRow result = rows.get(0);
           for (int i = 1; i < rows.size(); i++) {
             GenericRow current = rows.get(i);
             Object aggregatedValue =
                 ((Number) result.getValue(M1)).intValue() + ((Number) current.getValue(M1)).intValue();
-            result.putField(M1, aggregatedValue);
+            result.putValue(M1, aggregatedValue);
           }
           return result;
         }).setTotalNumPartition(1).build();
 
     List<File> result = segmentConverter.convertSegment();
 
-    Assert.assertEquals(result.size(), 1);
+    assertEquals(result.size(), 1);
     List<GenericRow> outputRows = new ArrayList<>();
     try (PinotSegmentRecordReader pinotSegmentRecordReader = new PinotSegmentRecordReader(result.get(0))) {
       while (pinotSegmentRecordReader.hasNext()) {
@@ -184,15 +163,16 @@ public class SegmentConverterTest {
       }
     }
     // Check that the segment is correctly rolled up on the time column
-    Assert.assertEquals(outputRows.size(), NUM_ROWS / REPEAT_ROWS,
+    assertEquals(outputRows.size(), NUM_ROWS / REPEAT_ROWS,
         "Number of rows returned by segment converter is incorrect");
 
     // Check the value
     int expectedValue = 0;
     for (GenericRow row : outputRows) {
-      Assert.assertEquals(row.getValue(D1), expectedValue);
-      Assert.assertEquals(row.getValue(D2), Integer.toString(expectedValue));
-      Assert.assertEquals(row.getValue(M1), expectedValue * NUM_SEGMENTS * REPEAT_ROWS);
+      assertEquals(row.getValue(D1), expectedValue);
+      assertEquals(row.getValue(D2), Integer.toString(expectedValue));
+      assertEquals(row.getValue(M1), expectedValue * NUM_SEGMENTS * REPEAT_ROWS);
+      assertEquals(row.getValue(T), BASE_TIMESTAMP);
       expectedValue++;
     }
   }
@@ -207,7 +187,7 @@ public class SegmentConverterTest {
 
     List<File> result = segmentConverter.convertSegment();
 
-    Assert.assertEquals(result.size(), 3);
+    assertEquals(result.size(), 3);
 
     List<List<GenericRow>> outputRows = new ArrayList<>();
     for (File resultFile : result) {
@@ -220,7 +200,7 @@ public class SegmentConverterTest {
       }
     }
 
-    Assert.assertEquals(outputRows.stream().mapToInt(r -> r.size()).sum(), NUM_ROWS * NUM_SEGMENTS);
+    assertEquals(outputRows.stream().mapToInt(List::size).sum(), NUM_ROWS * NUM_SEGMENTS);
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -99,7 +99,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
+    segmentGeneratorConfig.setSkipTimeValueCheck(true);
     segmentGeneratorConfig
         .setInvertedIndexCreationColumns(Arrays.asList("column6", "column7", "column11", "column17", "column18"));
 
@@ -132,7 +132,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
+    segmentGeneratorConfig.setSkipTimeValueCheck(true);
 
     // Build the index segment.
     driver = new SegmentIndexCreationDriverImpl();
@@ -214,8 +214,9 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
       boolean expectedIsFitForDictionary) {
     BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
 
-    boolean isFitForMetadataBasedPlan = PLAN_MAKER.isFitForMetadataBasedPlan(brokerRequest, indexSegment);
-    boolean isFitForDictionaryBasedPlan = PLAN_MAKER.isFitForDictionaryBasedPlan(brokerRequest, indexSegment);
+    boolean isFitForMetadataBasedPlan = InstancePlanMakerImplV2.isFitForMetadataBasedPlan(brokerRequest, indexSegment);
+    boolean isFitForDictionaryBasedPlan =
+        InstancePlanMakerImplV2.isFitForDictionaryBasedPlan(brokerRequest, indexSegment);
     Assert.assertEquals(isFitForMetadataBasedPlan, expectedIsFitForMetadata);
     Assert.assertEquals(isFitForDictionaryBasedPlan, expectedIsFitForDictionary);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/ColumnMetadataTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/ColumnMetadataTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
 
 public class ColumnMetadataTest {
   private static final String AVRO_DATA = "data/test_data-mv.avro";
-  private static final File INDEX_DIR = new File(ColumnMetadataTest.class.toString());
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "ColumnMetadataTest");
   private static final String CREATOR_VERSION = "TestHadoopJar.1.1.1";
 
   @BeforeMethod
@@ -67,13 +67,12 @@ public class ColumnMetadataTest {
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "daysSinceEpoch", TimeUnit.HOURS,
             "testTable");
     config.setSegmentNamePostfix("1");
-    config.setTimeColumnName("daysSinceEpoch");
     // The segment generation code in SegmentColumnarIndexCreator will throw
     // exception if start and end time in time column are not in acceptable
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    config.setCheckTimeColumnValidityDuringGeneration(false);
+    config.setSkipTimeValueCheck(true);
     return config;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/SegmentMetadataImplTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/SegmentMetadataImplTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.segment.index;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
@@ -40,14 +39,12 @@ import static org.testng.Assert.assertTrue;
 
 public class SegmentMetadataImplTest {
   private static final String AVRO_DATA = "data/test_data-mv.avro";
-  private File INDEX_DIR;
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "SegmentMetadataImplTest");
   private File segmentDirectory;
 
   @BeforeMethod
   public void setUp()
       throws Exception {
-    INDEX_DIR = Files.createTempDirectory(SegmentMetadataImplTest.class.getName() + "_segmentDir").toFile();
-
     final String filePath =
         TestUtils.getFileFromResourceUrl(SegmentMetadataImplTest.class.getClassLoader().getResource(AVRO_DATA));
 
@@ -56,13 +53,12 @@ public class SegmentMetadataImplTest {
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "daysSinceEpoch", TimeUnit.HOURS,
             "testTable");
     config.setSegmentNamePostfix("1");
-    config.setTimeColumnName("daysSinceEpoch");
     // The segment generation code in SegmentColumnarIndexCreator will throw
     // exception if start and end time in time column are not in acceptable
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    config.setCheckTimeColumnValidityDuringGeneration(false);
+    config.setSkipTimeValueCheck(true);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverterTest.java
@@ -63,13 +63,12 @@ public class SegmentV1V2ToV3FormatConverterTest {
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), _indexDir, "daysSinceEpoch", TimeUnit.HOURS,
             "testTable");
     config.setSegmentNamePostfix("1");
-    config.setTimeColumnName("daysSinceEpoch");
     // The segment generation code in SegmentColumnarIndexCreator will throw
     // exception if start and end time in time column are not in acceptable
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    config.setCheckTimeColumnValidityDuringGeneration(false);
+    config.setSkipTimeValueCheck(true);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -68,7 +68,7 @@ public class SegmentGenerationWithTimeColumnTest {
 
   @BeforeClass
   public void printSeed() {
-    System.out.println("Seed is: "+ seed);
+    System.out.println("Seed is: " + seed);
   }
 
   @BeforeMethod
@@ -98,15 +98,11 @@ public class SegmentGenerationWithTimeColumnTest {
     Assert.assertEquals(metadata.getEndTime(), maxTime);
   }
 
-  @Test
-  public void testSegmentGenerationWithInvalidTime() {
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testSegmentGenerationWithInvalidTime()
+      throws Exception {
     Schema schema = createSchema(false);
-    try {
-      buildSegment(schema, false, true);
-      Assert.fail("Expecting exception from buildSegment for invalid start/end time of segment");
-    } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Invalid start/end time. segment name: testSegment time column name: date"));
-    }
+    buildSegment(schema, false, true);
   }
 
   private Schema createSchema(boolean isSimpleDate) {
@@ -120,8 +116,7 @@ public class SegmentGenerationWithTimeColumnTest {
     return schema;
   }
 
-  private File buildSegment(final Schema schema, final boolean isSimpleDate,
-      final boolean isInvalidDate)
+  private File buildSegment(final Schema schema, final boolean isSimpleDate, final boolean isInvalidDate)
       throws Exception {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
     config.setRawIndexCreationColumns(schema.getDimensionNames());
@@ -177,8 +172,8 @@ public class SegmentGenerationWithTimeColumnTest {
   }
 
   private Object getRandomValueForTimeColumn(boolean isSimpleDate, boolean isInvalidDate) {
-    long randomMs = validMinTime + (long)(_random.nextDouble() * (startTime - validMinTime));
-    Preconditions.checkArgument(TimeUtils.timeValueInValidRange(randomMs), "Value " + randomMs +" out of range");
+    long randomMs = validMinTime + (long) (_random.nextDouble() * (startTime - validMinTime));
+    Preconditions.checkArgument(TimeUtils.timeValueInValidRange(randomMs), "Value " + randomMs + " out of range");
     long dateColVal = randomMs;
     Object result;
     if (isInvalidDate) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
@@ -126,7 +126,7 @@ public class SegmentPreProcessorTest {
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
+    segmentGeneratorConfig.setSkipTimeValueCheck(true);
     SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(segmentGeneratorConfig);
     driver.build();
@@ -277,15 +277,16 @@ public class SegmentPreProcessorTest {
       processor.process();
     }
 
-
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata hllMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_HLL_BYTE_METRIC_COLUMN_NAME);
     Assert.assertEquals(hllMetricMetadata.getDataType(), FieldSpec.DataType.BYTES);
-    Assert.assertEquals(hllMetricMetadata.getDefaultNullValueString(), "00000008000000ac00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+    Assert.assertEquals(hllMetricMetadata.getDefaultNullValueString(),
+        "00000008000000ac00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
 
     ColumnMetadata tDigestMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_TDIGEST_BYTE_METRIC_COLUMN_NAME);
     Assert.assertEquals(tDigestMetricMetadata.getDataType(), FieldSpec.DataType.BYTES);
-    Assert.assertEquals(tDigestMetricMetadata.getDefaultNullValueString(), "0000000141ba085ee15d2f3241ba085ee15d2f324059000000000000000000013ff000000000000041ba085ee15d2f32");
+    Assert.assertEquals(tDigestMetricMetadata.getDefaultNullValueString(),
+        "0000000141ba085ee15d2f3241ba085ee15d2f324059000000000000000000013ff000000000000041ba085ee15d2f32");
   }
 
   private void checkUpdateDefaultColumns()

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
@@ -19,47 +19,40 @@
 package org.apache.pinot.core.startree;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.math.util.MathUtils;
 import org.apache.pinot.common.data.DimensionFieldSpec;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.MetricFieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.data.StarTreeIndexSpec;
-import org.apache.pinot.common.data.TimeFieldSpec;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.FileFormat;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.startree.hll.HllConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class StarTreeIndexTestSegmentHelper {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StarTreeIndexTestSegmentHelper.class);
   private static final Random RANDOM = new Random();
 
-  private static final String TIME_COLUMN_NAME = "daysSinceEpoch";
   private static final int NUM_DIMENSIONS = 4;
   private static final int NUM_METRICS = 2;
   private static final int METRIC_MAX_VALUE = 10000;
 
-  public static Schema buildSegment(String segmentDirName, String segmentName)
+  public static void buildSegment(String segmentDirName, String segmentName)
       throws Exception {
-    return buildSegment(segmentDirName, segmentName, null);
+    buildSegment(segmentDirName, segmentName, null);
   }
 
-  public static Schema buildSegmentWithHll(String segmentDirName, String segmentName, HllConfig hllConfig)
+  public static void buildSegmentWithHll(String segmentDirName, String segmentName, HllConfig hllConfig)
       throws Exception {
-    return buildSegment(segmentDirName, segmentName, hllConfig);
+    buildSegment(segmentDirName, segmentName, hllConfig);
   }
 
-  private static Schema buildSegment(String segmentDirName, String segmentName, HllConfig hllConfig)
+  private static void buildSegment(String segmentDirName, String segmentName, HllConfig hllConfig)
       throws Exception {
     int numRows = (int) MathUtils.factorial(NUM_DIMENSIONS) * 100;
     Schema schema = new Schema();
@@ -70,7 +63,6 @@ public class StarTreeIndexTestSegmentHelper {
       schema.addField(dimensionFieldSpec);
     }
 
-    schema.addField(new TimeFieldSpec(TIME_COLUMN_NAME, FieldSpec.DataType.INT, TimeUnit.DAYS));
     for (int i = 0; i < NUM_METRICS; i++) {
       String metricName = "m" + (i + 1);
       MetricFieldSpec metricFieldSpec = new MetricFieldSpec(metricName, FieldSpec.DataType.INT);
@@ -85,46 +77,32 @@ public class StarTreeIndexTestSegmentHelper {
     config.setFormat(FileFormat.AVRO);
     config.setSegmentName(segmentName);
     config.setHllConfig(hllConfig);
-    // The segment generation code in SegmentColumnarIndexCreator will throw
-    // exception if start and end time in time column are not in acceptable
-    // range. For this test, we first need to fix the input avro data
-    // to have the time column values in allowed range. Until then, the check
-    // is explicitly disabled
-    config.setCheckTimeColumnValidityDuringGeneration(false);
 
     List<GenericRow> rows = new ArrayList<>(numRows);
     for (int rowId = 0; rowId < numRows; rowId++) {
-      HashMap<String, Object> map = new HashMap<>();
-      // Dim columns.
+      GenericRow genericRow = new GenericRow();
+      // Dimensions
       for (int i = 0; i < NUM_DIMENSIONS / 2; i++) {
         String dimName = schema.getDimensionFieldSpecs().get(i).getName();
-        map.put(dimName, dimName + "-v" + rowId % (NUM_DIMENSIONS - i));
+        genericRow.putValue(dimName, dimName + "-v" + rowId % (NUM_DIMENSIONS - i));
       }
       // Random values make cardinality of d3, d4 column values larger to better test hll
       for (int i = NUM_DIMENSIONS / 2; i < NUM_DIMENSIONS; i++) {
         String dimName = schema.getDimensionFieldSpecs().get(i).getName();
-        map.put(dimName, dimName + "-v" + RANDOM.nextInt(i * 100));
+        genericRow.putValue(dimName, dimName + "-v" + RANDOM.nextInt(i * 100));
       }
 
-      // Metric columns.
+      // Metrics
       for (int i = 0; i < NUM_METRICS; i++) {
         String metName = schema.getMetricFieldSpecs().get(i).getName();
-        map.put(metName, RANDOM.nextInt(METRIC_MAX_VALUE));
+        genericRow.putValue(metName, RANDOM.nextInt(METRIC_MAX_VALUE));
       }
 
-      // Time column.
-      map.put(TIME_COLUMN_NAME, rowId % 7);
-
-      GenericRow genericRow = new GenericRow();
-      genericRow.init(map);
       rows.add(genericRow);
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, new GenericRowRecordReader(rows, schema));
     driver.build();
-
-    LOGGER.info("Built segment {} at {}", segmentName, segmentDirName);
-    return schema;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/TestStarTreeMetadata.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/TestStarTreeMetadata.java
@@ -20,14 +20,12 @@ package org.apache.pinot.core.startree;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.data.StarTreeIndexSpec;
 import org.apache.pinot.common.segment.StarTreeMetadata;
-import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentCreationDriverFactory;
@@ -40,24 +38,18 @@ import org.testng.annotations.Test;
 
 
 public class TestStarTreeMetadata {
-  private final String AVRO_DATA = "data/test_sample_data.avro";
+  private static final String AVRO_DATA = "data/test_sample_data.avro";
   private static final int MAX_LEAF_RECORDS = 99;
 
   private static final int SKIP_CARDINALITY_THRESHOLD = 99999;
-  private static final List<String> DIMENSIONS_SPLIT_ORDER = Arrays.asList(new String[]{"column3", "column4"});
-
-  private static final Set<String> SKIP_STAR_NODE_CREATION_DIMENSTIONS =
-      new HashSet<String>(Arrays.asList(new String[]{"column9"}));
-
-  private static final Set<String> SKIP_MATERIALIZATION_DIMENSIONS =
-      new HashSet<String>(Arrays.asList(new String[]{"column11"}));
-
+  private static final List<String> DIMENSIONS_SPLIT_ORDER = Arrays.asList("column3", "column4");
+  private static final Set<String> SKIP_STAR_NODE_CREATION_DIMENSIONS = Collections.singleton("column9");
+  private static final Set<String> SKIP_MATERIALIZATION_DIMENSIONS = Collections.singleton("column11");
   private static final String TABLE_NAME = "starTreeTable";
   private static final String SEGMENT_NAME = "starTreeSegment";
 
   private static final String INDEX_DIR_NAME = FileUtils.getTempDirectory() + File.separator + "starTreeMetaData";
   private static File INDEX_DIR = new File(INDEX_DIR_NAME);
-  public static IndexSegment _indexSegment;
 
   /**
    * Build the StarTree segment
@@ -82,9 +74,8 @@ public class TestStarTreeMetadata {
       FileUtils.deleteQuietly(segmentDir);
     }
 
-    final SegmentGeneratorConfig config = SegmentTestUtils
-        .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), segmentDir, "time_day", TimeUnit.DAYS,
-            TABLE_NAME);
+    final SegmentGeneratorConfig config =
+        SegmentTestUtils.getSegmentGeneratorConfigWithoutTimeColumn(new File(filePath), segmentDir, TABLE_NAME);
 
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);
@@ -92,16 +83,10 @@ public class TestStarTreeMetadata {
     starTreeIndexSpec.setDimensionsSplitOrder(DIMENSIONS_SPLIT_ORDER);
     starTreeIndexSpec.setMaxLeafRecords(MAX_LEAF_RECORDS);
     starTreeIndexSpec.setSkipMaterializationCardinalityThreshold(SKIP_CARDINALITY_THRESHOLD);
-    starTreeIndexSpec.setSkipStarNodeCreationForDimensions(SKIP_STAR_NODE_CREATION_DIMENSTIONS);
+    starTreeIndexSpec.setSkipStarNodeCreationForDimensions(SKIP_STAR_NODE_CREATION_DIMENSIONS);
     starTreeIndexSpec.setSkipMaterializationForDimensions(SKIP_MATERIALIZATION_DIMENSIONS);
 
     config.enableStarTreeIndex(starTreeIndexSpec);
-    // The segment generation code in SegmentColumnarIndexCreator will throw
-    // exception if start and end time in time column are not in acceptable
-    // range. For this test, we first need to fix the input avro data
-    // to have the time column values in allowed range. Until then, the check
-    // is explicitly disabled
-    config.setCheckTimeColumnValidityDuringGeneration(false);
 
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
@@ -124,7 +109,7 @@ public class TestStarTreeMetadata {
     Assert.assertEquals(starTreeMetadata.getDimensionsSplitOrder(), DIMENSIONS_SPLIT_ORDER);
     Assert.assertEquals(starTreeMetadata.getMaxLeafRecords(), MAX_LEAF_RECORDS);
 
-    Assert.assertEquals(starTreeMetadata.getSkipStarNodeCreationForDimensions(), SKIP_STAR_NODE_CREATION_DIMENSTIONS);
+    Assert.assertEquals(starTreeMetadata.getSkipStarNodeCreationForDimensions(), SKIP_STAR_NODE_CREATION_DIMENSIONS);
     Assert.assertEquals(starTreeMetadata.getSkipMaterializationCardinality(), SKIP_CARDINALITY_THRESHOLD);
     Assert.assertEquals(starTreeMetadata.getSkipMaterializationForDimensions(), SKIP_MATERIALIZATION_DIMENSIONS);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
@@ -36,7 +36,6 @@ import org.apache.pinot.core.segment.creator.impl.SegmentCreationDriverFactory;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segments.v1.creator.SegmentTestUtils;
 import org.apache.pinot.startree.hll.HllConfig;
-import org.apache.pinot.startree.hll.HllConstants;
 import org.apache.pinot.util.TestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,14 +43,13 @@ import org.slf4j.LoggerFactory;
 
 public class SegmentWithHllIndexCreateHelper {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentWithHllIndexCreateHelper.class);
-  private static final String hllDeriveColumnSuffix = HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX;
 
   private final String tableName;
   private final File INDEX_DIR;
   private final File inputAvro;
   private final String timeColumnName;
   private final TimeUnit timeUnit;
-  private String segmentName = "starTreeSegment";
+  private String segmentName;
   private Schema schema;
 
   public SegmentWithHllIndexCreateHelper(String tableName, URL avroUrl, String timeColumnName, TimeUnit timeUnit,
@@ -139,7 +137,7 @@ public class SegmentWithHllIndexCreateHelper {
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    segmentGenConfig.setCheckTimeColumnValidityDuringGeneration(false);
+    segmentGenConfig.setSkipTimeValueCheck(true);
 
     if (enableStarTree) {
       setupStarTreeConfig(segmentGenConfig);

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/CrcUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/CrcUtilsTest.java
@@ -82,13 +82,12 @@ public class CrcUtilsTest {
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "daysSinceEpoch", TimeUnit.DAYS,
             "testTable");
     config.setSegmentNamePostfix("1");
-    config.setTimeColumnName("daysSinceEpoch");
     // The segment generation code in SegmentColumnarIndexCreator will throw
     // exception if start and end time in time column are not in acceptable
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    config.setCheckTimeColumnValidityDuringGeneration(false);
+    config.setSkipTimeValueCheck(true);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
@@ -105,7 +105,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
+    segmentGeneratorConfig.setSkipTimeValueCheck(true);
 
     // Build the index segment.
     SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -106,7 +106,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
+    segmentGeneratorConfig.setSkipTimeValueCheck(true);
     segmentGeneratorConfig
         .setInvertedIndexCreationColumns(Arrays.asList("column6", "column7", "column11", "column17", "column18"));
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -242,7 +242,6 @@ public class DistinctQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setTableName(tableName);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
     segmentGeneratorConfig.setSegmentName(segmentName);
-    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(segmentGeneratorConfig, recordReader);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -240,7 +240,7 @@ public class FastHllQueriesTest extends BaseQueriesTest {
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    segmentGeneratorConfig.setCheckTimeColumnValidityDuringGeneration(false);
+    segmentGeneratorConfig.setSkipTimeValueCheck(true);
     segmentGeneratorConfig
         .setInvertedIndexCreationColumns(Arrays.asList("column6", "column7", "column11", "column17", "column18"));
     if (hasPreGeneratedHllColumns) {

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
@@ -94,7 +94,7 @@ public class DictionariesTest {
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    config.setCheckTimeColumnValidityDuringGeneration(false);
+    config.setSkipTimeValueCheck(true);
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/IntArraysTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/IntArraysTest.java
@@ -46,8 +46,7 @@ import org.testng.annotations.Test;
 
 public class IntArraysTest {
   private static final String AVRO_DATA = "data/test_data-mv.avro";
-  private static File INDEX_DIR =
-      new File(FileUtils.getTempDirectory() + File.separator + IntArraysTest.class.getName());
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "IntArraysTest");
 
   @AfterClass
   public static void cleanup() {
@@ -63,19 +62,17 @@ public class IntArraysTest {
       FileUtils.deleteQuietly(INDEX_DIR);
     }
 
-//    System.out.println(INDEX_DIR.getAbsolutePath());
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
 
     final SegmentGeneratorConfig config = SegmentTestUtils
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "weeksSinceEpochSunday",
             TimeUnit.DAYS, "test");
-    config.setTimeColumnName("weeksSinceEpochSunday");
     // The segment generation code in SegmentColumnarIndexCreator will throw
     // exception if start and end time in time column are not in acceptable
     // range. For this test, we first need to fix the input avro data
     // to have the time column values in allowed range. Until then, the check
     // is explicitly disabled
-    config.setCheckTimeColumnValidityDuringGeneration(false);
+    config.setSkipTimeValueCheck(true);
     driver.init(config);
     driver.build();
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OfflineSegmentIntervalCheckerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OfflineSegmentIntervalCheckerCommand.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import org.apache.pinot.common.utils.time.TimeUtils;
 import org.apache.pinot.controller.util.SegmentIntervalUtils;
 import org.apache.pinot.tools.Command;
 import org.joda.time.Interval;
@@ -140,7 +141,7 @@ public class OfflineSegmentIntervalCheckerCommand extends AbstractBaseAdminComma
     if (SegmentIntervalUtils.eligibleForSegmentIntervalCheck(tableConfig.getValidationConfig())) {
       for (OfflineSegmentZKMetadata offlineSegmentZKMetadata : offlineSegmentZKMetadataList) {
         Interval timeInterval = offlineSegmentZKMetadata.getTimeInterval();
-        if (!SegmentIntervalUtils.isValidInterval(timeInterval)) {
+        if (timeInterval == null || !TimeUtils.isValidTimeInterval(timeInterval)) {
           segmentsWithInvalidIntervals.add(offlineSegmentZKMetadata.getSegmentName());
         }
       }


### PR DESCRIPTION
- Reverse the config so that the default is false (easier to use)
- Simplify the logic of time value check
- Fix the invalid time value in some tests

NOTE: This commit has backward-incompatible change on the config introduced in #4368 merged in 07/16/2019. In SegmentGeneratorConfig, `checkTimeColumnValidityDuringGeneration` (default true) is replaced with `skipTimeValueCheck` (default false).