### PR TITLE
[TE] Use default centralized cache settings if exception occurs during init

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/ThirdEyeCacheRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/ThirdEyeCacheRegistry.java
@@ -104,14 +104,8 @@ public class ThirdEyeCacheRegistry {
       URL cacheConfigUrl = thirdeyeConfig.getCacheConfigAsUrl();
       CacheConfig cacheConfig = CacheConfigLoader.fromCacheConfigUrl(cacheConfigUrl);
       if (cacheConfig == null) {
-        LOGGER.error("Could not get cache config from path {} - using default settings", cacheConfigUrl);
-
-        CentralizedCacheConfig cfg = new CentralizedCacheConfig();
-        cfg.setMaxParallelInserts(1);
-
-        CacheConfig.getInstance().setUseCentralizedCache(false);
-        CacheConfig.getInstance().setUseInMemoryCache(true);
-        CacheConfig.getInstance().setCentralizedCacheSettings(cfg);
+        LOGGER.error("Could not get cache config from path {} - reverting to default settings", cacheConfigUrl);
+        setupDefaultTimeSeriesCacheSettings();
       } else {
         CacheDataSource dataSource = CacheConfig.getInstance().getCentralizedCacheSettings().getDataSourceConfig();
 
@@ -131,9 +125,18 @@ public class ThirdEyeCacheRegistry {
         ThirdEyeCacheRegistry.getInstance().registerTimeSeriesCache(timeSeriesCache);
       }
     } catch (Exception e) {
-      LOGGER.error("Caught exception while initializing centralized cache", e);
-      System.exit(1);
+      LOGGER.error("Caught exception while initializing centralized cache - reverting to default settings", e);
+      setupDefaultTimeSeriesCacheSettings();
     }
+  }
+
+  private static void setupDefaultTimeSeriesCacheSettings() {
+    CentralizedCacheConfig cfg = new CentralizedCacheConfig();
+    cfg.setMaxParallelInserts(1);
+
+    CacheConfig.getInstance().setUseCentralizedCache(false);
+    CacheConfig.getInstance().setUseInMemoryCache(true);
+    CacheConfig.getInstance().setCentralizedCacheSettings(cfg);
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetUtils.java
@@ -35,6 +35,7 @@ import org.apache.pinot.thirdeye.datalayer.dto.DatasetConfigDTO;
 import org.apache.pinot.thirdeye.datasource.MetricFunction;
 import org.apache.pinot.thirdeye.datasource.ThirdEyeRequest;
 import org.apache.pinot.thirdeye.datasource.TimeRangeUtils;
+import org.apache.pinot.thirdeye.detection.cache.CacheConfig;
 import org.apache.pinot.thirdeye.util.ThirdEyeUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -152,7 +153,7 @@ public class ThirdEyeResultSetUtils {
           String[] rowValues = dataMap.get(compositeGroupKey);
           if (rowValues == null) {
             // add one to include the timestamp, if applicable
-            if (timestamp != null) {
+            if (timestamp != null && CacheConfig.getInstance().useCentralizedCache()) {
               rowValues = new String[numCols + 1];
             } else {
               rowValues = new String[numCols];
@@ -179,7 +180,7 @@ public class ThirdEyeResultSetUtils {
                   sourceName
               ));
 
-          if (timestamp != null) {
+          if (timestamp != null && CacheConfig.getInstance().useCentralizedCache()) {
             rowValues[rowValues.length - 1] = timestamp;
           }
         }


### PR DESCRIPTION
This mainly occurs if the config file is malformed in some way, e.g. The named value for 'cacheDataStoreName'  doesn't have a config set in 'cacheDataSources'

Also added a check to make sure that we include timestamps with the raw time-series data if centralized caching is enabled, as it's only used in that case.