### PR TITLE
Initial code dump for dynamically loading pinot plugins

### DIFF
--- a/pinot-record-readers/pom.xml
+++ b/pinot-record-readers/pom.xml
@@ -50,6 +50,7 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-spi</artifactId>
+      <scope>provided</scope>
     </dependency>
     <!-- test -->
     <dependency>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/Plugin.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/Plugin.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.plugin;
+
+import java.util.Objects;
+
+
+public class Plugin {
+
+  String _name;
+
+  public Plugin(String name) {
+    _name = name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Plugin plugin = (Plugin) o;
+    return Objects.equals(_name, plugin._name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_name);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginClassLoader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginClassLoader.java
@@ -1,0 +1,135 @@
+package org.apache.pinot.spi.plugin;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+
+public class PluginClassLoader extends URLClassLoader {
+
+  private final ClassLoader sysClzLoader;
+
+  public PluginClassLoader(URL[] urls, ClassLoader parent) {
+    super(urls, parent);
+    sysClzLoader = getSystemClassLoader();
+    URLClassLoader classLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+    Method method = null;
+    try {
+      method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
+
+    } catch (NoSuchMethodException e) {
+      //this should never happen
+      ExceptionUtils.rethrow(e);
+    }
+    method.setAccessible(true);
+    for (URL url : urls) {
+      try {
+        method.invoke(classLoader, url);
+      } catch (Exception e) {
+        ExceptionUtils.rethrow(e);
+      }
+    }
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve)
+      throws ClassNotFoundException {
+    if (name.endsWith("LocalFileSystem")) {
+      System.out.println("name = " + name);
+    }
+    System.out.println("PluginClassLoader.loadClass: " + name);
+    // has the class loaded already?
+    Class<?> loadedClass = findLoadedClass(name);
+    if (loadedClass == null) {
+      try {
+        if (sysClzLoader != null) {
+          loadedClass = sysClzLoader.loadClass(name);
+        }
+      } catch (ClassNotFoundException ex) {
+        // class not found in system class loader... silently skipping
+      }
+
+      try {
+        // find the class from given jar urls as in first constructor parameter.
+        if (loadedClass == null) {
+          loadedClass = findClass(name);
+        }
+      } catch (ClassNotFoundException e) {
+        // class is not found in the given urls.
+        // Let's try it in parent classloader.
+        // If class is still not found, then this method will throw class not found ex.
+        loadedClass = super.loadClass(name, resolve);
+      }
+    }
+
+    if (resolve) {      // marked to resolve
+      resolveClass(loadedClass);
+    }
+    return loadedClass;
+  }
+
+  @Override
+  public Enumeration<URL> getResources(String name)
+      throws IOException {
+    List<URL> allRes = new LinkedList<>();
+
+    // load resources from sys class loader
+    Enumeration<URL> sysResources = sysClzLoader.getResources(name);
+    if (sysResources != null) {
+      while (sysResources.hasMoreElements()) {
+        allRes.add(sysResources.nextElement());
+      }
+    }
+
+    // load resource from this classloader
+    Enumeration<URL> thisRes = findResources(name);
+    if (thisRes != null) {
+      while (thisRes.hasMoreElements()) {
+        allRes.add(thisRes.nextElement());
+      }
+    }
+
+    // then try finding resources from parent classloaders
+    Enumeration<URL> parentRes = super.findResources(name);
+    if (parentRes != null) {
+      while (parentRes.hasMoreElements()) {
+        allRes.add(parentRes.nextElement());
+      }
+    }
+
+    return new Enumeration<URL>() {
+      Iterator<URL> it = allRes.iterator();
+
+      @Override
+      public boolean hasMoreElements() {
+        return it.hasNext();
+      }
+
+      @Override
+      public URL nextElement() {
+        return it.next();
+      }
+    };
+  }
+
+  @Override
+  public URL getResource(String name) {
+    URL res = null;
+    if (sysClzLoader != null) {
+      res = sysClzLoader.getResource(name);
+    }
+    if (res == null) {
+      res = findResource(name);
+    }
+    if (res == null) {
+      res = super.getResource(name);
+    }
+    return res;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginClassLoader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginClassLoader.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.spi.plugin;
 
 import java.io.IOException;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginClassLoader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginClassLoader.java
@@ -58,10 +58,6 @@ public class PluginClassLoader extends URLClassLoader {
   @Override
   protected Class<?> loadClass(String name, boolean resolve)
       throws ClassNotFoundException {
-    if (name.endsWith("LocalFileSystem")) {
-      System.out.println("name = " + name);
-    }
-    System.out.println("PluginClassLoader.loadClass: " + name);
     // has the class loaded already?
     Class<?> loadedClass = findLoadedClass(name);
     if (loadedClass == null) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.plugin;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+
+
+public class PluginManager {
+
+  static PluginManager PLUGIN_MANAGER = new PluginManager();
+
+  Map<Plugin, PluginClassLoader> _registry = new HashMap<>();
+
+  private PluginManager() {
+
+  }
+
+  /**
+   * Loads jars recursively
+   * @param pluginName
+   * @param directory
+   */
+  public void load(String pluginName, File directory) {
+    Collection<File> jarFiles = FileUtils.listFiles(directory, new String[]{"jar"}, true);
+    Collection<URL> urlList = new ArrayList<>();
+    for (File jarFile : jarFiles) {
+      try {
+        urlList.add(jarFile.toURI().toURL());
+      } catch (MalformedURLException e) {
+        //ignore
+      }
+    }
+    PluginClassLoader classLoader = createClassLoader(urlList);
+    _registry.put(new Plugin(pluginName), classLoader);
+  }
+
+  private PluginClassLoader createClassLoader(Collection<URL> urlList) {
+    URL[] urls = new URL[urlList.size()];
+    urlList.toArray(urls);
+    //always sort to make the behavior predictable
+    Arrays.sort(urls);
+    return new PluginClassLoader(urls, Thread.currentThread().getContextClassLoader());
+  }
+
+  public Class<?> loadClass(String pluginName, String className)
+      throws ClassNotFoundException {
+    return PLUGIN_MANAGER._registry.get(new Plugin(pluginName)).loadClass(className, true);
+  }
+
+  public <T> T createInstance(String pluginName, String className)
+      throws Exception {
+    return createInstance(pluginName, className, new Class[]{}, new Object[]{});
+  }
+
+  /**
+   *
+   * @param pluginName
+   * @param className
+   * @param argTypes
+   * @param argValues
+   * @param <T>
+   * @return
+   */
+  public <T> T createInstance(String pluginName, String className, Class[] argTypes, Object[] argValues)
+      throws Exception {
+    PluginClassLoader pluginClassLoader = PLUGIN_MANAGER._registry.get(new Plugin(pluginName));
+    Class<T> loadedClass = (Class<T>) pluginClassLoader.loadClass(className, true);
+    Constructor<?> constructor = loadedClass.getConstructor(argTypes);
+    if (constructor != null) {
+      Object instance = constructor.newInstance(argValues);
+      return (T) instance;
+    }
+    return null;
+  }
+
+  public static PluginManager get() {
+    return PLUGIN_MANAGER;
+  }
+}
+

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -40,6 +40,7 @@ public class PluginManager {
 
   }
 
+
   /**
    * Loads jars recursively
    * @param pluginName

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -66,7 +66,7 @@ public class PluginManager {
     urlList.toArray(urls);
     //always sort to make the behavior predictable
     Arrays.sort(urls);
-    return new PluginClassLoader(urls, Thread.currentThread().getContextClassLoader());
+    return new PluginClassLoader(urls, this.getClass().getClassLoader());
   }
 
   /**

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.spi.plugin;
 
 import java.io.File;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
@@ -1,0 +1,86 @@
+package org.apache.pinot.spi.plugin;
+
+import java.io.File;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+//import org.xeustechnologies.jcl.JarClassLoader;
+//import org.xeustechnologies.jcl.JclObjectFactory;
+
+
+public class PluginManagerTest {
+//  public static void main(String[] args)
+//      throws Exception {
+////    testAvro();
+//
+////    testParquetWithJcl();
+//    testParquet();
+//  }
+//
+//  private static void testParquetWithJcl()
+//      throws Exception {
+//    File dir = new File("/tmp/pinot-plugins/pinot-parquet");
+//    PluginManager pluginManager = PluginManager.get();
+//    String pluginName = "pinot-parquet";
+//    pluginManager.load(pluginName, dir);
+//
+//    JarClassLoader jcl = new JarClassLoader();
+//    jcl.add(dir.toURI().toURL());
+//
+//    String parquetFilePath = "/tmp/sample.c000.snappy.parquet";
+//    File pinotSchemaFile = new File("/tmp/ops_wb_table_schema.json");
+//    Schema pinotSchema = Schema.fromFile(pinotSchemaFile);
+//    String recordReaderClassName = "org.apache.pinot.parquet.data.readers.ParquetRecordReader";
+//
+//    jcl.loadClass(recordReaderClassName, true);
+//    JclObjectFactory objectFactory = JclObjectFactory.getInstance();
+//    RecordReader recordReader = (RecordReader) objectFactory.create(jcl, recordReaderClassName);
+//    recordReader.init(new File(parquetFilePath), pinotSchema, null);
+//    while (recordReader.hasNext()) {
+//      GenericRow row = recordReader.next();
+//      System.out.println("row = " + row);
+//    }
+//  }
+//
+//  private static void testParquet()
+//      throws Exception {
+//    File dir = new File("/tmp/pinot-plugins/pinot-parquet");
+//    PluginManager pluginManager = PluginManager.get();
+//    String pluginName = "pinot-parquet";
+//    pluginManager.load(pluginName, dir);
+//
+//    String recordReaderClassName = "org.apache.pinot.parquet.data.readers.ParquetRecordReader";
+//    Class<?> recordReaderClass = pluginManager.loadClass(pluginName, recordReaderClassName);
+//    Class<?> fsClass = pluginManager.loadClass(pluginName, "org.apache.hadoop.fs.LocalFileSystem");
+//    System.out.println("recordReaderClass = " + recordReaderClass);
+//
+//    String parquetFilePath = "/tmp/sample.c000.snappy.parquet";
+//    File pinotSchemaFile = new File("/tmp/ops_wb_table_schema.json");
+//    Schema pinotSchema = Schema.fromFile(pinotSchemaFile);
+//
+//    RecordReader recordReader =
+//        pluginManager.createInstance(pluginName, recordReaderClassName, new Class[]{}, new Object[]{});
+//    Thread.currentThread().setContextClassLoader(recordReader.getClass().getClassLoader());
+//    recordReader.init(new File(parquetFilePath), pinotSchema, null);
+//
+//    while (recordReader.hasNext()) {
+//      GenericRow row = recordReader.next();
+//      System.out.println("row = " + row);
+//    }
+//  }
+//
+//  private static void testAvro()
+//      throws ClassNotFoundException {
+//    File dir =
+//        new File("/Users/kishoreg/projects/incubator-pinot/pinot-record-readers/pinot-avro/target/pinot-avro-pkg");
+//    PluginManager pluginManager = PluginManager.get();
+//    pluginManager.load("pinot-avro", dir);
+//
+//    Class<?> recordReaderClass =
+//        pluginManager.loadClass("pinot-avro", "org.apache.pinot.avro.data.readers.AvroRecordReader");
+//    System.out.println("recordReaderClass = " + recordReaderClass);
+//
+//    String avroFilePath =
+//        "/Users/kishoreg/projects/incubator-pinot/pinot-tools/src/main/resources/sample_data/airlineStats_data.avro";
+//  }
+}

--- a/pinot-spi/src/test/resources/TestRecordReader.java
+++ b/pinot-spi/src/test/resources/TestRecordReader.java
@@ -1,0 +1,61 @@
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
+
+
+/**
+ * Record reader for AVRO file.
+ */
+public class TestRecordReader implements RecordReader {
+
+  List<GenericRow> _rows = new ArrayList<>();
+  Iterator<GenericRow> _iterator;
+  Schema _schema;
+
+  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig)
+      throws IOException {
+    _schema = schema;
+    int numRows = 10;
+    for (int i = 0; i < numRows; i++) {
+      GenericRow row = new GenericRow();
+      row.putValue("key", "value-" + i);
+      _rows.add(row);
+    }
+    _iterator = _rows.iterator();
+  }
+
+  public boolean hasNext() {
+    return _iterator.hasNext();
+  }
+
+  public GenericRow next()
+      throws IOException {
+    return _iterator.next();
+  }
+
+  public GenericRow next(GenericRow reuse)
+      throws IOException {
+    return _iterator.next();
+  }
+
+  public void rewind()
+      throws IOException {
+    _iterator = _rows.iterator();
+  }
+
+  public Schema getSchema() {
+    return _schema;
+  }
+  public void close () {
+
+  }
+}


### PR DESCRIPTION
Submitting the PR for early review/feedback.

Here is how we want the end state of Pinot distribution

- Pinot-distribution
   - bin/<all_launchers>
   - repo/<all_jars_needed_for_pinot>
   - plugins/
       - record_readers
          - pinot-avro/pinot-avro-shaded.jar
          - pinot-parquet/pinot-avro-parquet.jar
          - ...
       - connectors
          - pinot-kafka-0.9/pinot-kafka-0.9-shaded.jar
          - pinot-kafka-2.0/pinot-kafka-2.0-shaded.jar
          - ...
       - file-sytem
          - pinot-hdfs/pinot-hdfs-shaded.jar
          - pinot-s3/pinot-s3-shaded.jar
          - pinot-azure/pinot-azure-shaded.jar
          - ...

All launchers will take two parameters plugin.directory and plugin.includes. These two parameters can be set as a system property and PluginManager will iterate recursively through the plugin directory and loaded them.

As of now, Pinot will load all the plugin jars into system/App Classloader.  I tried loading into separate classloaders but some libraries don't work (e.g. Parquet) since it depends on Hadoop (Hadoop has Class.forName all over the code). 


