### PR TITLE
Capture the exact UPDATE operation in DefaultColumnHandler

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/V3UpdateIndexException.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/V3UpdateIndexException.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.index.loader;
+
+/**
+ * The <code>V3UpdateIndexException</code> class extends {@link RuntimeException} and should be thrown out when trying
+ * to update an index from Pinot V3 format segment.
+ */
+public class V3UpdateIndexException extends RuntimeException {
+  public V3UpdateIndexException(String message) {
+    super(message);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/V3DefaultColumnHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/V3DefaultColumnHandler.java
@@ -26,6 +26,7 @@ import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.index.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.index.loader.LoaderUtils;
 import org.apache.pinot.core.segment.index.loader.V3RemoveIndexException;
+import org.apache.pinot.core.segment.index.loader.V3UpdateIndexException;
 import org.apache.pinot.core.segment.store.ColumnIndexType;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
 import org.slf4j.Logger;
@@ -50,7 +51,12 @@ public class V3DefaultColumnHandler extends BaseDefaultColumnHandler {
 
     // For V3 segment format, only support ADD action
     // For UPDATE and REMOVE action, throw exception to drop and re-download the segment
-    if (!action.isAddAction()) {
+    if (action.isUpdateAction()) {
+      throw new V3UpdateIndexException(
+          "Default value indices for column: " + column + " cannot be updated for V3 format segment.");
+    }
+
+    if (action.isRemoveAction()) {
       throw new V3RemoveIndexException(
           "Default value indices for column: " + column + " cannot be removed for V3 format segment.");
     }


### PR DESCRIPTION
It would be helpful if the logs show the exact UPDATE operation. For V3, we don't support REMOVE and UPDATE actions. An exception is thrown and the log doesn't indicate if for UPDATE, we were trying to update data type or default null value or SV to MV or vice versa. 

We recently noticed this in the production logs. 