### PR TITLE
Fix controller download segment api on non-local PinotFS.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -189,13 +189,7 @@ public class PinotSegmentUploadRestletResource {
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }
-    try {
-      segmentName = URLDecoder.decode(segmentName, URL_ENCODING_SCHEME);
-    } catch (UnsupportedEncodingException e) {
-      String errStr = "Could not decode segment name '" + segmentName + "'";
-      throw new ControllerApplicationException(LOGGER, errStr, Response.Status.BAD_REQUEST);
-    }
-
+    segmentName = URIUtils.decode(segmentName);
     final URI segmentFileURI = URIUtils.getUri(provider.getBaseDataDirURI().toString(), tableName, segmentName);
     PinotFS pinotFS = PinotFSFactory.create(provider.getBaseDataDirURI().getScheme());
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -28,10 +28,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
@@ -199,7 +197,7 @@ public class PinotSegmentUploadRestletResource {
     }
     Response.ResponseBuilder builder = Response.ok();
     File segmentFile;
-    // If the segment file is local, just use it as the return object; otherwise copy it from remote to local.
+    // If the segment file is local, just use it as the return entity; otherwise copy it from remote to local first.
     if (CommonConstants.Segment.LOCAL_SEGMENT_SCHEME.equals(segmentFileURI.getScheme())) {
       segmentFile = new File(provider.getBaseDataDir(), StringUtil.join("/", tableName, segmentName));
       builder.entity(segmentFile);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -32,7 +32,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
@@ -207,7 +206,7 @@ public class PinotSegmentUploadRestletResource {
     Response.ResponseBuilder builder = Response.ok();
     File segmentFile;
     // If the segment file is local, just use it as the return object; otherwise copy it from remote to local.
-    if (segmentFileURI.getScheme().equals(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME)) {
+    if (CommonConstants.Segment.LOCAL_SEGMENT_SCHEME.equals(segmentFileURI.getScheme())) {
       segmentFile = new File(provider.getBaseDataDir(), StringUtil.join("/", tableName, segmentName));
       builder.entity(segmentFile);
     } else {


### PR DESCRIPTION
Fix #3847. This PR replaces #3849 which is too old for github update.

The controller's segment download rest api now uses a local file object and does not work for a non local Pinot FS. This fix uses PinotFS interface instead. For local file system, It avoids copy for local file.

@mcvsubbu @npawar