### PR TITLE
[TE][notification] Support configuring reference links per dimensional recipients

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertFilterNotification.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Multimap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 
 
 /**
@@ -31,24 +32,24 @@ import java.util.Objects;
  */
 public class DetectionAlertFilterNotification {
 
-  Map<String, Object> notificationSchemeProps;
+  DetectionAlertConfigDTO subsConfig;
   Multimap<String, String> dimensionFilters;
 
-  public DetectionAlertFilterNotification(Map<String, Object> notificationSchemeProps) {
-    this(notificationSchemeProps, ArrayListMultimap.create());
+  public DetectionAlertFilterNotification(DetectionAlertConfigDTO subsConfig) {
+    this(subsConfig, ArrayListMultimap.create());
   }
 
-  public DetectionAlertFilterNotification(Map<String, Object> notificationSchemeProps, Multimap<String, String> dimensionFilters) {
-    this.notificationSchemeProps = notificationSchemeProps;
+  public DetectionAlertFilterNotification(DetectionAlertConfigDTO subsConfig, Multimap<String, String> dimensionFilters) {
+    this.subsConfig = subsConfig;
     this.dimensionFilters = dimensionFilters;
   }
 
-  public Map<String, Object> getNotificationSchemeProps() {
-    return notificationSchemeProps;
+  public DetectionAlertConfigDTO getSubscriptionConfig() {
+    return subsConfig;
   }
 
-  public void setNotificationSchemeProps(Map<String, Object> notificationSchemeProps) {
-    this.notificationSchemeProps = notificationSchemeProps;
+  public void setSubscriptionConfig(DetectionAlertConfigDTO subsConfig) {
+    this.subsConfig = subsConfig;
   }
 
   public Multimap<String, String> getDimensionFilters() {
@@ -68,13 +69,13 @@ public class DetectionAlertFilterNotification {
       return false;
     }
     DetectionAlertFilterNotification that = (DetectionAlertFilterNotification) o;
-    return Objects.equals(notificationSchemeProps, that.notificationSchemeProps) &&
+    return Objects.equals(subsConfig, that.subsConfig) &&
         Objects.equals(dimensionFilters, that.dimensionFilters);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(notificationSchemeProps, dimensionFilters);
+    return Objects.hash(subsConfig, dimensionFilters);
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/StatefulDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/StatefulDetectionAlertFilter.java
@@ -114,9 +114,9 @@ public abstract class StatefulDetectionAlertFilter extends DetectionAlertFilter 
     return filteredRecipients;
   }
 
-  protected Map<String, Object> generateNotificationSchemeProps(DetectionAlertConfigDTO config,
+  protected Map<String, Map<String, Object>> generateNotificationSchemeProps(DetectionAlertConfigDTO config,
       Set<String> to, Set<String> cc, Set<String> bcc) {
-    Map<String, Object> notificationSchemeProps = new HashMap<>();
+    Map<String, Map<String, Object>> notificationSchemeProps = new HashMap<>();
 
     if (config.getAlertSchemes() == null) {
       Map<String, Map<String, Object>> alertSchemes = new HashMap<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionDetectionAlertFilter.java
@@ -86,13 +86,15 @@ public class DimensionDetectionAlertFilter extends StatefulDetectionAlertFilter 
     });
 
     for (Map.Entry<String, Collection<MergedAnomalyResultDTO>> dimAnomalyMapping : grouped.asMap().entrySet()) {
+      DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(
+          generateNotificationSchemeProps(
+              this.config,
+              this.makeGroupRecipients(dimAnomalyMapping.getKey()),
+              this.recipients.get(PROP_CC),
+              this.recipients.get(PROP_BCC)));
+
       result.addMapping(
-          new DetectionAlertFilterNotification(
-              generateNotificationSchemeProps(
-                  this.config,
-                  this.makeGroupRecipients(dimAnomalyMapping.getKey()),
-                  this.recipients.get(PROP_CC),
-                  this.recipients.get(PROP_BCC))),
+          new DetectionAlertFilterNotification(subsConfig),
           new HashSet<>(dimAnomalyMapping.getValue()));
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
@@ -106,13 +106,15 @@ public class PerUserDimensionAlertFilter extends StatefulDetectionAlertFilter {
     }
 
     for (Map.Entry<String, List<MergedAnomalyResultDTO>> userAnomalyMapping : perUserAnomalies.entrySet()) {
+      DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(
+          generateNotificationSchemeProps(
+              this.config,
+              this.makeGroupRecipients(userAnomalyMapping.getKey()),
+              this.recipients.get(PROP_CC),
+              this.recipients.get(PROP_BCC)));
+
       result.addMapping(
-          new DetectionAlertFilterNotification(
-              generateNotificationSchemeProps(
-                  this.config,
-                  this.makeGroupRecipients(userAnomalyMapping.getKey()),
-                  this.recipients.get(PROP_CC),
-                  this.recipients.get(PROP_BCC))),
+          new DetectionAlertFilterNotification(subsConfig),
           new HashSet<>(userAnomalyMapping.getValue()));
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/SubscriptionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/SubscriptionUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.alert.filter;
+
+import java.util.Map;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+
+
+public class SubscriptionUtils {
+
+  public static DetectionAlertConfigDTO makeChildSubscriptionConfig(Map<String, Map<String, Object>> alertSchemes) {
+    return SubscriptionUtils.makeChildSubscriptionConfig(new DetectionAlertConfigDTO(), alertSchemes, null);
+  }
+
+  /**
+   * Make a new(child) subscription group from given(parent) subscription group.
+   *
+   * This is used   preparing the notification for each dimensional recipients.
+   */
+  public static DetectionAlertConfigDTO makeChildSubscriptionConfig(
+      DetectionAlertConfigDTO parentConfig,
+      Map<String, Map<String, Object>> alertSchemes,
+      Map<String, String> refLinks) {
+    DetectionAlertConfigDTO subsConfig = new DetectionAlertConfigDTO();
+    subsConfig.setId(parentConfig.getId());
+    subsConfig.setFrom(parentConfig.getFrom());
+    subsConfig.setActive(parentConfig.isActive());
+    subsConfig.setOwners(parentConfig.getOwners());
+    subsConfig.setYaml(parentConfig.getYaml());
+    subsConfig.setApplication(parentConfig.getApplication());
+    subsConfig.setName(parentConfig.getName());
+    subsConfig.setSubjectType(parentConfig.getSubjectType());
+    subsConfig.setProperties(parentConfig.getProperties());
+    subsConfig.setVectorClocks(parentConfig.getVectorClocks());
+
+    subsConfig.setAlertSchemes(alertSchemes);
+    subsConfig.setReferenceLinks(refLinks);
+
+    return subsConfig;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilter.java
@@ -69,13 +69,16 @@ public class ToAllRecipientsDetectionAlertFilter extends StatefulDetectionAlertF
     // Fetch all the anomalies to be notified to the recipients
     Set<MergedAnomalyResultDTO> anomalies = this.filter(this.makeVectorClocks(this.detectionConfigIds), minId);
 
+    DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(
+        generateNotificationSchemeProps(
+            this.config,
+            this.recipients.get(PROP_TO),
+            this.recipients.get(PROP_CC),
+            this.recipients.get(PROP_BCC))
+    );
+
     return result.addMapping(
-        new DetectionAlertFilterNotification(
-            generateNotificationSchemeProps(
-                this.config,
-                this.recipients.get(PROP_TO),
-                this.recipients.get(PROP_CC),
-                this.recipients.get(PROP_BCC))),
+        new DetectionAlertFilterNotification(subsConfig),
         anomalies);
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/AlertFilterUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/AlertFilterUtils.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
 
 import static org.apache.pinot.thirdeye.detection.alert.scheme.DetectionEmailAlerter.*;
@@ -47,8 +49,9 @@ public class AlertFilterUtils {
     return makeEmailNotifications(recipients, PROP_CC_VALUE, PROP_BCC_VALUE);
   }
 
-  static DetectionAlertFilterNotification makeEmailNotifications(Set<String> toRecipients, Set<String> ccRecipients, Set<String> bccRecipients) {
-    Map<String, Object> alertProps = new HashMap<>();
+  static DetectionAlertFilterNotification makeEmailNotifications(DetectionAlertConfigDTO config,
+      Set<String> toRecipients, Set<String> ccRecipients, Set<String> bccRecipients) {
+    Map<String, Map<String, Object>> alertProps = new HashMap<>();
 
     Map<String, Set<String>> recipients = new HashMap<>();
     recipients.put(PROP_TO, new HashSet<>(toRecipients));
@@ -59,6 +62,16 @@ public class AlertFilterUtils {
     emailRecipients.put(PROP_RECIPIENTS, recipients);
 
     alertProps.put(PROP_EMAIL_SCHEME, emailRecipients);
-    return new DetectionAlertFilterNotification(alertProps);
+
+    DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(alertProps);
+    subsConfig.setProperties(config.getProperties());
+    subsConfig.setVectorClocks(config.getVectorClocks());
+    subsConfig.setReferenceLinks(config.getReferenceLinks());
+
+    return new DetectionAlertFilterNotification(subsConfig);
+  }
+
+  static DetectionAlertFilterNotification makeEmailNotifications(Set<String> toRecipients, Set<String> ccRecipients, Set<String> bccRecipients) {
+    return makeEmailNotifications(new DetectionAlertConfigDTO(), toRecipients, ccRecipients, bccRecipients);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerterTest.java
@@ -34,6 +34,7 @@ import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
+import org.apache.pinot.thirdeye.detection.alert.filter.SubscriptionUtils;
 import org.apache.pinot.thirdeye.notification.commons.EmailEntity;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -134,8 +135,10 @@ public class DetectionEmailAlerterTest {
   @Test
   public void testSendEmailSuccessful() throws Exception {
     Map<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> result = new HashMap<>();
+    DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(
+        ConfigUtils.getMap(this.alertConfigDTO.getAlertSchemes()));
     result.put(
-        new DetectionAlertFilterNotification(ConfigUtils.getMap(this.alertConfigDTO.getAlertSchemes())),
+        new DetectionAlertFilterNotification(subsConfig),
         new HashSet<>(this.anomalyDAO.findAll()));
     DetectionAlertFilterResult notificationResults = new DetectionAlertFilterResult(result);
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerterTest.java
@@ -93,7 +93,8 @@ public class DetectionEmailAlerterTest {
     this.alertConfigDTO.setName(ALERT_NAME_VALUE);
     Map<Long, Long> vectorClocks = new HashMap<>();
     this.alertConfigDTO.setVectorClocks(vectorClocks);
-    this.alertConfigDAO.save(this.alertConfigDTO);
+    long id = this.alertConfigDAO.save(this.alertConfigDTO);
+    this.alertConfigDTO.setId(id);
 
     MergedAnomalyResultDTO anomalyResultDTO = new MergedAnomalyResultDTO();
     anomalyResultDTO.setStartTime(1000L);
@@ -122,7 +123,7 @@ public class DetectionEmailAlerterTest {
   }
 
   @AfterMethod(alwaysRun = true)
-  void afterClass() {
+  void AfterMethod() {
     testDAOProvider.cleanup();
   }
 
@@ -136,7 +137,9 @@ public class DetectionEmailAlerterTest {
   public void testSendEmailSuccessful() throws Exception {
     Map<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> result = new HashMap<>();
     DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(
-        ConfigUtils.getMap(this.alertConfigDTO.getAlertSchemes()));
+        this.alertConfigDTO,
+        ConfigUtils.getMap(this.alertConfigDTO.getAlertSchemes()),
+        new HashMap<>());
     result.put(
         new DetectionAlertFilterNotification(subsConfig),
         new HashSet<>(this.anomalyDAO.findAll()));

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerterTest.java
@@ -80,7 +80,8 @@ public class DetectionJiraAlerterTest {
     properties.put(PROP_DETECTION_CONFIG_IDS, Collections.singletonList(this.detectionConfigId));
 
     this.alertConfigDTO = TestJiraContentFormatter.createDimRecipientsDetectionAlertConfig(this.detectionConfigId);
-    this.alertConfigDAO.save(this.alertConfigDTO);
+    long id = this.alertConfigDAO.save(this.alertConfigDTO);
+    alertConfigDTO.setId(id);
 
     MergedAnomalyResultDTO anomalyResultDTO = new MergedAnomalyResultDTO();
     anomalyResultDTO.setStartTime(1000L);
@@ -125,7 +126,9 @@ public class DetectionJiraAlerterTest {
   @Test
   public void testUpdateJiraSuccessful() throws Exception {
     DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(
-        ConfigUtils.getMap(this.alertConfigDTO.getAlertSchemes()));
+        this.alertConfigDTO,
+        ConfigUtils.getMap(this.alertConfigDTO.getAlertSchemes()),
+        new HashMap<>());
     Map<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> result = new HashMap<>();
     result.put(new DetectionAlertFilterNotification(subsConfig), new HashSet<>(this.anomalyDAO.findAll()));
     DetectionAlertFilterResult notificationResults = new DetectionAlertFilterResult(result);

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerterTest.java
@@ -35,6 +35,7 @@ import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
+import org.apache.pinot.thirdeye.detection.alert.filter.SubscriptionUtils;
 import org.apache.pinot.thirdeye.notification.commons.JiraEntity;
 import org.apache.pinot.thirdeye.notification.commons.ThirdEyeJiraClient;
 import org.apache.pinot.thirdeye.notification.formatter.channels.TestJiraContentFormatter;
@@ -123,10 +124,10 @@ public class DetectionJiraAlerterTest {
 
   @Test
   public void testUpdateJiraSuccessful() throws Exception {
+    DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(
+        ConfigUtils.getMap(this.alertConfigDTO.getAlertSchemes()));
     Map<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> result = new HashMap<>();
-    result.put(
-        new DetectionAlertFilterNotification(ConfigUtils.getMap(this.alertConfigDTO.getAlertSchemes())),
-        new HashSet<>(this.anomalyDAO.findAll()));
+    result.put(new DetectionAlertFilterNotification(subsConfig), new HashSet<>(this.anomalyDAO.findAll()));
     DetectionAlertFilterResult notificationResults = new DetectionAlertFilterResult(result);
 
     final ThirdEyeJiraClient jiraClient = mock(ThirdEyeJiraClient.class);

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/suppress/DetectionTimeWindowSuppressorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/suppress/DetectionTimeWindowSuppressorTest.java
@@ -3,6 +3,7 @@ package org.apache.pinot.thirdeye.detection.alert.suppress;
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
@@ -14,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.pinot.thirdeye.detection.alert.filter.SubscriptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -116,13 +118,14 @@ public class DetectionTimeWindowSuppressorTest {
    */
   @Test
   public void testTimeWindowSuppressorWithThreshold() throws Exception {
-    Map<String, Set<String>> recipients = new HashMap<>();
+    Map<String, Object> recipients = new HashMap<>();
     recipients.put("to", Collections.singleton("test@test"));
 
     DetectionAlertFilterResult result = new DetectionAlertFilterResult();
-    Map<String, Object> alertProps = new HashMap<>();
-    alertProps.put("recipients", recipients);
-    result.addMapping(new DetectionAlertFilterNotification(alertProps), anomalies);
+    Map<String, Map<String, Object>> alertProps = new HashMap<>();
+    alertProps.put("emailScheme", recipients);
+    DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(alertProps);
+    result.addMapping(new DetectionAlertFilterNotification(subsConfig), anomalies);
 
     DetectionAlertTimeWindowSuppressor suppressor = new DetectionAlertTimeWindowSuppressor(config);
     DetectionAlertFilterResult resultsAfterSuppress = suppressor.run(result);
@@ -150,13 +153,14 @@ public class DetectionTimeWindowSuppressorTest {
     alertSuppressors.put(TIME_WINDOW_SUPPRESSOR_KEY, params);
     config.setAlertSuppressors(alertSuppressors);
 
-    Map<String, Set<String>> recipients = new HashMap<>();
+    Map<String, Object> recipients = new HashMap<>();
     recipients.put("to", Collections.singleton("test@test"));
 
     DetectionAlertFilterResult result = new DetectionAlertFilterResult();
-    Map<String, Object> alertProps = new HashMap<>();
-    alertProps.put("recipients", recipients);
-    result.addMapping(new DetectionAlertFilterNotification(alertProps), anomalies);
+    Map<String, Map<String, Object>> alertProps = new HashMap<>();
+    alertProps.put("emailScheme", recipients);
+    DetectionAlertConfigDTO subsConfig = SubscriptionUtils.makeChildSubscriptionConfig(alertProps);
+    result.addMapping(new DetectionAlertFilterNotification(subsConfig), anomalies);
 
     DetectionAlertTimeWindowSuppressor suppressor = new DetectionAlertTimeWindowSuppressor(config);
     DetectionAlertFilterResult resultsAfterSuppress = suppressor.run(result);

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
@@ -462,10 +462,16 @@ public class RunAdhocDatabaseQueriesTool {
   private void disableAllActiveSubsGroups(Collection<Long> excludeIds){
     List<DetectionAlertConfigDTO> subsConfigs = detectionAlertConfigDAO.findAll();
     for (DetectionAlertConfigDTO subsConfig : subsConfigs) {
-      if (subsConfig.isActive() && (CollectionUtils.isEmpty(excludeIds) || !excludeIds
-          .contains(subsConfig.getId()))) {
-        subsConfig.setActive(false);
+      // Activate the whitelisted configs
+      if (excludeIds.contains(subsConfig.getId())) {
+        subsConfig.setActive(true);
         detectionAlertConfigDAO.update(subsConfig);
+      } else {
+        // Disable other configs
+        if (subsConfig.isActive()) {
+          subsConfig.setActive(false);
+          detectionAlertConfigDAO.update(subsConfig);
+        }
       }
     }
   }
@@ -612,7 +618,7 @@ public class RunAdhocDatabaseQueriesTool {
       System.exit(1);
     }
     RunAdhocDatabaseQueriesTool dq = new RunAdhocDatabaseQueriesTool(persistenceFile);
-    dq.unsubscribedDetections();
+    dq.disableAllActiveSubsGroups(Collections.singleton(142644400L));
     LOG.info("DONE");
   }
 


### PR DESCRIPTION
This PR enables configuration of referenceLinks and potential other subscription related settings in the DIMENSIONS_ALERTER_PIPELINE. For example, this can enable users to configure different oncall-runbooks per anomalous dimension.