### PR TITLE
Removing dependency on Hadoop

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -223,48 +223,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.zookeeper</groupId>
-          <artifactId>zookeeper</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-math3</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.zookeeper</groupId>
-          <artifactId>zookeeper</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HdfsSegmentFetcher.java
+++ b/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HdfsSegmentFetcher.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.segment.fetcher;
+package org.apache.pinot.filesystem;
 
 import com.google.common.base.Strings;
 import java.io.File;
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.pinot.common.segment.fetcher.SegmentFetcher;
 import org.apache.pinot.common.utils.retry.RetryPolicies;
 import org.apache.pinot.common.utils.retry.RetryPolicy;
 import org.slf4j.Logger;
@@ -41,6 +42,8 @@ import static org.apache.pinot.common.utils.CommonConstants.SegmentOperations.RE
 import static org.apache.pinot.common.utils.CommonConstants.SegmentOperations.RETRY_WAITIME_MS_DEFAULT;
 
 
+// Use PinotFSSegmentFetcher instead
+@Deprecated
 public class HdfsSegmentFetcher implements SegmentFetcher {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HdfsSegmentFetcher.class);


### PR DESCRIPTION
Only class where we needed Hadoop was HdfsSegmentFetcher but I looked at SegmentFetcherFactory and it used PinotFSFetcher. Looks like this was needed before we added PinotFS.

@jamesyfshao can you please verify that you dont need this any longer.

@mcvsubbu @jenniferdai , should we move SegmentFetcher interface to pinot-spi or we can get rid of this interface and use PinotFSFetcher as the default implementation? 