### PR TITLE
[TE][notification] Ability to reopen and reuse existing Jira tickets for alerts

### DIFF
--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -303,7 +303,7 @@
     <dependency>
       <groupId>com.atlassian.jira</groupId>
       <artifactId>jira-rest-java-client-core</artifactId>
-      <version>2.0.0-m30</version>
+      <version>5.1.6</version>
       <exclusions>
         <exclusion>
           <groupId>com.sun.jersey</groupId>
@@ -316,19 +316,14 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>io.atlassian.fugue</groupId>
+      <artifactId>fugue</artifactId>
+      <version>4.7.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.atlassian.jira</groupId>
-      <artifactId>jira-rest-java-client-plugin</artifactId>
-      <version>2.0.0-m30</version>
-    </dependency>
-    <dependency>
-      <groupId>com.atlassian.jira</groupId>
-      <artifactId>jira-rest-java-client-api</artifactId>
-      <version>2.0.0-m30</version>
+      <version>1.3.7</version>
     </dependency>
   </dependencies>
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/JiraEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/JiraEntity.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.notification.commons;
+
+import java.util.List;
+
+
+/**
+ * ThirdEye's Jira Settings Holder
+ */
+public class JiraEntity {
+  private String jiraProject;
+  private Long jiraIssueTypeId;
+  private String summary;
+  private String description;
+  private String assignee;
+  private List<String> labels;
+  private long mergeGap;
+
+  public JiraEntity(String jiraProject, Long jiraIssueTypeId, String issueSummary) {
+    this.jiraProject = jiraProject;
+    this.jiraIssueTypeId = jiraIssueTypeId;
+    this.summary = issueSummary;
+  }
+
+  public String getJiraProject() {
+    return jiraProject;
+  }
+
+  public void setJiraProject(String jiraProject) {
+    this.jiraProject = jiraProject;
+  }
+
+  public Long getJiraIssueTypeId() {
+    return jiraIssueTypeId;
+  }
+
+  public void setJiraIssueTypeId(Long jiraIssueTypeId) {
+    this.jiraIssueTypeId = jiraIssueTypeId;
+  }
+
+  public String getSummary() {
+    return summary;
+  }
+
+  public void setSummary(String summary) {
+    this.summary = summary;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getAssignee() {
+    return assignee;
+  }
+
+  public void setAssignee(String assignee) {
+    this.assignee = assignee;
+  }
+
+  public long getMergeGap() {
+    return mergeGap;
+  }
+
+  public void setMergeGap(long mergeGap) {
+    this.mergeGap = mergeGap;
+  }
+
+  public List<String> getLabels() {
+    return labels;
+  }
+
+  public void setLabels(List<String> labels) {
+    this.labels = labels;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("Jira{");
+    sb.append("project='").append(jiraProject).append('\'');
+    sb.append(", type='").append(jiraIssueTypeId).append('\'');
+    sb.append(", assignee='").append(assignee).append('\'');
+    sb.append(", summary='").append(summary).append('\'');
+    sb.append(", labels='").append(labels).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/JiraEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/JiraEntity.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.thirdeye.notification.commons;
 
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -106,5 +107,10 @@ public class JiraEntity {
     sb.append(", labels='").append(labels).append('\'');
     sb.append('}');
     return sb.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(jiraProject, jiraIssueTypeId, assignee, summary, labels, mergeGap);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeJiraClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeJiraClient.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.notification.commons;
+
+import com.atlassian.jira.rest.client.api.JiraRestClient;
+import com.atlassian.jira.rest.client.api.domain.Comment;
+import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.api.domain.IssueFieldId;
+import com.atlassian.jira.rest.client.api.domain.SearchResult;
+import com.atlassian.jira.rest.client.api.domain.Transition;
+import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
+import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
+import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
+import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
+import com.google.common.base.Joiner;
+import java.net.URI;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A client to communicate with Jira
+ */
+public class ThirdEyeJiraClient {
+  private static final Logger LOG = LoggerFactory.getLogger(ThirdEyeJiraClient.class);
+
+  private JiraRestClient restClient;
+  private static final String JIRA_REOPEN_TRANSITION = "Reopen";
+
+  public ThirdEyeJiraClient(JiraConfiguration jiraAdminConfig) {
+    this.restClient = createJiraRestClient(jiraAdminConfig);
+  }
+
+  private JiraRestClient createJiraRestClient(JiraConfiguration jiraAdminConfig) {
+    return new AsynchronousJiraRestClientFactory().createWithBasicHttpAuthentication(
+        URI.create(jiraAdminConfig.getJiraHost()),
+        jiraAdminConfig.getJiraUser(),
+        jiraAdminConfig.getJiraPassword());
+  }
+
+  /**
+   * Search for all the existing jira tickets based on the filters
+   */
+  public SearchResult getIssue(String project, String summary, String reporter) {
+    LOG.info("Fetching Jira - project={}, reporter={}, labels=thirdeye, summary=\"{}\" ", project, reporter, summary);
+    return restClient.getSearchClient().searchJql("labels=thirdeye and reporter IN (" + reporter + ") and text~\""
+        + summary + "\" and project=" + project).claim();
+  }
+
+  /**
+   * Adds the specified comment to the jira ticket
+   */
+  public void addComment(Issue issue, String comment) {
+    // TODO: handle comments longer than X characters!
+    Comment resComment = Comment.valueOf(comment);
+    LOG.info("Commenting Jira {} with new anomalies", issue.getKey());
+    restClient.getIssueClient().addComment(issue.getCommentsUri(), resComment).claim();
+  }
+
+  /**
+   * Reopens an existing issue irrespective of its current state
+   */
+  public void reopenIssue(Issue issue) {
+    Iterable<Transition> issueTransIt = restClient.getIssueClient().getTransitions(issue).claim();
+    LOG.debug("Supported transitions for {} are {}", issue.getKey(), Joiner.on(",").join(issueTransIt));
+    Optional<Transition> openTransition = StreamSupport
+        .stream(issueTransIt.spliterator(), false)
+        .filter(issueTrans -> issueTrans.getName().contains(JIRA_REOPEN_TRANSITION))
+        .findFirst();
+
+    if (openTransition.isPresent()) {
+      TransitionInput trans = new TransitionInput(openTransition.get().getId());
+      LOG.info("Reopening Jira {} with [status={}]. Previous state [status={}]", issue.getKey(),
+          openTransition.get().getName(), issue.getStatus().getName());
+      restClient.getIssueClient().transition(issue, trans).claim();
+    } else {
+      LOG.warn("Unable to reopen issue {}! Cannot find a '{}' transition. Verify permissions!", issue.getKey(),
+          JIRA_REOPEN_TRANSITION);
+    }
+  }
+
+  /**
+   * Updates existing issue with assignee and labels
+   */
+  public void updateIssue(Issue issue, JiraEntity jiraEntity) {
+    IssueInput input = new IssueInputBuilder()
+        .setAssigneeName(jiraEntity.getAssignee())
+        .setFieldInput(new FieldInput(IssueFieldId.LABELS_FIELD, jiraEntity.getLabels()))
+        .build();
+    String prevAssignee = issue.getAssignee() == null ? "unassigned" : issue.getAssignee().getName();
+
+    LOG.info("Updating Jira {} with [assignee={}, labels={}]. Previous state [assignee={}, labels={}]", issue.getKey(),
+        jiraEntity.getAssignee(), jiraEntity.getLabels(), prevAssignee, issue.getLabels());
+    restClient.getIssueClient().updateIssue(issue.getKey(), input).claim();
+  }
+
+  /**
+   * Creates a new jira ticket with specified settings
+   */
+  public String createIssue(JiraEntity jiraEntity) {
+    IssueInputBuilder issueBuilder = new IssueInputBuilder(
+        jiraEntity.getJiraProject(), jiraEntity.getJiraIssueTypeId(), jiraEntity.getSummary());
+    issueBuilder.setAssigneeName(jiraEntity.getAssignee());
+    issueBuilder.setFieldInput(new FieldInput(IssueFieldId.LABELS_FIELD, jiraEntity.getLabels()));
+    issueBuilder.setDescription(jiraEntity.getDescription());
+
+    LOG.info("Creating Jira with settings {}", jiraEntity.toString());
+    return restClient.getIssueClient().createIssue(issueBuilder.build()).claim().getKey();
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerterTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.alert.scheme;
+
+import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.api.domain.SearchResult;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.mail.HtmlEmail;
+import org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
+import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionAlertConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
+import org.apache.pinot.thirdeye.detection.ConfigUtils;
+import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
+import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
+import org.apache.pinot.thirdeye.notification.commons.EmailEntity;
+import org.apache.pinot.thirdeye.notification.commons.JiraEntity;
+import org.apache.pinot.thirdeye.notification.commons.ThirdEyeJiraClient;
+import org.apache.pinot.thirdeye.notification.formatter.ADContentFormatterContext;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.thirdeye.detection.alert.filter.AlertFilterUtils.*;
+import static org.mockito.Mockito.*;
+
+
+public class DetectionJiraAlerterTest {
+  private static final String PROP_CLASS_NAME = "className";
+  private static final String PROP_DETECTION_CONFIG_IDS = "detectionConfigIds";
+  private static final String FROM_ADDRESS_VALUE = "test3@test.test";
+  private static final String ALERT_NAME_VALUE = "alert_name";
+  private static final String DASHBOARD_HOST_VALUE = "dashboard";
+  private static final String COLLECTION_VALUE = "test_dataset";
+  private static final String DETECTION_NAME_VALUE = "test detection";
+  private static final String METRIC_VALUE = "test_metric";
+
+  private DAOTestBase testDAOProvider;
+  private DetectionAlertConfigManager alertConfigDAO;
+  private MergedAnomalyResultManager anomalyDAO;
+  private DetectionConfigManager detectionDAO;
+  private DetectionAlertConfigDTO alertConfigDTO;
+  private Long detectionConfigId;
+  private ADContentFormatterContext adContext;
+  private ThirdEyeAnomalyConfiguration thirdEyeConfig;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    this.testDAOProvider = DAOTestBase.getInstance();
+    DAORegistry daoRegistry = DAORegistry.getInstance();
+    this.alertConfigDAO = daoRegistry.getDetectionAlertConfigManager();
+    this.anomalyDAO = daoRegistry.getMergedAnomalyResultDAO();
+    this.detectionDAO = daoRegistry.getDetectionConfigManager();
+
+    DetectionConfigDTO detectionConfig = new DetectionConfigDTO();
+    detectionConfig.setName(DETECTION_NAME_VALUE);
+    this.detectionConfigId = this.detectionDAO.save(detectionConfig);
+
+    this.alertConfigDTO = new DetectionAlertConfigDTO();
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(PROP_CLASS_NAME, "org.apache.pinot.thirdeye.detection.alert.filter.ToAllRecipientsDetectionAlertFilter");
+    properties.put(PROP_DETECTION_CONFIG_IDS, Collections.singletonList(this.detectionConfigId));
+
+    Map<String, Set<String>> recipients = new HashMap<>();
+    recipients.put(PROP_TO, PROP_TO_VALUE);
+    recipients.put(PROP_CC, PROP_CC_VALUE);
+    recipients.put(PROP_BCC, PROP_BCC_VALUE);
+
+    Map<String, Object> emailScheme = new HashMap<>();
+    emailScheme.put("className", "org.apache.pinot.thirdeye.detection.alert.scheme.RandomAlerter");
+    emailScheme.put(PROP_RECIPIENTS, recipients);
+    this.alertConfigDTO.setAlertSchemes(Collections.singletonMap("emailScheme", emailScheme));
+    this.alertConfigDTO.setProperties(properties);
+    this.alertConfigDTO.setFrom(FROM_ADDRESS_VALUE);
+    this.alertConfigDTO.setName(ALERT_NAME_VALUE);
+    Map<Long, Long> vectorClocks = new HashMap<>();
+    this.alertConfigDTO.setVectorClocks(vectorClocks);
+    this.alertConfigDAO.save(this.alertConfigDTO);
+
+    MergedAnomalyResultDTO anomalyResultDTO = new MergedAnomalyResultDTO();
+    anomalyResultDTO.setStartTime(1000L);
+    anomalyResultDTO.setEndTime(2000L);
+    anomalyResultDTO.setDetectionConfigId(this.detectionConfigId);
+    anomalyResultDTO.setCollection(COLLECTION_VALUE);
+    anomalyResultDTO.setMetric(METRIC_VALUE);
+    this.anomalyDAO.save(anomalyResultDTO);
+
+    MergedAnomalyResultDTO anomalyResultDTO2 = new MergedAnomalyResultDTO();
+    anomalyResultDTO2.setStartTime(3000L);
+    anomalyResultDTO2.setEndTime(4000L);
+    anomalyResultDTO2.setDetectionConfigId(this.detectionConfigId);
+    anomalyResultDTO2.setCollection(COLLECTION_VALUE);
+    anomalyResultDTO2.setMetric(METRIC_VALUE);
+    this.anomalyDAO.save(anomalyResultDTO2);
+
+    this.adContext = new ADContentFormatterContext();
+    adContext.setNotificationConfig(alertConfigDTO);
+
+    this.thirdEyeConfig = new ThirdEyeAnomalyConfiguration();
+    thirdEyeConfig.setDashboardHost(DASHBOARD_HOST_VALUE);
+    Map<String, Object> jiraProperties = new HashMap<>();
+    jiraProperties.put("jiraUser", "test");
+    jiraProperties.put("jiraUrl", "test");
+    jiraProperties.put("jiraDefaultProject", "THIRDEYE");
+    jiraProperties.put("jiraIssueTypeId", 19);
+    Map<String, Map<String, Object>> alerterProps = new HashMap<>();
+    alerterProps.put("jiraConfiguration", jiraProperties);
+    thirdEyeConfig.setAlerterConfiguration(alerterProps);
+  }
+
+  @AfterMethod(alwaysRun = true)
+  void afterClass() {
+    testDAOProvider.cleanup();
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void testFailAlertWithNullResult() throws Exception {
+    DetectionEmailAlerter alertTaskInfo = new DetectionEmailAlerter(this.adContext, this.thirdEyeConfig, null);
+    alertTaskInfo.run();
+  }
+
+  @Test
+  public void testSendEmailSuccessful() throws Exception {
+    Map<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> result = new HashMap<>();
+    result.put(
+        new DetectionAlertFilterNotification(ConfigUtils.getMap(this.alertConfigDTO.getAlertSchemes())),
+        new HashSet<>(this.anomalyDAO.findAll()));
+    DetectionAlertFilterResult notificationResults = new DetectionAlertFilterResult(result);
+
+    final ThirdEyeJiraClient jiraClient = mock(ThirdEyeJiraClient.class);
+    when(jiraClient.getIssue(anyString(), anyString(), anyString())).thenReturn(new SearchResult(0, 0, 0, null));
+    when(jiraClient.createIssue(any(JiraEntity.class))).thenReturn("created");
+
+    DetectionJiraAlerter jiraAlerter = new DetectionJiraAlerter(this.adContext, this.thirdEyeConfig, notificationResults);
+
+    // Executes successfully without errors
+    jiraAlerter.run();
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/channels/TestJiraContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/channels/TestJiraContentFormatter.java
@@ -1,7 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.pinot.thirdeye.notification.formatter.channels;
 
-import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
-import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,6 +42,7 @@ import org.apache.pinot.thirdeye.datalayer.pojo.AlertConfigBean;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.detection.alert.scheme.DetectionAlertScheme;
 import org.apache.pinot.thirdeye.notification.commons.JiraConfiguration;
+import org.apache.pinot.thirdeye.notification.commons.JiraEntity;
 import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
 import org.apache.pinot.thirdeye.notification.formatter.ADContentFormatterContext;
 import org.testng.Assert;
@@ -134,18 +152,18 @@ public class TestJiraContentFormatter {
     JiraContentFormatter jiraContent = new JiraContentFormatter(
         JiraConfiguration.createFromProperties(jiraConfiguration), jiraClientConfig, content, teConfig, adContext);
 
-    IssueInput issueInput = jiraContent.getJiraEntity(new HashSet<>(this.anomalyDAO.findAll()));
+    JiraEntity jiraEntity = jiraContent.getJiraEntity(new HashSet<>(this.anomalyDAO.findAll()));
 
     // Assert Jira fields
-    Assert.assertEquals(issueInput.getField(PROP_LABELS).getValue(), Arrays.asList("test-label-1", "test-label-2", "thirdeye"));
-    Assert.assertEquals(((ComplexIssueInputFieldValue) issueInput.getField(PROP_ISSUE_TYPE).getValue()).getValuesMap().get("id"), "16");
-    Assert.assertEquals(((ComplexIssueInputFieldValue) issueInput.getField(PROP_ASSIGNEE).getValue()).getValuesMap().get("name"), "test");
-    Assert.assertEquals(((ComplexIssueInputFieldValue) issueInput.getField(PROP_PROJECT).getValue()).getValuesMap().get("key"), "thirdeye");
+    Assert.assertEquals(jiraEntity.getLabels(), Arrays.asList("test-label-1", "test-label-2", "thirdeye"));
+    Assert.assertEquals(jiraEntity.getJiraIssueTypeId().longValue(), 16L);
+    Assert.assertEquals(jiraEntity.getAssignee(), "test");
+    Assert.assertEquals(jiraEntity.getJiraProject(), "thirdeye");
 
     // Assert summary and description
-    Assert.assertEquals(issueInput.getField(PROP_SUMMARY).getValue(), "Thirdeye Alert : alert_name - test_metric");
+    Assert.assertEquals(jiraEntity.getSummary(), "Thirdeye Alert : alert_name - test_metric");
     Assert.assertEquals(
-        issueInput.getField("description").getValue().toString().replaceAll(" ", ""),
+        jiraEntity.getDescription().replaceAll(" ", ""),
         IOUtils.toString(Thread.currentThread().getContextClassLoader()
             .getResourceAsStream("test-jira-anomalies-template.ftl")).replaceAll(" ", ""));
   }


### PR DESCRIPTION
Changes:
* Updated jira client version to the latest
* Added capability to reopen a previously filed Jira ticket. Merging criteria - 
** Reopen if jira ticket was filed in the last 1 day. Users can override this by specifying a mergeGap.
** Tickets filed by _thirdeye_ jira user, with _thirdeye_ label, and configured jira project and summary