### PR TITLE
Introduce a mode in the server to disable queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
@@ -222,9 +222,14 @@ public class HelixExternalViewBasedRouting implements ClusterChangeHandler, Rout
           previousInstanceConfig.getRecord().getSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS);
       String isShuttingDown =
           currentInstanceConfig.getRecord().getSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS);
+      String wasQueriesDisabled =
+          previousInstanceConfig.getRecord().getSimpleField(CommonConstants.Helix.QUERIES_DISABLED);
+      String isQueriesDisabled =
+          currentInstanceConfig.getRecord().getSimpleField(CommonConstants.Helix.QUERIES_DISABLED);
 
       boolean instancesChanged =
-          !EqualityUtils.isEqual(wasEnabled, isEnabled) || !EqualityUtils.isEqual(wasShuttingDown, isShuttingDown);
+          !EqualityUtils.isEqual(wasEnabled, isEnabled) || !EqualityUtils.isEqual(wasShuttingDown, isShuttingDown) ||
+          !EqualityUtils.isEqual(wasQueriesDisabled, isQueriesDisabled);
 
       if (instancesChanged) {
         LOGGER.info(

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
@@ -233,8 +233,10 @@ public class HelixExternalViewBasedRouting implements ClusterChangeHandler, Rout
 
       if (instancesChanged) {
         LOGGER.info(
-            "Routing table for table {} requires rebuild due to at least one instance changing state (instance {} enabled: {} -> {}; shutting down {} -> {})",
-            tableName, instanceName, wasEnabled, isEnabled, wasShuttingDown, isShuttingDown);
+            "Routing table for table {} requires rebuild due to at least one instance changing state " +
+                "(instance {} enabled: {} -> {}; shutting down {} -> {}; queries disabled {} -> {})",
+            tableName, instanceName, wasEnabled, isEnabled, wasShuttingDown, isShuttingDown,
+            wasQueriesDisabled, isQueriesDisabled);
         return true;
       } else {
         // Update the instance config in our last known instance config, since it hasn't changed

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/RoutingTableInstancePruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/RoutingTableInstancePruner.java
@@ -68,6 +68,12 @@ public class RoutingTableInstancePruner {
       return true;
     }
 
+    if (Boolean
+        .parseBoolean(instanceConfig.getRecord().getSimpleField(CommonConstants.Helix.QUERIES_DISABLED))) {
+      LOGGER.info("Instance '{}' has disabled queries", instanceName);
+      return true;
+    }
+
     return false;
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/LargeClusterRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/LargeClusterRoutingTableBuilderTest.java
@@ -87,13 +87,19 @@ public class LargeClusterRoutingTableBuilderTest {
     shuttingDownInstance.getRecord()
         .setSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(true));
 
+    final InstanceConfig queriesDisabledInstance = instanceConfigs.get(2);
+    final String queriesDisabledInstanceName = queriesDisabledInstance.getInstanceName();
+    queriesDisabledInstance.getRecord()
+        .setSimpleField(CommonConstants.Helix.QUERIES_DISABLED, Boolean.toString(true));
+
     validateAssertionForOneRoutingTable(new RoutingTableValidator() {
       @Override
       public boolean isRoutingTableValid(Map<String, List<String>> routingTable, ExternalView externalView,
           List<InstanceConfig> instanceConfigs) {
         for (String serverName : routingTable.keySet()) {
           // These servers should not appear in the routing table
-          if (serverName.equals(disabledHelixInstanceName) || serverName.equals(shuttingDownInstanceName)) {
+          if (serverName.equals(disabledHelixInstanceName) || serverName.equals(shuttingDownInstanceName) ||
+              serverName.equals(queriesDisabledInstanceName)) {
             return false;
           }
         }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -28,6 +28,7 @@ public class CommonConstants {
 
   public static class Helix {
     public static final String IS_SHUTDOWN_IN_PROGRESS = "shutdownInProgress";
+    public static final String QUERIES_DISABLED = "queriesDisabled";
 
     public static final String INSTANCE_CONNECTED_METRIC_NAME = "helix.connected";
 


### PR DESCRIPTION
When we have problems with pinot servers in production, and need to isolate the
server by not sending queries to it, we use the shutdownInProgress field in the
instance config. This does not work if the server is restarted (due to deployment
or by other automated systems) because the upon restart, the server automatically
sets shutdownInProgress to "false". We would still like to isolate the server to
find out what the real issue may be.

This commit introduces another field called "queriesDisabled" in the instance config
that the admin can set.  The broker pays attention to this field and excludes the
server from routing table computations (thus not routing queries to it).

This behavior continues until such time as the value of this field is set to false.