### PR TITLE
[TE] add event driven scheduler

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -25,6 +25,7 @@ import org.apache.pinot.thirdeye.anomaly.classification.ClassificationJobSchedul
 import org.apache.pinot.thirdeye.anomaly.classification.classifier.AnomalyClassifierFactory;
 import org.apache.pinot.thirdeye.anomaly.detection.DetectionJobScheduler;
 import org.apache.pinot.thirdeye.anomaly.detection.trigger.DataAvailabilityEventListenerDriver;
+import org.apache.pinot.thirdeye.anomaly.detection.trigger.DataAvailabilityTaskScheduler;
 import org.apache.pinot.thirdeye.anomaly.events.HolidayEventResource;
 import org.apache.pinot.thirdeye.anomaly.events.HolidayEventsLoader;
 import org.apache.pinot.thirdeye.anomaly.monitor.MonitorJobScheduler;
@@ -75,6 +76,7 @@ public class ThirdEyeAnomalyApplication
   private DetectionPipelineScheduler detectionPipelineScheduler = null;
   private DetectionAlertScheduler detectionAlertScheduler = null;
   private DataAvailabilityEventListenerDriver dataAvailabilityEventListenerDriver = null;
+  private DataAvailabilityTaskScheduler dataAvailabilityTaskScheduler = null;
 
   public static void main(final String[] args) throws Exception {
     List<String> argList = new ArrayList<>(Arrays.asList(args));
@@ -185,9 +187,15 @@ public class ThirdEyeAnomalyApplication
           detectionAlertScheduler = new DetectionAlertScheduler();
           detectionAlertScheduler.start();
         }
-        if (config.isTriggerEventListener()) {
-          dataAvailabilityEventListenerDriver = new DataAvailabilityEventListenerDriver(config.getDataAvailabilityListenerConfiguration());
+        if (config.isDataAvailabilityEventListener()) {
+          dataAvailabilityEventListenerDriver = new DataAvailabilityEventListenerDriver(config.getDataAvailabilitySchedulingConfiguration());
           dataAvailabilityEventListenerDriver.start();
+        }
+        if (config.isDataAvailabilityTaskScheduler()) {
+          dataAvailabilityTaskScheduler = new DataAvailabilityTaskScheduler(
+              config.getDataAvailabilitySchedulingConfiguration().getSchedulerDelayInSec(),
+              config.getDataAvailabilitySchedulingConfiguration().getTaskTriggerFallBackTimeInSec());
+          dataAvailabilityTaskScheduler.start();
         }
       }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
@@ -19,7 +19,7 @@
 
 package org.apache.pinot.thirdeye.anomaly;
 
-import org.apache.pinot.thirdeye.anomaly.detection.trigger.utils.DataAvailabilityListenerConfiguration;
+import org.apache.pinot.thirdeye.anomaly.detection.trigger.utils.DataAvailabilitySchedulingConfiguration;
 import org.apache.pinot.thirdeye.anomaly.monitor.MonitorConfiguration;
 import org.apache.pinot.thirdeye.anomaly.task.TaskDriverConfiguration;
 import org.apache.pinot.thirdeye.auto.onboard.AutoOnboardConfiguration;
@@ -40,7 +40,8 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
   private boolean worker = false;
   private boolean detectionPipeline = false;
   private boolean detectionAlert = false;
-  private boolean triggerEventListener = false;
+  private boolean dataAvailabilityEventListener = false;
+  private boolean dataAvailabilityTaskScheduler = false;
 
   private long id;
   private String dashboardHost;
@@ -48,8 +49,8 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
   private MonitorConfiguration monitorConfiguration = new MonitorConfiguration();
   private AutoOnboardConfiguration autoOnboardConfiguration = new AutoOnboardConfiguration();
   private TaskDriverConfiguration taskDriverConfiguration = new TaskDriverConfiguration();
-  private DataAvailabilityListenerConfiguration
-      dataAvailabilityListenerConfiguration = new DataAvailabilityListenerConfiguration();
+  private DataAvailabilitySchedulingConfiguration
+      dataAvailabilitySchedulingConfiguration = new DataAvailabilitySchedulingConfiguration();
   private String failureFromAddress;
   private String failureToAddress;
   private List<String> holidayCountriesWhitelist;
@@ -126,12 +127,20 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
     this.monitor = monitor;
   }
 
-  public boolean isTriggerEventListener() {
-    return triggerEventListener;
+  public boolean isDataAvailabilityEventListener() {
+    return dataAvailabilityEventListener;
   }
 
-  public void setTriggerEventListener(boolean triggerEventListener) {
-    this.triggerEventListener = triggerEventListener;
+  public void setDataAvailabilityEventListener(boolean dataAvailabilityEventListener) {
+    this.dataAvailabilityEventListener = dataAvailabilityEventListener;
+  }
+
+  public boolean isDataAvailabilityTaskScheduler() {
+    return dataAvailabilityTaskScheduler;
+  }
+
+  public void setDataAvailabilityEventScheduler(boolean dataAvailabilityEventScheduler) {
+    this.dataAvailabilityTaskScheduler = dataAvailabilityEventScheduler;
   }
 
   public MonitorConfiguration getMonitorConfiguration() {
@@ -222,12 +231,12 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
     this.holidayCountriesWhitelist = holidayCountriesWhitelist;
   }
 
-  public DataAvailabilityListenerConfiguration getDataAvailabilityListenerConfiguration() {
-    return dataAvailabilityListenerConfiguration;
+  public DataAvailabilitySchedulingConfiguration getDataAvailabilitySchedulingConfiguration() {
+    return dataAvailabilitySchedulingConfiguration;
   }
 
-  public void setDataAvailabilityListenerConfiguration(
-      DataAvailabilityListenerConfiguration dataAvailabilityListenerConfiguration) {
-    this.dataAvailabilityListenerConfiguration = dataAvailabilityListenerConfiguration;
+  public void setDataAvailabilitySchedulingConfiguration(
+      DataAvailabilitySchedulingConfiguration dataAvailabilitySchedulingConfiguration) {
+    this.dataAvailabilitySchedulingConfiguration = dataAvailabilitySchedulingConfiguration;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerDriver.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerDriver.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.pinot.thirdeye.anomaly.detection.trigger.filter.DataAvailabilityEventFilter;
 import org.apache.pinot.thirdeye.anomaly.detection.trigger.utils.DatasetTriggerInfoRepo;
-import org.apache.pinot.thirdeye.anomaly.detection.trigger.utils.DataAvailabilityListenerConfiguration;
+import org.apache.pinot.thirdeye.anomaly.detection.trigger.utils.DataAvailabilitySchedulingConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +41,11 @@ import org.slf4j.LoggerFactory;
 public class DataAvailabilityEventListenerDriver {
   private static final Logger LOG = LoggerFactory.getLogger(DataAvailabilityEventListenerDriver.class);
   private ExecutorService executorService;
-  private DataAvailabilityListenerConfiguration config;
+  private DataAvailabilitySchedulingConfiguration config;
   private Properties consumerProps;
   private List<DataAvailabilityEventListener> listeners;
 
-  public DataAvailabilityEventListenerDriver(DataAvailabilityListenerConfiguration config) throws IOException {
+  public DataAvailabilityEventListenerDriver(DataAvailabilitySchedulingConfiguration config) throws IOException {
     String rootDir = System.getProperty("dw.rootDir");
     this.config = config;
     this.executorService = Executors.newFixedThreadPool(this.config.getNumParallelConsumer(),

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskScheduler.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.anomaly.detection.trigger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.pinot.thirdeye.anomaly.task.TaskConstants;
+import org.apache.pinot.thirdeye.anomaly.task.TaskInfoFactory;
+import org.apache.pinot.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
+import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.TaskManager;
+import org.apache.pinot.thirdeye.datalayer.dto.DatasetConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.TaskDTO;
+import org.apache.pinot.thirdeye.datalayer.pojo.DetectionConfigBean;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
+import org.apache.pinot.thirdeye.detection.DetectionPipelineTaskInfo;
+import org.apache.pinot.thirdeye.formatter.DetectionConfigFormatter;
+import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
+import org.apache.pinot.thirdeye.util.ThirdEyeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is to schedule detection tasks based on data availability events.
+ */
+public class DataAvailabilityTaskScheduler implements Runnable {
+  private static final Logger LOG = LoggerFactory.getLogger(DataAvailabilityTaskScheduler.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private ScheduledExecutorService executorService;
+  private long delayInSec;
+  private long fallBackTimeInSec;
+  private Map<Long, Long> taskLastCreateTimeMap;
+  private TaskManager taskDAO;
+  private DetectionConfigManager detectionConfigDAO;
+  private DatasetConfigManager datasetConfigDAO;
+  /**
+   * Construct an instance of {@link DataAvailabilityTaskScheduler}
+   * @param delayInSec delay after each run to avoid polling the database too often
+   * @param fallBackTimeInSec global threshold for fallback if detection level one is not set
+   */
+  public DataAvailabilityTaskScheduler(long delayInSec, long fallBackTimeInSec) {
+    this.delayInSec = delayInSec;
+    this.fallBackTimeInSec = fallBackTimeInSec;
+    this.taskLastCreateTimeMap = new HashMap<>();
+    this.executorService = Executors.newSingleThreadScheduledExecutor();
+    this.taskDAO = DAORegistry.getInstance().getTaskDAO();
+    this.detectionConfigDAO = DAORegistry.getInstance().getDetectionConfigManager();
+    this.datasetConfigDAO = DAORegistry.getInstance().getDatasetConfigDAO();
+  }
+
+  @Override
+  public void run() {
+    Map<DetectionConfigDTO, Set<String>> detection2DatasetMap = new HashMap<>();
+    Map<String, Long> dataset2RefreshTimeMap = new HashMap<>();
+    populateDetectionMapAndDataset2RefreshTimeMap(detection2DatasetMap, dataset2RefreshTimeMap);
+    Map<Long, TaskDTO> runningDetection = retrieveRunningDetectionTasks();
+    int taskCount = 0;
+    for (DetectionConfigDTO detectionConfig : detection2DatasetMap.keySet()) {
+      try {
+        long detectionConfigId = detectionConfig.getId();
+        if (!runningDetection.containsKey(detectionConfigId)) {
+          if (isAllDatasetUpdated(detectionConfig, detection2DatasetMap.get(detectionConfig), dataset2RefreshTimeMap)) {
+            //TODO: additional check is required if detection is based on aggregated value across multiple data points
+            createDetectionTask(detectionConfig);
+            ThirdeyeMetricsUtil.eventScheduledTaskCounter.inc();
+            taskCount++;
+          } else if (needFallback(detectionConfig)) {
+            LOG.info("Scheduling a task for detection {} due to the fallback mechanism", detectionConfigId);
+            createDetectionTask(detectionConfig);
+            ThirdeyeMetricsUtil.eventScheduledTaskFallbackCounter.inc();
+            taskCount++;
+          }
+        } else {
+          LOG.info("Skipping creating detection task for detection {} because task {} is not finished.",
+              detectionConfigId, runningDetection.get(detectionConfigId));
+        }
+      } catch (Exception e) {
+        LOG.error("Error in scheduling a detection...", e);
+      }
+    }
+    LOG.info("Schedule {} tasks in this run...", taskCount);
+  }
+
+  public void start() {
+    executorService.scheduleWithFixedDelay(this, 0, delayInSec, TimeUnit.SECONDS);
+  }
+
+  public void close() {
+    executorService.shutdownNow();
+  }
+
+  private void populateDetectionMapAndDataset2RefreshTimeMap(
+      Map<DetectionConfigDTO, Set<String>> dataset2DetectionMap, Map<String, Long> dataset2RefreshTimeMap) {
+    Map<Long, Set<String>> metricCache = new HashMap<>();
+    List<DetectionConfigDTO> detectionConfigs = detectionConfigDAO.findAllActive()
+        .stream().filter(DetectionConfigBean::isDataAvailabilitySchedule).collect(Collectors.toList());
+    for (DetectionConfigDTO detectionConfig : detectionConfigs) {
+      List<String> metricUrns = DetectionConfigFormatter
+          .extractMetricUrnsFromProperties(detectionConfig.getProperties());
+      Set<String> datasets = new HashSet<>();
+      for (String urn : metricUrns) {
+        MetricEntity me = MetricEntity.fromURN(urn);
+        if (!metricCache.containsKey(me.getId())) {
+          datasets.addAll(ThirdEyeUtils.getDatasetConfigsFromMetricUrn(urn)
+              .stream().map(DatasetConfigDTO::getName).collect(Collectors.toList()));
+          // cache the mapping in memory to avoid duplicate retrieval
+          metricCache.put(me.getId(), datasets);
+        } else {
+          // retrieve dataset mapping from memory
+          datasets.addAll(metricCache.get(me.getId()));
+        }
+      }
+      if (datasets.isEmpty()) {
+        LOG.error("No valid dataset is found for detection {}", detectionConfig.getId());
+        continue;
+      }
+      dataset2DetectionMap.put(detectionConfig, datasets);
+      for (String dataset : datasets) {
+        if (!dataset2RefreshTimeMap.containsKey(dataset)) {
+          DatasetConfigDTO datasetConfig = datasetConfigDAO.findByDataset(dataset);
+          dataset2RefreshTimeMap.put(dataset, datasetConfig.getLastRefreshTime());
+        }
+      }
+    }
+  }
+
+  private Map<Long, TaskDTO> retrieveRunningDetectionTasks() {
+    List<TaskConstants.TaskStatus> statusList = new ArrayList<>();
+    statusList.add(TaskConstants.TaskStatus.WAITING);
+    statusList.add(TaskConstants.TaskStatus.RUNNING);
+    List<TaskDTO> tasks = taskDAO.findByStatusesAndTypeWithinDays(statusList, TaskConstants.TaskType.DETECTION,
+        (int) TimeUnit.MILLISECONDS.toDays(ThirdEyeUtils.DETECTION_TASK_MAX_LOOKBACK_WINDOW));
+    Map<Long, TaskDTO> res = new HashMap<>(tasks.size());
+    for (TaskDTO task : tasks) {
+      res.put(ThirdEyeUtils.getDetectionIdFromJobName(task.getJobName()), task);
+    }
+    return res;
+  }
+
+  private long createDetectionTask(DetectionConfigDTO detectionConfig) throws JsonProcessingException {
+    long detectionConfigId = detectionConfig.getId();
+    // Make sure start time is not out of DETECTION_TASK_MAX_LOOKBACK_WINDOW
+    long end = System.currentTimeMillis();
+    long start = Math.max(detectionConfig.getLastTimestamp(),
+        end - ThirdEyeUtils.DETECTION_TASK_MAX_LOOKBACK_WINDOW);
+    DetectionPipelineTaskInfo taskInfo = new DetectionPipelineTaskInfo(detectionConfigId, start, end);
+    String taskInfoJson = OBJECT_MAPPER.writeValueAsString(taskInfo);
+    TaskDTO taskDTO = new TaskDTO();
+    taskDTO.setTaskType(TaskConstants.TaskType.DETECTION);
+    taskDTO.setJobName(TaskConstants.TaskType.DETECTION.toString() + "_" + detectionConfigId);
+    taskDTO.setStatus(TaskConstants.TaskStatus.WAITING);
+    taskDTO.setTaskInfo(taskInfoJson);
+    long taskId = taskDAO.save(taskDTO);
+    LOG.info("Created detection pipeline task {} with taskId {}", taskDTO, taskId);
+    taskLastCreateTimeMap.put(detectionConfigId, end);
+    return taskId;
+  }
+
+  private void loadLatestTaskCreateTime(DetectionConfigDTO detectionConfig) throws Exception {
+    long detectionConfigId = detectionConfig.getId();
+    List<TaskDTO> tasks = taskDAO.findByNameOrderByCreateTime(TaskConstants.TaskType.DETECTION.toString() +
+        "_" + detectionConfigId, 1,false);
+    if (tasks.size() == 0) {
+      taskLastCreateTimeMap.put(detectionConfigId, 0L);
+    } else {
+      DetectionPipelineTaskInfo taskInfo = (DetectionPipelineTaskInfo) TaskInfoFactory.getTaskInfoFromTaskType(
+          TaskConstants.TaskType.DETECTION, tasks.get(0).getTaskInfo());
+      taskLastCreateTimeMap.put(detectionConfigId, taskInfo.getEnd());
+    }
+  }
+
+  private boolean isAllDatasetUpdated(DetectionConfigDTO detectionConfig, Set<String> datasets,
+      Map<String, Long> dataset2RefreshTimeMap) {
+    long lastTimestamp = detectionConfig.getLastTimestamp();
+    return datasets.stream().allMatch(d -> dataset2RefreshTimeMap.get(d) >= lastTimestamp);
+  }
+
+  private boolean needFallback(DetectionConfigDTO detectionConfig) throws Exception {
+    long detectionConfigId = detectionConfig.getId();
+    long notRunThreshold = ((detectionConfig.getTaskTriggerFallBackTimeInSec() == 0) ?
+        fallBackTimeInSec : detectionConfig.getTaskTriggerFallBackTimeInSec()) * 1000;
+    if (!taskLastCreateTimeMap.containsKey(detectionConfigId)) {
+      loadLatestTaskCreateTime(detectionConfig);
+    }
+    long lastRunTime = taskLastCreateTimeMap.get(detectionConfigId);
+    return (System.currentTimeMillis() - lastRunTime >= notRunThreshold);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DataAvailabilitySchedulingConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DataAvailabilitySchedulingConfiguration.java
@@ -21,11 +21,10 @@ package org.apache.pinot.thirdeye.anomaly.detection.trigger.utils;
 
 import java.util.List;
 
-
 /**
  * Configuration class for DataAvailabilityListener.
  */
-public class DataAvailabilityListenerConfiguration {
+public class DataAvailabilitySchedulingConfiguration {
   private String consumerClass;
   private String kafkaBootstrapServers;
   private String kafkaTopic;
@@ -37,6 +36,10 @@ public class DataAvailabilityListenerConfiguration {
   private long consumerPollTimeInMilli = 5_000; // consumer wait 5 secs by default for the buffer to be filled
   private List<String> dataSourceWhitelist;
   private List<String> filterClassList;
+  // delay time after each run for the scheduler to reduce DB polling
+  private long schedulerDelayInSec = 300;
+  // default threshold if detection level threshold is not set
+  private long taskTriggerFallBackTimeInSec = 24 * 60;
 
   public String getConsumerClass() {
     return consumerClass;
@@ -124,5 +127,21 @@ public class DataAvailabilityListenerConfiguration {
 
   public void setFilterClassList(List<String> filterClassList) {
     this.filterClassList = filterClassList;
+  }
+
+  public long getSchedulerDelayInSec() {
+    return schedulerDelayInSec;
+  }
+
+  public void setSchedulerDelayInSec(long schedulerDelayInSec) {
+    this.schedulerDelayInSec = schedulerDelayInSec;
+  }
+
+  public long getTaskTriggerFallBackTimeInSec() {
+    return taskTriggerFallBackTimeInSec;
+  }
+
+  public void setTaskTriggerFallBackTimeInSec(long taskTriggerFallBackTimeInSec) {
+    this.taskTriggerFallBackTimeInSec = taskTriggerFallBackTimeInSec;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/task/TaskDriver.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/task/TaskDriver.java
@@ -123,7 +123,6 @@ public class TaskDriver {
                 TaskType taskType = anomalyTaskSpec.getTaskType();
                 TaskRunner taskRunner = TaskRunnerFactory.getTaskRunnerFromTaskType(taskType);
                 TaskInfo taskInfo = TaskInfoFactory.getTaskInfoFromTaskType(taskType, anomalyTaskSpec.getTaskInfo());
-                updateTaskStartTime(anomalyTaskSpec.getId());
                 Future<List<TaskResult>> future = taskExecutorService.submit(new Callable<List<TaskResult>>() {
                   @Override
                   public List<TaskResult> call() throws Exception {
@@ -211,9 +210,8 @@ public class TaskDriver {
 
           boolean success = false;
           try {
-            success = taskDAO
-                .updateStatusAndWorkerId(workerId, anomalyTaskSpec.getId(), allowedOldTaskStatus,
-                    TaskStatus.RUNNING, anomalyTaskSpec.getVersion());
+            success = taskDAO.updateStatusAndWorkerId(workerId, anomalyTaskSpec.getId(),
+                    allowedOldTaskStatus, anomalyTaskSpec.getVersion());
             LOG.info("Trying to acquire task id [{}], success status: [{}] with version [{}]",
                 anomalyTaskSpec.getId(), success, anomalyTaskSpec.getVersion());
           } catch (Exception e) {
@@ -247,17 +245,6 @@ public class TaskDriver {
       }
     }
     return null;
-  }
-
-  private void updateTaskStartTime(long taskId) {
-    LOG.info("Starting updateTaskStartTime for task id {}", taskId);
-    try {
-      long startTime = System.currentTimeMillis();
-      taskDAO.updateTaskStartTime(taskId, startTime);
-      LOG.info("Updated task start time {}", startTime);
-    } catch (Exception e) {
-      LOG.error("Exception in updating task start time", e);
-    }
   }
 
   private void updateStatusAndTaskEndTime(long taskId, TaskStatus oldStatus, TaskStatus newStatus, String message) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/utils/ThirdeyeMetricsUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/utils/ThirdeyeMetricsUtil.java
@@ -155,6 +155,12 @@ public class ThirdeyeMetricsUtil {
   public static final Counter processedTriggerEventCounter =
       metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "processedTriggerEventCounter");
 
+  public static final Counter eventScheduledTaskCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "eventScheduledTaskCounter");
+
+  public static final Counter eventScheduledTaskFallbackCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "eventScheduledTaskFallbackCounter");
+
   public static MetricsRegistry getMetricsRegistry() {
     return metricsRegistry;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/TaskManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/TaskManager.java
@@ -21,6 +21,7 @@ package org.apache.pinot.thirdeye.datalayer.bao;
 
 import java.util.List;
 
+import org.apache.pinot.thirdeye.anomaly.task.TaskConstants;
 import org.apache.pinot.thirdeye.anomaly.task.TaskConstants.TaskStatus;
 import org.apache.pinot.thirdeye.datalayer.dto.TaskDTO;
 import java.util.Set;
@@ -29,9 +30,13 @@ public interface TaskManager extends AbstractManager<TaskDTO>{
 
   List<TaskDTO> findByJobIdStatusNotIn(Long jobId, TaskStatus status);
 
+  List<TaskDTO> findByNameOrderByCreateTime(String name, int fetchSize, boolean asc);
+
   List<TaskDTO> findByStatusNotIn(TaskStatus status);
 
   List<TaskDTO> findByStatusWithinDays(TaskStatus status, int days);
+
+  List<TaskDTO> findByStatusesAndTypeWithinDays(List<TaskStatus> statuses, TaskConstants.TaskType type, int days);
 
   List<TaskDTO> findTimeoutTasksWithinDays(int days, long maxTaskTime);
 
@@ -39,8 +44,7 @@ public interface TaskManager extends AbstractManager<TaskDTO>{
 
   List<TaskDTO> findByStatusAndWorkerId(Long workerId, TaskStatus status);
 
-  boolean updateStatusAndWorkerId(Long workerId, Long id, Set<TaskStatus> allowedOldStatus,
-      TaskStatus newStatus, int expectedVersion);
+  boolean updateStatusAndWorkerId(Long workerId, Long id, Set<TaskStatus> allowedOldStatus, int expectedVersion);
 
   void updateStatusAndTaskEndTime(Long id, TaskStatus oldStatus, TaskStatus newStatus,
       Long taskEndTime, String message);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DetectionConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DetectionConfigBean.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-
 /**
  * ConfigBean holds namespaced key-value configuration values.  Values are serialized into the
  * database using the default object mapper.  ConfigBean serves as a light-weight
@@ -44,6 +43,8 @@ public class DetectionConfigBean extends AbstractBean {
   Map<String, Object> componentSpecs;
   long lastTuningTimestamp;
   List<String> owners;
+  boolean isDataAvailabilitySchedule;
+  long taskTriggerFallBackTimeInSec;
 
   public List<String> getOwners() {
     return owners;
@@ -125,6 +126,22 @@ public class DetectionConfigBean extends AbstractBean {
     this.active = active;
   }
 
+  public boolean isDataAvailabilitySchedule() {
+    return isDataAvailabilitySchedule;
+  }
+
+  public void setDataAvailabilitySchedule(boolean dataAvailabilitySchedule) {
+    isDataAvailabilitySchedule = dataAvailabilitySchedule;
+  }
+
+  public long getTaskTriggerFallBackTimeInSec() {
+    return taskTriggerFallBackTimeInSec;
+  }
+
+  public void setTaskTriggerFallBackTimeInSec(long taskTriggerFallBackTimeInSec) {
+    this.taskTriggerFallBackTimeInSec = taskTriggerFallBackTimeInSec;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -136,7 +153,8 @@ public class DetectionConfigBean extends AbstractBean {
     DetectionConfigBean that = (DetectionConfigBean) o;
     return lastTimestamp == that.lastTimestamp && active == that.active && Objects.equals(cron, that.cron)
         && Objects.equals(name, that.name) && Objects.equals(properties, that.properties) && Objects.equals(yaml,
-        that.yaml);
+        that.yaml) && Objects.equals(isDataAvailabilitySchedule, that.isDataAvailabilitySchedule) && Objects
+        .equals(taskTriggerFallBackTimeInSec, that.taskTriggerFallBackTimeInSec);
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.pinot.thirdeye.anomaly.detection.trigger;
 
 import java.util.ArrayList;
@@ -23,7 +39,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
 
 public class DataAvailabilityEventListenerTest {
   private Logger LOG = LoggerFactory.getLogger(this.getClass());

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskSchedulerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskSchedulerTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.thirdeye.anomaly.detection.trigger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.pinot.thirdeye.anomaly.task.TaskConstants;
+import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
+import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.MetricConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.TaskManager;
+import org.apache.pinot.thirdeye.datalayer.dto.DatasetConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.MetricConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.TaskDTO;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
+import org.apache.pinot.thirdeye.detection.DetectionPipelineTaskInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.thirdeye.dashboard.resources.EntityManagerResource.*;
+
+public class DataAvailabilityTaskSchedulerTest {
+  private static final Logger LOG = LoggerFactory.getLogger(DataAvailabilityTaskSchedulerTest.class);
+  private static final long TEST_TIME = System.currentTimeMillis();
+  private static String TEST_DATASET_PREFIX = "ds_trigger_scheduler_";
+  private DAOTestBase testDAOProvider;
+  private DataAvailabilityTaskScheduler dataAvailabilityTaskScheduler;
+  private long metricId1;
+  private long metricId2;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    testDAOProvider = DAOTestBase.getInstance();
+    MetricConfigManager metricConfigManager = DAORegistry.getInstance().getMetricConfigDAO();
+    final String TEST_METRIC_PREFIX = "metric_trigger_scheduler_";
+
+    MetricConfigDTO metric1 = new MetricConfigDTO();
+    metric1.setDataset(TEST_DATASET_PREFIX + 1);
+    metric1.setName(TEST_METRIC_PREFIX + 1);
+    metric1.setActive(true);
+    metric1.setDerived(false);
+    metric1.setAlias("");
+    metricId1 = metricConfigManager.save(metric1);
+
+    MetricConfigDTO metric2 = new MetricConfigDTO();
+    metric2.setDataset(TEST_DATASET_PREFIX + 2);
+    metric2.setName(TEST_METRIC_PREFIX + 2);
+    metric2.setActive(true);
+    metric1.setDerived(false);
+    metric2.setAlias("");
+    metricId2 = metricConfigManager.save(metric2);
+    dataAvailabilityTaskScheduler = new DataAvailabilityTaskScheduler(60, 24 * 60 * 60);
+  }
+
+  @AfterMethod
+  public void afterMethod() {
+    testDAOProvider.cleanup();
+  }
+
+  @Test
+  public void testCreateOneTask() {
+    List<Long> metrics = Arrays.asList(metricId1, metricId2);
+    long detectionId = createDetection(1, metrics, TEST_TIME - TimeUnit.DAYS.toMillis(1),0);
+    createDataset(1, TEST_TIME);
+    createDataset(2, TEST_TIME);
+    dataAvailabilityTaskScheduler.run();
+    TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
+    List<TaskDTO> tasks = taskManager.findAll();
+    Assert.assertEquals(tasks.size(), 1);
+    TaskDTO task = tasks.get(0);
+    Assert.assertEquals(task.getStatus(), TaskConstants.TaskStatus.WAITING);
+    Assert.assertEquals(task.getJobName(), TaskConstants.TaskType.DETECTION.toString() + "_" + detectionId);
+  }
+
+  @Test
+  public void testCreateMultipleTasks() {
+    List<Long> metrics1 = Arrays.asList(metricId1, metricId2);
+    long oneDayAgo = TEST_TIME - TimeUnit.DAYS.toMillis(1);
+    long detection1 = createDetection(1, metrics1, oneDayAgo, 0);
+    long detection2 = createDetection(2, metrics1, oneDayAgo, 0);
+    List<Long> singleMetric = Collections.singletonList(metricId2);
+    long detection3 = createDetection(3, singleMetric, oneDayAgo, 0);
+    createDataset(1, TEST_TIME);
+    createDataset(2, TEST_TIME);
+    dataAvailabilityTaskScheduler.run();
+    TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
+    List<TaskDTO> tasks = taskManager.findAll();
+    Assert.assertEquals(tasks.size(), 3);
+    Assert.assertEquals(tasks.get(0).getStatus(), TaskConstants.TaskStatus.WAITING);
+    Assert.assertEquals(tasks.get(1).getStatus(), TaskConstants.TaskStatus.WAITING);
+    Assert.assertEquals(tasks.get(2).getStatus(), TaskConstants.TaskStatus.WAITING);
+    Assert.assertEquals(
+        Stream.of(detection1, detection2, detection3)
+            .map(x -> TaskConstants.TaskType.DETECTION.toString() + "_" + x)
+            .collect(Collectors.toSet()),
+        new HashSet<>(Arrays.asList(tasks.get(0).getJobName(), tasks.get(1).getJobName(), tasks.get(2).getJobName())));
+  }
+
+  @Test
+  public void testNoReadyDetection() {
+    List<Long> metrics1 = Arrays.asList(metricId1, metricId2);
+    long detection1 = createDetection(1, metrics1, TEST_TIME, 0);
+    long detection2 = createDetection(2, Collections.singletonList(metricId2), TEST_TIME, 0);
+    createDataset(1, TEST_TIME + TimeUnit.HOURS.toMillis(1)); // updated dataset
+    createDataset(2, TEST_TIME - TimeUnit.HOURS.toMillis(1)); // not updated dataset
+    createDetectionTask(detection1, TEST_TIME - 60_000, TaskConstants.TaskStatus.COMPLETED);
+    createDetectionTask(detection2, TEST_TIME - 60_000, TaskConstants.TaskStatus.COMPLETED);
+    DetectionConfigManager detectionConfigManager = DAORegistry.getInstance().getDetectionConfigManager();
+    List<DetectionConfigDTO> detectionConfigs = detectionConfigManager.findAll();
+    Assert.assertEquals(detectionConfigs.size(), 2);
+    dataAvailabilityTaskScheduler.run();
+    TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
+    List<TaskDTO> tasks = taskManager.findAll();
+    Assert.assertEquals(tasks.size(), 2);
+  }
+
+  @Test
+  public void testDetectionExceedNotRunThreshold() {
+    List<Long> metrics1 = Arrays.asList(metricId1, metricId2);
+    long oneDayAgo = TEST_TIME - TimeUnit.DAYS.toMillis(1);
+    long detection1 = createDetection(1, metrics1, oneDayAgo, 0);
+    long detection2 = createDetection(2, Collections.singletonList(metricId2), oneDayAgo, 0);
+    long detection3 = createDetection(3, Collections.singletonList(metricId2), oneDayAgo, 2 * 24 * 60 * 60);
+    createDataset(1, oneDayAgo - 60_000); // not updated dataset
+    createDataset(2, oneDayAgo - 60_000); // not updated dataset
+    createDetectionTask(detection1, oneDayAgo - 60_000, TaskConstants.TaskStatus.COMPLETED);
+    createDetectionTask(detection2, oneDayAgo - 60_000, TaskConstants.TaskStatus.COMPLETED);
+    createDetectionTask(detection3, oneDayAgo - 60_000, TaskConstants.TaskStatus.COMPLETED);
+    dataAvailabilityTaskScheduler.run();
+    TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
+    List<TaskDTO> tasks = taskManager.findAll();
+    Assert.assertEquals(tasks.size(), 5);
+    Assert.assertEquals(tasks.stream().filter(t -> t.getStatus() == TaskConstants.TaskStatus.COMPLETED).count(), 3);
+    Assert.assertEquals(tasks.stream().filter(t -> t.getStatus() == TaskConstants.TaskStatus.WAITING).count(), 2);
+  }
+
+  @Test
+  public void testScheduleWithUnfinishedTask() {
+    List<Long> metrics1 = Arrays.asList(metricId1, metricId2);
+    long oneDayAgo = TEST_TIME - TimeUnit.DAYS.toMillis(1);
+    long detection1 = createDetection(1, metrics1, oneDayAgo, 0);
+    long detection2 = createDetection(2, metrics1, oneDayAgo, 0);
+    List<Long> singleMetric = Collections.singletonList(metricId2);
+    long detection3 = createDetection(3, singleMetric, oneDayAgo, 0);
+    createDataset(1, TEST_TIME);
+    createDataset(2, TEST_TIME);
+    createDetectionTask(detection1, oneDayAgo, TaskConstants.TaskStatus.RUNNING);
+    dataAvailabilityTaskScheduler.run();
+    TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
+    List<TaskDTO> tasks = taskManager.findAll();
+    Assert.assertEquals(tasks.size(), 3);
+    List<TaskDTO> waitingTasks = tasks.stream().filter(t -> t.getStatus() == TaskConstants.TaskStatus.WAITING).collect(
+        Collectors.toList());
+    Assert.assertEquals(tasks.stream().filter(t -> t.getStatus() == TaskConstants.TaskStatus.RUNNING).count(), 1);
+    Assert.assertEquals(waitingTasks.size(), 2);
+    Assert.assertEquals(
+        Stream.of(detection2, detection3)
+            .map(x -> TaskConstants.TaskType.DETECTION.toString() + "_" + x)
+            .collect(Collectors.toSet()),
+        new HashSet<>(Arrays.asList(tasks.get(1).getJobName(), tasks.get(2).getJobName())));
+  }
+
+  private long createDataset(int intSuffix, long refreshTime) {
+    DatasetConfigManager datasetConfigDAO = DAORegistry.getInstance().getDatasetConfigDAO();
+    DatasetConfigDTO ds1 = new DatasetConfigDTO();
+    ds1.setDataset(TEST_DATASET_PREFIX + intSuffix);
+    ds1.setLastRefreshTime(refreshTime);
+    return datasetConfigDAO.save(ds1);
+  }
+
+  private long createDetection(int intSuffix, List<Long> metrics, long lastTimestamp, int notRunThreshold) {
+    DetectionConfigManager detectionConfigManager = DAORegistry.getInstance().getDetectionConfigManager();
+    final String TEST_DETECTION_PREFIX = "detection_trigger_listener_";
+    DetectionConfigDTO detect = new DetectionConfigDTO();
+    detect.setName(TEST_DETECTION_PREFIX + intSuffix);
+    detect.setActive(true);
+    Map<String, Object> props = new HashMap<>();
+    List<String> metricUrns = metrics.stream().map(x -> "thirdeye:metric:" + x).collect(Collectors.toList());
+    props.put("nestedMetricUrns", metricUrns);
+    detect.setProperties(props);
+    detect.setLastTimestamp(lastTimestamp);
+    detect.setDataAvailabilitySchedule(true);
+    detect.setTaskTriggerFallBackTimeInSec(notRunThreshold);
+    return detectionConfigManager.save(detect);
+  }
+
+  private long createDetectionTask(long detectionId, long createTime, TaskConstants.TaskStatus status) {
+    TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
+    TaskDTO task = new TaskDTO();
+    DetectionPipelineTaskInfo taskInfo = new DetectionPipelineTaskInfo(detectionId, createTime - 1, createTime);
+    String taskInfoJson = null;
+    try {
+      taskInfoJson = OBJECT_MAPPER.writeValueAsString(taskInfo);
+    } catch (JsonProcessingException e) {
+      LOG.error("Exception when converting DetectionPipelineTaskInfo {} to jsonString", taskInfo, e);
+    }
+    task.setTaskType(TaskConstants.TaskType.DETECTION);
+    task.setJobName(TaskConstants.TaskType.DETECTION.toString() + "_" + detectionId);
+    task.setStatus(status);
+    task.setTaskInfo(taskInfoJson);
+    return taskManager.save(task);
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DatasetTriggerInfoRepoTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DatasetTriggerInfoRepoTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.pinot.thirdeye.anomaly.detection.trigger;
 
 import java.util.ArrayList;
@@ -18,7 +34,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
 
 public class DatasetTriggerInfoRepoTest {
   private static String TEST_DATA_SOURCE = "TestSource";

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
@@ -82,14 +82,13 @@ public class TestAnomalyTaskManager {
 
   @Test(dependsOnMethods = { "testFindAll" })
   public void testUpdateStatusAndWorkerId() {
-    TaskStatus newStatus = TaskStatus.RUNNING;
     Long workerId = 1L;
     TaskDTO taskDTO = taskDAO.findById(anomalyTaskId1);
     boolean status =
-        taskDAO.updateStatusAndWorkerId(workerId, anomalyTaskId1, allowedOldTaskStatus, newStatus, taskDTO.getVersion());
+        taskDAO.updateStatusAndWorkerId(workerId, anomalyTaskId1, allowedOldTaskStatus, taskDTO.getVersion());
     TaskDTO anomalyTask = taskDAO.findById(anomalyTaskId1);
     Assert.assertTrue(status);
-    Assert.assertEquals(anomalyTask.getStatus(), newStatus);
+    Assert.assertEquals(anomalyTask.getStatus(), TaskStatus.RUNNING);
     Assert.assertEquals(anomalyTask.getWorkerId(), workerId);
     Assert.assertEquals(anomalyTask.getVersion(), taskDTO.getVersion() + 1);
 


### PR DESCRIPTION
This PR is second one for event driven scheduling (data availability scheduling). It mainly includes the scheduler that runs in certain frequency to schedule tasks based on the event information updated by the event listener (in the first PR). 