### PR TITLE
Add getFinalResultColumnType to be used in constructing ResultTable::dataSchema

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -110,7 +110,6 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   /**
    * Returns the {@link ColumnDataType} of the final result.
    * <p>This column data type is used for constructing the result table</p>
-   * @return
    */
   ColumnDataType getFinalResultColumnType();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -108,6 +108,13 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   ColumnDataType getIntermediateResultColumnType();
 
   /**
+   * Returns the {@link ColumnDataType} of the final result.
+   * <p>This column data type is used for constructing the result table</p>
+   * @return
+   */
+  ColumnDataType getFinalResultColumnType();
+
+  /**
    * Extracts the final result used in the broker response from the given intermediate result.
    * TODO: Support serializing/deserializing null values in DataTable and use null as the empty intermediate result
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -179,6 +179,11 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE;
+  }
+
+  @Override
   public Double extractFinalResult(AvgPair intermediateResult) {
     long count = intermediateResult.getCount();
     if (count == 0L) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -136,6 +136,11 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.LONG;
+  }
+
+  @Override
   public Long extractFinalResult(Long intermediateResult) {
     return intermediateResult;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
@@ -172,6 +172,11 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    throw new UnsupportedOperationException("Operation not supported for DISTINCT aggregation function");
+  }
+
+  @Override
   public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
     throw new UnsupportedOperationException("Operation not supported for DISTINCT aggregation function");
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -214,6 +214,11 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.INT;
+  }
+
+  @Override
   public Integer extractFinalResult(IntOpenHashSet intermediateResult) {
     return intermediateResult.size();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -306,6 +306,11 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.LONG;
+  }
+
+  @Override
   public Long extractFinalResult(HyperLogLog intermediateResult) {
     return intermediateResult.cardinality();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -106,6 +106,11 @@ public class DistinctCountRawHLLAggregationFunction implements AggregationFuncti
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.STRING;
+  }
+
+  @Override
   public SerializedHLL extractFinalResult(HyperLogLog intermediateResult) {
     return SerializedHLL.of(intermediateResult);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -147,6 +147,11 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.LONG;
+  }
+
+  @Override
   public Long extractFinalResult(HyperLogLog intermediateResult) {
     return intermediateResult.cardinality();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -125,6 +125,11 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE;
+  }
+
+  @Override
   public Double extractFinalResult(Double intermediateResult) {
     return intermediateResult;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -125,6 +125,11 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE;
+  }
+
+  @Override
   public Double extractFinalResult(Double intermediateResult) {
     return intermediateResult;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -189,6 +189,11 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE;
+  }
+
+  @Override
   public Double extractFinalResult(MinMaxRangePair intermediateResult) {
     return intermediateResult.getMax() - intermediateResult.getMin();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -132,6 +132,11 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE;
+  }
+
+  @Override
   public Double extractFinalResult(DoubleArrayList intermediateResult) {
     int size = intermediateResult.size();
     if (size == 0) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -187,6 +187,11 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.LONG;
+  }
+
+  @Override
   public Long extractFinalResult(QuantileDigest intermediateResult) {
     return intermediateResult.getQuantile(_percentile / 100.0);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -189,6 +189,11 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE;
+  }
+
+  @Override
   public Double extractFinalResult(TDigest intermediateResult) {
     return intermediateResult.quantile(_percentile / 100.0);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -113,6 +113,11 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE;
+  }
+
+  @Override
   public Double extractFinalResult(Double intermediateResult) {
     return intermediateResult;
   }


### PR DESCRIPTION
This is necessary because for the sql compliance work, we will be making each query type generate results into ResultTable. ResultTable needs to set the dataSchema of the final results, and we need a way to get the data type of the final extracted aggregation results.

https://github.com/apache/incubator-pinot/issues/4450