### PR TITLE
Pushing PinotFS to pinot-spi

### DIFF
--- a/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
@@ -42,6 +42,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.broker.api;
 
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.common.request.BrokerRequest;
 
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/ClusterChangeHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/ClusterChangeHandler.java
@@ -20,8 +20,8 @@ package org.apache.pinot.broker.broker.helix;
 
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixManager;
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 
 
 /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/RowMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/RowMetadata.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.common.metadata;
 
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 
 
 /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/fetcher/PinotFSSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/fetcher/PinotFSSegmentFetcher.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.Set;
 import org.apache.commons.configuration.Configuration;
-import org.apache.pinot.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.filesystem.PinotFSFactory;
 
 

--- a/pinot-common/src/main/java/org/apache/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-common/src/main/java/org/apache/pinot/filesystem/LocalPinotFS.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.URIUtils;
+import org.apache.pinot.spi.filesystem.PinotFS;
 
 
 /**

--- a/pinot-common/src/main/java/org/apache/pinot/filesystem/PinotFSFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/filesystem/PinotFSFactory.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-common/src/test/java/org/apache/pinot/filesystem/PinotFSFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/filesystem/PinotFSFactoryTest.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Constructor;
 import java.net.URI;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
@@ -19,8 +19,8 @@
 package org.apache.pinot.controller.api.access;
 
 import javax.ws.rs.core.HttpHeaders;
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 
 
 @InterfaceAudience.Public

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlFactory.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.controller.api.access;
 
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 
 
 @InterfaceAudience.Public

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/FileUploadPathProvider.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/FileUploadPathProvider.java
@@ -26,7 +26,7 @@ import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.filesystem.LocalPinotFS;
-import org.apache.pinot.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.filesystem.PinotFSFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -54,7 +54,7 @@ import org.apache.pinot.controller.helix.core.realtime.segment.CommittingSegment
 import org.apache.pinot.controller.util.SegmentCompletionUtils;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
-import org.apache.pinot.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.filesystem.PinotFSFactory;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -75,7 +75,7 @@ import org.apache.pinot.core.crypt.PinotCrypter;
 import org.apache.pinot.core.crypt.PinotCrypterFactory;
 import org.apache.pinot.core.metadata.DefaultMetadataExtractor;
 import org.apache.pinot.core.metadata.MetadataExtractorFactory;
-import org.apache.pinot.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.filesystem.PinotFSFactory;
 import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -33,7 +33,7 @@ import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.resources.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
-import org.apache.pinot.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.filesystem.PinotFSFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -41,7 +41,7 @@ import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.utils.SegmentName;
 import org.apache.pinot.common.utils.URIUtils;
-import org.apache.pinot.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.filesystem.PinotFSFactory;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -78,7 +78,7 @@ import org.apache.pinot.core.realtime.stream.PartitionOffsetFetcher;
 import org.apache.pinot.core.realtime.stream.StreamConfig;
 import org.apache.pinot.core.realtime.stream.StreamConfigProperties;
 import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
-import org.apache.pinot.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.filesystem.PinotFSFactory;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/IndexSegment.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/IndexSegment.java
@@ -20,7 +20,7 @@ package org.apache.pinot.core.indexsegment;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.common.segment.SegmentMetadata;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.spi.data.readers.GenericRow;

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/MessageBatch.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/MessageBatch.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.realtime.stream;
 
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.common.metadata.RowMetadata;
 
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/PartitionLevelConsumer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/PartitionLevelConsumer.java
@@ -19,8 +19,8 @@
 package org.apache.pinot.core.realtime.stream;
 
 import java.io.Closeable;
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 
 
 /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamLevelConsumer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamLevelConsumer.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.realtime.stream;
 
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamMessageDecoder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamMessageDecoder.java
@@ -19,8 +19,8 @@
 package org.apache.pinot.core.realtime.stream;
 
 import java.util.Map;
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamMetadataProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamMetadataProvider.java
@@ -20,8 +20,8 @@ package org.apache.pinot.core.realtime.stream;
 
 import java.io.Closeable;
 import javax.annotation.Nonnull;
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 
 
 /**

--- a/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.pinot.common.utils.retry.RetryPolicies;
 import org.apache.pinot.common.utils.retry.RetryPolicy;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -57,6 +57,20 @@
   </build>
   <dependencies>
     <dependency>
+      <groupId>commons-configuration</groupId>
+      <artifactId>commons-configuration</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/InterfaceAudience.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/InterfaceAudience.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.annotations;
+package org.apache.pinot.spi.annotations;
 
 import java.lang.annotation.Documented;
 
@@ -24,23 +24,23 @@ import java.lang.annotation.Documented;
 /**
  * Annotation to inform users of a package, class or method's intended audience.
  *
- * Currently the audience can be {@link org.apache.pinot.annotations.InterfaceAudience.Public},
- * {@link org.apache.pinot.annotations.InterfaceAudience.LimitedPrivate} or
- * {@link org.apache.pinot.annotations.InterfaceAudience.Private}. <br>
+ * Currently the audience can be {@link InterfaceAudience.Public},
+ * {@link InterfaceAudience.LimitedPrivate} or
+ * {@link InterfaceAudience.Private}. <br>
  *
  * <ul>
  * <li>Public classes that are not marked with this annotation must be
- * considered by default as {@link org.apache.pinot.annotations.InterfaceAudience.Private}.</li>
+ * considered by default as {@link InterfaceAudience.Private}.</li>
  *
  * <li>External application developers depending on Pinot must only use classes that are marked
- * {@link org.apache.pinot.annotations.InterfaceAudience.Public}. Do not depend on classes without an
+ * {@link InterfaceAudience.Public}. Do not depend on classes without an
  * explicit InterfaceAudience.Public annotation as these classes
  * could be removed or change in incompatible ways.</li>
  *
  * <li> Methods may have a different annotation that it is more restrictive
  * compared to the audience classification of the class. Example: A class
- * might be {@link org.apache.pinot.annotations.InterfaceAudience.Public},
- * but a method may be {@link org.apache.pinot.annotations.InterfaceAudience.LimitedPrivate}
+ * might be {@link InterfaceAudience.Public},
+ * but a method may be {@link InterfaceAudience.LimitedPrivate}
  * </li></ul>
  *
  * The annotation is borrowed from a similar Apache Hadoop annotation.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/InterfaceStability.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/InterfaceStability.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.annotations;
+package org.apache.pinot.spi.annotations;
 
 import java.lang.annotation.Documented;
 
@@ -24,14 +24,14 @@ import java.lang.annotation.Documented;
 /**
  * Annotation to inform users of how much to rely on a particular package,
  * class or method not changing over time. Currently the stability can be
- * {@link org.apache.pinot.annotations.InterfaceStability.Stable},
- * {@link org.apache.pinot.annotations.InterfaceStability.Evolving} or
- * {@link org.apache.pinot.annotations.InterfaceStability.Unstable}. <br>
+ * {@link InterfaceStability.Stable},
+ * {@link InterfaceStability.Evolving} or
+ * {@link InterfaceStability.Unstable}. <br>
  *
  * <ul>
- *   <li>All classes that are annotated with {@link org.apache.pinot.annotations.InterfaceAudience.Public} must have
+ *   <li>All classes that are annotated with {@link InterfaceAudience.Public} must have
  *       InterfaceStability annotation. </li>
- *   <li>Classes that are {@link org.apache.pinot.annotations.InterfaceAudience.Private} are to be considered unstable
+ *   <li>Classes that are {@link InterfaceAudience.Private} are to be considered unstable
  *       unless a different InterfaceStability annotation states otherwise.</li>
  *   <li>Pinot contributors should NOT make incompatible changes to classes marked as stable.
  *       Some things to watch out for classes marked as stable:

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.filesystem;
+package org.apache.pinot.spi.filesystem;
 
 import java.io.Closeable;
 import java.io.File;
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Paths;
 import org.apache.commons.configuration.Configuration;
-import org.apache.pinot.annotations.InterfaceAudience;
-import org.apache.pinot.annotations.InterfaceStability;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Moving PinotFS from pinot-common to pinot-spi. This was straight forward and very easy. With this, we are set to handle all batch ingestion jobs without depending on pinot-common or core.

Next steps.
-  move record readers' implementations out of Pinot.
-  Move the pinot fs implementation modules into separate folder and remove dependency on pinot-common and pinot-core.
- Get rid of all hadoop dependencies in pinot-core. Avro dependency will continue to exist because of real-time.

Overall we got the following additional dependencies to pinot-spi. Most of them are not adding much value and used sparingly - it shouldn't be hard to get rid of them.

>     <dependency>
>       <groupId>commons-configuration</groupId>
>       <artifactId>commons-configuration</artifactId>
>       <exclusions>
>         <exclusion>
>           <groupId>commons-logging</groupId>
>           <artifactId>commons-logging</artifactId>
>         </exclusion>
>         <exclusion>
>           <groupId>commons-lang</groupId>
>           <artifactId>commons-lang</artifactId>
>         </exclusion>
>       </exclusions>
>     </dependency>
>     <dependency>
>       <groupId>org.testng</groupId>
>       <artifactId>testng</artifactId>
>       <scope>test</scope>
>     </dependency>
>     <dependency>
>       <groupId>com.google.guava</groupId>
>       <artifactId>guava</artifactId>
>     </dependency>
>     <dependency>
>       <groupId>com.google.code.findbugs</groupId>
>       <artifactId>jsr305</artifactId>
>     </dependency>
>     <dependency>
>       <groupId>org.apache.logging.log4j</groupId>
>       <artifactId>log4j-slf4j-impl</artifactId>
>     </dependency>
>     <dependency>
>       <groupId>org.apache.logging.log4j</groupId>
>       <artifactId>log4j-1.2-api</artifactId>
>     </dependency>
>     <dependency>
>       <groupId>joda-time</groupId>
>       <artifactId>joda-time</artifactId>
>     </dependency>
>     <dependency>
>       <groupId>com.fasterxml.jackson.core</groupId>
>       <artifactId>jackson-annotations</artifactId>
>     </dependency>
>     <dependency>
>       <groupId>com.fasterxml.jackson.core</groupId>
>       <artifactId>jackson-databind</artifactId>
>     </dependency>
>     <dependency>
>       <groupId>commons-codec</groupId>
>       <artifactId>commons-codec</artifactId>
>     </dependency>
>     <dependency>
>       <groupId>org.apache.commons</groupId>
>       <artifactId>commons-lang3</artifactId>
>       <version>3.5</version>
>     </dependency>`