### PR TITLE
Rewrite single predicate IN as EQUALS

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
@@ -20,148 +20,312 @@ package org.apache.pinot.broker.requesthandler;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 
 
 /**
- * Optimizer that collapses multiple OR clauses to IN clauses. For example, <code>a = 1 OR a = 2 OR a =
- * 3</code> gets turned to <code>a IN (1, 2, 3)</code>.
+ * The optimizer looks at the FilterQueryTree to convert
+ *
+ * (1) multiple OR equality predicates into a single IN predicate
+ * e.g COL = 1 OR COl = 2 OR COL = 3 is rewritten as COL IN (1, 2, 3)
+ *
+ * (2) single value IN predicate into equality predicate
+ * e.g COL IN (1) is rewritten as COL = 1
+ *
+ * (3) Deduplicates the predicate values for IN.
+ *
+ * These rewrites are also done for child subtrees (handling nested nature)
+ *
+ * NOTE: This optimizer is dependent on {@link FlattenNestedPredicatesFilterQueryTreeOptimizer}
+ * first flattening the tree and removing redundant operators.
  */
 public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer extends FilterQueryTreeOptimizer {
+
   @Override
   public FilterQueryTree optimize(FilterQueryOptimizerRequest request) {
-    return optimize(request.getFilterQueryTree(), null);
+    return optimize(request.getFilterQueryTree());
   }
 
-  private FilterQueryTree optimize(FilterQueryTree filterQueryTree, FilterQueryTree parent) {
+  /**
+   * Optimize a FilterQueryTree. When we look at the root operator,
+   * there are 3 possible cases:
+   *
+   * (1) root is OR
+   * (2) root is AND
+   * (3) root itself is a leaf level operator: EQUALITY, RANGE, IN etc
+   *
+   * For (1) and (2), we look at the subtrees (children). For (3), currently
+   * the only case where rewrite is needed is for single predicate IN
+   *
+   * @param filterQueryTree root of tree to optimize/rewrite
+   * @return root of optimized tree
+   */
+  private FilterQueryTree optimize(FilterQueryTree filterQueryTree) {
     if (filterQueryTree.getOperator() == FilterOperator.OR) {
-      Map<String, Set<String>> columnToValues = new HashMap<>();
-      List<FilterQueryTree> nonEqualityOperators = new ArrayList<>();
-
-      // Collect all equality/in values and non-equality operators
-      boolean containsDuplicates = collectChildOperators(filterQueryTree, columnToValues, nonEqualityOperators);
-
-      // If we have at least one column to return
-      if (!columnToValues.isEmpty()) {
-        // We can eliminate the OR node if there is only one column with multiple values
-        if (columnToValues.size() == 1 && nonEqualityOperators.isEmpty()) {
-          Map.Entry<String, Set<String>> columnAndValues = columnToValues.entrySet().iterator().next();
-
-          return buildFilterQueryTreeForColumnAndValues(columnAndValues);
-        }
-
-        // Check if we need to rebuild the predicate
-        boolean rebuildRequired = isRebuildRequired(columnToValues, containsDuplicates);
-
-        if (!rebuildRequired) {
-          // No mutation needed, so just return the same tree
-          return filterQueryTree;
+      // CASE 1: Root operator is OR
+      return optimizeTreeRootedAtOR(filterQueryTree);
+    } else if (filterQueryTree.getOperator() == FilterOperator.AND) {
+      // CASE 2: Root operator is AND
+      return optimizeTreeRootedAtAND(filterQueryTree);
+    } else {
+      // CASE 3:
+      // if we are here, it means the query has a single predicate
+      // (just one column with one or more predicate values)
+      // a = 1
+      // a IN (1)
+      // a > 7
+      // a IN (1, 2, 3, 4)
+      // .... anything single predicate
+      if (filterQueryTree.getOperator() == FilterOperator.IN) {
+        // for single predicate rewriting, we currently handle the following scenario:
+        // for IN , dedup the values and rewrite it as IN/EQ based on
+        // whether the number of predicate values is more than 1 or 1
+        List<String> values = filterQueryTree.getValue();
+        if (values.size() > 1) {
+          // if more than 1 value, dedup them
+          // rewrite as IN if more than 1 value after deduping
+          // rewrite as EQ if 1 value after deduping
+          Set<String> deduped = new HashSet<>(values);
+          values = new ArrayList<>(deduped);
+          if (deduped.size() > 1) {
+            // e.g a IN (1, 2, 3, 4, 2, 3) -> a IN (1, 2, 3, 4)
+            return new FilterQueryTree(filterQueryTree.getColumn(), values, FilterOperator.IN, null);
+          }
+          // e.g a IN (1, 1, 1) -> a = 1
+          return new FilterQueryTree(filterQueryTree.getColumn(), values, FilterOperator.EQUALITY, null);
         } else {
-          // Rebuild the predicates
-          return rebuildFilterPredicate(columnToValues, nonEqualityOperators);
+          // e.g a IN (1) -> a = 1
+          return new FilterQueryTree(filterQueryTree.getColumn(), values, FilterOperator.EQUALITY, null);
         }
       }
-    } else if (filterQueryTree.getChildren() != null) {
-      // Optimize the child nodes, if any
-      applyOptimizationToChildNodes(filterQueryTree);
+      return filterQueryTree;
+    }
+  }
+
+  /**
+   * Optimize FilterQueryTree rooted at OR. We look at the immediate children
+   * of OR from two different scenarios:
+   *
+   * (1) The immediate child could be a IN or an EQUALITY operator
+   * (2) The immediate child could be other operators -- AND, NOT, RANGE, BETWEEN etc
+   *
+   * We first go over the immediate children and collect the operators
+   * in two separate data structures.
+   *
+   * (1) is maintained in a map of column name to unique set of 1 or more
+   * predicate values. For this we also track in a local variable whether
+   * the predicates in the map need to be rewritten or not. This decision
+   * is made by {@link #collectChildOperatorsOfRootOROperator(FilterQueryTree,
+   * Map, List)} method as it builds the data structure
+   *
+   * (2) is maintained in a simple list of FilterQueryTrees representing the
+   * non EQUALITY/IN operators. Also, as {@link #collectChildOperatorsOfRootOROperator
+   * (FilterQueryTree, Map, List)} builds this list, it also optimizes these set of
+   * FilterQueryTrees.
+   *
+   * We first deal with a very special case where the entire filter just has one column
+   * and there aren't any non EQUALITY/IN operators. Few examples to represent this
+   * scenario:
+   *
+   * A = 100 OR A = 200 OR A = 300
+   * A IN (100) OR A IN (200) OR A IN (300)
+   * A = 100 OR A = 200 OR A = 300 OR A IN (200, 300, 400, 500, 600)
+   *
+   * We simply remove OR and return a FilterQueryTree with leaf operator
+   * -- if the number of values is 1, use EQUALITY
+   * -- else use IN
+   *
+   * If this scenario is not applicable, we only need to look if EQUALITY/IN set
+   * of child operators need to be rewritten. This is already tracked in the
+   * boolean variable so we just need to check that.
+   *
+   * If the  variable is false, then we are done and return.
+   * Else, we go over each predicate in map, rewrite it and in the end append the
+   * list of non EQUALITY/IN operators (note hat these were already optimized as
+   * part of collect method). Finally, we return the root of this optimized tree
+   *
+   * Examples:
+   *
+   * a IN (1) OR b IN (2) -- two IN operators and zero other operators
+   * both IN operators can be rewritten to EQUALITY
+   *
+   * a IN (100) OR b = 300 -- one IN and one EQUALITY operator,
+   * zero other operators, IN can be rewritten
+   *
+   * a = 100 OR b = 300 -- two equality and zero other operators
+   * nothing needs to be rewritten
+   *
+   * a = 1 OR b = 2 OR c > 20 -- two equality and one other operator
+   * nothing needs to be rewritten
+
+   * a IN (1) OR b IN (2) OR c > 20 -- two IN operators and one other operators
+   * both IN operators can be rewritten to EQUALITY and other operator need not
+   * be rewritten
+   *
+   * a IN (1) OR b IN (2) OR (c > 20 AND a > 200)
+   * two IN operators and AND other operator. both IN can be rewritten
+   * and for AND we can't decide unless we drill down so we recurse.
+   *
+   * a = 1 OR b = 2 OR (c > 20 AND a > 200)
+   * two EQUALITY operators and AND other operator.
+   * both EQUALITY need not be rewritten
+   * and for AND we can't decide unless we drill down so we recurse
+   *
+   * a = 1 OR b = 2 OR (c IN (20) AND a > 200)
+   * two EQUALITY operators and AND other operator.
+   * both EQUALITY need not be rewritten
+   * and for AND we can't decide unless we drill down so we recurse --
+   * the recursion will return the AND tree with the inner IN rewritten
+   *
+   * @param filterQueryTree root of tree to optimize
+   * @return root of optimized tree
+   */
+  private FilterQueryTree optimizeTreeRootedAtOR(FilterQueryTree filterQueryTree) {
+    // TODO: evaluate if we can use TreeMap and TreeSet here
+    Map<String, Set<String>> columnToInEqPredicateValues = new HashMap<>();
+    List<FilterQueryTree> nonEqInOperators = new ArrayList<>();
+
+    // Collect all equality/in operators and non-equality operators
+    // these are the immediate children of root OR operator
+    boolean rewriteINEQChildrenOfORRootOperator = collectChildOperatorsOfRootOROperator(filterQueryTree, columnToInEqPredicateValues, nonEqInOperators);
+
+    if (columnToInEqPredicateValues.size() == 1 && nonEqInOperators.isEmpty()) {
+      // We can eliminate the OR root node if there is exactly one unique column with one or more
+      // predicate values(could be duplicate) using IN/OR. Rewritten as follows:
+      // -- if there is one predicate (after deduping), use EQUALITY
+      // -- else use IN
+      // e.g:
+      // a = 1 OR a = 1 --> can be rewritten as a = 1
+      // a = 1 OR a = 2 OR a = 3 --> can be rewritten as a IN (1, 2, 3)
+      Map.Entry<String, Set<String>> columnAndValues = columnToInEqPredicateValues.entrySet().iterator().next();
+      return buildFilterQueryTreeForColumnAndPredicateInfo(columnAndValues.getKey(), columnAndValues.getValue());
     }
 
+    if (!rewriteINEQChildrenOfORRootOperator) {
+      // No predicate rewriting, so just return the same tree
+      return filterQueryTree;
+    }
+
+    // Rewrite the IN/EQUALITY child operators
+    FilterQueryTree optimizedRoot = rebuildFilterPredicate(columnToInEqPredicateValues);
+    // append all non EQ/IN child operators
+    optimizedRoot.getChildren().addAll(nonEqInOperators);
+
+    return optimizedRoot;
+  }
+
+  /**
+   * Optimize FilterQueryTree rooted at AND. We recurse for each
+   * subtree by calling optimize
+   * The root (AND) is kept same and optimize is invoked on
+   * each subtree and updated in the children list of root
+   * @param filterQueryTree root of tree to optimize
+   * @return root of optimized tree
+   *
+   * Examples:
+   *
+   * a IN (1) AND b = 3 -- rewritten to a = 1 AND b = 3
+   * a IN (1) AND b IN (3) -- rewritten to a = 1 AND b = 3
+   * (a = 1 OR a = 2) AND b = 3 -- rewritten to (a IN (1, 2)) AND b = 3
+   * a > 20 AND a < 100 -- not rewritten
+   * a = 100 AND b = 300 -- not rewritten
+   * (a IN (1, 2, 3) OR b IN (4, 5, 6)) AND (a < 20 OR b > 2) -- not rewritten
+   */
+  private FilterQueryTree optimizeTreeRootedAtAND(FilterQueryTree filterQueryTree) {
+    List<FilterQueryTree> children = filterQueryTree.getChildren();
+    int numChildren = children.size();
+    for (int i = 0; i < numChildren; i++) {
+      FilterQueryTree childQueryTree = children.get(i);
+      children.set(i, optimize(childQueryTree));
+    }
     return filterQueryTree;
   }
 
-  private void applyOptimizationToChildNodes(FilterQueryTree filterQueryTree) {
-    Iterator<FilterQueryTree> childTreeIterator = filterQueryTree.getChildren().iterator();
-    List<FilterQueryTree> childrenToAdd = null;
-
-    while (childTreeIterator.hasNext()) {
-      FilterQueryTree childQueryTree = childTreeIterator.next();
-      FilterQueryTree optimizedChildQueryTree = optimize(childQueryTree, filterQueryTree);
-      if (childQueryTree != optimizedChildQueryTree) {
-        childTreeIterator.remove();
-        if (childrenToAdd == null) {
-          childrenToAdd = new ArrayList<>();
-        }
-        childrenToAdd.add(optimizedChildQueryTree);
-      }
-    }
-
-    if (childrenToAdd != null) {
-      filterQueryTree.getChildren().addAll(childrenToAdd);
-    }
-  }
-
-  private boolean collectChildOperators(FilterQueryTree filterQueryTree, Map<String, Set<String>> columnToValues,
-      List<FilterQueryTree> nonEqualityOperators) {
-    boolean containsDuplicates = false;
-
+  /**
+   * Collect the immediate children of FilterQueryTree rooted at OR.
+   * The children are collected in two separate data structures.
+   *
+   * (1) If the child operator is IN/EQUALITY, then it is stored
+   * in a map of column name to a predicate info containing the unique
+   * set of 1 or more predicate values and whether or not this predicate has to
+   * be rewritten. We decide this on the basis of:
+   *
+   * If there are duplicate values or if the column has occurred multiple times
+   * or if it is a single value IN predicate.
+   *
+   * (2) For all the other kinds of child operators (AND, <, >, BETWEEN etc),
+   * we simply collect the child FilterQueryTree in a list after calling
+   * optimize() on them if need be
+   *
+   * @param filterQueryTree root of OR tree
+   * @param columnToInEqPredicateValues Map data structure to collect all
+   *                                    immediate IN/EQUALITY child operators
+   * @param nonEqInOperators list to collect all other immediate child
+   *                         operators
+   * @return true if EQ/IN operators should be rewritten, false otherwise
+   */
+  private boolean collectChildOperatorsOfRootOROperator(FilterQueryTree filterQueryTree,
+      Map<String, Set<String>> columnToInEqPredicateValues, List<FilterQueryTree> nonEqInOperators) {
+    // create the array of overall size; it doesn't matter since we
+    // won't be using this array if non EQ/IN operator list is empty
+    boolean rewriteINEQChildrenOfORRootOperator = false;
     for (FilterQueryTree childQueryTree : filterQueryTree.getChildren()) {
-      if (childQueryTree.getOperator() == FilterOperator.EQUALITY
-          || childQueryTree.getOperator() == FilterOperator.IN) {
+      FilterOperator operator = childQueryTree.getOperator();
+      if (operator == FilterOperator.EQUALITY || operator == FilterOperator.IN) {
+        // the immediate child of root OR operator is EQUALITY or IN
         List<String> childValues = childQueryTree.getValue();
-        if (!columnToValues.containsKey(childQueryTree.getColumn())) {
-          TreeSet<String> value = new TreeSet<>(childValues);
-          columnToValues.put(childQueryTree.getColumn(), value);
-          if (!containsDuplicates && value.size() != childValues.size()) {
-            containsDuplicates = true;
+        String column = childQueryTree.getColumn();
+        Set<String> predicateValues = columnToInEqPredicateValues.get(column);
+        if (predicateValues == null) {
+          // we didn't see this column before
+          predicateValues = new HashSet<>(childValues);
+          // if after adding to the set, the number of predicate values become different (less),
+          // it implies that values got deduplicated and so we need to rewrite this predicate later
+          // similarly, if this is a single value IN predicate, we need to rewrite it later to equality
+          int numChildren = childValues.size();
+          if (operator == FilterOperator.IN && (numChildren == 1 || numChildren != predicateValues.size())) {
+            rewriteINEQChildrenOfORRootOperator = true;
           }
+          columnToInEqPredicateValues.put(column, predicateValues);
         } else {
-          Set<String> currentValues = columnToValues.get(childQueryTree.getColumn());
-          for (String childValue : childValues) {
-            if (!containsDuplicates && currentValues.contains(childValue)) {
-              containsDuplicates = true;
-            } else {
-              currentValues.add(childValue);
-            }
-          }
+          // if we had earlier seen this column, we need to rewrite the predicate
+          predicateValues.addAll(childValues);
+          rewriteINEQChildrenOfORRootOperator = true;
         }
       } else {
-        nonEqualityOperators.add(childQueryTree);
-      }
-    }
-
-    return containsDuplicates;
-  }
-
-  private boolean isRebuildRequired(Map<String, Set<String>> columnToValues, boolean containsDuplicates) {
-    // We need to rebuild the predicate if there were duplicate values detected (eg. a = 1 OR a = 1) or if there is
-    // more than one value for a column (eg. a = 1 OR a = 2)
-    boolean rebuildRequired = containsDuplicates;
-
-    if (!rebuildRequired) {
-      for (Set<String> columnValues : columnToValues.values()) {
-        if (1 < columnValues.size()) {
-          rebuildRequired = true;
-          break;
+        // the immediate child of root OR operator is AND, RANGE, BETWEEN etc
+        // only AND needs to be considered for optimization
+        // rest are not candidates
+        if (childQueryTree.getOperator() == FilterOperator.AND) {
+          nonEqInOperators.add(optimizeTreeRootedAtAND(childQueryTree));
+        } else {
+          nonEqInOperators.add(childQueryTree);
         }
       }
     }
-    return rebuildRequired;
+    return rewriteINEQChildrenOfORRootOperator;
   }
 
-  private FilterQueryTree rebuildFilterPredicate(Map<String, Set<String>> columnToValues,
-      List<FilterQueryTree> nonEqualityOperators) {
+  private FilterQueryTree rebuildFilterPredicate(Map<String, Set<String>> columnToInEqPredicateValues) {
     ArrayList<FilterQueryTree> newChildren = new ArrayList<>();
-    for (Map.Entry<String, Set<String>> columnAndValues : columnToValues.entrySet()) {
-      newChildren.add(buildFilterQueryTreeForColumnAndValues(columnAndValues));
+    for (Map.Entry<String, Set<String>> columnAndPredicate : columnToInEqPredicateValues.entrySet()) {
+      newChildren.add(buildFilterQueryTreeForColumnAndPredicateInfo(columnAndPredicate.getKey(), columnAndPredicate.getValue()));
     }
-    newChildren.addAll(nonEqualityOperators);
     return new FilterQueryTree(null, null, FilterOperator.OR, newChildren);
   }
 
-  private FilterQueryTree buildFilterQueryTreeForColumnAndValues(Map.Entry<String, Set<String>> columnAndValues) {
+  private FilterQueryTree buildFilterQueryTreeForColumnAndPredicateInfo(String column, Set<String> predicateValues) {
     // If there's only one value, turn it into an equality, otherwise turn it into an IN clause
-    if (columnAndValues.getValue().size() == 1) {
-      return new FilterQueryTree(columnAndValues.getKey(), new ArrayList<>(columnAndValues.getValue()),
-          FilterOperator.EQUALITY, null);
+    List<String> values = new ArrayList<>(predicateValues);
+    if (predicateValues.size() == 1) {
+      return new FilterQueryTree(column, values, FilterOperator.EQUALITY, null);
     } else {
-      return new FilterQueryTree(columnAndValues.getKey(), new ArrayList<>(columnAndValues.getValue()),
-          FilterOperator.IN, null);
+      return new FilterQueryTree(column, values, FilterOperator.IN, null);
     }
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
@@ -18,8 +18,19 @@
  */
 package org.apache.pinot.broker.requesthandler;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.FilterOperator;
+import org.apache.pinot.common.request.FilterQuery;
 import org.apache.pinot.common.utils.StringUtil;
+import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.testng.Assert;
@@ -66,15 +77,14 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
     checkForIdenticalFilterQueryTrees("select * from a where a = 1 OR a = 1", "select * from a where a = 1");
 
     // (a = 1 OR a = 1) AND b = 2 -> a = 1 AND b = 2 (no OR node either)
-    // These are reordered due to an implementation detail
     checkOptimizedFilterQueryTreeForQuery("select * from a where (a = 1 OR a = 1) AND b = 2",
-        "AND\n" + " b EQUALITY [2]\n" + " a EQUALITY [1]");
+        "AND\n" + " a EQUALITY [1]\n" + " b EQUALITY [2]");
   }
 
   @Test
   public void testEqualityAndInMerge() {
     // a = 1 OR a IN (2,3,4) -> a IN (1,2,3,4)
-    checkForIdenticalFilterQueryTrees("select * from a where a = 1 OR a IN (2,3,4,31)",
+    testHelper("select * from a where a = 1 OR a IN (2,3,4,31)",
         "select * from a where a IN (1,2,3,31,4)");
   }
 
@@ -85,7 +95,7 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
   }
 
   private static final Pql2Compiler COMPILER = new Pql2Compiler();
-  public static final BrokerRequestOptimizer OPTIMIZER = new BrokerRequestOptimizer();
+  public static final BrokerRequestOptimizer BROKER_REQUEST_OPTIMIZER = new BrokerRequestOptimizer();
 
   private String stripIds(String filterQueryTree) {
     String[] lines = filterQueryTree.split("\n");
@@ -99,7 +109,7 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
   }
 
   private String filterQueryTreeForQuery(String query) {
-    BrokerRequest brokerRequest = OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(query), null /* timeColumn */);
+    BrokerRequest brokerRequest = BROKER_REQUEST_OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(query), null /* timeColumn */);
     return RequestUtils.generateFilterQueryTree(brokerRequest).toString();
   }
 
@@ -115,5 +125,377 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
 
     Assert.assertEquals(queryFilterTree, stripIds(optimizedFilterQueryTree),
         "Optimized filter query trees are different for query " + query);
+  }
+
+  /**
+   * {@link MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer} returns
+   * the same FilterQueryTree (both instance and contents) which was originally
+   * passed to it as part of BrokerRequest if the query is not rewritten
+   */
+  @Test
+  public void testNoQueryRewrite() {
+    String query = "SELECT * FROM foo WHERE A IN (1, 2, 3)";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE A = 1";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE A = 1 OR A > 7";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE A IN (1, 2, 3, 4) OR A > 7";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE a = 100 OR (a = 200 AND b = 300)";
+    testNoQueryRewriteHelper(query);
+
+    // NOTE: this query should however be optimized by FlattenOptimizer to get rid of first predicate
+    query = "SELECT * FROM foo WHERE a = 100 OR (a = 100 AND b = 300)";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE A = 200 OR B = 300";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4) OR b = 100";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4) OR b IN (1, 2, 3, 4)";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4) OR b = 100 OR (a > 100 and b = 25)";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4) OR a > 10 OR b = 100";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE a > 20 AND a < 100";
+    testNoQueryRewriteHelper(query);
+
+    query = "SELECT * FROM foo WHERE (a IN (1, 2, 3) OR b IN (4, 5, 6)) AND (a < 20 OR b > 2)";
+    testNoQueryRewriteHelper(query);
+  }
+
+  private void testNoQueryRewriteHelper(String query) {
+    BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
+    // get the FilterQueryTree before running optimizer
+    FilterQueryTree filterQueryTreeBeforeOptimization = RequestUtils.generateFilterQueryTree(brokerRequest);
+
+    BROKER_REQUEST_OPTIMIZER.optimize(brokerRequest, null);
+    FilterQueryTree optimizedFilterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+
+    // compare both FilterQueryTrees to confirm that filter query
+    // tree didn't change at all -- this verifies that for cases where we don't
+    // have to rewrite the tree, we return the original tree
+    compareFilterQueryTreeIgnoringOrder(filterQueryTreeBeforeOptimization, optimizedFilterQueryTree);
+  }
+
+  @Test
+  public void testORRootOperatorWithSingleUniqueColumn() {
+    // tests for single unique column with EQ/IN filter operators
+
+    String queryToOptimize = "SELECT * FROM foo WHERE a IN (1)";
+    String goodQuery = "SELECT * FROM foo WHERE a = 1";
+    testHelper(queryToOptimize, goodQuery);
+
+    // 1. multiple EQs to single IN rewrite
+    queryToOptimize = "SELECT * FROM foo WHERE A = 100 OR A = 200 OR A = 300";
+    goodQuery = "SELECT * FROM foo WHERE A IN (100, 200, 300)";
+    testHelper(queryToOptimize, goodQuery);
+
+    // 2. multiple INs to single IN rewrite
+    queryToOptimize = "SELECT * FROM foo WHERE A IN (100) OR A IN (200) OR A IN (300)";
+    goodQuery = "SELECT * FROM foo WHERE A IN (100, 200, 300)";
+    testHelper(queryToOptimize, goodQuery);
+
+    // 3. rewrite EQ and IN as EQ
+    queryToOptimize = "SELECT * FROM foo WHERE A = 100 OR A IN (100)";
+    goodQuery = "SELECT * FROM foo WHERE A = 100";
+    testHelper(queryToOptimize, goodQuery);
+
+    // 4. rewrite EQ and EQ as EQ
+    queryToOptimize = "SELECT * FROM foo WHERE A = 100 OR A = 100";
+    goodQuery = "SELECT * FROM foo WHERE A = 100";
+    testHelper(queryToOptimize, goodQuery);
+
+    // 5. rewrite EQ and IN as IN with deduplication
+    queryToOptimize = "SELECT * FROM foo WHERE A = 100 OR A = 200 OR A = 300 OR A IN (200, 300, 400, 500, 600)";
+    goodQuery = "SELECT * FROM foo WHERE A IN (100, 200, 300, 400, 500, 600)";
+    testHelper(queryToOptimize, goodQuery);
+
+    // tests for single unique column with both EQ/IN and non EQ/IN operators
+
+    // 6. rewrite IN as EQ along with no rewrite for range on the same column
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1) OR a > 7";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 OR a > 7";
+    testHelper(queryToOptimize, goodQuery);
+
+    // 7. rewrite EQ and EQ as EQ along with no rewrite for range on the same column
+    queryToOptimize = "SELECT * FROM foo WHERE a = 1 OR a = 1 OR a > 7";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 OR a > 7";
+    testHelper(queryToOptimize, goodQuery);
+
+    // 8. rewrite EQ and EQ as IN along with no rewrite for range on the same column
+    queryToOptimize = "SELECT * FROM foo WHERE a = 1 OR a = 2 OR a > 7";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2) OR a > 7";
+    testHelper(queryToOptimize, goodQuery);
+
+    // 9. rewrite EQ and IN as IN along with no rewrite for range on the same column
+    queryToOptimize = "SELECT * FROM foo WHERE a = 1 OR a IN (2, 3, 4) OR a > 7";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4) OR a > 7";
+    testHelper(queryToOptimize, goodQuery);
+
+    // 10. rewrite EQ and IN as IN along with no rewrite for range on the same column
+    queryToOptimize = "SELECT * FROM foo WHERE a = 1 OR a IN (2, 3, 4) OR (a > 7 AND a < 20)";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4) OR (a > 7 AND a < 20)";
+    testHelper(queryToOptimize, goodQuery);
+  }
+
+  @Test
+  public void testORRootOperatorWithMultipleColumns() {
+    // tests for multiple columns with EQ/IN filter operators
+
+    String queryToOptimize = "SELECT * FROM foo WHERE a IN (1)";
+    String goodQuery = "SELECT * FROM foo WHERE a = 1";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1, 1, 1)";
+    goodQuery = "SELECT * FROM foo WHERE a = 1";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4, 1, 2)";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4)";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1) OR b IN (2)";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 OR b = 2";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4) OR b IN (4, 5, 6, 7) OR a IN (2, 5, 6)";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4, 5, 6) OR b IN (4, 5, 6, 7)";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (100) OR b = 300";
+    goodQuery = "SELECT * FROM foo WHERE a = 100 OR b = 300";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a = 100 OR a = 200 OR b = 300";
+    goodQuery = "SELECT * FROM foo WHERE a IN (100, 200) OR b = 300";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a = 1 OR a = 2 OR a IN (4, 5, 6, 7) OR b = 3";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2, 4, 5, 6, 7) OR b = 3";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a = 1 OR a = 1 OR b = 3";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 OR b = 3";
+    testHelper(queryToOptimize, goodQuery);
+
+    // tests for multiple columns with both EQ/IN and non EQ/IN operators
+
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1) OR b IN (2) OR c > 20";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 OR b = 2 OR c > 20";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1) OR b IN (2) OR c > 20 OR a > 200";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 OR b = 2 OR a > 200 OR c > 20";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1) OR b IN (2) OR (c > 20 AND a > 200)";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 OR b = 2 OR (c > 20 AND a > 200)";
+    testHelper(queryToOptimize, goodQuery);
+
+    // nested rewrite
+    queryToOptimize = "SELECT * FROM foo WHERE a = 1 OR b = 2 OR (c IN (20) AND a > 200)";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 OR b = 2 OR (c = 20 AND a > 200)";
+    testHelper(queryToOptimize, goodQuery);
+
+    // nested rewrite
+    queryToOptimize = "SELECT * FROM foo WHERE a = 1 OR b = 2 OR (c IN (20) AND a IN (200))";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 OR b = 2 OR (c = 20 AND a = 200)";
+    testHelper(queryToOptimize, goodQuery);
+
+    // nested rewrite
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1) OR a IN (2) OR b IN (2) OR (c IN (100) AND d IN (200))";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2) OR b = 2 OR (c = 100 AND d = 200)";
+    testHelper(queryToOptimize, goodQuery);
+
+    // nested rewrite
+    queryToOptimize = "SELECT * FROM foo WHERE a = 1 OR a IN (2, 3, 4) OR (a > 7 AND a < 20 AND b IN (2))";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2, 3, 4) OR (a > 7 AND a < 20 AND b = 2)";
+    testHelper(queryToOptimize, goodQuery);
+
+    // nested rewrite
+    queryToOptimize = "SELECT * FROM foo WHERE (a IN (1, 2, 3, 4) AND b > 20) OR (a > 7 AND a < 20 AND b IN (2))";
+    goodQuery = "SELECT * FROM foo WHERE (a IN (1, 2, 3, 4) AND b > 20) OR (a > 7 AND a < 20 AND b = 2)";
+    testHelper(queryToOptimize, goodQuery);
+
+    // nested rewrite
+    queryToOptimize = "SELECT * FROM foo WHERE (a IN (1, 2, 3, 4) AND (c = 20 OR c = 30 OR c = 40 OR b > 20)) OR (a > 7 AND a < 20 AND b IN (2))";
+    goodQuery = "SELECT * FROM foo WHERE (a IN (1, 2, 3, 4) AND (c IN (20, 30, 40) OR b > 20)) OR (a > 7 AND a < 20 AND b = 2)";
+    testHelper(queryToOptimize, goodQuery);
+  }
+
+  @Test
+  public void testANDRootOperator() {
+    String queryToOptimize = "SELECT * FROM foo WHERE a IN (1) AND b = 3";
+    String goodQuery = "SELECT * FROM foo WHERE a = 1 AND b = 3";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE a IN (1) AND b IN (3)";
+    goodQuery = "SELECT * FROM foo WHERE a = 1 AND b = 3";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE (a = 1 OR a = 2) AND b = 3";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2) AND b = 3";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE (a = 1 OR a = 2) AND b = 3 AND c > 7";
+    goodQuery = "SELECT * FROM foo WHERE a IN (1, 2) AND b = 3 AND c > 7";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE (a IN (1) OR b IN (3)) AND (b < 20 OR c > 20)";
+    goodQuery = "SELECT * FROM foo WHERE (a = 1 OR b = 3) AND (b < 20 OR c > 20)";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE (a = 1 OR a IN (1, 2, 3) OR b IN (3)) AND (b < 20 OR c > 20)";
+    goodQuery = "SELECT * FROM foo WHERE (a IN (1, 2, 3) OR b = 3) AND (b < 20 OR c > 20)";
+    testHelper(queryToOptimize, goodQuery);
+
+    queryToOptimize = "SELECT * FROM foo WHERE (a = 1 OR a IN (1, 2, 3) OR b IN (3)) AND (c IN (20) OR d > 100)";
+    goodQuery = "SELECT * FROM foo WHERE (a IN (1, 2, 3) OR b = 3) AND (c = 20 OR d > 100)";
+    testHelper(queryToOptimize, goodQuery);
+  }
+
+  /**
+   * Runs a candidate query to optimize/rewrite and another "good" query
+   * which need not be optimized.
+   *
+   * Verification is done by first checking that "good" query is indeed good
+   * and that no optimization/rewrite is required on it.
+   *
+   * Secondly, we compile good query and get its broker request and FilterQueryTree
+   *
+   * We then compile the candidate query and get its broker request and FilterQueryTree.
+   * Optimize this one and compare the resulting FilterQuery with that of good query.
+   *
+   * @param queryToOptimize candidate query to optimize
+   * @param goodQuery good query that is not rewritten
+   */
+  private void testHelper(String queryToOptimize, String goodQuery) {
+    // first check that goodQuery is not rewritten
+    testNoQueryRewriteHelper(goodQuery);
+
+    // compile good query, get broker request and filter query tree
+    BrokerRequest goodQueryBrokerRequest = COMPILER.compileToBrokerRequest(goodQuery);
+    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(goodQueryBrokerRequest);
+
+    // compile candidate query, get broker request and optimize it
+    BrokerRequest brokerRequestToOptimize = COMPILER.compileToBrokerRequest(queryToOptimize);
+    // this would update the broker request with optimized filter query
+    BROKER_REQUEST_OPTIMIZER.optimize(brokerRequestToOptimize, null);
+    FilterQueryTree optimizedFilterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequestToOptimize);
+
+    // compare the optimized filter query tree with filter query tree of good query
+    compareFilterQueryTreeIgnoringOrder(filterQueryTree, optimizedFilterQueryTree);
+  }
+
+  private void compareFilterQueryTreeIgnoringOrder(FilterQueryTree fq1, FilterQueryTree fq2) {
+    Assert.assertNotNull(fq1);
+    Assert.assertNotNull(fq2);
+
+    Assert.assertEquals(fq1.getOperator(), fq2.getOperator());
+    Assert.assertEquals(fq1.getColumn(), fq2.getColumn());
+
+    List<FilterQueryTree> children1 = fq1.getChildren();
+    List<FilterQueryTree> children2 = fq2.getChildren();
+
+    if (children1 == null) {
+      Assert.assertNull(children2);
+    } else {
+      Assert.assertNotNull(children2);
+    }
+
+    if (children1 == null) {
+      // this is a leaf level ROOT operator so we need to only compare predicate
+      // values ignoring order since we have already compared the operator name and column name
+      // above
+      compareValues(fq1.getValue(), fq2.getValue());
+    } else {
+      Assert.assertEquals(children1.size(), children2.size());
+      // this is a non leaf ROOT operator (OR, AND)
+
+      // STEP 1: get its leaf operator children -- IN, EQ, >, <, BETWEEN etc
+      List<FilterQueryTree> childrenThatAreLeafOperators1 = getChildrenThatAreLeafOperators(fq1);
+      List<FilterQueryTree> childrenThatAreLeafOperators2 = getChildrenThatAreLeafOperators(fq2);
+      // compare them by sorting on column and comparing the predicate values ignoring order
+      compareLeafOperators(childrenThatAreLeafOperators1, childrenThatAreLeafOperators2);
+
+      // STEP 2: get its non-leaf operator children -- AND, OR
+      List<FilterQueryTree> childrenThatAreNonLeafOperators1 = getChildrenThatAreNonLeafOperators(fq1);
+      List<FilterQueryTree> childrenThatAreNonLeafOperators2 = getChildrenThatAreNonLeafOperators(fq2);
+
+      // compare the size
+      Assert.assertEquals(childrenThatAreNonLeafOperators1.size(), childrenThatAreNonLeafOperators2.size());
+
+      // the optimizer adds them in the same order so we simply need to recurse
+      // and let the rest of this code compare the subtrees ignoring order
+      for (int i = 0; i < childrenThatAreNonLeafOperators1.size(); i++) {
+        FilterQueryTree f1 = childrenThatAreNonLeafOperators1.get(i);
+        FilterQueryTree f2 = childrenThatAreNonLeafOperators2.get(i);
+        compareFilterQueryTreeIgnoringOrder(f1, f2);
+      }
+    }
+  }
+
+  private void compareLeafOperators(List<FilterQueryTree> childrenThatAreLeafOperators1, List<FilterQueryTree> childrenThatAreLeafOperators2) {
+    Assert.assertNotNull(childrenThatAreLeafOperators1);
+    Assert.assertNotNull(childrenThatAreLeafOperators2);
+    Assert.assertEquals(childrenThatAreLeafOperators1.size(), childrenThatAreLeafOperators2.size());
+    Comparator<FilterQueryTree> comparator = new Comparator<FilterQueryTree>() {
+      @Override
+      public int compare(FilterQueryTree o1, FilterQueryTree o2) {
+        return o1.getColumn().compareTo(o2.getColumn());
+      }
+    };
+
+    Collections.sort(childrenThatAreLeafOperators1, comparator);
+    Collections.sort(childrenThatAreLeafOperators2, comparator);
+
+    for (int i = 0; i < childrenThatAreLeafOperators1.size(); i++) {
+      FilterQueryTree fq1 = childrenThatAreLeafOperators1.get(i);
+      FilterQueryTree fq2 = childrenThatAreLeafOperators2.get(i);
+      // this will straight go into comparing a root operator that is leaf
+      compareFilterQueryTreeIgnoringOrder(fq1, fq2);
+    }
+  }
+
+  private List<FilterQueryTree> getChildrenThatAreNonLeafOperators(FilterQueryTree filterQueryTree) {
+    List<FilterQueryTree> result = new ArrayList<>();
+    for (FilterQueryTree child : filterQueryTree.getChildren()) {
+      if (child.getOperator() == FilterOperator.AND || child.getOperator() == FilterOperator.OR) {
+        result.add(child);
+      }
+    }
+    return result;
+  }
+
+  private List<FilterQueryTree> getChildrenThatAreLeafOperators(FilterQueryTree filterQueryTree) {
+    List<FilterQueryTree> result = new ArrayList<>();
+    for (FilterQueryTree child : filterQueryTree.getChildren()) {
+      if (child.getOperator() != FilterOperator.AND && child.getOperator() != FilterOperator.OR) {
+        result.add(child);
+      }
+    }
+    return result;
+  }
+
+  private void compareValues(List<String> values1, List<String> values2) {
+    Assert.assertNotNull(values1);
+    Assert.assertNotNull(values2);
+    Assert.assertEquals(values1.size(), values2.size());
+    Set<String> set = new HashSet<>(values1);
+    for (String val : values2) {
+      Assert.assertTrue(set.contains(val));
+    }
   }
 }


### PR DESCRIPTION
Rewrite single value IN predicate as EQUALITY. Also add support for doing the predicate rewriting
for nested tree in MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer
    
Added plenty of more tests covering:
    
(1) tests for cases where query need not be rewritten (the existing code didn't handle this well)
    
(2) nested query rewrite
    
(3) tests for both AND, OR rooted trees