### PR TITLE
[TE] deactivate metrics instead of deleting

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
@@ -146,7 +146,7 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
       List<MetricConfigDTO> metrics = metricDAO.findByDataset(datasetConfigDTO.getDataset());
       int metricCount = metrics.size();
       for (MetricConfigDTO metric : metrics) {
-        if (!metric.isDerived()) {
+        if (!metric.isDerived() && !metric.getName().equals(ROW_COUNT)) {
           metric.setActive(false);
           metricDAO.save(metric);
           metricCount--;
@@ -313,6 +313,7 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
     for (MetricConfigDTO metricConfig : datasetMetricConfigs) {
       if (!schemaMetricNames.contains(getColumnName(metricConfig))) {
         if (!metricConfig.isDerived() && !metricConfig.getName().equals(ROW_COUNT)) {
+          // if metric is removed from schema and not a derived/row_count metric, deactivate it
           LOG.info("Deactivating metric {} in {}", metricConfig.getName(), dataset);
           metricConfig.setActive(false);
           this.metricDAO.save(metricConfig);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
@@ -35,7 +35,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -108,10 +107,9 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
       Map<String, Map<String, String>> allCustomConfigs = new HashMap<>();
       loadDatasets(allDatasets, allSchemas, allCustomConfigs);
       LOG.info("Checking all datasets");
-      removeDeletedDataset(allDatasets);
+      deactivateDatasets(allDatasets);
       for (String dataset : allDatasets) {
         LOG.info("Checking dataset {}", dataset);
-
         Schema schema = allSchemas.get(dataset);
         Map<String, String> customConfigs = allCustomConfigs.get(dataset);
         DatasetConfigDTO datasetConfig = datasetDAO.findByDataset(dataset);
@@ -122,8 +120,8 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
     }
   }
 
-  void removeDeletedDataset(List<String> allDatasets) {
-    LOG.info("Removing deleted Pinot datasets");
+  void deactivateDatasets(List<String> allDatasets) {
+    LOG.info("deactivating deleted Pinot datasets");
     List<DatasetConfigDTO> allExistingDataset = this.datasetDAO.findAll();
     Set<String> datasets = new HashSet<>(allDatasets);
 
@@ -135,31 +133,22 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
     });
 
     for (DatasetConfigDTO datasetConfigDTO : filtered) {
-      if (shouldRemoveDataset(datasetConfigDTO, datasets)) {
-        LOG.info("Deleting pinot dataset '{}'", datasetConfigDTO.getDataset());
-        datasetDAO.deleteByPredicate(Predicate.EQ("dataset", datasetConfigDTO.getDataset()));
-        deleteAutoCreatedAlertGroup(datasetConfigDTO);
+      if (shouldDeactivateDataset(datasetConfigDTO, datasets)) {
+        LOG.info("Deactivating pinot dataset '{}'", datasetConfigDTO.getDataset());
+        datasetConfigDTO.setActive(false);
+        datasetDAO.save(datasetConfigDTO);
       }
     }
   }
 
-  private void deleteAutoCreatedAlertGroup(DatasetConfigDTO datasetConfigDTO) {
-    String alertGroupName = AutoOnboardUtility.getAutoAlertGroupName(datasetConfigDTO.getDataset());
-    AlertConfigDTO alertGroupDTO = alertDAO.findWhereNameEquals(alertGroupName);
-    if (alertGroupDTO != null) {
-      alertDAO.deleteById(alertGroupDTO.getId());
-      LOG.info("Deleting auto created alert group {} associated with pinot dataset '{}'", alertGroupDTO.getName(),
-          datasetConfigDTO.getDataset());
-    }
-  }
-
-  private boolean shouldRemoveDataset(DatasetConfigDTO datasetConfigDTO, Set<String> datasets) {
+  private boolean shouldDeactivateDataset(DatasetConfigDTO datasetConfigDTO, Set<String> datasets) {
     if (!datasets.contains(datasetConfigDTO.getDataset())) {
       List<MetricConfigDTO> metrics = metricDAO.findByDataset(datasetConfigDTO.getDataset());
       int metricCount = metrics.size();
       for (MetricConfigDTO metric : metrics) {
-        if (!metric.isDerived() && !metric.getName().equals(ROW_COUNT)) {
-          metricDAO.delete(metric);
+        if (!metric.isDerived()) {
+          metric.setActive(false);
+          metricDAO.save(metric);
           metricCount--;
         }
       }
@@ -221,6 +210,7 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
     checkMetricChanges(dataset, datasetConfig, schema);
     checkTimeFieldChanges(datasetConfig, schema);
     appendNewCustomConfigs(datasetConfig, customConfigs);
+    datasetConfig.setActive(true);
   }
 
   private void checkDimensionChanges(String dataset, DatasetConfigDTO datasetConfig, Schema schema) {
@@ -315,16 +305,23 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
       if (!datasetMetricNames.contains(metricSpec.getName())) {
         MetricConfigDTO metricConfigDTO = ConfigGenerator.generateMetricConfig(metricSpec, dataset);
         LOG.info("Creating metric {} in {}", metricSpec.getName(), dataset);
-        DAO_REGISTRY.getMetricConfigDAO().save(metricConfigDTO);
+        this.metricDAO.save(metricConfigDTO);
       }
     }
 
-    // remove deleted metrics from ThirdEye
+    // audit existing metrics in ThirdEye
     for (MetricConfigDTO metricConfig : datasetMetricConfigs) {
-      if (!metricConfig.isDerived()) {
-        if (!schemaMetricNames.contains(getColumnName(metricConfig))) {
-          LOG.info("Deleting metric {} in {}", metricConfig.getName(), dataset);
-          DAO_REGISTRY.getMetricConfigDAO().delete(metricConfig);
+      if (!schemaMetricNames.contains(getColumnName(metricConfig))) {
+        if (!metricConfig.isDerived() && !metricConfig.getName().equals(ROW_COUNT)) {
+          LOG.info("Deactivating metric {} in {}", metricConfig.getName(), dataset);
+          metricConfig.setActive(false);
+          this.metricDAO.save(metricConfig);
+        }
+      } else {
+        if (!metricConfig.isActive()) {
+          LOG.info("Activating metric {} in {}", metricConfig.getName(), dataset);
+          metricConfig.setActive(true);
+          this.metricDAO.save(metricConfig);
         }
       }
     }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsServiceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsServiceTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
 import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.MetricConfigManager;
 import org.apache.pinot.thirdeye.datalayer.dto.DatasetConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MetricConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.pojo.MetricConfigBean;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
@@ -159,9 +160,11 @@ public class AutoOnboardPinotMetricsServiceTest {
   }
 
   @Test (dependsOnMethods={"testRefreshDataset"})
-  public void testRemoveDataset() throws Exception {
+  public void testDeactivate() throws Exception {
     Assert.assertEquals(datasetConfigDAO.findAll().size(), 1);
-    testAutoLoadPinotMetricsService.removeDeletedDataset(Collections.<String>emptyList());
-    Assert.assertEquals(datasetConfigDAO.findAll().size(), 0);
+    testAutoLoadPinotMetricsService.deactivateDatasets(Collections.<String>emptyList());
+    List<DatasetConfigDTO> datasets = datasetConfigDAO.findAll();
+    Assert.assertEquals(datasets.size(), 1);
+    Assert.assertFalse(datasets.get(0).isActive());
   }
 }


### PR DESCRIPTION
Deactivate pinot metrics/datasets instead of deleting. Because some metrics can be removed and re-added later into the database with a different id. It will break existing detections. This PR changes the behavior to deactivate instead of deleting, which will maintain the id of the metrics and datasets.