### PR TITLE
Moving dependencies and enabling a shaded jar

### DIFF
--- a/pinot-batch-ingestion/pinot-hadoop/pom.xml
+++ b/pinot-batch-ingestion/pinot-hadoop/pom.xml
@@ -144,7 +144,6 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-json</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pinot-batch-ingestion/pinot-hadoop/pom.xml
+++ b/pinot-batch-ingestion/pinot-hadoop/pom.xml
@@ -131,6 +131,22 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-thrift</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-csv</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-json</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <scope>provided</scope>

--- a/pinot-batch-ingestion/pinot-spark/pom.xml
+++ b/pinot-batch-ingestion/pinot-spark/pom.xml
@@ -128,6 +128,16 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-thrift</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-csv</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-orc</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/pinot-connectors/pinot-connector-kafka-base/pom.xml
+++ b/pinot-connectors/pinot-connector-kafka-base/pom.xml
@@ -35,29 +35,6 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
   </properties>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-      <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
   <dependencies>
     <!-- test -->

--- a/pinot-connectors/pinot-connector-kafka-base/pom.xml
+++ b/pinot-connectors/pinot-connector-kafka-base/pom.xml
@@ -35,6 +35,29 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
   </properties>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+      <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <dependencies>
     <!-- test -->

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -71,21 +71,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-csv</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-json</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-thrift</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
     </dependency>
     <dependency>

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -185,6 +185,18 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-csv</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-json</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-spi</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>


### PR DESCRIPTION
Removed pinot-core dependency on pinot-thrift, pinot-json and pinot-csv.
Instead, added these as dependencies inside pinot-hadoop and pinot-spark.