### PR TITLE
[TE] [WIP] Presto query optimization by using raw field name rather than functions

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
@@ -52,7 +52,6 @@ import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.apache.pinot.thirdeye.util.ThirdEyeUtils;
 import org.apache.tomcat.jdbc.pool.DataSource;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -363,7 +362,7 @@ public class SqlUtils {
    * @param dateTime datetime
    * @return formatted string, aligned to upper bound
    */
-  private static String getCeilingAlignedStartDateTimeString(DateTime dateTime, long dataGranularityMillis, String timeFormat) {
+  public static String getCeilingAlignedStartDateTimeString(DateTime dateTime, long dataGranularityMillis, String timeFormat) {
     long distanceToNextGranularityBoundary = dateTime.getMillis() % dataGranularityMillis;
 
     // if the date isn't a perfect multiple of the granularity, then we need to shift the given date to the next granularity.
@@ -375,7 +374,7 @@ public class SqlUtils {
 
     // Round up
     DateTime alignedDateTime = dateTime.withPeriodAdded(new Period(distanceToNextGranularityBoundary), 1);
-    return DateTimeFormat.forPattern(timeFormat).print(alignedDateTime);
+    return DateTimeFormat.forPattern(timeFormat).withOffsetParsed().print(alignedDateTime);
   }
 
   /**
@@ -383,7 +382,7 @@ public class SqlUtils {
    * @param dateTime datetime
    * @return formatted string, aligned to lower bound
    */
-  private static String getFloorAlignedEndDateTimeString(DateTime dateTime, long dataGranularityMillis, String timeFormat) {
+  public static String getFloorAlignedEndDateTimeString(DateTime dateTime, long dataGranularityMillis, String timeFormat) {
     long distanceToNextGranularityBoundary = dateTime.getMillis() % dataGranularityMillis;
 
     // if the date is a perfect multiple of the granularity, subtract one whole granularity instead.
@@ -392,11 +391,9 @@ public class SqlUtils {
       distanceToNextGranularityBoundary = dataGranularityMillis;
     }
 
-    DateTimeFormatter formatter = DateTimeFormat.forPattern(timeFormat);
-
     // Round down, since the end date is exclusive.
     DateTime alignedDateTime = dateTime.withPeriodAdded(new Period(distanceToNextGranularityBoundary), -1);
-    return DateTimeFormat.forPattern(timeFormat).print(alignedDateTime);
+    return DateTimeFormat.forPattern(timeFormat).withOffsetParsed().print(alignedDateTime);
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtilsTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtilsTest.java
@@ -43,7 +43,7 @@ public class SqlUtilsTest {
 
   @BeforeMethod
   public void beforeMethod() {
-    dateTime = DateTimeFormat.forPattern("mm/DD/yyyy").parseDateTime("01/01/2000").withZone(DateTimeZone.forID("US/Pacific"));
+    dateTime = DateTimeFormat.forPattern("MM/dd/yyyy HH:mm:ss").parseDateTime("01/01/2000 00:00:00").withZone(DateTimeZone.forID("America/Los_Angeles"));
   }
 
   @AfterMethod
@@ -57,7 +57,7 @@ public class SqlUtilsTest {
   @Test
   public void testGetCeilingAlignedStartDateTimeStringWithPerfectFactorDailyGranularity() {
     Assert.assertEquals(
-        SqlUtils.getCeilingAlignedStartDateTimeString(dateTime, dailyGranularity.toMillis(), dailyTimeFormat),
+        SqlUtils.getCeilingAlignedStartDateTimeString(dateTime, dailyGranularity, dailyTimeFormat),
         "20000101");
   }
 
@@ -66,7 +66,7 @@ public class SqlUtilsTest {
   public void testGetCeilingAlignedStartDateTimeStringWithoutPerfectFactorDailyGranularity() {
     addHalfStep();
     Assert.assertEquals(
-        SqlUtils.getCeilingAlignedStartDateTimeString(dateTime, dailyGranularity.toMillis(), dailyTimeFormat),
+        SqlUtils.getCeilingAlignedStartDateTimeString(dateTime, dailyGranularity, dailyTimeFormat),
         "20000102");
   }
 
@@ -74,7 +74,7 @@ public class SqlUtilsTest {
   public void testGetFloorAlignedEndDateTimeStringWithPerfectFactorDailyGranularity() {
     // should be dateTime minus one full time granularity.
     Assert.assertEquals(
-        SqlUtils.getFloorAlignedEndDateTimeString(dateTime, dailyGranularity.toMillis(), dailyTimeFormat),
+        SqlUtils.getFloorAlignedEndDateTimeString(dateTime, dailyGranularity, dailyTimeFormat),
         "19991231");
   }
 
@@ -82,7 +82,7 @@ public class SqlUtilsTest {
   public void testGetFloorAlignedEndDateTimeStringWithoutPerfectFactorDailyGranularity() {
     addHalfStep();
     Assert.assertEquals(
-        SqlUtils.getFloorAlignedEndDateTimeString(dateTime, dailyGranularity.toMillis(), dailyTimeFormat),
+        SqlUtils.getFloorAlignedEndDateTimeString(dateTime, dailyGranularity, dailyTimeFormat),
         "20000101");
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtilsTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtilsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.datasource.sql;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.thirdeye.common.time.TimeGranularity;
+import org.apache.pinot.thirdeye.common.time.TimeSpec;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Period;
+import org.joda.time.format.DateTimeFormat;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class SqlUtilsTest {
+
+  String dailyColumnName = "timestamp";
+  TimeGranularity dailyGranularity = new TimeGranularity(1, TimeUnit.DAYS);
+  String dailyTimeFormat = "yyyyMMdd";
+  TimeSpec dailyTimeSpec = new TimeSpec(dailyColumnName, dailyGranularity, dailyTimeFormat);
+
+  DateTime dateTime;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    dateTime = DateTimeFormat.forPattern("mm/DD/yyyy").parseDateTime("01/01/2000").withZone(DateTimeZone.forID("US/Pacific"));
+  }
+
+  @AfterMethod
+  public void afterMethod() {
+
+  }
+
+  // Tests using daily data granularity
+
+  // test how getCeilingAlignedStartDateTimeString behaves when the data granularity is a perfect multiple of the input dateTime.
+  @Test
+  public void testGetCeilingAlignedStartDateTimeStringWithPerfectFactorDailyGranularity() {
+    Assert.assertEquals(
+        SqlUtils.getCeilingAlignedStartDateTimeString(dateTime, dailyGranularity.toMillis(), dailyTimeFormat),
+        "20000101");
+  }
+
+  // test how getCeilingAlignedStartDateTimeString behaves when the data granularity isn't a perfect multiple of the input dateTime.
+  @Test
+  public void testGetCeilingAlignedStartDateTimeStringWithoutPerfectFactorDailyGranularity() {
+    addHalfStep();
+    Assert.assertEquals(
+        SqlUtils.getCeilingAlignedStartDateTimeString(dateTime, dailyGranularity.toMillis(), dailyTimeFormat),
+        "20000102");
+  }
+
+  @Test
+  public void testGetFloorAlignedEndDateTimeStringWithPerfectFactorDailyGranularity() {
+    // should be dateTime minus one full time granularity.
+    Assert.assertEquals(
+        SqlUtils.getFloorAlignedEndDateTimeString(dateTime, dailyGranularity.toMillis(), dailyTimeFormat),
+        "19991231");
+  }
+
+  @Test
+  public void testGetFloorAlignedEndDateTimeStringWithoutPerfectFactorDailyGranularity() {
+    addHalfStep();
+    Assert.assertEquals(
+        SqlUtils.getFloorAlignedEndDateTimeString(dateTime, dailyGranularity.toMillis(), dailyTimeFormat),
+        "20000101");
+  }
+
+
+  // Tests using hourly data granularity
+
+  private void addHalfStep() {
+    dateTime = dateTime.withPeriodAdded(Period.hours(12), 1);
+  }
+}


### PR DESCRIPTION
This PR aims to optimize the run speed for Presto queries by changing ThirdEye's Presto query building. Currently, we use some nested functions which help us avoid these time alignment issues but significantly slows down query speed. In order for ThirdEye to scale properly, we will need to do some ugly client-side parsing to deal with time alignment issues, since the current queries are taking up to 50x longer to execute.

This optimization is not added for MySQL, H2, or Vertica query building because I haven't done enough analysis on the performance yet.

Note that this may lead to misalignment issues in the future from Daylight Savings Time shifts. We need to add some tests to the whole SqlUtils class in the future.