### PR TITLE
[TE] Extending Jira Merge capabilities for supporting dimensional alerter

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
@@ -19,6 +19,8 @@
 
 package org.apache.pinot.thirdeye.datalayer.dto;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import org.apache.pinot.thirdeye.anomalydetection.context.AnomalyFeedback;
 import org.apache.pinot.thirdeye.anomalydetection.context.AnomalyResult;
 
@@ -27,6 +29,7 @@ import org.apache.pinot.thirdeye.datalayer.pojo.MergedAnomalyResultBean;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -58,6 +61,15 @@ public class MergedAnomalyResultDTO extends MergedAnomalyResultBean implements A
     setAvgBaselineVal(anomalyResult.getAvgBaselineVal());
     setFeedback(anomalyResult.getFeedback());
     setProperties(anomalyResult.getProperties());
+  }
+
+  public Multimap<String, String> getDimensionMap() {
+    Multimap<String, String> dimMap = ArrayListMultimap.create();
+    if (this.getMetricUrn() != null) {
+      dimMap = MetricEntity.fromURN(this.getMetricUrn()).getFilters();
+    }
+
+    return dimMap;
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
@@ -19,6 +19,8 @@
 
 package org.apache.pinot.thirdeye.detection.alert;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -30,13 +32,13 @@ import java.util.Objects;
 public class DetectionAlertFilterNotification {
 
   Map<String, Object> notificationSchemeProps;
-  Map<String, String> dimensionFilters;
+  Multimap<String, String> dimensionFilters;
 
   public DetectionAlertFilterNotification(Map<String, Object> notificationSchemeProps) {
-    this(notificationSchemeProps, new HashMap<>());
+    this(notificationSchemeProps, ArrayListMultimap.create());
   }
 
-  public DetectionAlertFilterNotification(Map<String, Object> notificationSchemeProps, Map<String, String> dimensionFilters) {
+  public DetectionAlertFilterNotification(Map<String, Object> notificationSchemeProps, Multimap<String, String> dimensionFilters) {
     this.notificationSchemeProps = notificationSchemeProps;
     this.dimensionFilters = dimensionFilters;
   }
@@ -49,11 +51,11 @@ public class DetectionAlertFilterNotification {
     this.notificationSchemeProps = notificationSchemeProps;
   }
 
-  public Map<String, String> getDimensionFilters() {
+  public Multimap<String, String> getDimensionFilters() {
     return dimensionFilters;
   }
 
-  public void setDimensionFilters(Map<String, String> dimensions) {
+  public void setDimensionFilters(Multimap<String, String> dimensions) {
     this.dimensionFilters = dimensions;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.detection.alert;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -27,19 +28,33 @@ import java.util.Objects;
  * Container class for notification properties
  */
 public class DetectionAlertFilterNotification {
+
   Map<String, Object> notificationSchemeProps;
+  Map<String, String> dimensionFilters;
 
   public DetectionAlertFilterNotification(Map<String, Object> notificationSchemeProps) {
+    this(notificationSchemeProps, new HashMap<>());
+  }
+
+  public DetectionAlertFilterNotification(Map<String, Object> notificationSchemeProps, Map<String, String> dimensionFilters) {
     this.notificationSchemeProps = notificationSchemeProps;
+    this.dimensionFilters = dimensionFilters;
   }
 
   public Map<String, Object> getNotificationSchemeProps() {
     return notificationSchemeProps;
   }
 
-  public DetectionAlertFilterNotification setNotificationSchemeProps(Map<String, Object> notificationSchemeProps) {
+  public void setNotificationSchemeProps(Map<String, Object> notificationSchemeProps) {
     this.notificationSchemeProps = notificationSchemeProps;
-    return this;
+  }
+
+  public Map<String, String> getDimensionFilters() {
+    return dimensionFilters;
+  }
+
+  public void setDimensionFilters(Map<String, String> dimensions) {
+    this.dimensionFilters = dimensions;
   }
 
   @Override
@@ -51,12 +66,13 @@ public class DetectionAlertFilterNotification {
       return false;
     }
     DetectionAlertFilterNotification that = (DetectionAlertFilterNotification) o;
-    return Objects.equals(notificationSchemeProps, that.notificationSchemeProps);
+    return Objects.equals(notificationSchemeProps, that.notificationSchemeProps) &&
+        Objects.equals(dimensionFilters, that.dimensionFilters);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(notificationSchemeProps);
+    return Objects.hash(notificationSchemeProps, dimensionFilters);
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsRecipientAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsRecipientAlertFilter.java
@@ -66,10 +66,10 @@ import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
  */
 @AlertFilter(type = "DIMENSIONS_ALERTER_PIPELINE")
 public class DimensionsRecipientAlertFilter extends StatefulDetectionAlertFilter {
-  protected static final String PROP_DETECTION_CONFIG_IDS = "detectionConfigIds";
-  protected static final String PROP_DIMENSION = "dimensions";
-  protected static final String PROP_NOTIFY = "notify";
-  protected static final String PROP_DIMENSION_RECIPIENTS = "dimensionRecipients";
+  public static final String PROP_DETECTION_CONFIG_IDS = "detectionConfigIds";
+  public static final String PROP_DIMENSION = "dimensions";
+  public static final String PROP_NOTIFY = "notify";
+  public static final String PROP_DIMENSION_RECIPIENTS = "dimensionRecipients";
   private static final String PROP_SEND_ONCE = "sendOnce";
 
   private Map<String, Object> defaultNotificationSchemeProps = new HashMap<>();
@@ -94,6 +94,7 @@ public class DimensionsRecipientAlertFilter extends StatefulDetectionAlertFilter
 
     Set<MergedAnomalyResultDTO> anomalies = this.filter(this.makeVectorClocks(this.detectionConfigIds), minId);
 
+    // Prepare mapping from dimension-recipients to anomalies
     for (Map<String, Object> dimensionRecipient : this.dimensionRecipients) {
       Map<String, String> dimensionFilters = ConfigUtils.getMap(dimensionRecipient.get(PROP_DIMENSION));
       Set<MergedAnomalyResultDTO> notifyAnomalies = new HashSet<>();
@@ -105,11 +106,13 @@ public class DimensionsRecipientAlertFilter extends StatefulDetectionAlertFilter
       }
 
       if (!notifyAnomalies.isEmpty()) {
-        result.addMapping(new DetectionAlertFilterNotification(ConfigUtils.getMap(dimensionRecipient.get(PROP_NOTIFY))),
+        result.addMapping(
+            new DetectionAlertFilterNotification(ConfigUtils.getMap(dimensionRecipient.get(PROP_NOTIFY)), dimensionFilters),
             notifyAnomalies);
       }
     }
 
+    // Notify the remaining anomalies to default recipients
     Set<MergedAnomalyResultDTO> notifiedAnomalies = new HashSet<>(result.getAllAnomalies());
     Set<MergedAnomalyResultDTO> defaultAnomalies = new HashSet<>();
     for (MergedAnomalyResultDTO anomaly : anomalies) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsRecipientAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsRecipientAlertFilter.java
@@ -96,11 +96,11 @@ public class DimensionsRecipientAlertFilter extends StatefulDetectionAlertFilter
 
     // Prepare mapping from dimension-recipients to anomalies
     for (Map<String, Object> dimensionRecipient : this.dimensionRecipients) {
-      Map<String, String> dimensionFilters = ConfigUtils.getMap(dimensionRecipient.get(PROP_DIMENSION));
+      Multimap<String, String> dimensionFilters = ConfigUtils.getMultimap(dimensionRecipient.get(PROP_DIMENSION));
       Set<MergedAnomalyResultDTO> notifyAnomalies = new HashSet<>();
       for (MergedAnomalyResultDTO anomaly : anomalies) {
         Multimap<String, String> anamolousDims = MetricEntity.fromURN(anomaly.getMetricUrn()).getFilters();
-        if (anamolousDims.entries().containsAll(dimensionFilters.entrySet())) {
+        if (anamolousDims.entries().containsAll(dimensionFilters.entries())) {
           notifyAnomalies.add(anomaly);
         }
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/JiraEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/JiraEntity.java
@@ -105,6 +105,7 @@ public class JiraEntity {
     sb.append(", assignee='").append(assignee).append('\'');
     sb.append(", summary='").append(summary).append('\'');
     sb.append(", labels='").append(labels).append('\'');
+    sb.append(", mergeGap='").append(mergeGap).append('\'');
     sb.append('}');
     return sb.toString();
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/BaseNotificationContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/BaseNotificationContent.java
@@ -277,11 +277,11 @@ public abstract class BaseNotificationContent implements NotificationContent {
   /**
    * Flatten the dimension map
    */
-  protected static List<String> getDimensionsList(DimensionMap dimensionMap) {
+  protected static List<String> getDimensionsList(Multimap<String, String> dimensions) {
     List<String> dimensionsList = new ArrayList<>();
-    if (dimensionMap != null && !dimensionMap.isEmpty()) {
-      for (Map.Entry<String, String> entry : dimensionMap.entrySet()) {
-        dimensionsList.add(entry.getKey() + " : " + entry.getValue());
+    if (dimensions != null && !dimensions.isEmpty()) {
+      for (Map.Entry<String, Collection<String>> entry : dimensions.asMap().entrySet()) {
+        dimensionsList.add(entry.getKey() + " : " + String.join(",", entry.getValue()));
       }
     }
     return dimensionsList;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/EntityGroupKeyContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/EntityGroupKeyContent.java
@@ -40,6 +40,7 @@ import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
+import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
 import org.apache.pinot.thirdeye.util.ThirdEyeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,7 +148,7 @@ public class EntityGroupKeyContent extends BaseNotificationContent {
     AnomalyReportEntity anomalyReport = new AnomalyReportEntity(String.valueOf(anomaly.getId()),
         getAnomalyURL(anomaly, thirdEyeAnomalyConfig.getDashboardHost()),
         anomaly.getAvgBaselineVal(),
-        anomaly.getAvgCurrentVal(), 0d, getDimensionsList(anomaly.getDimensions()),
+        anomaly.getAvgCurrentVal(), 0d, getDimensionsList(anomaly.getDimensionMap()),
         getTimeDiffInHours(anomaly.getStartTime(), anomaly.getEndTime()), getFeedbackValue(anomaly.getFeedback()),
         detectionConfig.getName(), detectionConfig.getDescription(), anomaly.getMetric(),
         getDateString(anomaly.getStartTime(), dateTimeZone), getDateString(anomaly.getEndTime(), dateTimeZone),

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/HierarchicalAnomaliesContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/HierarchicalAnomaliesContent.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
+import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
@@ -150,7 +151,7 @@ public class HierarchicalAnomaliesContent extends BaseNotificationContent {
         anomaly.getAvgBaselineVal(),
         anomaly.getAvgCurrentVal(),
         anomaly.getImpactToGlobal(),
-        getDimensionsList(anomaly.getDimensions()),
+        getDimensionsList(anomaly.getDimensionMap()),
         getTimeDiffInHours(anomaly.getStartTime(), anomaly.getEndTime()), // duration
         feedbackVal,
         anomaly.getFunction().getFunctionName(),

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/MetricAnomaliesContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/MetricAnomaliesContent.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
+import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,7 +130,7 @@ public class MetricAnomaliesContent extends BaseNotificationContent {
           anomaly.getAvgBaselineVal(),
           anomaly.getAvgCurrentVal(),
           0d,
-          getDimensionsList(anomaly.getDimensions()),
+          getDimensionsList(anomaly.getDimensionMap()),
           getTimeDiffInHours(anomaly.getStartTime(), anomaly.getEndTime()), // duration
           feedbackVal,
           functionName,

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsDetectionAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsDetectionAlertFilterTest.java
@@ -107,9 +107,9 @@ public class DimensionsDetectionAlertFilterTest {
     PROP_ID_VALUE.add(detectionId2);
 
     Map<String, Object> dimensionRecipient1 = new HashMap<>();
-    Map<String, Object> dimensionKeys1 = new HashMap<>();
+    Multimap<String, String> dimensionKeys1 = ArrayListMultimap.create();
     dimensionKeys1.put("key", "value");
-    dimensionRecipient1.put(PROP_DIMENSION, dimensionKeys1);
+    dimensionRecipient1.put(PROP_DIMENSION, dimensionKeys1.asMap());
     Map<String, Object> notificationValues1 = new HashMap<>();
     Map<String, Object> notificationEmailParams1 = new HashMap<>();
     Map<String, Object> recipients1 = new HashMap<>();
@@ -121,10 +121,10 @@ public class DimensionsDetectionAlertFilterTest {
     dimensionRecipient1.put(PROP_NOTIFY, notificationValues1);
 
     Map<String, Object> dimensionRecipient2 = new HashMap<>();
-    Map<String, Object> dimensionKeys2 = new HashMap<>();
+    Multimap<String, String> dimensionKeys2 = ArrayListMultimap.create();
     dimensionKeys2.put("key1", "anotherValue1");
     dimensionKeys2.put("key2", "anotherValue2");
-    dimensionRecipient2.put(PROP_DIMENSION, dimensionKeys2);
+    dimensionRecipient2.put(PROP_DIMENSION, dimensionKeys2.asMap());
     Map<String, Object> notificationValues2 = new HashMap<>();
     Map<String, Object> notificationEmailParams2 = new HashMap<>();
     Map<String, Object> recipients2 = new HashMap<>();

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsDetectionAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsDetectionAlertFilterTest.java
@@ -16,22 +16,20 @@
 
 package org.apache.pinot.thirdeye.detection.alert.filter;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.io.IOUtils;
 import org.apache.pinot.thirdeye.constant.AnomalyFeedbackType;
-import org.apache.pinot.thirdeye.dashboard.DetectionPreviewConfiguration;
 import org.apache.pinot.thirdeye.datalayer.bao.ApplicationManager;
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
-import org.apache.pinot.thirdeye.datalayer.bao.DetectionAlertConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
 import org.apache.pinot.thirdeye.datalayer.dto.AnomalyFeedbackDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.ApplicationDTO;
@@ -39,7 +37,6 @@ import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
-import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.detection.MockDataProvider;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilter;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
@@ -198,7 +195,7 @@ public class DimensionsDetectionAlertFilterTest {
     DetectionAlertFilterNotification recDefault = AlertFilterUtils.makeEmailNotifications();
     Assert.assertEquals(result.getResult().get(recDefault), makeSet(0, 3, 4));
 
-    Map<String, String> dimFilters = new HashMap<>();
+    Multimap<String, String> dimFilters = ArrayListMultimap.create();
     dimFilters.put("key", "value");
 
     // Send anomalies who dimensions are configured to appropriate recipients
@@ -206,7 +203,7 @@ public class DimensionsDetectionAlertFilterTest {
     recValue.setDimensionFilters(dimFilters);
     Assert.assertEquals(result.getResult().get(recValue), makeSet(1, 5));
 
-    dimFilters.remove("key");
+    dimFilters.removeAll("key");
     dimFilters.put("key1", "anotherValue1");
     dimFilters.put("key2", "anotherValue2");
 
@@ -227,7 +224,7 @@ public class DimensionsDetectionAlertFilterTest {
 
     this.detectedAnomalies.add(child);
 
-    Map<String, String> dimFilters = new HashMap<>();
+    Multimap<String, String> dimFilters = ArrayListMultimap.create();
     dimFilters.put("key", "value");
     DetectionAlertFilterNotification recValue = AlertFilterUtils.makeEmailNotifications(PROP_TO_FOR_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
     recValue.setDimensionFilters(dimFilters);
@@ -265,7 +262,7 @@ public class DimensionsDetectionAlertFilterTest {
     DetectionAlertFilterResult result = this.alertFilter.run();
     Assert.assertEquals(result.getResult().size(), 2);
 
-    Map<String, String> dimFilters = new HashMap<>();
+    Multimap<String, String> dimFilters = ArrayListMultimap.create();
     dimFilters.put("key", "value");
 
     DetectionAlertFilterNotification recDefault = AlertFilterUtils.makeEmailNotifications(PROP_TO_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsDetectionAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsDetectionAlertFilterTest.java
@@ -198,13 +198,22 @@ public class DimensionsDetectionAlertFilterTest {
     DetectionAlertFilterNotification recDefault = AlertFilterUtils.makeEmailNotifications();
     Assert.assertEquals(result.getResult().get(recDefault), makeSet(0, 3, 4));
 
+    Map<String, String> dimFilters = new HashMap<>();
+    dimFilters.put("key", "value");
+
     // Send anomalies who dimensions are configured to appropriate recipients
     DetectionAlertFilterNotification recValue = AlertFilterUtils.makeEmailNotifications(PROP_TO_FOR_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
+    recValue.setDimensionFilters(dimFilters);
     Assert.assertEquals(result.getResult().get(recValue), makeSet(1, 5));
+
+    dimFilters.remove("key");
+    dimFilters.put("key1", "anotherValue1");
+    dimFilters.put("key2", "anotherValue2");
 
     // Send alert when configured dimensions is a subset of anomaly dimensions
     // Anomaly 2 occurs on 3 dimensions (key 1, 2 & 3), dimensionRecipients is configured on (key 1 & 2) - send alert
     DetectionAlertFilterNotification recAnotherValue = AlertFilterUtils.makeEmailNotifications(PROP_TO_FOR_ANOTHER_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
+    recAnotherValue.setDimensionFilters(dimFilters);
     Assert.assertEquals(result.getResult().get(recAnotherValue), makeSet(2));
   }
 
@@ -218,7 +227,10 @@ public class DimensionsDetectionAlertFilterTest {
 
     this.detectedAnomalies.add(child);
 
+    Map<String, String> dimFilters = new HashMap<>();
+    dimFilters.put("key", "value");
     DetectionAlertFilterNotification recValue = AlertFilterUtils.makeEmailNotifications(PROP_TO_FOR_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
+    recValue.setDimensionFilters(dimFilters);
 
     DetectionAlertFilterResult result = this.alertFilter.run();
 
@@ -253,6 +265,9 @@ public class DimensionsDetectionAlertFilterTest {
     DetectionAlertFilterResult result = this.alertFilter.run();
     Assert.assertEquals(result.getResult().size(), 2);
 
+    Map<String, String> dimFilters = new HashMap<>();
+    dimFilters.put("key", "value");
+
     DetectionAlertFilterNotification recDefault = AlertFilterUtils.makeEmailNotifications(PROP_TO_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
     Assert.assertTrue(result.getResult().containsKey(recDefault));
     Assert.assertEquals(result.getResult().get(recDefault).size(), 2);
@@ -260,6 +275,7 @@ public class DimensionsDetectionAlertFilterTest {
     Assert.assertTrue(result.getResult().get(recDefault).contains(anomalyWithNull));
 
     DetectionAlertFilterNotification recValue = AlertFilterUtils.makeEmailNotifications(PROP_TO_FOR_VALUE, PROP_CC_VALUE, PROP_BCC_VALUE);
+    recValue.setDimensionFilters(dimFilters);
     Assert.assertTrue(result.getResult().containsKey(recValue));
     Assert.assertEquals(result.getResult().get(recValue).size(), 1);
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/content/templates/TestMetricAnomaliesContent.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/content/templates/TestMetricAnomaliesContent.java
@@ -149,6 +149,7 @@ public class TestMetricAnomaliesContent {
     anomaly.setDetectionConfigId(detectionConfigDTO.getId());
     anomaly.setAvgCurrentVal(1.1);
     anomaly.setAvgBaselineVal(1.0);
+    anomaly.setMetricUrn("thirdeye:metric:1");
     mergedAnomalyResultDAO.save(anomaly);
     anomalies.add(anomaly);
     anomaly = DaoTestUtils.getTestMergedAnomalyResult(
@@ -158,6 +159,7 @@ public class TestMetricAnomaliesContent {
     anomaly.setDetectionConfigId(detectionConfigDTO.getId());
     anomaly.setAvgCurrentVal(0.9);
     anomaly.setAvgBaselineVal(1.0);
+    anomaly.setMetricUrn("thirdeye:metric:2");
     mergedAnomalyResultDAO.save(anomaly);
     anomalies.add(anomaly);
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/channels/TestJiraContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/channels/TestJiraContentFormatter.java
@@ -257,7 +257,7 @@ public class TestJiraContentFormatter {
 
     BaseNotificationContent content = DetectionAlertScheme.buildNotificationContent(jiraClientConfig);
     JiraContentFormatter jiraContent = new JiraContentFormatter(
-        JiraConfiguration.createFromProperties(jiraConfiguration), jiraClientConfig, content, teConfig, this.alertConfigDTO);
+        JiraConfiguration.createFromProperties(jiraConfiguration), jiraClientConfig, content, teConfig, this.alertConfigDimAlerter);
 
     Multimap<String, String> dimensionKeys1 = ArrayListMultimap.create();
     dimensionKeys1.put("key", "value");

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/channels/TestJiraContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/channels/TestJiraContentFormatter.java
@@ -19,6 +19,8 @@
 
 package org.apache.pinot.thirdeye.notification.formatter.channels;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -217,7 +219,7 @@ public class TestJiraContentFormatter {
     JiraContentFormatter jiraContent = new JiraContentFormatter(
         JiraConfiguration.createFromProperties(jiraConfiguration), jiraClientConfig, content, teConfig, this.alertConfigDTO);
 
-    JiraEntity jiraEntity = jiraContent.getJiraEntity(new HashMap<>(), new HashSet<>(this.anomalyDAO.findAll()));
+    JiraEntity jiraEntity = jiraContent.getJiraEntity(ArrayListMultimap.create(), new HashSet<>(this.anomalyDAO.findAll()));
 
     // Assert Jira fields
     Assert.assertEquals(jiraEntity.getLabels(), Arrays.asList("test-label-1", "test-label-2", "thirdeye", "subsId=" + subsId1));
@@ -257,7 +259,7 @@ public class TestJiraContentFormatter {
     JiraContentFormatter jiraContent = new JiraContentFormatter(
         JiraConfiguration.createFromProperties(jiraConfiguration), jiraClientConfig, content, teConfig, this.alertConfigDTO);
 
-    Map<String, String> dimensionKeys1 = new HashMap<>();
+    Multimap<String, String> dimensionKeys1 = ArrayListMultimap.create();
     dimensionKeys1.put("key", "value");
     JiraEntity jiraEntity = jiraContent.getJiraEntity(dimensionKeys1, new HashSet<>(this.anomalyDAO.findAll()));
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/channels/TestJiraContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/channels/TestJiraContentFormatter.java
@@ -19,10 +19,12 @@
 
 package org.apache.pinot.thirdeye.notification.formatter.channels;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
@@ -48,6 +50,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.thirdeye.detection.alert.filter.DimensionsRecipientAlertFilter.*;
 import static org.apache.pinot.thirdeye.notification.commons.JiraConfiguration.*;
 import static org.apache.pinot.thirdeye.notification.formatter.channels.JiraContentFormatter.*;
 
@@ -61,19 +64,22 @@ public class TestJiraContentFormatter {
   private static final String DETECTION_NAME_VALUE = "test detection";
   private static final String METRIC_VALUE = "test_metric";
 
-  private DAOTestBase testDAOProvider;
+  private static final List<Map<String, Object>> PROP_DIMENSION_RECIPIENTS_VALUE = new ArrayList<>();
+
   private DetectionAlertConfigManager alertConfigDAO;
   private MergedAnomalyResultManager anomalyDAO;
   private DetectionConfigManager detectionDAO;
   private MetricConfigManager metricDAO;
   private DatasetConfigManager dataSetDAO;
   private DetectionAlertConfigDTO alertConfigDTO;
-  private Long alertConfigId;
+  private DetectionAlertConfigDTO alertConfigDimAlerter;
   private Long detectionConfigId;
+  private Long subsId1;
+  private Long subsId2;
 
   @BeforeMethod
   public void beforeMethod() throws Exception {
-    this.testDAOProvider = DAOTestBase.getInstance();
+    DAOTestBase.getInstance();
     DAORegistry daoRegistry = DAORegistry.getInstance();
     this.alertConfigDAO = daoRegistry.getDetectionAlertConfigManager();
     this.anomalyDAO = daoRegistry.getMergedAnomalyResultDAO();
@@ -91,23 +97,9 @@ public class TestJiraContentFormatter {
     detectionConfig.setName(DETECTION_NAME_VALUE);
     this.detectionConfigId = this.detectionDAO.save(detectionConfig);
 
-    this.alertConfigDTO = new DetectionAlertConfigDTO();
-    Map<String, Object> properties = new HashMap<>();
-    properties.put(PROP_CLASS_NAME, "org.apache.pinot.thirdeye.detection.alert.filter.ToAllRecipientsDetectionAlertFilter");
-    properties.put(PROP_DETECTION_CONFIG_IDS, Collections.singletonList(this.detectionConfigId));
-
-    Map<String, Object> jiraScheme = new HashMap<>();
-    jiraScheme.put("className", "org.apache.pinot.thirdeye.detection.alert.scheme.RandomAlerter");
-    this.alertConfigDTO.setAlertSchemes(Collections.singletonMap("jiraScheme", jiraScheme));
-    this.alertConfigDTO.setProperties(properties);
-    this.alertConfigDTO.setFrom(FROM_ADDRESS_VALUE);
-    this.alertConfigDTO.setName(ALERT_NAME_VALUE);
-    this.alertConfigDTO.setVectorClocks(new HashMap<>());
-    Map<String, String> refLinks = new HashMap<>();
-    refLinks.put("test_ref_key", "test_ref_value");
-    this.alertConfigDTO.setReferenceLinks(refLinks);
-
-    this.alertConfigId = this.alertConfigDAO.save(this.alertConfigDTO);
+    this.alertConfigDTO = createDetectionAlertConfig(this.detectionConfigId);
+    subsId1 = this.alertConfigDAO.save(this.alertConfigDTO);
+    this.alertConfigDTO.setId(subsId1);
 
     MergedAnomalyResultDTO anomalyResultDTO = new MergedAnomalyResultDTO();
     anomalyResultDTO.setStartTime(1000L);
@@ -115,12 +107,90 @@ public class TestJiraContentFormatter {
     anomalyResultDTO.setDetectionConfigId(this.detectionConfigId);
     anomalyResultDTO.setCollection(COLLECTION_VALUE);
     anomalyResultDTO.setMetric(METRIC_VALUE);
+    anomalyResultDTO.setMetricUrn("thirdeye:metric:123:key%3Dvalue");
     this.anomalyDAO.save(anomalyResultDTO);
 
     DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO();
     datasetConfigDTO.setDataset(COLLECTION_VALUE);
     datasetConfigDTO.setDataSource("myDataSource");
     this.dataSetDAO.save(datasetConfigDTO);
+
+    this.alertConfigDimAlerter = createDimRecipientsDetectionAlertConfig(this.detectionConfigId);
+    subsId2 = this.alertConfigDAO.save(this.alertConfigDimAlerter);
+    alertConfigDimAlerter.setId(subsId2);
+  }
+
+  public static DetectionAlertConfigDTO createDetectionAlertConfig(Long detectionConfigId) {
+    DetectionAlertConfigDTO alertConfig = new DetectionAlertConfigDTO();
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(PROP_CLASS_NAME, "org.apache.pinot.thirdeye.detection.alert.filter.ToAllRecipientsDetectionAlertFilter");
+    properties.put(PROP_DETECTION_CONFIG_IDS, Collections.singletonList(detectionConfigId));
+
+    Map<String, Object> jiraScheme = new HashMap<>();
+    jiraScheme.put("className", "org.apache.pinot.thirdeye.detection.alert.scheme.RandomAlerter");
+    alertConfig.setAlertSchemes(Collections.singletonMap("jiraScheme", jiraScheme));
+    alertConfig.setProperties(properties);
+    alertConfig.setFrom(FROM_ADDRESS_VALUE);
+    alertConfig.setName(ALERT_NAME_VALUE + 1);
+    alertConfig.setVectorClocks(new HashMap<>());
+    Map<String, String> refLinks = new HashMap<>();
+    refLinks.put("test_ref_key", "test_ref_value");
+    alertConfig.setReferenceLinks(refLinks);
+
+    return alertConfig;
+  }
+
+  public static DetectionAlertConfigDTO createDimRecipientsDetectionAlertConfig(Long detectionConfigId) {
+    DetectionAlertConfigDTO alertConfig = new DetectionAlertConfigDTO();
+
+    Map<String, Object> dimensionRecipient1 = new HashMap<>();
+    Map<String, String> dimensionKeys1 = new HashMap<>();
+    dimensionKeys1.put("key", "value");
+    dimensionRecipient1.put(PROP_DIMENSION, dimensionKeys1);
+    Map<String, Object> notificationValues1 = new HashMap<>();
+    Map<String, Object> notificationJiraParams1 = new HashMap<>();
+    notificationJiraParams1.put("project", "THIRDEYE1");
+    notificationJiraParams1.put("assignee", "thirdeye1");
+    notificationValues1.put("jiraScheme", notificationJiraParams1);
+    dimensionRecipient1.put(PROP_NOTIFY, notificationValues1);
+
+    Map<String, Object> dimensionRecipient2 = new HashMap<>();
+    Map<String, String> dimensionKeys2 = new HashMap<>();
+    dimensionKeys2.put("key1", "anotherValue1");
+    dimensionKeys2.put("key2", "anotherValue2");
+    dimensionRecipient2.put(PROP_DIMENSION, dimensionKeys2);
+    Map<String, Object> notificationValues2 = new HashMap<>();
+    Map<String, Object> notificationJiraParams2 = new HashMap<>();
+    notificationJiraParams2.put("project", "THIRDEYE2");
+    notificationJiraParams2.put("assignee", "thirdeye2");
+    notificationValues2.put("jiraScheme", notificationJiraParams2);
+    dimensionRecipient2.put(PROP_NOTIFY, notificationValues2);
+
+    PROP_DIMENSION_RECIPIENTS_VALUE.add(dimensionRecipient1);
+    PROP_DIMENSION_RECIPIENTS_VALUE.add(dimensionRecipient2);
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(PROP_CLASS_NAME, "org.apache.pinot.thirdeye.detection.alert.filter.DimensionsRecipientAlertFilter");
+    properties.put(PROP_DETECTION_CONFIG_IDS, Collections.singletonList(detectionConfigId));
+    properties.put(PROP_DIMENSION_RECIPIENTS, PROP_DIMENSION_RECIPIENTS_VALUE);
+
+    Map<String, Object> jiraScheme = new HashMap<>();
+    jiraScheme.put("className", "org.apache.pinot.thirdeye.detection.alert.scheme.RandomAlerter");
+    alertConfig.setAlertSchemes(Collections.singletonMap("jiraScheme", jiraScheme));
+    alertConfig.setProperties(properties);
+    alertConfig.setFrom(FROM_ADDRESS_VALUE);
+    alertConfig.setName(ALERT_NAME_VALUE + 2);
+    alertConfig.setVectorClocks(new HashMap<>());
+    Map<String, String> refLinks = new HashMap<>();
+    refLinks.put("test_ref_key", "test_ref_value");
+    alertConfig.setReferenceLinks(refLinks);
+
+    Map<Long, Long> vectorClocks = new HashMap<>();
+    vectorClocks.put(detectionConfigId, 0L);
+    alertConfig.setVectorClocks(vectorClocks);
+
+    return alertConfig;
   }
 
   @Test
@@ -147,19 +217,61 @@ public class TestJiraContentFormatter {
     JiraContentFormatter jiraContent = new JiraContentFormatter(
         JiraConfiguration.createFromProperties(jiraConfiguration), jiraClientConfig, content, teConfig, this.alertConfigDTO);
 
-    JiraEntity jiraEntity = jiraContent.getJiraEntity(new HashSet<>(this.anomalyDAO.findAll()));
+    JiraEntity jiraEntity = jiraContent.getJiraEntity(new HashMap<>(), new HashSet<>(this.anomalyDAO.findAll()));
 
     // Assert Jira fields
-    Assert.assertEquals(jiraEntity.getLabels(), Arrays.asList("test-label-1", "test-label-2", "thirdeye"));
+    Assert.assertEquals(jiraEntity.getLabels(), Arrays.asList("test-label-1", "test-label-2", "thirdeye", "subsId=" + subsId1));
     Assert.assertEquals(jiraEntity.getJiraIssueTypeId().longValue(), 16L);
     Assert.assertEquals(jiraEntity.getAssignee(), "test");
     Assert.assertEquals(jiraEntity.getJiraProject(), "thirdeye");
 
     // Assert summary and description
-    Assert.assertEquals(jiraEntity.getSummary(), "Thirdeye Alert : alert_name - test_metric");
+    Assert.assertEquals(jiraEntity.getSummary(), "Thirdeye Alert : alert_name1 - test_metric");
     Assert.assertEquals(
         jiraEntity.getDescription().replaceAll(" ", ""),
         IOUtils.toString(Thread.currentThread().getContextClassLoader()
             .getResourceAsStream("test-jira-anomalies-template.ftl")).replaceAll(" ", ""));
+  }
+
+  @Test
+  public void testJiraContentWithDimRecipientsAlerter() throws Exception {
+    Map<String,Object> jiraConfiguration = new HashMap<>();
+    jiraConfiguration.put(JIRA_URL_KEY, "jira-test-url");
+    jiraConfiguration.put(JIRA_USER_KEY, "test");
+    jiraConfiguration.put(JIRA_PASSWD_KEY, "test");
+    jiraConfiguration.put(JIRA_DEFAULT_PROJECT_KEY, "thirdeye");
+    jiraConfiguration.put(JIRA_ISSUE_TYPE_KEY, 16);
+
+    Map<String, Map<String, Object>> alerterConfigurations = new HashMap<>();
+    alerterConfigurations.put(JIRA_CONFIG_KEY, jiraConfiguration);
+    ThirdEyeAnomalyConfiguration teConfig = new ThirdEyeAnomalyConfiguration();
+    teConfig.setAlerterConfiguration(alerterConfigurations);
+    teConfig.setDashboardHost("test");
+
+    Properties jiraClientConfig = new Properties();
+    jiraClientConfig.put(PROP_ASSIGNEE, "test");
+    jiraClientConfig.put(PROP_LABELS, Arrays.asList("test-label-1", "test-label-2"));
+    jiraClientConfig.put(PROP_SUBJECT_STYLE, AlertConfigBean.SubjectType.METRICS);
+
+    BaseNotificationContent content = DetectionAlertScheme.buildNotificationContent(jiraClientConfig);
+    JiraContentFormatter jiraContent = new JiraContentFormatter(
+        JiraConfiguration.createFromProperties(jiraConfiguration), jiraClientConfig, content, teConfig, this.alertConfigDTO);
+
+    Map<String, String> dimensionKeys1 = new HashMap<>();
+    dimensionKeys1.put("key", "value");
+    JiraEntity jiraEntity = jiraContent.getJiraEntity(dimensionKeys1, new HashSet<>(this.anomalyDAO.findAll()));
+
+    // Assert Jira fields
+    Assert.assertEquals(jiraEntity.getLabels(), Arrays.asList("test-label-1", "test-label-2", "thirdeye", "subsId=" + subsId2, "key=value"));
+    Assert.assertEquals(jiraEntity.getJiraIssueTypeId().longValue(), 16L);
+    Assert.assertEquals(jiraEntity.getAssignee(), "test");
+    Assert.assertEquals(jiraEntity.getJiraProject(), "thirdeye");
+
+    // Assert summary and description
+    Assert.assertEquals(jiraEntity.getSummary(), "Thirdeye Alert : alert_name2 - test_metric, key=value");
+    Assert.assertEquals(
+        jiraEntity.getDescription().replaceAll(" ", ""),
+        IOUtils.toString(Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream("test-jira-anomalies-template.ftl")).replaceAll(" ", "").replaceAll("alert_name1", "alert_name2"));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/resources/test-jira-anomalies-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/test/resources/test-jira-anomalies-template.ftl
@@ -8,7 +8,7 @@ ThirdEye has detected [<strong>an anomaly</strong>|test/app/#/anomalies?anomalyI
 *Description:*
 
 ||Start||Duration||Dimensions||Current||Predicted||Change||
-|[Dec 31, 16:00 PDT|test/app/#/rootcause?anomalyId=4]|0.00028 hours|-|_0_|_0_|_+100.00 %_|
+|[Dec 31, 16:00 PDT|test/app/#/rootcause?anomalyId=4]|0.00028 hours|key:value\\|_0_|_0_|_+100.00 %_|
 
 =======================================================================================
 
@@ -17,4 +17,4 @@ ThirdEye has detected [<strong>an anomaly</strong>|test/app/#/anomalies?anomalyI
 
 =======================================================================================
 
-_You are receiving this alert because you have subscribed to ThirdEye Alert Service for *alert_name*. If you have any questions regarding this report, please email ask_thirdeye@linkedin.com_
+_You are receiving this alert because you have subscribed to ThirdEye Alert Service for *alert_name1*. If you have any questions regarding this report, please email ask_thirdeye@linkedin.com_


### PR DESCRIPTION
Changes:
* Support for merging jira tickets when dimensions_alerter_pipeline is enabled.
* Injects dimensions and subsId as jira labels.
* Pass the dimensions info in addition to the recipients to the alerter.

Other changes:
* Truncate Jira Summary field which has a static limit of 255 characters max.
* Optm: Query Jira using mergeGap rather than fetching all and filtering in-memory.
* Deprecate DimensionMap and use Multimap

Testing:
* added unit tests
* tested end-to-end by deploying locally