### PR TITLE
Enhance RoutingTable with ServerInstance

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -40,6 +40,7 @@ import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.transport.AsyncQueryResponse;
 import org.apache.pinot.core.transport.QueryRouter;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.ServerResponse;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 
@@ -70,8 +71,8 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
   @Override
   protected BrokerResponse processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
-      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<String, List<String>> offlineRoutingTable,
-      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<String, List<String>> realtimeRoutingTable,
+      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable,
       long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)
       throws Exception {
     assert offlineBrokerRequest != null || realtimeBrokerRequest != null;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
@@ -20,6 +20,8 @@ package org.apache.pinot.broker.routing;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.core.transport.ServerInstance;
 
 
 /**
@@ -28,27 +30,27 @@ import java.util.Map;
 public interface RoutingTable {
 
   /**
-   * Get the routing table (map from server to list of segments) based on the lookup request.
+   * Returns the routing table (map from server instance to list of segments hosted by the server) based on the lookup
+   * request.
    *
    * @param request Routing table lookup request
-   * @return Map from server to list of segments
+   * @return Map from server instance to list of segments hosted by the server
    */
-  Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request);
+  Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request);
 
   /**
-   * Return whether the routing table for the given table exists.
+   * Returns whether the routing table for the given table exists.
    *
-   * @param tableName Table name
+   * @param tableNameWithType Table name with type suffix
    * @return Whether the routing table exists
    */
-  boolean routingTableExists(String tableName);
+  boolean routingTableExists(String tableNameWithType);
 
   /**
-   * Dump a snapshot of all the routing tables for the given table.
+   * Dumps a snapshot of all the routing tables for the given table.
    *
-   * @param tableName Table name or null for all tables.
-   * @throws Exception
+   * @param tableName Table name (with or without type suffix) or null for all tables
    */
-  String dumpSnapshot(String tableName)
+  String dumpSnapshot(@Nullable String tableName)
       throws Exception;
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
@@ -22,12 +22,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.core.transport.ServerInstance;
 
 
 /**
@@ -46,16 +46,14 @@ public class BalancedRandomRoutingTableBuilder extends BaseRoutingTableBuilder {
     _numRoutingTables = configuration.getInt(NUM_ROUTING_TABLES_KEY, DEFAULT_NUM_ROUTING_TABLES);
   }
 
-  protected List<Map<String, List<String>>> computeRoutingTablesFromSegmentToServersMap(
-      Map<String, List<String>> segmentToServersMap) {
-    List<Map<String, List<String>>> routingTables = new ArrayList<>(_numRoutingTables);
-    Set<String> segmentsToQuery = segmentToServersMap.keySet();
-
+  @Override
+  protected List<Map<ServerInstance, List<String>>> computeRoutingTablesFromSegmentToServersMap(
+      Map<String, List<ServerInstance>> segmentToServersMap) {
+    List<Map<ServerInstance, List<String>>> routingTables = new ArrayList<>(_numRoutingTables);
     for (int i = 0; i < _numRoutingTables; i++) {
-      Map<String, List<String>> routingTable = new HashMap<>();
-      for (String segmentName : segmentsToQuery) {
-        List<String> servers = segmentToServersMap.get(segmentName);
-        routingTable.get(getServerWithLeastSegmentsAssigned(servers, routingTable)).add(segmentName);
+      Map<ServerInstance, List<String>> routingTable = new HashMap<>();
+      for (Map.Entry<String, List<ServerInstance>> entry : segmentToServersMap.entrySet()) {
+        assignSegmentToLeastAssignedServer(entry.getKey(), entry.getValue(), routingTable);
       }
       routingTables.add(routingTable);
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BasePartitionAwareRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BasePartitionAwareRoutingTableBuilder.java
@@ -37,6 +37,7 @@ import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +63,7 @@ public abstract class BasePartitionAwareRoutingTableBuilder implements RoutingTa
 
   // Map from segment name to map from replica id to server
   // Set variable as volatile so all threads can get the up-to-date map
-  protected volatile Map<String, Map<Integer, String>> _segmentToReplicaToServerMap;
+  protected volatile Map<String, Map<Integer, ServerInstance>> _segmentToReplicaToServerMap;
 
   // Cache for segment zk metadata to reduce the lookup to ZK store
   protected Map<String, SegmentZKMetadata> _segmentToZkMetadataMapping = new ConcurrentHashMap<>();
@@ -87,9 +88,10 @@ public abstract class BasePartitionAwareRoutingTableBuilder implements RoutingTa
   }
 
   @Override
-  public Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
+  public Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request,
+      SegmentSelector segmentSelector) {
     // Copy the reference for the current segment to replica to server mapping for snapshot
-    Map<String, Map<Integer, String>> segmentToReplicaToServerMap = _segmentToReplicaToServerMap;
+    Map<String, Map<Integer, ServerInstance>> segmentToReplicaToServerMap = _segmentToReplicaToServerMap;
 
     // Get all available segments for table
     Set<String> segmentsToQuery = segmentToReplicaToServerMap.keySet();
@@ -99,7 +101,7 @@ public abstract class BasePartitionAwareRoutingTableBuilder implements RoutingTa
       segmentsToQuery = segmentSelector.selectSegments(request, segmentsToQuery);
     }
 
-    Map<String, List<String>> routingTable = new HashMap<>();
+    Map<ServerInstance, List<String>> routingTable = new HashMap<>();
     SegmentPrunerContext prunerContext = new SegmentPrunerContext(request.getBrokerRequest());
 
     // Shuffle the replica group ids in order to satisfy:
@@ -119,19 +121,19 @@ public abstract class BasePartitionAwareRoutingTableBuilder implements RoutingTa
 
       if (!segmentPruned) {
         // 2b. Segment cannot be pruned. Assign the segment to a server based on the shuffled replica group ids
-        Map<Integer, String> replicaIdToServerMap = segmentToReplicaToServerMap.get(segmentName);
+        Map<Integer, ServerInstance> replicaIdToServerMap = segmentToReplicaToServerMap.get(segmentName);
 
-        String serverName = null;
+        ServerInstance serverInstance = null;
         for (int i = 0; i < _numReplicas; i++) {
-          serverName = replicaIdToServerMap.get(shuffledReplicaGroupIds[i]);
+          serverInstance = replicaIdToServerMap.get(shuffledReplicaGroupIds[i]);
           // If a server is found, update routing table for the current segment
-          if (serverName != null) {
+          if (serverInstance != null) {
             break;
           }
         }
 
-        if (serverName != null) {
-          routingTable.computeIfAbsent(serverName, k -> new ArrayList<>()).add(segmentName);
+        if (serverInstance != null) {
+          routingTable.computeIfAbsent(serverInstance, k -> new ArrayList<>()).add(segmentName);
         } else {
           // No server is found for this segment if the code reach here
 
@@ -145,7 +147,7 @@ public abstract class BasePartitionAwareRoutingTableBuilder implements RoutingTa
   }
 
   @Override
-  public List<Map<String, List<String>>> getRoutingTables() {
+  public List<Map<ServerInstance, List<String>>> getRoutingTables() {
     throw new UnsupportedOperationException("Partition aware routing table cannot be pre-computed");
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BaseRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BaseRoutingTableBuilder.java
@@ -36,7 +36,9 @@ import org.apache.pinot.common.config.RoutingConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
-import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,10 +56,10 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
 
   // Set variable as volatile so all threads can get the up-to-date routing tables
   // Routing tables are used for storing pre-computed routing table
-  protected volatile List<Map<String, List<String>>> _routingTables;
+  protected volatile List<Map<ServerInstance, List<String>>> _routingTables;
 
   // A mapping of segments to servers is used for dynamic routing table building process
-  protected volatile Map<String, List<String>> _segmentToServersMap;
+  protected volatile Map<String, List<ServerInstance>> _segmentToServersMap;
 
   @Override
   public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore,
@@ -69,33 +71,34 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
     if (routingConfig != null) {
       Map<String, String> routingOption = routingConfig.getRoutingTableBuilderOptions();
-      _enableDynamicComputing = Boolean.valueOf(routingOption.get(RoutingConfig.ENABLE_DYNAMIC_COMPUTING_KEY));
+      _enableDynamicComputing = Boolean.parseBoolean(routingOption.get(RoutingConfig.ENABLE_DYNAMIC_COMPUTING_KEY));
       if (_enableDynamicComputing) {
         LOGGER.info("Dynamic routing table computation is enabled for table {}", _tableName);
       }
     }
   }
 
-  protected static String getServerWithLeastSegmentsAssigned(List<String> servers,
-      Map<String, List<String>> routingTable) {
+  protected static void assignSegmentToLeastAssignedServer(String segmentName, List<ServerInstance> servers,
+      Map<ServerInstance, List<String>> routingTable) {
     Collections.shuffle(servers);
 
-    String selectedServer = null;
+    List<String> segmentsForLeastAssignedServer = null;
     int minNumSegmentsAssigned = Integer.MAX_VALUE;
-    for (String server : servers) {
-      List<String> segments = routingTable.get(server);
-      if (segments == null) {
-        routingTable.put(server, new ArrayList<>());
-        return server;
+    for (ServerInstance serverInstance : servers) {
+      List<String> segments = routingTable.computeIfAbsent(serverInstance, k -> new ArrayList<>());
+      int numSegmentsAssigned = segments.size();
+      if (numSegmentsAssigned == 0) {
+        segments.add(segmentName);
+        return;
       } else {
-        int numSegmentsAssigned = segments.size();
         if (numSegmentsAssigned < minNumSegmentsAssigned) {
           minNumSegmentsAssigned = numSegmentsAssigned;
-          selectedServer = server;
+          segmentsForLeastAssignedServer = segments;
         }
       }
     }
-    return selectedServer;
+    assert segmentsForLeastAssignedServer != null;
+    segmentsForLeastAssignedServer.add(segmentName);
   }
 
   /**
@@ -114,7 +117,7 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
   @Override
   public void computeOnExternalViewChange(String tableName, ExternalView externalView,
       List<InstanceConfig> instanceConfigs) {
-    Map<String, List<String>> segmentToServersMap =
+    Map<String, List<ServerInstance>> segmentToServersMap =
         computeSegmentToServersMapFromExternalView(externalView, instanceConfigs);
 
     if (_enableDynamicComputing) {
@@ -122,15 +125,15 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
       _segmentToServersMap = segmentToServersMap;
     } else {
       // Otherwise, we cache the pre-computed routing tables
-      List<Map<String, List<String>>> routingTables = computeRoutingTablesFromSegmentToServersMap(segmentToServersMap);
-      _routingTables = routingTables;
+      _routingTables = computeRoutingTablesFromSegmentToServersMap(segmentToServersMap);
     }
   }
 
-  public Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
+  public Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request,
+      SegmentSelector segmentSelector) {
     if (_enableDynamicComputing) {
       // Copy the pointer for snapshot since the pointer for segment to servers map can change at anytime
-      Map<String, List<String>> segmentToServersMap = _segmentToServersMap;
+      Map<String, List<ServerInstance>> segmentToServersMap = _segmentToServersMap;
 
       // Selecting segments only required for processing a query
       Set<String> segmentsToQuery = segmentToServersMap.keySet();
@@ -147,7 +150,7 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public List<Map<String, List<String>>> getRoutingTables() {
+  public List<Map<ServerInstance, List<String>>> getRoutingTables() {
     return _routingTables;
   }
 
@@ -158,14 +161,13 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
    * @param segmentsToQuery a list of segments that need to be processed for a particular query
    * @return a routing table
    */
-  public Map<String, List<String>> computeDynamicRoutingTable(Map<String, List<String>> segmentToServersMap,
-      Set<String> segmentsToQuery) {
-    Map<String, List<String>> routingTable = new HashMap<>();
+  public Map<ServerInstance, List<String>> computeDynamicRoutingTable(
+      Map<String, List<ServerInstance>> segmentToServersMap, Set<String> segmentsToQuery) {
+    Map<ServerInstance, List<String>> routingTable = new HashMap<>();
     for (String segmentName : segmentsToQuery) {
-      List<String> servers = segmentToServersMap.get(segmentName);
-      String selectedServer = servers.get(_random.nextInt(servers.size()));
-      List<String> segments = routingTable.computeIfAbsent(selectedServer, k -> new ArrayList<>());
-      segments.add(segmentName);
+      List<ServerInstance> servers = segmentToServersMap.get(segmentName);
+      ServerInstance selectedServer = servers.get(_random.nextInt(servers.size()));
+      routingTable.computeIfAbsent(selectedServer, k -> new ArrayList<>()).add(segmentName);
     }
     return routingTable;
   }
@@ -178,18 +180,22 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
    * @param instanceConfigs a list of instance config
    * @return a mapping of segment to servers
    */
-  protected Map<String, List<String>> computeSegmentToServersMapFromExternalView(ExternalView externalView,
+  protected Map<String, List<ServerInstance>> computeSegmentToServersMapFromExternalView(ExternalView externalView,
       List<InstanceConfig> instanceConfigs) {
-    Map<String, List<String>> segmentToServersMap = new HashMap<>();
-    RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigs);
-    for (String segmentName : externalView.getPartitionSet()) {
-      // List of servers that are active and are serving the segment
-      List<String> servers = new ArrayList<>();
-      for (Map.Entry<String, String> entry : externalView.getStateMap(segmentName).entrySet()) {
-        String serverName = entry.getKey();
-        if (entry.getValue().equals(CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.ONLINE)
-            && !instancePruner.isInactive(serverName)) {
-          servers.add(serverName);
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    Map<String, List<ServerInstance>> segmentToServersMap =
+        new HashMap<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
+    InstanceConfigManager instanceConfigManager = new InstanceConfigManager(instanceConfigs);
+    for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
+      String segmentName = entry.getKey();
+      Map<String, String> instanceStateMap = entry.getValue();
+      List<ServerInstance> servers = new ArrayList<>(instanceStateMap.size());
+      for (Map.Entry<String, String> instanceStateEntry : instanceStateMap.entrySet()) {
+        if (instanceStateEntry.getValue().equals(SegmentOnlineOfflineStateModel.ONLINE)) {
+          InstanceConfig instanceConfig = instanceConfigManager.getActiveInstanceConfig(instanceStateEntry.getKey());
+          if (instanceConfig != null) {
+            servers.add(new ServerInstance(instanceConfig));
+          }
         }
       }
       if (!servers.isEmpty()) {
@@ -208,6 +214,6 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
    * @param segmentToServersMap a mapping of segment to servers
    * @return a list of final routing tables
    */
-  protected abstract List<Map<String, List<String>>> computeRoutingTablesFromSegmentToServersMap(
-      Map<String, List<String>> segmentToServersMap);
+  protected abstract List<Map<ServerInstance, List<String>>> computeRoutingTablesFromSegmentToServersMap(
+      Map<String, List<ServerInstance>> segmentToServersMap);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/DefaultOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/DefaultOfflineRoutingTableBuilder.java
@@ -31,6 +31,7 @@ import org.apache.pinot.broker.routing.RoutingTableLookupRequest;
 import org.apache.pinot.broker.routing.selector.SegmentSelector;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,12 +127,13 @@ public class DefaultOfflineRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
+  public Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request,
+      SegmentSelector segmentSelector) {
     return _routingTableBuilder.getRoutingTable(request, segmentSelector);
   }
 
   @Override
-  public List<Map<String, List<String>>> getRoutingTables() {
+  public List<Map<ServerInstance, List<String>>> getRoutingTables() {
     return _routingTableBuilder.getRoutingTables();
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
@@ -32,6 +32,7 @@ import org.apache.pinot.broker.routing.selector.SegmentSelector;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.utils.SegmentName;
+import org.apache.pinot.core.transport.ServerInstance;
 
 
 /**
@@ -73,7 +74,8 @@ public class DefaultRealtimeRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector) {
+  public Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request,
+      SegmentSelector segmentSelector) {
     boolean forceLLC = false;
     boolean forceHLC = false;
     for (String routingOption : request.getRoutingOptions()) {
@@ -105,7 +107,7 @@ public class DefaultRealtimeRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public List<Map<String, List<String>>> getRoutingTables() {
+  public List<Map<ServerInstance, List<String>>> getRoutingTables() {
     if (_hasLLC) {
       return _realtimeLLCRoutingTableBuilder.getRoutingTables();
     } else if (_hasHLC) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilder.java
@@ -30,9 +30,10 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
-import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
 import org.apache.pinot.common.utils.LLCUtils;
 import org.apache.pinot.common.utils.SegmentName;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +67,7 @@ public class LowLevelConsumerRoutingTableBuilder extends GeneratorBasedRoutingTa
   }
 
   @Override
-  protected Map<String, List<String>> computeSegmentToServersMapFromExternalView(ExternalView externalView,
+  protected Map<String, List<ServerInstance>> computeSegmentToServersMapFromExternalView(ExternalView externalView,
       List<InstanceConfig> instanceConfigs) {
     // We build the segment to servers mapping here. What we want to do is to make sure that we uphold
     // the guarantees clients expect (no duplicate records, eventual consistency) and spreading the load as equally as
@@ -80,7 +81,7 @@ public class LowLevelConsumerRoutingTableBuilder extends GeneratorBasedRoutingTa
     // The upstream code in BaseRoutingTableGenerator will generate routing tables based on taking a subset of servers
     // if the cluster is large enough as well as ensure that the best routing tables are used for routing.
 
-    Map<String, List<String>> segmentToServersMap = new HashMap<>();
+    Map<String, List<ServerInstance>> segmentToServersMap = new HashMap<>();
 
     // 1. Gather all segments and group them by partition, sorted by sequence number
     Map<String, SortedSet<SegmentName>> sortedSegmentsByStreamPartition =
@@ -90,10 +91,7 @@ public class LowLevelConsumerRoutingTableBuilder extends GeneratorBasedRoutingTa
     Map<String, SegmentName> allowedSegmentInConsumingStateByPartition =
         LowLevelRoutingTableBuilderUtil.getAllowedConsumingStateSegments(externalView, sortedSegmentsByStreamPartition);
 
-    // 3. Sort all the segments to be used during assignment in ascending order of replicas
-
-    // PriorityQueue throws IllegalArgumentException when given a size of zero
-    RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigs);
+    InstanceConfigManager instanceConfigManager = new InstanceConfigManager(instanceConfigs);
 
     for (Map.Entry<String, SortedSet<SegmentName>> entry : sortedSegmentsByStreamPartition.entrySet()) {
       String partitionId = entry.getKey();
@@ -103,29 +101,19 @@ public class LowLevelConsumerRoutingTableBuilder extends GeneratorBasedRoutingTa
       SegmentName validConsumingSegment = allowedSegmentInConsumingStateByPartition.get(partitionId);
 
       for (SegmentName segmentName : segmentNames) {
-        List<String> validServers = new ArrayList<>();
+        List<ServerInstance> validServers = new ArrayList<>();
         String segmentNameStr = segmentName.getSegmentName();
-        Map<String, String> externalViewState = externalView.getStateMap(segmentNameStr);
+        Map<String, String> instanceStateMap = externalView.getStateMap(segmentNameStr);
 
-        for (Map.Entry<String, String> instanceAndStateEntry : externalViewState.entrySet()) {
-          String instance = instanceAndStateEntry.getKey();
-          String state = instanceAndStateEntry.getValue();
-
-          // Skip pruned replicas (shutting down or otherwise disabled)
-          if (instancePruner.isInactive(instance)) {
-            continue;
-          }
-
-          // Replicas in ONLINE state are always allowed
-          if (state.equalsIgnoreCase(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
-            validServers.add(instance);
-            continue;
-          }
-
-          // If the server is in CONSUMING status, the segment has to be match with the valid consuming segment
-          if (state.equals(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING)
-              && validConsumingSegment != null && segmentNameStr.equals(validConsumingSegment.getSegmentName())) {
-            validServers.add(instance);
+        for (Map.Entry<String, String> instanceStateEntry : instanceStateMap.entrySet()) {
+          String state = instanceStateEntry.getValue();
+          if (state.equals(RealtimeSegmentOnlineOfflineStateModel.ONLINE) || (
+              state.equals(RealtimeSegmentOnlineOfflineStateModel.CONSUMING) && validConsumingSegment != null
+                  && segmentNameStr.equals(validConsumingSegment.getSegmentName()))) {
+            InstanceConfig instanceConfig = instanceConfigManager.getActiveInstanceConfig(instanceStateEntry.getKey());
+            if (instanceConfig != null) {
+              validServers.add(new ServerInstance(instanceConfig));
+            }
           }
         }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
@@ -38,7 +38,9 @@ import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.BrokerMetrics;
-import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.core.transport.ServerInstance;
 
 
 /**
@@ -87,9 +89,6 @@ public class PartitionAwareOfflineRoutingTableBuilder extends BasePartitionAware
   @Override
   public synchronized void computeOnExternalViewChange(String tableName, ExternalView externalView,
       List<InstanceConfig> instanceConfigs) {
-    RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigs);
-    Set<String> segmentSet = externalView.getPartitionSet();
-
     // Fetch the instance partitions from the property store
     String instancePartitionsName =
         InstancePartitionsUtils.getInstancePartitionsName(tableName, InstancePartitionsType.OFFLINE);
@@ -105,8 +104,9 @@ public class PartitionAwareOfflineRoutingTableBuilder extends BasePartitionAware
     }
 
     // 1. Compute the partition id set by looking at the segment zk metadata and cache metadata when possible
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
     Set<Integer> partitionIds = new HashSet<>();
-    for (String segmentName : segmentSet) {
+    for (String segmentName : segmentAssignment.keySet()) {
       SegmentZKMetadata segmentZKMetadata = _segmentToZkMetadataMapping.get(segmentName);
       if (segmentZKMetadata == null || segmentZKMetadata.getPartitionMetadata() == null
           || segmentZKMetadata.getPartitionMetadata().getColumnPartitionMap().size() == 0) {
@@ -135,26 +135,32 @@ public class PartitionAwareOfflineRoutingTableBuilder extends BasePartitionAware
     }
 
     // 3. Compute the final routing look up table
-    Map<String, Map<Integer, String>> segmentToReplicaToServerMap = new HashMap<>();
-    for (String segmentName : segmentSet) {
+    InstanceConfigManager instanceConfigManager = new InstanceConfigManager(instanceConfigs);
+    Map<String, Map<Integer, ServerInstance>> segmentToReplicaToServerMap =
+        new HashMap<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
+    for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
       // Get partition_id from cached segment zk metadata
+      String segmentName = entry.getKey();
       SegmentZKMetadata segmentZKMetadata = _segmentToZkMetadataMapping.get(segmentName);
       int partitionId = getPartitionId(segmentZKMetadata);
 
       // Initialize data intermediate data structures or data
-      Map<Integer, String> replicaToServerMap = new HashMap<>();
+      Map<Integer, ServerInstance> replicaToServerMap = new HashMap<>();
       int replicaIdForNoPartitionMetadata = 0;
 
-      for (Map.Entry<String, String> entry : externalView.getStateMap(segmentName).entrySet()) {
-        String serverName = entry.getKey();
-        if (entry.getValue().equals(CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.ONLINE)
-            && !instancePruner.isInactive(serverName)) {
-          // If there's no partition number in the metadata, assign replica id sequentially.
-          if (partitionId == NO_PARTITION_NUMBER) {
-            replicaToServerMap.put(replicaIdForNoPartitionMetadata++, serverName);
-          } else {
-            int replicaId = partitionToServerToReplicaMap.get(partitionId).get(serverName);
-            replicaToServerMap.put(replicaId, serverName);
+      for (Map.Entry<String, String> instanceStateEntry : entry.getValue().entrySet()) {
+        if (instanceStateEntry.getValue().equals(SegmentOnlineOfflineStateModel.ONLINE)) {
+          String instanceName = instanceStateEntry.getKey();
+          InstanceConfig instanceConfig = instanceConfigManager.getActiveInstanceConfig(instanceName);
+          if (instanceConfig != null) {
+            ServerInstance serverInstance = new ServerInstance(instanceConfig);
+            // If there's no partition number in the metadata, assign replica id sequentially.
+            if (partitionId == NO_PARTITION_NUMBER) {
+              replicaToServerMap.put(replicaIdForNoPartitionMetadata++, serverInstance);
+            } else {
+              int replicaId = partitionToServerToReplicaMap.get(partitionId).get(instanceName);
+              replicaToServerMap.put(replicaId, serverInstance);
+            }
           }
         }
       }
@@ -168,11 +174,7 @@ public class PartitionAwareOfflineRoutingTableBuilder extends BasePartitionAware
     }
 
     // Delete segment metadata from cache if the segment no longer exists in the external view.
-    for (String segmentName : _segmentToZkMetadataMapping.keySet()) {
-      if (!segmentSet.contains(segmentName)) {
-        _segmentToZkMetadataMapping.remove(segmentName);
-      }
-    }
+    _segmentToZkMetadataMapping.keySet().retainAll(segmentAssignment.keySet());
 
     // Update segment to replica to server mapping
     _segmentToReplicaToServerMap = segmentToReplicaToServerMap;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
@@ -34,10 +34,12 @@ import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.BrokerMetrics;
-import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.LLCUtils;
 import org.apache.pinot.common.utils.SegmentName;
+import org.apache.pinot.core.transport.ServerInstance;
 
 
 /**
@@ -54,15 +56,15 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends BasePartitionAwar
   public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics) {
     super.init(configuration, tableConfig, propertyStore, brokerMetrics);
-    _numReplicas = Integer.valueOf(tableConfig.getValidationConfig().getReplicasPerPartition());
+    _numReplicas = Integer.parseInt(tableConfig.getValidationConfig().getReplicasPerPartition());
   }
 
   @Override
   public synchronized void computeOnExternalViewChange(String tableName, ExternalView externalView,
       List<InstanceConfig> instanceConfigs) {
     // Update the cache for the segment ZK metadata
-    Set<String> segmentSet = externalView.getPartitionSet();
-    for (String segmentName : segmentSet) {
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    for (String segmentName : segmentAssignment.keySet()) {
       SegmentZKMetadata segmentZKMetadata = _segmentToZkMetadataMapping.get(segmentName);
       if (segmentZKMetadata == null || segmentZKMetadata.getPartitionMetadata() == null
           || segmentZKMetadata.getPartitionMetadata().getColumnPartitionMap().size() == 0) {
@@ -81,34 +83,27 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends BasePartitionAwar
     Map<String, SegmentName> allowedSegmentInConsumingStateByPartition =
         LowLevelRoutingTableBuilderUtil.getAllowedConsumingStateSegments(externalView, sortedSegmentsByStreamPartition);
 
-    RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigs);
+    InstanceConfigManager instanceConfigManager = new InstanceConfigManager(instanceConfigs);
 
     // Compute map from segment to map from replica to server
-    Map<String, Map<Integer, String>> segmentToReplicaToServerMap = new HashMap<>();
-    for (String segmentName : segmentSet) {
+    Map<String, Map<Integer, ServerInstance>> segmentToReplicaToServerMap =
+        new HashMap<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
+    for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
+      String segmentName = entry.getKey();
       int partitionId = getPartitionId(segmentName);
       SegmentName validConsumingSegment = allowedSegmentInConsumingStateByPartition.get(Integer.toString(partitionId));
 
-      Map<Integer, String> replicaToServerMap = new HashMap<>();
+      Map<Integer, ServerInstance> replicaToServerMap = new HashMap<>();
       int replicaId = 0;
-      for (Map.Entry<String, String> entry : externalView.getStateMap(segmentName).entrySet()) {
-        String serverName = entry.getKey();
-        String state = entry.getValue();
-
-        // Do not add the server if it is inactive
-        if (instancePruner.isInactive(serverName)) {
-          continue;
-        }
-
-        // If the server is in ONLINE status, it's always to safe to add
-        if (state.equals(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
-          replicaToServerMap.put(replicaId++, serverName);
-        }
-
-        // If the server is in CONSUMING status, the segment has to be match with the valid consuming segment
-        if (state.equals(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING)
-            && validConsumingSegment != null && segmentName.equals(validConsumingSegment.getSegmentName())) {
-          replicaToServerMap.put(replicaId++, serverName);
+      for (Map.Entry<String, String> instanceStateEntry : entry.getValue().entrySet()) {
+        String state = instanceStateEntry.getValue();
+        if (state.equals(RealtimeSegmentOnlineOfflineStateModel.ONLINE) || (
+            state.equals(RealtimeSegmentOnlineOfflineStateModel.CONSUMING) && validConsumingSegment != null
+                && segmentName.equals(validConsumingSegment.getSegmentName()))) {
+          InstanceConfig instanceConfig = instanceConfigManager.getActiveInstanceConfig(instanceStateEntry.getKey());
+          if (instanceConfig != null) {
+            replicaToServerMap.put(replicaId++, new ServerInstance(instanceConfig));
+          }
         }
       }
 
@@ -121,15 +116,11 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends BasePartitionAwar
     }
 
     // Delete segment metadata from the cache if the segment no longer exists in the external view.
-    for (String segmentName : _segmentToZkMetadataMapping.keySet()) {
-      if (!segmentSet.contains(segmentName)) {
-        _segmentToZkMetadataMapping.remove(segmentName);
-      }
-    }
+    _segmentToZkMetadataMapping.keySet().retainAll(segmentAssignment.keySet());
 
     // Get the unique set of replica ids and find the maximum id to update the number of replicas
     Set<Integer> replicaGroupIds = new HashSet<>();
-    for (Map<Integer, String> replicaToServer : segmentToReplicaToServerMap.values()) {
+    for (Map<Integer, ServerInstance> replicaToServer : segmentToReplicaToServerMap.values()) {
       replicaGroupIds.addAll(replicaToServer.keySet());
     }
     int numReplicas = Collections.max(replicaGroupIds) + 1;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/RoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/RoutingTableBuilder.java
@@ -29,6 +29,7 @@ import org.apache.pinot.broker.routing.RoutingTableLookupRequest;
 import org.apache.pinot.broker.routing.selector.SegmentSelector;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.core.transport.ServerInstance;
 
 
 /**
@@ -54,10 +55,10 @@ public interface RoutingTableBuilder {
    * TODO: we need to consider relocating segment selector into the routing table builder instead of passing it
    * from outside.
    */
-  Map<String, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector);
+  Map<ServerInstance, List<String>> getRoutingTable(RoutingTableLookupRequest request, SegmentSelector segmentSelector);
 
   /**
    * Get all pre-computed routing tables.
    */
-  List<Map<String, List<String>>> getRoutingTables();
+  List<Map<ServerInstance, List<String>>> getRoutingTables();
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -43,6 +43,7 @@ import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -138,7 +139,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
     assertTrue(routing.routingTableExists(REALTIME_TABLE_NAME));
 
     RoutingTableLookupRequest routingTableLookupRequest = new RoutingTableLookupRequest(OFFLINE_TABLE_NAME);
-    Map<String, List<String>> routingTable = routing.getRoutingTable(routingTableLookupRequest);
+    Map<ServerInstance, List<String>> routingTable = routing.getRoutingTable(routingTableLookupRequest);
     assertEquals(routingTable.size(), NUM_SERVERS);
     assertEquals(routingTable.values().iterator().next().size(), NUM_OFFLINE_SEGMENTS);
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RandomRoutingTableTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RandomRoutingTableTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableConfig.Builder;
 import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -65,7 +66,8 @@ public class RandomRoutingTableTest {
     routing.markDataResourceOnline(generateTableConfig(tableName), externalView, instanceConfigs);
 
     for (int i = 0; i < NUM_ROUNDS; i++) {
-      Map<String, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(tableName));
+      Map<ServerInstance, List<String>> routingTable =
+          routing.getRoutingTable(new RoutingTableLookupRequest(tableName));
       Assert.assertEquals(routingTable.size(), numServersInEV);
       int numSegments = 0;
       for (List<String> segmentsForServer : routingTable.values()) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RoutingTableTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RoutingTableTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 import org.apache.pinot.common.utils.HLCSegmentName;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -150,7 +151,7 @@ public class RoutingTableTest {
 
   private void assertResourceRequest(HelixExternalViewBasedRouting routing, String resource, String expectedSegmentList,
       int expectedNumSegment) {
-    Map<String, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(resource));
+    Map<ServerInstance, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(resource));
     List<String> selectedSegments = new ArrayList<>();
     for (List<String> segmentsForServer : routingTable.values()) {
       selectedSegments.addAll(segmentsForServer);
@@ -257,7 +258,7 @@ public class RoutingTableTest {
 
   private void assertResourceRequest(HelixExternalViewBasedRouting routing, String resource,
       String[] expectedSegmentLists, int expectedNumSegment) {
-    Map<String, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(resource));
+    Map<ServerInstance, List<String>> routingTable = routing.getRoutingTable(new RoutingTableLookupRequest(resource));
     List<String> selectedSegments = new ArrayList<>();
     for (List<String> segmentsForServer : routingTable.values()) {
       selectedSegments.addAll(segmentsForServer);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilderTest.java
@@ -29,6 +29,7 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.broker.routing.RoutingTableLookupRequest;
 import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -50,13 +51,13 @@ public class BalancedRandomRoutingTableBuilderTest {
 
     // Build routing table
     routingTableBuilder.computeOnExternalViewChange("dummy", externalView, instanceConfigList);
-    List<Map<String, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
+    List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
 
     // Check that at least two routing tables are different
-    Iterator<Map<String, List<String>>> routingTableIterator = routingTables.iterator();
-    Map<String, List<String>> previous = routingTableIterator.next();
+    Iterator<Map<ServerInstance, List<String>>> routingTableIterator = routingTables.iterator();
+    Map<ServerInstance, List<String>> previous = routingTableIterator.next();
     while (routingTableIterator.hasNext()) {
-      Map<String, List<String>> current = routingTableIterator.next();
+      Map<ServerInstance, List<String>> current = routingTableIterator.next();
       if (!current.equals(previous)) {
         return;
       }
@@ -83,7 +84,7 @@ public class BalancedRandomRoutingTableBuilderTest {
     // Build routing table
     routingTableBuilder.computeOnExternalViewChange("dummy", externalView, instanceConfigList);
     RoutingTableLookupRequest request = new RoutingTableLookupRequest(tableNameWithType);
-    Map<String, List<String>> routingTable = routingTableBuilder.getRoutingTable(request, null);
+    Map<ServerInstance, List<String>> routingTable = routingTableBuilder.getRoutingTable(request, null);
 
     Set<String> segmentsInRoutingTable = new HashSet<>();
     for (List<String> segments : routingTable.values()) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/HighLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/HighLevelConsumerRoutingTableBuilderTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.broker.routing.RoutingTableLookupRequest;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.HLCSegmentName;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -99,7 +100,7 @@ public class HighLevelConsumerRoutingTableBuilderTest {
       // Check if the routing table result is correct
       for (int run = 0; run < MAX_NUM_GROUPS * 10; run++) {
         RoutingTableLookupRequest request = new RoutingTableLookupRequest(tableNameWithType);
-        Map<String, List<String>> routingTable = routingTableBuilder.getRoutingTable(request, null);
+        Map<ServerInstance, List<String>> routingTable = routingTableBuilder.getRoutingTable(request, null);
         Set<String> coveredSegments = new HashSet<>();
         for (List<String> segmentsForServer : routingTable.values()) {
           coveredSegments.addAll(segmentsForServer);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/LargeClusterRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/LargeClusterRoutingTableBuilderTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -41,7 +42,7 @@ public class LargeClusterRoutingTableBuilderTest {
   private LargeClusterRoutingTableBuilder _largeClusterRoutingTableBuilder = new LargeClusterRoutingTableBuilder();
 
   private interface RoutingTableValidator {
-    boolean isRoutingTableValid(Map<String, List<String>> routingTable, ExternalView externalView,
+    boolean isRoutingTableValid(Map<ServerInstance, List<String>> routingTable, ExternalView externalView,
         List<InstanceConfig> instanceConfigs);
   }
 
@@ -49,7 +50,7 @@ public class LargeClusterRoutingTableBuilderTest {
   public void testRoutingTableCoversAllSegmentsExactlyOnce() {
     validateAssertionOverMultipleRoutingTables(new RoutingTableValidator() {
       @Override
-      public boolean isRoutingTableValid(Map<String, List<String>> routingTable, ExternalView externalView,
+      public boolean isRoutingTableValid(Map<ServerInstance, List<String>> routingTable, ExternalView externalView,
           List<InstanceConfig> instanceConfigs) {
         Set<String> unassignedSegments = new HashSet<>();
         unassignedSegments.addAll(externalView.getPartitionSet());
@@ -78,28 +79,28 @@ public class LargeClusterRoutingTableBuilderTest {
     ExternalView externalView = createExternalView(tableName, segmentCount, replicationFactor, instanceCount);
     List<InstanceConfig> instanceConfigs = createInstanceConfigs(instanceCount);
 
-    final InstanceConfig disabledHelixInstance = instanceConfigs.get(0);
-    final String disabledHelixInstanceName = disabledHelixInstance.getInstanceName();
-    disabledHelixInstance.setInstanceEnabled(false);
+    InstanceConfig helixDisabledInstanceConfig = instanceConfigs.get(0);
+    helixDisabledInstanceConfig.setInstanceEnabled(false);
+    ServerInstance helixDisabledInstance = new ServerInstance(helixDisabledInstanceConfig);
 
-    final InstanceConfig shuttingDownInstance = instanceConfigs.get(1);
-    final String shuttingDownInstanceName = shuttingDownInstance.getInstanceName();
-    shuttingDownInstance.getRecord()
+    InstanceConfig shuttingDownInstanceConfig = instanceConfigs.get(1);
+    shuttingDownInstanceConfig.getRecord()
         .setSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(true));
+    ServerInstance shuttingDownInstance = new ServerInstance(shuttingDownInstanceConfig);
 
-    final InstanceConfig queriesDisabledInstance = instanceConfigs.get(2);
-    final String queriesDisabledInstanceName = queriesDisabledInstance.getInstanceName();
-    queriesDisabledInstance.getRecord()
+    InstanceConfig queriesDisabledInstanceConfig = instanceConfigs.get(2);
+    queriesDisabledInstanceConfig.getRecord()
         .setSimpleField(CommonConstants.Helix.QUERIES_DISABLED, Boolean.toString(true));
+    ServerInstance queriesDisabledInstance = new ServerInstance(queriesDisabledInstanceConfig);
 
     validateAssertionForOneRoutingTable(new RoutingTableValidator() {
       @Override
-      public boolean isRoutingTableValid(Map<String, List<String>> routingTable, ExternalView externalView,
+      public boolean isRoutingTableValid(Map<ServerInstance, List<String>> routingTable, ExternalView externalView,
           List<InstanceConfig> instanceConfigs) {
-        for (String serverName : routingTable.keySet()) {
+        for (ServerInstance serverInstance : routingTable.keySet()) {
           // These servers should not appear in the routing table
-          if (serverName.equals(disabledHelixInstanceName) || serverName.equals(shuttingDownInstanceName) ||
-              serverName.equals(queriesDisabledInstanceName)) {
+          if (serverInstance.equals(helixDisabledInstance) || serverInstance.equals(shuttingDownInstance)
+              || serverInstance.equals(queriesDisabledInstance)) {
             return false;
           }
         }
@@ -122,12 +123,12 @@ public class LargeClusterRoutingTableBuilderTest {
 
     _largeClusterRoutingTableBuilder.computeOnExternalViewChange(tableName, externalView, instanceConfigs);
 
-    List<Map<String, List<String>>> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
+    List<Map<ServerInstance, List<String>>> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
 
     int routingTableCount = 0;
     int largerThanDesiredRoutingTableCount = 0;
 
-    for (Map<String, List<String>> routingTable : routingTables) {
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       routingTableCount++;
       if (desiredServerCount < routingTable.size()) {
         largerThanDesiredRoutingTableCount++;
@@ -154,22 +155,22 @@ public class LargeClusterRoutingTableBuilderTest {
 
       _largeClusterRoutingTableBuilder.computeOnExternalViewChange(tableName, externalView, instanceConfigs);
 
-      List<Map<String, List<String>>> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
+      List<Map<ServerInstance, List<String>>> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
 
-      Map<String, Integer> segmentCountPerServer = new HashMap<>();
+      Map<ServerInstance, Integer> segmentCountPerServer = new HashMap<>();
 
       // Count number of segments assigned per server
-      for (Map<String, List<String>> routingTable : routingTables) {
-        for (Map.Entry<String, List<String>> entry : routingTable.entrySet()) {
-          String serverName = entry.getKey();
-          Integer numSegmentsForServer = segmentCountPerServer.get(serverName);
+      for (Map<ServerInstance, List<String>> routingTable : routingTables) {
+        for (Map.Entry<ServerInstance, List<String>> entry : routingTable.entrySet()) {
+          ServerInstance serverInstance = entry.getKey();
+          Integer numSegmentsForServer = segmentCountPerServer.get(serverInstance);
 
           if (numSegmentsForServer == null) {
             numSegmentsForServer = 0;
           }
 
           numSegmentsForServer += entry.getValue().size();
-          segmentCountPerServer.put(serverName, numSegmentsForServer);
+          segmentCountPerServer.put(serverInstance, numSegmentsForServer);
         }
       }
 
@@ -253,9 +254,9 @@ public class LargeClusterRoutingTableBuilderTest {
       ExternalView externalView, List<InstanceConfig> instanceConfigs, String tableName) {
 
     _largeClusterRoutingTableBuilder.computeOnExternalViewChange(tableName, externalView, instanceConfigs);
-    List<Map<String, List<String>>> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
+    List<Map<ServerInstance, List<String>>> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
 
-    for (Map<String, List<String>> routingTable : routingTables) {
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       assertTrue(routingTableValidator.isRoutingTableValid(routingTable, externalView, instanceConfigs), message);
     }
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilderTest.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentName;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -135,13 +136,13 @@ public class LowLevelConsumerRoutingTableBuilderTest {
       long startTime = System.nanoTime();
       routingTableBuilder.computeOnExternalViewChange("table_REALTIME", externalView, instanceConfigs);
 
-      List<Map<String, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
+      List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
 
       long endTime = System.nanoTime();
       totalNanos += endTime - startTime;
 
       // Check that all routing tables generated match all segments, with no duplicates
-      for (Map<String, List<String>> routingTable : routingTables) {
+      for (Map<ServerInstance, List<String>> routingTable : routingTables) {
         Set<String> assignedSegments = new HashSet<>();
 
         for (List<String> segmentsForServer : routingTable.values()) {
@@ -198,8 +199,8 @@ public class LowLevelConsumerRoutingTableBuilderTest {
     externalView.setState(consumingSegment2, instance2, RealtimeSegmentOnlineOfflineStateModel.CONSUMING);
 
     routingTableBuilder.computeOnExternalViewChange(realtimeTableName, externalView, instanceConfigs);
-    List<Map<String, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
-    for (Map<String, List<String>> routingTable : routingTables) {
+    List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       ArrayList<String> segmentsInRoutingTable = new ArrayList<>();
       for (List<String> segmentsForServer : routingTable.values()) {
         segmentsInRoutingTable.addAll(segmentsForServer);
@@ -248,22 +249,22 @@ public class LowLevelConsumerRoutingTableBuilderTest {
     }
 
     routingTableBuilder.computeOnExternalViewChange(rawTableName, externalView, instanceConfigs);
-    List<Map<String, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
-    for (Map<String, List<String>> routingTable : routingTables) {
+    List<Map<ServerInstance, List<String>>> routingTables = routingTableBuilder.getRoutingTables();
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       Assert.assertTrue(routingTable.isEmpty());
     }
 
     instanceConfig.getRecord().setSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS, "false");
     routingTableBuilder.computeOnExternalViewChange(rawTableName, externalView, instanceConfigs);
     routingTables = routingTableBuilder.getRoutingTables();
-    for (Map<String, List<String>> routingTable : routingTables) {
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       Assert.assertFalse(routingTable.isEmpty());
     }
 
     instanceConfig.getRecord().setSimpleField(CommonConstants.Helix.QUERIES_DISABLED, "true");
     routingTableBuilder.computeOnExternalViewChange(rawTableName, externalView, instanceConfigs);
     routingTables = routingTableBuilder.getRoutingTables();
-    for (Map<String, List<String>> routingTable : routingTables) {
+    for (Map<ServerInstance, List<String>> routingTable : routingTables) {
       Assert.assertTrue(routingTable.isEmpty());
     }
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -116,7 +117,7 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
 
       // Check the query that requires to scan all segment.
       String countStarQuery = "select count(*) from myTable";
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
 
       // Check that the number of servers picked are always equal or less than the number of servers
@@ -217,10 +218,10 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
     // Compute routing table and this should not throw null pointer exception
     routingTableBuilder.computeOnExternalViewChange(OFFLINE_TABLE_NAME, newExternalView, instanceConfigs);
 
-    Set<String> servers = new HashSet<>();
+    Set<ServerInstance> servers = new HashSet<>();
     for (int i = 0; i < 100; i++) {
       String countStarQuery = "select count(*) from " + OFFLINE_TABLE_NAME;
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
       Assert.assertEquals(routingTable.keySet().size(), 1);
       servers.add(routingTable.keySet().iterator().next());
@@ -278,10 +279,10 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
     RoutingTableBuilder routingTableBuilder =
         buildPartitionAwareOfflineRoutingTableBuilder(fakePropertyStore, tableConfig, externalView, instanceConfigs);
 
-    Set<String> servers = new HashSet<>();
+    Set<ServerInstance> servers = new HashSet<>();
     for (int i = 0; i < 100; i++) {
       String countStarQuery = "select count(*) from " + OFFLINE_TABLE_NAME;
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
       Assert.assertEquals(routingTable.keySet().size(), 1);
       servers.add(routingTable.keySet().iterator().next());

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -104,7 +105,7 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
 
       // Check the query that requires to scan all segment.
       String countStarQuery = "select count(*) from myTable";
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
 
       // Check that all segments are covered exactly for once.
@@ -181,7 +182,7 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
 
     // Check the query that requires to scan all segment.
     String countStarQuery = "select count(*) from myTable";
-    Map<String, List<String>> routingTable =
+    Map<ServerInstance, List<String>> routingTable =
         routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
 
     // Check that all segments are covered exactly for once.
@@ -254,10 +255,10 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
     // Compute routing table
     routingTableBuilder.computeOnExternalViewChange(REALTIME_TABLE_NAME, newExternalView, instanceConfigs);
 
-    Set<String> servers = new HashSet<>();
+    Set<ServerInstance> servers = new HashSet<>();
     for (int i = 0; i < 100; i++) {
       String countStarQuery = "select count(*) from " + REALTIME_TABLE_NAME;
-      Map<String, List<String>> routingTable =
+      Map<ServerInstance, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery), null);
       Assert.assertEquals(routingTable.keySet().size(), 1);
       servers.addAll(routingTable.keySet());

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -55,8 +55,8 @@ public class QueryRouter {
   }
 
   public AsyncQueryResponse submitQuery(long requestId, String rawTableName,
-      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<String, List<String>> offlineRoutingTable,
-      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<String, List<String>> realtimeRoutingTable,
+      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable,
       long timeoutMs) {
     assert offlineBrokerRequest != null || realtimeBrokerRequest != null;
 
@@ -64,16 +64,16 @@ public class QueryRouter {
     Map<ServerRoutingInstance, InstanceRequest> requestMap = new HashMap<>();
     if (offlineBrokerRequest != null) {
       assert offlineRoutingTable != null;
-      for (Map.Entry<String, List<String>> entry : offlineRoutingTable.entrySet()) {
-        ServerRoutingInstance serverRoutingInstance = new ServerRoutingInstance(entry.getKey(), TableType.OFFLINE);
+      for (Map.Entry<ServerInstance, List<String>> entry : offlineRoutingTable.entrySet()) {
+        ServerRoutingInstance serverRoutingInstance = entry.getKey().toServerRoutingInstance(TableType.OFFLINE);
         InstanceRequest instanceRequest = getInstanceRequest(requestId, offlineBrokerRequest, entry.getValue());
         requestMap.put(serverRoutingInstance, instanceRequest);
       }
     }
     if (realtimeBrokerRequest != null) {
       assert realtimeRoutingTable != null;
-      for (Map.Entry<String, List<String>> entry : realtimeRoutingTable.entrySet()) {
-        ServerRoutingInstance serverRoutingInstance = new ServerRoutingInstance(entry.getKey(), TableType.REALTIME);
+      for (Map.Entry<ServerInstance, List<String>> entry : realtimeRoutingTable.entrySet()) {
+        ServerRoutingInstance serverRoutingInstance = entry.getKey().toServerRoutingInstance(TableType.REALTIME);
         InstanceRequest instanceRequest = getInstanceRequest(requestId, realtimeBrokerRequest, entry.getValue());
         requestMap.put(serverRoutingInstance, instanceRequest);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.transport;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.utils.CommonConstants.Helix;
+
+
+public class ServerInstance {
+  private static final int SERVER_INSTANCE_PREFIX_LENGTH = Helix.PREFIX_OF_SERVER_INSTANCE.length();
+  private static final String HOSTNAME_PORT_DELIMITER = "_";
+
+  private final String _hostname;
+  private final int _port;
+
+  /**
+   * By default (auto joined instances), server instance name is of format: {@code Server_<hostname>_<port>}, e.g.
+   * {@code Server_localhost_12345}, hostname is of format: {@code Server_<hostname>}, e.g. {@code Server_localhost}.
+   */
+  public ServerInstance(InstanceConfig instanceConfig) {
+    String hostname = instanceConfig.getHostName();
+    if (hostname != null) {
+      if (hostname.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)) {
+        _hostname = hostname.substring(SERVER_INSTANCE_PREFIX_LENGTH);
+      } else {
+        _hostname = hostname;
+      }
+      _port = Integer.parseInt(instanceConfig.getPort());
+    } else {
+      // Hostname might be null in some tests (InstanceConfig created by calling the constructor instead of fetching
+      // from ZK), directly parse the instance name
+      String instanceName = instanceConfig.getInstanceName();
+      String[] hostnameAndPort = instanceName.split(Helix.PREFIX_OF_SERVER_INSTANCE)[1].split(HOSTNAME_PORT_DELIMITER);
+      _hostname = hostnameAndPort[0];
+      _port = Integer.parseInt(hostnameAndPort[1]);
+    }
+  }
+
+  @VisibleForTesting
+  ServerInstance(String hostname, int port) {
+    _hostname = hostname;
+    _port = port;
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public int getPort() {
+    return _port;
+  }
+
+  public ServerRoutingInstance toServerRoutingInstance(Helix.TableType tableType) {
+    return new ServerRoutingInstance(_hostname, _port, tableType);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * _hostname.hashCode() + _port;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof ServerInstance) {
+      ServerInstance that = (ServerInstance) obj;
+      return _hostname.equals(that._hostname) && _port == that._port;
+    }
+    return false;
+  }
+
+  /**
+   * Use default format {@code Server_<hostname>_<port>} for backward-compatibility.
+   */
+  @Override
+  public String toString() {
+    return Helix.PREFIX_OF_SERVER_INSTANCE + _hostname + HOSTNAME_PORT_DELIMITER + _port;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerRoutingInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerRoutingInstance.java
@@ -22,7 +22,6 @@ import com.google.common.net.InternetDomainName;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.pinot.common.utils.CommonConstants.Helix;
 import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 
 
@@ -34,7 +33,6 @@ import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
  */
 @ThreadSafe
 public class ServerRoutingInstance {
-  private static final String HOSTNAME_PORT_DELIMITER = "_";
   private static final String SHORT_OFFLINE_SUFFIX = "_O";
   private static final String SHORT_REALTIME_SUFFIX = "_R";
   private static final Map<String, String> SHORT_HOSTNAME_MAP = new ConcurrentHashMap<>();
@@ -42,16 +40,6 @@ public class ServerRoutingInstance {
   private final String _hostname;
   private final int _port;
   private final TableType _tableType;
-
-  /**
-   * NOTE: server instance name is of format: {@code Server_<hostname>_<port>}, e.g. {@code Server_localhost_12345}.
-   */
-  public ServerRoutingInstance(String instanceName, TableType tableType) {
-    String[] hostnameAndPort = instanceName.split(Helix.PREFIX_OF_SERVER_INSTANCE)[1].split(HOSTNAME_PORT_DELIMITER);
-    _hostname = hostnameAndPort[0];
-    _port = Integer.parseInt(hostnameAndPort[1]);
-    _tableType = tableType;
-  }
 
   public ServerRoutingInstance(String hostname, int port, TableType tableType) {
     _hostname = hostname;

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRouterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRouterTest.java
@@ -35,14 +35,14 @@ import org.testng.annotations.Test;
 
 public class QueryRouterTest {
   private static final int TEST_PORT = 12345;
-  private static final String SERVER_INSTANCE_NAME = "Server_localhost_" + TEST_PORT;
+  private static final ServerInstance SERVER_INSTANCE = new ServerInstance("localhost", TEST_PORT);
   private static final ServerRoutingInstance OFFLINE_SERVER_ROUTING_INSTANCE =
-      new ServerRoutingInstance(SERVER_INSTANCE_NAME, TableType.OFFLINE);
+      SERVER_INSTANCE.toServerRoutingInstance(TableType.OFFLINE);
   private static final ServerRoutingInstance REALTIME_SERVER_ROUTING_INSTANCE =
-      new ServerRoutingInstance(SERVER_INSTANCE_NAME, TableType.REALTIME);
+      SERVER_INSTANCE.toServerRoutingInstance(TableType.REALTIME);
   private static final BrokerRequest BROKER_REQUEST = new BrokerRequest();
-  private static final Map<String, List<String>> ROUTING_TABLE =
-      Collections.singletonMap(SERVER_INSTANCE_NAME, Collections.emptyList());
+  private static final Map<ServerInstance, List<String>> ROUTING_TABLE =
+      Collections.singletonMap(SERVER_INSTANCE, Collections.emptyList());
 
   private QueryRouter _queryRouter;
 


### PR DESCRIPTION
Currently, RoutingTable is represented as `Map<String, List>`, a map from serverInstanceName to list of segments hosted by the server. The rest of the code derives the hostname and port by parsing serverInstanceName assuming it's of the format: `Server_<hostname>_<port>`.
This PR replaces serverInstanceName with a concrete ServerInstance Object initiated from the InstanceConfig.
NOTE: this ServerInstance is not the same as the existing ServerInstance class which tight to the connection-pool routing and subject to be cleaned up.
This will allow user to de-couple the instance name from hostname and port for the instance.

Issue link #4525
Based on #4817
Replace #4795