### PR TITLE
Add getResultColumnName API to AggregationFunction to fetch sql compliant result name

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -57,17 +57,16 @@ public class TableResizer {
     int numAggregations = aggregationInfos.size();
     int numKeyColumns = numColumns - numAggregations;
 
-    int aggIdx = 0;
     Map<String, Integer> columnIndexMap = new HashMap<>();
     Map<String, AggregationFunction> aggregationColumnToFunction = new HashMap<>();
     for (int i = 0; i < numColumns; i++) {
-      String columnName = dataSchema.getColumnName(i).toLowerCase();
+      String columnName = dataSchema.getColumnName(i);
       columnIndexMap.put(columnName, i);
       if (i >= numKeyColumns) {
+        AggregationInfo aggregationInfo = aggregationInfos.get(i - numKeyColumns);
         AggregationFunction aggregationFunction =
-            AggregationFunctionUtils.getAggregationFunctionContext(aggregationInfos.get(aggIdx)).getAggregationFunction();
+            AggregationFunctionUtils.getAggregationFunctionContext(aggregationInfo).getAggregationFunction();
         aggregationColumnToFunction.put(columnName, aggregationFunction);
-        aggIdx++;
       }
     }
 
@@ -78,7 +77,7 @@ public class TableResizer {
     if (numKeyColumns < numColumns) {
       for (int orderByIdx = 0; orderByIdx < _numOrderBy; orderByIdx++) {
         SelectionSort selectionSort = orderBy.get(orderByIdx);
-        String column = selectionSort.getColumn().toLowerCase();
+        String column = selectionSort.getColumn();
 
         if (columnIndexMap.containsKey(column)) {
           int index = columnIndexMap.get(column);
@@ -115,7 +114,7 @@ public class TableResizer {
       boolean[] orderByAsc = new boolean[_numOrderBy];
       for (int i = 0; i < _numOrderBy; i++) {
         SelectionSort selectionSort = orderBy.get(i);
-        String column = selectionSort.getColumn().toLowerCase();
+        String column = selectionSort.getColumn();
         int orderByColIndex = columnIndexMap.get(column);
         orderByIndexes[i] = orderByColIndex;
         if (selectionSort.isIsAsc()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
@@ -80,8 +80,7 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
 
     // extract column names and data types for aggregations
     for (AggregationFunctionContext functionContext : functionContexts) {
-      columnNames[index] = functionContext.getAggregationFunction().getType().toString().toLowerCase() + "("
-          + functionContext.getColumn() + ")";
+      columnNames[index] = functionContext.getResultColumnName();
       columnDataTypes[index] = functionContext.getAggregationFunction().getIntermediateResultColumnType();
       index++;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/AggregationFunctionContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/AggregationFunctionContext.java
@@ -54,4 +54,12 @@ public class AggregationFunctionContext {
   public String getAggregationColumnName() {
     return _aggregationFunction.getColumnName(_column);
   }
+
+  /**
+   * Returns the aggregation column name for the result table.
+   * <p>E.g. AVGMV(foo) -> avgMV(foo)
+   */
+  public String getResultColumnName() {
+    return _aggregationFunction.getResultColumnName(_column);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -41,12 +41,16 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   /**
    * Returns the result column name for the given aggregation column, e.g. 'SUM(foo)' -> 'sum_foo'.
    */
-  String getColumnName(String column);
+  default String getColumnName(String column) {
+    return getType().getName() + "_" + column;
+  }
 
   /**
-   * Returns the column name to be used in the data schema of results. e.g. 'MINMAXRANGEMV( foo)' -> 'minMaxRangeMV(foo)', 'PERCENTILE75(bar)' -> 'percentile75(bar)'
+   * Returns the column name to be used in the data schema of results. e.g. 'MINMAXRANGEMV( foo)' -> 'minmaxrangemv(foo)', 'PERCENTILE75(bar)' -> 'percentile75(bar)'
    */
-  String getResultColumnName(String column);
+  default String getResultColumnName(String column) {
+    return getType().getName().toLowerCase() + "(" + column + ")";
+  }
 
   /**
    * Accepts an aggregation function visitor to visit.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -44,6 +44,11 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   String getColumnName(String column);
 
   /**
+   * Returns the column name to be used in the data schema of results. e.g. 'MINMAXRANGEMV( foo)' -> 'minMaxRangeMV(foo)', 'PERCENTILE75(bar)' -> 'percentile75(bar)'
+   */
+  String getResultColumnName(String column);
+
+  /**
    * Accepts an aggregation function visitor to visit.
    */
   void accept(AggregationFunctionVisitorBase visitor);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -49,11 +49,6 @@ public class AggregationFunctionUtils {
     return aggregationInfo.getAggregationParams().get(COLUMN_KEY);
   }
 
-  public static String getAggregationColumnName(AggregationInfo aggregationInfo) {
-    return aggregationInfo.getAggregationType().toLowerCase() + "(" + AggregationFunctionUtils.getColumn(aggregationInfo)
-        + ")";
-  }
-
   /**
    * Creates an {@link AggregationFunctionColumnPair} from the {@link AggregationInfo}.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -45,7 +45,7 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.AVG.getName() + "(" + column + ")";
+    return AggregationFunctionType.AVG.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -44,6 +44,11 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.AVG.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -39,16 +39,6 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.AVG.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.AVG.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
@@ -37,6 +37,11 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.AVGMV.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
@@ -38,7 +38,7 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.AVGMV.getName() + "(" + column + ")";
+    return AggregationFunctionType.AVGMV.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
@@ -32,16 +32,6 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.AVGMV.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.AVGMV.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -42,6 +42,11 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.COUNT.getName() + "(*)";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -43,7 +43,7 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.COUNT.getName() + "(*)";
+    return AggregationFunctionType.COUNT.getName().toLowerCase() + "(*)";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -32,16 +32,6 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.COUNTMV.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.COUNTMV.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -32,6 +32,16 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
   }
 
   @Override
+  public String getColumnName(String column) {
+    return AggregationFunctionType.COUNTMV.getName() + "_" + column;
+  }
+
+  @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.COUNTMV.getName().toLowerCase() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -37,6 +37,11 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.COUNTMV.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -38,7 +38,7 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.COUNTMV.getName() + "(" + column + ")";
+    return AggregationFunctionType.COUNTMV.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
@@ -72,6 +72,11 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.DISTINCT.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
@@ -67,16 +67,6 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.DISTINCT.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCT.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
@@ -73,7 +73,7 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCT.getName() + "(" + column + ")";
+    return AggregationFunctionType.DISTINCT.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -37,16 +37,6 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNT.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNT.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -43,7 +43,7 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNT.getName() + "(" + column + ")";
+    return AggregationFunctionType.DISTINCTCOUNT.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -42,6 +42,11 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.DISTINCTCOUNT.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -45,6 +45,11 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.DISTINCTCOUNTHLL.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -46,7 +46,7 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTHLL.getName() + "(" + column + ")";
+    return AggregationFunctionType.DISTINCTCOUNTHLL.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -40,16 +40,6 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTHLL.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTHLL.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -40,7 +40,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTHLLMV.getName() + "(" + column + ")";
+    return AggregationFunctionType.DISTINCTCOUNTHLLMV.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -39,6 +39,11 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.DISTINCTCOUNTHLLMV.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -34,16 +34,6 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTHLLMV.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTHLLMV.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
@@ -34,16 +34,6 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTMV.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTMV.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
@@ -40,7 +40,7 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTMV.getName() + "(" + column + ")";
+    return AggregationFunctionType.DISTINCTCOUNTMV.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
@@ -39,6 +39,11 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.DISTINCTCOUNTMV.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -49,6 +49,11 @@ public class DistinctCountRawHLLAggregationFunction implements AggregationFuncti
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.DISTINCTCOUNTRAWHLL.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     _distinctCountHLLAggregationFunction.accept(visitor);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -44,16 +44,6 @@ public class DistinctCountRawHLLAggregationFunction implements AggregationFuncti
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTRAWHLL.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTRAWHLL.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     _distinctCountHLLAggregationFunction.accept(visitor);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -50,7 +50,7 @@ public class DistinctCountRawHLLAggregationFunction implements AggregationFuncti
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTRAWHLL.getName() + "(" + column + ")";
+    return AggregationFunctionType.DISTINCTCOUNTRAWHLL.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
@@ -31,14 +31,4 @@ public class DistinctCountRawHLLMVAggregationFunction extends DistinctCountRawHL
   public AggregationFunctionType getType() {
     return AggregationFunctionType.DISTINCTCOUNTRAWHLLMV;
   }
-
-  @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTRAWHLLMV.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTRAWHLLMV.getName().toLowerCase() + "(" + column + ")";
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
@@ -39,6 +39,6 @@ public class DistinctCountRawHLLMVAggregationFunction extends DistinctCountRawHL
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.DISTINCTCOUNTRAWHLLMV.getName() + "(" + column + ")";
+    return AggregationFunctionType.DISTINCTCOUNTRAWHLLMV.getName().toLowerCase() + "(" + column + ")";
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
@@ -36,4 +36,9 @@ public class DistinctCountRawHLLMVAggregationFunction extends DistinctCountRawHL
   public String getColumnName(String column) {
     return AggregationFunctionType.DISTINCTCOUNTRAWHLLMV.getName() + "_" + column;
   }
+
+  @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.DISTINCTCOUNTRAWHLLMV.getName() + "(" + column + ")";
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -45,7 +45,7 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.FASTHLL.getName() + "(" + column + ")";
+    return AggregationFunctionType.FASTHLL.getName().toLowerCase() + "(" + column + ")";
   }
 
   public void setLog2m(int log2m) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -43,6 +43,11 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
     return AggregationFunctionType.FASTHLL.getName() + "_" + column;
   }
 
+  @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.FASTHLL.getName() + "(" + column + ")";
+  }
+
   public void setLog2m(int log2m) {
     _log2m = log2m;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -38,16 +38,6 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
     return AggregationFunctionType.FASTHLL;
   }
 
-  @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.FASTHLL.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.FASTHLL.getName().toLowerCase() + "(" + column + ")";
-  }
-
   public void setLog2m(int log2m) {
     _log2m = log2m;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -42,7 +42,7 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.MAX.getName() + "(" + column + ")";
+    return AggregationFunctionType.MAX.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -36,16 +36,6 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.MAX.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.MAX.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -41,6 +41,11 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.MAX.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
@@ -37,6 +37,11 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.MAXMV.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
@@ -38,7 +38,7 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.MAXMV.getName() + "(" + column + ")";
+    return AggregationFunctionType.MAXMV.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
@@ -32,16 +32,6 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.MAXMV.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.MAXMV.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -42,7 +42,7 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.MIN.getName() + "(" + column + ")";
+    return AggregationFunctionType.MIN.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -41,6 +41,11 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.MIN.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -36,16 +36,6 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.MIN.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.MIN.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
@@ -32,16 +32,6 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.MINMV.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.MINMV.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
@@ -38,7 +38,7 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.MINMV.getName() + "(" + column + ")";
+    return AggregationFunctionType.MINMV.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
@@ -37,6 +37,11 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.MINMV.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -44,7 +44,7 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.MINMAXRANGE.getName() + "(" + column + ")";
+    return AggregationFunctionType.MINMAXRANGE.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -38,16 +38,6 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.MINMAXRANGE.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.MINMAXRANGE.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -43,6 +43,11 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.MINMAXRANGE.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
@@ -37,6 +37,11 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.MINMAXRANGEMV.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
@@ -38,7 +38,7 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.MINMAXRANGEMV.getName() + "(" + column + ")";
+    return AggregationFunctionType.MINMAXRANGEMV.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
@@ -32,16 +32,6 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.MINMAXRANGEMV.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.MINMAXRANGEMV.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -49,6 +49,11 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -50,7 +50,7 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "(" + column + ")";
+    return AggregationFunctionType.PERCENTILE.getName().toLowerCase() + _percentile + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -51,7 +51,7 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "(" + column + ")";
+    return AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + _percentile + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -50,6 +50,11 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -42,6 +42,11 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -43,7 +43,7 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV(" + column + ")";
+    return AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + _percentile + "mv(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -43,7 +43,7 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "MV(" + column + ")";
+    return AggregationFunctionType.PERCENTILE.getName().toLowerCase() + _percentile + "mv(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -42,6 +42,11 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "MV(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -54,7 +54,7 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "(" + column + ")";
+    return AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + _percentile + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -53,6 +53,11 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -42,6 +42,11 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -43,7 +43,7 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV(" + column + ")";
+    return AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + _percentile + "mv(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -36,16 +36,6 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.SUM.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.SUM.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -41,6 +41,11 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.SUM.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -42,7 +42,7 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.SUM.getName() + "(" + column + ")";
+    return AggregationFunctionType.SUM.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -37,6 +37,11 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
   }
 
   @Override
+  public String getResultColumnName(String column) {
+    return AggregationFunctionType.SUMMV.getName() + "(" + column + ")";
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -32,16 +32,6 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
   }
 
   @Override
-  public String getColumnName(String column) {
-    return AggregationFunctionType.SUMMV.getName() + "_" + column;
-  }
-
-  @Override
-  public String getResultColumnName(String column) {
-    return AggregationFunctionType.SUMMV.getName().toLowerCase() + "(" + column + ")";
-  }
-
-  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -38,7 +38,7 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
 
   @Override
   public String getResultColumnName(String column) {
-    return AggregationFunctionType.SUMMV.getName() + "(" + column + ")";
+    return AggregationFunctionType.SUMMV.getName().toLowerCase() + "(" + column + ")";
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.utils.CommonConstants.Broker.Request;
+import org.apache.pinot.common.utils.DataSchema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -35,14 +36,15 @@ import org.testng.annotations.Test;
 public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQueriesTest {
 
   @Test(dataProvider = "orderByDataProvider")
-  public void testAggregationOrderedGroupByResults(String query, List<Object[]> expectedResults,
-      long expectedNumEntriesScannedPostFilter) {
+  public void testGroupByOrderByMVSQLResults(String query, List<Object[]> expectedResults,
+      long expectedNumEntriesScannedPostFilter, DataSchema expectedDataSchema) {
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(Request.QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(Request.QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
-    QueriesTestUtils.testInterSegmentGroupByOrderByResultSQL(brokerResponse, 400000L, 0,
-        expectedNumEntriesScannedPostFilter, 400000L, expectedResults);
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0, expectedNumEntriesScannedPostFilter, 400000L,
+            expectedResults, expectedResults.size(), expectedDataSchema);
   }
 
   /**
@@ -55,60 +57,84 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
     List<Object[]> data = new ArrayList<>();
     String query;
     List<Object[]> results;
+    DataSchema dataSchema;
     long numEntriesScannedPostFilter;
 
     query = "SELECT SUMMV(column7) FROM testTable GROUP BY column3 ORDER BY column3";
     results = Lists.newArrayList(new Object[]{"", 63917703269308.0}, new Object[]{"L", 33260235267900.0},
         new Object[]{"P", 212961658305696.0}, new Object[]{"PbQd", 2001454759004.0},
         new Object[]{"w", 116831822080776.0});
+    dataSchema = new DataSchema(new String[]{"column3", "sumMV(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
-    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
 
     query = "SELECT SUMMV(column7) FROM testTable GROUP BY column5 ORDER BY column5 DESC TOP 4";
-    results = Lists.newArrayList(new Object[]{"yQkJTLOQoOqqhkAClgC", 61100215182228.00000},
-        new Object[]{"mhoVvrJm", 5806796153884.00000},
-        new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 51891832239248.00000},
-        new Object[]{"PbQd", 36532997335388.00000});
+    results = Lists.newArrayList(new Object[]{"yQkJTLOQoOqqhkAClgC", 61100215182228.0},
+        new Object[]{"mhoVvrJm", 5806796153884.0}, new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 51891832239248.0},
+        new Object[]{"PbQd", 36532997335388.0});
+    dataSchema = new DataSchema(new String[]{"column5", "sumMV(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
-    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
 
-    query = "SELECT SUMMV(column7) FROM testTable GROUP BY column5 ORDER BY SUMMV(column7) TOP 5";
-    results = Lists.newArrayList(new Object[]{"NCoFku", 489626381288.00000},
-        new Object[]{"mhoVvrJm", 5806796153884.00000},
-        new Object[]{"JXRmGakTYafZFPm", 18408231081808.00000}, new Object[]{"PbQd", 36532997335388.00000},
-        new Object[]{"OKyOqU", 51067166589176.00000});
+    query = "SELECT SUMMV(column7) FROM testTable GROUP BY column5 ORDER BY sumMV(column7) TOP 5";
+    results = Lists
+        .newArrayList(new Object[]{"NCoFku", 489626381288.0}, new Object[]{"mhoVvrJm", 5806796153884.0},
+            new Object[]{"JXRmGakTYafZFPm", 18408231081808.0}, new Object[]{"PbQd", 36532997335388.0},
+            new Object[]{"OKyOqU", 51067166589176.0});
+    dataSchema = new DataSchema(new String[]{"column5", "sumMV(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
-    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
 
     // object type aggregations
     query = "SELECT MINMAXRANGEMV(column7) FROM testTable GROUP BY column5 ORDER BY column5";
-    results = Lists.newArrayList(new Object[]{"AKXcXcIqsqOJFsdwxZ", 2147483446.00000},
-        new Object[]{"EOFxevm", 2147483446.00000}, new Object[]{"JXRmGakTYafZFPm", 2147483443.00000},
-        new Object[]{"NCoFku", 2147483436.00000}, new Object[]{"OKyOqU", 2147483443.00000},
-        new Object[]{"PbQd", 2147483443.00000},
-        new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.00000},
-        new Object[]{"mhoVvrJm", 2147483438.00000}, new Object[]{"yQkJTLOQoOqqhkAClgC", 2147483446.00000});
+    results = Lists
+        .newArrayList(new Object[]{"AKXcXcIqsqOJFsdwxZ", 2147483446.0}, new Object[]{"EOFxevm", 2147483446.0},
+            new Object[]{"JXRmGakTYafZFPm", 2147483443.0}, new Object[]{"NCoFku", 2147483436.0},
+            new Object[]{"OKyOqU", 2147483443.0}, new Object[]{"PbQd", 2147483443.0},
+            new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.0}, new Object[]{"mhoVvrJm", 2147483438.0},
+            new Object[]{"yQkJTLOQoOqqhkAClgC", 2147483446.0});
+    dataSchema = new DataSchema(new String[]{"column5", "minMaxRangeMV(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
-    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
 
     // object type aggregations
     query =
-        "SELECT MINMAXRANGEMV(column7) FROM testTable GROUP BY column5 ORDER BY MINMAXRANGEMV(column7), column5 desc";
-    results = Lists.newArrayList(new Object[]{"NCoFku", 2147483436.00000},
-        new Object[]{"mhoVvrJm", 2147483438.00000}, new Object[]{"PbQd", 2147483443.00000},
-        new Object[]{"OKyOqU", 2147483443.00000}, new Object[]{"JXRmGakTYafZFPm", 2147483443.00000},
-        new Object[]{"yQkJTLOQoOqqhkAClgC", 2147483446.00000},
-        new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.00000},
-        new Object[]{"EOFxevm", 2147483446.00000}, new Object[]{"AKXcXcIqsqOJFsdwxZ", 2147483446.00000});
+        "SELECT minmaxrangemv(column7) FROM testTable GROUP BY column5 ORDER BY MINMAXRANGEMV(column7), column5 desc";
+    results = Lists.newArrayList(new Object[]{"NCoFku", 2147483436.0}, new Object[]{"mhoVvrJm", 2147483438.0},
+        new Object[]{"PbQd", 2147483443.0}, new Object[]{"OKyOqU", 2147483443.0},
+        new Object[]{"JXRmGakTYafZFPm", 2147483443.0}, new Object[]{"yQkJTLOQoOqqhkAClgC", 2147483446.0},
+        new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.0}, new Object[]{"EOFxevm", 2147483446.0},
+        new Object[]{"AKXcXcIqsqOJFsdwxZ", 2147483446.0});
+    dataSchema = new DataSchema(new String[]{"column5", "minMaxRangeMV(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
-    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
 
     // object type aggregations - non comparable intermediate results
-    query = "SELECT DISTINCTCOUNTMV(column7) FROM testTable GROUP BY column5 ORDER BY DISTINCTCOUNTMV(column7) top 5";
-    results = Lists.newArrayList(new Object[]{"NCoFku", 26}, new Object[]{"mhoVvrJm", 65},
-        new Object[]{"JXRmGakTYafZFPm", 126}, new Object[]{"PbQd", 211}, new Object[]{"OKyOqU", 216});
+    query = "SELECT DISTINCTCOUNTMV(column7) FROM testTable GROUP BY column5 ORDER BY distinctCountMV(column7) top 5";
+    results = Lists
+        .newArrayList(new Object[]{"NCoFku", 26}, new Object[]{"mhoVvrJm", 65}, new Object[]{"JXRmGakTYafZFPm", 126},
+            new Object[]{"PbQd", 211}, new Object[]{"OKyOqU", 216});
+    dataSchema = new DataSchema(new String[]{"column5", "distinctCountMV(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     numEntriesScannedPostFilter = 800000;
-    data.add(new Object[]{query, results, numEntriesScannedPostFilter});
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
+
+    // percentile
+    query =
+        "SELECT PERCENTILE90MV(column7) FROM testTable GROUP BY column5 ORDER BY percentile90mv(column7), column5 DESC TOP 5";
+    results = Lists
+        .newArrayList(new Object[]{"yQkJTLOQoOqqhkAClgC", 2.147483647E9}, new Object[]{"mhoVvrJm", 2.147483647E9},
+            new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2.147483647E9}, new Object[]{"PbQd", 2.147483647E9},
+            new Object[]{"OKyOqU", 2.147483647E9});
+    dataSchema = new DataSchema(new String[]{"column5", "percentile90MV(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+    numEntriesScannedPostFilter = 800000;
+    data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
 
     return data.toArray(new Object[data.size()][]);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
@@ -64,16 +64,16 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
     results = Lists.newArrayList(new Object[]{"", 63917703269308.0}, new Object[]{"L", 33260235267900.0},
         new Object[]{"P", 212961658305696.0}, new Object[]{"PbQd", 2001454759004.0},
         new Object[]{"w", 116831822080776.0});
-    dataSchema = new DataSchema(new String[]{"column3", "sumMV(column7)"},
+    dataSchema = new DataSchema(new String[]{"column3", "summv(column7)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
     data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
 
-    query = "SELECT SUMMV(column7) FROM testTable GROUP BY column5 ORDER BY column5 DESC TOP 4";
+    query = "SELECT sumMV(column7) FROM testTable GROUP BY column5 ORDER BY column5 DESC TOP 4";
     results = Lists.newArrayList(new Object[]{"yQkJTLOQoOqqhkAClgC", 61100215182228.0},
         new Object[]{"mhoVvrJm", 5806796153884.0}, new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 51891832239248.0},
         new Object[]{"PbQd", 36532997335388.0});
-    dataSchema = new DataSchema(new String[]{"column5", "sumMV(column7)"},
+    dataSchema = new DataSchema(new String[]{"column5", "summv(column7)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
     data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
@@ -83,7 +83,7 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
         .newArrayList(new Object[]{"NCoFku", 489626381288.0}, new Object[]{"mhoVvrJm", 5806796153884.0},
             new Object[]{"JXRmGakTYafZFPm", 18408231081808.0}, new Object[]{"PbQd", 36532997335388.0},
             new Object[]{"OKyOqU", 51067166589176.0});
-    dataSchema = new DataSchema(new String[]{"column5", "sumMV(column7)"},
+    dataSchema = new DataSchema(new String[]{"column5", "summv(column7)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
     data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
@@ -96,20 +96,20 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
             new Object[]{"OKyOqU", 2147483443.0}, new Object[]{"PbQd", 2147483443.0},
             new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.0}, new Object[]{"mhoVvrJm", 2147483438.0},
             new Object[]{"yQkJTLOQoOqqhkAClgC", 2147483446.0});
-    dataSchema = new DataSchema(new String[]{"column5", "minMaxRangeMV(column7)"},
+    dataSchema = new DataSchema(new String[]{"column5", "minmaxrangemv(column7)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
     data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
 
     // object type aggregations
     query =
-        "SELECT minmaxrangemv(column7) FROM testTable GROUP BY column5 ORDER BY MINMAXRANGEMV(column7), column5 desc";
+        "SELECT minmaxrangemv(column7) FROM testTable GROUP BY column5 ORDER BY minMaxRangeMV(column7), column5 desc";
     results = Lists.newArrayList(new Object[]{"NCoFku", 2147483436.0}, new Object[]{"mhoVvrJm", 2147483438.0},
         new Object[]{"PbQd", 2147483443.0}, new Object[]{"OKyOqU", 2147483443.0},
         new Object[]{"JXRmGakTYafZFPm", 2147483443.0}, new Object[]{"yQkJTLOQoOqqhkAClgC", 2147483446.0},
         new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.0}, new Object[]{"EOFxevm", 2147483446.0},
         new Object[]{"AKXcXcIqsqOJFsdwxZ", 2147483446.0});
-    dataSchema = new DataSchema(new String[]{"column5", "minMaxRangeMV(column7)"},
+    dataSchema = new DataSchema(new String[]{"column5", "minmaxrangemv(column7)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
     data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
@@ -119,7 +119,7 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
     results = Lists
         .newArrayList(new Object[]{"NCoFku", 26}, new Object[]{"mhoVvrJm", 65}, new Object[]{"JXRmGakTYafZFPm", 126},
             new Object[]{"PbQd", 211}, new Object[]{"OKyOqU", 216});
-    dataSchema = new DataSchema(new String[]{"column5", "distinctCountMV(column7)"},
+    dataSchema = new DataSchema(new String[]{"column5", "distinctcountmv(column7)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     numEntriesScannedPostFilter = 800000;
     data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
@@ -131,7 +131,7 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
         .newArrayList(new Object[]{"yQkJTLOQoOqqhkAClgC", 2.147483647E9}, new Object[]{"mhoVvrJm", 2.147483647E9},
             new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2.147483647E9}, new Object[]{"PbQd", 2.147483647E9},
             new Object[]{"OKyOqU", 2.147483647E9});
-    dataSchema = new DataSchema(new String[]{"column5", "percentile90MV(column7)"},
+    dataSchema = new DataSchema(new String[]{"column5", "percentile90mv(column7)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     numEntriesScannedPostFilter = 800000;
     data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
@@ -42,14 +42,17 @@ import org.testng.annotations.Test;
 public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQueriesTest {
 
   @Test(dataProvider = "orderBySQLResultTableProvider")
-  public void testGroupByOrderBySQL(String query, List<Object[]> expectedResults, long expectedNumDocsScanned,
-      long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter, long expectedNumTotalDocs) {
+  public void testGroupByOrderBySQLResponse(String query, List<Object[]> expectedResults, long expectedNumDocsScanned,
+      long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter, long expectedNumTotalDocs,
+      DataSchema expectedDataSchema) {
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
     BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
-    QueriesTestUtils.testInterSegmentGroupByOrderByResultSQL(brokerResponse, expectedNumDocsScanned,
-        expectedNumEntriesScannedInFilter, expectedNumEntriesScannedPostFilter, expectedNumTotalDocs, expectedResults);
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, expectedNumDocsScanned, expectedNumEntriesScannedInFilter,
+            expectedNumEntriesScannedPostFilter, expectedNumTotalDocs, expectedResults, expectedResults.size(),
+            expectedDataSchema);
   }
 
   @Test(dataProvider = "orderByPQLResultProvider")
@@ -142,6 +145,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     List<Object[]> data = new ArrayList<>();
     String query;
     List<Object[]> results;
+    DataSchema dataSchema;
     long numDocsScanned = 120000;
     long numEntriesScannedInFilter = 0;
     long numEntriesScannedPostFilter;
@@ -151,106 +155,121 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11";
     results = Lists.newArrayList(new Object[]{"", 5935285005452.0}, new Object[]{"P", 88832999206836.0},
         new Object[]{"gFuH", 63202785888.0}, new Object[]{"o", 18105331533948.0}, new Object[]{"t", 16331923219264.0});
-
+    dataSchema = new DataSchema(new String[]{"column11", "sum(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 240000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // order by one of the group by columns DESC
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11 DESC";
     results = Lists.newArrayList(results);
     Collections.reverse(results);
+    dataSchema = new DataSchema(new String[]{"column11", "sum(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 240000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // order by one of the group by columns, TOP less than default
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11 TOP 3";
     results = Lists.newArrayList(results);
     Collections.reverse(results);
     results = results.subList(0, 3);
+    dataSchema = new DataSchema(new String[]{"column11", "sum(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 240000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // group by 2 dimensions, order by both, tie breaker
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, column12";
     results = Lists.newArrayList(new Object[]{"", "HEuxNvH", 3789390396216.0},
-        new Object[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.00000},
-        new Object[]{"", "MaztCmmxxgguBUxPti", 1333941430664.00000}, new Object[]{"", "dJWwFk", 55470665124.0000},
-        new Object[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.00000}, new Object[]{"P", "HEuxNvH", 21998672845052.00000},
-        new Object[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx", 18069909216728.00000},
-        new Object[]{"P", "MaztCmmxxgguBUxPti", 27177029040008.00000},
-        new Object[]{"P", "TTltMtFiRqUjvOG", 4462670055540.00000}, new Object[]{"P", "XcBNHe", 120021767504.00000});
+        new Object[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.0},
+        new Object[]{"", "MaztCmmxxgguBUxPti", 1333941430664.0}, new Object[]{"", "dJWwFk", 55470665124.0000},
+        new Object[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.0}, new Object[]{"P", "HEuxNvH", 21998672845052.0},
+        new Object[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx", 18069909216728.0},
+        new Object[]{"P", "MaztCmmxxgguBUxPti", 27177029040008.0},
+        new Object[]{"P", "TTltMtFiRqUjvOG", 4462670055540.0}, new Object[]{"P", "XcBNHe", 120021767504.0});
+    dataSchema = new DataSchema(new String[]{"column11", "column12", "sum(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 360000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // group by 2 columns, order by both, TOP more than default
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, column12 TOP 15";
     results = Lists.newArrayList(results);
-    results.add(new Object[]{"P", "dJWwFk", 6224665921376.00000});
-    results.add(new Object[]{"P", "fykKFqiw", 1574451324140.00000});
-    results.add(new Object[]{"P", "gFuH", 860077643636.00000});
-    results.add(new Object[]{"P", "oZgnrlDEtjjVpUoFLol", 8345501392852.00000});
-    results.add(new Object[]{"gFuH", "HEuxNvH", 29872400856.00000});
+    results.add(new Object[]{"P", "dJWwFk", 6224665921376.0});
+    results.add(new Object[]{"P", "fykKFqiw", 1574451324140.0});
+    results.add(new Object[]{"P", "gFuH", 860077643636.0});
+    results.add(new Object[]{"P", "oZgnrlDEtjjVpUoFLol", 8345501392852.0});
+    results.add(new Object[]{"gFuH", "HEuxNvH", 29872400856.0});
+    dataSchema = new DataSchema(new String[]{"column11", "column12", "sum(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 360000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // group by 2 columns, order by both, one of them DESC
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, column12 DESC";
-    results = Lists.newArrayList(new Object[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.00000},
-        new Object[]{"", "dJWwFk", 55470665124.0000}, new Object[]{"", "MaztCmmxxgguBUxPti", 1333941430664.00000},
-        new Object[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.00000},
-        new Object[]{"", "HEuxNvH", 3789390396216.00000}, new Object[]{"P", "oZgnrlDEtjjVpUoFLol", 8345501392852.00000},
-        new Object[]{"P", "gFuH", 860077643636.00000}, new Object[]{"P", "fykKFqiw", 1574451324140.00000},
-        new Object[]{"P", "dJWwFk", 6224665921376.00000}, new Object[]{"P", "XcBNHe", 120021767504.00000});
+    results = Lists.newArrayList(new Object[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.0},
+        new Object[]{"", "dJWwFk", 55470665124.0000}, new Object[]{"", "MaztCmmxxgguBUxPti", 1333941430664.0},
+        new Object[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.0},
+        new Object[]{"", "HEuxNvH", 3789390396216.0}, new Object[]{"P", "oZgnrlDEtjjVpUoFLol", 8345501392852.0},
+        new Object[]{"P", "gFuH", 860077643636.0}, new Object[]{"P", "fykKFqiw", 1574451324140.0},
+        new Object[]{"P", "dJWwFk", 6224665921376.0}, new Object[]{"P", "XcBNHe", 120021767504.0});
+    dataSchema = new DataSchema(new String[]{"column11", "column12", "sum(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 360000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // order by group by column and an aggregation
-    query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, SUM(column1)";
-    results = Lists.newArrayList(new Object[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.00000},
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, sum(column1)";
+    results = Lists.newArrayList(new Object[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.0},
         new Object[]{"", "dJWwFk", 55470665124.0000},
-        new Object[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.00000},
-        new Object[]{"", "MaztCmmxxgguBUxPti", 1333941430664.00000}, new Object[]{"", "HEuxNvH", 3789390396216.00000},
-        new Object[]{"P", "XcBNHe", 120021767504.00000}, new Object[]{"P", "gFuH", 860077643636.00000},
-        new Object[]{"P", "fykKFqiw", 1574451324140.00000}, new Object[]{"P", "TTltMtFiRqUjvOG", 4462670055540.00000},
-        new Object[]{"P", "dJWwFk", 6224665921376.00000});
+        new Object[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.0},
+        new Object[]{"", "MaztCmmxxgguBUxPti", 1333941430664.0}, new Object[]{"", "HEuxNvH", 3789390396216.0},
+        new Object[]{"P", "XcBNHe", 120021767504.0}, new Object[]{"P", "gFuH", 860077643636.0},
+        new Object[]{"P", "fykKFqiw", 1574451324140.0}, new Object[]{"P", "TTltMtFiRqUjvOG", 4462670055540.0},
+        new Object[]{"P", "dJWwFk", 6224665921376.0});
+    dataSchema = new DataSchema(new String[]{"column11", "column12", "sum(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 360000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // order by only aggregation, DESC, TOP
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY SUM(column1) DESC TOP 50";
-    results = Lists.newArrayList(new Object[]{"P", "MaztCmmxxgguBUxPti", 27177029040008.00000},
-        new Object[]{"P", "HEuxNvH", 21998672845052.00000},
-        new Object[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx", 18069909216728.00000},
-        new Object[]{"P", "oZgnrlDEtjjVpUoFLol", 8345501392852.00000},
-        new Object[]{"o", "MaztCmmxxgguBUxPti", 6905624581072.00000}, new Object[]{"P", "dJWwFk", 6224665921376.00000},
-        new Object[]{"o", "HEuxNvH", 5026384681784.00000}, new Object[]{"t", "MaztCmmxxgguBUxPti", 4492405624940.00000},
-        new Object[]{"P", "TTltMtFiRqUjvOG", 4462670055540.00000}, new Object[]{"t", "HEuxNvH", 4424489490364.00000},
-        new Object[]{"o", "KrNxpdycSiwoRohEiTIlLqDHnx", 4051812250524.00000},
-        new Object[]{"", "HEuxNvH", 3789390396216.00000},
-        new Object[]{"t", "KrNxpdycSiwoRohEiTIlLqDHnx", 3529048341192.00000},
-        new Object[]{"P", "fykKFqiw", 1574451324140.00000}, new Object[]{"t", "dJWwFk", 1349058948804.00000},
-        new Object[]{"", "MaztCmmxxgguBUxPti", 1333941430664.00000}, new Object[]{"o", "dJWwFk", 1152689463360.00000},
-        new Object[]{"t", "oZgnrlDEtjjVpUoFLol", 1039101333316.00000}, new Object[]{"P", "gFuH", 860077643636.00000},
-        new Object[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.00000},
-        new Object[]{"o", "oZgnrlDEtjjVpUoFLol", 699381633640.00000},
-        new Object[]{"t", "TTltMtFiRqUjvOG", 675238030848.00000}, new Object[]{"t", "fykKFqiw", 480973878052.00000},
-        new Object[]{"t", "gFuH", 330331507792.00000}, new Object[]{"o", "TTltMtFiRqUjvOG", 203835153352.00000},
-        new Object[]{"P", "XcBNHe", 120021767504.00000}, new Object[]{"o", "fykKFqiw", 62975165296.00000},
-        new Object[]{"", "dJWwFk", 55470665124.0000}, new Object[]{"gFuH", "HEuxNvH", 29872400856.00000},
-        new Object[]{"gFuH", "MaztCmmxxgguBUxPti", 29170832184.00000},
-        new Object[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.00000}, new Object[]{"t", "XcBNHe", 11276063956.00000},
-        new Object[]{"gFuH", "KrNxpdycSiwoRohEiTIlLqDHnx", 4159552848.00000},
-        new Object[]{"o", "gFuH", 2628604920.00000});
+    results = Lists.newArrayList(new Object[]{"P", "MaztCmmxxgguBUxPti", 27177029040008.0},
+        new Object[]{"P", "HEuxNvH", 21998672845052.0},
+        new Object[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx", 18069909216728.0},
+        new Object[]{"P", "oZgnrlDEtjjVpUoFLol", 8345501392852.0},
+        new Object[]{"o", "MaztCmmxxgguBUxPti", 6905624581072.0}, new Object[]{"P", "dJWwFk", 6224665921376.0},
+        new Object[]{"o", "HEuxNvH", 5026384681784.0}, new Object[]{"t", "MaztCmmxxgguBUxPti", 4492405624940.0},
+        new Object[]{"P", "TTltMtFiRqUjvOG", 4462670055540.0}, new Object[]{"t", "HEuxNvH", 4424489490364.0},
+        new Object[]{"o", "KrNxpdycSiwoRohEiTIlLqDHnx", 4051812250524.0},
+        new Object[]{"", "HEuxNvH", 3789390396216.0},
+        new Object[]{"t", "KrNxpdycSiwoRohEiTIlLqDHnx", 3529048341192.0},
+        new Object[]{"P", "fykKFqiw", 1574451324140.0}, new Object[]{"t", "dJWwFk", 1349058948804.0},
+        new Object[]{"", "MaztCmmxxgguBUxPti", 1333941430664.0}, new Object[]{"o", "dJWwFk", 1152689463360.0},
+        new Object[]{"t", "oZgnrlDEtjjVpUoFLol", 1039101333316.0}, new Object[]{"P", "gFuH", 860077643636.0},
+        new Object[]{"", "KrNxpdycSiwoRohEiTIlLqDHnx", 733802350944.0},
+        new Object[]{"o", "oZgnrlDEtjjVpUoFLol", 699381633640.0},
+        new Object[]{"t", "TTltMtFiRqUjvOG", 675238030848.0}, new Object[]{"t", "fykKFqiw", 480973878052.0},
+        new Object[]{"t", "gFuH", 330331507792.0}, new Object[]{"o", "TTltMtFiRqUjvOG", 203835153352.0},
+        new Object[]{"P", "XcBNHe", 120021767504.0}, new Object[]{"o", "fykKFqiw", 62975165296.0},
+        new Object[]{"", "dJWwFk", 55470665124.0000}, new Object[]{"gFuH", "HEuxNvH", 29872400856.0},
+        new Object[]{"gFuH", "MaztCmmxxgguBUxPti", 29170832184.0},
+        new Object[]{"", "oZgnrlDEtjjVpUoFLol", 22680162504.0}, new Object[]{"t", "XcBNHe", 11276063956.0},
+        new Object[]{"gFuH", "KrNxpdycSiwoRohEiTIlLqDHnx", 4159552848.0},
+        new Object[]{"o", "gFuH", 2628604920.0});
+    dataSchema = new DataSchema(new String[]{"column11", "column12", "sum(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 360000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // multiple aggregations
     query = "SELECT SUM(column1), MIN(column6) FROM testTable GROUP BY column11 ORDER BY column11";
@@ -258,29 +277,35 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         .newArrayList(new Object[]{"", 5935285005452.0, 2.96467636E8}, new Object[]{"P", 88832999206836.0, 1689277.0},
             new Object[]{"gFuH", 63202785888.0, 2.96467636E8}, new Object[]{"o", 18105331533948.0, 2.96467636E8},
             new Object[]{"t", 16331923219264.0, 1980174.0});
+    dataSchema = new DataSchema(new String[]{"column11", "sum(column1)", "min(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 360000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // order by aggregation with space/tab in order by
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY SUM  ( column1) DESC TOP 3";
-    results = Lists.newArrayList(new Object[]{"P", "MaztCmmxxgguBUxPti", 27177029040008.00000},
-        new Object[]{"P", "HEuxNvH", 21998672845052.00000},
-        new Object[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx", 18069909216728.00000});
+    results = Lists.newArrayList(new Object[]{"P", "MaztCmmxxgguBUxPti", 27177029040008.0},
+        new Object[]{"P", "HEuxNvH", 21998672845052.0},
+        new Object[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx", 18069909216728.0});
+    dataSchema = new DataSchema(new String[]{"column11", "column12", "sum(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 360000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // order by an aggregation DESC, and group by column
-    query = "SELECT MIN(column6) FROM testTable GROUP BY column12 ORDER BY MIN(column6) DESC, column12";
-    results = Lists.newArrayList(new Object[]{"XcBNHe", 329467557.00000}, new Object[]{"fykKFqiw", 296467636.00000},
-        new Object[]{"gFuH", 296467636.00000}, new Object[]{"HEuxNvH", 6043515.00000},
-        new Object[]{"MaztCmmxxgguBUxPti", 6043515.00000}, new Object[]{"dJWwFk", 6043515.00000},
-        new Object[]{"KrNxpdycSiwoRohEiTIlLqDHnx", 1980174.00000}, new Object[]{"TTltMtFiRqUjvOG", 1980174.00000},
-        new Object[]{"oZgnrlDEtjjVpUoFLol", 1689277.00000});
+    query = "SELECT MIN(column6) FROM testTable GROUP BY column12 ORDER BY min(column6) DESC, column12";
+    results = Lists.newArrayList(new Object[]{"XcBNHe", 329467557.0}, new Object[]{"fykKFqiw", 296467636.0},
+        new Object[]{"gFuH", 296467636.0}, new Object[]{"HEuxNvH", 6043515.0},
+        new Object[]{"MaztCmmxxgguBUxPti", 6043515.0}, new Object[]{"dJWwFk", 6043515.0},
+        new Object[]{"KrNxpdycSiwoRohEiTIlLqDHnx", 1980174.0}, new Object[]{"TTltMtFiRqUjvOG", 1980174.0},
+        new Object[]{"oZgnrlDEtjjVpUoFLol", 1689277.0});
+    dataSchema = new DataSchema(new String[]{"column12", "min(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 240000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // numeric dimension should follow numeric ordering
     query = "select count(*) from testTable group by column17 order by column17 top 15";
@@ -290,39 +315,49 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
             new Object[]{635942547, 3308L}, new Object[]{638936844, 3816L}, new Object[]{939479517, 3116L},
             new Object[]{984091268, 3824L}, new Object[]{1230252339, 5620L}, new Object[]{1284373442, 7428L},
             new Object[]{1555255521, 2900L}, new Object[]{1618904660, 2744L}, new Object[]{1670085862, 3388L});
+    dataSchema = new DataSchema(new String[]{"column17", "count(*)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG});
     numEntriesScannedPostFilter = 120000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // group by UDF order by UDF
     query = "SELECT COUNT(*) FROM testTable GROUP BY sub(column1, 100000) TOP 3 ORDER BY sub(column1, 100000)";
     results = Lists.newArrayList(new Object[]{140528.0, 28L}, new Object[]{194355.0, 12L}, new Object[]{532157.0, 12L});
+    dataSchema = new DataSchema(new String[]{"sub(column1,'100000')", "count(*)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.LONG});
     numEntriesScannedPostFilter = 120000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // spaces in UDF
     query = "SELECT COUNT(*) FROM testTable GROUP BY sub(column1, 100000) TOP 3 ORDER BY SUB(   column1, 100000 )";
     results = Lists.newArrayList(new Object[]{140528.0, 28L}, new Object[]{194355.0, 12L}, new Object[]{532157.0, 12L});
+    dataSchema = new DataSchema(new String[]{"sub(column1,'100000')", "count(*)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.LONG});
     numEntriesScannedPostFilter = 120000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // Object type aggregation - comparable intermediate results (AVG, MINMAXRANGE)
     query = "SELECT AVG(column6) FROM testTable GROUP BY column11  ORDER BY column11";
     results = Lists.newArrayList(new Object[]{"", 296467636.0}, new Object[]{"P", 909380310.3521485},
         new Object[]{"gFuH", 296467636.0}, new Object[]{"o", 296467636.0}, new Object[]{"t", 526245333.3900426});
+    dataSchema = new DataSchema(new String[]{"column11", "avg(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 240000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     query = "SELECT AVG(column6) FROM testTable GROUP BY column11 ORDER BY AVG(column6), column11 DESC";
     results = Lists
         .newArrayList(new Object[]{"o", 296467636.0}, new Object[]{"gFuH", 296467636.0}, new Object[]{"", 296467636.0},
             new Object[]{"t", 526245333.3900426}, new Object[]{"P", 909380310.3521485});
+    dataSchema = new DataSchema(new String[]{"column11", "avg(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 240000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // Object type aggregation - non comparable intermediate results (DISTINCTCOUNT)
     query = "SELECT DISTINCTCOUNT(column11) FROM testTable GROUP BY column12 ORDER BY column12";
@@ -330,28 +365,44 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new Object[]{"MaztCmmxxgguBUxPti", 5}, new Object[]{"TTltMtFiRqUjvOG", 3}, new Object[]{"XcBNHe", 2},
         new Object[]{"dJWwFk", 4}, new Object[]{"fykKFqiw", 3}, new Object[]{"gFuH", 3},
         new Object[]{"oZgnrlDEtjjVpUoFLol", 4});
+    dataSchema = new DataSchema(new String[]{"column12", "distinctCount(column11)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     numEntriesScannedPostFilter = 240000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     query =
-        "SELECT DISTINCTCOUNT(column11) FROM testTable GROUP BY column12 ORDER BY DISTINCTCOUNT(column11), column12 DESC";
+        "SELECT DISTINCTCOUNT(column11) FROM testTable GROUP BY column12 ORDER BY distinctCount(column11), column12 DESC";
     results = Lists.newArrayList(new Object[]{"XcBNHe", 2}, new Object[]{"gFuH", 3}, new Object[]{"fykKFqiw", 3},
         new Object[]{"TTltMtFiRqUjvOG", 3}, new Object[]{"oZgnrlDEtjjVpUoFLol", 4}, new Object[]{"dJWwFk", 4},
         new Object[]{"MaztCmmxxgguBUxPti", 5}, new Object[]{"KrNxpdycSiwoRohEiTIlLqDHnx", 5},
         new Object[]{"HEuxNvH", 5});
+    dataSchema = new DataSchema(new String[]{"column12", "distinctCount(column11)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     numEntriesScannedPostFilter = 240000;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
+
+    // percentile
+    query = "SELECT percentile90(column6) FROM testTable GROUP BY column11  ORDER BY PERCENTILE90(column6), column11 TOP 3";
+    results = Lists.newArrayList(new Object[]{"", 2.96467636E8}, new Object[]{"gFuH", 2.96467636E8},
+        new Object[]{"o", 2.96467636E8});
+    dataSchema = new DataSchema(new String[]{"column11", "percentile90(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    numEntriesScannedPostFilter = 240000;
+    data.add(
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // empty results
     query =
         "SELECT MIN(column6) FROM testTable where column12='non-existent-value' GROUP BY column11 order by column11";
     results = new ArrayList<>(0);
+    dataSchema = new DataSchema(new String[]{"column11", "min(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numDocsScanned = 0;
     numEntriesScannedPostFilter = 0;
     data.add(
-        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+        new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     return data.toArray(new Object[data.size()][]);
   }
@@ -415,8 +466,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new String[]{"P", "HEuxNvH"}, new String[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx"},
         new String[]{"P", "MaztCmmxxgguBUxPti"}, new String[]{"P", "TTltMtFiRqUjvOG"}, new String[]{"P", "XcBNHe"});
     result1 = Lists
-        .newArrayList(3789390396216.0, 733802350944.00000, 1333941430664.00000, 55470665124.0000, 22680162504.00000,
-            21998672845052.00000, 18069909216728.00000, 27177029040008.00000, 4462670055540.00000, 120021767504.00000);
+        .newArrayList(3789390396216.0, 733802350944.0, 1333941430664.0, 55470665124.0000, 22680162504.0,
+            21998672845052.0, 18069909216728.0, 27177029040008.0, 4462670055540.0, 120021767504.0);
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
@@ -431,11 +482,11 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     groups.add(new String[]{"P", "oZgnrlDEtjjVpUoFLol"});
     groups.add(new String[]{"gFuH", "HEuxNvH"});
     result1 = Lists.newArrayList(result1);
-    result1.add(6224665921376.00000);
-    result1.add(1574451324140.00000);
-    result1.add(860077643636.00000);
-    result1.add(8345501392852.00000);
-    result1.add(29872400856.00000);
+    result1.add(6224665921376.0);
+    result1.add(1574451324140.0);
+    result1.add(860077643636.0);
+    result1.add(8345501392852.0);
+    result1.add(29872400856.0);
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
@@ -448,8 +499,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new String[]{"", "HEuxNvH"}, new String[]{"P", "oZgnrlDEtjjVpUoFLol"}, new String[]{"P", "gFuH"},
         new String[]{"P", "fykKFqiw"}, new String[]{"P", "dJWwFk"}, new String[]{"P", "XcBNHe"});
     result1 = Lists
-        .newArrayList(22680162504.00000, 55470665124.0000, 1333941430664.00000, 733802350944.00000, 3789390396216.00000,
-            8345501392852.00000, 860077643636.00000, 1574451324140.00000, 6224665921376.00000, 120021767504.00000);
+        .newArrayList(22680162504.0, 55470665124.0000, 1333941430664.0, 733802350944.0, 3789390396216.0,
+            8345501392852.0, 860077643636.0, 1574451324140.0, 6224665921376.0, 120021767504.0);
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
@@ -462,8 +513,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new String[]{"", "HEuxNvH"}, new String[]{"P", "XcBNHe"}, new String[]{"P", "gFuH"},
         new String[]{"P", "fykKFqiw"}, new String[]{"P", "TTltMtFiRqUjvOG"}, new String[]{"P", "dJWwFk"});
     result1 = Lists
-        .newArrayList(22680162504.00000, 55470665124.0000, 733802350944.00000, 1333941430664.00000, 3789390396216.00000,
-            120021767504.00000, 860077643636.00000, 1574451324140.00000, 4462670055540.00000, 6224665921376.00000);
+        .newArrayList(22680162504.0, 55470665124.0000, 733802350944.0, 1333941430664.0, 3789390396216.0,
+            120021767504.0, 860077643636.0, 1574451324140.0, 4462670055540.0, 6224665921376.0);
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
@@ -484,13 +535,13 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new String[]{"o", "fykKFqiw"}, new String[]{"", "dJWwFk"}, new String[]{"gFuH", "HEuxNvH"},
         new String[]{"gFuH", "MaztCmmxxgguBUxPti"}, new String[]{"", "oZgnrlDEtjjVpUoFLol"},
         new String[]{"t", "XcBNHe"}, new String[]{"gFuH", "KrNxpdycSiwoRohEiTIlLqDHnx"}, new String[]{"o", "gFuH"});
-    result1 = Lists.newArrayList(27177029040008.00000, 21998672845052.00000, 18069909216728.00000, 8345501392852.00000,
-        6905624581072.00000, 6224665921376.00000, 5026384681784.00000, 4492405624940.00000, 4462670055540.00000,
-        4424489490364.00000, 4051812250524.00000, 3789390396216.00000, 3529048341192.00000, 1574451324140.00000,
-        1349058948804.00000, 1333941430664.00000, 1152689463360.00000, 1039101333316.00000, 860077643636.00000,
-        733802350944.00000, 699381633640.00000, 675238030848.00000, 480973878052.00000, 330331507792.00000,
-        203835153352.00000, 120021767504.00000, 62975165296.00000, 55470665124.0000, 29872400856.00000,
-        29170832184.00000, 22680162504.00000, 11276063956.00000, 4159552848.00000, 2628604920.00000);
+    result1 = Lists.newArrayList(27177029040008.0, 21998672845052.0, 18069909216728.0, 8345501392852.0,
+        6905624581072.0, 6224665921376.0, 5026384681784.0, 4492405624940.0, 4462670055540.0,
+        4424489490364.0, 4051812250524.0, 3789390396216.0, 3529048341192.0, 1574451324140.0,
+        1349058948804.0, 1333941430664.0, 1152689463360.0, 1039101333316.0, 860077643636.0,
+        733802350944.0, 699381633640.0, 675238030848.0, 480973878052.0, 330331507792.0,
+        203835153352.0, 120021767504.0, 62975165296.0, 55470665124.0000, 29872400856.0,
+        29170832184.0, 22680162504.0, 11276063956.0, 4159552848.0, 2628604920.0);
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
@@ -512,7 +563,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY SUM  ( column1) DESC TOP 3";
     groups = Lists.newArrayList(new String[]{"P", "MaztCmmxxgguBUxPti"}, new String[]{"P", "HEuxNvH"},
         new String[]{"P", "KrNxpdycSiwoRohEiTIlLqDHnx"});
-    result1 = Lists.newArrayList(27177029040008.00000, 21998672845052.00000, 18069909216728.00000);
+    result1 = Lists.newArrayList(27177029040008.0, 21998672845052.0, 18069909216728.0);
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
@@ -525,8 +576,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
             new String[]{"MaztCmmxxgguBUxPti"}, new String[]{"dJWwFk"}, new String[]{"KrNxpdycSiwoRohEiTIlLqDHnx"},
             new String[]{"TTltMtFiRqUjvOG"}, new String[]{"oZgnrlDEtjjVpUoFLol"});
     result1 = Lists
-        .newArrayList(329467557.00000, 296467636.00000, 296467636.00000, 6043515.00000, 6043515.00000, 6043515.00000,
-            1980174.00000, 1980174.00000, 1689277.00000);
+        .newArrayList(329467557.0, 296467636.0, 296467636.0, 6043515.0, 6043515.0, 6043515.0,
+            1980174.0, 1980174.0, 1689277.0);
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 240000;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
@@ -162,7 +162,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // order by one of the group by columns DESC
-    query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11 DESC";
+    query = "SELECT sum(column1) FROM testTable GROUP BY column11 ORDER BY column11 DESC";
     results = Lists.newArrayList(results);
     Collections.reverse(results);
     dataSchema = new DataSchema(new String[]{"column11", "sum(column1)"},
@@ -172,7 +172,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // order by one of the group by columns, TOP less than default
-    query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11 TOP 3";
+    query = "SELECT Sum(column1) FROM testTable GROUP BY column11 ORDER BY column11 TOP 3";
     results = Lists.newArrayList(results);
     Collections.reverse(results);
     results = results.subList(0, 3);
@@ -272,7 +272,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // multiple aggregations
-    query = "SELECT SUM(column1), MIN(column6) FROM testTable GROUP BY column11 ORDER BY column11";
+    query = "SELECT sum(column1), MIN(column6) FROM testTable GROUP BY column11 ORDER BY column11";
     results = Lists
         .newArrayList(new Object[]{"", 5935285005452.0, 2.96467636E8}, new Object[]{"P", 88832999206836.0, 1689277.0},
             new Object[]{"gFuH", 63202785888.0, 2.96467636E8}, new Object[]{"o", 18105331533948.0, 2.96467636E8},
@@ -295,7 +295,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     // order by an aggregation DESC, and group by column
-    query = "SELECT MIN(column6) FROM testTable GROUP BY column12 ORDER BY min(column6) DESC, column12";
+    query = "SELECT MIN(column6) FROM testTable GROUP BY column12 ORDER BY Min(column6) DESC, column12";
     results = Lists.newArrayList(new Object[]{"XcBNHe", 329467557.0}, new Object[]{"fykKFqiw", 296467636.0},
         new Object[]{"gFuH", 296467636.0}, new Object[]{"HEuxNvH", 6043515.0},
         new Object[]{"MaztCmmxxgguBUxPti", 6043515.0}, new Object[]{"dJWwFk", 6043515.0},
@@ -365,19 +365,19 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new Object[]{"MaztCmmxxgguBUxPti", 5}, new Object[]{"TTltMtFiRqUjvOG", 3}, new Object[]{"XcBNHe", 2},
         new Object[]{"dJWwFk", 4}, new Object[]{"fykKFqiw", 3}, new Object[]{"gFuH", 3},
         new Object[]{"oZgnrlDEtjjVpUoFLol", 4});
-    dataSchema = new DataSchema(new String[]{"column12", "distinctCount(column11)"},
+    dataSchema = new DataSchema(new String[]{"column12", "distinctcount(column11)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     numEntriesScannedPostFilter = 240000;
     data.add(
         new Object[]{query, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs, dataSchema});
 
     query =
-        "SELECT DISTINCTCOUNT(column11) FROM testTable GROUP BY column12 ORDER BY distinctCount(column11), column12 DESC";
+        "SELECT DISTINCTCOUNT(column11) FROM testTable GROUP BY column12 ORDER BY DistinctCount(column11), column12 DESC";
     results = Lists.newArrayList(new Object[]{"XcBNHe", 2}, new Object[]{"gFuH", 3}, new Object[]{"fykKFqiw", 3},
         new Object[]{"TTltMtFiRqUjvOG", 3}, new Object[]{"oZgnrlDEtjjVpUoFLol", 4}, new Object[]{"dJWwFk", 4},
         new Object[]{"MaztCmmxxgguBUxPti", 5}, new Object[]{"KrNxpdycSiwoRohEiTIlLqDHnx", 5},
         new Object[]{"HEuxNvH", 5});
-    dataSchema = new DataSchema(new String[]{"column12", "distinctCount(column11)"},
+    dataSchema = new DataSchema(new String[]{"column12", "distinctcount(column11)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     numEntriesScannedPostFilter = 240000;
     data.add(

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.GroupByResult;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.response.broker.SelectionResults;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
@@ -122,20 +123,25 @@ public class QueriesTestUtils {
     }
   }
 
-  static void testInterSegmentGroupByOrderByResultSQL(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,
+  static void testInterSegmentResultTable(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,
       long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter, long expectedNumTotalDocs,
-      List<Object[]> expectedResults) {
+      List<Object[]> expectedResults, int expectedResultsSize, DataSchema expectedDataSchema) {
     Assert.assertEquals(brokerResponse.getNumDocsScanned(), expectedNumDocsScanned);
     Assert.assertEquals(brokerResponse.getNumEntriesScannedInFilter(), expectedNumEntriesScannedInFilter);
     Assert.assertEquals(brokerResponse.getNumEntriesScannedPostFilter(), expectedNumEntriesScannedPostFilter);
     Assert.assertEquals(brokerResponse.getTotalDocs(), expectedNumTotalDocs);
 
     ResultTable resultTable = brokerResponse.getResultTable();
+    DataSchema actualDataSchema = resultTable.getDataSchema();
     List<Object[]> actualResults = resultTable.getRows();
 
-    Assert.assertEquals(actualResults.size(), expectedResults.size());
+    Assert.assertEquals(actualResults.size(), expectedResultsSize);
+    Assert.assertEquals(actualDataSchema.size(), expectedDataSchema.size());
+    Assert.assertEquals(actualDataSchema.getColumnNames(), expectedDataSchema.getColumnNames());
+    // TODO : Add this back after PR 4863, which sets the right final column data types for aggregations
+    //Assert.assertEquals(actualDataSchema.getColumnDataTypes(), expectedDataSchema.getColumnDataTypes());
 
-    for (int i = 0; i < actualResults.size(); i++) {
+    for (int i = 0; i < expectedResults.size(); i++) {
       Assert.assertEquals(Arrays.asList(actualResults.get(i)), Arrays.asList(expectedResults.get(i)));
     }
   }


### PR DESCRIPTION
PQL converts column name as "AVG(foo)" -> "avg_foo". In the SQL style, this would have been "avg(foo)". Adding a new API to get the new result name.
Enhanced tests to check the right name is received at the ResultTable in the broker results