### PR TITLE
Removing segment generation config from RecordReader interface

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/AvroRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/AvroRecordReader.java
@@ -56,7 +56,8 @@ public class AvroRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
 
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/AvroRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/AvroRecordReader.java
@@ -21,12 +21,12 @@ package org.apache.pinot.core.data.readers;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.util.AvroUtils;
 
 
@@ -56,9 +56,7 @@ public class AvroRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/CSVRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/CSVRecordReader.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -29,7 +30,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 
 
 /**
@@ -93,16 +93,14 @@ public class CSVRecordReader implements RecordReader {
     init();
   }
 
-  @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
-  }
-
   private void init()
       throws IOException {
     _parser = _format.parse(RecordReaderUtils.getBufferedReader(_dataFile));
     _iterator = _parser.iterator();
+  }
+
+  @Override
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/CSVRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/CSVRecordReader.java
@@ -94,7 +94,8 @@ public class CSVRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
 
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/GenericRowRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/GenericRowRecordReader.java
@@ -41,7 +41,8 @@ public class GenericRowRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
 
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/GenericRowRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/GenericRowRecordReader.java
@@ -18,10 +18,11 @@
  */
 package org.apache.pinot.core.data.readers;
 
+import java.io.File;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 
 
 /**
@@ -41,9 +42,7 @@ public class GenericRowRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/JSONRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/JSONRecordReader.java
@@ -24,11 +24,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.utils.JsonUtils;
 import org.apache.pinot.core.data.GenericRow;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 
 
 /**
@@ -62,9 +62,7 @@ public class JSONRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/JSONRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/JSONRecordReader.java
@@ -62,7 +62,9 @@ public class JSONRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
+
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReader.java
@@ -53,11 +53,6 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
     this(indexDirs, null, null);
   }
 
-  @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
-
-  }
-
   /**
    * Read records using the passed in schema and in the order of sorted column from multiple pinot segments.
    * <p>Passed in schema must be a subset of the segment schema.
@@ -104,6 +99,12 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
         }
       }
     }
+  }
+
+  @Override
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
+
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReader.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 
 
 /**
@@ -101,17 +100,15 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
     }
   }
 
-  @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
-  }
-
   /**
    * Indicate whether the segment should be sorted or not
    */
   private boolean isSortedSegment() {
     return _sortOrder != null && !_sortOrder.isEmpty();
+  }
+
+  @Override
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReader.java
@@ -60,11 +60,6 @@ public class PinotSegmentRecordReader implements RecordReader {
     this(indexDir, null, null);
   }
 
-  @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
-
-  }
-
   /**
    * Read records using the segment schema with the given schema and sort order
    * <p>Passed in schema must be a subset of the segment schema.
@@ -108,6 +103,12 @@ public class PinotSegmentRecordReader implements RecordReader {
       _immutableSegment.destroy();
       throw e;
     }
+  }
+
+  @Override
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
+
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReader.java
@@ -33,7 +33,6 @@ import org.apache.pinot.common.segment.SegmentMetadata;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.sort.PinotSegmentSorter;
 import org.apache.pinot.core.data.readers.sort.SegmentSorter;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
@@ -105,12 +104,6 @@ public class PinotSegmentRecordReader implements RecordReader {
     }
   }
 
-  @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
-  }
-
   /**
    * Prepare sorted docIds in order of the given sort order columns
    */
@@ -119,6 +112,10 @@ public class PinotSegmentRecordReader implements RecordReader {
       SegmentSorter sorter = new PinotSegmentSorter(_numDocs, schema, _columnReaderMap);
       _docIdsInSortedColumnOrder = sorter.getSortedDocIds(sortOrder);
     }
+  }
+
+  @Override
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReader.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.data.readers;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.data.Schema;
@@ -34,16 +35,15 @@ import org.apache.pinot.core.data.GenericRow;
 public interface RecordReader extends Closeable {
 
   /**
-   * initializing recordreader with inputpath, schema and recordreader config. <br/>
-   * The implementation can chose to ignore one or more of these parameters and handle null gracefully <br/>
+   * Initializes the record reader with data file, schema and (optional) record reader config.
    *
-   * @param inputPath absolute path to the file/directory
+   * @param dataFile Data file
    * @param schema Pinot Schema associated with the table
-   * @param recordReaderConfig config for the reader specific to the format. e.g. delimiter for csv format etc
-   * @throws Exception if the arguments are invalid
+   * @param recordReaderConfig Config for the reader specific to the format. e.g. delimiter for csv format etc
+   * @throws IOException If an I/O error occurs
    */
-  void init(@Nullable String inputPath, @Nullable Schema schema, @Nullable RecordReaderConfig recordReaderConfig)
-      throws Exception;
+  void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig)
+      throws IOException;
 
   /**
    * Return <code>true</code> if more records remain to be read.

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReader.java
@@ -20,9 +20,9 @@ package org.apache.pinot.core.data.readers;
 
 import java.io.Closeable;
 import java.io.IOException;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 
 
 /**
@@ -34,10 +34,16 @@ import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 public interface RecordReader extends Closeable {
 
   /**
-   * Initializes the record reader when needed
+   * initializing recordreader with inputpath, schema and recordreader config. <br/>
+   * The implementation can chose to ignore one or more of these parameters and handle null gracefully <br/>
+   *
+   * @param inputPath absolute path to the file/directory
+   * @param schema Pinot Schema associated with the table
+   * @param recordReaderConfig config for the reader specific to the format. e.g. delimiter for csv format etc
+   * @throws Exception if the arguments are invalid
    */
-  void init(SegmentGeneratorConfig segmentGeneratorConfig)
-      throws IOException;
+  void init(@Nullable String inputPath, @Nullable Schema schema, @Nullable RecordReaderConfig recordReaderConfig)
+      throws Exception;
 
   /**
    * Return <code>true</code> if more records remain to be read.

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReaderFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReaderFactory.java
@@ -52,7 +52,7 @@ public class RecordReaderFactory {
             .warn("Using class: {} to read segment, ignoring configured file format: {}", recordReaderPath, fileFormat);
       }
       RecordReader recordReader = (RecordReader) Class.forName(recordReaderPath).newInstance();
-      recordReader.init(dataFile.getAbsolutePath(), schema, segmentGeneratorConfig.getReaderConfig());
+      recordReader.init(dataFile, schema, segmentGeneratorConfig.getReaderConfig());
       return recordReader;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReaderFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/RecordReaderFactory.java
@@ -52,7 +52,7 @@ public class RecordReaderFactory {
             .warn("Using class: {} to read segment, ignoring configured file format: {}", recordReaderPath, fileFormat);
       }
       RecordReader recordReader = (RecordReader) Class.forName(recordReaderPath).newInstance();
-      recordReader.init(segmentGeneratorConfig);
+      recordReader.init(dataFile.getAbsolutePath(), schema, segmentGeneratorConfig.getReaderConfig());
       return recordReader;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/ThriftRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/ThriftRecordReader.java
@@ -66,6 +66,12 @@ public class ThriftRecordReader implements RecordReader {
     init();
   }
 
+  @Override
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
+
+  }
+
   private void init()
       throws IOException {
     _inputStream = RecordReaderUtils.getBufferedInputStream(_dataFile);
@@ -76,11 +82,6 @@ public class ThriftRecordReader implements RecordReader {
       _inputStream.close();
       throw e;
     }
-  }
-
-  @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
-
   }
 
   private boolean hasMoreToRead()

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/ThriftRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/ThriftRecordReader.java
@@ -24,10 +24,10 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -66,12 +66,6 @@ public class ThriftRecordReader implements RecordReader {
     init();
   }
 
-  @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
-  }
-
   private void init()
       throws IOException {
     _inputStream = RecordReaderUtils.getBufferedInputStream(_dataFile);
@@ -90,6 +84,10 @@ public class ThriftRecordReader implements RecordReader {
     int nextByte = _inputStream.read();
     _inputStream.reset();
     return nextByte != -1;
+  }
+
+  @Override
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -84,7 +84,7 @@ public class SegmentGeneratorConfig {
   private String _dataDir = null;
   private String _inputFilePath = null;
   private FileFormat _format = FileFormat.AVRO;
-  private String _recordReaderPath = null;
+  private String _recordReaderPath = null; //TODO: this should be renamed to recordReaderClass or even better removed
   private String _outDir = null;
   private boolean _overwrite = false;
   private String _tableName = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/BackfillDateTimeColumn.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/BackfillDateTimeColumn.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.minion;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.data.DateTimeFieldSpec;
 import org.apache.pinot.common.data.DateTimeFormatSpec;
 import org.apache.pinot.common.data.Schema;
@@ -63,9 +63,8 @@ public class BackfillDateTimeColumn {
   private final TimeFieldSpec _srcTimeFieldSpec;
   private final DateTimeFieldSpec _destDateTimeFieldSpec;
 
-  public BackfillDateTimeColumn(@Nonnull String rawTableName, @Nonnull File originalIndexDir, @Nonnull File backfilledIndexDir,
-      @Nonnull TimeFieldSpec srcTimeSpec, @Nonnull DateTimeFieldSpec destDateTimeSpec)
-      throws Exception {
+  public BackfillDateTimeColumn(String rawTableName, File originalIndexDir, File backfilledIndexDir,
+      TimeFieldSpec srcTimeSpec, DateTimeFieldSpec destDateTimeSpec) {
     _rawTableName = rawTableName;
     _originalIndexDir = originalIndexDir;
     _backfilledIndexDir = backfilledIndexDir;
@@ -138,9 +137,7 @@ public class BackfillDateTimeColumn {
     }
 
     @Override
-    public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-        throws Exception {
-
+    public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/BackfillDateTimeColumn.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/BackfillDateTimeColumn.java
@@ -33,6 +33,7 @@ import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.FileFormat;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.data.readers.RecordReader;
+import org.apache.pinot.core.data.readers.RecordReaderConfig;
 import org.apache.pinot.core.data.recordtransformer.CompositeTransformer;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.segment.creator.RecordReaderSegmentCreationDataSource;
@@ -137,7 +138,8 @@ public class BackfillDateTimeColumn {
     }
 
     @Override
-    public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
+    public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+        throws Exception {
 
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.segment.StarTreeMetadata;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.data.readers.RecordReader;
+import org.apache.pinot.core.data.readers.RecordReaderConfig;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
@@ -170,7 +171,9 @@ public class SegmentPurger {
     }
 
     @Override
-    public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
+    public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+        throws Exception {
+
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.data.StarTreeIndexSpec;
@@ -58,8 +57,8 @@ public class SegmentPurger {
   private int _numRecordsPurged;
   private int _numRecordsModified;
 
-  public SegmentPurger(@Nonnull String rawTableName, @Nonnull File originalIndexDir, @Nonnull File workingDir,
-      @Nullable RecordPurger recordPurger, @Nullable RecordModifier recordModifier) {
+  public SegmentPurger(String rawTableName, File originalIndexDir, File workingDir, @Nullable RecordPurger recordPurger,
+      @Nullable RecordModifier recordModifier) {
     Preconditions.checkArgument(recordPurger != null || recordModifier != null,
         "At least one of record purger and modifier should be non-null");
     _rawTableName = rawTableName;
@@ -171,9 +170,7 @@ public class SegmentPurger {
     }
 
     @Override
-    public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-        throws Exception {
-
+    public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
     }
 
     @Override
@@ -263,7 +260,7 @@ public class SegmentPurger {
     /**
      * Get the {@link RecordPurger} for the given table.
      */
-    RecordPurger getRecordPurger(@Nonnull String rawTableName);
+    RecordPurger getRecordPurger(String rawTableName);
   }
 
   /**
@@ -285,7 +282,7 @@ public class SegmentPurger {
     /**
      * Get the {@link RecordModifier} for the given table.
      */
-    RecordModifier getRecordModifier(@Nonnull String rawTableName);
+    RecordModifier getRecordModifier(String rawTableName);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/MapperRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/MapperRecordReader.java
@@ -22,12 +22,12 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.MultiplePinotSegmentRecordReader;
 import org.apache.pinot.core.data.readers.RecordReader;
 import org.apache.pinot.core.data.readers.RecordReaderConfig;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 
 
 /**
@@ -55,9 +55,7 @@ public class MapperRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/MapperRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/MapperRecordReader.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.MultiplePinotSegmentRecordReader;
 import org.apache.pinot.core.data.readers.RecordReader;
+import org.apache.pinot.core.data.readers.RecordReaderConfig;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 
 
@@ -54,7 +55,8 @@ public class MapperRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
 
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/ReducerRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/ReducerRecordReader.java
@@ -22,12 +22,12 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.data.readers.RecordReader;
 import org.apache.pinot.core.data.readers.RecordReaderConfig;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 
 
 /**
@@ -52,9 +52,7 @@ public class ReducerRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/ReducerRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/ReducerRecordReader.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.data.readers.RecordReader;
+import org.apache.pinot.core.data.readers.RecordReaderConfig;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 
 
@@ -51,7 +52,8 @@ public class ReducerRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
 
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.realtime.converter;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.RecordReader;
+import org.apache.pinot.core.data.readers.RecordReaderConfig;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.mutable.MutableSegmentImpl;
 
@@ -51,7 +52,8 @@ public class RealtimeSegmentRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig) {
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+      throws Exception {
 
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
@@ -18,11 +18,12 @@
  */
 package org.apache.pinot.core.realtime.converter;
 
+import java.io.File;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.RecordReader;
 import org.apache.pinot.core.data.readers.RecordReaderConfig;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.mutable.MutableSegmentImpl;
 
 
@@ -51,14 +52,12 @@ public class RealtimeSegmentRecordReader implements RecordReader {
     _sortedDocIdIterationOrder = realtimeSegment.getSortedDocIdIterationOrderWithSortedColumn(sortedColumn);
   }
 
-  @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws Exception {
-
-  }
-
   public int[] getSortedDocIdIterationOrder() {
     return _sortedDocIdIterationOrder;
+  }
+
+  @Override
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override

--- a/pinot-orc/src/main/java/org/apache/pinot/orc/data/readers/ORCRecordReader.java
+++ b/pinot-orc/src/main/java/org/apache/pinot/orc/data/readers/ORCRecordReader.java
@@ -45,6 +45,7 @@ import org.apache.orc.mapred.OrcMapredRecordReader;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.RecordReader;
+import org.apache.pinot.core.data.readers.RecordReaderConfig;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,9 +84,9 @@ public class ORCRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig)
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
       throws IOException {
-    init(segmentGeneratorConfig.getInputFilePath(), segmentGeneratorConfig.getSchema());
+    init(inputPath, schema);
   }
 
   @Override

--- a/pinot-orc/src/main/java/org/apache/pinot/orc/data/readers/ORCRecordReader.java
+++ b/pinot-orc/src/main/java/org/apache/pinot/orc/data/readers/ORCRecordReader.java
@@ -19,9 +19,11 @@
 package org.apache.pinot.orc.data.readers;
 
 import com.google.common.collect.ImmutableList;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
@@ -46,7 +48,6 @@ import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.RecordReader;
 import org.apache.pinot.core.data.readers.RecordReaderConfig;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,10 +70,11 @@ public class ORCRecordReader implements RecordReader {
   private org.apache.orc.RecordReader _recordReader;
   private VectorizedRowBatch _reusableVectorizedRowBatch;
 
-  private void init(String inputPath, Schema schema)
+  @Override
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
     _pinotSchema = schema;
-    Path dataFilePath = new Path(LOCAL_FS_PREFIX + inputPath);
+    Path dataFilePath = new Path(LOCAL_FS_PREFIX + dataFile.getAbsolutePath());
     LOGGER.info("Creating segment from path: {}", dataFilePath);
     _reader = OrcFile.createReader(dataFilePath, OrcFile.readerOptions(new Configuration()));
     _orcSchema = _reader.getSchema();
@@ -81,12 +83,6 @@ public class ORCRecordReader implements RecordReader {
 
     // Create a row batch with max size 1
     _reusableVectorizedRowBatch = _orcSchema.createRowBatch(1);
-  }
-
-  @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
-      throws IOException {
-    init(inputPath, schema);
   }
 
   @Override
@@ -169,7 +165,7 @@ public class ORCRecordReader implements RecordReader {
     } else if (BytesWritable.class.isAssignableFrom(w.getClass())) {
       obj = ((BytesWritable) w).getBytes();
     } else if (Text.class.isAssignableFrom(w.getClass())) {
-      obj = ((Text) w).toString();
+      obj = w.toString();
     } else if (OrcList.class.isAssignableFrom(w.getClass())) {
       obj = translateList((OrcList) w);
     } else {

--- a/pinot-orc/src/test/java/org/apache/pinot/orc/data/readers/ORCRecordReaderTest.java
+++ b/pinot-orc/src/test/java/org/apache/pinot/orc/data/readers/ORCRecordReaderTest.java
@@ -114,15 +114,12 @@ public class ORCRecordReaderTest {
       throws IOException {
     ORCRecordReader orcRecordReader = new ORCRecordReader();
 
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig();
-    segmentGeneratorConfig.setInputFilePath(ORC_FILE.getAbsolutePath());
     Schema schema = new Schema();
     FieldSpec xFieldSpec = new DimensionFieldSpec("x", FieldSpec.DataType.LONG, true);
     schema.addField(xFieldSpec);
     FieldSpec yFieldSpec = new DimensionFieldSpec("y", FieldSpec.DataType.BYTES, true);
     schema.addField(yFieldSpec);
-    segmentGeneratorConfig.setSchema(schema);
-    orcRecordReader.init(segmentGeneratorConfig);
+    orcRecordReader.init(ORC_FILE.getAbsolutePath(), schema, null);
 
     List<GenericRow> genericRows = new ArrayList<>();
     while (orcRecordReader.hasNext()) {
@@ -140,16 +137,12 @@ public class ORCRecordReaderTest {
   @Test
   public void testReadMVData() throws IOException{
     ORCRecordReader orcRecordReader = new ORCRecordReader();
-
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig();
-    segmentGeneratorConfig.setInputFilePath(MULTIVALUE_ORC_FILE.getAbsolutePath());
     Schema schema = new Schema();
     FieldSpec emailsFieldSpec = new DimensionFieldSpec("emails", FieldSpec.DataType.STRING, false);
     schema.addField(emailsFieldSpec);
     FieldSpec xFieldSpec = new DimensionFieldSpec("x", FieldSpec.DataType.INT, true);
     schema.addField(xFieldSpec);
-    segmentGeneratorConfig.setSchema(schema);
-    orcRecordReader.init(segmentGeneratorConfig);
+    orcRecordReader.init(MULTIVALUE_ORC_FILE.getAbsolutePath(), schema, null);
 
     List<GenericRow> genericRows = new ArrayList<>();
     while (orcRecordReader.hasNext()) {

--- a/pinot-orc/src/test/java/org/apache/pinot/orc/data/readers/ORCRecordReaderTest.java
+++ b/pinot-orc/src/test/java/org/apache/pinot/orc/data/readers/ORCRecordReaderTest.java
@@ -59,17 +59,15 @@ public class ORCRecordReaderTest {
       throws Exception {
     FileUtils.deleteQuietly(TEMP_DIR);
 
-    TypeDescription schema =
-        TypeDescription.fromString("struct<x:int,y:string>");
+    TypeDescription schema = TypeDescription.fromString("struct<x:int,y:string>");
 
     Writer writer = OrcFile.createWriter(new Path(ORC_FILE.getAbsolutePath()),
-        OrcFile.writerOptions(new Configuration())
-            .setSchema(schema));
+        OrcFile.writerOptions(new Configuration()).setSchema(schema));
 
     VectorizedRowBatch batch = schema.createRowBatch();
     LongColumnVector x = (LongColumnVector) batch.cols[0];
     BytesColumnVector y = (BytesColumnVector) batch.cols[1];
-    for(int r=0; r < 5; ++r) {
+    for (int r = 0; r < 5; ++r) {
       int row = batch.size++;
       x.vector[row] = r;
       byte[] buffer = ("Last-" + (r * 3)).getBytes(StandardCharsets.UTF_8);
@@ -101,8 +99,7 @@ public class ORCRecordReaderTest {
     struct.setFieldValue("x", new IntWritable(1));
 
     Writer mvWriter = OrcFile.createWriter(new Path(MULTIVALUE_ORC_FILE.getAbsolutePath()),
-        OrcFile.writerOptions(new Configuration())
-            .setSchema(orcTypeDesc));
+        OrcFile.writerOptions(new Configuration()).setSchema(orcTypeDesc));
 
     OrcMapredRecordWriter mrRecordWriter = new OrcMapredRecordWriter(mvWriter);
     mrRecordWriter.write(null, struct);
@@ -119,7 +116,7 @@ public class ORCRecordReaderTest {
     schema.addField(xFieldSpec);
     FieldSpec yFieldSpec = new DimensionFieldSpec("y", FieldSpec.DataType.BYTES, true);
     schema.addField(yFieldSpec);
-    orcRecordReader.init(ORC_FILE.getAbsolutePath(), schema, null);
+    orcRecordReader.init(ORC_FILE, schema, null);
 
     List<GenericRow> genericRows = new ArrayList<>();
     while (orcRecordReader.hasNext()) {
@@ -135,14 +132,15 @@ public class ORCRecordReaderTest {
   }
 
   @Test
-  public void testReadMVData() throws IOException{
+  public void testReadMVData()
+      throws IOException {
     ORCRecordReader orcRecordReader = new ORCRecordReader();
     Schema schema = new Schema();
     FieldSpec emailsFieldSpec = new DimensionFieldSpec("emails", FieldSpec.DataType.STRING, false);
     schema.addField(emailsFieldSpec);
     FieldSpec xFieldSpec = new DimensionFieldSpec("x", FieldSpec.DataType.INT, true);
     schema.addField(xFieldSpec);
-    orcRecordReader.init(MULTIVALUE_ORC_FILE.getAbsolutePath(), schema, null);
+    orcRecordReader.init(MULTIVALUE_ORC_FILE, schema, null);
 
     List<GenericRow> genericRows = new ArrayList<>();
     while (orcRecordReader.hasNext()) {
@@ -165,5 +163,4 @@ public class ORCRecordReaderTest {
   public void tearDown() {
     FileUtils.deleteQuietly(TEMP_DIR);
   }
-
 }

--- a/pinot-parquet/src/main/java/org/apache/pinot/parquet/data/readers/ParquetRecordReader.java
+++ b/pinot-parquet/src/main/java/org/apache/pinot/parquet/data/readers/ParquetRecordReader.java
@@ -27,6 +27,7 @@ import org.apache.pinot.common.data.FieldSpec;
 import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.RecordReader;
+import org.apache.pinot.core.data.readers.RecordReaderConfig;
 import org.apache.pinot.core.data.readers.RecordReaderUtils;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.util.AvroUtils;
@@ -43,10 +44,10 @@ public class ParquetRecordReader implements RecordReader {
   private GenericRecord _nextRecord;
 
   @Override
-  public void init(SegmentGeneratorConfig segmentGeneratorConfig)
+  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
       throws IOException {
-    _dataFilePath = new Path(segmentGeneratorConfig.getInputFilePath());
-    _schema = segmentGeneratorConfig.getSchema();
+    _dataFilePath = new Path(inputPath);
+    _schema = schema;
     AvroUtils.validateSchema(_schema, ParquetUtils.getParquetSchema(_dataFilePath));
 
     _fieldSpecs = RecordReaderUtils.extractFieldSpecs(_schema);

--- a/pinot-parquet/src/main/java/org/apache/pinot/parquet/data/readers/ParquetRecordReader.java
+++ b/pinot-parquet/src/main/java/org/apache/pinot/parquet/data/readers/ParquetRecordReader.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.parquet.data.readers;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
@@ -29,7 +31,6 @@ import org.apache.pinot.core.data.GenericRow;
 import org.apache.pinot.core.data.readers.RecordReader;
 import org.apache.pinot.core.data.readers.RecordReaderConfig;
 import org.apache.pinot.core.data.readers.RecordReaderUtils;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.util.AvroUtils;
 
 
@@ -44,9 +45,9 @@ public class ParquetRecordReader implements RecordReader {
   private GenericRecord _nextRecord;
 
   @Override
-  public void init(String inputPath, Schema schema, RecordReaderConfig recordReaderConfig)
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
-    _dataFilePath = new Path(inputPath);
+    _dataFilePath = new Path(dataFile.getAbsolutePath());
     _schema = schema;
     AvroUtils.validateSchema(_schema, ParquetUtils.getParquetSchema(_dataFilePath));
 

--- a/pinot-parquet/src/test/java/org/apache/pinot/parquet/data/readers/ParquetRecordReaderTest.java
+++ b/pinot-parquet/src/test/java/org/apache/pinot/parquet/data/readers/ParquetRecordReaderTest.java
@@ -28,7 +28,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.pinot.core.data.readers.RecordReaderTest;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -82,7 +81,7 @@ public class ParquetRecordReaderTest extends RecordReaderTest {
   public void testParquetRecordReader()
       throws Exception {
     try (ParquetRecordReader recordReader = new ParquetRecordReader()) {
-      recordReader.init(DATA_FILE.getAbsolutePath(), SCHEMA, null);
+      recordReader.init(DATA_FILE, SCHEMA, null);
       checkValue(recordReader);
       recordReader.rewind();
       checkValue(recordReader);

--- a/pinot-parquet/src/test/java/org/apache/pinot/parquet/data/readers/ParquetRecordReaderTest.java
+++ b/pinot-parquet/src/test/java/org/apache/pinot/parquet/data/readers/ParquetRecordReaderTest.java
@@ -81,12 +81,8 @@ public class ParquetRecordReaderTest extends RecordReaderTest {
   @Test
   public void testParquetRecordReader()
       throws Exception {
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig();
-    segmentGeneratorConfig.setInputFilePath(DATA_FILE.getAbsolutePath());
-    segmentGeneratorConfig.setSchema(SCHEMA);
-
     try (ParquetRecordReader recordReader = new ParquetRecordReader()) {
-      recordReader.init(segmentGeneratorConfig);
+      recordReader.init(DATA_FILE.getAbsolutePath(), SCHEMA, null);
       checkValue(recordReader);
       recordReader.rewind();
       checkValue(recordReader);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -410,12 +410,12 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
               switch (config.getFormat()) {
                 case PARQUET:
                   RecordReader parquetRecordReader = new ParquetRecordReader();
-                  parquetRecordReader.init(localFile, Schema.fromFile(new File(_schemaFile)), null);
+                  parquetRecordReader.init(new File(localFile), Schema.fromFile(new File(_schemaFile)), null);
                   driver.init(config, parquetRecordReader);
                   break;
                 case ORC:
                   RecordReader orcRecordReader = new ORCRecordReader();
-                  orcRecordReader.init(localFile, Schema.fromFile(new File(_schemaFile)), null);
+                  orcRecordReader.init(new File(localFile), Schema.fromFile(new File(_schemaFile)), null);
                   driver.init(config, orcRecordReader);
                   break;
                 default:
@@ -449,7 +449,8 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   }
 
   private boolean verifySegment(File indexDir) {
-    File localTempDir = new File(FileUtils.getTempDirectory(), org.apache.pinot.common.utils.FileUtils.getRandomFileName());
+    File localTempDir =
+        new File(FileUtils.getTempDirectory(), org.apache.pinot.common.utils.FileUtils.getRandomFileName());
     try {
       try {
         localTempDir.getParentFile().mkdirs();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.pinot.common.data.Schema;
 import org.apache.pinot.common.data.StarTreeIndexSpec;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.JsonUtils;
@@ -409,12 +410,12 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
               switch (config.getFormat()) {
                 case PARQUET:
                   RecordReader parquetRecordReader = new ParquetRecordReader();
-                  parquetRecordReader.init(config);
+                  parquetRecordReader.init(localFile, Schema.fromFile(new File(_schemaFile)), null);
                   driver.init(config, parquetRecordReader);
                   break;
                 case ORC:
                   RecordReader orcRecordReader = new ORCRecordReader();
-                  orcRecordReader.init(config);
+                  orcRecordReader.init(localFile, Schema.fromFile(new File(_schemaFile)), null);
                   driver.init(config, orcRecordReader);
                   break;
                 default:


### PR DESCRIPTION
Related to #4731 
refactoring the existing code to prepare for moving RecordReader to pinot-spi module. 

As of today, RecordReader takes in SegmentGenerationConfig which makes it very hard to extract RecordReader to pinot-spi. 

current interface
`void init(SegmentGenerationConfig config)`

new interface
`void init(String inputPath, Schema schema, ReaderConfig readerConfig)`

Next step:
- Move record reader interface to pinot-spi module
- Move Schema and related classes
- Instantiate record readers dynamically during segment generation (this is optional and might do it later depending on how easy/hard). We don't need it until we last steps 