### PR TITLE
Handle default value after adding new  byte column

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderTest.java
@@ -23,8 +23,10 @@ import java.net.URL;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.data.DimensionFieldSpec;
 import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.MetricFieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.segment.ReadMode;
+import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
@@ -223,6 +225,22 @@ public class LoaderTest {
     indexSegment = ImmutableSegmentLoader.load(_indexDir, _v3IndexLoadingConfig, schema);
     Assert.assertEquals(indexSegment.getDataSource("SVString").getDictionary().get(0), "");
     Assert.assertEquals(indexSegment.getDataSource("MVString").getDictionary().get(0), "");
+    indexSegment.destroy();
+  }
+
+  @Test
+  public void testDefaultValueByteColumn()
+      throws Exception {
+    Schema schema = constructV1Segment();
+    String newColumnName = "byteMetric";
+    String defaultValue = "0000ac0000";
+
+    FieldSpec byteMetric = new MetricFieldSpec(newColumnName, FieldSpec.DataType.BYTES, defaultValue);
+    schema.addField(byteMetric);
+    IndexSegment indexSegment = ImmutableSegmentLoader.load(_indexDir, _v3IndexLoadingConfig, schema);
+    Assert
+        .assertEquals(BytesUtils.toHexString((byte[]) indexSegment.getDataSource(newColumnName).getDictionary().get(0)),
+            defaultValue);
     indexSegment.destroy();
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderTest.java
@@ -229,7 +229,7 @@ public class LoaderTest {
   }
 
   @Test
-  public void testDefaultValueByteColumn()
+  public void testDefaultBytesColumn()
       throws Exception {
     Schema schema = constructV1Segment();
     String newColumnName = "byteMetric";


### PR DESCRIPTION
There are two issues:

* When a new byte column is added to the schema, our current code does not update the `columnMaxLength` with the length of default value in local metadata during the reload, which makes the assertion failed like below:
```
Caused by: java.lang.IllegalStateException: Buffer size mismatch: bufferSize = 180, numValues = 1, numByesPerValue = 0
        at com.google.common.base.Preconditions.checkState(Preconditions.java:842) ~[guava-27.0.1-jre.jar:?]
        at org.apache.pinot.core.segment.index.readers.BaseImmutableDictionary.<init>(BaseImmutableDictionary.java:42) ~[pinot-core-0.2.1147.jar:0.2.0-SNAPSHOT-4445fdcc465a481e25cd8e25257f6bc7d7d184e5]
        at org.apache.pinot.core.segment.index.readers.BytesDictionary.<init>(BytesDictionary.java:31) ~[pinot-core-0.2.1147.jar:0.2.0-SNAPSHOT-4445fdcc465a481e25cd8e25257f6bc7d7d184e5]
        at org.apache.pinot.core.segment.index.column.PhysicalColumnIndexContainer.loadDictionary(PhysicalColumnIndexContainer.java:192) ~[pinot-core-0.2.1147.jar:0.2.0-SNAPSHOT-4445fdcc465a481e25cd8e2525
7f6bc7d7d184e5]
```
* When fetching the column metadata from schema, the current code does not convert the byte array of default in schema to make the comparison with the one in local metadata. 

This PR fixes these bugs and unit test added.