### PR TITLE
Remove deprecated server config keys

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -256,21 +256,6 @@ public class CommonConstants {
         "pinot.server.shutdown.resourceCheckIntervalMs";
     public static final long DEFAULT_SHUTDOWN_RESOURCE_CHECK_INTERVAL_MS = 10_000L;
 
-    // TODO: remove the deprecated config keys in the new release
-    @Deprecated
-    public static final String CONFIG_OF_STARTER_ENABLE_SEGMENTS_LOADING_CHECK =
-        "pinot.server.starter.enableSegmentsLoadingCheck";
-    @Deprecated
-    public static final String CONFIG_OF_STARTER_TIMEOUT_IN_SECONDS = "pinot.server.starter.timeoutInSeconds";
-    @Deprecated
-    public static final String CONFIG_OF_ENABLE_SHUTDOWN_DELAY = "pinot.server.instance.enable.shutdown.delay";
-    @Deprecated
-    public static final String CONFIG_OF_INSTANCE_MAX_SHUTDOWN_WAIT_TIME =
-        "pinot.server.instance.starter.maxShutdownWaitTime";
-    @Deprecated
-    public static final String CONFIG_OF_INSTANCE_CHECK_INTERVAL_TIME =
-        "pinot.server.instance.starter.checkIntervalTime";
-
     public static final String DEFAULT_COLUMN_MIN_MAX_VALUE_GENERATOR_MODE = "TIME";
 
     public static class SegmentCompletionProtocol {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -109,36 +109,6 @@ public class HelixServerStarter {
     // Make a clone so that changes to the config won't propagate to the caller
     _serverConf = ConfigurationUtils.cloneConfiguration(serverConf);
 
-    // Log warnings for usage of deprecated config keys
-    Map<String, String> deprecatedConfigKeyWarnings = new HashMap<String, String>() {{
-      //noinspection deprecation
-      put(CONFIG_OF_STARTER_ENABLE_SEGMENTS_LOADING_CHECK, String.format(
-          "use %s instead, which will check the service status instead of comparing currentState/externalView with idealState (enabled by default)",
-          CONFIG_OF_STARTUP_ENABLE_SERVICE_STATUS_CHECK));
-      //noinspection deprecation
-      put(CONFIG_OF_STARTER_TIMEOUT_IN_SECONDS, String
-          .format("use %s instead, which is the timeout for the whole startup process (10 minutes by default)",
-              CONFIG_OF_STARTUP_TIMEOUT_MS));
-      //noinspection deprecation
-      put(CONFIG_OF_ENABLE_SHUTDOWN_DELAY, String.format(
-          "use %s instead, which will drain the queries (no incoming queries and all existing queries finished) (enabled by default)",
-          CONFIG_OF_SHUTDOWN_ENABLE_QUERY_CHECK));
-      //noinspection deprecation
-      put(CONFIG_OF_INSTANCE_MAX_SHUTDOWN_WAIT_TIME, String
-          .format("use %s instead, which is the timeout for the whole shutdown process (10 minutes by default)",
-              CONFIG_OF_SHUTDOWN_TIMEOUT_MS));
-      //noinspection deprecation
-      put(CONFIG_OF_INSTANCE_CHECK_INTERVAL_TIME, String
-          .format("use %s instead, which is the interval for the resource check (10 seconds by default)",
-              CONFIG_OF_SHUTDOWN_RESOURCE_CHECK_INTERVAL_MS));
-    }};
-    for (Map.Entry<String, String> entry : deprecatedConfigKeyWarnings.entrySet()) {
-      String deprecatedConfigKey = entry.getKey();
-      if (_serverConf.containsKey(deprecatedConfigKey)) {
-        LOGGER.warn("Found usage of deprecated config key: {}, {}", deprecatedConfigKey, entry.getValue());
-      }
-    }
-
     if (_serverConf.containsKey(CONFIG_OF_INSTANCE_ID)) {
       _instanceId = _serverConf.getString(CONFIG_OF_INSTANCE_ID);
     } else {


### PR DESCRIPTION
The following server config keys are removed:
- pinot.server.starter.enableSegmentsLoadingCheck
- pinot.server.starter.timeoutInSeconds
- pinot.server.instance.enable.shutdown.delay
- pinot.server.instance.starter.maxShutdownWaitTime
- pinot.server.instance.starter.checkIntervalTime