### PR TITLE
Fix the bug of releasing the segment when there are still threads working on it

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/BaseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/BaseOperator.java
@@ -33,6 +33,9 @@ public abstract class BaseOperator<T extends Block> implements Operator<T> {
 
   @Override
   public final T nextBlock() {
+    if (Thread.interrupted()) {
+      throw new RuntimeException("Thread has been interrupted");
+    }
     if (TraceContext.traceEnabled()) {
       long start = System.currentTimeMillis();
       T nextBlock = getNextBlock();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -102,8 +103,6 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
    */
   @Override
   protected IntermediateResultsBlock getNextBlock() {
-    int numOperators = _operators.size();
-    CountDownLatch operatorLatch = new CountDownLatch(numOperators);
     ConcurrentHashMap<String, Object[]> resultsMap = new ConcurrentHashMap<>();
     AtomicInteger numGroups = new AtomicInteger();
     ConcurrentLinkedQueue<ProcessingException> mergedProcessingExceptions = new ConcurrentLinkedQueue<>();
@@ -116,6 +115,17 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       aggregationFunctions[i] = aggregationFunctionContexts[i].getAggregationFunction();
     }
 
+    // We use a CountDownLatch to track if all Futures are finished by the query timeout, and cancel the unfinished
+    // futures (try to interrupt the execution if it already started).
+    // Besides the CountDownLatch, we also use a Phaser to ensure all the Futures are done (not scheduled, finished or
+    // interrupted) before the main thread returns. We need to ensure no execution left before the main thread returning
+    // because the main thread holds the reference to the segments, and if the segments are deleted/refreshed, the
+    // segments can be released after the main thread returns, which would lead to undefined behavior (even JVM crash)
+    // when executing queries against them.
+    int numOperators = _operators.size();
+    CountDownLatch operatorLatch = new CountDownLatch(numOperators);
+    Phaser phaser = new Phaser(1);
+
     Future[] futures = new Future[numOperators];
     for (int i = 0; i < numOperators; i++) {
       int index = i;
@@ -123,9 +133,15 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
         @SuppressWarnings("unchecked")
         @Override
         public void runJob() {
-          AggregationGroupByResult aggregationGroupByResult;
-
           try {
+            // Register the thread to the phaser.
+            // If the phaser is terminated (returning negative value) when trying to register the thread, that means the
+            // query execution has timed out, and the main thread has deregistered itself and returned the result.
+            // Directly return as no execution result will be taken.
+            if (phaser.register() < 0) {
+              return;
+            }
+
             IntermediateResultsBlock intermediateResultsBlock =
                 (IntermediateResultsBlock) _operators.get(index).nextBlock();
 
@@ -136,7 +152,7 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
             }
 
             // Merge aggregation group-by result.
-            aggregationGroupByResult = intermediateResultsBlock.getAggregationGroupByResult();
+            AggregationGroupByResult aggregationGroupByResult = intermediateResultsBlock.getAggregationGroupByResult();
             if (aggregationGroupByResult != null) {
               // Iterate over the group-by keys, for each key, update the group-by result in the resultsMap.
               Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
@@ -164,9 +180,10 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
             LOGGER.error("Exception processing CombineGroupBy for index {}, operator {}", index,
                 _operators.get(index).getClass().getName(), e);
             mergedProcessingExceptions.add(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+          } finally {
+            operatorLatch.countDown();
+            phaser.arriveAndDeregister();
           }
-
-          operatorLatch.countDown();
         }
       });
     }
@@ -224,6 +241,8 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
           future.cancel(true);
         }
       }
+      // Deregister the main thread and wait for all threads done
+      phaser.awaitAdvance(phaser.arriveAndDeregister());
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/CombineSlowOperatorsTest.java
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.pinot.common.response.ProcessingException;
+import org.apache.pinot.core.common.Block;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
+import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * This test mimic the behavior of combining slow operators, where operation is not done by the timeout. When the
+ * combine operator returns, test whether the slow operators are properly interrupted, and if all the slow operators are
+ * not running in order to safely release the segment references.
+ */
+public class CombineSlowOperatorsTest {
+  private static final int NUM_OPERATORS = 10;
+  private static final int NUM_THREADS = 2;
+  private static final long TIMEOUT_MS = 100L;
+  private static final Pql2Compiler COMPILER = new Pql2Compiler();
+
+  private ExecutorService _executorService;
+
+  @BeforeClass
+  public void setUp() {
+    _executorService = Executors.newFixedThreadPool(NUM_THREADS);
+  }
+
+  @Test
+  public void testCombineOperator() {
+    List<Operator> operators = getOperators();
+    CombineOperator combineOperator = new CombineOperator(operators, _executorService, TIMEOUT_MS,
+        COMPILER.compileToBrokerRequest("SELECT * FROM table"));
+    testCombineOperator(operators, combineOperator);
+  }
+
+  @Test
+  public void testCombineGroupByOperator() {
+    List<Operator> operators = getOperators();
+    CombineGroupByOperator combineGroupByOperator = new CombineGroupByOperator(operators,
+        COMPILER.compileToBrokerRequest("SELECT COUNT(*) FROM table GROUP BY column"), _executorService, TIMEOUT_MS,
+        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
+    testCombineOperator(operators, combineGroupByOperator);
+  }
+
+  @Test
+  public void testCombineGroupByOrderByOperator() {
+    List<Operator> operators = getOperators();
+    CombineGroupByOrderByOperator combineGroupByOrderByOperator = new CombineGroupByOrderByOperator(operators,
+        COMPILER.compileToBrokerRequest("SELECT COUNT(*) FROM table GROUP BY column"), _executorService, TIMEOUT_MS);
+    testCombineOperator(operators, combineGroupByOrderByOperator);
+  }
+
+  public void testCombineOperator(List<Operator> operators, BaseOperator combineOperator) {
+    IntermediateResultsBlock intermediateResultsBlock = (IntermediateResultsBlock) combineOperator.nextBlock();
+    List<ProcessingException> processingExceptions = intermediateResultsBlock.getProcessingExceptions();
+    assertNotNull(processingExceptions);
+    assertEquals(processingExceptions.size(), 1);
+    assertTrue(processingExceptions.get(0).getMessage().contains(TimeoutException.class.getName()));
+
+    // When the CombineOperator returns, all operators should be either not scheduled or interrupted, and no operator
+    // should be running so that the segment references can be safely released
+    for (Operator operator : operators) {
+      SlowOperator slowOperator = (SlowOperator) operator;
+      assertFalse(slowOperator._operationInProgress.get());
+      assertFalse(slowOperator._notInterrupted.get());
+    }
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _executorService.shutdown();
+  }
+
+  private List<Operator> getOperators() {
+    List<Operator> operators = new ArrayList<>(NUM_OPERATORS);
+    for (int i = 0; i < NUM_OPERATORS; i++) {
+      operators.add(new SlowOperator());
+    }
+    return operators;
+  }
+
+  private static class SlowOperator extends BaseOperator {
+    final AtomicBoolean _operationInProgress = new AtomicBoolean();
+    final AtomicBoolean _notInterrupted = new AtomicBoolean();
+
+    @Override
+    protected Block getNextBlock() {
+      _operationInProgress.set(true);
+      try {
+        Thread.sleep(3_600_000L);
+      } catch (InterruptedException e) {
+        // Thread should be interrupted
+        throw new RuntimeException(e);
+      } finally {
+        // Wait for 100 milliseconds before marking the operation done
+        try {
+          Thread.sleep(100L);
+          _operationInProgress.set(false);
+        } catch (InterruptedException e) {
+          // Thread should not be interrupted again, and we should be able to mark the operation done
+        }
+      }
+      _notInterrupted.set(true);
+      return null;
+    }
+
+    @Override
+    public String getOperatorName() {
+      return "SlowOperator";
+    }
+
+    @Override
+    public ExecutionStatistics getExecutionStatistics() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Issue:
When we execute a query, the main thread holds the segment reference,
and avoid the segment getting released during the query execution.
When the query timed out, the main thread will return the exception
and release the segment reference without waiting for all the worker
threads finish the work. This can cause severe issue when segment get
released due to segment deletion/refresh while worker threads are
still accessing it, even JVM crash.

Solution:
Use a Phaser for the query execution to ensure when the main thread
returns the result, all the worker threads are not accessing the
segment (not scheduled or done). To shorten the period of waiting,
check the interrupt flag when the operator starts processing the next
block, and interrupt the execution if the thread is interrupted.

Applied the solution to both planning phase and execution phase, and
also added tests to check the behavior.