### PR TITLE
[TE] fix mismatch in dataset names in data availability listener

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListener.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListener.java
@@ -58,12 +58,12 @@ public class DataAvailabilityEventListener implements Runnable {
       while (!(Thread.interrupted())) {
         processOneBatch();
       }
-    } catch (InterruptedException e) {
-      LOG.error("Caught Interrupted Exception", e);
+    } catch (Exception e) {
+      LOG.error("Caught an exception while processing event.", e);
     } finally {
       consumer.close();
     }
-    LOG.info("TriggerEventListener under thread {} is closed.", Thread.currentThread().getName());
+    LOG.info("DataAvailabilityEventListener under thread {} is closed.", Thread.currentThread().getName());
   }
 
   public void close() {
@@ -74,14 +74,18 @@ public class DataAvailabilityEventListener implements Runnable {
     List<DataAvailabilityEvent> events = consumer.poll(pollTimeInMilli);
     ThirdeyeMetricsUtil.triggerEventCounter.inc(events.size());
     for (DataAvailabilityEvent event : events) {
-      if (checkAllFiltersPassed(event)) {
-        LOG.info("Processing event: " + event.getDatasetName() + " with watermark " + event.getHighWatermark());
-        String dataset = event.getDatasetName();
-        datasetTriggerInfoRepo.setLastUpdateTimestamp(dataset, event.getHighWatermark());
-        //Note: Batch update the timestamps of dataset if the event traffic spike
-        datasetConfigManager.updateLastRefreshTime(dataset, event.getHighWatermark());
-        ThirdeyeMetricsUtil.processedTriggerEventCounter.inc();
-        LOG.info("Finished processing event: " + event.getDatasetName());
+      try {
+        if (checkAllFiltersPassed(event)) {
+          LOG.info("Processing event: " + event.getDatasetName() + " with watermark " + event.getHighWatermark());
+          String dataset = event.getDatasetName();
+          datasetTriggerInfoRepo.setLastUpdateTimestamp(dataset, event.getHighWatermark());
+          //Note: Batch update the timestamps of dataset if the event traffic spike
+          datasetConfigManager.updateLastRefreshTime(dataset, event.getHighWatermark());
+          ThirdeyeMetricsUtil.processedTriggerEventCounter.inc();
+          LOG.info("Finished processing event: " + event.getDatasetName());
+        }
+      } catch (Exception e) {
+        LOG.error("Error in processing event for {}, so skipping...", event.getDatasetName(), e);
       }
     }
     if (!events.isEmpty()) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerDriver.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerDriver.java
@@ -49,7 +49,7 @@ public class DataAvailabilityEventListenerDriver {
     String rootDir = System.getProperty("dw.rootDir");
     this.config = config;
     this.executorService = Executors.newFixedThreadPool(this.config.getNumParallelConsumer(),
-        new ThreadFactoryBuilder().setNameFormat("trigger-event-consumer-%d").build());
+        new ThreadFactoryBuilder().setNameFormat("data-avail-event-consumer-%d").build());
     this.consumerProps = new Properties();
     this.consumerProps.load(new FileInputStream(rootDir + "/" + this.config.getKafkaConsumerPropPath()));
     this.listeners = new ArrayList<>();
@@ -65,7 +65,7 @@ public class DataAvailabilityEventListenerDriver {
       listeners.add(listener);
       executorService.submit(listener);
     }
-    LOG.info("Started {} TriggerEventListener...", listeners.size());
+    LOG.info("Started {} DataAvailabilityEventListener...", listeners.size());
   }
 
   public void shutdown() {
@@ -79,6 +79,7 @@ public class DataAvailabilityEventListenerDriver {
     try {
       Constructor<?> constructor = Class.forName(className)
           .getConstructor(String.class, String.class, String.class, Properties.class);
+      LOG.info("Loaded consumer class: {}", className);
       return (DataAvailabilityKafkaConsumer) constructor.newInstance(config.getKafkaTopic(),
           config.getKafkaConsumerGroupId(), config.getKafkaBootstrapServers(), consumerProps);
     } catch (Exception e) {
@@ -92,6 +93,7 @@ public class DataAvailabilityEventListenerDriver {
       try {
         DataAvailabilityEventFilter filter = (DataAvailabilityEventFilter) Class.forName(filterClassName).newInstance();
         filters.add(filter);
+        LOG.info("Loaded event filter: {}", filterClassName);
       } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
         throw new IllegalArgumentException("Failed to initialize trigger event filter.", e.getCause());
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskScheduler.java
@@ -131,7 +131,7 @@ public class DataAvailabilityTaskScheduler implements Runnable {
         MetricEntity me = MetricEntity.fromURN(urn);
         if (!metricCache.containsKey(me.getId())) {
           datasets.addAll(ThirdEyeUtils.getDatasetConfigsFromMetricUrn(urn)
-              .stream().map(DatasetConfigDTO::getName).collect(Collectors.toList()));
+              .stream().map(DatasetConfigDTO::getDataset).collect(Collectors.toList()));
           // cache the mapping in memory to avoid duplicate retrieval
           metricCache.put(me.getId(), datasets);
         } else {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DatasetTriggerInfoRepo.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DatasetTriggerInfoRepo.java
@@ -113,7 +113,7 @@ public class DatasetTriggerInfoRepo {
         }
         List<DatasetConfigDTO> datasetConfigs = ThirdEyeUtils.getDatasetConfigsFromMetricUrn(urn);
         for (DatasetConfigDTO datasetConfig : datasetConfigs) {
-          String datasetName = datasetConfig.getName();
+          String datasetName = datasetConfig.getDataset();
           if (!datasetRefreshTimeMap.containsKey(datasetName)
               && dataSourceWhitelist.contains(datasetConfig.getDataSource())) {
             datasetRefreshTimeMap.put(datasetName, datasetConfig.getLastRefreshTime());

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerTest.java
@@ -101,7 +101,7 @@ public class DataAvailabilityEventListenerTest {
   }
 
   @Test
-  public void testConsume1() throws InterruptedException {
+  public void testUpdateOneDataset() throws InterruptedException {
     _dataAvailabilityEventListener.processOneBatch();
     DatasetConfigManager datasetConfigManager = DAORegistry.getInstance().getDatasetConfigDAO();
     DatasetConfigDTO dataset1 = datasetConfigManager.findByDataset(TEST_DATASET_PREFIX + 1);
@@ -113,8 +113,8 @@ public class DataAvailabilityEventListenerTest {
     Assert.assertEquals(dataset2.getLastRefreshTime(), 3000);
   }
 
-  @Test
-  public void testConsume2() throws InterruptedException {
+  @Test(dependsOnMethods = { "testUpdateOneDataset" })
+  public void testUpdateTwoDataset() throws InterruptedException {
     _dataAvailabilityEventListener.processOneBatch();
     DatasetConfigManager datasetConfigManager = DAORegistry.getInstance().getDatasetConfigDAO();
     DatasetConfigDTO dataset1 = datasetConfigManager.findByDataset(TEST_DATASET_PREFIX + 1);
@@ -126,10 +126,8 @@ public class DataAvailabilityEventListenerTest {
     Assert.assertEquals(dataset2.getLastRefreshTime(), 3000);
   }
 
-  @Test
-  public void testConsume3() throws InterruptedException {
-    LOG.info("in testConsume3");
-
+  @Test(dependsOnMethods = { "testUpdateTwoDataset" })
+  public void testNoUpdate() throws InterruptedException {
     _dataAvailabilityEventListener.processOneBatch();
     DatasetConfigManager datasetConfigManager = DAORegistry.getInstance().getDatasetConfigDAO();
     DatasetConfigDTO dataset1 = datasetConfigManager.findByDataset(TEST_DATASET_PREFIX + 1);

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListenerTest.java
@@ -37,7 +37,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class DataAvailabilityEventListenerTest {
@@ -47,9 +49,10 @@ public class DataAvailabilityEventListenerTest {
   static String TEST_METRIC_PREFIX = "metric_trigger_listener_";
   private DAOTestBase testDAOProvider;
   private DataAvailabilityEventListener _dataAvailabilityEventListener;
+  private MockConsumerDataAvailability consumer = new MockConsumerDataAvailability();
 
-  @BeforeClass
-  public void beforeCLass() {
+  @BeforeMethod
+  public void beforeMethod() {
     testDAOProvider = DAOTestBase.getInstance();
     DetectionConfigManager detectionConfigManager = DAORegistry.getInstance().getDetectionConfigManager();
     MetricConfigManager metricConfigManager = DAORegistry.getInstance().getMetricConfigDAO();
@@ -92,7 +95,6 @@ public class DataAvailabilityEventListenerTest {
     ds2.setLastRefreshTime(2000);
     datasetConfigDAO.save(ds2);
 
-    MockConsumerDataAvailability consumer = new MockConsumerDataAvailability();
     DatasetTriggerInfoRepo.init(100, Collections.singletonList(TEST_DATA_SOURCE));
     List<DataAvailabilityEventFilter> filters = new ArrayList<>();
     filters.add(new OnTimeFilter());
@@ -133,14 +135,14 @@ public class DataAvailabilityEventListenerTest {
     DatasetConfigDTO dataset1 = datasetConfigManager.findByDataset(TEST_DATASET_PREFIX + 1);
     DatasetConfigDTO dataset2 = datasetConfigManager.findByDataset(TEST_DATASET_PREFIX + 2);
     DatasetTriggerInfoRepo datasetTriggerInfoRepo = DatasetTriggerInfoRepo.getInstance();
-    Assert.assertEquals(datasetTriggerInfoRepo.getLastUpdateTimestamp(TEST_DATASET_PREFIX + 1), 3000);
-    Assert.assertEquals(datasetTriggerInfoRepo.getLastUpdateTimestamp(TEST_DATASET_PREFIX + 2), 3000);
-    Assert.assertEquals(dataset1.getLastRefreshTime(), 3000);
-    Assert.assertEquals(dataset2.getLastRefreshTime(), 3000);
+    Assert.assertEquals(datasetTriggerInfoRepo.getLastUpdateTimestamp(TEST_DATASET_PREFIX + 1), 1000);
+    Assert.assertEquals(datasetTriggerInfoRepo.getLastUpdateTimestamp(TEST_DATASET_PREFIX + 2), 2000);
+    Assert.assertEquals(dataset1.getLastRefreshTime(), 1000);
+    Assert.assertEquals(dataset2.getLastRefreshTime(), 2000);
   }
 
-  @AfterClass()
-  public void afterClass() {
+  @AfterMethod()
+  public void afterMethod() {
     _dataAvailabilityEventListener.close();
     testDAOProvider.cleanup();
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DatasetTriggerInfoRepoTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DatasetTriggerInfoRepoTest.java
@@ -100,7 +100,7 @@ public class DatasetTriggerInfoRepoTest {
     Assert.assertEquals(datasetTriggerInfoRepo.getLastUpdateTimestamp(TEST_DATASET_PREFIX + 3), 0);
   }
 
-  @Test
+  @Test(dependsOnMethods = { "testInitAndGetInstance" })
   public void testSetLastUpdateTimestamp() {
     DatasetTriggerInfoRepo datasetTriggerInfoRepo = DatasetTriggerInfoRepo.getInstance();
     datasetTriggerInfoRepo.setLastUpdateTimestamp(TEST_DATASET_PREFIX + 1, 3000);
@@ -109,7 +109,7 @@ public class DatasetTriggerInfoRepoTest {
     Assert.assertEquals(datasetTriggerInfoRepo.getLastUpdateTimestamp(TEST_DATASET_PREFIX + 4), 0);
   }
 
-  @Test
+  @Test(dependsOnMethods = { "testSetLastUpdateTimestamp" })
   public void testRefresh() throws InterruptedException {
     DetectionConfigManager detectionConfigManager = DAORegistry.getInstance().getDetectionConfigManager();
     MetricConfigManager metricConfigManager = DAORegistry.getInstance().getMetricConfigDAO();

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DatasetTriggerInfoRepoTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DatasetTriggerInfoRepoTest.java
@@ -32,7 +32,9 @@ import org.apache.pinot.thirdeye.datalayer.dto.MetricConfigDTO;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class DatasetTriggerInfoRepoTest {
@@ -41,8 +43,8 @@ public class DatasetTriggerInfoRepoTest {
   private static String TEST_METRIC_PREFIX = "test_metric_";
   private DAOTestBase testDAOProvider;
 
-  @BeforeClass
-  public void BeforeClass() {
+  @BeforeMethod
+  public void BeforeMethod() {
     testDAOProvider = DAOTestBase.getInstance();
     DetectionConfigManager detectionConfigManager = DAORegistry.getInstance().getDetectionConfigManager();
     MetricConfigManager metricConfigManager = DAORegistry.getInstance().getMetricConfigDAO();
@@ -84,11 +86,11 @@ public class DatasetTriggerInfoRepoTest {
     ds2.setDataSource(TEST_DATA_SOURCE);
     ds2.setLastRefreshTime(2000);
     datasetConfigDAO.save(ds2);
+    DatasetTriggerInfoRepo.init(1, Collections.singletonList(TEST_DATA_SOURCE));
   }
 
   @Test
   public void testInitAndGetInstance () {
-    DatasetTriggerInfoRepo.init(1, Collections.singletonList(TEST_DATA_SOURCE));
     DatasetTriggerInfoRepo datasetTriggerInfoRepo = DatasetTriggerInfoRepo.getInstance();
         Assert.assertSame(datasetTriggerInfoRepo, DatasetTriggerInfoRepo.getInstance());
     Assert.assertSame(datasetTriggerInfoRepo, DatasetTriggerInfoRepo.getInstance());
@@ -144,8 +146,8 @@ public class DatasetTriggerInfoRepoTest {
     Assert.assertEquals(datasetTriggerInfoRepo.getLastUpdateTimestamp(TEST_DATASET_PREFIX + 3), 3000);
   }
 
-  @AfterClass
-  public void afterClass() {
+  @AfterMethod
+  public void afterMethod() {
     DatasetTriggerInfoRepo datasetTriggerInfoRepo = DatasetTriggerInfoRepo.getInstance();
     datasetTriggerInfoRepo.close();
     testDAOProvider.cleanup();

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/MockConsumerDataAvailability.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/MockConsumerDataAvailability.java
@@ -23,7 +23,9 @@ public class MockConsumerDataAvailability extends DataAvailabilityKafkaConsumer 
       res.add(createEvent(1, 2000, 3000));
       res.add(createEvent(1, 2000, 3000));
       res.add(createEvent(1, 1000, 2000));
+      res.add(createEvent(2, 1000, 3000));
     } else if (callCount == 2) {
+      res.add(createEvent(1, 0, 1000));
       res.add(createEvent(3, 1000, 2000));
       res.add(createEvent(4, 1000, 2000));
     }


### PR DESCRIPTION
This PR is to fix misuse of `datasetConfigDTO.getName()` mainly and also include miscellaneous changes.