### PR TITLE
AvroSchemaToPinotSchema should return immediately if outputDir doesn't exist

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
@@ -91,7 +91,8 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
 
     File outputDir = new File(_outputDir);
     if (!outputDir.isDirectory()) {
-      LOGGER.error("ERROR: Output directory: %s does not exist or is not a directory", _outputDir);
+      LOGGER.error("ERROR: Output directory: {} does not exist or is not a directory", _outputDir);
+      return false;
     }
     File outputFile = new File(outputDir, _pinotSchemaName + ".json");
     LOGGER.info("Store Pinot schema to file: {}", outputFile.getAbsolutePath());


### PR DESCRIPTION
I ran `pinot-admin.sh AvroSchemaToPinotSchema` with non-existent output directory and got the following error. It should exit immediately after the error message is displayed.

```
$ bin/pinot-admin.sh AvroSchemaToPinotSchema -outputDir /tmp/foo -pinotSchemaName weather -dimensions station -metrics temp -timeColumnName time -avroDataFile ~/repos/avro/share/test/data/weather.avro 
ERROR: Output directory: %s does not exist or is not a directory
Store Pinot schema to file: /tmp/foo/weather.json
Exception caught: 
java.io.FileNotFoundException: /tmp/foo/weather.json (No such file or directory)
(snip)
```