### PR TITLE
Adding pinotFS.open(URI) method to pinotFS

### DIFF
--- a/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-azure-filesystem/src/main/java/org/apache/pinot/filesystem/AzurePinotFS.java
@@ -250,4 +250,10 @@ public class AzurePinotFS extends PinotFS {
     }
     return true;
   }
+
+  @Override
+  public InputStream open(URI uri)
+      throws IOException {
+    return _adlStoreClient.getReadStream(uri.getPath());
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-common/src/main/java/org/apache/pinot/filesystem/LocalPinotFS.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.filesystem;
 
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -142,6 +145,12 @@ public class LocalPinotFS extends PinotFS {
       return file.createNewFile();
     }
     return file.setLastModified(System.currentTimeMillis());
+  }
+
+  @Override
+  public InputStream open(URI uri)
+      throws IOException {
+    return new BufferedInputStream(new FileInputStream(toFile(uri)));
   }
 
   private static File toFile(URI uri) {

--- a/pinot-common/src/test/java/org/apache/pinot/filesystem/PinotFSFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/filesystem/PinotFSFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.filesystem;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.net.URI;
 import org.apache.commons.configuration.Configuration;
@@ -139,6 +140,12 @@ public class PinotFSFactoryTest {
     public boolean touch(URI uri)
         throws IOException {
       return true;
+    }
+
+    @Override
+    public InputStream open(URI uri)
+        throws IOException {
+      return null;
     }
   }
 }

--- a/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
@@ -21,6 +21,7 @@ package org.apache.pinot.filesystem;
 import com.google.common.base.Strings;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -228,6 +229,13 @@ public class HadoopPinotFS extends PinotFS {
       _hadoopFS.setTimes(path, System.currentTimeMillis(), -1);
     }
     return true;
+  }
+
+  @Override
+  public InputStream open(URI uri)
+      throws IOException {
+    Path path = new Path(uri);
+    return _hadoopFS.open(path);
   }
 
   private void authenticate(org.apache.hadoop.conf.Configuration hadoopConf,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.filesystem;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Paths;
 import org.apache.commons.configuration.Configuration;
@@ -204,6 +205,18 @@ public abstract class PinotFS implements Closeable {
    * @throws IOException if the parent directory doesn't exist
    */
   public abstract boolean touch(URI uri)
+      throws IOException;
+
+  /**
+   * Opens a file in the underlying filesystem and returns an InputStream to read it.
+   * Note that the caller can invoke close on this inputstream.
+   * Some implementations can choose to copy the original file to local temp file and return the inputstream.
+   * In this case, the implementation it should delete the temp file when close is invoked.
+   * @param uri location of the file to open
+   * @return a new InputStream
+   * @throws IOException on any IO error - missing file, not a file etc
+   */
+  public abstract InputStream open(URI uri)
       throws IOException;
 
   /**


### PR DESCRIPTION
This will allow us to make pinot-ingestion-job independent of hadoop libraries.  DefaultControllerRestApi.pushSegments relies on getting an inputstream.  With this change, we can  rewrite pinot-ingestion-common to use pinot-fs api's instead of relying on hadoop apis.


See line 114
`         try (InputStream inputStream = fileSystem.open(tarFilePath)) {`
