### PR TITLE
Fix a wrong option name for AddSchema in the information log

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
@@ -65,7 +65,7 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
   @Override
   public String toString() {
     String retString =
-        ("AddSchema -controllerHost " + _controllerHost + " -controllerPort " + _controllerPort + " -schemaFilePath "
+        ("AddSchema -controllerHost " + _controllerHost + " -controllerPort " + _controllerPort + " -schemaFile "
             + _schemaFile);
 
     return ((_exec) ? (retString + " -exec") : retString);


### PR DESCRIPTION
I ran the quickstart and saw the following logs:

```
$ bin/quick-start-offline.sh 

(snip)

***** Adding baseballStats schema *****
Executing command: AddSchema -controllerHost 192.168.0.6 -controllerPort 9000 -schemaFilePath /home/sekikn/repos/incubator-pinot/pinot-distribution/target/apache-pinot-incubating-0.2.0-SNAPSHOT-bin/apache-pinot-incubating-0.2.0-SNAPSHOT-bin/quickStartData1572217342286/baseballStats_schema.json -exec
```

Then I tried to re-run the same command manually, but encountered the following error:

```
$ JAVA_OPTS="-Dpinot.admin.system.exit=true" bin/pinot-admin.sh AddSchema -controllerHost 192.168.0.6 -controllerPort 9000 -schemaFilePath /home/sekikn/repos/incubator-pinot/pinot-distribution/target/apache-pinot-incubating-0.2.0-SNAPSHOT-bin/apache-pinot-incubating-0.2.0-SNAPSHOT-bin/quickStartData1572217342286/baseballStats_schema.json -exec
08:04:18.867 PinotAdministrator - Error: "-schemaFilePath" is not a valid option
```

The right option name is `-schemaFile`, not `-schemaFilePath`.