### PR TITLE
Decoupling Server instance name from physical host and port

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -49,6 +49,9 @@ import org.apache.pinot.broker.requesthandler.ConnectionPoolBrokerRequestHandler
 import org.apache.pinot.broker.routing.HelixExternalViewBasedRouting;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.config.TagNameUtils;
+import org.apache.pinot.common.helix.ClusterChangeHandler;
+import org.apache.pinot.common.helix.ClusterChangeMediator;
+import org.apache.pinot.common.helix.HelixInstanceConfigCache;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -167,6 +170,11 @@ public class HelixBrokerStarter {
     _propertyStore = _spectatorHelixManager.getHelixPropertyStore();
     _helixDataAccessor = _spectatorHelixManager.getHelixDataAccessor();
 
+    // Set up Instance Config Cache
+    LOGGER.info("Setting up broker instance config cache");
+    HelixInstanceConfigCache instanceConfigCache = HelixInstanceConfigCache.getInstance();
+    instanceConfigCache.init(_spectatorHelixManager);
+
     // Set up the broker server builder
     LOGGER.info("Setting up broker server builder");
     _helixExternalViewBasedRouting =
@@ -198,6 +206,7 @@ public class HelixBrokerStarter {
       instanceConfigChangeHandler.init(_spectatorHelixManager);
     }
     _instanceConfigChangeHandlers.add(_helixExternalViewBasedRouting);
+    _instanceConfigChangeHandlers.add(instanceConfigCache);
     for (ClusterChangeHandler liveInstanceChangeHandler : _liveInstanceChangeHandlers) {
       liveInstanceChangeHandler.init(_spectatorHelixManager);
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/LiveInstanceChangeHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/LiveInstanceChangeHandler.java
@@ -27,6 +27,8 @@ import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.model.LiveInstance;
+import org.apache.pinot.common.helix.ClusterChangeHandler;
+import org.apache.pinot.common.helix.HelixInstanceConfigCache;
 import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.transport.netty.PooledNettyClientResourceManager;
@@ -82,16 +84,9 @@ public class LiveInstanceChangeHandler implements ClusterChangeHandler {
         continue;
       }
 
-      String namePortStr = instanceId.split(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)[1];
-      String hostName = namePortStr.split("_")[0];
-      int port;
-      try {
-        port = Integer.parseInt(namePortStr.split("_")[1]);
-      } catch (Exception e) {
-        port = CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
-        LOGGER
-            .warn("Port for server instance {} does not appear to be numeric, defaulting to {}.", instanceId, port, e);
-      }
+      HelixInstanceConfigCache instanceCache = HelixInstanceConfigCache.getInstance();
+      String hostName = instanceCache.getHostname(instanceId);
+      int port = instanceCache.getPort(instanceId);
 
       if (_liveInstanceToSessionIdMap.containsKey(instanceId)) {
         // sessionId has changed

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
@@ -30,7 +30,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.apache.pinot.broker.broker.helix.ClusterChangeHandler;
+import org.apache.pinot.common.helix.ClusterChangeHandler;
 import org.apache.pinot.common.config.QuotaConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
@@ -41,7 +41,7 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.apache.pinot.broker.broker.helix.ClusterChangeHandler;
+import org.apache.pinot.common.helix.ClusterChangeHandler;
 import org.apache.pinot.broker.routing.builder.RoutingTableBuilder;
 import org.apache.pinot.broker.routing.selector.SegmentSelector;
 import org.apache.pinot.broker.routing.selector.SegmentSelectorProvider;

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/ClusterChangeHandler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/ClusterChangeHandler.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.broker.helix;
+package org.apache.pinot.common.helix;
 
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixManager;

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/ClusterChangeMediator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/ClusterChangeMediator.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.broker.helix;
+package org.apache.pinot.common.helix;
 
 import java.util.HashMap;
 import java.util.List;

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/HelixInstanceConfigCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/HelixInstanceConfigCache.java
@@ -65,7 +65,9 @@ public class HelixInstanceConfigCache implements ClusterChangeHandler {
 
   @Override
   public void init(HelixManager helixManager) {
-    Preconditions.checkState(_helixManager == null, "HelixInstanceConfigCache is already initialized");
+    if (_initialized) {
+      return;
+    }
     _helixManager = helixManager;
     _instanceNameToConfigMap = new HashMap<>();
     _initialized = true;
@@ -85,7 +87,9 @@ public class HelixInstanceConfigCache implements ClusterChangeHandler {
 
   public String getHostname(String instanceName) {
     Preconditions.checkNotNull(_instanceNameToConfigMap.get(instanceName));
-    return _instanceNameToConfigMap.get(instanceName).getHostName();
+    String helixHostName = _instanceNameToConfigMap.get(instanceName).getHostName();
+    String hostName = helixHostName.split(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)[1];
+    return hostName;
   }
 
   public int getPort(String instanceName) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/HelixInstanceConfigCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/HelixInstanceConfigCache.java
@@ -1,0 +1,86 @@
+package org.apache.pinot.common.helix;
+
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.HelixConstants;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.helix.ClusterChangeHandler;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Helper class to maintain a cache of all the {@code INSTANCE_CONFIG} managed by
+ * the Pinot Helix cluster. It provides a singleton object to lookup the host
+ * and port information based on the specified instance name.
+ *
+ * This will be helpful in decoupling instance name from the physical host and port
+ * information (https://github.com/apache/incubator-pinot/issues/4525)
+ */
+public class HelixInstanceConfigCache implements ClusterChangeHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HelixInstanceConfigCache.class);
+  private HelixManager _helixManager;
+  private Map<String, InstanceConfig> _instanceNameToConfigMap;
+  private static HelixInstanceConfigCache _instance;
+  private volatile boolean _initialized;
+
+  private HelixInstanceConfigCache() {
+    _initialized = false;
+  }
+
+  public static synchronized HelixInstanceConfigCache getInstance() {
+    if (_instance == null) {
+      _instance = new HelixInstanceConfigCache();
+    }
+    return _instance;
+  }
+
+  public boolean isInitialized() {
+    return _initialized;
+  }
+
+  @Override
+  public void init(HelixManager helixManager) {
+    Preconditions.checkState(_helixManager == null, "HelixInstanceConfigCache is already initialized");
+    _helixManager = helixManager;
+    _instanceNameToConfigMap = new HashMap<>();
+    _initialized = true;
+  }
+
+  @Override
+  public void processClusterChange(HelixConstants.ChangeType changeType) {
+    Preconditions
+        .checkState(changeType == HelixConstants.ChangeType.INSTANCE_CONFIG, "Illegal change type: " + changeType);
+    HelixDataAccessor helixDataAccessor = _helixManager.getHelixDataAccessor();
+    PropertyKey.Builder propertyKeyBuilder = helixDataAccessor.keyBuilder();
+    List<InstanceConfig> instanceConfigs = helixDataAccessor.getChildValues(propertyKeyBuilder.instanceConfigs());
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      _instanceNameToConfigMap.put(instanceConfig.getInstanceName(), instanceConfig);
+    }
+  }
+
+  public String getHostname(String instanceName) {
+    Preconditions.checkNotNull(_instanceNameToConfigMap.get(instanceName));
+    return _instanceNameToConfigMap.get(instanceName).getHostName();
+  }
+
+  public int getPort(String instanceName) {
+    Preconditions.checkNotNull(_instanceNameToConfigMap.get(instanceName));
+    int port;
+
+    try {
+      port = Integer.parseInt(_instanceNameToConfigMap.get(instanceName).getPort());
+    } catch (Exception e) {
+      port = CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
+      LOGGER
+          .warn("Port for server instance {} does not appear to be numeric, defaulting to {}.", instanceName, port, e);
+    }
+    return port;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/HelixInstanceConfigCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/HelixInstanceConfigCache.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.common.helix;
 
 import com.google.common.base.Preconditions;

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/ServerInstance.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/ServerInstance.java
@@ -57,6 +57,8 @@ public class ServerInstance {
 
   /**
    * Use this constructor if the name and port are embedded as string with ":" as delimiter
+   *
+   * Note: This constructor is used primarily for testing.
    */
   public ServerInstance(String namePortPair) {
     this(namePortPair.split(NAME_PORT_DELIMITER)[0], Integer.parseInt(namePortPair.split(NAME_PORT_DELIMITER)[1]));
@@ -88,6 +90,7 @@ public class ServerInstance {
   /**
    * Server instance name is formatted as {@code Server_<host>_<port>}
    */
+  @Deprecated
   public static ServerInstance forInstanceName(String instanceName) {
     String[] parts = instanceName.split(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)[1]
         .split(NAME_PORT_DELIMITER_FOR_INSTANCE_NAME);

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/ServerInstance.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/ServerInstance.java
@@ -89,6 +89,9 @@ public class ServerInstance {
 
   /**
    * Server instance name is formatted as {@code Server_<host>_<port>}
+   *
+   * Note: This static method is deprecated. Use the constructor instead to create a
+   * {@link ServerInstance} object using host and port explicitly.
    */
   @Deprecated
   public static ServerInstance forInstanceName(String instanceName) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/Server.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/Server.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.transport;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.InternetDomainName;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -45,11 +46,25 @@ public class Server {
 
   /**
    * NOTE: server instance name is of format: {@code Server_<hostName>_<port>}, e.g. {@code Server_localhost_12345}.
+   *
+   * This constructor is primarily used in unit tests.
    */
-  public Server(String instanceName, TableType tableType) {
+  @VisibleForTesting
+  Server(String instanceName, TableType tableType) {
     String[] hostNameAndPort = instanceName.split(PREFIX_OF_SERVER_INSTANCE)[1].split(NAME_PORT_DELIMITER);
     _hostName = hostNameAndPort[0];
     _port = Integer.parseInt(hostNameAndPort[1]);
+    _tableType = tableType;
+  }
+
+  /**
+   * Create a Server instance using explicit hostname and port. This is useful when the
+   * instance name can be independent of the physical address. More details can be found
+   * in this issue: https://github.com/apache/incubator-pinot/issues/4525
+   */
+  public Server(String hostname, int port, TableType tableType) {
+    _hostName = hostname;
+    _port = port;
     _tableType = tableType;
   }
 

--- a/pinot-transport/src/test/java/org/apache/pinot/transport/scattergather/ScatterGatherTest.java
+++ b/pinot-transport/src/test/java/org/apache/pinot/transport/scattergather/ScatterGatherTest.java
@@ -76,7 +76,7 @@ public class ScatterGatherTest {
       String serverName = CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE + LOCAL_HOST
           + ServerInstance.NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + serverPort;
       serverNames[i] = serverName;
-      serverInstances[i] = ServerInstance.forInstanceName(serverName);
+      serverInstances[i] = new ServerInstance(LOCAL_HOST, serverPort);
       routingTable.put(serverName, Collections.singletonList("segment_" + i));
     }
 
@@ -138,7 +138,7 @@ public class ScatterGatherTest {
       String serverName = CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE + LOCAL_HOST
           + ServerInstance.NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + serverPort;
       serverNames[i] = serverName;
-      serverInstances[i] = ServerInstance.forInstanceName(serverName);
+      serverInstances[i] = new ServerInstance(LOCAL_HOST, serverPort);
       routingTable.put(serverName, Collections.singletonList("segment_" + i));
     }
 
@@ -202,7 +202,7 @@ public class ScatterGatherTest {
       String serverName = CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE + LOCAL_HOST
           + ServerInstance.NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + serverPort;
       serverNames[i] = serverName;
-      serverInstances[i] = ServerInstance.forInstanceName(serverName);
+      serverInstances[i] = new ServerInstance(LOCAL_HOST, serverPort);
       routingTable.put(serverName, Collections.singletonList("segment_" + i));
     }
 


### PR DESCRIPTION
This PR modifies the way host and port information is discovered for a given Server. The original implementation assumes that instance name contains the host and port information. This is not ideal for cloud deployments. This PR instead uses the instance name to look up the host and port using a cache (populated using Helix). 

This will resolve the first problem referenced in this issue: https://github.com/apache/incubator-pinot/issues/4525