### PR TITLE
Simplifying interface related to StreamLevelConsumer

### DIFF
--- a/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConsumerFactory.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConsumerFactory.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.core.realtime.impl.kafka;
 
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.realtime.stream.PartitionLevelConsumer;
 import org.apache.pinot.core.realtime.stream.StreamConsumerFactory;
 import org.apache.pinot.core.realtime.stream.StreamLevelConsumer;

--- a/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConsumerFactory.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaConsumerFactory.java
@@ -48,14 +48,13 @@ public class KafkaConsumerFactory extends StreamConsumerFactory {
    * @param clientId
    * @param tableName
    * @param schema
-   * @param instanceZKMetadata
-   * @param serverMetrics
+   * @param groupId
    * @return
    */
   @Override
   public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema,
-      InstanceZKMetadata instanceZKMetadata, ServerMetrics serverMetrics) {
-    return new KafkaStreamLevelConsumer(clientId, tableName, _streamConfig, schema, instanceZKMetadata, serverMetrics);
+      String groupId) {
+    return new KafkaStreamLevelConsumer(clientId, tableName, _streamConfig, schema, groupId);
   }
 
   /**

--- a/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamConfig.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamConfig.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import kafka.consumer.ConsumerConfig;
-import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
 import org.apache.pinot.spi.utils.EqualityUtils;
 import org.apache.pinot.core.realtime.stream.StreamConfig;
 import org.apache.pinot.core.realtime.stream.StreamConfigProperties;

--- a/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamConfig.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamConfig.java
@@ -65,10 +65,10 @@ public class KafkaHighLevelStreamConfig {
    * Builds a wrapper around {@link StreamConfig} to fetch kafka stream level consumer specific configs
    * @param streamConfig
    * @param tableName
-   * @param instanceZKMetadata
+   * @param groupId
    */
   public KafkaHighLevelStreamConfig(StreamConfig streamConfig, String tableName,
-      InstanceZKMetadata instanceZKMetadata) {
+      String groupId) {
     Map<String, String> streamConfigMap = streamConfig.getStreamConfigsMap();
 
     _kafkaTopicName = streamConfig.getTopicName();
@@ -78,7 +78,7 @@ public class KafkaHighLevelStreamConfig {
     _zkBrokerUrl = streamConfigMap.get(hlcZkBrokerUrlKey);
     Preconditions.checkNotNull(_zkBrokerUrl,
         "Must specify zk broker connect string " + hlcZkBrokerUrlKey + " in high level kafka consumer");
-    _groupId = instanceZKMetadata.getGroupId(tableName);
+    _groupId = groupId;
 
     _kafkaConsumerProperties = new HashMap<>();
     String kafkaConsumerPropertyPrefix =

--- a/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaStreamLevelConsumer.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaStreamLevelConsumer.java
@@ -18,18 +18,14 @@
  */
 package org.apache.pinot.core.realtime.impl.kafka;
 
-import com.yammer.metrics.core.Meter;
 import kafka.consumer.ConsumerIterator;
 import kafka.javaapi.consumer.ConsumerConnector;
-import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
-import org.apache.pinot.common.metrics.ServerMeter;
-import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.core.realtime.stream.StreamConfig;
 import org.apache.pinot.core.realtime.stream.StreamDecoderProvider;
 import org.apache.pinot.core.realtime.stream.StreamLevelConsumer;
 import org.apache.pinot.core.realtime.stream.StreamMessageDecoder;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,9 +50,6 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
   private long lastLogTime = 0;
   private long lastCount = 0;
   private long currentCount = 0L;
-
-  private Meter tableAndStreamRowsConsumed = null;
-  private Meter tableRowsConsumed = null;
 
   public KafkaStreamLevelConsumer(String clientId, String tableName, StreamConfig streamConfig, Schema schema,
       String groupId) {

--- a/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaStreamLevelConsumer.java
+++ b/pinot-connectors/pinot-connector-kafka-0.9/src/main/java/org/apache/pinot/core/realtime/impl/kafka/KafkaStreamLevelConsumer.java
@@ -55,16 +55,14 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
   private long lastCount = 0;
   private long currentCount = 0L;
 
-  private ServerMetrics _serverMetrics;
   private Meter tableAndStreamRowsConsumed = null;
   private Meter tableRowsConsumed = null;
 
   public KafkaStreamLevelConsumer(String clientId, String tableName, StreamConfig streamConfig, Schema schema,
-      InstanceZKMetadata instanceZKMetadata, ServerMetrics serverMetrics) {
+      String groupId) {
     _clientId = clientId;
     _streamConfig = streamConfig;
-    _kafkaHighLevelStreamConfig = new KafkaHighLevelStreamConfig(streamConfig, tableName, instanceZKMetadata);
-    _serverMetrics = serverMetrics;
+    _kafkaHighLevelStreamConfig = new KafkaHighLevelStreamConfig(streamConfig, tableName, groupId);
 
     _messageDecoder = StreamDecoderProvider.create(streamConfig, schema);
 
@@ -87,12 +85,6 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
     if (kafkaIterator.hasNext()) {
       try {
         destination = _messageDecoder.decode(kafkaIterator.next().message(), destination);
-        tableAndStreamRowsConsumed = _serverMetrics
-            .addMeteredTableValue(_tableAndStreamName, ServerMeter.REALTIME_ROWS_CONSUMED, 1L,
-                tableAndStreamRowsConsumed);
-        tableRowsConsumed =
-            _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_ROWS_CONSUMED, 1L, tableRowsConsumed);
-
         ++currentCount;
 
         final long now = System.currentTimeMillis();
@@ -110,8 +102,6 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
         return destination;
       } catch (Exception e) {
         INSTANCE_LOGGER.warn("Caught exception while consuming events", e);
-        _serverMetrics.addMeteredTableValue(_tableAndStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
-        _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
         throw e;
       }
     }
@@ -121,8 +111,6 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
   @Override
   public void commit() {
     consumer.commitOffsets();
-    _serverMetrics.addMeteredTableValue(_tableAndStreamName, ServerMeter.REALTIME_OFFSET_COMMITS, 1L);
-    _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_OFFSET_COMMITS, 1L);
   }
 
   @Override

--- a/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaConsumerFactory.java
+++ b/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaConsumerFactory.java
@@ -35,8 +35,8 @@ public class KafkaConsumerFactory extends StreamConsumerFactory {
 
   @Override
   public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema,
-      InstanceZKMetadata instanceZKMetadata, ServerMetrics serverMetrics) {
-    return new KafkaStreamLevelConsumer(clientId, tableName, _streamConfig, schema, instanceZKMetadata, serverMetrics);
+      String groupId) {
+    return new KafkaStreamLevelConsumer(clientId, tableName, _streamConfig, schema, groupId);
   }
 
   @Override

--- a/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaConsumerFactory.java
+++ b/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaConsumerFactory.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.core.realtime.impl.kafka2;
 
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.realtime.stream.PartitionLevelConsumer;
 import org.apache.pinot.core.realtime.stream.StreamConsumerFactory;
 import org.apache.pinot.core.realtime.stream.StreamLevelConsumer;

--- a/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaStreamLevelConsumer.java
+++ b/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaStreamLevelConsumer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.realtime.impl.kafka2;
 
-import com.yammer.metrics.core.Meter;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -30,9 +29,6 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
-import org.apache.pinot.common.metrics.ServerMeter;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.core.realtime.stream.StreamConfig;
 import org.apache.pinot.core.realtime.stream.StreamDecoderProvider;

--- a/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaStreamLevelStreamConfig.java
+++ b/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaStreamLevelStreamConfig.java
@@ -46,10 +46,10 @@ public class KafkaStreamLevelStreamConfig {
    * Builds a wrapper around {@link StreamConfig} to fetch kafka stream level consumer specific configs
    * @param streamConfig
    * @param tableName
-   * @param instanceZKMetadata
+   * @param groupId
    */
   public KafkaStreamLevelStreamConfig(StreamConfig streamConfig, String tableName,
-      InstanceZKMetadata instanceZKMetadata) {
+      String groupId) {
     Map<String, String> streamConfigMap = streamConfig.getStreamConfigsMap();
 
     _kafkaTopicName = streamConfig.getTopicName();
@@ -58,7 +58,7 @@ public class KafkaStreamLevelStreamConfig {
     _bootstrapServers = streamConfigMap.get(hlcBootstrapBrokerUrlKey);
     Preconditions.checkNotNull(_bootstrapServers,
         "Must specify bootstrap broker connect string " + hlcBootstrapBrokerUrlKey + " in high level kafka consumer");
-    _groupId = instanceZKMetadata.getGroupId(tableName);
+    _groupId = groupId;
 
     _kafkaConsumerProperties = new HashMap<>();
     String kafkaConsumerPropertyPrefix =

--- a/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaStreamLevelStreamConfig.java
+++ b/pinot-connectors/pinot-connector-kafka-2.0/src/main/java/org/apache/pinot/core/realtime/impl/kafka2/KafkaStreamLevelStreamConfig.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
 import org.apache.pinot.spi.utils.EqualityUtils;
 import org.apache.pinot.core.realtime.impl.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.core.realtime.stream.StreamConfig;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -41,7 +41,7 @@ import org.apache.pinot.common.config.SegmentPartitionConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.data.StarTreeIndexSpec;
-import org.apache.pinot.common.metadata.RowMetadata;
+import org.apache.pinot.core.realtime.stream.RowMetadata;
 import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegment.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegment.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.indexsegment.mutable;
 
 import javax.annotation.Nullable;
-import org.apache.pinot.common.metadata.RowMetadata;
+import org.apache.pinot.core.realtime.stream.RowMetadata;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -35,7 +35,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.common.metadata.RowMetadata;
+import org.apache.pinot.core.realtime.stream.RowMetadata;
 import org.apache.pinot.common.segment.SegmentMetadata;
 import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.spi.data.readers.GenericRow;

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/MessageBatch.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/MessageBatch.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.realtime.stream;
 
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
-import org.apache.pinot.common.metadata.RowMetadata;
 
 
 /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/RowMetadata.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/RowMetadata.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.metadata;
+package org.apache.pinot.core.realtime.stream;
 
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConsumerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamConsumerFactory.java
@@ -50,12 +50,11 @@ public abstract class StreamConsumerFactory {
    * @param clientId a client id to identify the creator of this consumer
    * @param tableName the table name for the topic of this consumer
    * @param schema the pinot schema of the event being consumed
-   * @param instanceZKMetadata the instance metadata
-   * @param serverMetrics metrics object to emit consumption related metrics
+   * @param groupId consumer group Id
    * @return
    */
   public abstract StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema,
-      InstanceZKMetadata instanceZKMetadata, ServerMetrics serverMetrics);
+      String groupId);
 
   /**
    * Creates a metadata provider which provides partition specific metadata

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamMessageMetadata.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/stream/StreamMessageMetadata.java
@@ -18,9 +18,6 @@
  */
 package org.apache.pinot.core.realtime.stream;
 
-import org.apache.pinot.common.metadata.RowMetadata;
-
-
 /**
  * A class that provides metadata associated with the message of a stream, for e.g.,
  * ingestion-timestamp of the message.

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
@@ -49,7 +49,7 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
 
   @Override
   public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema,
-      InstanceZKMetadata instanceZKMetadata, ServerMetrics serverMetrics) {
+      String groupId) {
     return new FakeStreamLevelConsumer();
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/FlakyConsumerRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/FlakyConsumerRealtimeClusterIntegrationTest.java
@@ -58,8 +58,7 @@ public class FlakyConsumerRealtimeClusterIntegrationTest extends RealtimeCluster
         String groupId) {
       try {
         final Constructor constructor = Class.forName(KafkaStarterUtils.KAFKA_STREAM_LEVEL_CONSUMER_CLASS_NAME)
-            .getConstructor(String.class, String.class, StreamConfig.class, Schema.class, InstanceZKMetadata.class,
-                ServerMetrics.class);
+            .getConstructor(String.class, String.class, StreamConfig.class, Schema.class, String.class);
         _streamLevelConsumer = (StreamLevelConsumer) constructor
             .newInstance(clientId, tableName, streamConfig, schema, groupId);
       } catch (Exception e) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/FlakyConsumerRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/FlakyConsumerRealtimeClusterIntegrationTest.java
@@ -55,13 +55,13 @@ public class FlakyConsumerRealtimeClusterIntegrationTest extends RealtimeCluster
     private Random _random = new Random();
 
     public FlakyStreamLevelConsumer(String clientId, String tableName, StreamConfig streamConfig, Schema schema,
-        InstanceZKMetadata instanceZKMetadata, ServerMetrics serverMetrics) {
+        String groupId) {
       try {
         final Constructor constructor = Class.forName(KafkaStarterUtils.KAFKA_STREAM_LEVEL_CONSUMER_CLASS_NAME)
             .getConstructor(String.class, String.class, StreamConfig.class, Schema.class, InstanceZKMetadata.class,
                 ServerMetrics.class);
         _streamLevelConsumer = (StreamLevelConsumer) constructor
-            .newInstance(clientId, tableName, streamConfig, schema, instanceZKMetadata, serverMetrics);
+            .newInstance(clientId, tableName, streamConfig, schema, groupId);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -114,9 +114,8 @@ public class FlakyConsumerRealtimeClusterIntegrationTest extends RealtimeCluster
 
     @Override
     public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema,
-        InstanceZKMetadata instanceZKMetadata, ServerMetrics serverMetrics) {
-      return new FlakyStreamLevelConsumer(clientId, tableName, _streamConfig, schema, instanceZKMetadata,
-          serverMetrics);
+        String groupId) {
+      return new FlakyStreamLevelConsumer(clientId, tableName, _streamConfig, schema, groupId);
     }
 
     @Override


### PR DESCRIPTION
I tried to move the real-time interfaces to pinot-spi but saw that we depend on InstanceMetadata and ServerMetrics for stream level consumer. This dependency was needed to get the groupId and log some metrics. I moved the logging to common Pinot HLC Consumer and passed groupId as part of the interface.

OLD

`  public abstract StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema, InstanceMetadata instanceMetadata, ServerMetrics serverMetrics);`

NEW 

 ` public abstract StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema, String groupId);`