### PR TITLE
Support ORDER BY for DISTINCT queries

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -30,8 +30,8 @@ public class QueryValidationTest {
   public void testUnsupportedDistinctQueries() {
     Pql2Compiler compiler = new Pql2Compiler();
 
-    String pql = "SELECT DISTINCT(col1, col2) FROM foo ORDER BY col1, col2";
-    testUnsupportedQueriesHelper(compiler, pql, "DISTINCT with ORDER BY is currently not supported");
+    String pql = "SELECT DISTINCT(col1, col2) FROM foo ORDER BY col3";
+    testUnsupportedQueriesHelper(compiler, pql, "ORDER By should be only on some/all of the columns passed as arguments to DISTINCT");
 
     pql = "SELECT DISTINCT(col1, col2) FROM foo GROUP BY col1";
     testUnsupportedQueriesHelper(compiler, pql, "DISTINCT with GROUP BY is currently not supported");
@@ -53,8 +53,9 @@ public class QueryValidationTest {
     try {
       BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
       BaseBrokerRequestHandler.validateRequest(brokerRequest, 1000);
+      Assert.fail("query should have failed");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains(errorMessage));
+      Assert.assertTrue(e.getMessage().equals(errorMessage));
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -126,14 +126,6 @@ public class CalciteSqlParser {
     switch (sqlNode.getKind()) {
       case ORDER_BY:
         selectOrderBySqlNode = (SqlOrderBy) sqlNode;
-        SqlNode sqlSelectNode = selectOrderBySqlNode.query;
-        if (sqlSelectNode instanceof SqlSelect) {
-          SqlSelect sqlSelect = (SqlSelect) sqlSelectNode;
-          if (sqlSelect.getModifierNode(SqlSelectKeyword.DISTINCT) != null) {
-            // TODO: add support for ORDER BY with DISTINCT
-            throw new SqlCompilationException("DISTINCT with ORDER BY is not supported");
-          }
-        }
         if (selectOrderBySqlNode.orderList != null) {
           pinotQuery.setOrderByList(convertOrderByList(selectOrderBySqlNode.orderList));
         }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -602,16 +602,6 @@ public class CalciteSqlCompilerTest {
           "Syntax error: Pinot currently does not support DISTINCT with *. Please specify each column name after DISTINCT keyword"));
     }
 
-    // Pinot currently does not support ORDER BY with DISTINCT
-    try {
-      sql = "SELECT DISTINCT C1, C2 FROM foo ORDER BY C1, C2";
-      CalciteSqlParser.compileToPinotQuery(sql);
-      Assert.fail("Query should have failed compilation");
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof SqlCompilationException);
-      Assert.assertTrue(e.getMessage().contains("DISTINCT with ORDER BY is not supported"));
-    }
-
     // Pinot currently does not support GROUP BY with DISTINCT
     try {
       sql = "SELECT DISTINCT C1, C2 FROM foo GROUP BY C1";

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
@@ -42,4 +42,15 @@ public class Record {
   public String toString() {
     return Arrays.deepToString(_values);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    Record that = (Record) o;
+    return Arrays.deepEquals(_values, that._values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.deepHashCode(_values);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.data.table;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.function.Function;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.SelectionSort;
@@ -39,11 +41,12 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils
 /**
  * Helper class for trimming and sorting records in the IndexedTable, based on the order by information
  */
-class TableResizer {
+public class TableResizer {
 
   private OrderByValueExtractor[] _orderByValueExtractors;
   private Comparator<IntermediateRecord> _intermediateRecordComparator;
-  private int _numOrderBy;
+  private Comparator<Record> _recordComparator;
+  protected int _numOrderBy;
 
   TableResizer(DataSchema dataSchema, List<AggregationInfo> aggregationInfos, List<SelectionSort> orderBy) {
 
@@ -69,40 +72,57 @@ class TableResizer {
     _orderByValueExtractors = new OrderByValueExtractor[_numOrderBy];
     Comparator[] comparators = new Comparator[_numOrderBy];
 
-    for (int orderByIdx = 0; orderByIdx < _numOrderBy; orderByIdx++) {
-      SelectionSort selectionSort = orderBy.get(orderByIdx);
-      String column = selectionSort.getColumn();
+    if (numKeyColumns < numColumns) {
+      for (int orderByIdx = 0; orderByIdx < _numOrderBy; orderByIdx++) {
+        SelectionSort selectionSort = orderBy.get(orderByIdx);
+        String column = selectionSort.getColumn();
 
-      if (columnIndexMap.containsKey(column)) {
-        int index = columnIndexMap.get(column);
-        if (index < numKeyColumns) {
-          _orderByValueExtractors[orderByIdx] = new KeyColumnExtractor(index);
+        if (columnIndexMap.containsKey(column)) {
+          int index = columnIndexMap.get(column);
+          if (index < numKeyColumns) {
+            _orderByValueExtractors[orderByIdx] = new KeyColumnExtractor(index);
+          } else {
+            AggregationInfo aggregationInfo = aggregationColumnToInfo.get(column);
+            AggregationFunction aggregationFunction =
+                AggregationFunctionUtils.getAggregationFunctionContext(aggregationInfo).getAggregationFunction();
+            _orderByValueExtractors[orderByIdx] = new AggregationColumnExtractor(index, aggregationFunction);
+          }
         } else {
-          AggregationInfo aggregationInfo = aggregationColumnToInfo.get(column);
-          AggregationFunction aggregationFunction =
-              AggregationFunctionUtils.getAggregationFunctionContext(aggregationInfo).getAggregationFunction();
-          _orderByValueExtractors[orderByIdx] = new AggregationColumnExtractor(index, aggregationFunction);
+          throw new IllegalStateException("Could not find column " + column + " in data schema");
         }
-      } else {
-        throw new IllegalStateException("Could not find column " + column + " in data schema");
+
+        comparators[orderByIdx] = Comparator.naturalOrder();
+        if (!selectionSort.isIsAsc()) {
+          comparators[orderByIdx] = comparators[orderByIdx].reversed();
+        }
       }
 
-      comparators[orderByIdx] = Comparator.naturalOrder();
-      if (!selectionSort.isIsAsc()) {
-        comparators[orderByIdx] = comparators[orderByIdx].reversed();
-      }
-    }
+      _intermediateRecordComparator = (o1, o2) -> {
 
-    _intermediateRecordComparator = (o1, o2) -> {
-
+        for (int i = 0; i < _numOrderBy; i++) {
+          int result = comparators[i].compare(o1._values[i], o2._values[i]);
+          if (result != 0) {
+            return result;
+          }
+        }
+        return 0;
+      };
+    } else {
+      // For cases where the entire Record is unique and is treated as a key
+      Preconditions.checkState(numKeyColumns == numColumns, "number of key columns should be equal to total number of columns");
+      int[] orderByIndexes = new int[_numOrderBy];
+      boolean[] orderByAsc = new boolean[_numOrderBy];
       for (int i = 0; i < _numOrderBy; i++) {
-        int result = comparators[i].compare(o1._values[i], o2._values[i]);
-        if (result != 0) {
-          return result;
+        SelectionSort selectionSort = orderBy.get(i);
+        String column = selectionSort.getColumn();
+        int orderByColIndex = columnIndexMap.get(column);
+        orderByIndexes[i] = orderByColIndex;
+        if (selectionSort.isIsAsc()) {
+          orderByAsc[i] = true;
         }
       }
-      return 0;
-    };
+      _recordComparator = new RecordComparator(orderByIndexes, orderByAsc);
+    }
   }
 
   /**
@@ -298,6 +318,120 @@ class TableResizer {
     Comparable extract(Record record) {
       Object aggregationColumn = record.getValues()[_index];
       return _convertorFunction.apply(aggregationColumn);
+    }
+  }
+
+
+  /********************************************************
+   *                                                      *
+   * Resize functions for Set based table implementation  *
+   *                                                      *
+   ********************************************************/
+
+  private class RecordComparator implements Comparator<Record> {
+    final int[] _orderByColumnIndexes;
+    final boolean[] _orderByAsc;
+
+    RecordComparator(int[] orderByColumnIndexes, boolean[] orderByAsc) {
+      _orderByColumnIndexes = orderByColumnIndexes;
+      _orderByAsc = orderByAsc;
+    }
+
+    @Override
+    public int compare(Record record1, Record record2) {
+      Object[] values1 = record1.getValues();
+      Object[] values2 = record2.getValues();
+      for (int i = 0; i < _numOrderBy; i++) {
+        Comparable valueToCompare1 = (Comparable)values1[_orderByColumnIndexes[i]];
+        Comparable valueToCompare2 = (Comparable)values2[_orderByColumnIndexes[i]];
+        int result = _orderByAsc[i] ? valueToCompare1.compareTo(valueToCompare2) : valueToCompare2.compareTo(valueToCompare1);
+        if (result != 0) {
+          return result;
+        }
+      }
+      return 0;
+    }
+  }
+
+  public void resizeRecordsSet(Set<Record> recordSet, int trimToSize) {
+    int numRecordsToEvict = recordSet.size() - trimToSize;
+    if (numRecordsToEvict > 0) {
+      if (numRecordsToEvict < trimToSize) {
+        // num records to evict is smaller than num records to retain
+        // make PQ of records to evict
+        PriorityQueue<Record> priorityQueue = buildPriorityQueueFromRecordSet(numRecordsToEvict, recordSet, _recordComparator);
+        for (Record recordToEvict : priorityQueue) {
+          recordSet.remove(recordToEvict);
+        }
+      } else {
+        // num records to retain is smaller than num records to evict
+        // make PQ of records to retain
+        PriorityQueue<Record> priorityQueue = buildPriorityQueueFromRecordSet(trimToSize, recordSet, _recordComparator.reversed());
+        ObjectOpenHashSet<Record> recordsToRetain = new ObjectOpenHashSet<>(priorityQueue.size());
+        for (Record recordToRetain : priorityQueue) {
+          recordsToRetain.add(recordToRetain);
+        }
+        recordSet.retainAll(recordsToRetain);
+      }
+    }
+  }
+
+  private PriorityQueue<Record> buildPriorityQueueFromRecordSet(
+      int size,
+      Set<Record> recordSet,
+      Comparator<Record> comparator) {
+    PriorityQueue<Record> priorityQueue = new PriorityQueue<>(size, comparator);
+    for (Record record : recordSet) {
+      if (priorityQueue.size() < size) {
+        priorityQueue.offer(record);
+      } else {
+        Record peek = priorityQueue.peek();
+        if (comparator.compare(peek, record) < 0) {
+          priorityQueue.poll();
+          priorityQueue.offer(record);
+        }
+      }
+    }
+    return priorityQueue;
+  }
+
+  private List<Record> sortRecordSet(Set<Record> recordSet) {
+    int numRecords = recordSet.size();
+    List<Record> sortedRecords = new ArrayList<>(numRecords);
+    sortedRecords.addAll(recordSet);
+    sortedRecords.sort(_recordComparator);
+    return sortedRecords;
+  }
+
+  public List<Record> resizeAndSortRecordSet(Set<Record> recordSet, int trimToSize) {
+    int numRecords = recordSet.size();
+    if (numRecords == 0) {
+      return Collections.emptyList();
+    }
+
+    int numRecordsToRetain = Math.min(numRecords, trimToSize);
+    int numRecordsToEvict = numRecords - numRecordsToRetain;
+
+    if (numRecordsToEvict < numRecordsToRetain) {
+      // num records to evict is smaller than num records to retain
+      if (numRecordsToEvict > 0) {
+        // make PQ of records to evict
+        PriorityQueue<Record> priorityQueue = buildPriorityQueueFromRecordSet(numRecordsToEvict, recordSet, _recordComparator);
+        for (Record recordToEvict : priorityQueue) {
+          recordSet.remove(recordToEvict);
+        }
+      }
+      return sortRecordSet(recordSet);
+    } else {
+      // make PQ of records to retain
+      PriorityQueue<Record> priorityQueue = buildPriorityQueueFromRecordSet(numRecordsToRetain, recordSet, _recordComparator.reversed());
+      // use PQ to get sorted list
+      Record[] sortedArray = new Record[numRecordsToRetain];
+      while (!priorityQueue.isEmpty()) {
+        Record record = priorityQueue.poll();
+        sortedArray[--numRecordsToRetain] = record;
+      }
+      return Arrays.asList(sortedArray);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DistinctTable.java
@@ -20,17 +20,22 @@ package org.apache.pinot.core.query.aggregation;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.common.datatable.DataTableFactory;
+import org.apache.pinot.core.data.table.BaseTable;
 import org.apache.pinot.core.data.table.Key;
-
+import org.apache.pinot.core.data.table.Record;
 
 /**
  * This serves the following purposes:
@@ -39,85 +44,54 @@ import org.apache.pinot.core.data.table.Key;
  * (2) The same object is serialized by the server inside the data table
  * for sending the results to broker. Broker deserializes it.
  */
-public class DistinctTable {
+public class DistinctTable extends BaseTable {
   private static final double LOAD_FACTOR = 0.75;
   private static final int MAX_INITIAL_CAPACITY = 64 * 1024;
-  private FieldSpec.DataType[] _columnTypes;
-  private String[] _columnNames;
-  private Set<Key> _table;
+  private Set<Record> _uniqueRecordsSet;
+  private boolean _noMoreNewRecords;
+  private Iterator<Record> _sortedIterator;
 
-  /**
-   * Add a row to hash table
-   * @param key multi-column key to add
-   */
-  public void addKey(final Key key) {
-    _table.add(key);
-  }
-
-  public DistinctTable(int limit) {
+  public DistinctTable(DataSchema dataSchema, List<SelectionSort> orderBy, int limit) {
     // TODO: see if 64k is the right max initial capacity to use
     // if it turns out that users always use LIMIT N > 0.75 * 64k and
     // there are indeed that many records, then there will be resizes.
     // The current method of setting the initial capacity as
     // min(64k, limit/loadFactor) will not require resizes for LIMIT N
     // where N <= 48000
+    super(dataSchema, Collections.emptyList(), orderBy, limit);
     int initialCapacity = Math.min(MAX_INITIAL_CAPACITY, Math.abs(nextPowerOfTwo((int) (limit / LOAD_FACTOR))));
-    _table = new HashSet<>(initialCapacity);
+    _uniqueRecordsSet = new HashSet<>(initialCapacity);
+    _noMoreNewRecords = false;
   }
 
-  /**
-   * DESERIALIZE: Broker side
-   * @param byteBuffer data to deserialize
-   * @throws IOException
-   */
-  public DistinctTable(ByteBuffer byteBuffer)
-      throws IOException {
-    DataTable dataTable = DataTableFactory.getDataTable(byteBuffer);
-    DataSchema dataSchema = dataTable.getDataSchema();
-    int numRows = dataTable.getNumberOfRows();
-    int numColumns = dataSchema.size();
+  @Override
+  public boolean upsert(Key key, Record record) {
+    throw new UnsupportedOperationException("Operation not supported");
+  }
 
-    _table = new HashSet<>();
-
-    // extract rows from the datatable
-    for (int rowIndex = 0; rowIndex < numRows; rowIndex++) {
-      Object[] columnValues = new Object[numColumns];
-      for (int colIndex = 0; colIndex < numColumns; colIndex++) {
-        DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(colIndex);
-        switch (columnDataType) {
-          case INT:
-            columnValues[colIndex] = dataTable.getInt(rowIndex, colIndex);
-            break;
-          case LONG:
-            columnValues[colIndex] = dataTable.getLong(rowIndex, colIndex);
-            break;
-          case FLOAT:
-            columnValues[colIndex] = dataTable.getFloat(rowIndex, colIndex);
-            break;
-          case DOUBLE:
-            columnValues[colIndex] = dataTable.getDouble(rowIndex, colIndex);
-            break;
-          case STRING:
-            columnValues[colIndex] = dataTable.getString(rowIndex, colIndex);
-            break;
-          case BYTES:
-            columnValues[colIndex] = dataTable.getString(rowIndex, colIndex);
-          default:
-            throw new IllegalStateException(
-                "Unexpected column data type " + columnDataType + " while deserializing data table for DISTINCT query");
-        }
-      }
-
-      _table.add(new Key(columnValues));
+  @Override
+  public boolean upsert(Record newRecord) {
+    if (_noMoreNewRecords) {
+      // for no ORDER BY queries, if we have reached the N as specified
+      // in LIMIT N (or default 10 if user didn't specify anything)
+      // then this function is NOOP
+      return false;
     }
 
-    _columnNames = dataSchema.getColumnNames();
+    _uniqueRecordsSet.add(newRecord);
 
-    // note: when deserializing at broker, we don't need to build
-    // FieldSpec.DataType since the work is already done.
-    // we have the column names and unique rows in set and that
-    // is all what we need to set the broker response. the deserialized
-    // column data types from schema are enough to work with each cell
+    if (_uniqueRecordsSet.size() >= _maxCapacity) {
+      if (_isOrderBy) {
+        // ORDER BY; capacity < maxCapacity so trim to capacity
+        resize(_capacity);
+      } else {
+        // No ORDER BY; capacity == maxCapacity == user specified limit
+        // we can simply stop accepting anymore records from now on
+        _noMoreNewRecords = true;
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -127,48 +101,21 @@ public class DistinctTable {
    */
   public byte[] toBytes()
       throws IOException {
-    final String[] columnNames = new String[_columnNames.length];
-    final DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[_columnNames.length];
-
-    // set actual column names and column data types in data schema
-    for (int i = 0; i < _columnNames.length; i++) {
-      columnNames[i] = _columnNames[i];
-      switch (_columnTypes[i]) {
-        case INT:
-          columnDataTypes[i] = DataSchema.ColumnDataType.INT;
-          break;
-        case LONG:
-          columnDataTypes[i] = DataSchema.ColumnDataType.LONG;
-          break;
-        case FLOAT:
-          columnDataTypes[i] = DataSchema.ColumnDataType.FLOAT;
-          break;
-        case DOUBLE:
-          columnDataTypes[i] = DataSchema.ColumnDataType.DOUBLE;
-          break;
-        case STRING:
-          columnDataTypes[i] = DataSchema.ColumnDataType.STRING;
-          break;
-        case BYTES:
-          columnDataTypes[i] = DataSchema.ColumnDataType.BYTES;
-        default:
-          throw new IllegalStateException(
-              "Unexpected column data type " + _columnTypes[i] + " while serializing data table for DISTINCT query");
-      }
-    }
-
     // build rows for data table
-    DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(columnNames, columnDataTypes));
-
-    final Iterator<Key> iterator = _table.iterator();
+    // Only after the server level merge is done by CombineOperator to merge all the indexed tables
+    // of segments 1 .. N - 1 into the indexed table of 0th segment, we do finish(false) as that
+    // time we need the iterator as well and we send a trimmed set of records to the broker.
+    // finish is NOOP for non ORDER BY queries.
+    finish(false);
+    DataTableBuilder dataTableBuilder = new DataTableBuilder(_dataSchema);
+    Iterator<Record> iterator = iterator();
     while (iterator.hasNext()) {
       dataTableBuilder.startRow();
-      final Key key = iterator.next();
-      serializeColumns(key.getColumns(), columnDataTypes, dataTableBuilder);
+      final Record record = iterator.next();
+      serializeColumns(record.getValues(), _dataSchema.getColumnDataTypes(), dataTableBuilder);
       dataTableBuilder.finishRow();
     }
-
-    final DataTable dataTable = dataTableBuilder.build();
+    DataTable dataTable = dataTableBuilder.build();
     return dataTable.toBytes();
   }
 
@@ -197,28 +144,71 @@ public class DistinctTable {
     }
   }
 
-  public int size() {
-    return _table.size();
+  /**
+   * DESERIALIZE: Broker side
+   * @param byteBuffer data to deserialize
+   * @throws IOException
+   */
+  public DistinctTable(ByteBuffer byteBuffer) throws IOException {
+    // This is called by the BrokerReduceService when it de-serializes the
+    // DISTINCT result from the DataTable. As of now we don't have all the
+    // information to pass to super class so just pass null, empty lists
+    // and the broker will set the correct information before merging the
+    // data tables.
+    super(new DataSchema(new String[0], new DataSchema.ColumnDataType[0]), Collections.emptyList(), new ArrayList<>(), 0);
+    DataTable dataTable = DataTableFactory.getDataTable(byteBuffer);
+    _dataSchema = dataTable.getDataSchema();
+    _uniqueRecordsSet = new HashSet<>();
+
+    int numRows = dataTable.getNumberOfRows();
+    int numColumns = _dataSchema.size();
+
+    // extract rows from the datatable
+    for (int rowIndex = 0; rowIndex < numRows; rowIndex++) {
+      Object[] columnValues = new Object[numColumns];
+      for (int colIndex = 0; colIndex < numColumns; colIndex++) {
+        DataSchema.ColumnDataType columnDataType = _dataSchema.getColumnDataType(colIndex);
+        switch (columnDataType) {
+          case INT:
+            columnValues[colIndex] = dataTable.getInt(rowIndex, colIndex);
+            break;
+          case LONG:
+            columnValues[colIndex] = dataTable.getLong(rowIndex, colIndex);
+            break;
+          case FLOAT:
+            columnValues[colIndex] = dataTable.getFloat(rowIndex, colIndex);
+            break;
+          case DOUBLE:
+            columnValues[colIndex] = dataTable.getDouble(rowIndex, colIndex);
+            break;
+          case STRING:
+            columnValues[colIndex] = dataTable.getString(rowIndex, colIndex);
+            break;
+          case BYTES:
+            columnValues[colIndex] = dataTable.getString(rowIndex, colIndex);
+          default:
+            throw new IllegalStateException(
+                "Unexpected column data type " + columnDataType + " while deserializing data table for DISTINCT query");
+        }
+      }
+
+      Record record = new Record(columnValues);
+      _uniqueRecordsSet.add(record);
+    }
   }
 
-  public Iterator<Key> getIterator() {
-    return _table.iterator();
-  }
-
-  public void setColumnNames(String[] columnNames) {
-    _columnNames = columnNames;
-  }
-
-  public void setColumnTypes(FieldSpec.DataType[] columnTypes) {
-    _columnTypes = columnTypes;
-  }
-
-  public String[] getColumnNames() {
-    return _columnNames;
-  }
-
-  public FieldSpec.DataType[] getColumnTypes() {
-    return _columnTypes;
+  /**
+   * Called by {@link org.apache.pinot.core.query.reduce.BrokerReduceService}
+   * just before it attempts to invoke merge() on
+   * {@link org.apache.pinot.core.query.aggregation.function.AggregationFunction}
+   * for DISTINCT. Since the DISTINCT uses IndexedTable underneath as the main
+   * data structure to hold unique tuples/rows and also for resizing/trimming/sorting,
+   * we need to pass info on limit, order by to super class
+   * {@link org.apache.pinot.core.data.table.IndexedTable}.
+   * @param brokerRequest broker request
+   */
+  public void addLimitAndOrderByInfo(BrokerRequest brokerRequest) {
+    addCapacityAndOrderByInfo(brokerRequest.getOrderBy(), brokerRequest.getLimit());
   }
 
   private static int nextPowerOfTwo(int val) {
@@ -230,6 +220,32 @@ public class DistinctTable {
       return val;
     } else {
       return highestBit << 1;
+    }
+  }
+
+  private void resize(int trimToSize) {
+    _tableResizer.resizeRecordsSet(_uniqueRecordsSet, trimToSize);
+  }
+
+  @Override
+  public int size() {
+    return _uniqueRecordsSet.size();
+  }
+
+  @Override
+  public Iterator<Record> iterator() {
+    return _sortedIterator != null ? _sortedIterator : _uniqueRecordsSet.iterator();
+  }
+
+  @Override
+  public void finish(boolean sort) {
+    if (_isOrderBy) {
+      if (sort) {
+        List<Record> sortedRecords = _tableResizer.resizeAndSortRecordSet(_uniqueRecordsSet, _capacity);
+        _sortedIterator = sortedRecords.iterator();
+      } else {
+        resize(_capacity);
+      }
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DistinctTable.java
@@ -43,6 +43,8 @@ import org.apache.pinot.core.data.table.Record;
  * (1) Intermediate result object for Distinct aggregation function
  * (2) The same object is serialized by the server inside the data table
  * for sending the results to broker. Broker deserializes it.
+ * (3) This is also another concrete implementation of {@link BaseTable} and
+ * uses {@link Set} to store unique records.
  */
 public class DistinctTable extends BaseTable {
   private static final double LOAD_FACTOR = 0.75;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -113,7 +113,7 @@ public class AggregationFunctionFactory {
             return new DistinctCountRawHLLMVAggregationFunction();
           case DISTINCT:
             return new DistinctAggregationFunction(AggregationFunctionUtils.getColumn(aggregationInfo),
-                brokerRequest != null ? brokerRequest.getLimit() : SelectAstNode.DEFAULT_RECORD_LIMIT);
+                brokerRequest != null ? brokerRequest.getLimit() : SelectAstNode.DEFAULT_RECORD_LIMIT, brokerRequest.getOrderBy());
           default:
             throw new IllegalArgumentException();
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
@@ -19,13 +19,20 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.SelectionSort;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.RowBasedBlockValueFetcher;
 import org.apache.pinot.core.data.table.Key;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.data.table.SimpleIndexedTable;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.DistinctTable;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
@@ -38,16 +45,20 @@ import org.apache.pinot.pql.parsers.pql2.ast.FunctionCallAstNode;
  * // TODO: Support group-by
  */
 public class DistinctAggregationFunction implements AggregationFunction<DistinctTable, Comparable> {
-  private final DistinctTable _distinctTable;
+  private DistinctTable _distinctTable;
   private final String[] _columnNames;
   private final int _limit;
+  private final List<SelectionSort> _orderBy;
 
   private FieldSpec.DataType[] _dataTypes;
 
-  DistinctAggregationFunction(String multiColumnExpression, int limit) {
-    _distinctTable = new DistinctTable(limit);
+  DistinctAggregationFunction(String multiColumnExpression, int limit, List<SelectionSort> orderBy) {
     _columnNames = multiColumnExpression.split(FunctionCallAstNode.DISTINCT_MULTI_COLUMN_SEPARATOR);
-    _limit = limit;
+    _orderBy = orderBy;
+    // use a multiplier for trim size when DISTINCT queries have ORDER BY. This logic
+    // is similar to what we have in GROUP BY with ORDER BY
+    // this does not guarantee 100% accuracy but still takes closer to it
+    _limit = CollectionUtils.isNotEmpty(_orderBy) ? limit * 5 : limit;
   }
 
   @Override
@@ -70,6 +81,36 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
     return new ObjectAggregationResultHolder();
   }
 
+  private ColumnDataType[] fieldSpecTypeToColumnTypes() {
+    int numColumns = _dataTypes.length;
+    ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
+    for (int i = 0; i < numColumns; i++) {
+      switch (_dataTypes[i]) {
+        case INT:
+          columnDataTypes[i] = ColumnDataType.INT;
+          break;
+        case LONG:
+          columnDataTypes[i] = ColumnDataType.LONG;
+          break;
+        case FLOAT:
+          columnDataTypes[i] = ColumnDataType.FLOAT;
+          break;
+        case DOUBLE:
+          columnDataTypes[i] = ColumnDataType.DOUBLE;
+          break;
+        case STRING:
+          columnDataTypes[i] = ColumnDataType.STRING;
+          break;
+        case BYTES:
+          columnDataTypes[i] = ColumnDataType.BYTES;
+          break;
+        default:
+          throw new UnsupportedOperationException("DISTINCT currently does not support type: " + _dataTypes[i]);
+      }
+    }
+    return columnDataTypes;
+  }
+
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
     int numColumns = _columnNames.length;
@@ -81,8 +122,9 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
       for (int i = 0; i < numColumns; i++) {
         _dataTypes[i] = blockValSets[i].getValueType();
       }
-      _distinctTable.setColumnNames(_columnNames);
-      _distinctTable.setColumnTypes(_dataTypes);
+      ColumnDataType[] columnDataTypes =  fieldSpecTypeToColumnTypes();
+      DataSchema dataSchema = new DataSchema(_columnNames, columnDataTypes);
+      _distinctTable = new DistinctTable(dataSchema, _orderBy, _limit);
     }
 
     // TODO: Follow up PR will make few changes to start using DictionaryBasedAggregationOperator
@@ -95,9 +137,10 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
     // that will require the interface change since this function
     // has to communicate back that required number of records have
     // been collected
-    while (rowIndex < length && _distinctTable.size() < _limit) {
+    while (rowIndex < length) {
       Object[] columnData = blockValueFetcher.getRow(rowIndex);
-      _distinctTable.addKey(new Key(columnData));
+      Record record = new Record(columnData);
+      _distinctTable.upsert(record);
       rowIndex++;
     }
   }
@@ -110,10 +153,10 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
   @Override
   public DistinctTable merge(DistinctTable inProgressMergedResult, DistinctTable newResultToMerge) {
     // do the union
-    Iterator<Key> iterator = newResultToMerge.getIterator();
-    while (iterator.hasNext() && inProgressMergedResult.size() < _limit) {
-      Key key = iterator.next();
-      inProgressMergedResult.addKey(key);
+    Iterator<Record> iterator = newResultToMerge.iterator();
+    while (iterator.hasNext()) {
+      Record record = iterator.next();
+      inProgressMergedResult.upsert(record);
     }
     return inProgressMergedResult;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
@@ -20,9 +20,13 @@ package org.apache.pinot.core.data.table;
 
 import com.google.common.collect.Lists;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.utils.DataSchema;
@@ -460,5 +464,161 @@ public class TableResizerTest {
       Assert.assertEquals(intermediateRecord._values[0],
           distinctCountFunction.extractFinalResult(record.getValues()[5]));
     }
+  }
+
+  @Test
+  public void testResizerForSetBasedTable() {
+    String[] columns = new String[]{"STRING_COL"};
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING};
+
+    DataSchema schema = new DataSchema(columns, columnDataTypes);
+    SelectionSort selectionSort = new SelectionSort();
+    selectionSort.setColumn("STRING_COL");
+    selectionSort.setIsAsc(true);
+
+    TableResizer tableResizer = new TableResizer(schema, Collections.emptyList(), Lists.newArrayList(selectionSort));
+    Set<Record> uniqueRecordsSet = new HashSet<>();
+
+    Record r1 = new Record(new Object[]{"B"});
+    Record r2 = new Record(new Object[]{"A"});
+    Record r3 = new Record(new Object[]{"D"});
+    Record r4 = new Record(new Object[]{"C"});
+    Record r5 = new Record(new Object[]{"E"});
+
+    uniqueRecordsSet.add(r1);
+    uniqueRecordsSet.add(r2);
+    uniqueRecordsSet.add(r3);
+    uniqueRecordsSet.add(r4);
+    uniqueRecordsSet.add(r5);
+
+    int trimSize = 5;
+    // no records should have been evicted
+    Set<Record> copiedRecordSet = new HashSet<>(uniqueRecordsSet);
+    tableResizer.resizeRecordsSet(copiedRecordSet, trimSize);
+    Assert.assertTrue(copiedRecordSet.contains(r1));
+    Assert.assertTrue(copiedRecordSet.contains(r2));
+    Assert.assertTrue(copiedRecordSet.contains(r3));
+    Assert.assertTrue(copiedRecordSet.contains(r4));
+    Assert.assertTrue(copiedRecordSet.contains(r5));
+
+    List<Record> sorted = tableResizer.resizeAndSortRecordSet(copiedRecordSet, trimSize);
+    Assert.assertEquals(trimSize, sorted.size());
+    Assert.assertEquals(r2, sorted.get(0));
+    Assert.assertEquals(r1, sorted.get(1));
+    Assert.assertEquals(r4, sorted.get(2));
+    Assert.assertEquals(r3, sorted.get(3));
+    Assert.assertEquals(r5, sorted.get(4));
+
+    trimSize = 3;
+    // D and E should have been evicted through PQ
+    copiedRecordSet = new HashSet<>(uniqueRecordsSet);
+    tableResizer.resizeRecordsSet(copiedRecordSet, trimSize);
+    Assert.assertTrue(copiedRecordSet.contains(r1));
+    Assert.assertTrue(copiedRecordSet.contains(r2));
+    Assert.assertTrue(copiedRecordSet.contains(r4));
+    Assert.assertFalse(copiedRecordSet.contains(r3));
+    Assert.assertFalse(copiedRecordSet.contains(r5));
+
+    sorted = tableResizer.resizeAndSortRecordSet(copiedRecordSet, trimSize);
+    Assert.assertEquals(trimSize, sorted.size());
+    Assert.assertEquals(r2, sorted.get(0));
+    Assert.assertEquals(r1, sorted.get(1));
+    Assert.assertEquals(r4, sorted.get(2));
+
+    trimSize = 2;
+    // A and B should have been retained through PQ
+    copiedRecordSet = new HashSet<>(uniqueRecordsSet);
+    tableResizer.resizeRecordsSet(copiedRecordSet, trimSize);
+    Assert.assertTrue(copiedRecordSet.contains(r1));
+    Assert.assertTrue(copiedRecordSet.contains(r2));
+    Assert.assertFalse(copiedRecordSet.contains(r3));
+    Assert.assertFalse(copiedRecordSet.contains(r4));
+    Assert.assertFalse(copiedRecordSet.contains(r5));
+
+    sorted = tableResizer.resizeAndSortRecordSet(copiedRecordSet, trimSize);
+    Assert.assertEquals(2, sorted.size());
+    Assert.assertEquals(r2, sorted.get(0));
+    Assert.assertEquals(r1, sorted.get(1));
+
+    trimSize = 1;
+    // A should have been retained through PQ
+    copiedRecordSet = new HashSet<>(uniqueRecordsSet);
+    tableResizer.resizeRecordsSet(copiedRecordSet, trimSize);
+    Assert.assertFalse(copiedRecordSet.contains(r1));
+    Assert.assertTrue(copiedRecordSet.contains(r2));
+    Assert.assertFalse(copiedRecordSet.contains(r3));
+    Assert.assertFalse(copiedRecordSet.contains(r4));
+    Assert.assertFalse(copiedRecordSet.contains(r5));
+
+    sorted = tableResizer.resizeAndSortRecordSet(copiedRecordSet, trimSize);
+    Assert.assertEquals(1, sorted.size());
+    Assert.assertEquals(r2, sorted.get(0));
+
+    // change the order to DESC
+    selectionSort.setIsAsc(false);
+    tableResizer = new TableResizer(schema, Collections.emptyList(), Lists.newArrayList(selectionSort));
+
+    trimSize = 5;
+    // no records should have been evicted
+    copiedRecordSet = new HashSet<>(uniqueRecordsSet);
+    tableResizer.resizeRecordsSet(copiedRecordSet, trimSize);
+    Assert.assertTrue(copiedRecordSet.contains(r1));
+    Assert.assertTrue(copiedRecordSet.contains(r2));
+    Assert.assertTrue(copiedRecordSet.contains(r3));
+    Assert.assertTrue(copiedRecordSet.contains(r4));
+    Assert.assertTrue(copiedRecordSet.contains(r5));
+
+    sorted = tableResizer.resizeAndSortRecordSet(copiedRecordSet, trimSize);
+    Assert.assertEquals(trimSize, sorted.size());
+    Assert.assertEquals(r5, sorted.get(0));
+    Assert.assertEquals(r3, sorted.get(1));
+    Assert.assertEquals(r4, sorted.get(2));
+    Assert.assertEquals(r1, sorted.get(3));
+    Assert.assertEquals(r2, sorted.get(4));
+
+    trimSize = 3;
+    // A and B should have been evicted through PQ
+    copiedRecordSet = new HashSet<>(uniqueRecordsSet);
+    tableResizer.resizeRecordsSet(copiedRecordSet, trimSize);
+    Assert.assertFalse(copiedRecordSet.contains(r1));
+    Assert.assertFalse(copiedRecordSet.contains(r2));
+    Assert.assertTrue(copiedRecordSet.contains(r4));
+    Assert.assertTrue(copiedRecordSet.contains(r3));
+    Assert.assertTrue(copiedRecordSet.contains(r5));
+
+    sorted = tableResizer.resizeAndSortRecordSet(copiedRecordSet, trimSize);
+    Assert.assertEquals(3, sorted.size());
+    Assert.assertEquals(r5, sorted.get(0));
+    Assert.assertEquals(r3, sorted.get(1));
+    Assert.assertEquals(r4, sorted.get(2));
+
+    trimSize = 2;
+    // D and E should have been retained through PQ
+    copiedRecordSet = new HashSet<>(uniqueRecordsSet);
+    tableResizer.resizeRecordsSet(copiedRecordSet, trimSize);
+    Assert.assertFalse(copiedRecordSet.contains(r1));
+    Assert.assertFalse(copiedRecordSet.contains(r2));
+    Assert.assertFalse(copiedRecordSet.contains(r4));
+    Assert.assertTrue(copiedRecordSet.contains(r3));
+    Assert.assertTrue(copiedRecordSet.contains(r5));
+
+    sorted = tableResizer.resizeAndSortRecordSet(copiedRecordSet, trimSize);
+    Assert.assertEquals(2, sorted.size());
+    Assert.assertEquals(r5, sorted.get(0));
+    Assert.assertEquals(r3, sorted.get(1));
+
+    trimSize = 1;
+    // E should have been retained through PQ
+    copiedRecordSet = new HashSet<>(uniqueRecordsSet);
+    tableResizer.resizeRecordsSet(copiedRecordSet, trimSize);
+    Assert.assertFalse(copiedRecordSet.contains(r1));
+    Assert.assertFalse(copiedRecordSet.contains(r2));
+    Assert.assertFalse(copiedRecordSet.contains(r4));
+    Assert.assertFalse(copiedRecordSet.contains(r3));
+    Assert.assertTrue(copiedRecordSet.contains(r5));
+
+    sorted = tableResizer.resizeAndSortRecordSet(copiedRecordSet, trimSize);
+    Assert.assertEquals(1, sorted.size());
+    Assert.assertEquals(r5, sorted.get(0));
   }
 }


### PR DESCRIPTION
Use Table for segment level execution, server combine and broker reduce We were already using DistinctTable (a custom object serialized as a single column value). DistinctTable now extends BaseTable

Added ORDER BY queries to existing unit tests

cc @npawar , @mayankshriv , @Jackie-Jiang 

One of the key things identified is that IndexedTable and IndexedTableResizer interface is very strongly coupled with Record level abstraction whereas for DISTINCT (and may be in future for other scenarios), we only need Key part of Record. So currently this forces an extra object construction. I will have a follow-up PR to address this by redesigning some parts of IndexedTable interface or at least provide alternate APIs that work at Key level. I have some thoughts on this but needs some whiteboarding

UPDATE 11/18 : Based on the discussion and changes as part of PR https://github.com/apache/incubator-pinot/pull/4798, we now extend BaseTable. As discussed, this will be another concrete Table implementation -- Set based implementation as compared to Map based used in GROUP BY.