### PR TITLE
[TE] quick fix for error in retriving legacy anomaly

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/api/user/dashboard/UserDashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/api/user/dashboard/UserDashboardResource.java
@@ -236,8 +236,15 @@ public class UserDashboardResource {
       if (anomaly.getDetectionConfigId() != null) {
         long detectionConfigId = anomaly.getDetectionConfigId();
         DetectionConfigDTO detectionDTO = this.detectionDAO.findById(detectionConfigId);
-        summary.setFunctionName(detectionDTO.getName());
-        summary.setDetectionConfigId(detectionConfigId);
+        if (detectionDTO != null) {
+          summary.setFunctionName(detectionDTO.getName());
+          summary.setDetectionConfigId(detectionConfigId);
+        } else {
+          // this can happen when legacy anomalies are retrieved
+          LOG.error("Cannot find detectionConfig with id {}, so skipping the anomaly {}...",
+              detectionConfigId, anomaly.getId());
+          continue;
+        }
       }
 
       summary.setMetricName(anomaly.getMetric());


### PR DESCRIPTION
This PR provides quick fix when a legacy anomaly is retrieved and there is no detection associated with it. In that case, the backend just skip all legacy/invalid anomalies. 