### PR TITLE
Revert "Fix controller download segment api on non-local PinotFS."

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -30,7 +30,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.URI;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -53,7 +52,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -66,7 +64,6 @@ import org.apache.pinot.common.segment.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.JsonUtils;
-import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.ControllerConf;
@@ -82,8 +79,6 @@ import org.apache.pinot.core.crypt.PinotCrypter;
 import org.apache.pinot.core.crypt.PinotCrypterFactory;
 import org.apache.pinot.core.metadata.DefaultMetadataExtractor;
 import org.apache.pinot.core.metadata.MetadataExtractorFactory;
-import org.apache.pinot.filesystem.PinotFS;
-import org.apache.pinot.filesystem.PinotFSFactory;
 import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -98,7 +93,6 @@ public class PinotSegmentUploadRestletResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotSegmentUploadRestletResource.class);
   private static final String TMP_DIR_PREFIX = "tmp-";
   private static final String ENCRYPTED_SUFFIX = "_encrypted";
-  private static final String URL_ENCODING_SCHEME = "UTF-8";
 
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
@@ -166,7 +160,7 @@ public class PinotSegmentUploadRestletResource {
   public Response downloadSegment(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
-      @Context HttpHeaders httpHeaders) throws Exception {
+      @Context HttpHeaders httpHeaders) {
     // Validate data access
     boolean hasDataAccess;
     try {
@@ -188,34 +182,14 @@ public class PinotSegmentUploadRestletResource {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }
     segmentName = URIUtils.decode(segmentName);
-    final URI segmentFileURI = URIUtils.getUri(provider.getBaseDataDirURI().toString(), tableName, segmentName);
-    PinotFS pinotFS = PinotFSFactory.create(provider.getBaseDataDirURI().getScheme());
-
-    if (!pinotFS.exists(segmentFileURI)) {
+    File dataFile = new File(provider.getBaseDataDir(), String.join(File.separator, tableName, segmentName));
+    if (!dataFile.exists()) {
       throw new ControllerApplicationException(LOGGER,
-          "Segment " + segmentName + " or table " + tableName + " not found in " + segmentFileURI.toString(), Response.Status.NOT_FOUND);
+          "Segment " + segmentName + " or table " + tableName + " not found", Response.Status.NOT_FOUND);
     }
-    Response.ResponseBuilder builder = Response.ok();
-    File segmentFile;
-    // If the segment file is local, just use it as the return entity; otherwise copy it from remote to local first.
-    if (CommonConstants.Segment.LOCAL_SEGMENT_SCHEME.equals(segmentFileURI.getScheme())) {
-      segmentFile = new File(provider.getBaseDataDir(), StringUtil.join("/", tableName, segmentName));
-      builder.entity(segmentFile);
-    } else {
-      segmentFile = new File(StringUtil.join("/", _controllerConf.getLocalTempDir(), tableName,
-          StringUtil.join("_", segmentName, String.valueOf(System.nanoTime()))));
-      pinotFS.copyToLocalFile(segmentFileURI, segmentFile);
-      // Streaming in the tmp file and delete it afterward.
-      builder.entity((StreamingOutput) output -> {
-        try {
-          Files.copy(segmentFile.toPath(), output);
-        } finally {
-          FileUtils.deleteQuietly(segmentFile);
-        }
-      });
-    }
-    builder.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + segmentFile.getName());
-    builder.header(HttpHeaders.CONTENT_LENGTH, segmentFile.length());
+    Response.ResponseBuilder builder = Response.ok(dataFile);
+    builder.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + dataFile.getName());
+    builder.header(HttpHeaders.CONTENT_LENGTH, dataFile.length());
     return builder.build();
   }
 


### PR DESCRIPTION
Reverts apache/incubator-pinot#4757

The Travis tests did not actually pass for this commit (it can be seen in the commits list https://github.com/apache/incubator-pinot/commits/master)
Seems something was off with the Travis job. The tests that passed on this PR: https://travis-ci.org/apache/incubator-pinot/builds/604817613?utm_source=github_status&utm_medium=notification were actually Thirdeye tests.
The test failures have broken the build, hence reverting this.
Sorry about that @chenboat. Would you please take a look at your commit again and the failing tests? Thanks!