### PR TITLE
Remove the redundant testSqlQueriesFromQueryFile() in integration tests

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -262,8 +262,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
 
   /**
    * Test random SQL queries from the query file.
-   *
-   * @throws Exception
+   * TODO: fix this teat by adding the SQL query file
    */
   public void testSqlQueriesFromQueryFile()
       throws Exception {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -262,7 +262,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
 
   /**
    * Test random SQL queries from the query file.
-   * TODO: fix this teat by adding the SQL query file
+   * TODO: fix this test by adding the SQL query file
    */
   public void testSqlQueriesFromQueryFile()
       throws Exception {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DefaultCommitterRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DefaultCommitterRealtimeIntegrationTest.java
@@ -186,11 +186,6 @@ public class DefaultCommitterRealtimeIntegrationTest extends RealtimeClusterInte
   }
 
   @Override
-  public void testSqlQueriesFromQueryFile()
-      throws Exception {
-  }
-
-  @Override
   public void testQueryExceptions()
       throws Exception {
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HadoopSegmentBuildPushOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HadoopSegmentBuildPushOfflineClusterIntegrationTest.java
@@ -143,13 +143,6 @@ public class HadoopSegmentBuildPushOfflineClusterIntegrationTest extends BaseClu
 
   @Test
   @Override
-  public void testSqlQueriesFromQueryFile()
-      throws Exception {
-    super.testQueriesFromQueryFile();
-  }
-
-  @Test
-  @Override
   public void testGeneratedQueriesWithMultiValues()
       throws Exception {
     super.testGeneratedQueriesWithMultiValues();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -235,13 +235,6 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
 
   @Test
   @Override
-  public void testSqlQueriesFromQueryFile()
-      throws Exception {
-    super.testQueriesFromQueryFile();
-  }
-
-  @Test
-  @Override
   public void testGeneratedQueriesWithMultiValues()
       throws Exception {
     super.testGeneratedQueriesWithMultiValues();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -47,13 +47,6 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
 
   @Test
   @Override
-  public void testSqlQueriesFromQueryFile()
-      throws Exception {
-    super.testQueriesFromQueryFile();
-  }
-
-  @Test
-  @Override
   public void testGeneratedQueriesWithMultiValues()
       throws Exception {
     super.testGeneratedQueriesWithMultiValues();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -809,11 +809,4 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     sql = "SELECT DISTINCT Carrier, DestAirportID, DestCityName FROM mytable";
     testQuery(pql, Collections.singletonList(sql));
   }
-
-  @Test
-  @Override
-  public void testSqlQueriesFromQueryFile()
-      throws Exception {
-    super.testQueriesFromQueryFile();
-  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -83,13 +83,6 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
 
   @Test
   @Override
-  public void testSqlQueriesFromQueryFile()
-      throws Exception {
-    super.testQueriesFromQueryFile();
-  }
-
-  @Test
-  @Override
   public void testGeneratedQueriesWithMultiValues()
       throws Exception {
     super.testGeneratedQueriesWithMultiValues();


### PR DESCRIPTION
This test is calling the testQueriesFromQueryFile(), which is already called in the test
To fix this test, we need to generate a SQL version of the query file