### PR TITLE
 Failure to recover after segment reload failure does not release segment lock

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -236,14 +236,16 @@ public class HelixInstanceDataManager implements InstanceDataManager {
 
       // Delete segment temporary directory
       FileUtils.deleteDirectory(segmentTempDir);
-    } finally {
+    } catch (Exception reloadFailureException) {
       try {
         LoaderUtils.reloadFailureRecovery(indexDir);
-      } catch (Exception e) {
-        LOGGER.error("Failed to recover after reload failure, error: ", e);
-      } finally {
-        segmentLock.unlock();
+      } catch (Exception recoveryFailureException) {
+        LOGGER.error("Failed to recover after reload failure ", recoveryFailureException);
+        reloadFailureException.addSuppressed(recoveryFailureException);
       }
+      throw reloadFailureException;
+    } finally {
+      segmentLock.unlock();
     }
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -237,8 +237,13 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       // Delete segment temporary directory
       FileUtils.deleteDirectory(segmentTempDir);
     } finally {
-      LoaderUtils.reloadFailureRecovery(indexDir);
-      segmentLock.unlock();
+      try {
+        LoaderUtils.reloadFailureRecovery(indexDir);
+      } catch (Exception e) {
+        LOGGER.error("Failed to recover after reload failure, error: ", e);
+      } finally {
+        segmentLock.unlock();
+      }
     }
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -240,7 +240,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       try {
         LoaderUtils.reloadFailureRecovery(indexDir);
       } catch (Exception recoveryFailureException) {
-        LOGGER.error("Failed to recover after reload failure ", recoveryFailureException);
+        LOGGER.error("Failed to recover after reload failure", recoveryFailureException);
         reloadFailureException.addSuppressed(recoveryFailureException);
       }
       throw reloadFailureException;


### PR DESCRIPTION
This was noticed while going through some recent segment reload failure logs.

While the best way to do this would be to use AutoCloseable but Lock interface is not AutoCloseable. An alternative would be to simply wrap it around AutoCloseable and then use try with resource but that will result in an unnecessary short-lived object. So right now, the fix is to just use additional 'finally' block. 