### PR TITLE
[TE] Generify centralized cache DAO and add certificate-based authentication support for Couchbase

### DIFF
--- a/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
+++ b/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
@@ -12,7 +12,7 @@ centralizedCacheSettings:
     couchbase:
       className: org.apache.pinot.thirdeye.detection.cache.CouchbaseCacheDAO
       config:
-        useCertificateBasedAuthentication: falses
+        useCertificateBasedAuthentication: false
         # at least 1 host needed
         hosts:
           - 'host1' # ex. http://localhost:8091

--- a/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
+++ b/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
@@ -23,7 +23,7 @@ centralizedCacheSettings:
         # if using certificate-based authentication, authUsername and authPassword values don't matter and won't be used
         authUsername: 'your_bucket_user_username'
         authPassword: 'your_bucket_user_password'
-        enableDnsSrv: true
+        enableDnsSrv: false
         # certificate based authentication is only available in Couchbase enterprise edition. 
         keyStoreFilePath: 'key/store/path/keystore_file' # e.g. '/var/identity.p12'
         # if your keystore has a password, enter it here. by default, Java uses 'work_around_jdk-6879539' to enable empty passwords for certificates.

--- a/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
+++ b/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
@@ -12,7 +12,7 @@ centralizedCacheSettings:
     couchbase:
       className: org.apache.pinot.thirdeye.detection.cache.CouchbaseCacheDAO
       config:
-        useCertificateBasedAuthentication: false
+        useCertificateBasedAuthentication: falses
         # at least 1 host needed
         hosts:
           - 'host1' # ex. http://localhost:8091
@@ -23,6 +23,7 @@ centralizedCacheSettings:
         # if using certificate-based authentication, authUsername and authPassword values don't matter and won't be used
         authUsername: 'your_bucket_user_username'
         authPassword: 'your_bucket_user_password'
+        enableDnsSrv: true
         # certificate based authentication is only available in Couchbase enterprise edition. 
         keyStoreFilePath: 'key/store/path/keystore_file' # e.g. '/var/identity.p12'
         # by default, Java uses this password to enable empty passwords for certificates.

--- a/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
+++ b/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
@@ -26,9 +26,9 @@ centralizedCacheSettings:
         enableDnsSrv: true
         # certificate based authentication is only available in Couchbase enterprise edition. 
         keyStoreFilePath: 'key/store/path/keystore_file' # e.g. '/var/identity.p12'
-        # by default, Java uses this password to enable empty passwords for certificates.
+        # if your keystore has a password, enter it here. by default, Java uses 'work_around_jdk-6879539' to enable empty passwords for certificates.
         keyStorePassword: 'work_around_jdk-6879539'
         trustStoreFilePath: 'trust/store/path/truststore_file' # e.g. '/etc/riddler/cacerts'
-        trustStorePassword: '' 
+        trustStorePassword: ''
     # add your store of choice here
 

--- a/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
+++ b/thirdeye/thirdeye-pinot/config/data-sources/cache-config.yml
@@ -1,5 +1,3 @@
-
-# please use at most one cache at a time, either the in-memory cache or the centralized cache.
 useInMemoryCache: true
 useCentralizedCache: false
 
@@ -9,12 +7,27 @@ centralizedCacheSettings:
   # if inserting data points individually, max number of threads to spawn to parallel insert at a time
   maxParallelInserts: 10
   # which store to use
-  cacheDataStoreName: couchbase
+  cacheDataStoreName: 'couchbase'
   cacheDataSources:
     couchbase:
-      # host can just be localhost if you're using this locally.
-      host: your_host
-      authUsername: your_username
-      authPassword: your_password
-      bucketName: your_bucket_name
+      className: org.apache.pinot.thirdeye.detection.cache.CouchbaseCacheDAO
+      config:
+        useCertificateBasedAuthentication: false
+        # at least 1 host needed
+        hosts:
+          - 'host1' # ex. http://localhost:8091
+          - 'host2' # ex. http://localhost:8092
+          - 'host3' # ex. http://localhost:8093
+          - 'host4' # and so on...
+        bucketName: 'your_bucket_name'
+        # if using certificate-based authentication, authUsername and authPassword values don't matter and won't be used
+        authUsername: 'your_bucket_user_username'
+        authPassword: 'your_bucket_user_password'
+        # certificate based authentication is only available in Couchbase enterprise edition. 
+        keyStoreFilePath: 'key/store/path/keystore_file' # e.g. '/var/identity.p12'
+        # by default, Java uses this password to enable empty passwords for certificates.
+        keyStorePassword: 'work_around_jdk-6879539'
+        trustStoreFilePath: 'trust/store/path/truststore_file' # e.g. '/etc/riddler/cacerts'
+        trustStorePassword: '' 
     # add your store of choice here
+

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/ThirdEyeCacheRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/ThirdEyeCacheRegistry.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.thirdeye.detection.cache.CacheConfig;
 import org.apache.pinot.thirdeye.detection.cache.CacheConfigLoader;
+import org.apache.pinot.thirdeye.detection.cache.CacheDAO;
 import org.apache.pinot.thirdeye.detection.cache.CacheDataSource;
 import org.apache.pinot.thirdeye.detection.cache.CentralizedCacheConfig;
 import org.apache.pinot.thirdeye.detection.cache.CouchbaseCacheDAO;
@@ -106,20 +107,17 @@ public class ThirdEyeCacheRegistry {
       if (cacheConfig == null) {
         LOGGER.error("Could not get cache config from path {} - reverting to default settings", cacheConfigUrl);
         setupDefaultTimeSeriesCacheSettings();
-      } else {
-        CacheDataSource dataSource = CacheConfig.getInstance().getCentralizedCacheSettings().getDataSourceConfig();
+      }
 
-        cacheConfig.setHost(dataSource.getHost());
-        cacheConfig.setAuthUsername(dataSource.getAuthUsername());
-        cacheConfig.setAuthPassword(dataSource.getAuthPassword());
-        cacheConfig.setBucketName(dataSource.getBucketName());
+      CacheDAO cacheDAO = null;
+      if (cacheConfig.useCentralizedCache()) {
+        cacheDAO = CacheConfigLoader.loadCacheDAO(cacheConfig);
       }
 
       if (INSTANCE.getTimeSeriesCache() == null) {
-        // TODO: add generic cache DAO
         TimeSeriesCache timeSeriesCache = new DefaultTimeSeriesCache(DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO(),
             ThirdEyeCacheRegistry.getInstance().getQueryCache(),
-            new CouchbaseCacheDAO(),
+            cacheDAO,
             Executors.newFixedThreadPool(CacheConfig.getInstance().getCentralizedCacheSettings().getMaxParallelInserts()));
 
         ThirdEyeCacheRegistry.getInstance().registerTimeSeriesCache(timeSeriesCache);
@@ -130,6 +128,9 @@ public class ThirdEyeCacheRegistry {
     }
   }
 
+  /**
+   * Use "default" cache settings, meaning
+   */
   private static void setupDefaultTimeSeriesCacheSettings() {
     CentralizedCacheConfig cfg = new CentralizedCacheConfig();
     cfg.setMaxParallelInserts(1);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheConfig.java
@@ -25,22 +25,13 @@ package org.apache.pinot.thirdeye.detection.cache;
  */
 public class CacheConfig {
 
-  public static CacheConfig instance = new CacheConfig();
+  public static CacheConfig INSTANCE = new CacheConfig();
 
   /**
-   * flags for which cache to use; recommended to only use one at a time
+   * flags for which cache(s) to use
    */
   private static boolean useInMemoryCache;
   private static boolean useCentralizedCache;
-
-  /**
-   * config values for accessing the centralized cache. should be set from CentralizedCacheConfig values.
-   * these are added here for ease-of-access and making code a little more readable.
-   */
-  private static String host;
-  private static String authUsername;
-  private static String authPassword;
-  private static String bucketName;
 
   /**
    * settings for centralized cache.
@@ -50,24 +41,13 @@ public class CacheConfig {
   // left blank
   public CacheConfig() {}
 
-  public static CacheConfig getInstance() { return instance; }
+  public static CacheConfig getInstance() { return INSTANCE; }
 
   public boolean useCentralizedCache() { return useCentralizedCache; }
   public boolean useInMemoryCache() { return useInMemoryCache; }
   public CentralizedCacheConfig getCentralizedCacheSettings() { return centralizedCacheSettings; }
 
-  public String getHost() { return host; }
-  public String getAuthUsername() { return authUsername; }
-  public String getAuthPassword() { return authPassword; }
-  public String getBucketName() { return bucketName; }
-
   public void setUseCentralizedCache(boolean toggle) { useCentralizedCache = toggle; }
   public void setUseInMemoryCache(boolean toggle) { useInMemoryCache = toggle; }
   public void setCentralizedCacheSettings(CentralizedCacheConfig centralizedCacheConfig) { centralizedCacheSettings = centralizedCacheConfig; }
-
-  public void setHost(String host) { CacheConfig.host = host; }
-  public void setAuthUsername(String authUsername) { CacheConfig.authUsername = authUsername; }
-  public void setAuthPassword(String authPassword) { CacheConfig.authPassword = authPassword; }
-  public void setBucketName(String bucketName) { CacheConfig.bucketName = bucketName; }
-
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheConfigLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheConfigLoader.java
@@ -22,6 +22,7 @@ package org.apache.pinot.thirdeye.detection.cache;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.net.URL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,5 +48,11 @@ public class CacheConfigLoader {
       LOG.error("Exception in reading cache config {}", cacheConfigUrl, e);
     }
     return cacheConfig;
+  }
+
+  public static CacheDAO loadCacheDAO(CacheConfig config) throws Exception {
+    String className = config.getCentralizedCacheSettings().getDataSourceConfig().getClassName();
+    Constructor<?> constructor = Class.forName(className).getConstructor();
+    return (CacheDAO) constructor.newInstance();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheDAO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheDAO.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.cache;
+
+/**
+ * interface for cache DAO. Should handle all read/write access to the data store of choice.
+ */
+public interface CacheDAO {
+
+  /**
+   * Tries to fetch the data for a given ThirdEyeCacheRequest and returns it.
+   * @param request ThirdEyeCacheRequest
+   * @return ThirdEyeCacheResponse containing a list of {@link org.apache.pinot.thirdeye.detection.cache.TimeSeriesDataPoint}
+   * @throws Exception Only thrown if query errored out, NOT if no data was found!
+   */
+  ThirdEyeCacheResponse tryFetchExistingTimeSeries(ThirdEyeCacheRequest request) throws Exception;
+
+  /**
+   * Insert a TimeSeriesDataPoint into data store. Schema design is up to the user, although we show an example
+   * schema that we use for Couchbase in {@link CouchbaseCacheDAO#insertTimeSeriesDataPoint(TimeSeriesDataPoint)}
+   * @param point TimeSeriesDataPoint
+   */
+  void insertTimeSeriesDataPoint(TimeSeriesDataPoint point);
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheDataSource.java
@@ -19,6 +19,9 @@
 
 package org.apache.pinot.thirdeye.detection.cache;
 
+import java.util.Map;
+
+
 /**
  * Config for a single centralized cache data source.
  * For example, this class could be for Couchbase, or Redis, or Cassandra, etc.
@@ -26,23 +29,25 @@ package org.apache.pinot.thirdeye.detection.cache;
 public class CacheDataSource {
 
   /**
-   * authentication stuff.
+   * class name, e.g. org.apache.pinot.thirdeye.detection.cache.CouchbaseCacheDAO
    */
-  private String host;
-  private String authUsername;
-  private String authPassword;
-  private String bucketName;
+  private String className;
+
+  /**
+   * settings/config for the specific data source. generic since different
+   * data stores may have different authentication methods.
+   */
+  private Map<String, Object> config;
 
   // left blank
   public CacheDataSource() {}
 
-  public String getHost() { return host; }
-  public String getAuthUsername() { return authUsername; }
-  public String getAuthPassword() { return authPassword; }
-  public String getBucketName() { return bucketName; }
+  public String getClassName() { return className; }
+  public Map<String, Object> getConfig() { return config; }
 
-  public void setHost(String host) { this.host = host; }
-  public void setAuthUsername(String authUsername) { this.authUsername = authUsername; }
-  public void setAuthPassword(String authPassword) { this.authPassword = authPassword; }
-  public void setBucketName(String bucketName) { this.bucketName = bucketName; }
+  public Object getField(String fieldName) { return config.get(fieldName); }
+  public String getFieldAsString(String fieldName) { return String.valueOf(config.get(fieldName)); }
+
+  public void setClassName(String className) { this.className = className; }
+  public void setConfig(Map<String, Object> config) { this.config = config; }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheDataSource.java
@@ -47,6 +47,7 @@ public class CacheDataSource {
 
   public Object getField(String fieldName) { return config.get(fieldName); }
   public String getFieldAsString(String fieldName) { return String.valueOf(config.get(fieldName)); }
+  public Boolean getFieldAsBoolean(String fieldName) { return Boolean.parseBoolean(this.getFieldAsString(fieldName)); }
 
   public void setClassName(String className) { this.className = className; }
   public void setConfig(Map<String, Object> config) { this.config = config; }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheDataSource.java
@@ -45,10 +45,6 @@ public class CacheDataSource {
   public String getClassName() { return className; }
   public Map<String, Object> getConfig() { return config; }
 
-  public Object getField(String fieldName) { return config.get(fieldName); }
-  public String getFieldAsString(String fieldName) { return String.valueOf(config.get(fieldName)); }
-  public Boolean getFieldAsBoolean(String fieldName) { return Boolean.parseBoolean(this.getFieldAsString(fieldName)); }
-
   public void setClassName(String className) { this.className = className; }
   public void setConfig(Map<String, Object> config) { this.config = config; }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CentralizedCacheConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CentralizedCacheConfig.java
@@ -60,7 +60,7 @@ public class CentralizedCacheConfig {
    * shorthand to get the config for the single data source specified in the config file
    * @return CacheDataSource with auth info
    */
-  public CacheDataSource getDataSourceConfig() { return cacheDataSources.get(cacheDataStoreName);  }
+  public CacheDataSource getDataSourceConfig() { return cacheDataSources.get(cacheDataStoreName); }
 
   public void setTTL(int ttl) { this.ttl = ttl; }
   public void setMaxParallelInserts(int maxParallelInserts) { this.maxParallelInserts = maxParallelInserts; }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CouchbaseCacheDAO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CouchbaseCacheDAO.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.configuration2.ConfigurationUtils;
 import org.apache.pinot.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.util.CacheUtils;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CouchbaseCacheDAO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CouchbaseCacheDAO.java
@@ -49,6 +49,7 @@ public class CouchbaseCacheDAO implements CacheDAO {
   private static final String BUCKET_NAME = "bucketName";
   private static final String AUTH_USERNAME = "authUsername";
   private static final String AUTH_PASSWORD = "authPassword";
+  private static final String ENABLE_DNS_SRV = "enableDnsSrv";
   private static final String KEY_STORE_FILE_PATH = "keyStoreFilePath";
   private static final String KEY_STORE_PASSWORD = "keyStorePassword";
   private static final String TRUST_STORE_FILE_PATH = "trustStoreFilePath";
@@ -70,11 +71,12 @@ public class CouchbaseCacheDAO implements CacheDAO {
     List<String> hosts = (List)config.getField(HOSTS);
 
     Cluster cluster;
-    if (Boolean.parseBoolean(config.getFieldAsString(USE_CERT_BASED_AUTH))) {
+    if (config.getFieldAsBoolean(USE_CERT_BASED_AUTH)) {
       CouchbaseEnvironment env = DefaultCouchbaseEnvironment
           .builder()
           .sslEnabled(true)
           .certAuthEnabled(true)
+          .dnsSrvEnabled(config.getFieldAsBoolean(ENABLE_DNS_SRV))
           .sslKeystoreFile(config.getFieldAsString(KEY_STORE_FILE_PATH))
           .sslKeystorePassword(config.getFieldAsString(KEY_STORE_PASSWORD))
           .sslTruststoreFile(config.getFieldAsString(TRUST_STORE_FILE_PATH))

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CouchbaseCacheDAO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CouchbaseCacheDAO.java
@@ -49,7 +49,6 @@ public class CouchbaseCacheDAO implements CacheDAO {
 
   private static final String USE_CERT_BASED_AUTH = "useCertificateBasedAuthentication";
   private static final String HOSTS = "hosts";
-  private static final String BUCKET_NAME = "bucketName";
   private static final String AUTH_USERNAME = "authUsername";
   private static final String AUTH_PASSWORD = "authPassword";
   private static final String ENABLE_DNS_SRV = "enableDnsSrv";

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/DefaultTimeSeriesCache.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/DefaultTimeSeriesCache.java
@@ -57,10 +57,10 @@ public class DefaultTimeSeriesCache implements TimeSeriesCache {
   private final MetricConfigManager metricDAO;
   private final DatasetConfigManager datasetDAO;
   private final QueryCache queryCache;
-  private CouchbaseCacheDAO cacheDAO;
+  private CacheDAO cacheDAO;
   private final ExecutorService executor;
 
-  public DefaultTimeSeriesCache(MetricConfigManager metricDAO, DatasetConfigManager datasetDAO, QueryCache queryCache, CouchbaseCacheDAO cacheDAO, ExecutorService executorService) {
+  public DefaultTimeSeriesCache(MetricConfigManager metricDAO, DatasetConfigManager datasetDAO, QueryCache queryCache, CacheDAO cacheDAO, ExecutorService executorService) {
     this.metricDAO = metricDAO;
     this.datasetDAO = datasetDAO;
     this.queryCache = queryCache;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/CacheUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/CacheUtils.java
@@ -24,7 +24,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.CRC32;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.pinot.thirdeye.detection.cache.CacheConfig;
 import org.apache.pinot.thirdeye.detection.cache.CacheConstants;
 import org.apache.pinot.thirdeye.detection.cache.TimeSeriesDataPoint;
 import org.slf4j.Logger;
@@ -38,9 +41,16 @@ import org.slf4j.LoggerFactory;
 public class CacheUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(CacheUtils.class);
+
+  private static final String BUCKET_NAME = "bucketName";
+
   // We use CRC32 as the hash function to generate keys for cache documents.
   public static CRC32 hashGenerator = new CRC32();
 
+  public static String getBucketName() {
+    Map<String, Object> config = CacheConfig.getInstance().getCentralizedCacheSettings().getDataSourceConfig().getConfig();
+    return MapUtils.getString(config, BUCKET_NAME);
+  }
   /**
    * Hashes the metricURN, so that the return value can be used as a key to
    * the key-value pair in a cache document.
@@ -86,7 +96,7 @@ public class CacheUtils {
    */
   public static String buildQuery(JsonObject parameters) {
     return String.format("SELECT timestamp, `%s` FROM `%s` WHERE metricId = %d AND `%s` IS NOT MISSING AND timestamp BETWEEN %d AND %d ORDER BY time ASC",
-        parameters.getString("dimensionKey"),
+        parameters.getString( "dimensionKey"),
         parameters.getString("bucket"),
         parameters.getLong("metricId"),
         parameters.getString("dimensionKey"),
@@ -99,7 +109,7 @@ public class CacheUtils {
    * string, it will parse out the proper host for the URI.
    * Example: "http://localhost:8091" -> "localhost"
    * @param bootstrapUris
-   * @return
+   * @return list of hosts (as strings)
    */
   public static List<String> getBootstrapHosts(List<String> bootstrapUris) {
     List<String> bootstrapHosts = new ArrayList<>(bootstrapUris.size());
@@ -111,7 +121,11 @@ public class CacheUtils {
           uri = new URI("http://" + bootstrapUri);
         }
         String host = uri.getHost();
-        bootstrapHosts.add(host);
+        if (host != null) {
+          bootstrapHosts.add(host);
+        } else {
+          LOG.warn("Received incorrectly formatted URI {}, excluding it from list of hosts to connect to...", bootstrapUri);
+        }
       } catch (URISyntaxException e) {
         LOG.error("Exception while parsing host for URI {}", bootstrapUri, e);
       }


### PR DESCRIPTION
Made Cache DAO an interface and generified config code to allow users to use their own data store of choice.

Also adds support for authenticating to Couchbase using certificates. This is a Couchbase Enterprise Edition feature, but some users with enterprise Couchbase setups may find this feature useful.