### PR TITLE
Bug Fix: Fix segment download url in SegmentZkMetadata.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -352,10 +352,10 @@ public class PinotSegmentUploadRestletResource {
     if (baseDataDirURI.getScheme().equalsIgnoreCase(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME)) {
       return URIUtils.constructDownloadUrl(provider.getVip(), rawTableName, segmentName);
     } else {
-      // Receiving .tar.gz segment upload for pluggable storage
-      LOGGER.info("Using configured data dir {} for segment {} of table {}", _controllerConf.getDataDir(), segmentName,
-          rawTableName);
-      return URIUtils.constructDownloadUrl(baseDataDirURI.toString(), rawTableName, segmentName);
+      // Receiving .tar.gz segment upload for pluggable storage. Download URI is the same as final segment location.
+      String downloadUri = URIUtils.getPath(baseDataDirURI.toString(), rawTableName, URIUtils.encode(segmentName));
+      LOGGER.info("Using download uri: {} for segment: {} of table {}", downloadUri, segmentName, rawTableName);
+      return downloadUri;
     }
   }
 


### PR DESCRIPTION
It turns out that for the case when segment data directory is
deep-storage, but the segment upload method is with segment payload
being puhsed (as opposed to deep-store URI), the code had a bug where it
was generating incorrect download URL in the SegmentZkMetadata.

This PR fixes the issue with minimal change, by making the download URL
the same as the final location of the segment in deep-store. Having said
that, this part of the code seems quite complex with too many variable
controls (segment upload type, segment moving or not to final location,
etc), it would be good to clean this up at some point.