### PR TITLE
Enhance RoutingTable to use ServerInstance  

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -53,6 +53,7 @@ import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.FilterQuery;
 import org.apache.pinot.common.request.FilterQueryMap;
 import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Broker;
@@ -261,8 +262,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // Calculate routing table for the query
     long routingStartTimeNs = System.nanoTime();
-    Map<String, List<String>> offlineRoutingTable = null;
-    Map<String, List<String>> realtimeRoutingTable = null;
+    Map<ServerInstance, List<String>> offlineRoutingTable = null;
+    Map<ServerInstance, List<String>> realtimeRoutingTable = null;
     if (offlineBrokerRequest != null) {
       offlineRoutingTable = _routingTable.getRoutingTable(new RoutingTableLookupRequest(offlineBrokerRequest));
       if (offlineRoutingTable.isEmpty()) {
@@ -577,8 +578,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * Processes the optimized broker requests for both OFFLINE and REALTIME table.
    */
   protected abstract BrokerResponse processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
-      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<String, List<String>> offlineRoutingTable,
-      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<String, List<String>> realtimeRoutingTable,
+      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable,
       long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)
       throws Exception;
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ConnectionPoolBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ConnectionPoolBrokerRequestHandler.java
@@ -131,8 +131,8 @@ public class ConnectionPoolBrokerRequestHandler extends BaseBrokerRequestHandler
 
   @Override
   protected BrokerResponse processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
-      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<String, List<String>> offlineRoutingTable,
-      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<String, List<String>> realtimeRoutingTable,
+      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable,
       long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)
       throws Exception {
     ScatterGatherStats scatterGatherStats = new ScatterGatherStats();
@@ -238,7 +238,7 @@ public class ConnectionPoolBrokerRequestHandler extends BaseBrokerRequestHandler
    * @return composite future used to gather responses.
    */
   private CompositeFuture<byte[]> scatterBrokerRequest(long requestId, BrokerRequest brokerRequest,
-      Map<String, List<String>> routingTable, boolean isOfflineTable, long timeoutMs,
+      Map<ServerInstance, List<String>> routingTable, boolean isOfflineTable, long timeoutMs,
       ScatterGatherStats scatterGatherStats, PhaseTimes phaseTimes)
       throws InterruptedException {
     long scatterStartTimeNs = System.nanoTime();
@@ -355,12 +355,12 @@ public class ConnectionPoolBrokerRequestHandler extends BaseBrokerRequestHandler
 
   private static class ScatterGatherRequestImpl implements ScatterGatherRequest {
     private final BrokerRequest _brokerRequest;
-    private final Map<String, List<String>> _routingTable;
+    private final Map<ServerInstance, List<String>> _routingTable;
     private final long _requestId;
     private final long _requestTimeoutMs;
     private final String _brokerId;
 
-    public ScatterGatherRequestImpl(BrokerRequest request, Map<String, List<String>> routingTable, long requestId,
+    public ScatterGatherRequestImpl(BrokerRequest request, Map<ServerInstance, List<String>> routingTable, long requestId,
         long requestTimeoutMs, String brokerId) {
       _brokerRequest = request;
       _routingTable = routingTable;
@@ -370,7 +370,7 @@ public class ConnectionPoolBrokerRequestHandler extends BaseBrokerRequestHandler
     }
 
     @Override
-    public Map<String, List<String>> getRoutingTable() {
+    public Map<ServerInstance, List<String>> getRoutingTable() {
       return _routingTable;
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -71,8 +71,8 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
   @Override
   protected BrokerResponse processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
-      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<String, List<String>> offlineRoutingTable,
-      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<String, List<String>> realtimeRoutingTable,
+      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable,
       long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)
       throws Exception {
     assert offlineBrokerRequest != null || realtimeBrokerRequest != null;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
@@ -612,7 +612,11 @@ public class HelixExternalViewBasedRouting implements ClusterChangeHandler, Rout
         RoutingTableBuilder routingTableBuilder = _routingTableBuilderMap.get(currentTable);
         List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
         for (Map<ServerInstance, List<String>> routingTable : routingTables) {
-          entries.add(JsonUtils.objectToJsonNode(routingTable));
+          Map<String, List<String>> map = new HashMap<>();
+          for(Map.Entry<ServerInstance,List<String>> e: routingTable.entrySet()) {
+            map.put(e.getKey().getInstanceName(), e.getValue());
+          }
+          entries.add(JsonUtils.objectToJsonNode(map));
         }
         tableEntry.set("routingTableEntries", entries);
         routingTableSnapshot.add(tableEntry);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/HelixExternalViewBasedRouting.java
@@ -50,6 +50,7 @@ import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.BrokerTimer;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.EqualityUtils;
 import org.apache.pinot.common.utils.JsonUtils;
@@ -112,7 +113,7 @@ public class HelixExternalViewBasedRouting implements ClusterChangeHandler, Rout
   }
 
   @Override
-  public Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request) {
+  public Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request) {
     String tableName = request.getTableName();
     RoutingTableBuilder routingTableBuilder = _routingTableBuilderMap.get(tableName);
     return routingTableBuilder.getRoutingTable(request, _segmentSelectorMap.get(tableName));
@@ -609,8 +610,8 @@ public class HelixExternalViewBasedRouting implements ClusterChangeHandler, Rout
 
         ArrayNode entries = JsonUtils.newArrayNode();
         RoutingTableBuilder routingTableBuilder = _routingTableBuilderMap.get(currentTable);
-        List<Map<String, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
-        for (Map<String, List<String>> routingTable : routingTables) {
+        List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
+        for (Map<ServerInstance, List<String>> routingTable : routingTables) {
           entries.add(JsonUtils.objectToJsonNode(routingTable));
         }
         tableEntry.set("routingTableEntries", entries);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
@@ -20,6 +20,7 @@ package org.apache.pinot.broker.routing;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.response.ServerInstance;
 
 
 /**
@@ -33,7 +34,7 @@ public interface RoutingTable {
    * @param request Routing table lookup request
    * @return Map from server to list of segments
    */
-  Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request);
+  Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request);
 
   /**
    * Return whether the routing table for the given table exists.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
@@ -28,6 +28,7 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.ServerInstance;
 
 
 /**
@@ -46,15 +47,15 @@ public class BalancedRandomRoutingTableBuilder extends BaseRoutingTableBuilder {
     _numRoutingTables = configuration.getInt(NUM_ROUTING_TABLES_KEY, DEFAULT_NUM_ROUTING_TABLES);
   }
 
-  protected List<Map<String, List<String>>> computeRoutingTablesFromSegmentToServersMap(
-      Map<String, List<String>> segmentToServersMap) {
-    List<Map<String, List<String>>> routingTables = new ArrayList<>(_numRoutingTables);
+  protected List<Map<ServerInstance, List<String>>> computeRoutingTablesFromSegmentToServersMap(
+      Map<String, List<ServerInstance>> segmentToServersMap) {
+    List<Map<ServerInstance, List<String>>> routingTables = new ArrayList<>(_numRoutingTables);
     Set<String> segmentsToQuery = segmentToServersMap.keySet();
 
     for (int i = 0; i < _numRoutingTables; i++) {
-      Map<String, List<String>> routingTable = new HashMap<>();
+      Map<ServerInstance, List<String>> routingTable = new HashMap<>();
       for (String segmentName : segmentsToQuery) {
-        List<String> servers = segmentToServersMap.get(segmentName);
+        List<ServerInstance> servers = segmentToServersMap.get(segmentName);
         routingTable.get(getServerWithLeastSegmentsAssigned(servers, routingTable)).add(segmentName);
       }
       routingTables.add(routingTable);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BaseRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BaseRoutingTableBuilder.java
@@ -36,6 +36,7 @@ import org.apache.pinot.common.config.RoutingConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,10 +55,10 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
 
   // Set variable as volatile so all threads can get the up-to-date routing tables
   // Routing tables are used for storing pre-computed routing table
-  protected volatile List<Map<String, List<String>>> _routingTables;
+  protected volatile List<Map<ServerInstance, List<String>>> _routingTables;
 
   // A mapping of segments to servers is used for dynamic routing table building process
-  protected volatile Map<String, List<String>> _segmentToServersMap;
+  protected volatile Map<String, List<ServerInstance>> _segmentToServersMap;
 
   @Override
   public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore,
@@ -76,13 +77,13 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
     }
   }
 
-  protected static String getServerWithLeastSegmentsAssigned(List<String> servers,
-      Map<String, List<String>> routingTable) {
+  protected static ServerInstance getServerWithLeastSegmentsAssigned(List<ServerInstance> servers,
+      Map<ServerInstance, List<String>> routingTable) {
     Collections.shuffle(servers);
 
-    String selectedServer = null;
+    ServerInstance selectedServer = null;
     int minNumSegmentsAssigned = Integer.MAX_VALUE;
-    for (String server : servers) {
+    for (ServerInstance server : servers) {
       List<String> segments = routingTable.get(server);
       if (segments == null) {
         routingTable.put(server, new ArrayList<>());
@@ -114,7 +115,7 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
   @Override
   public void computeOnExternalViewChange(String tableName, ExternalView externalView,
       List<InstanceConfig> instanceConfigs) {
-    Map<String, List<String>> segmentToServersMap =
+    Map<String, List<ServerInstance>> segmentToServersMap =
         computeSegmentToServersMapFromExternalView(externalView, instanceConfigs);
 
     if (_enableDynamicComputing) {
@@ -122,15 +123,15 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
       _segmentToServersMap = segmentToServersMap;
     } else {
       // Otherwise, we cache the pre-computed routing tables
-      List<Map<String, List<String>>> routingTables = computeRoutingTablesFromSegmentToServersMap(segmentToServersMap);
+      List<Map<ServerInstance, List<String>>> routingTables = computeRoutingTablesFromSegmentToServersMap(segmentToServersMap);
       _routingTables = routingTables;
     }
   }
 
-  public Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
+  public Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
     if (_enableDynamicComputing) {
       // Copy the pointer for snapshot since the pointer for segment to servers map can change at anytime
-      Map<String, List<String>> segmentToServersMap = _segmentToServersMap;
+      Map<String, List<ServerInstance>> segmentToServersMap = _segmentToServersMap;
 
       // Selecting segments only required for processing a query
       Set<String> segmentsToQuery = segmentToServersMap.keySet();
@@ -147,7 +148,7 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public List<Map<String, List<String>>> getRoutingTables() {
+  public List<Map<ServerInstance, List<String>>> getRoutingTables() {
     return _routingTables;
   }
 
@@ -158,12 +159,12 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
    * @param segmentsToQuery a list of segments that need to be processed for a particular query
    * @return a routing table
    */
-  public Map<String, List<String>> computeDynamicRoutingTable(Map<String, List<String>> segmentToServersMap,
+  public Map<ServerInstance, List<String>> computeDynamicRoutingTable(Map<String, List<ServerInstance>> segmentToServersMap,
       Set<String> segmentsToQuery) {
-    Map<String, List<String>> routingTable = new HashMap<>();
+    Map<ServerInstance, List<String>> routingTable = new HashMap<>();
     for (String segmentName : segmentsToQuery) {
-      List<String> servers = segmentToServersMap.get(segmentName);
-      String selectedServer = servers.get(_random.nextInt(servers.size()));
+      List<ServerInstance> servers = segmentToServersMap.get(segmentName);
+      ServerInstance selectedServer = servers.get(_random.nextInt(servers.size()));
       List<String> segments = routingTable.computeIfAbsent(selectedServer, k -> new ArrayList<>());
       segments.add(segmentName);
     }
@@ -178,18 +179,18 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
    * @param instanceConfigs a list of instance config
    * @return a mapping of segment to servers
    */
-  protected Map<String, List<String>> computeSegmentToServersMapFromExternalView(ExternalView externalView,
+  protected Map<String, List<ServerInstance>> computeSegmentToServersMapFromExternalView(ExternalView externalView,
       List<InstanceConfig> instanceConfigs) {
-    Map<String, List<String>> segmentToServersMap = new HashMap<>();
+    Map<String, List<ServerInstance>> segmentToServersMap = new HashMap<>();
     RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigs);
     for (String segmentName : externalView.getPartitionSet()) {
       // List of servers that are active and are serving the segment
-      List<String> servers = new ArrayList<>();
+      List<ServerInstance> servers = new ArrayList<>();
       for (Map.Entry<String, String> entry : externalView.getStateMap(segmentName).entrySet()) {
         String serverName = entry.getKey();
         if (entry.getValue().equals(CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.ONLINE)
             && !instancePruner.isInactive(serverName)) {
-          servers.add(serverName);
+          servers.add(ServerInstance.forInstanceName(serverName));
         }
       }
       if (!servers.isEmpty()) {
@@ -208,6 +209,6 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
    * @param segmentToServersMap a mapping of segment to servers
    * @return a list of final routing tables
    */
-  protected abstract List<Map<String, List<String>>> computeRoutingTablesFromSegmentToServersMap(
-      Map<String, List<String>> segmentToServersMap);
+  protected abstract List<Map<ServerInstance, List<String>>> computeRoutingTablesFromSegmentToServersMap(
+      Map<String, List<ServerInstance>> segmentToServersMap);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/DefaultOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/DefaultOfflineRoutingTableBuilder.java
@@ -31,6 +31,7 @@ import org.apache.pinot.broker.routing.RoutingTableLookupRequest;
 import org.apache.pinot.broker.routing.selector.SegmentSelector;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.ServerInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,12 +127,12 @@ public class DefaultOfflineRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
+  public Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
     return _routingTableBuilder.getRoutingTable(request, segmentSelector);
   }
 
   @Override
-  public List<Map<String, List<String>>> getRoutingTables() {
+  public List<Map<ServerInstance, List<String>>> getRoutingTables() {
     return _routingTableBuilder.getRoutingTables();
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
@@ -31,6 +31,7 @@ import org.apache.pinot.broker.routing.RoutingTableLookupRequest;
 import org.apache.pinot.broker.routing.selector.SegmentSelector;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.SegmentName;
 
 
@@ -73,7 +74,7 @@ public class DefaultRealtimeRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
+  public Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
     boolean forceLLC = false;
     boolean forceHLC = false;
     for (String routingOption : request.getRoutingOptions()) {
@@ -105,7 +106,7 @@ public class DefaultRealtimeRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public List<Map<String, List<String>>> getRoutingTables() {
+  public List<Map<ServerInstance, List<String>>> getRoutingTables() {
     if (_hasLLC) {
       return _realtimeLLCRoutingTableBuilder.getRoutingTables();
     } else if (_hasHLC) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/GeneratorBasedRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/GeneratorBasedRoutingTableBuilder.java
@@ -28,6 +28,7 @@ import java.util.PriorityQueue;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.response.ServerInstance;
 
 
 /**
@@ -47,10 +48,11 @@ public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTable
    * Generates a routing table, decorated with a metric.
    *
    * @return A pair of a routing table and its associated metric.
+   * @param segmentToServersMap
    */
-  private Pair<Map<String, List<String>>, Float> generateRoutingTableWithMetric(
-      Map<String, List<String>> segmentToServersMap) {
-    Map<String, List<String>> routingTable = generateRoutingTable(segmentToServersMap);
+  private Pair<Map<ServerInstance, List<String>>, Float> generateRoutingTableWithMetric(
+      Map<String, List<ServerInstance>> segmentToServersMap) {
+    Map<ServerInstance, List<String>> routingTable = generateRoutingTable(segmentToServersMap);
     int segmentCount = 0;
     int serverCount = 0;
 
@@ -73,26 +75,26 @@ public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTable
     return new ImmutablePair<>(routingTable, variance);
   }
 
-  private Map<String, List<String>> generateRoutingTable(Map<String, List<String>> segmentToServersMap) {
+  private Map<ServerInstance, List<String>> generateRoutingTable(Map<String, List<ServerInstance>> segmentToServersMap) {
 
-    Map<String, List<String>> routingTable = new HashMap<>();
+    Map<ServerInstance, List<String>> routingTable = new HashMap<>();
 
     if (segmentToServersMap.isEmpty()) {
       return routingTable;
     }
 
     // Construct the map from server to list of segments
-    Map<String, List<String>> serverToSegmentsMap = new HashMap<>();
-    for (Map.Entry<String, List<String>> entry : segmentToServersMap.entrySet()) {
-      List<String> servers = entry.getValue();
-      for (String serverName : servers) {
-        List<String> segmentsForServer = serverToSegmentsMap.computeIfAbsent(serverName, k -> new ArrayList<>());
+    Map<ServerInstance, List<String>> serverToSegmentsMap = new HashMap<>();
+    for (Map.Entry<String, List<ServerInstance>> entry : segmentToServersMap.entrySet()) {
+      List<ServerInstance> servers = entry.getValue();
+      for (ServerInstance serverInstance : servers) {
+        List<String> segmentsForServer = serverToSegmentsMap.computeIfAbsent(serverInstance, k -> new ArrayList<>());
         segmentsForServer.add(entry.getKey());
       }
     }
 
     int numSegments = segmentToServersMap.size();
-    List<String> servers = new ArrayList<>(serverToSegmentsMap.keySet());
+    List<ServerInstance> servers = new ArrayList<>(serverToSegmentsMap.keySet());
     int numServers = servers.size();
 
     // Set of segments that have no instance serving them
@@ -100,7 +102,7 @@ public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTable
 
     // Set of servers in this routing table
     int targetNumServersPerQuery = getTargetNumServersPerQuery();
-    Set<String> serversInRoutingTable = new HashSet<>(targetNumServersPerQuery);
+    Set<ServerInstance> serversInRoutingTable = new HashSet<>(targetNumServersPerQuery);
 
     if (numServers <= targetNumServersPerQuery) {
       // If there are not enough instances, add them all
@@ -109,7 +111,7 @@ public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTable
     } else {
       // Otherwise add _targetNumServersPerQuery instances
       while (serversInRoutingTable.size() < targetNumServersPerQuery) {
-        String randomServer = servers.get(_random.nextInt(numServers));
+        ServerInstance randomServer = servers.get(_random.nextInt(numServers));
         if (!serversInRoutingTable.contains(randomServer)) {
           serversInRoutingTable.add(randomServer);
           segmentsNotHandledByServers.removeAll(serverToSegmentsMap.get(randomServer));
@@ -122,32 +124,32 @@ public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTable
       String segmentNotHandledByServers = segmentsNotHandledByServers.iterator().next();
 
       // Pick a random server that can serve this segment
-      List<String> serversForSegment = segmentToServersMap.get(segmentNotHandledByServers);
-      String randomServer = serversForSegment.get(_random.nextInt(serversForSegment.size()));
+      List<ServerInstance> serversForSegment = segmentToServersMap.get(segmentNotHandledByServers);
+      ServerInstance randomServer = serversForSegment.get(_random.nextInt(serversForSegment.size()));
       serversInRoutingTable.add(randomServer);
       segmentsNotHandledByServers.removeAll(serverToSegmentsMap.get(randomServer));
     }
 
     // Sort all the segments to be used during assignment in ascending order of replicas
-    PriorityQueue<Pair<String, List<String>>> segmentToReplicaSetQueue =
+    PriorityQueue<Pair<String, List<ServerInstance>>> segmentToReplicaSetQueue =
         new PriorityQueue<>(numSegments, Comparator.comparingInt(pair -> pair.getRight().size()));
 
-    for (Map.Entry<String, List<String>> entry : segmentToServersMap.entrySet()) {
+    for (Map.Entry<String, List<ServerInstance>> entry : segmentToServersMap.entrySet()) {
       // Servers for the segment is the intersection of all servers for this segment and the servers that we have in
       // this routing table
-      List<String> serversForSegment = new ArrayList<>(entry.getValue());
+      List<ServerInstance> serversForSegment = new ArrayList<>(entry.getValue());
       serversForSegment.retainAll(serversInRoutingTable);
 
       segmentToReplicaSetQueue.add(new ImmutablePair<>(entry.getKey(), serversForSegment));
     }
 
     // Assign each segment to a server
-    Pair<String, List<String>> segmentServersPair;
+    Pair<String, List<ServerInstance>> segmentServersPair;
     while ((segmentServersPair = segmentToReplicaSetQueue.poll()) != null) {
       String segmentName = segmentServersPair.getLeft();
-      List<String> serversForSegment = segmentServersPair.getRight();
+      List<ServerInstance> serversForSegment = segmentServersPair.getRight();
 
-      String serverWithLeastSegmentsAssigned = getServerWithLeastSegmentsAssigned(serversForSegment, routingTable);
+      ServerInstance serverWithLeastSegmentsAssigned = getServerWithLeastSegmentsAssigned(serversForSegment, routingTable);
       List<String> segmentsAssignedToServer =
           routingTable.computeIfAbsent(serverWithLeastSegmentsAssigned, k -> new ArrayList<>());
       segmentsAssignedToServer.add(segmentName);
@@ -220,8 +222,8 @@ public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTable
     */
 
   @Override
-  protected List<Map<String, List<String>>> computeRoutingTablesFromSegmentToServersMap(
-      Map<String, List<String>> segmentToServersMap) {
+  protected List<Map<ServerInstance, List<String>>> computeRoutingTablesFromSegmentToServersMap(
+      Map<String, List<ServerInstance>> segmentToServersMap) {
     // The default routing table algorithm tries to balance all available segments across all servers, so that each
     // server is hit on every query. This works fine with small clusters (say less than 20 servers) but for larger
     // clusters, this adds up to significant overhead (one request must be enqueued for each server, processed,
@@ -260,7 +262,7 @@ public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTable
     // in workload per server across all the routing tables. To do so, we generate an initial set of routing tables
     // according to a per-routing table metric and discard the worst routing tables.
 
-    PriorityQueue<Pair<Map<String, List<String>>, Float>> topRoutingTables =
+    PriorityQueue<Pair<Map<ServerInstance, List<String>>, Float>> topRoutingTables =
         new PriorityQueue<>(ROUTING_TABLE_COUNT, (left, right) -> {
           // Float.compare sorts in ascending order and we want a max heap, so we need to return the negative
           // of the comparison
@@ -273,8 +275,8 @@ public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTable
 
     // Generate routing more tables and keep the ROUTING_TABLE_COUNT top ones
     for (int i = 0; i < (ROUTING_TABLE_GENERATION_COUNT - ROUTING_TABLE_COUNT); ++i) {
-      Pair<Map<String, List<String>>, Float> newRoutingTable = generateRoutingTableWithMetric(segmentToServersMap);
-      Pair<Map<String, List<String>>, Float> worstRoutingTable = topRoutingTables.peek();
+      Pair<Map<ServerInstance, List<String>>, Float> newRoutingTable = generateRoutingTableWithMetric(segmentToServersMap);
+      Pair<Map<ServerInstance, List<String>>, Float> worstRoutingTable = topRoutingTables.peek();
 
       // If the new routing table is better than the worst one, keep it
       if (newRoutingTable.getRight() < worstRoutingTable.getRight()) {
@@ -284,7 +286,7 @@ public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTable
     }
 
     // Return the best routing tables
-    List<Map<String, List<String>>> routingTables = new ArrayList<>(topRoutingTables.size());
+    List<Map<ServerInstance, List<String>>> routingTables = new ArrayList<>(topRoutingTables.size());
     while (!topRoutingTables.isEmpty()) {
       routingTables.add(topRoutingTables.poll().getKey());
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/HighLevelConsumerBasedRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/HighLevelConsumerBasedRoutingTableBuilder.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.HLCSegmentName;
 import org.apache.pinot.common.utils.SegmentName;
@@ -33,17 +34,17 @@ import org.apache.pinot.common.utils.SegmentName;
 public class HighLevelConsumerBasedRoutingTableBuilder extends BaseRoutingTableBuilder {
 
   @Override
-  protected Map<String, List<String>> computeSegmentToServersMapFromExternalView(ExternalView externalView,
+  protected Map<String, List<ServerInstance>> computeSegmentToServersMapFromExternalView(ExternalView externalView,
       List<InstanceConfig> instanceConfigs) {
-    Map<String, List<String>> segmentToServersMap = new HashMap<>();
+    Map<String, List<ServerInstance>> segmentToServersMap = new HashMap<>();
     RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigs);
     for (String segmentName : externalView.getPartitionSet()) {
-      List<String> servers = new ArrayList<>();
+      List<ServerInstance> servers = new ArrayList<>();
       for (Map.Entry<String, String> entry : externalView.getStateMap(segmentName).entrySet()) {
         String serverName = entry.getKey();
         if (entry.getValue().equals(CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.ONLINE)
             && !instancePruner.isInactive(serverName) && SegmentName.isHighLevelConsumerSegmentName(segmentName)) {
-          servers.add(serverName);
+          servers.add(ServerInstance.forInstanceName(serverName));
         }
       }
       if (servers.size() != 0) {
@@ -56,20 +57,20 @@ public class HighLevelConsumerBasedRoutingTableBuilder extends BaseRoutingTableB
   }
 
   @Override
-  protected List<Map<String, List<String>>> computeRoutingTablesFromSegmentToServersMap(
-      Map<String, List<String>> segmentsToServerMap) {
-    List<Map<String, List<String>>> routingTables = new ArrayList<>();
-    Map<String, Map<String, List<String>>> groupIdToRouting = new HashMap<>();
-    for (Map.Entry<String, List<String>> entry : segmentsToServerMap.entrySet()) {
+  protected List<Map<ServerInstance, List<String>>> computeRoutingTablesFromSegmentToServersMap(
+      Map<String, List<ServerInstance>> segmentsToServerMap) {
+    List<Map<ServerInstance, List<String>>> routingTables = new ArrayList<>();
+    Map<String, Map<ServerInstance, List<String>>> groupIdToRouting = new HashMap<>();
+    for (Map.Entry<String, List<ServerInstance>> entry : segmentsToServerMap.entrySet()) {
       String segmentName = entry.getKey();
       HLCSegmentName hlcSegmentName = new HLCSegmentName(segmentName);
       String groupId = hlcSegmentName.getGroupId();
-      Map<String, List<String>> routingTableForGroupId =
+      Map<ServerInstance, List<String>> routingTableForGroupId =
           groupIdToRouting.computeIfAbsent(groupId, k -> new HashMap<>());
 
-      List<String> servers = entry.getValue();
-      for (String serverName : servers) {
-        List<String> segmentsForServer = routingTableForGroupId.computeIfAbsent(serverName, k -> new ArrayList<>());
+      List<ServerInstance> servers = entry.getValue();
+      for (ServerInstance serverInstance : servers) {
+        List<String> segmentsForServer = routingTableForGroupId.computeIfAbsent(serverInstance, k -> new ArrayList<>());
         segmentsForServer.add(segmentName);
       }
     }
@@ -78,7 +79,7 @@ public class HighLevelConsumerBasedRoutingTableBuilder extends BaseRoutingTableB
   }
 
   @Override
-  public Map<String, List<String>> computeDynamicRoutingTable(Map<String, List<String>> segmentToServersMap,
+  public Map<ServerInstance, List<String>> computeDynamicRoutingTable(Map<String, List<ServerInstance>> segmentToServersMap,
       Set<String> segmentsToQuery) {
     throw new UnsupportedOperationException(
         "Dynamic routing table computation for high level consumer base routing is not supported");

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
@@ -38,6 +38,7 @@ import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants;
 
 
@@ -135,14 +136,14 @@ public class PartitionAwareOfflineRoutingTableBuilder extends BasePartitionAware
     }
 
     // 3. Compute the final routing look up table
-    Map<String, Map<Integer, String>> segmentToReplicaToServerMap = new HashMap<>();
+    Map<String, Map<Integer, ServerInstance>> segmentToReplicaToServerMap = new HashMap<>();
     for (String segmentName : segmentSet) {
       // Get partition_id from cached segment zk metadata
       SegmentZKMetadata segmentZKMetadata = _segmentToZkMetadataMapping.get(segmentName);
       int partitionId = getPartitionId(segmentZKMetadata);
 
       // Initialize data intermediate data structures or data
-      Map<Integer, String> replicaToServerMap = new HashMap<>();
+      Map<Integer, ServerInstance> replicaToServerMap = new HashMap<>();
       int replicaIdForNoPartitionMetadata = 0;
 
       for (Map.Entry<String, String> entry : externalView.getStateMap(segmentName).entrySet()) {
@@ -151,10 +152,10 @@ public class PartitionAwareOfflineRoutingTableBuilder extends BasePartitionAware
             && !instancePruner.isInactive(serverName)) {
           // If there's no partition number in the metadata, assign replica id sequentially.
           if (partitionId == NO_PARTITION_NUMBER) {
-            replicaToServerMap.put(replicaIdForNoPartitionMetadata++, serverName);
+            replicaToServerMap.put(replicaIdForNoPartitionMetadata++, ServerInstance.forInstanceName(serverName));
           } else {
             int replicaId = partitionToServerToReplicaMap.get(partitionId).get(serverName);
-            replicaToServerMap.put(replicaId, serverName);
+            replicaToServerMap.put(replicaId, ServerInstance.forInstanceName(serverName));
           }
         }
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/RoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/RoutingTableBuilder.java
@@ -29,6 +29,7 @@ import org.apache.pinot.broker.routing.RoutingTableLookupRequest;
 import org.apache.pinot.broker.routing.selector.SegmentSelector;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.ServerInstance;
 
 
 /**
@@ -54,10 +55,10 @@ public interface RoutingTableBuilder {
    * TODO: we need to consider relocating segment selector into the routing table builder instead of passing it
    * from outside.
    */
-  Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector);
+  Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector);
 
   /**
    * Get all pre-computed routing tables.
    */
-  List<Map<String, List<String>>> getRoutingTables();
+  List<Map<ServerInstance, List<String>>> getRoutingTables();
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.common.config.TagNameUtils;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants.Broker;
 import org.apache.pinot.common.utils.CommonConstants.Helix;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
@@ -138,7 +139,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
     assertTrue(routing.routingTableExists(REALTIME_TABLE_NAME));
 
     RoutingTableLookupRequest routingTableLookupRequest = new RoutingTableLookupRequest(OFFLINE_TABLE_NAME);
-    Map<String, List<String>> routingTable = routing.getRoutingTable(routingTableLookupRequest);
+    Map<ServerInstance, List<String>> routingTable = routing.getRoutingTable(routingTableLookupRequest);
     assertEquals(routingTable.size(), NUM_SERVERS);
     assertEquals(routingTable.values().iterator().next().size(), NUM_OFFLINE_SEGMENTS);
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RandomRoutingTableTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RandomRoutingTableTest.java
@@ -35,6 +35,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableConfig.Builder;
 import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -65,7 +66,7 @@ public class RandomRoutingTableTest {
     routing.markDataResourceOnline(generateTableConfig(tableName), externalView, instanceConfigs);
 
     for (int i = 0; i < NUM_ROUNDS; i++) {
-      Map<String, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(tableName));
+      Map<ServerInstance, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(tableName));
       Assert.assertEquals(routingTable.size(), numServersInEV);
       int numSegments = 0;
       for (List<String> segmentsForServer : routingTable.values()) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RoutingTableTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RoutingTableTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 import org.apache.pinot.common.utils.HLCSegmentName;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -150,7 +151,7 @@ public class RoutingTableTest {
 
   private void assertResourceRequest(HelixExternalViewBasedRouting routing, String resource, String expectedSegmentList,
       int expectedNumSegment) {
-    Map<String, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(resource));
+    Map<ServerInstance, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(resource));
     List<String> selectedSegments = new ArrayList<>();
     for (List<String> segmentsForServer : routingTable.values()) {
       selectedSegments.addAll(segmentsForServer);
@@ -257,7 +258,7 @@ public class RoutingTableTest {
 
   private void assertResourceRequest(HelixExternalViewBasedRouting routing, String resource,
       String[] expectedSegmentLists, int expectedNumSegment) {
-    Map<String, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(resource));
+    Map<ServerInstance, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(resource));
     List<String> selectedSegments = new ArrayList<>();
     for (List<String> segmentsForServer : routingTable.values()) {
       selectedSegments.addAll(segmentsForServer);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilderTest.java
@@ -29,6 +29,7 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.broker.routing.RoutingTableLookupRequest;
 import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.response.ServerInstance;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -50,13 +51,13 @@ public class BalancedRandomRoutingTableBuilderTest {
 
     // Build routing table
     routingTableBuilder.computeOnExternalViewChange("dummy", externalView, instanceConfigList);
-    List<Map<String, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
+    List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
 
     // Check that at least two routing tables are different
-    Iterator<Map<String, List<String>>> routingTableIterator = routingTables.iterator();
-    Map<String, List<String>> previous = routingTableIterator.next();
+    Iterator<Map<ServerInstance, List<String>>> routingTableIterator = routingTables.iterator();
+    Map<ServerInstance, List<String>> previous = routingTableIterator.next();
     while (routingTableIterator.hasNext()) {
-      Map<String, List<String>> current = routingTableIterator.next();
+      Map<ServerInstance, List<String>> current = routingTableIterator.next();
       if (!current.equals(previous)) {
         return;
       }
@@ -83,7 +84,7 @@ public class BalancedRandomRoutingTableBuilderTest {
     // Build routing table
     routingTableBuilder.computeOnExternalViewChange("dummy", externalView, instanceConfigList);
     RoutingTableLookupRequest request = new RoutingTableLookupRequest(tableNameWithType);
-    Map<String, List<String>> routingTable = routingTableBuilder.getRoutingTable(request, null);
+    Map<ServerInstance, List<String>> routingTable = routingTableBuilder.getRoutingTable(request, null);
 
     Set<String> segmentsInRoutingTable = new HashSet<>();
     for (List<String> segments : routingTable.values()) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/HighLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/HighLevelConsumerRoutingTableBuilderTest.java
@@ -30,6 +30,7 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.broker.routing.RoutingTableLookupRequest;
 import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.HLCSegmentName;
 import org.testng.Assert;
@@ -99,7 +100,7 @@ public class HighLevelConsumerRoutingTableBuilderTest {
       // Check if the routing table result is correct
       for (int run = 0; run < MAX_NUM_GROUPS * 10; run++) {
         RoutingTableLookupRequest request = new RoutingTableLookupRequest(tableNameWithType);
-        Map<String, List<String>> routingTable = routingTableBuilder.getRoutingTable(request, null);
+        Map<ServerInstance, List<String>> routingTable = routingTableBuilder.getRoutingTable(request, null);
         Set<String> coveredSegments = new HashSet<>();
         for (List<String> segmentsForServer : routingTable.values()) {
           coveredSegments.addAll(segmentsForServer);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilderTest.java
@@ -30,6 +30,7 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -135,13 +136,13 @@ public class LowLevelConsumerRoutingTableBuilderTest {
       long startTime = System.nanoTime();
       routingTableBuilder.computeOnExternalViewChange("table_REALTIME", externalView, instanceConfigs);
 
-      List<Map<String, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
+      List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
 
       long endTime = System.nanoTime();
       totalNanos += endTime - startTime;
 
       // Check that all routing tables generated match all segments, with no duplicates
-      for (Map<String, List<String>> routingTable : routingTables) {
+      for (Map<ServerInstance, List<String>> routingTable : routingTables) {
         Set<String> assignedSegments = new HashSet<>();
 
         for (List<String> segmentsForServer : routingTable.values()) {
@@ -198,8 +199,8 @@ public class LowLevelConsumerRoutingTableBuilderTest {
     externalView.setState(consumingSegment2, instance2, RealtimeSegmentOnlineOfflineStateModel.CONSUMING);
 
     routingTableBuilder.computeOnExternalViewChange(realtimeTableName, externalView, instanceConfigs);
-    List<Map<String, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
-    for (Map<String, List<String>> routingTable : routingTables) {
+    List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       ArrayList<String> segmentsInRoutingTable = new ArrayList<>();
       for (List<String> segmentsForServer : routingTable.values()) {
         segmentsInRoutingTable.addAll(segmentsForServer);
@@ -248,22 +249,22 @@ public class LowLevelConsumerRoutingTableBuilderTest {
     }
 
     routingTableBuilder.computeOnExternalViewChange(rawTableName, externalView, instanceConfigs);
-    List<Map<String, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
-    for (Map<String, List<String>> routingTable : routingTables) {
+    List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       Assert.assertTrue(routingTable.isEmpty());
     }
 
     instanceConfig.getRecord().setSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS, "false");
     routingTableBuilder.computeOnExternalViewChange(rawTableName, externalView, instanceConfigs);
     routingTables = routingTableBuilder.getRoutingTables();
-    for (Map<String, List<String>> routingTable : routingTables) {
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       Assert.assertFalse(routingTable.isEmpty());
     }
 
     instanceConfig.getRecord().setSimpleField(CommonConstants.Helix.QUERIES_DISABLED, "true");
     routingTableBuilder.computeOnExternalViewChange(rawTableName, externalView, instanceConfigs);
     routingTables = routingTableBuilder.getRoutingTables();
-    for (Map<String, List<String>> routingTable : routingTables) {
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       Assert.assertTrue(routingTable.isEmpty());
     }
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.testng.Assert;
@@ -116,7 +117,7 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
 
       // Check the query that requires to scan all segment.
       String countStarQuery = "select count(*) from myTable";
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
 
       // Check that the number of servers picked are always equal or less than the number of servers
@@ -217,10 +218,10 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
     // Compute routing table and this should not throw null pointer exception
     routingTableBuilder.computeOnExternalViewChange(OFFLINE_TABLE_NAME, newExternalView, instanceConfigs);
 
-    Set<String> servers = new HashSet<>();
+    Set<ServerInstance> servers = new HashSet<>();
     for (int i = 0; i < 100; i++) {
       String countStarQuery = "select count(*) from " + OFFLINE_TABLE_NAME;
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
       Assert.assertEquals(routingTable.keySet().size(), 1);
       servers.add(routingTable.keySet().iterator().next());
@@ -278,10 +279,10 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
     RoutingTableBuilder routingTableBuilder =
         buildPartitionAwareOfflineRoutingTableBuilder(fakePropertyStore, tableConfig, externalView, instanceConfigs);
 
-    Set<String> servers = new HashSet<>();
+    Set<ServerInstance> servers = new HashSet<>();
     for (int i = 0; i < 100; i++) {
       String countStarQuery = "select count(*) from " + OFFLINE_TABLE_NAME;
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
       Assert.assertEquals(routingTable.keySet().size(), 1);
       servers.add(routingTable.keySet().iterator().next());

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
@@ -104,7 +105,7 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
 
       // Check the query that requires to scan all segment.
       String countStarQuery = "select count(*) from myTable";
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
 
       // Check that all segments are covered exactly for once.
@@ -181,7 +182,7 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
 
     // Check the query that requires to scan all segment.
     String countStarQuery = "select count(*) from myTable";
-    Map<String, List<String>> routingTable =
+    Map<ServerInstance, List<String>> routingTable =
         routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
 
     // Check that all segments are covered exactly for once.
@@ -254,10 +255,10 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
     // Compute routing table
     routingTableBuilder.computeOnExternalViewChange(REALTIME_TABLE_NAME, newExternalView, instanceConfigs);
 
-    Set<String> servers = new HashSet<>();
+    Set<ServerInstance> servers = new HashSet<>();
     for (int i = 0; i < 100; i++) {
       String countStarQuery = "select count(*) from " + REALTIME_TABLE_NAME;
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
       Assert.assertEquals(routingTable.keySet().size(), 1);
       servers.addAll(routingTable.keySet());

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/ServerInstance.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/ServerInstance.java
@@ -144,6 +144,11 @@ public class ServerInstance {
     return _port;
   }
 
+  public String getInstanceName() {
+    return toString();
+  }
+
+
   public ServerInstance withSeq(int seq) {
     return new ServerInstance(_hostName, _shortHostName, _port, seq);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/ServerInstance.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/ServerInstance.java
@@ -45,10 +45,12 @@ public class ServerInstance {
 
   private static final ConcurrentHashMap<String, HostNamePair> HOST_NAME_MAP = new ConcurrentHashMap<>();
 
+  private final String _instanceName;
   /** Host-name where the service is running **/
   private final String _hostName;
 
   private final String _shortHostName;
+
 
   /** Service Port **/
   private final int _port;
@@ -63,22 +65,33 @@ public class ServerInstance {
   }
 
   public ServerInstance(String name, int port) {
-    this(name, port, 0);
+    this(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE + NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + name
+        + NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + port, name, port);
+  }
+
+  public ServerInstance(String instanceName, String name, int port) {
+    this(instanceName, name, port, 0);
   }
 
   public ServerInstance(String name, int port, int seq) {
+    this(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE + NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + name
+        + NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + port, name, port, seq);
+  }
+  public ServerInstance(String instanceName, String name, int port, int seq) {
     HostNamePair hostNamePair = HOST_NAME_MAP.computeIfAbsent(name, key -> {
       String hostName = getHostName(name);
       String shortHostName = getShortHostName(hostName);
       return new HostNamePair(hostName, shortHostName);
     });
+    _instanceName = instanceName;
     _hostName = hostNamePair._hostName;
     _shortHostName = hostNamePair._shortHostName;
     _port = port;
     _seq = seq;
   }
 
-  private ServerInstance(String hostName, String shortHostName, int port, int seq) {
+  private ServerInstance(String instanceName, String hostName, String shortHostName, int port, int seq) {
+    _instanceName = instanceName;
     _hostName = hostName;
     _shortHostName = shortHostName;
     _port = port;
@@ -91,7 +104,7 @@ public class ServerInstance {
   public static ServerInstance forInstanceName(String instanceName) {
     String[] parts = instanceName.split(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)[1]
         .split(NAME_PORT_DELIMITER_FOR_INSTANCE_NAME);
-    return new ServerInstance(parts[0], Integer.parseInt(parts[1]));
+    return new ServerInstance(instanceName, parts[0], Integer.parseInt(parts[1]));
   }
 
   /**
@@ -145,12 +158,12 @@ public class ServerInstance {
   }
 
   public String getInstanceName() {
-    return toString();
+    return _instanceName;
   }
 
 
   public ServerInstance withSeq(int seq) {
-    return new ServerInstance(_hostName, _shortHostName, _port, seq);
+    return new ServerInstance(_instanceName, _hostName, _shortHostName, _port, seq);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.InstanceRequest;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 import org.apache.pinot.common.utils.DataTable;
 import org.slf4j.Logger;
@@ -55,8 +56,8 @@ public class QueryRouter {
   }
 
   public AsyncQueryResponse submitQuery(long requestId, String rawTableName,
-      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<String, List<String>> offlineRoutingTable,
-      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<String, List<String>> realtimeRoutingTable,
+      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable,
       long timeoutMs) {
     assert offlineBrokerRequest != null || realtimeBrokerRequest != null;
 
@@ -64,16 +65,18 @@ public class QueryRouter {
     Map<Server, InstanceRequest> requestMap = new HashMap<>();
     if (offlineBrokerRequest != null) {
       assert offlineRoutingTable != null;
-      for (Map.Entry<String, List<String>> entry : offlineRoutingTable.entrySet()) {
-        Server server = new Server(entry.getKey(), TableType.OFFLINE);
+      for (Map.Entry<ServerInstance, List<String>> entry : offlineRoutingTable.entrySet()) {
+        ServerInstance serverInstance = entry.getKey();
+        Server server = new Server(serverInstance.getHostname(), serverInstance.getPort(), TableType.OFFLINE);
         InstanceRequest instanceRequest = getInstanceRequest(requestId, offlineBrokerRequest, entry.getValue());
         requestMap.put(server, instanceRequest);
       }
     }
     if (realtimeBrokerRequest != null) {
       assert realtimeRoutingTable != null;
-      for (Map.Entry<String, List<String>> entry : realtimeRoutingTable.entrySet()) {
-        Server server = new Server(entry.getKey(), TableType.REALTIME);
+      for (Map.Entry<ServerInstance, List<String>> entry : realtimeRoutingTable.entrySet()) {
+        ServerInstance serverInstance = entry.getKey();
+        Server server = new Server(serverInstance.getHostname(), serverInstance.getPort(), TableType.REALTIME);
         InstanceRequest instanceRequest = getInstanceRequest(requestId, realtimeBrokerRequest, entry.getValue());
         requestMap.put(server, instanceRequest);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/Server.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/Server.java
@@ -53,6 +53,12 @@ public class Server {
     _tableType = tableType;
   }
 
+  public Server(String hostName, int port, TableType tableType) {
+    _hostName = hostName;
+    _port = port;
+    _tableType = tableType;
+  }
+
   public String getHostName() {
     return _hostName;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRouterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRouterTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.common.datatable.DataTableImplV2;
@@ -39,8 +40,8 @@ public class QueryRouterTest {
   private static final Server OFFLINE_SERVER = new Server(SERVER_INSTANCE_NAME, TableType.OFFLINE);
   private static final Server REALTIME_SERVER = new Server(SERVER_INSTANCE_NAME, TableType.REALTIME);
   private static final BrokerRequest BROKER_REQUEST = new BrokerRequest();
-  private static final Map<String, List<String>> ROUTING_TABLE =
-      Collections.singletonMap(SERVER_INSTANCE_NAME, Collections.emptyList());
+  private static final Map<ServerInstance, List<String>> ROUTING_TABLE =
+      Collections.singletonMap(ServerInstance.forInstanceName(SERVER_INSTANCE_NAME), Collections.emptyList());
 
   private QueryRouter _queryRouter;
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -201,7 +201,7 @@ public class Quickstart {
     printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q5)));
     printStatus(Color.GREEN, "***************************************************");
 
-    printStatus(Color.GREEN, "You can always go to http://localhost:9000/query/ to play around in the query console");
+    printStatus(Color.GREEN, "You can always go to http://localhost:9000/query to play around in the query console");
   }
 
   public static void main(String[] args)

--- a/pinot-transport/src/main/java/org/apache/pinot/transport/config/PerTableRoutingConfig.java
+++ b/pinot-transport/src/main/java/org/apache/pinot/transport/config/PerTableRoutingConfig.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.common.response.ServerInstance;
 
 
 /**
@@ -125,10 +126,10 @@ public class PerTableRoutingConfig {
    *
    * @return
    */
-  public Map<String, List<String>> buildRequestRoutingMap() {
-    Map<String, List<String>> resultMap = new HashMap<>();
+  public Map<ServerInstance, List<String>> buildRequestRoutingMap() {
+    Map<ServerInstance, List<String>> resultMap = new HashMap<>();
     for (String serverName : _defaultServers) {
-      resultMap.put(serverName, Collections.singletonList("default"));
+      resultMap.put(ServerInstance.forInstanceName(serverName), Collections.singletonList("default"));
     }
     return resultMap;
   }

--- a/pinot-transport/src/main/java/org/apache/pinot/transport/scattergather/ScatterGatherImpl.java
+++ b/pinot-transport/src/main/java/org/apache/pinot/transport/scattergather/ScatterGatherImpl.java
@@ -96,14 +96,14 @@ public class ScatterGatherImpl implements ScatterGather {
       ScatterGatherStats scatterGatherStats, Boolean isOfflineTable, BrokerMetrics brokerMetrics)
       throws InterruptedException {
     ScatterGatherRequest scatterGatherRequest = scatterGatherRequestContext._request;
-    Map<String, List<String>> routingTable = scatterGatherRequest.getRoutingTable();
+    Map<ServerInstance, List<String>> routingTable = scatterGatherRequest.getRoutingTable();
     CountDownLatch requestDispatchLatch = new CountDownLatch(routingTable.size());
 
     // async checkout of connections and then dispatch of request
     List<SingleRequestHandler> handlers = new ArrayList<>(routingTable.size());
 
-    for (Entry<String, List<String>> entry : routingTable.entrySet()) {
-      ServerInstance serverInstance = ServerInstance.forInstanceName(entry.getKey());
+    for (Entry<ServerInstance, List<String>> entry : routingTable.entrySet()) {
+      ServerInstance serverInstance = entry.getKey();
       String shortServerName = serverInstance.getShortHostName();
       if (isOfflineTable != null) {
         if (isOfflineTable) {

--- a/pinot-transport/src/main/java/org/apache/pinot/transport/scattergather/ScatterGatherRequest.java
+++ b/pinot-transport/src/main/java/org/apache/pinot/transport/scattergather/ScatterGatherRequest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.transport.scattergather;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.response.ServerInstance;
 
 
 /**
@@ -35,7 +36,7 @@ public interface ScatterGatherRequest {
    *
    * @return Map from server to list of segments
    */
-  Map<String, List<String>> getRoutingTable();
+  Map<ServerInstance, List<String>> getRoutingTable();
 
   /**
    * Get the request to be sent to the server.

--- a/pinot-transport/src/test/java/org/apache/pinot/transport/perf/ScatterGatherPerfClient.java
+++ b/pinot-transport/src/test/java/org/apache/pinot/transport/perf/ScatterGatherPerfClient.java
@@ -388,7 +388,7 @@ public class ScatterGatherPerfClient implements Runnable {
   public static class SimpleScatterGatherRequest implements ScatterGatherRequest {
     private final byte[] _brokerRequest;
     private final long _requestId;
-    private final Map<String, List<String>> _pgToServersMap;
+    private final Map<ServerInstance, List<String>> _pgToServersMap;
 
     public SimpleScatterGatherRequest(byte[] q, PerTableRoutingConfig routingConfig, long requestId) {
       _brokerRequest = q;
@@ -397,7 +397,7 @@ public class ScatterGatherPerfClient implements Runnable {
     }
 
     @Override
-    public Map<String, List<String>> getRoutingTable() {
+    public Map<ServerInstance, List<String>> getRoutingTable() {
       return _pgToServersMap;
     }
 

--- a/pinot-transport/src/test/java/org/apache/pinot/transport/scattergather/ScatterGatherTest.java
+++ b/pinot-transport/src/test/java/org/apache/pinot/transport/scattergather/ScatterGatherTest.java
@@ -100,7 +100,7 @@ public class ScatterGatherTest {
     Assert.assertEquals(serverToResponseMap.size(), NUM_SERVERS);
     for (int i = 0; i < NUM_SERVERS; i++) {
       Assert.assertEquals(new String(serverToResponseMap.get(serverInstances[i])),
-          routingTable.get(serverNames[i]).get(0));
+          routingTable.get(serverInstances[i]).get(0));
     }
 
     // Should get empty error map
@@ -162,7 +162,7 @@ public class ScatterGatherTest {
     Assert.assertEquals(serverToResponseMap.size(), NUM_SERVERS - 1);
     for (int i = 1; i < NUM_SERVERS; i++) {
       Assert.assertEquals(new String(serverToResponseMap.get(serverInstances[i])),
-          routingTable.get(serverNames[i]).get(0));
+          routingTable.get(serverInstances[i]).get(0));
     }
 
     // Should get error from the timeout server
@@ -226,7 +226,7 @@ public class ScatterGatherTest {
     Assert.assertEquals(serverToResponseMap.size(), NUM_SERVERS - 1);
     for (int i = 1; i < NUM_SERVERS; i++) {
       Assert.assertEquals(new String(serverToResponseMap.get(serverInstances[i])),
-          routingTable.get(serverNames[i]).get(0));
+          routingTable.get(serverInstances[i]).get(0));
     }
 
     // Should get error from the error server

--- a/pinot-transport/src/test/java/org/apache/pinot/transport/scattergather/ScatterGatherTest.java
+++ b/pinot-transport/src/test/java/org/apache/pinot/transport/scattergather/ScatterGatherTest.java
@@ -66,7 +66,7 @@ public class ScatterGatherTest {
     NettyServer[] nettyServers = new NettyServer[NUM_SERVERS];
     String[] serverNames = new String[NUM_SERVERS];
     ServerInstance[] serverInstances = new ServerInstance[NUM_SERVERS];
-    Map<String, List<String>> routingTable = new HashMap<>(NUM_SERVERS);
+    Map<ServerInstance, List<String>> routingTable = new HashMap<>(NUM_SERVERS);
 
     for (int i = 0; i < NUM_SERVERS; i++) {
       int serverPort = BASE_SERVER_PORT + i;
@@ -77,7 +77,7 @@ public class ScatterGatherTest {
           + ServerInstance.NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + serverPort;
       serverNames[i] = serverName;
       serverInstances[i] = ServerInstance.forInstanceName(serverName);
-      routingTable.put(serverName, Collections.singletonList("segment_" + i));
+      routingTable.put(serverInstances[i], Collections.singletonList("segment_" + i));
     }
 
     // Setup client
@@ -122,7 +122,7 @@ public class ScatterGatherTest {
     NettyServer[] nettyServers = new NettyServer[NUM_SERVERS];
     String[] serverNames = new String[NUM_SERVERS];
     ServerInstance[] serverInstances = new ServerInstance[NUM_SERVERS];
-    Map<String, List<String>> routingTable = new HashMap<>(NUM_SERVERS);
+    Map<ServerInstance, List<String>> routingTable = new HashMap<>(NUM_SERVERS);
 
     for (int i = 0; i < NUM_SERVERS; i++) {
       int serverPort = BASE_SERVER_PORT + i;
@@ -139,7 +139,7 @@ public class ScatterGatherTest {
           + ServerInstance.NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + serverPort;
       serverNames[i] = serverName;
       serverInstances[i] = ServerInstance.forInstanceName(serverName);
-      routingTable.put(serverName, Collections.singletonList("segment_" + i));
+      routingTable.put(serverInstances[i], Collections.singletonList("segment_" + i));
     }
 
     // Setup client
@@ -185,7 +185,7 @@ public class ScatterGatherTest {
     NettyServer[] nettyServers = new NettyServer[NUM_SERVERS];
     String[] serverNames = new String[NUM_SERVERS];
     ServerInstance[] serverInstances = new ServerInstance[NUM_SERVERS];
-    Map<String, List<String>> routingTable = new HashMap<>(NUM_SERVERS);
+    Map<ServerInstance, List<String>> routingTable = new HashMap<>(NUM_SERVERS);
 
     for (int i = 0; i < NUM_SERVERS; i++) {
       int serverPort = BASE_SERVER_PORT + i;
@@ -203,7 +203,7 @@ public class ScatterGatherTest {
           + ServerInstance.NAME_PORT_DELIMITER_FOR_INSTANCE_NAME + serverPort;
       serverNames[i] = serverName;
       serverInstances[i] = ServerInstance.forInstanceName(serverName);
-      routingTable.put(serverName, Collections.singletonList("segment_" + i));
+      routingTable.put(serverInstances[i], Collections.singletonList("segment_" + i));
     }
 
     // Setup client
@@ -257,16 +257,16 @@ public class ScatterGatherTest {
   }
 
   private static class TestScatterGatherRequest implements ScatterGatherRequest {
-    private final Map<String, List<String>> _routingTable;
+    private final Map<ServerInstance, List<String>> _routingTable;
     private final long _timeoutMs;
 
-    public TestScatterGatherRequest(Map<String, List<String>> routingTable, long timeoutMs) {
+    public TestScatterGatherRequest(Map<ServerInstance, List<String>> routingTable, long timeoutMs) {
       _routingTable = routingTable;
       _timeoutMs = timeoutMs;
     }
 
     @Override
-    public Map<String, List<String>> getRoutingTable() {
+    public Map<ServerInstance, List<String>> getRoutingTable() {
       return _routingTable;
     }
 


### PR DESCRIPTION
Pre-cursor to #4525.

Currently, RoutingTable is represented as Map<String, List<String>>. This is a map of serverInstanceName to list of segments on that server. The rest of the code derives the host and port by parsing serverInstanceName assuming that it's of the Server_host_port. 

This PR replaces serverInstanceName with a concrete ServerInstance object - no change in functionality.

In the next PR, we will construct the ServerInstance using the real host and port from the Helix Instance Config.

Testing: Ran quick start, offline, realtime and hybrid integration tests
