### PR TITLE
Add back avro to fix master

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -127,6 +127,16 @@
       <artifactId>libthrift</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
     </dependency>


### PR DESCRIPTION
Master is broken with message
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project pinot-common: Compilation failure: Compilation failure: 
[ERROR] /home/travis/build/apache/incubator-pinot/pinot-common/src/main/java/org/apache/pinot/common/utils/AvroSchemaUtil.java:[23,23] package org.apache.avro does not exist
[ERROR] /home/travis/build/apache/incubator-pinot/pinot-common/src/main/java/org/apache/pinot/common/utils/AvroSchemaUtil.java:[32,50] package Schema does not exist
```
Travis: https://travis-ci.org/apache/incubator-pinot/builds/623949286

Partially reverting the potentially offending diff #4915 by adding back avro