### PR TITLE
Results in ResultTable if responseFormat=sql

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -50,7 +50,6 @@ import org.apache.pinot.core.query.exception.BadQueryRequestException;
 import org.apache.pinot.core.query.pruner.SegmentPrunerService;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.TimerContext;
-import org.apache.pinot.core.util.QueryOptions;
 import org.apache.pinot.core.util.trace.TraceContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -183,18 +182,6 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
     DataTable dataTable = null;
     try {
-      // The behavior of GROUP BY with multiple aggregations, is different in PQL vs SQL.
-      // As a result, we have 2 groupByModes, to maintain backward compatibility.
-      // The results of PQL groupByMode (if numAggregations > 1) cannot be returned in SQL responseFormat, as the results are non-tabular
-      // Checking for this upfront, to avoid executing the query and wasting resources
-      QueryOptions queryOptions = new QueryOptions(brokerRequest.getQueryOptions());
-      if (brokerRequest.isSetAggregationsInfo() && brokerRequest.getGroupBy() != null) {
-        if (brokerRequest.getAggregationsInfoSize() > 1 && queryOptions.isResponseFormatSQL() && !queryOptions
-            .isGroupByModeSQL()) {
-          throw new UnsupportedOperationException(
-              "The results of a GROUP BY query with multiple aggregations in PQL is not tabular, and cannot be returned in SQL responseFormat");
-        }
-      }
       TimerContext.Timer segmentPruneTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.SEGMENT_PRUNING);
       long totalRawDocs = pruneSegments(tableDataManager, segmentDataManagers, queryRequest);
       segmentPruneTimer.stopAndRecord();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.query.aggregation.AggregationFunctionContext;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
@@ -158,7 +159,9 @@ public class AggregationDataTableReducer implements DataTableReducer {
     String[] finalColumnNames = new String[_numAggregationFunctions];
     DataSchema.ColumnDataType[] finalColumnDataTypes = new DataSchema.ColumnDataType[_numAggregationFunctions];
     for (int i = 0; i < _numAggregationFunctions; i++) {
-      finalColumnNames[i] = AggregationFunctionUtils.getAggregationColumnName(_aggregationInfos.get(i));
+      AggregationFunctionContext aggregationFunctionContext =
+          AggregationFunctionUtils.getAggregationFunctionContext(_aggregationInfos.get(i));
+      finalColumnNames[i] = aggregationFunctionContext.getResultColumnName();
       finalColumnDataTypes[i] = _aggregationFunctions[i].getFinalResultColumnType();
     }
     return new DataSchema(finalColumnNames, finalColumnDataTypes);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
@@ -21,12 +21,15 @@ package org.apache.pinot.core.query.reduce;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
@@ -41,33 +44,46 @@ import org.apache.pinot.core.util.QueryOptions;
 public class AggregationDataTableReducer implements DataTableReducer {
 
   private final AggregationFunction[] _aggregationFunctions;
+  private final List<AggregationInfo> _aggregationInfos;
+  private final int _numAggregationFunctions;
   private final boolean _preserveType;
+  private boolean _responseFormatSql;
 
   AggregationDataTableReducer(BrokerRequest brokerRequest, AggregationFunction[] aggregationFunctions,
       QueryOptions queryOptions) {
     _aggregationFunctions = aggregationFunctions;
+    _aggregationInfos = brokerRequest.getAggregationsInfo();
+    _numAggregationFunctions = aggregationFunctions.length;
     _preserveType = queryOptions.isPreserveType();
+    _responseFormatSql = queryOptions.isResponseFormatSQL();
   }
 
   /**
-   * Reduces data tables and sets aggregations results into BrokerResponseNative::AggregationResults
+   * Reduces data tables and sets aggregations results into
+   * 1. ResultTable if _responseFormatSql is true
+   * 2. AggregationResults by default
    */
   @Override
-  public void reduceAndSetResults(String tableName, DataSchema dataSchema, Map<ServerRoutingInstance, DataTable> dataTableMap,
-      BrokerResponseNative brokerResponseNative, BrokerMetrics brokerMetrics) {
+  public void reduceAndSetResults(String tableName, DataSchema dataSchema,
+      Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
+      BrokerMetrics brokerMetrics) {
+
     if (dataTableMap.isEmpty()) {
+      if (_responseFormatSql) {
+        DataSchema finalDataSchema = getResultTableDataSchema();
+        brokerResponseNative.setResultTable(new ResultTable(finalDataSchema, Collections.emptyList()));
+      }
       return;
     }
 
     assert dataSchema != null;
 
-    int numAggregationFunctions = _aggregationFunctions.length;
     Collection<DataTable> dataTables = dataTableMap.values();
 
     // Merge results from all data tables.
-    Object[] intermediateResults = new Object[numAggregationFunctions];
+    Object[] intermediateResults = new Object[_numAggregationFunctions];
     for (DataTable dataTable : dataTables) {
-      for (int i = 0; i < numAggregationFunctions; i++) {
+      for (int i = 0; i < _numAggregationFunctions; i++) {
         Object intermediateResultToMerge;
         DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
         switch (columnDataType) {
@@ -92,9 +108,37 @@ public class AggregationDataTableReducer implements DataTableReducer {
       }
     }
 
+    if (_responseFormatSql) {
+      brokerResponseNative.setResultTable(reduceToResultTable(intermediateResults));
+    } else {
+      brokerResponseNative
+          .setAggregationResults(reduceToAggregationResult(intermediateResults, dataSchema));
+    }
+  }
+
+  /**
+   * Sets aggregation results into ResultsTable
+   */
+  private ResultTable reduceToResultTable(Object[] intermediateResults) {
+    List<Object[]> rows = new ArrayList<>(1);
+    Object[] row = new Object[_numAggregationFunctions];
+    for (int i = 0; i < _numAggregationFunctions; i++) {
+      row[i] = _aggregationFunctions[i].extractFinalResult(intermediateResults[i]);
+    }
+    rows.add(row);
+
+    DataSchema finalDataSchema = getResultTableDataSchema();
+    return new ResultTable(finalDataSchema, rows);
+  }
+
+  /**
+   * Sets aggregation results into AggregationResults
+   */
+  private List<AggregationResult> reduceToAggregationResult(Object[] intermediateResults,
+      DataSchema dataSchema) {
     // Extract final results and set them into the broker response.
-    List<AggregationResult> reducedAggregationResults = new ArrayList<>(numAggregationFunctions);
-    for (int i = 0; i < numAggregationFunctions; i++) {
+    List<AggregationResult> reducedAggregationResults = new ArrayList<>(_numAggregationFunctions);
+    for (int i = 0; i < _numAggregationFunctions; i++) {
       Serializable resultValue = AggregationFunctionUtils
           .getSerializableValue(_aggregationFunctions[i].extractFinalResult(intermediateResults[i]));
 
@@ -104,6 +148,19 @@ public class AggregationDataTableReducer implements DataTableReducer {
       }
       reducedAggregationResults.add(new AggregationResult(dataSchema.getColumnName(i), resultValue));
     }
-    brokerResponseNative.setAggregationResults(reducedAggregationResults);
+    return reducedAggregationResults;
+  }
+
+  /**
+   * Constructs the data schema for the final results table
+   */
+  private DataSchema getResultTableDataSchema() {
+    String[] finalColumnNames = new String[_numAggregationFunctions];
+    DataSchema.ColumnDataType[] finalColumnDataTypes = new DataSchema.ColumnDataType[_numAggregationFunctions];
+    for (int i = 0; i < _numAggregationFunctions; i++) {
+      finalColumnNames[i] = AggregationFunctionUtils.getAggregationColumnName(_aggregationInfos.get(i));
+      finalColumnDataTypes[i] = _aggregationFunctions[i].getFinalResultColumnType();
+    }
+    return new DataSchema(finalColumnNames, finalColumnDataTypes);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -23,12 +23,14 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.response.broker.SelectionResults;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
@@ -48,23 +50,33 @@ public class DistinctDataTableReducer implements DataTableReducer {
 
   private final BrokerRequest _brokerRequest;
   private final AggregationFunction _aggregationFunction;
+  private boolean _responseFormatSql;
 
   DistinctDataTableReducer(BrokerRequest brokerRequest, AggregationFunction aggregationFunction,
       QueryOptions queryOptions) {
     _brokerRequest = brokerRequest;
     _aggregationFunction = aggregationFunction;
+    _responseFormatSql = queryOptions.isResponseFormatSQL();
   }
 
   /**
-   * Reduces and sets results of distinct into SelectionResults
+   * Reduces and sets results of distinct into
+   * 1. ResultTable if _responseFormatSql is true
+   * 2. SelectionResults by default
    */
   @Override
-  public void reduceAndSetResults(String tableName, DataSchema dataSchema, Map<ServerRoutingInstance, DataTable> dataTableMap,
-      BrokerResponseNative brokerResponseNative, BrokerMetrics brokerMetrics) {
+  public void reduceAndSetResults(String tableName, DataSchema dataSchema,
+      Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
+      BrokerMetrics brokerMetrics) {
 
     if (dataTableMap.isEmpty()) {
-      brokerResponseNative
-          .setSelectionResults(new SelectionResults(Arrays.asList(getDistinctColumns()), new ArrayList<>(0)));
+      if (_responseFormatSql) {
+        DataSchema finalDataSchema = getResultTableDataSchema();
+        brokerResponseNative.setResultTable(new ResultTable(finalDataSchema, Collections.emptyList()));
+      } else {
+        brokerResponseNative
+            .setSelectionResults(new SelectionResults(Arrays.asList(getDistinctColumns()), Collections.emptyList()));
+      }
       return;
     }
 
@@ -102,6 +114,19 @@ public class DistinctDataTableReducer implements DataTableReducer {
     // finish the merging, sort (if ORDER BY), get iterator
     distinctTable.finish(true);
 
+    // Up until now, we have treated DISTINCT similar to another aggregation function even in terms
+    // of the result from function and merging results.
+    // However, the DISTINCT query is just another SELECTION style query from the user's point
+    // of view and will return one or records in the result table for the column(s) selected and so
+    // for that reason, response from broker should be a selection query result.
+    if (_responseFormatSql) {
+      brokerResponseNative.setResultTable(reduceToResultTable(distinctTable));
+    } else {
+      brokerResponseNative.setSelectionResults(reduceToSelectionResult(distinctTable));
+    }
+  }
+
+  private SelectionResults reduceToSelectionResult(DistinctTable distinctTable) {
     List<Serializable[]> resultSet = new ArrayList<>(distinctTable.size());
     String[] columnNames = distinctTable.getDataSchema().getColumnNames();
     Iterator<Record> iterator = distinctTable.iterator();
@@ -115,18 +140,31 @@ public class DistinctDataTableReducer implements DataTableReducer {
       }
       resultSet.add(distinctRow);
     }
+    return new SelectionResults(Arrays.asList(columnNames), resultSet);
+  }
 
-    // Up until now, we have treated DISTINCT similar to another aggregation function even in terms
-    // of the result from function and merging results.
-    // However, the DISTINCT query is just another SELECTION style query from the user's point
-    // of view and will return one or records in the result table for the column(s) selected and so
-    // for that reason, response from broker should be a selection query result.
-    brokerResponseNative.setSelectionResults((new SelectionResults(Arrays.asList(columnNames), resultSet)));
+  private ResultTable reduceToResultTable(DistinctTable distinctTable) {
+    List<Object[]> resultSet = new ArrayList<>(distinctTable.size());
+    Iterator<Record> iterator = distinctTable.iterator();
+    while (iterator.hasNext()) {
+      Record record = iterator.next();
+      resultSet.add(record.getValues());
+    }
+    DataSchema finalDataSchema = getResultTableDataSchema();
+    return new ResultTable(finalDataSchema, resultSet);
   }
 
   private String[] getDistinctColumns() {
     return _brokerRequest.getAggregationsInfo().get(0).getAggregationParams()
         .get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO)
         .split(FunctionCallAstNode.DISTINCT_MULTI_COLUMN_SEPARATOR);
+  }
+
+  private DataSchema getResultTableDataSchema() {
+    String[] columns = getDistinctColumns();
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[columns.length];
+    // TODO: there's no way currently to get the data types of the distinct columns
+    Arrays.fill(columnDataTypes, DataSchema.ColumnDataType.STRING);
+    return new DataSchema(columns, columnDataTypes);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -71,7 +71,9 @@ public class DistinctDataTableReducer implements DataTableReducer {
 
     if (dataTableMap.isEmpty()) {
       if (_responseFormatSql) {
-        DataSchema finalDataSchema = getResultTableDataSchema();
+        // TODO: This returns schema with all STRING data types.
+        //  There's no way currently to get the data types of the distinct columns for empty results
+        DataSchema finalDataSchema = getEmptyResultTableDataSchema();
         brokerResponseNative.setResultTable(new ResultTable(finalDataSchema, Collections.emptyList()));
       } else {
         brokerResponseNative
@@ -150,8 +152,7 @@ public class DistinctDataTableReducer implements DataTableReducer {
       Record record = iterator.next();
       resultSet.add(record.getValues());
     }
-    DataSchema finalDataSchema = getResultTableDataSchema();
-    return new ResultTable(finalDataSchema, resultSet);
+    return new ResultTable(distinctTable.getDataSchema(), resultSet);
   }
 
   private String[] getDistinctColumns() {
@@ -160,10 +161,9 @@ public class DistinctDataTableReducer implements DataTableReducer {
         .split(FunctionCallAstNode.DISTINCT_MULTI_COLUMN_SEPARATOR);
   }
 
-  private DataSchema getResultTableDataSchema() {
+  private DataSchema getEmptyResultTableDataSchema() {
     String[] columns = getDistinctColumns();
     DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[columns.length];
-    // TODO: there's no way currently to get the data types of the distinct columns
     Arrays.fill(columnDataTypes, DataSchema.ColumnDataType.STRING);
     return new DataSchema(columns, columnDataTypes);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.BiFunction;
+import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.AggregationInfo;
@@ -39,6 +40,7 @@ import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.GroupByResult;
+import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.common.utils.DataSchema;
@@ -61,6 +63,12 @@ public class GroupByDataTableReducer implements DataTableReducer {
 
   private final BrokerRequest _brokerRequest;
   private final AggregationFunction[] _aggregationFunctions;
+  private final List<AggregationInfo> _aggregationInfos;
+  private final List<SelectionSort> _orderBy;
+  private final GroupBy _groupBy;
+  private final int _numAggregationFunctions;
+  private final int _numGroupBy;
+  private final int _numColumns;
   private final boolean _preserveType;
   private final boolean _groupByModeSql;
   private final boolean _responseFormatSql;
@@ -69,6 +77,12 @@ public class GroupByDataTableReducer implements DataTableReducer {
       QueryOptions queryOptions) {
     _brokerRequest = brokerRequest;
     _aggregationFunctions = aggregationFunctions;
+    _aggregationInfos = brokerRequest.getAggregationsInfo();
+    _numAggregationFunctions = aggregationFunctions.length;
+    _groupBy = brokerRequest.getGroupBy();
+    _numGroupBy = _groupBy.getExpressionsSize();
+    _orderBy = brokerRequest.getOrderBy();
+    _numColumns = _numAggregationFunctions + _numGroupBy;
     _preserveType = queryOptions.isPreserveType();
     _groupByModeSql = queryOptions.isGroupByModeSQL();
     _responseFormatSql = queryOptions.isResponseFormatSQL();
@@ -79,8 +93,9 @@ public class GroupByDataTableReducer implements DataTableReducer {
    * By default, sets group by results into GroupByResults
    */
   @Override
-  public void reduceAndSetResults(String tableName, DataSchema dataSchema, Map<ServerRoutingInstance, DataTable> dataTableMap,
-      BrokerResponseNative brokerResponseNative, BrokerMetrics brokerMetrics) {
+  public void reduceAndSetResults(String tableName, DataSchema dataSchema,
+      Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
+      BrokerMetrics brokerMetrics) {
     if (dataTableMap.isEmpty() && !_responseFormatSql) {
       return;
     }
@@ -89,35 +104,39 @@ public class GroupByDataTableReducer implements DataTableReducer {
     int resultSize = 0;
     Collection<DataTable> dataTables = dataTableMap.values();
 
-    // Aggregation group-by query.
-    // read results as records if  GROUP_BY_MODE is explicitly set to SQL
-
     if (_groupByModeSql) {
 
-      // if RESPONSE_FORMAT is SQL, return results in {@link ResultTable}
       if (_responseFormatSql) {
-        setSQLGroupByOrderByResults(brokerResponseNative, dataSchema, _brokerRequest.getAggregationsInfo(),
-            _brokerRequest.getGroupBy(), _brokerRequest.getOrderBy(), dataTables);
+        setSQLGroupByInResultTable(brokerResponseNative, dataSchema, dataTables);
         resultSize = brokerResponseNative.getResultTable().getRows().size();
       } else {
-        setPQLGroupByOrderByResults(brokerResponseNative, dataSchema, _brokerRequest.getAggregationsInfo(),
-            _brokerRequest.getGroupBy(), _brokerRequest.getOrderBy(), dataTables);
+        setSQLGroupByInAggregationResults(brokerResponseNative, dataSchema, dataTables);
         if (!brokerResponseNative.getAggregationResults().isEmpty()) {
           resultSize = brokerResponseNative.getAggregationResults().get(0).getGroupByResult().size();
         }
       }
     } else {
 
-      boolean[] aggregationFunctionSelectStatus =
-          AggregationFunctionUtils.getAggregationFunctionsSelectStatus(_brokerRequest.getAggregationsInfo());
-      setGroupByHavingResults(brokerResponseNative, aggregationFunctionSelectStatus, _brokerRequest.getGroupBy(),
-          dataTables, _brokerRequest.getHavingFilterQuery(), _brokerRequest.getHavingFilterSubQueryMap());
-      // We emit the group by size when the result isn't empty. All the sizes among group-by results should be the same.
-      // Thus, we can just emit the one from the 1st result.
-      if (!brokerResponseNative.getAggregationResults().isEmpty()) {
-        resultSize = brokerResponseNative.getAggregationResults().get(0).getGroupByResult().size();
+      if (_responseFormatSql && _numAggregationFunctions > 1) {
+        brokerResponseNative.addToExceptions(new QueryProcessingException(QueryException.MERGE_RESPONSE_ERROR_CODE,
+            "Sql response format is unsupported for pql execution mode with multiple aggregations"));
+      } else {
+        boolean[] aggregationFunctionSelectStatus =
+            AggregationFunctionUtils.getAggregationFunctionsSelectStatus(_aggregationInfos);
+        setGroupByHavingResults(brokerResponseNative, aggregationFunctionSelectStatus, dataTables,
+            _brokerRequest.getHavingFilterQuery(), _brokerRequest.getHavingFilterSubQueryMap());
+        if (_responseFormatSql) {
+          resultSize = brokerResponseNative.getResultTable().getRows().size();
+        } else {
+          // We emit the group by size when the result isn't empty. All the sizes among group-by results should be the same.
+          // Thus, we can just emit the one from the 1st result.
+          if (!brokerResponseNative.getAggregationResults().isEmpty()) {
+            resultSize = brokerResponseNative.getAggregationResults().get(0).getGroupByResult().size();
+          }
+        }
       }
     }
+
     if (brokerMetrics != null && resultSize > 0) {
       brokerMetrics.addMeteredQueryValue(_brokerRequest, BrokerMeter.GROUP_BY_SIZE, resultSize);
     }
@@ -127,30 +146,24 @@ public class GroupByDataTableReducer implements DataTableReducer {
    * Extract group by order by results and set into {@link ResultTable}
    * @param brokerResponseNative broker response
    * @param dataSchema data schema
-   * @param aggregationInfos aggregations info
-   * @param groupBy group by info
-   * @param orderBy order by info
    * @param dataTables Collection of data tables
    */
-  private void setSQLGroupByOrderByResults(BrokerResponseNative brokerResponseNative, DataSchema dataSchema,
-      List<AggregationInfo> aggregationInfos, GroupBy groupBy, List<SelectionSort> orderBy,
+  private void setSQLGroupByInResultTable(BrokerResponseNative brokerResponseNative, DataSchema dataSchema,
       Collection<DataTable> dataTables) {
 
-    IndexedTable indexedTable = getIndexedTable(groupBy, aggregationInfos, orderBy, dataSchema, dataTables);
+    IndexedTable indexedTable = getIndexedTable(dataSchema, dataTables);
 
     List<Object[]> rows = new ArrayList<>();
-    int numColumns = dataSchema.size();
-    int numGroupBy = groupBy.getExpressionsSize();
     Iterator<Record> sortedIterator = indexedTable.iterator();
     int numRows = 0;
-    while (numRows < groupBy.getTopN() && sortedIterator.hasNext()) {
+    while (numRows < _groupBy.getTopN() && sortedIterator.hasNext()) {
 
       Record nextRecord = sortedIterator.next();
       Object[] values = nextRecord.getValues();
 
-      int index = numGroupBy;
+      int index = _numGroupBy;
       int aggNum = 0;
-      while (index < numColumns) {
+      while (index < _numColumns) {
         values[index] = _aggregationFunctions[aggNum++].extractFinalResult(values[index]);
         index++;
       }
@@ -158,19 +171,41 @@ public class GroupByDataTableReducer implements DataTableReducer {
       numRows++;
     }
 
-    brokerResponseNative.setResultTable(new ResultTable(dataSchema, rows));
+    DataSchema finalDataSchema = getSQLResultTableSchema(dataSchema);
+    brokerResponseNative.setResultTable(new ResultTable(finalDataSchema, rows));
   }
 
-  private IndexedTable getIndexedTable(GroupBy groupBy, List<AggregationInfo> aggregationInfos,
-      List<SelectionSort> orderBy, DataSchema dataSchema, Collection<DataTable> dataTables) {
+  /**
+   * Constructs the final result table schema for sql mode execution
+   * The data type for the aggregations needs to be taken from the final result's data type
+   */
+  private DataSchema getSQLResultTableSchema(DataSchema dataSchema) {
+    String[] columns = dataSchema.getColumnNames();
+    DataSchema.ColumnDataType[] finalColumnDataTypes = new DataSchema.ColumnDataType[_numColumns];
+    int aggIdx = 0;
+    for (int i = 0; i < _numColumns; i++) {
+      if (i < _numGroupBy) {
+        finalColumnDataTypes[i] = dataSchema.getColumnDataType(i);
+      } else {
+        _aggregationFunctions[aggIdx] =
+            AggregationFunctionUtils.getAggregationFunctionContext(_aggregationInfos.get(aggIdx))
+                .getAggregationFunction();
+        finalColumnDataTypes[i] = _aggregationFunctions[aggIdx].getFinalResultColumnType();
+        aggIdx++;
+      }
+    }
+    return new DataSchema(columns, finalColumnDataTypes);
+  }
 
-    int numColumns = dataSchema.size();
-    int indexedTableCapacity = GroupByUtils.getTableCapacity(groupBy, orderBy);
-    IndexedTable indexedTable = new ConcurrentIndexedTable(dataSchema, aggregationInfos, orderBy, indexedTableCapacity);
+  private IndexedTable getIndexedTable(DataSchema dataSchema, Collection<DataTable> dataTables) {
+
+    int indexedTableCapacity = GroupByUtils.getTableCapacity(_groupBy, _orderBy);
+    IndexedTable indexedTable =
+        new ConcurrentIndexedTable(dataSchema, _aggregationInfos, _orderBy, indexedTableCapacity);
 
     for (DataTable dataTable : dataTables) {
-      BiFunction[] functions = new BiFunction[numColumns];
-      for (int i = 0; i < numColumns; i++) {
+      BiFunction[] functions = new BiFunction[_numColumns];
+      for (int i = 0; i < _numColumns; i++) {
         DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
         BiFunction<Integer, Integer, Object> function;
         switch (columnDataType) {
@@ -201,8 +236,8 @@ public class GroupByDataTableReducer implements DataTableReducer {
       }
 
       for (int row = 0; row < dataTable.getNumberOfRows(); row++) {
-        Object[] columns = new Object[numColumns];
-        for (int col = 0; col < numColumns; col++) {
+        Object[] columns = new Object[_numColumns];
+        for (int col = 0; col < _numColumns; col++) {
           columns[col] = functions[col].apply(row, col);
         }
         Record record = new Record(columns);
@@ -218,59 +253,47 @@ public class GroupByDataTableReducer implements DataTableReducer {
    * There will be 1 aggregation result per aggregation. The group by keys will be the same across all aggregations
    * @param brokerResponseNative broker response
    * @param dataSchema data schema
-   * @param aggregationInfos aggregations info
-   * @param groupBy group by info
-   * @param orderBy order by info
    * @param dataTables Collection of data tables
    */
-  private void setPQLGroupByOrderByResults(BrokerResponseNative brokerResponseNative, DataSchema dataSchema,
-      List<AggregationInfo> aggregationInfos, GroupBy groupBy, List<SelectionSort> orderBy,
+  private void setSQLGroupByInAggregationResults(BrokerResponseNative brokerResponseNative, DataSchema dataSchema,
       Collection<DataTable> dataTables) {
-    int numGroupBy = groupBy.getExpressionsSize();
-    int numAggregations = aggregationInfos.size();
-    int numColumns = numGroupBy + numAggregations;
 
-    List<String> groupByColumns = new ArrayList<>(numGroupBy);
+    List<String> groupByColumns = new ArrayList<>(_numGroupBy);
     int idx = 0;
-    while (idx < numGroupBy) {
+    while (idx < _numGroupBy) {
       groupByColumns.add(dataSchema.getColumnName(idx));
       idx++;
     }
 
-    List<String> aggregationColumns = new ArrayList<>(numAggregations);
-    AggregationFunction[] aggregationFunctions = new AggregationFunction[aggregationInfos.size()];
-    List<List<GroupByResult>> groupByResults = new ArrayList<>(numAggregations);
-    int aggIdx = 0;
-    while (idx < numColumns) {
+    List<String> aggregationColumns = new ArrayList<>(_numAggregationFunctions);
+    List<List<GroupByResult>> groupByResults = new ArrayList<>(_numAggregationFunctions);
+    while (idx < _numColumns) {
       aggregationColumns.add(dataSchema.getColumnName(idx));
-      aggregationFunctions[aggIdx] =
-          AggregationFunctionUtils.getAggregationFunctionContext(aggregationInfos.get(aggIdx)).getAggregationFunction();
       groupByResults.add(new ArrayList<>());
       idx++;
-      aggIdx++;
     }
 
     if (!dataTables.isEmpty()) {
-      IndexedTable indexedTable = getIndexedTable(groupBy, aggregationInfos, orderBy, dataSchema, dataTables);
+      IndexedTable indexedTable = getIndexedTable(dataSchema, dataTables);
 
       Iterator<Record> sortedIterator = indexedTable.iterator();
       int numRows = 0;
-      while (numRows < groupBy.getTopN() && sortedIterator.hasNext()) {
+      while (numRows < _groupBy.getTopN() && sortedIterator.hasNext()) {
 
         Record nextRecord = sortedIterator.next();
         Object[] values = nextRecord.getValues();
 
         int index = 0;
-        List<String> group = new ArrayList<>(numGroupBy);
-        while (index < numGroupBy) {
+        List<String> group = new ArrayList<>(_numGroupBy);
+        while (index < _numGroupBy) {
           group.add(values[index].toString());
           index++;
         }
 
         int aggNum = 0;
-        while (index < numColumns) {
+        while (index < _numColumns) {
           Serializable serializableValue =
-              getSerializableValue(aggregationFunctions[aggNum].extractFinalResult(values[index]));
+              getSerializableValue(_aggregationFunctions[aggNum].extractFinalResult(values[index]));
           if (!_preserveType) {
             serializableValue = AggregationFunctionUtils.formatValue(serializableValue);
           }
@@ -285,8 +308,8 @@ public class GroupByDataTableReducer implements DataTableReducer {
       }
     }
 
-    List<AggregationResult> aggregationResults = new ArrayList<>(numAggregations);
-    for (int i = 0; i < numAggregations; i++) {
+    List<AggregationResult> aggregationResults = new ArrayList<>(_numAggregationFunctions);
+    for (int i = 0; i < _numAggregationFunctions; i++) {
       AggregationResult aggregationResult =
           new AggregationResult(groupByResults.get(i), groupByColumns, aggregationColumns.get(i));
       aggregationResults.add(aggregationResult);
@@ -303,25 +326,40 @@ public class GroupByDataTableReducer implements DataTableReducer {
   }
 
   /**
+   * Constructs the final result table schema for PQL execution mode
+   */
+  private DataSchema getPQLResultTableSchema(String finalAggregationName, AggregationFunction aggregationFunction) {
+    String[] finalDataSchemaColumns = new String[_numColumns];
+    DataSchema.ColumnDataType[] finalColumnDataTypes = new DataSchema.ColumnDataType[_numColumns];
+    int i;
+    List<String> groupByExpressions = _groupBy.getExpressions();
+    for (i = 0; i < _numGroupBy; i++) {
+      finalDataSchemaColumns[i] = groupByExpressions.get(i);
+      finalColumnDataTypes[i] = DataSchema.ColumnDataType.STRING;
+    }
+    finalDataSchemaColumns[i] = finalAggregationName;
+    finalColumnDataTypes[i] = aggregationFunction.getFinalResultColumnType();
+    return new DataSchema(finalDataSchemaColumns, finalColumnDataTypes);
+  }
+
+  /**
    * Reduce group-by results from multiple servers and set them into BrokerResponseNative passed in.
    *
    * @param brokerResponseNative broker response.
-   * @param groupBy group-by information.
    * @param dataTables Collection of data tables
    * @param havingFilterQuery having filter query
    * @param havingFilterQueryMap having filter query map
    */
   @SuppressWarnings("unchecked")
   private void setGroupByHavingResults(BrokerResponseNative brokerResponseNative,
-      boolean[] aggregationFunctionsSelectStatus, GroupBy groupBy, Collection<DataTable> dataTables,
-      HavingFilterQuery havingFilterQuery, HavingFilterQueryMap havingFilterQueryMap) {
-    int numAggregationFunctions = _aggregationFunctions.length;
+      boolean[] aggregationFunctionsSelectStatus, Collection<DataTable> dataTables, HavingFilterQuery havingFilterQuery,
+      HavingFilterQueryMap havingFilterQueryMap) {
 
     // Merge results from all data tables.
-    String[] columnNames = new String[numAggregationFunctions];
-    Map<String, Object>[] intermediateResultMaps = new Map[numAggregationFunctions];
+    String[] columnNames = new String[_numAggregationFunctions];
+    Map<String, Object>[] intermediateResultMaps = new Map[_numAggregationFunctions];
     for (DataTable dataTable : dataTables) {
-      for (int i = 0; i < numAggregationFunctions; i++) {
+      for (int i = 0; i < _numAggregationFunctions; i++) {
         if (columnNames[i] == null) {
           columnNames[i] = dataTable.getString(i, 0);
           intermediateResultMaps[i] = dataTable.getObject(i, 1);
@@ -344,8 +382,8 @@ public class GroupByDataTableReducer implements DataTableReducer {
     }
 
     // Extract final result maps from the merged intermediate result maps.
-    Map<String, Comparable>[] finalResultMaps = new Map[numAggregationFunctions];
-    for (int i = 0; i < numAggregationFunctions; i++) {
+    Map<String, Comparable>[] finalResultMaps = new Map[_numAggregationFunctions];
+    for (int i = 0; i < _numAggregationFunctions; i++) {
       Map<String, Object> intermediateResultMap = intermediateResultMaps[i];
       Map<String, Comparable> finalResultMap = new HashMap<>();
       for (String groupKey : intermediateResultMap.keySet()) {
@@ -363,25 +401,25 @@ public class GroupByDataTableReducer implements DataTableReducer {
       //In other words, we just keep intersection of groups of different aggregation functions.
       //Here we calculate the intersection of group key sets of different aggregation functions
       Set<String> intersectionOfKeySets = finalResultMaps[0].keySet();
-      for (int i = 1; i < numAggregationFunctions; i++) {
+      for (int i = 1; i < _numAggregationFunctions; i++) {
         intersectionOfKeySets.retainAll(finalResultMaps[i].keySet());
       }
 
       //Now it is time to remove those groups that do not validate HAVING clause predicate
       //We use TreeMap which supports CASE_INSENSITIVE_ORDER
       Map<String, Comparable> singleGroupAggResults = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-      Map<String, Comparable>[] finalFilteredResultMaps = new Map[numAggregationFunctions];
-      for (int i = 0; i < numAggregationFunctions; i++) {
+      Map<String, Comparable>[] finalFilteredResultMaps = new Map[_numAggregationFunctions];
+      for (int i = 0; i < _numAggregationFunctions; i++) {
         finalFilteredResultMaps[i] = new HashMap<>();
       }
 
       for (String groupKey : intersectionOfKeySets) {
-        for (int i = 0; i < numAggregationFunctions; i++) {
+        for (int i = 0; i < _numAggregationFunctions; i++) {
           singleGroupAggResults.put(columnNames[i], finalResultMaps[i].get(groupKey));
         }
         //if this group validate HAVING predicate keep it in the new map
         if (havingClauseComparisonTree.isThisGroupPassPredicates(singleGroupAggResults)) {
-          for (int i = 0; i < numAggregationFunctions; i++) {
+          for (int i = 0; i < _numAggregationFunctions; i++) {
             finalFilteredResultMaps[i].put(groupKey, singleGroupAggResults.get(columnNames[i]));
           }
         }
@@ -391,7 +429,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
     }
 
     int aggregationNumsInFinalResult = 0;
-    for (int i = 0; i < numAggregationFunctions; i++) {
+    for (int i = 0; i < _numAggregationFunctions; i++) {
       if (aggregationFunctionsSelectStatus[i]) {
         aggregationNumsInFinalResult++;
       }
@@ -400,36 +438,55 @@ public class GroupByDataTableReducer implements DataTableReducer {
     if (aggregationNumsInFinalResult > 0) {
       String[] finalColumnNames = new String[aggregationNumsInFinalResult];
       Map<String, Comparable>[] finalOutResultMaps = new Map[aggregationNumsInFinalResult];
+      String[] finalResultTableAggNames = new String[aggregationNumsInFinalResult];
       AggregationFunction[] finalAggregationFunctions = new AggregationFunction[aggregationNumsInFinalResult];
       int count = 0;
-      for (int i = 0; i < numAggregationFunctions; i++) {
+      for (int i = 0; i < _numAggregationFunctions; i++) {
         if (aggregationFunctionsSelectStatus[i]) {
           finalColumnNames[count] = columnNames[i];
           finalOutResultMaps[count] = finalResultMaps[i];
+          finalResultTableAggNames[count] = AggregationFunctionUtils.getAggregationColumnName(_aggregationInfos.get(i));
           finalAggregationFunctions[count] = _aggregationFunctions[i];
           count++;
         }
       }
       // Trim the final result maps to topN and set them into the broker response.
       AggregationGroupByTrimmingService aggregationGroupByTrimmingService =
-          new AggregationGroupByTrimmingService(finalAggregationFunctions, (int) groupBy.getTopN());
+          new AggregationGroupByTrimmingService(finalAggregationFunctions, (int) _groupBy.getTopN());
       List<GroupByResult>[] groupByResultLists = aggregationGroupByTrimmingService.trimFinalResults(finalOutResultMaps);
 
-      // Format the value into string if required
-      if (!_preserveType) {
-        for (List<GroupByResult> groupByResultList : groupByResultLists) {
-          for (GroupByResult groupByResult : groupByResultList) {
-            groupByResult.setValue(AggregationFunctionUtils.formatValue(groupByResult.getValue()));
+      if (_responseFormatSql) {
+        assert aggregationNumsInFinalResult == 1;
+        List<GroupByResult> groupByResultList = groupByResultLists[0];
+        List<Object[]> rows = new ArrayList<>();
+        for (GroupByResult groupByResult : groupByResultList) {
+          Object[] row = new Object[_numColumns];
+          int i = 0;
+          for (String column : groupByResult.getGroup()) {
+            row[i++] = column;
+          }
+          row[i] = groupByResult.getValue();
+          rows.add(row);
+        }
+        DataSchema finalDataSchema = getPQLResultTableSchema(finalResultTableAggNames[0], finalAggregationFunctions[0]);
+        brokerResponseNative.setResultTable(new ResultTable(finalDataSchema, rows));
+      } else {
+        // Format the value into string if required
+        if (!_preserveType) {
+          for (List<GroupByResult> groupByResultList : groupByResultLists) {
+            for (GroupByResult groupByResult : groupByResultList) {
+              groupByResult.setValue(AggregationFunctionUtils.formatValue(groupByResult.getValue()));
+            }
           }
         }
+        List<AggregationResult> aggregationResults = new ArrayList<>(count);
+        for (int i = 0; i < aggregationNumsInFinalResult; i++) {
+          List<GroupByResult> groupByResultList = groupByResultLists[i];
+          aggregationResults
+              .add(new AggregationResult(groupByResultList, _groupBy.getExpressions(), finalColumnNames[i]));
+        }
+        brokerResponseNative.setAggregationResults(aggregationResults);
       }
-
-      List<AggregationResult> aggregationResults = new ArrayList<>(count);
-      for (int i = 0; i < aggregationNumsInFinalResult; i++) {
-        List<GroupByResult> groupByResultList = groupByResultLists[i];
-        aggregationResults.add(new AggregationResult(groupByResultList, groupBy.getExpressions(), finalColumnNames[i]));
-      }
-      brokerResponseNative.setAggregationResults(aggregationResults);
     } else {
       throw new IllegalStateException(
           "There should be minimum one aggregation function in the select list of a Group by query");

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.GroupByResult;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.core.query.aggregation.AggregationFunctionContext;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
@@ -64,6 +65,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
   private final BrokerRequest _brokerRequest;
   private final AggregationFunction[] _aggregationFunctions;
   private final List<AggregationInfo> _aggregationInfos;
+  private final AggregationFunctionContext[] _aggregationFunctionContexts;
   private final List<SelectionSort> _orderBy;
   private final GroupBy _groupBy;
   private final int _numAggregationFunctions;
@@ -78,6 +80,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
     _brokerRequest = brokerRequest;
     _aggregationFunctions = aggregationFunctions;
     _aggregationInfos = brokerRequest.getAggregationsInfo();
+    _aggregationFunctionContexts = AggregationFunctionUtils.getAggregationFunctionContexts(_brokerRequest, null);
     _numAggregationFunctions = aggregationFunctions.length;
     _groupBy = brokerRequest.getGroupBy();
     _numGroupBy = _groupBy.getExpressionsSize();
@@ -187,9 +190,6 @@ public class GroupByDataTableReducer implements DataTableReducer {
       if (i < _numGroupBy) {
         finalColumnDataTypes[i] = dataSchema.getColumnDataType(i);
       } else {
-        _aggregationFunctions[aggIdx] =
-            AggregationFunctionUtils.getAggregationFunctionContext(_aggregationInfos.get(aggIdx))
-                .getAggregationFunction();
         finalColumnDataTypes[i] = _aggregationFunctions[aggIdx].getFinalResultColumnType();
         aggIdx++;
       }
@@ -445,7 +445,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
         if (aggregationFunctionsSelectStatus[i]) {
           finalColumnNames[count] = columnNames[i];
           finalOutResultMaps[count] = finalResultMaps[i];
-          finalResultTableAggNames[count] = AggregationFunctionUtils.getAggregationColumnName(_aggregationInfos.get(i));
+          finalResultTableAggNames[count] = _aggregationFunctionContexts[i].getResultColumnName();
           finalAggregationFunctions[count] = _aggregationFunctions[i];
           count++;
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -434,12 +434,12 @@ public class SelectionOperatorUtils {
   }
 
   /**
-   * Render the selection rows to a formatted {@link ResultTable} object for selection queries without
-   * <code>ORDER BY</code>. (Broker side)
-   * <p>{@link ResultTable} object will be used to build the broker response.
+   * Render the selection rows to a {@link ResultTable} object
+   * for selection queries without <code>ORDER BY</code>
+   * <p>{@link ResultTable} object will be used to set in the broker response.
    * <p>Should be called after method "reduceWithoutOrdering()".
    *
-   * @param rows unformatted selection rows.
+   * @param rows selection rows.
    * @param dataSchema data schema.
    * @return {@link ResultTable} object results.
    */

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -101,7 +101,17 @@ public abstract class BaseQueriesTest {
   private BrokerResponseNative getBrokerResponseForQuery(String query, PlanMaker planMaker,
       Map<String, String> queryOptions) {
     BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
-    brokerRequest.setQueryOptions(queryOptions);
+    Map<String, String> allQueryOptions = new HashMap<>();
+
+    if (queryOptions != null) {
+      allQueryOptions.putAll(queryOptions);
+    }
+    if (brokerRequest.getQueryOptions() != null) {
+      allQueryOptions.putAll(brokerRequest.getQueryOptions());
+    }
+    if (!allQueryOptions.isEmpty()) {
+      brokerRequest.setQueryOptions(allQueryOptions);
+    }
 
     // Server side.
     Plan plan = planMaker.makeInterSegmentPlan(getSegmentDataManagers(), brokerRequest, EXECUTOR_SERVICE,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
@@ -132,7 +132,7 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
             new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2.147483647E9}, new Object[]{"PbQd", 2.147483647E9},
             new Object[]{"OKyOqU", 2.147483647E9});
     dataSchema = new DataSchema(new String[]{"column5", "percentile90mv(column7)"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     numEntriesScannedPostFilter = 800000;
     data.add(new Object[]{query, results, numEntriesScannedPostFilter, dataSchema});
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
@@ -36,6 +36,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+
 /**
  * Tests order by queries
  */
@@ -56,9 +57,9 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
   }
 
   @Test(dataProvider = "orderByPQLResultProvider")
-  public void testGroupByOrderByPQL(String query, List<String[]> expectedGroups, List<List<Serializable>> expectedValues,
-      long expectedNumDocsScanned, long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter,
-      long expectedNumTotalDocs) {
+  public void testGroupByOrderByPQLResponse(String query, List<String[]> expectedGroups,
+      List<List<Serializable>> expectedValues, long expectedNumDocsScanned, long expectedNumEntriesScannedInFilter,
+      long expectedNumEntriesScannedPostFilter, long expectedNumTotalDocs) {
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.PQL);
@@ -99,14 +100,23 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     Assert.assertNotNull(brokerResponse.getAggregationResults());
     Assert.assertNull(brokerResponse.getResultTable());
 
-    // PQL, SQL - don't execute order by, return aggregationResults.
+    // PQL, SQL - don't execute order by, multiple agg not supported
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.PQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
     brokerResponse = getBrokerResponseForQuery(query, queryOptions);
-    Assert.assertNotNull(brokerResponse.getAggregationResults());
+    Assert.assertNull(brokerResponse.getAggregationResults());
     Assert.assertNull(brokerResponse.getResultTable());
 
+    // PQL, SQL - don't execute order by, return aggregationResults.
+    query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11";
+    queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.PQL);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    Assert.assertNull(brokerResponse.getAggregationResults());
+    Assert.assertNotNull(brokerResponse.getResultTable());
+
     // SQL, PQL - execute the order by, but return aggregationResults. Keys should be same across aggregation functions.
+    query = "SELECT SUM(column1), MIN(column6) FROM testTable GROUP BY column11 ORDER BY column11";
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.PQL);
     brokerResponse = getBrokerResponseForQuery(query, queryOptions);
@@ -131,8 +141,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     DataSchema dataSchema = brokerResponse.getResultTable().getDataSchema();
     Assert.assertEquals(dataSchema.size(), 3);
     Assert.assertEquals(dataSchema.getColumnNames(), new String[]{"column11", "sum(column1)", "min(column6)"});
-    Assert.assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING,
-        DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    Assert.assertEquals(dataSchema.getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
   }
 
   /**
@@ -408,7 +418,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
   }
 
   /**
-   * Provides various combinations of order by in ResultTable.
+   * Provides various combinations of order by in PQL style results (GroupByResults).
    * In order to calculate the expected results, the results from a group by were taken, and then ordered accordingly.
    */
   @DataProvider(name = "orderByPQLResultProvider")
@@ -433,7 +443,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 240000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // order by one of the group by columns DESC
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11 DESC";
@@ -444,7 +455,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 240000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // order by one of the group by columns, TOP less than default
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11 TOP 3";
@@ -457,7 +469,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 240000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // group by 2 dimensions, order by both, tie breaker
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, column12";
@@ -471,7 +484,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // group by 2 columns, order by both, TOP more than default
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, column12 TOP 15";
@@ -490,7 +504,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // group by 2 columns, order by both, one of them DESC
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, column12 DESC";
@@ -504,7 +519,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // order by group by column and an aggregation
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY column11, SUM(column1)";
@@ -518,7 +534,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // order by only aggregation, DESC, TOP
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY SUM(column1) DESC TOP 50";
@@ -545,7 +562,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // multiple aggregations
     query = "SELECT SUM(column1), MIN(column6) FROM testTable GROUP BY column11 ORDER BY column11";
@@ -557,7 +575,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results.add(result1);
     results.add(result2);
     numEntriesScannedPostFilter = 360000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // order by aggregation with space/tab in order by
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11, column12 ORDER BY SUM  ( column1) DESC TOP 3";
@@ -567,7 +586,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 360000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // order by an aggregation DESC, and group by column
     query = "SELECT MIN(column6) FROM testTable GROUP BY column12 ORDER BY MIN(column6) DESC, column12";
@@ -581,7 +601,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 240000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // numeric dimension should follow numeric ordering
     query = "select count(*) from testTable group by column17 order by column17 top 15";
@@ -590,11 +611,13 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
         new String[]{"638936844"}, new String[]{"939479517"}, new String[]{"984091268"}, new String[]{"1230252339"},
         new String[]{"1284373442"}, new String[]{"1555255521"}, new String[]{"1618904660"}, new String[]{"1670085862"});
     result1 = Lists
-        .newArrayList(2924L, 3892L, 6564L, 7304L, 6556L, 7420L, 3308L, 3816L, 3116L, 3824L, 5620L, 7428L, 2900L, 2744L, 3388L);
+        .newArrayList(2924L, 3892L, 6564L, 7304L, 6556L, 7420L, 3308L, 3816L, 3116L, 3824L, 5620L, 7428L, 2900L, 2744L,
+            3388L);
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 120000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // group by UDF order by UDF
     query = "SELECT COUNT(*) FROM testTable GROUP BY sub(column1, 100000) TOP 3 ORDER BY sub(column1, 100000)";
@@ -603,7 +626,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 120000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // spaces in UDF
     query = "SELECT COUNT(*) FROM testTable GROUP BY sub(column1, 100000) TOP 3 ORDER BY SUB(   column1, 100000 )";
@@ -612,7 +636,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 120000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // Object type aggregation - comparable intermediate results (AVG, MINMAXRANGE)
     query = "SELECT AVG(column6) FROM testTable GROUP BY column11  ORDER BY column11";
@@ -622,7 +647,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 240000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     query = "SELECT AVG(column6) FROM testTable GROUP BY column11 ORDER BY AVG(column6), column11 DESC";
     groups = Lists
@@ -631,7 +657,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 240000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // Object type aggregation - non comparable intermediate results (DISTINCTCOUNT)
     query = "SELECT DISTINCTCOUNT(column11) FROM testTable GROUP BY column12 ORDER BY column12";
@@ -642,7 +669,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 240000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     query =
         "SELECT DISTINCTCOUNT(column11) FROM testTable GROUP BY column12 ORDER BY DISTINCTCOUNT(column11), column12 DESC";
@@ -653,7 +681,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>();
     results.add(result1);
     numEntriesScannedPostFilter = 240000;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     // empty results
     query =
@@ -662,7 +691,8 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     results = new ArrayList<>(0);
     numDocsScanned = 0;
     numEntriesScannedPostFilter = 0;
-    data.add(new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
+    data.add(
+        new Object[]{query, groups, results, numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, numTotalDocs});
 
     return data.toArray(new Object[data.size()][]);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
@@ -100,13 +100,6 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     Assert.assertNotNull(brokerResponse.getAggregationResults());
     Assert.assertNull(brokerResponse.getResultTable());
 
-    // PQL, SQL - don't execute order by, multiple agg not supported
-    queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.PQL);
-    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
-    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
-    Assert.assertNull(brokerResponse.getAggregationResults());
-    Assert.assertNull(brokerResponse.getResultTable());
-
     // PQL, SQL - don't execute order by, return aggregationResults.
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11";
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.PQL);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
@@ -22,15 +22,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.response.broker.SelectionResults;
-import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.query.aggregation.function.customobject.SerializedHLL;
 import org.apache.pinot.core.startree.hll.HllUtil;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
@@ -1,0 +1,896 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.response.broker.SelectionResults;
+import org.apache.pinot.common.utils.BytesUtils;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.aggregation.function.customobject.SerializedHLL;
+import org.apache.pinot.core.startree.hll.HllUtil;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests Response Format = sql for selection, distinct, aggregations and aggregation group bys
+ */
+public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValueQueriesTest {
+  private static String SV_GROUP_BY = " group by column8";
+  private static String MV_GROUP_BY = " group by column7";
+
+  @Test
+  public void testCountMV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT COUNTMV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"countmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{426752L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{62480L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "countmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"674022574", 231056L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "countmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"2147483647", 199896L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testMaxMV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT MAXMV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"maxmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "maxmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"711508739", 2147483647.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "maxmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"353", 2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testMinMV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT MINMV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"minmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1001.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1009.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "minmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"674022574", 1001.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "minmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"469", 1001.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testSumMV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT SUMMV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"summv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{484324601810280.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{114652613591912.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "summv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"674022574", 402591409613620.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "summv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"2147483647", 393483780531788.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testAvgMV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT AVGMV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"avgmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1134908803.7320974});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1835029026.759155});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "avgmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"1040894941", 2147483647.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "avgmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"208", 2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testMinMaxRangeMV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT MINMAXRANGEMV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"minmaxrangemv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147482646.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147482638.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "minmaxrangemv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"674022574", 2147482646.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "minmaxrangemv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"469", 2147482646.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testDistinctCountMV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT DISTINCTCOUNTMV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"distinctcountmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{18499});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1186});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "distinctcountmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"674022574", 4784});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "distinctcountmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"363", 3434});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testDistinctCountHLLMV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT DISTINCTCOUNTHLLMV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"distinctcounthllmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{20039L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1296L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "distinctcounthllmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"674022574",4715L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "distinctcounthllmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"363", 3490L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testDistinctCountRawHLLMV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+    String query = "SELECT DISTINCTCOUNTRAWHLLMV(column6) FROM testTable";
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"distinctcountrawhllmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING});
+    rows = new ArrayList<>();
+    Object[] expectedRow0 = new Object[]{20039L};
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+    Object[] row0 = brokerResponse.getResultTable().getRows().get(0);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[0].toString())).cardinality(), expectedRow0[0]);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    expectedRow0 = new Object[]{1296L};
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+    row0 = brokerResponse.getResultTable().getRows().get(0);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[0].toString())).cardinality(), expectedRow0[0]);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "distinctcountrawhllmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+    expectedRow0 = new Object[]{"674022574", 4715L};
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+    row0 = brokerResponse.getResultTable().getRows().get(0);
+    Assert.assertEquals(row0[0], expectedRow0[0]);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "distinctcountrawhllmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+    expectedRow0 = new Object[]{"363", 3490L};
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+    row0 = brokerResponse.getResultTable().getRows().get(0);
+    Assert.assertEquals(row0[0], expectedRow0[0]);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
+  }
+
+  @Test
+  public void testPercentile50MV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILE50MV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentile50mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "percentile50mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"169878844", 2147483647.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "percentile50mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"372", 2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentile90MV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILE90MV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentile90mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "percentile90mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"600729221", 2147483647.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "percentile90mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"475", 2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentile95MV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILE95MV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentile95mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "percentile95mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"711508739", 2147483647.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "percentile95mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"354", 2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentile99MV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILE99MV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentile99mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "percentile99mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"711508739", 2147483647.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "percentile99mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"353", 2147483647.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentileEst50MV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILEEST50MV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentileest50mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "percentileest50mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"169878844", 2147483647L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "percentileest50mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"372", 2147483647L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentileEst90MV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILEEST90MV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentileest90mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "percentileest90mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"600729221", 2147483647L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "percentileest90mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"475", 2147483647L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentileEst95MV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILEEST95MV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentileest95mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "percentileest95mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"711508739", 2147483647L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "percentileest95mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"354", 2147483647L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentileEst99MV() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILEEST99MV(column6) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentileest99mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2147483647L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column8", "percentileest99mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"711508739", 2147483647L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column7", "percentileest99mv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"353", 2147483647L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  /**
+   * Tests Selection with SelectionResults and also ResultTable
+   */
+  @Test
+  public void testSelection() {
+    // select *
+    String query = "SELECT * FROM testTable";
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    SelectionResults selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT * FROM testTable option(responseFormat=sql)";
+    BrokerResponseNative brokerResponseSQL = getBrokerResponseForQuery(query);
+    ResultTable resultTable = brokerResponseSQL.getResultTable();
+
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 10);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(),
+        new String[]{"column1", "column10", "column2", "column3", "column5", "column6", "column7", "column8", "column9", "daysSinceEpoch"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT});
+    Assert.assertEquals(resultTable.getRows().size(), 10);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+
+    // select * limit infinite
+    query = "SELECT * FROM testTable limit 50";
+    brokerResponse = getBrokerResponseForQuery(query);
+    selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT * FROM testTable LIMIT 50 option(responseFormat=sql)";
+    brokerResponseSQL = getBrokerResponseForQuery(query);
+    resultTable = brokerResponseSQL.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 10);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(),
+        new String[]{"column1", "column10", "column2", "column3", "column5", "column6", "column7", "column8", "column9", "daysSinceEpoch"});
+    Assert.assertEquals(resultTable.getRows().size(), 50);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+
+    // select 1
+    query = "SELECT column6 FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query);
+    selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT column6 FROM testTable option(responseFormat=sql)";
+    brokerResponseSQL = getBrokerResponseForQuery(query);
+    resultTable = brokerResponseSQL.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 1);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column6"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT_ARRAY});
+    Assert.assertEquals(resultTable.getRows().size(), 10);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+
+    // select 3
+    query = "SELECT column1, column6, column7 FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query);
+    selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT column1, column6, column7 FROM testTable option(responseFormat=sql)";
+    brokerResponseSQL = getBrokerResponseForQuery(query);
+    resultTable = brokerResponseSQL.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 3);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column6", "column7"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.INT_ARRAY});
+    Assert.assertEquals(resultTable.getRows().size(), 10);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
@@ -98,15 +98,6 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
   }
 
   @Test
-  public void testMultipleAggregationsFailure() {
-    String query = "SELECT MAX(column1), MAX(column3) FROM testTable";
-    Map<String, String> queryOptions = new HashMap<>(2);
-    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
-    Assert.assertEquals(brokerResponse.getProcessingExceptions().size(), 1);
-  }
-
-  @Test
   public void testMax() {
     DataSchema dataSchema;
     List<Object[]> rows;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
@@ -855,7 +855,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Assert.assertEquals(resultTable.getDataSchema().size(), 1);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1"});
     Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING});
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
     Assert.assertEquals(resultTable.getRows().size(), 6582);
 
     query = "SELECT DISTINCT(column1, column3) FROM testTable LIMIT 1000000";
@@ -864,7 +864,16 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Assert.assertEquals(resultTable.getDataSchema().size(), 2);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column3"});
     Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT});
+    Assert.assertEquals(resultTable.getRows().size(), 21968);
+
+    query = "SELECT DISTINCT(column1, column5, column3) FROM testTable LIMIT 1000000";
+    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    resultTable = brokerResponse.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().size(), 3);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column5", "column3"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     Assert.assertEquals(resultTable.getRows().size(), 21968);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
@@ -23,16 +23,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.response.broker.SelectionResults;
-import org.apache.pinot.common.utils.BytesUtils;
 import org.apache.pinot.common.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.common.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.startree.hll.HllUtil;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
@@ -1,0 +1,977 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.response.broker.SelectionResults;
+import org.apache.pinot.common.utils.BytesUtils;
+import org.apache.pinot.common.utils.CommonConstants.Broker.Request;
+import org.apache.pinot.common.utils.CommonConstants.Broker.Request.QueryOptionKey;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.startree.hll.HllUtil;
+import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests Response Format = sql for selection, distinct, aggregations and aggregation group bys
+ */
+public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleValueQueriesTest {
+  private static String GROUP_BY = " group by column9";
+
+  @Test
+  public void testCount() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+
+    String query = "SELECT COUNT(*) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema =
+        new DataSchema(new String[]{"count(*)"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{120000L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 0L, 120000L, rows, expectedResultsSize, dataSchema);
+
+    // filter
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{24516L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 0L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    // group by
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "count(*)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 64420L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 120000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    // filter + group by
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 17080L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 24516L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    // empty results
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + " where column5='non-existent-value'", queryOptions);
+    rows = new ArrayList<>();
+    expectedResultsSize = 0;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 0, 0, 0, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testMultipleAggregationsFailure() {
+    String query = "SELECT MAX(column1), MAX(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    Assert.assertEquals(brokerResponse.getProcessingExceptions().size(), 1);
+  }
+
+  @Test
+  public void testMax() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+
+    String query = "SELECT MAX(column1), MAX(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    // Query should be answered by MetadataBasedAggregationOperator, so check if numEntriesScannedInFilter and
+    // numEntriesScannedPostFilter are 0
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"max(column1)", "max(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2146952047.0, 2147419555.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 0L, 120000L, rows, expectedResultsSize, dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2146952047.0, 999813884.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "select max(column1) from testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "max(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 2146952047.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 2146952047.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testMin() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT MIN(column1), MIN(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    // Query should be answered by MetadataBasedAggregationOperator, so check if numEntriesScannedInFilter and
+    // numEntriesScannedPostFilter are 0
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"min(column1)", "min(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{240528.0, 17891.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 0L, 120000L, rows, expectedResultsSize, dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{101116473.0, 20396372.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT MIN(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "min(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 17891.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 20396372.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testSum() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT SUM(column1), SUM(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"sum(column1)", "sum(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{129268741751388.0, 129156636756600.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{27503790384288.0, 12429178874916.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT SUM(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "sum(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 69225631719808.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 8606725456500.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testAvg() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT AVG(column1), AVG(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"avg(column1)", "avg(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1077239514.5949, 1076305306.305});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1121871038.680372, 506982332.9627998});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "select avg(column3) from testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "avg(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"1642909995", 2141451242.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"438926263", 999309554.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testMinMaxRange() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+
+    String query = "SELECT MINMAXRANGE(column1), MINMAXRANGE(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"minmaxrange(column1)", "minmaxrange(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2146711519.0, 2147401664.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 0L, 120000L, rows, expectedResultsSize, dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2045835574.0, 979417512.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT MINMAXRANGE(column1) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "minmaxrange(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 2146711519.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 2044094181.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testDistinctCount() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT DISTINCTCOUNT(column1), DISTINCTCOUNT(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"distinctcount(column1)", "distinctcount(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{6582, 21910});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1872, 4556});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT DISTINCTCOUNT(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "distinctcount(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 11961});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 3289});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testDistinctCountHLL() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT DISTINCTCOUNTHLL(column1), DISTINCTCOUNTHLL(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"distinctcounthll(column1)", "distinctcounthll(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{5977L, 23825L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1886L, 4492L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT DISTINCTCOUNTHLL(column1) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "distinctcounthll(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 3592L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"296467636", 1324L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testDistinctCountRawHLL() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT DISTINCTCOUNTRAWHLL(column1), DISTINCTCOUNTRAWHLL(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"distinctcountrawhll(column1)", "distinctcountrawhll(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+    rows = new ArrayList<>();
+    Object[] expectedRow0 = new Object[]{5977L, 23825L};
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+    Object[] row0 = brokerResponse.getResultTable().getRows().get(0);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[0].toString())).cardinality(), expectedRow0[0]);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    expectedRow0 = new Object[]{1886L, 4492L};
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+    row0 = brokerResponse.getResultTable().getRows().get(0);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[0].toString())).cardinality(), expectedRow0[0]);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
+
+    query = "SELECT DISTINCTCOUNTRAWHLL(column1) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "distinctcountrawhll(column1)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+    expectedRow0 = new Object[]{"296467636", 3592L};
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+    row0 = brokerResponse.getResultTable().getRows().get(0);
+    Assert.assertEquals(row0[0], expectedRow0[0]);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    expectedRow0 = new Object[]{"296467636", 1324L};
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+    row0 = brokerResponse.getResultTable().getRows().get(0);
+    Assert.assertEquals(row0[0], expectedRow0[0]);
+    Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
+  }
+
+  @Test
+  public void testPercentile50() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILE50(column1), PERCENTILE50(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentile50(column1)", "percentile50(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1107310944.0, 1080136306.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1139674505.0, 505053732.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT PERCENTILE50(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "percentile50(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"1642909995", 2141451242.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"438926263", 999309554.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentile90() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILE90(column1), PERCENTILE90(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentile90(column1)", "percentile90(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1943040511.0, 1936611145.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1936730975.0, 899534534.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT PERCENTILE90(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "percentile90(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"2101070986", 2147278341.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"438926263", 999309554.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentile95() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILE95(column1), PERCENTILE95(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentile95(column1)", "percentile95(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2071559385.0, 2042409652.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2096857943.0, 947763150.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT PERCENTILE95(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "percentile95(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"147745543", 2147419555.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"438926263", 999309554.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentile99() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILE99(column1), PERCENTILE99(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentile99(column1)", "percentile99(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2139354437.0, 2125299552.0});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2146232405.0, 990669195.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT PERCENTILE99(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "percentile99(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"147745543", 2147419555.0});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"438926263", 999309554.0});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentileEst50() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILEEST50(column1), PERCENTILEEST50(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentileest50(column1)", "percentileest50(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1107310944L, 1082130431L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1139674505L, 509607935L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT PERCENTILEEST50(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "percentileest50(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"1642909995", 2141451242L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"438926263", 999309554L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentileEst90() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILEEST90(column1), PERCENTILEEST90(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentileest90(column1)", "percentileest90(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1946157055L, 1946157055L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{1939865599L, 902299647L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT PERCENTILEEST90(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "percentileest90(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"2101070986", 2147278341L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"438926263", 999309554L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentileEst95() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILEEST95(column1), PERCENTILEEST95(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentileest95(column1)", "percentileest95(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2080374783L, 2051014655L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2109734911L, 950009855L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT PERCENTILEEST95(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "percentileest95(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"147745543", 2147419555L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"438926263", 999309554L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  @Test
+  public void testPercentileEst99() {
+    DataSchema dataSchema;
+    List<Object[]> rows;
+    int expectedResultsSize;
+    String query = "SELECT PERCENTILEEST99(column1), PERCENTILEEST99(column3) FROM testTable";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    dataSchema = new DataSchema(new String[]{"percentileest99(column1)", "percentileest99(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2143289343L, 2143289343L});
+    expectedResultsSize = 1;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{2146232405L, 991952895L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    query = "SELECT PERCENTILEEST99(column3) FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    dataSchema = new DataSchema(new String[]{"column9", "percentileest99(column3)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"147745543", 2147419555L});
+    expectedResultsSize = 10;
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+
+    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    rows = new ArrayList<>();
+    rows.add(new Object[]{"438926263", 999309554L});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
+            dataSchema);
+  }
+
+  /**
+   * Test DISTINCT on multiple segment. Since the dataset
+   * is Avro files, the only thing we currently check
+   * for correctness is the actual number of DISTINCT
+   * records returned
+   */
+  @Test
+  public void testInterSegmentDistinct() {
+    Pql2Compiler.ENABLE_DISTINCT = true;
+    String query = "SELECT DISTINCT(column1) FROM testTable LIMIT 1000000";
+    Map<String, String> queryOptions = new HashMap<>(2);
+    queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    ResultTable resultTable = brokerResponse.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().size(), 1);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING});
+    Assert.assertEquals(resultTable.getRows().size(), 6582);
+
+    query = "SELECT DISTINCT(column1, column3) FROM testTable LIMIT 1000000";
+    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    resultTable = brokerResponse.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().size(), 2);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column3"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+    Assert.assertEquals(resultTable.getRows().size(), 21968);
+  }
+
+  /**
+   * Tests Selection with SelectionResults and also ResultTable
+   */
+  @Test
+  public void testSelection() {
+    // select *
+    String query = "SELECT * FROM testTable";
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    SelectionResults selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT * FROM testTable option(responseFormat=sql)";
+    BrokerResponseNative brokerResponseSQL = getBrokerResponseForQuery(query);
+    ResultTable resultTable = brokerResponseSQL.getResultTable();
+
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 11);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(),
+        new String[]{"column1", "column11", "column12", "column17", "column18", "column3", "column5", "column6", "column7", "column9", "daysSinceEpoch"});
+    Assert.assertEquals(resultTable.getRows().size(), 10);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+
+    // select * limit infinite
+    query = "SELECT * FROM testTable limit 50";
+    brokerResponse = getBrokerResponseForQuery(query);
+    selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT * FROM testTable LIMIT 50 option(responseFormat=sql)";
+    brokerResponseSQL = getBrokerResponseForQuery(query);
+    resultTable = brokerResponseSQL.getResultTable();
+
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 11);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(),
+        new String[]{"column1", "column11", "column12", "column17", "column18", "column3", "column5", "column6", "column7", "column9", "daysSinceEpoch"});
+    Assert.assertEquals(resultTable.getRows().size(), 50);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+
+    // select 1
+    query = "SELECT column3 FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query);
+    selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT column3 FROM testTable option(responseFormat=sql)";
+    brokerResponseSQL = getBrokerResponseForQuery(query);
+    resultTable = brokerResponseSQL.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 1);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column3"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
+    Assert.assertEquals(resultTable.getRows().size(), 10);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+
+    // select 3
+    query = "SELECT column1, column3, column11 FROM testTable";
+    brokerResponse = getBrokerResponseForQuery(query);
+    selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT column1, column3, column11 FROM testTable option(responseFormat=sql)";
+    brokerResponseSQL = getBrokerResponseForQuery(query);
+    resultTable = brokerResponseSQL.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 3);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column3", "column11"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
+    Assert.assertEquals(resultTable.getRows().size(), 10);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+
+    // select + order by
+    query = "SELECT column1, column3 FROM testTable ORDER BY column3 option(preserveType=true)";
+    brokerResponse = getBrokerResponseForQuery(query);
+    selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT column1, column3 FROM testTable ORDER BY column3 option(responseFormat=sql)";
+    brokerResponseSQL = getBrokerResponseForQuery(query);
+    resultTable = brokerResponseSQL.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 2);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column3"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT});
+    Assert.assertEquals(resultTable.getRows().size(), 10);
+    List<Object[]> rows = Lists.newArrayList(new Object[]{142002934, 17891}, new Object[]{142002934, 17891},
+        new Object[]{142002934, 17891}, new Object[]{142002934, 17891}, new Object[]{33273941, 84046},
+        new Object[]{33273941, 84046}, new Object[]{33273941, 84046}, new Object[]{33273941, 84046},
+        new Object[]{1002250922, 177388}, new Object[]{1002250922, 177388});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+    for (int i = 0; i < 10; i++) {
+      Assert.assertEquals(selectionResults.getRows().get(i), resultTable.getRows().get(i));
+      Assert.assertEquals(resultTable.getRows().get(i), rows.get(i));
+    }
+
+    query = "SELECT column1, column3 FROM testTable ORDER BY column3 option(preserveType=true)";
+    brokerResponse = getBrokerResponseForQuery(query);
+    selectionResults = brokerResponse.getSelectionResults();
+    query = "SELECT column1, column3 FROM testTable ORDER BY column3 option(responseFormat=sql)";
+    brokerResponseSQL = getBrokerResponseForQuery(query);
+    resultTable = brokerResponseSQL.getResultTable();
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 2);
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column3"});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT});
+    Assert.assertEquals(resultTable.getRows().size(), 10);
+    rows = Lists
+        .newArrayList(new Object[]{142002934, 17891}, new Object[]{142002934, 17891}, new Object[]{142002934, 17891},
+            new Object[]{142002934, 17891}, new Object[]{33273941, 84046}, new Object[]{33273941, 84046},
+            new Object[]{33273941, 84046}, new Object[]{33273941, 84046}, new Object[]{1002250922, 177388},
+            new Object[]{1002250922, 177388});
+    Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), selectionResults.getColumns().toArray());
+    for (int i = 0; i < 10; i++) {
+      Assert.assertEquals(selectionResults.getRows().get(i), resultTable.getRows().get(i));
+      Assert.assertEquals(resultTable.getRows().get(i), rows.get(i));
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -27,7 +27,6 @@ import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.GroupByResult;
 import org.apache.pinot.common.response.broker.ResultTable;
-import org.apache.pinot.common.response.broker.SelectionResults;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
@@ -138,8 +137,7 @@ public class QueriesTestUtils {
     Assert.assertEquals(actualResults.size(), expectedResultsSize);
     Assert.assertEquals(actualDataSchema.size(), expectedDataSchema.size());
     Assert.assertEquals(actualDataSchema.getColumnNames(), expectedDataSchema.getColumnNames());
-    // TODO : Add this back after PR 4863, which sets the right final column data types for aggregations
-    //Assert.assertEquals(actualDataSchema.getColumnDataTypes(), expectedDataSchema.getColumnDataTypes());
+    Assert.assertEquals(actualDataSchema.getColumnDataTypes(), expectedDataSchema.getColumnDataTypes());
 
     for (int i = 0; i < expectedResults.size(); i++) {
       Assert.assertEquals(Arrays.asList(actualResults.get(i)), Arrays.asList(expectedResults.get(i)));


### PR DESCRIPTION
This falls under the sql compliance work. We are moving to ResultTable, which will serve as the single tabular sql like structure to return results from all types of queries.
This is currently turned off by default. This feature can be enabled by passing responseFormat=sql in queryOptions.

PS: this is the 3rd step of the breakdown of PR #4833