### PR TITLE
After pulling in the latest changes, mvn clean install fails.

### DIFF
--- a/pinot-record-readers/pinot-csv/pom.xml
+++ b/pinot-record-readers/pinot-csv/pom.xml
@@ -22,7 +22,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>pinot</artifactId>
+    <artifactId>pinot-record-readers</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>0.3.0-SNAPSHOT</version>
   </parent>
@@ -44,10 +44,6 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-spi</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -60,11 +56,6 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <!-- test dependencies -->
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/pinot-record-readers/pinot-json/pom.xml
+++ b/pinot-record-readers/pinot-json/pom.xml
@@ -22,7 +22,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>pinot</artifactId>
+    <artifactId>pinot-record-readers</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>0.3.0-SNAPSHOT</version>
   </parent>
@@ -44,10 +44,6 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-spi</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -56,11 +52,6 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <!-- test dependencies -->
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/pinot-record-readers/pinot-orc/pom.xml
+++ b/pinot-record-readers/pinot-orc/pom.xml
@@ -23,7 +23,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>pinot</artifactId>
+    <artifactId>pinot-record-readers</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>0.3.0-SNAPSHOT</version>
   </parent>
@@ -63,15 +63,6 @@
           <artifactId>hadoop-yarn-common</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-spi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-record-readers/pinot-parquet/pom.xml
+++ b/pinot-record-readers/pinot-parquet/pom.xml
@@ -22,7 +22,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>pinot</artifactId>
+    <artifactId>pinot-record-readers</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>0.3.0-SNAPSHOT</version>
   </parent>
@@ -43,10 +43,6 @@
     </plugins>
   </build>
   <dependencies>
-    <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-spi</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-avro</artifactId>
@@ -72,11 +68,6 @@
       </exclusions>
     </dependency>
     <!-- test dependencies -->
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-spi</artifactId>

--- a/pinot-record-readers/pinot-thrift/pom.xml
+++ b/pinot-record-readers/pinot-thrift/pom.xml
@@ -22,7 +22,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>pinot</artifactId>
+    <artifactId>pinot-record-readers</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>0.3.0-SNAPSHOT</version>
   </parent>
@@ -44,10 +44,6 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-spi</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -60,11 +56,6 @@
       <artifactId>libthrift</artifactId>
     </dependency>
     <!-- test dependencies -->
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/pinot-record-readers/pom.xml
+++ b/pinot-record-readers/pom.xml
@@ -19,57 +19,44 @@
     under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pinot-record-readers</artifactId>
+    <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>0.3.0-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>pinot-avro</artifactId>
-  <name>Pinot Avro</name>
+  <artifactId>pinot-record-readers</artifactId>
+  <packaging>pom</packaging>
+  <name>Pinot Record Readers</name>
   <url>https://pinot.apache.org/</url>
   <properties>
-    <pinot.root>${basedir}/../..</pinot.root>
+    <pinot.root>${basedir}/..</pinot.root>
   </properties>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>jetty</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
-    <!-- test dependencies -->
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>test</scope>
-    </dependency>
+  <modules>
+    <module>pinot-avro</module>
+    <module>pinot-orc</module>
+    <module>pinot-json</module>
+    <module>pinot-parquet</module>
+    <module>pinot-csv</module>
+    <module>pinot-thrift</module>
+  </modules>
+
+  <dependencies>
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-spi</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
+    </dependency>
+    <!-- test -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,7 @@
     <module>pinot-minion</module>
     <module>pinot-hadoop-filesystem</module>
     <module>pinot-azure-filesystem</module>
-    <module>pinot-record-readers/pinot-avro</module>
-    <module>pinot-record-readers/pinot-csv</module>
-    <module>pinot-record-readers/pinot-json</module>
-    <module>pinot-record-readers/pinot-orc</module>
-    <module>pinot-record-readers/pinot-parquet</module>
-    <module>pinot-record-readers/pinot-thrift</module>
+    <module>pinot-record-readers</module>
     <module>pinot-connectors</module>
   </modules>
 


### PR DESCRIPTION
The reason is that source code in pinot-record-readers module is not immediately in the sub-directory. 

We have 6 additional sub-modules pinot-avro, pinot-json etc and they were not able to reference the parent pom -- since the parent pom is not in the immediate parent directory. 

The <relativePath></relativePath> by default uses ".." to resolve the parent artifact. However, in this case we fail because the parent pom is not in the immediate parent directory.

The fix is to add a parent pom.