### PR TITLE
Clean up the un-necessary split for IN/NOT_IN predicates

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.broker.requesthandler;
 
-import com.google.common.base.Splitter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -104,8 +103,7 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer extends Filt
     for (FilterQueryTree childQueryTree : filterQueryTree.getChildren()) {
       if (childQueryTree.getOperator() == FilterOperator.EQUALITY
           || childQueryTree.getOperator() == FilterOperator.IN) {
-        List<String> childValues = valueDoubleTabListToElements(childQueryTree.getValue());
-
+        List<String> childValues = childQueryTree.getValue();
         if (!columnToValues.containsKey(childQueryTree.getColumn())) {
           TreeSet<String> value = new TreeSet<>(childValues);
           columnToValues.put(childQueryTree.getColumn(), value);
@@ -165,16 +163,5 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer extends Filt
       return new FilterQueryTree(columnAndValues.getKey(), new ArrayList<>(columnAndValues.getValue()),
           FilterOperator.IN, null);
     }
-  }
-
-  private List<String> valueDoubleTabListToElements(List<String> doubleTabSeparatedElements) {
-    Splitter valueSplitter = Splitter.on("\t\t");
-    List<String> valueElements = new ArrayList<>();
-
-    for (String value : doubleTabSeparatedElements) {
-      valueElements.addAll(valueSplitter.splitToList(value));
-    }
-
-    return valueElements;
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
  * Test for MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.
  */
 public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
+
   @Test
   public void testSimpleOrCase() {
     // a = 1 OR a = 2 OR a = 3 should be rewritten to a IN (1, 2, 3)
@@ -74,7 +75,7 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
   public void testEqualityAndInMerge() {
     // a = 1 OR a IN (2,3,4) -> a IN (1,2,3,4)
     checkForIdenticalFilterQueryTrees("select * from a where a = 1 OR a IN (2,3,4,31)",
-        "select * from a where a IN (1,2,31,3,4)");
+        "select * from a where a IN (1,2,3,31,4)");
   }
 
   @Test

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/FilterQueryTree.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/FilterQueryTree.java
@@ -18,13 +18,9 @@
  */
 package org.apache.pinot.common.utils.request;
 
-import com.google.common.collect.Lists;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
-import org.apache.pinot.common.utils.StringUtil;
 
 
 public class FilterQueryTree {
@@ -78,27 +74,12 @@ public class FilterQueryTree {
     }
     if (operator == FilterOperator.OR || operator == FilterOperator.AND) {
       stringBuffer.append(operator);
-    } else {
-      List<String> sortedValues = new ArrayList<>(value);
-
-      // Old style double-tab separated list
-      if (sortedValues.size() == 1) {
-        String firstItem = sortedValues.get(0);
-        List<String> firstItemValues = Lists.newArrayList(firstItem.split("\t\t"));
-        Collections.sort(firstItemValues);
-        sortedValues.set(0, StringUtil.join("\t\t", firstItemValues.toArray(new String[firstItemValues.size()])));
-      }
-
-      Collections.sort(sortedValues);
-
-      stringBuffer.append(column).append(" ").append(operator).append(" ").append(sortedValues);
-    }
-
-    if (children != null) {
       for (FilterQueryTree child : children) {
         stringBuffer.append('\n');
         child.recursiveToStringIntoBuffer(indent + 1, stringBuffer);
       }
+    } else {
+      stringBuffer.append(column).append(' ').append(operator).append(' ').append(value);
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -53,8 +53,6 @@ import org.apache.pinot.pql.parsers.pql2.ast.StringLiteralAstNode;
 
 
 public class RequestUtils {
-  private static String DELIMTER = "\t\t";
-
   private RequestUtils() {
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/RegexpLikePredicateAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/RegexpLikePredicateAstNode.java
@@ -19,12 +19,9 @@
 package org.apache.pinot.pql.parsers.pql2.ast;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.FilterOperator;
-import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.HavingQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
@@ -32,7 +29,6 @@ import org.apache.pinot.pql.parsers.Pql2CompilationException;
 
 
 public class RegexpLikePredicateAstNode extends PredicateAstNode {
-  private static final String SEPERATOR = "\t\t";
   private String _identifier;
 
   @Override
@@ -56,24 +52,12 @@ public class RegexpLikePredicateAstNode extends PredicateAstNode {
     if (_identifier == null) {
       throw new Pql2CompilationException("REGEXP_LIKE predicate has no identifier");
     }
-
-    Set<String> values = new HashSet<>();
-
-    for (AstNode astNode : getChildren()) {
-      if (astNode instanceof LiteralAstNode) {
-        LiteralAstNode node = (LiteralAstNode) astNode;
-        String expr = node.getValueAsString();
-        values.add(expr);
-      }
-    }
-    if (values.size() > 1) {
+    List<? extends AstNode> children = getChildren();
+    if (children.size() > 1) {
       throw new Pql2CompilationException("Matching more than one regex is NOT supported currently");
     }
-
-    String[] valueArray = values.toArray(new String[values.size()]);
-    FilterOperator filterOperator = FilterOperator.REGEXP_LIKE;
-    List<String> value = Collections.singletonList(StringUtil.join(SEPERATOR, valueArray));
-    return new FilterQueryTree(_identifier, value, filterOperator, null);
+    String value = ((LiteralAstNode) children.get(0)).getValueAsString();
+    return new FilterQueryTree(_identifier, Collections.singletonList(value), FilterOperator.REGEXP_LIKE, null);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/Predicate.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/Predicate.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.common;
 
-import java.util.Arrays;
 import java.util.List;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
@@ -64,8 +63,7 @@ public abstract class Predicate {
 
   @Override
   public String toString() {
-    return "Predicate: type: " + type + ", left : " + lhs + ", right : " + Arrays.toString(rhs.toArray(new String[0]))
-        + "\n";
+    return "Predicate: type: " + type + ", left: " + lhs + ", right: " + rhs;
   }
 
   public static Predicate newPredicate(FilterQueryTree filterQueryTree) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/predicate/BaseInPredicate.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/predicate/BaseInPredicate.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.common.predicate;
 
-import java.util.Arrays;
 import java.util.List;
 import org.apache.pinot.core.common.Predicate;
 
@@ -27,25 +26,12 @@ import org.apache.pinot.core.common.Predicate;
  * Abstract base class for IN and NOT IN predicates.
  */
 public abstract class BaseInPredicate extends Predicate {
-  public static final String DELIMITER = "\t\t";
 
   public BaseInPredicate(String lhs, Type predicateType, List<String> rhs) {
     super(lhs, predicateType, rhs);
   }
 
-  @Override
-  public String toString() {
-    List<String> rhs = getRhs();
-    return "Predicate: type: " + getType() + ", left : " + getLhs() + ", right : " + Arrays
-        .toString(rhs.toArray(new String[rhs.size()])) + "\n";
-  }
-
   public String[] getValues() {
-    /* To maintain backward compatibility, we always split if number of values is one. We do not support
-       case where DELIMITER is a sub-string of value.
-       TODO: Clean this up after broker changes to enable splitting have been around for sometime.
-     */
-    List<String> values = getRhs();
-    return (values.size() > 1) ? values.toArray(new String[values.size()]) : values.get(0).split(DELIMITER);
+    return getRhs().toArray(new String[0]);
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/InPredicateFilter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/InPredicateFilter.java
@@ -18,33 +18,32 @@
  */
 package org.apache.pinot.tools.scan.query;
 
-import java.util.HashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.List;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 
 
 public class InPredicateFilter implements PredicateFilter {
-  private static final String SEPARATOR = "\t\t";
-  HashSet<Integer> inSet = new HashSet<>();
+  private final IntSet _inSet;
 
-  public InPredicateFilter(Dictionary dictionaryReader, List<String> predicateValue) {
-    for (String values : predicateValue) {
-      for (String value : values.split(SEPARATOR)) {
-        inSet.add(dictionaryReader.indexOf(value));
-      }
+  public InPredicateFilter(Dictionary dictionary, List<String> values) {
+    _inSet = new IntOpenHashSet(values.size());
+    for (String value : values) {
+      _inSet.add(dictionary.indexOf(value));
     }
   }
 
   @Override
   public boolean apply(int dictId) {
-    return (inSet.contains(dictId));
+    return (_inSet.contains(dictId));
   }
 
   @Override
   public boolean apply(int[] dictIds, int length) {
     // length <= dictIds.length
     for (int i = 0; i < length; ++i) {
-      if (inSet.contains(dictIds[i])) {
+      if (_inSet.contains(dictIds[i])) {
         return true;
       }
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/NotInPredicateFilter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/NotInPredicateFilter.java
@@ -18,20 +18,19 @@
  */
 package org.apache.pinot.tools.scan.query;
 
-import java.util.HashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.List;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 
 
 public class NotInPredicateFilter implements PredicateFilter {
-  private static final String SEPARATOR = "\t\t";
-  HashSet<Integer> _notInSet = new HashSet<>();
+  private final IntSet _notInSet;
 
-  public NotInPredicateFilter(Dictionary dictionaryReader, List<String> predicateValue) {
-    for (String values : predicateValue) {
-      for (String value : values.split(SEPARATOR)) {
-        _notInSet.add(dictionaryReader.indexOf(value));
-      }
+  public NotInPredicateFilter(Dictionary dictionary, List<String> values) {
+    _notInSet = new IntOpenHashSet(values.size());
+    for (String value : values) {
+      _notInSet.add(dictionary.indexOf(value));
     }
   }
 


### PR DESCRIPTION
- The values for IN/NOT_IN predicates are already individual values, no need to split
- Also remove the dedup logic in compiling phase because it is done in optimizer