### PR TITLE
Encrypt segments during segment creation [1]

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -114,6 +114,7 @@ public class SegmentGeneratorConfig {
   private boolean _onHeap = false;
   private boolean _skipTimeValueCheck = false;
   private boolean _nullHandlingEnabled = false;
+  private boolean _createTarGz = false;
 
   public SegmentGeneratorConfig() {
   }
@@ -164,6 +165,7 @@ public class SegmentGeneratorConfig {
     _recordReaderPath = config._recordReaderPath;
     _skipTimeValueCheck = config._skipTimeValueCheck;
     _nullHandlingEnabled = config._nullHandlingEnabled;
+    _createTarGz = config._createTarGz;
   }
 
   /**
@@ -350,6 +352,14 @@ public class SegmentGeneratorConfig {
 
   public void setRecordReaderPath(String recordReaderPath) {
     _recordReaderPath = recordReaderPath;
+  }
+
+  public boolean isCreateTarGz() {
+    return _createTarGz;
+  }
+
+  public void setCreateTarGz(boolean createTarGz) {
+    _createTarGz = createTarGz;
   }
 
   public String getOutDir() {

--- a/pinot-ingestion-jobs/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/common/JobConfigConstants.java
+++ b/pinot-ingestion-jobs/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/common/JobConfigConstants.java
@@ -76,4 +76,7 @@ public class JobConfigConstants {
 
   // Assign sequence ids to input files based at each local directory level
   public static final String LOCAL_DIRECTORY_SEQUENCE_ID = "local.directory.sequence.id";
+
+  // Creates a tar gz file
+  public static final String CREATE_TAR_GZ = "create.tar.gz";
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HadoopSegmentBuildPushOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HadoopSegmentBuildPushOfflineClusterIntegrationTest.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.v2.MiniMRYarnCluster;
 import org.apache.pinot.common.config.ColumnPartitionConfig;
 import org.apache.pinot.common.config.SegmentPartitionConfig;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.core.data.partition.PartitionFunction;
 import org.apache.pinot.core.data.partition.PartitionFunctionFactory;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
@@ -48,6 +47,7 @@ import org.apache.pinot.hadoop.job.HadoopSegmentCreationJob;
 import org.apache.pinot.hadoop.job.HadoopSegmentPreprocessingJob;
 import org.apache.pinot.ingestion.common.JobConfigConstants;
 import org.apache.pinot.ingestion.jobs.SegmentTarPushJob;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.util.TestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -173,6 +173,8 @@ public class HadoopSegmentBuildPushOfflineClusterIntegrationTest extends BaseClu
     // Setting this will fetch the schema & table config from the controller
     properties.setProperty(JobConfigConstants.PUSH_TO_HOSTS, getDefaultControllerConfiguration().getControllerHost());
     properties.setProperty(JobConfigConstants.PUSH_TO_PORT, getDefaultControllerConfiguration().getControllerPort());
+
+    properties.setProperty(JobConfigConstants.CREATE_TAR_GZ, "true");
 
     Properties preComputeProperties = new Properties();
     preComputeProperties.putAll(properties);


### PR DESCRIPTION
Currently, the segment is generated in one place, tar/gzipped in another, and encrypted elsewhere. This PR takes steps to consolidate it in one place.

Our current encryption scheme assumes that segments are formatted as .tar.gz files. We want to support encryption, and thus, .tar.gz compression, as an option for all Pinot segment creation entry points.

We will add two optional parameters - .tar.gz compression and encryption into SegmentIndexCreationDriverImpl, as both pinot admin endpoints and hadoop endpoints will go through this logic.

This PR, Part 1/2, adds .tar.gz support and wires it through the open source SegmentCreationMapper.