### PR TITLE
Fixing encryption for .tar.gz upload

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -192,7 +192,7 @@ public class PinotSegmentUploadDownloadRestletResource {
                   metadataProviderClass);
           break;
         case SEGMENT:
-          getFileFromMultipart(multiPart, tempDecryptedFile);
+          getFileFromMultipart(multiPart, tempEncryptedFile);
           segmentMetadata = getSegmentMetadata(crypterClassName, tempEncryptedFile, tempDecryptedFile, tempSegmentDir,
               metadataProviderClass);
           break;
@@ -303,14 +303,14 @@ public class PinotSegmentUploadDownloadRestletResource {
     return MetadataExtractorFactory.create(metadataProviderClass).extractMetadata(tempDecryptedFile, tempSegmentDir);
   }
 
-  private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File tempDecryptedFile,
+  private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File tempEncryptedFile,
       FileUploadPathProvider provider, String rawTableName, SegmentMetadata segmentMetadata, String segmentName,
       String zkDownloadURI, boolean moveSegmentToFinalLocation)
       throws Exception {
     URI finalSegmentLocationURI =
         URIUtils.getUri(provider.getBaseDataDirURI().toString(), rawTableName, URIUtils.encode(segmentName));
     ZKOperator zkOperator = new ZKOperator(_pinotHelixResourceManager, _controllerConf, _controllerMetrics);
-    zkOperator.completeSegmentOperations(rawTableName, segmentMetadata, finalSegmentLocationURI, tempDecryptedFile,
+    zkOperator.completeSegmentOperations(rawTableName, segmentMetadata, finalSegmentLocationURI, tempEncryptedFile,
         enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation);
   }
 


### PR DESCRIPTION
* If an encrypted file comes, its encryptedFile location will be different than its decryptedFile location; otherwise, they will be the same. Therefore, segments should always be streamed into the encryptedFile location rather than the decryptedFile location to prevent a FileNotFoundException.