### PR TITLE
[TE] Set non additive flag for Pinot dataset

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
@@ -45,17 +45,17 @@ import org.apache.pinot.common.data.TimeGranularitySpec;
 import org.apache.pinot.thirdeye.datalayer.bao.AlertConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.MetricConfigManager;
-import org.apache.pinot.thirdeye.datalayer.dto.AlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.DatasetConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MetricConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.pojo.MetricConfigBean;
 import org.apache.pinot.thirdeye.datalayer.pojo.MetricConfigBean.DimensionAsMetricProperties;
-import org.apache.pinot.thirdeye.datalayer.util.Predicate;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.datasource.MetadataSourceConfig;
 import org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.thirdeye.auto.onboard.ConfigGenerator.*;
 
 /**
  * This is a service to onboard datasets automatically to thirdeye from pinot
@@ -210,6 +210,7 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
     checkMetricChanges(dataset, datasetConfig, schema);
     checkTimeFieldChanges(datasetConfig, schema);
     appendNewCustomConfigs(datasetConfig, customConfigs);
+    checkNonAdditive(datasetConfig);
     datasetConfig.setActive(true);
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/ConfigGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/ConfigGenerator.java
@@ -41,6 +41,8 @@ public class ConfigGenerator {
 
   private static final String PDT_TIMEZONE = "US/Pacific";
   private static final String BYTES_STRING = "BYTES";
+  private static final String NON_ADDITIVE = "non_additive";
+  private static final String PINOT_PRE_AGGREGATED_KEYWORD = "*";
 
   public static void setTimeSpecs(DatasetConfigDTO datasetConfigDTO, TimeGranularitySpec timeSpec) {
     datasetConfigDTO.setTimeColumn(timeSpec.getName());
@@ -71,6 +73,7 @@ public class ConfigGenerator {
     setTimeSpecs(datasetConfigDTO, timeSpec);
     datasetConfigDTO.setDataSource(PinotThirdEyeDataSource.DATA_SOURCE_NAME);
     datasetConfigDTO.setProperties(customConfigs);
+    checkNonAdditive(datasetConfigDTO);
     return datasetConfigDTO;
   }
 
@@ -92,6 +95,16 @@ public class ConfigGenerator {
     return expectedDelay;
   }
 
+  /**
+   * Check if the dataset is non-additive. If it is, set the additive flag to false and set the pre-aggregated keyword.
+   * @param dataset the dataset DTO to check
+   */
+  static void checkNonAdditive(DatasetConfigDTO dataset) {
+    if (dataset.isAdditive() && dataset.getDataset().endsWith(NON_ADDITIVE)) {
+      dataset.setAdditive(false);
+      dataset.setPreAggregatedKeyword(PINOT_PRE_AGGREGATED_KEYWORD);
+    }
+  }
 
   public static MetricConfigDTO generateMetricConfig(MetricFieldSpec metricFieldSpec, String dataset) {
     MetricConfigDTO metricConfigDTO = new MetricConfigDTO();


### PR DESCRIPTION
The nonadditive flag was not set for Pinot non-additive dataset when importing the metric, which can cause the value to be wrong in ThirdEye. This PR fixes the issue.