### PR TITLE
Fix the bug of uneven task distribution for threads

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -97,7 +97,6 @@ public class CombinePlanNode implements PlanNode {
 
       int numThreads = Math.min((numPlanNodes + TARGET_NUM_PLANS_PER_THREAD - 1) / TARGET_NUM_PLANS_PER_THREAD,
           MAX_NUM_THREADS_PER_QUERY);
-      int numPlansPerThread = (numPlanNodes + numThreads - 1) / numThreads;
 
       // Use a Phaser to ensure all the Futures are done (not scheduled, finished or interrupted) before the main thread
       // returns. We need to ensure no execution left before the main thread returning because the main thread holds the
@@ -123,9 +122,7 @@ public class CombinePlanNode implements PlanNode {
               }
 
               List<Operator> operators = new ArrayList<>();
-              int start = index * numPlansPerThread;
-              int end = Math.min(start + numPlansPerThread, numPlanNodes);
-              for (int i = start; i < end; i++) {
+              for (int i = index; i < numPlanNodes; i += numThreads) {
                 operators.add(_planNodes.get(i).run());
               }
               return operators;


### PR DESCRIPTION
E.g. 5 threads, 11 tasks
If we pre-calculate the numTasksPerThread, each thread will get 3 tasks
Thread 0-2 will get 3 tasks; thread 3 will get 2 tasks; thread 4 will get 0 task

Instead, we should do round-robin, and thread 0 will get 3 tasks, thread 1-4 will get 2 tasks