### PR TITLE
Prepare License and Notice files for 0.2.0 release

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -205,6 +205,7 @@ This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
 com.101tec:zkclient:0.7
+com.amazonaws:aws-java-sdk:1.7.4
 com.clearspring.analytics:stream:2.7.0
 com.fasterxml.jackson.core:jackson-annotations:2.9.8
 com.fasterxml.jackson.core:jackson-core:2.9.8
@@ -218,6 +219,7 @@ com.google.code.gson:gson:2.2.4
 com.google.guava:guava:20.0
 com.google.inject.extensions:guice-servlet:3.0
 com.google.inject:guice:3.0
+com.jamesmurty.utils:java-xmlbuilder:0.4
 com.lmax:disruptor:3.3.4
 commons-beanutils:commons-beanutils:1.8.3
 commons-beanutils:commons-beanutils-core:1.8.0
@@ -248,9 +250,12 @@ io.vavr:vavr:0.9.2
 io.vavr:vavr-match:0.9.2
 it.unimi.dsi:fastutil:8.2.3
 javax.inject:javax.inject:1
+javax.servlet.jsp:jsp-api:2.1
+javax.servlet:servlet-api:2.5
 javax.validation:validation-api:2.0.1.Final
 joda-time:joda-time:2.0
 me.lemire.integercompression:JavaFastPFOR:0.0.13
+net.java.dev.jets3t:jets3t:0.9.0
 net.jpountz.lz4:lz4:1.2.0
 org.apache.avro:avro:1.7.6
 org.apache.avro:avro-ipc:1.7.4
@@ -266,12 +271,14 @@ org.apache.commons:commons-math3:3.2
 org.apache.commons:commons-math3:3.2
 org.apache.curator:curator-client:2.7.1
 org.apache.curator:curator-framework:2.7.1
+org.apache.curator:curator-recipes:2.7.1
 org.apache.directory.api:api-asn1-api:1.0.0-M20
 org.apache.directory.api:api-util:1.0.0-M20
 org.apache.directory.server:apacheds-i18n:2.0.0-M15
 org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M15
 org.apache.hadoop:hadoop-annotations:2.2.0
 org.apache.hadoop:hadoop-auth:2.7.0
+org.apache.hadoop:hadoop-aws:2.7.0
 org.apache.hadoop:hadoop-common:2.7.0
 org.apache.hadoop:hadoop-hdfs:2.2.0
 org.apache.hadoop:hadoop-mapreduce-client-core:2.2.0
@@ -290,6 +297,13 @@ org.apache.logging.log4j:log4j-slf4j-impl:2.11.2
 org.apache.orc:orc-core:1.5.2
 org.apache.orc:orc-mapreduce:1.5.2
 org.apache.orc:orc-shims:1.5.2
+org.apache.parquet:parquet-avro:1.8.0
+org.apache.parquet:parquet-column:1.8.0
+org.apache.parquet:parquet-common:1.8.0
+org.apache.parquet:parquet-encoding:1.8.0
+org.apache.parquet:parquet-format:2.3.0-incubating
+org.apache.parquet:parquet-hadoop:1.8.0
+org.apache.parquet:parquet-jackson:1.8.0
 org.apache.thrift:libthrift:0.12.0
 org.apache.velocity:velocity:1.7
 org.apache.yetus:audience-annotations:0.5.0

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -4,17 +4,13 @@ Copyright 2018 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
-
 // ------------------------------------------------------------------
 // NOTICE file corresponding to the section 4d of The Apache License,
 // Version 2.0, in this case for 
 // ------------------------------------------------------------------
 
-The HermiteInterpolator class and its corresponding test have been imported from
-the orekit library distributed under the terms of the Apache 2 licence. Original
-source copyright:
-Copyright 2010-2012 CS Systèmes d'Information
-===============================================================================
+htrace-core
+Copyright 2015 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -363,30 +359,6 @@ Copyright 2013-2018 The Apache Software Foundation
 ORC Shims
 Copyright 2013-2018 The Apache Software Foundation
 
-Apache Commons Net
-Copyright 2001-2012 The Apache Software Foundation
-
-ApacheDS Protocol Kerberos Codec
-Copyright 2003-2013 The Apache Software Foundation
-
-ApacheDS I18n
-Copyright 2003-2013 The Apache Software Foundation
-
-Apache Directory API ASN.1 API
-Copyright 2003-2013 The Apache Software Foundation
-
-Apache Directory LDAP API Utilities
-Copyright 2003-2013 The Apache Software Foundation
-
-Curator Framework
-Copyright 2011-2015 The Apache Software Foundation
-
-Curator Client
-Copyright 2011-2015 The Apache Software Foundation
-
-htrace-core
-Copyright 2015 The Apache Software Foundation
-
 Hive Storage API
 Copyright 2018 The Apache Software Foundation
 
@@ -401,6 +373,27 @@ Copyright 2006-2011 Google, Inc.
 
 Google Guice - Core Library
 Copyright 2006-2011 Google, Inc.
+
+Apache Parquet Avro
+Copyright 2015 The Apache Software Foundation
+
+Apache Parquet Column
+Copyright 2015 The Apache Software Foundation
+
+Apache Parquet Common
+Copyright 2015 The Apache Software Foundation
+
+Apache Parquet Encodings
+Copyright 2015 The Apache Software Foundation
+
+Apache Parquet Hadoop
+Copyright 2015 The Apache Software Foundation
+
+Apache Parquet Jackson
+Copyright 2015 The Apache Software Foundation
+
+Apache Parquet Format (Incubating)
+Copyright 2015 The Apache Software Foundation
 
 Apache Commons Math
 Copyright 2001-2013 The Apache Software Foundation
@@ -463,7 +456,37 @@ terms of the Apache 2 licence. Original source copyright:
 Copyright 2010 CS Systèmes d'Information
 ===============================================================================
 
+The HermiteInterpolator class and its corresponding test have been imported from
+the orekit library distributed under the terms of the Apache 2 licence. Original
+source copyright:
+Copyright 2010-2012 CS Systèmes d'Information
+===============================================================================
+
 The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
 by an original code donated by Sébastien Brisard.
 ===============================================================================
+
+Apache Commons Net
+Copyright 2001-2012 The Apache Software Foundation
+
+ApacheDS Protocol Kerberos Codec
+Copyright 2003-2013 The Apache Software Foundation
+
+ApacheDS I18n
+Copyright 2003-2013 The Apache Software Foundation
+
+Apache Directory API ASN.1 API
+Copyright 2003-2013 The Apache Software Foundation
+
+Apache Directory LDAP API Utilities
+Copyright 2003-2013 The Apache Software Foundation
+
+Curator Framework
+Copyright 2011-2015 The Apache Software Foundation
+
+Curator Client
+Copyright 2011-2015 The Apache Software Foundation
+
+Curator Recipes
+Copyright 2011-2015 The Apache Software Foundation
 


### PR DESCRIPTION
These files have been generated according to instructions in
https://cwiki.apache.org/confluence/display/PINOT/Creating+an+Apache+Release
while setting the sources to be as follows:

  checkout commit hash f8c2cf3d87a2849c029e861c5470311e0c217011
  Apply patch c77dad1e9683e80ea5dc20703cace70ee024b547 from branch selection_comparator_hotfix