### PR TITLE
[TE] change default time zone to pacific time zone

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbsoluteChangeRuleAnomalyFilterSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbsoluteChangeRuleAnomalyFilterSpec.java
@@ -20,7 +20,7 @@
 package org.apache.pinot.thirdeye.detection.spec;
 
 public class AbsoluteChangeRuleAnomalyFilterSpec extends AbstractSpec {
-  private String timezone = "UTC";
+  private String timezone = DEFAULT_TIMEZONE;
   private double threshold = Double.NaN;
   private String offset;
   private String pattern = "UP_OR_DOWN";

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbsoluteChangeRuleDetectorSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbsoluteChangeRuleDetectorSpec.java
@@ -25,7 +25,7 @@ import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
 public class AbsoluteChangeRuleDetectorSpec extends AbstractSpec {
   private double absoluteChange = Double.NaN;
   private String offset = "wo1w";
-  private String timezone = "UTC";
+  private String timezone = DEFAULT_TIMEZONE;
   private String pattern = "UP_OR_DOWN";
   private String monitoringGranularity = MetricSlice.NATIVE_GRANULARITY.toAggregationGranularityString(); // use native granularity by default
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/AbstractSpec.java
@@ -28,6 +28,7 @@ import org.modelmapper.convention.MatchingStrategies;
  * Base class for component specs
  */
 public abstract class AbstractSpec {
+  static final String DEFAULT_TIMEZONE = "America/Los_Angeles";
 
   public static <T extends AbstractSpec> T fromProperties(Map<String, Object> properties, Class<T> specClass) {
     // don't reuse model mapper instance. It caches typeMaps and will result in unexpected mappings

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/PercentageChangeRuleAnomalyFilterSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/PercentageChangeRuleAnomalyFilterSpec.java
@@ -20,7 +20,7 @@
 package org.apache.pinot.thirdeye.detection.spec;
 
 public class PercentageChangeRuleAnomalyFilterSpec extends AbstractSpec {
-  private String timezone = "UTC";
+  private String timezone = DEFAULT_TIMEZONE;
   private String offset;
   private String pattern= "UP_OR_DOWN";
   private double threshold = 0.0; // by default set threshold to 0 to pass all anomalies

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/PercentageChangeRuleDetectorSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/PercentageChangeRuleDetectorSpec.java
@@ -25,7 +25,7 @@ import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
 public class PercentageChangeRuleDetectorSpec extends AbstractSpec {
   private double percentageChange = Double.NaN;
   private String offset = "wo1w";
-  private String timezone = "UTC";
+  private String timezone = DEFAULT_TIMEZONE;
   private String pattern = "UP_OR_DOWN";
   private String monitoringGranularity = MetricSlice.NATIVE_GRANULARITY.toAggregationGranularityString(); // use native granularity by default
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/RuleBaselineProviderSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/RuleBaselineProviderSpec.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RuleBaselineProviderSpec extends AbstractSpec{
-  private String timezone = "UTC";
+  private String timezone = DEFAULT_TIMEZONE;
   private String offset = "wo1w";
 
   public RuleBaselineProviderSpec(String timezone, String offset) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/SitewideImpactRuleAnomalyFilterSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/SitewideImpactRuleAnomalyFilterSpec.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 
 public class SitewideImpactRuleAnomalyFilterSpec extends AbstractSpec {
-  private String timezone = "UTC";
+  private String timezone = DEFAULT_TIMEZONE;
   private double threshold = Double.NaN;
   private String offset;
   private String pattern = "UP_OR_DOWN";

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetectorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/PercentageChangeRuleDetectorTest.java
@@ -187,6 +187,7 @@ public class PercentageChangeRuleDetectorTest {
     AnomalyDetector percentageRule = new PercentageChangeRuleDetector();
     PercentageChangeRuleDetectorSpec spec = new PercentageChangeRuleDetectorSpec();
     spec.setOffset("mo1m");
+    spec.setTimezone("UTC");
     spec.setPercentageChange(0.4);
     spec.setMonitoringGranularity("1_MONTHS");
     percentageRule.init(spec, new DefaultInputDataFetcher(this.provider, -1));


### PR DESCRIPTION
Change default time zone to pacific time zone in anomaly detection. Previously it was using UTC as the default time zone and does not take daylight savings time into consideration.