### PR TITLE
Build shaded jar for all record readers 

### DIFF
--- a/pinot-record-readers/pinot-avro/pom.xml
+++ b/pinot-record-readers/pinot-avro/pom.xml
@@ -60,7 +60,7 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>target/plugins/record-reader/avro-record-reader-package</outputDirectory>
+                  <outputDirectory>target/plugins/record-readers/pinot-avro</outputDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/pinot-record-readers/pinot-avro/pom.xml
+++ b/pinot-record-readers/pinot-avro/pom.xml
@@ -42,6 +42,33 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>target/plugins/record-reader/avro-record-reader-package</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/pinot-record-readers/pinot-csv/pom.xml
+++ b/pinot-record-readers/pinot-csv/pom.xml
@@ -42,6 +42,33 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>target/plugins/record-reader/csv-record-reader-package</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pinot-record-readers/pinot-csv/pom.xml
+++ b/pinot-record-readers/pinot-csv/pom.xml
@@ -60,7 +60,7 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>target/plugins/record-reader/csv-record-reader-package</outputDirectory>
+                  <outputDirectory>target/plugins/record-readers/pinot-csv</outputDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/pinot-record-readers/pinot-json/pom.xml
+++ b/pinot-record-readers/pinot-json/pom.xml
@@ -60,7 +60,7 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>target/plugins/record-reader/json-record-reader-package</outputDirectory>
+                  <outputDirectory>target/plugins/record-readers/pinot-json</outputDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/pinot-record-readers/pinot-json/pom.xml
+++ b/pinot-record-readers/pinot-json/pom.xml
@@ -42,6 +42,33 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>target/plugins/record-reader/json-record-reader-package</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pinot-record-readers/pinot-orc/pom.xml
+++ b/pinot-record-readers/pinot-orc/pom.xml
@@ -43,6 +43,33 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>target/plugins/record-reader/orc-record-reader-package</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.apache.orc</groupId>

--- a/pinot-record-readers/pinot-orc/pom.xml
+++ b/pinot-record-readers/pinot-orc/pom.xml
@@ -61,7 +61,7 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>target/plugins/record-reader/orc-record-reader-package</outputDirectory>
+                  <outputDirectory>target/plugins/record-readers/pinot-orc</outputDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/pinot-record-readers/pinot-parquet/pom.xml
+++ b/pinot-record-readers/pinot-parquet/pom.xml
@@ -60,7 +60,7 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>target/plugins/record-reader/parquet-record-reader-package</outputDirectory>
+                  <outputDirectory>target/plugins/record-readers/pinot-parquet</outputDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/pinot-record-readers/pinot-parquet/pom.xml
+++ b/pinot-record-readers/pinot-parquet/pom.xml
@@ -42,6 +42,33 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>target/plugins/record-reader/parquet-record-reader-package</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-record-readers/pinot-thrift/pom.xml
+++ b/pinot-record-readers/pinot-thrift/pom.xml
@@ -42,6 +42,33 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>target/plugins/record-reader/thrift-record-reader-package</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pinot-record-readers/pinot-thrift/pom.xml
+++ b/pinot-record-readers/pinot-thrift/pom.xml
@@ -60,7 +60,7 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>target/plugins/record-reader/thrift-record-reader-package</outputDirectory>
+                  <outputDirectory>target/plugins/record-readers/pinot-thrift</outputDirectory>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
- Build shaded jar for all record readers by default
- Output shaded jar to directory: `target/plugins/record-reader/${file-format}-record-reader-package`