### PR TITLE
Support STRING and BYTES for no dictionary columns in realtime consuming segments

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/io/readerwriter/BaseSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/readerwriter/BaseSingleColumnSingleValueReaderWriter.java
@@ -92,7 +92,7 @@ public abstract class BaseSingleColumnSingleValueReaderWriter<T extends ReaderCo
 
   @Override
   public byte[] getBytes(int row, ReaderContext context) {
-    throw new UnsupportedOperationException();
+    return getBytes(row);
   }
 
   @Override
@@ -142,6 +142,14 @@ public abstract class BaseSingleColumnSingleValueReaderWriter<T extends ReaderCo
 
   @Override
   public void setBytes(int row, byte[] bytes) {
+    throw new UnsupportedOperationException();
+  }
+
+  public int getLengthOfShortestElement() {
+    throw new UnsupportedOperationException();
+  }
+
+  public int getLengthOfLongestElement() {
     throw new UnsupportedOperationException();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
@@ -72,6 +72,16 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
   }
 
   @Override
+  public int getLengthOfShortestElement() {
+    return _columnSizesInBytes;
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    return _columnSizesInBytes;
+  }
+
+  @Override
   public void close()
       throws IOException {
     for (ReaderWithOffset reader : _readers) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/readerwriter/impl/VarByteSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/readerwriter/impl/VarByteSingleColumnSingleValueReaderWriter.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.io.readerwriter.impl;
+
+import java.io.IOException;
+import org.apache.pinot.common.utils.StringUtil;
+import org.apache.pinot.core.io.readerwriter.BaseSingleColumnSingleValueReaderWriter;
+import org.apache.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import org.apache.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
+
+public class VarByteSingleColumnSingleValueReaderWriter extends BaseSingleColumnSingleValueReaderWriter {
+  private final MutableOffHeapByteArrayStore _byteArrayStore;
+  private int _lengthOfShortestElement;
+  private int _lengthOfLongestElement;
+
+  public VarByteSingleColumnSingleValueReaderWriter(
+      PinotDataBufferMemoryManager memoryManager,
+      String allocationContext,
+      int estimatedMaxNumberOfValues,
+      int estimatedAverageStringLength) {
+    _byteArrayStore = new MutableOffHeapByteArrayStore(memoryManager, allocationContext, estimatedMaxNumberOfValues, estimatedAverageStringLength);
+    _lengthOfShortestElement = Integer.MAX_VALUE;
+    _lengthOfLongestElement = Integer.MIN_VALUE;
+  }
+
+  @Override
+  public int getLengthOfShortestElement() {
+    return _lengthOfShortestElement;
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    return _lengthOfLongestElement;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _byteArrayStore.close();
+  }
+
+  @Override
+  public void setInt(int row, int i) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getInt(int row) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setLong(int row, long l) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLong(int row) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setFloat(int row, float f) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float getFloat(int row) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setDouble(int row, double d) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDouble(int row) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setString(int row, String val) {
+    byte[] serializedValue = StringUtil.encodeUtf8(val);
+    setBytes(row, serializedValue);
+  }
+
+  @Override
+  public String getString(int row) {
+    return StringUtil.decodeUtf8(_byteArrayStore.get(row));
+  }
+
+  @Override
+  public void setBytes(int row, byte[] value) {
+    _byteArrayStore.add(value);
+    _lengthOfLongestElement = Math.max(_lengthOfLongestElement, value.length);
+    _lengthOfShortestElement = Math.min(_lengthOfShortestElement, value.length);
+  }
+
+  @Override
+  public byte[] getBytes(int row) {
+    return _byteArrayStore.get(row);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/data/source/ColumnDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/data/source/ColumnDataSource.java
@@ -190,4 +190,8 @@ public final class ColumnDataSource extends DataSource {
   public String getOperatorName() {
     return _operatorName;
   }
+
+  public DataFileReader getForwardIndex() {
+    return _forwardIndex;
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/index/readerwriter/VarByteSingleColumnSingleValueReaderWriterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/index/readerwriter/VarByteSingleColumnSingleValueReaderWriterTest.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.index.readerwriter;
+
+import java.io.IOException;
+import java.util.Random;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.pinot.common.utils.StringUtil;
+import org.apache.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import org.apache.pinot.core.io.readerwriter.impl.VarByteSingleColumnSingleValueReaderWriter;
+import org.apache.pinot.core.io.writer.impl.DirectMemoryManager;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class VarByteSingleColumnSingleValueReaderWriterTest {
+  private PinotDataBufferMemoryManager _memoryManager;
+
+  @BeforeClass
+  public void setUp() {
+    _memoryManager = new DirectMemoryManager(VarByteSingleColumnSingleValueReaderWriterTest.class.getName());
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    _memoryManager.close();
+  }
+
+  @Test
+  public void testString()
+      throws IOException {
+    // use arbitrary cardinality and avg string length
+    // we will test with complete randomness
+    int initialCapacity = 5;
+    int estimatedAvgStringLength = 30;
+    try (VarByteSingleColumnSingleValueReaderWriter readerWriter =
+        new VarByteSingleColumnSingleValueReaderWriter(_memoryManager, "StringColumn",  initialCapacity, estimatedAvgStringLength)) {
+      int rows = 1000;
+      Random random = new Random();
+      String[] data = new String[rows];
+
+      for (int i = 0; i < rows; i++) {
+        // generate a random string of length between 10 and 100
+        int length = 10 + random.nextInt(100 - 10);
+        data[i] = RandomStringUtils.randomAlphanumeric(length);
+        readerWriter.setString(i, data[i]);
+      }
+
+      for (int i = 0; i < rows; i++) {
+        Assert.assertEquals(readerWriter.getString(i), data[i]);
+      }
+    }
+  }
+
+  @Test
+  public void testBytes()
+      throws IOException {
+    int initialCapacity = 5;
+    int estimatedAvgStringLength = 30;
+    try (VarByteSingleColumnSingleValueReaderWriter readerWriter =
+        new VarByteSingleColumnSingleValueReaderWriter(_memoryManager, "StringColumn",  initialCapacity, estimatedAvgStringLength)) {
+      int rows = 1000;
+      Random random = new Random();
+      String[] data = new String[rows];
+
+      for (int i = 0; i < rows; i++) {
+        int length = 10 + random.nextInt(100 - 10);
+        data[i] = RandomStringUtils.randomAlphanumeric(length);
+        readerWriter.setBytes(i, StringUtil.encodeUtf8(data[i]));
+      }
+
+      for (int i = 0; i < rows; i++) {
+        Assert.assertEquals(StringUtil.decodeUtf8(readerWriter.getBytes(i)), data[i]);
+      }
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -368,6 +368,14 @@ public abstract class FieldSpec implements Comparable<FieldSpec> {
           throw new UnsupportedOperationException("Unsupported data type: " + this);
       }
     }
+
+    /**
+     * Check if the data type is for fixed width data (INT, LONG, FLOAT, DOUBLE)
+     * or variable width data (STRING, BYTES)
+     */
+    public boolean isFixedWidth() {
+      return this != STRING && this != BYTES;
+    }
   }
 
   @Override


### PR DESCRIPTION
Added support for creation of raw index for var length columns in realtime consuming segments.

Issue https://github.com/apache/incubator-pinot/issues/4034

cc @mcvsubbu 

This is also needed for text search feature.