### PR TITLE
Fix infinite loop when fetching anomaly

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
@@ -75,8 +75,8 @@ public class AutoOnboardPinotMetricsUtils {
       try {
         // Accept all SSL certificate because we assume that the Pinot broker are setup in the same internal network
         SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(null, new AcceptAllTrustStrategy()).build();
-        this.pinotControllerClient =
-            HttpClients.custom().setSSLContext(sslContext).setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
+        //this.pinotControllerClient =
+        //    HttpClients.custom().setSSLContext(sslContext).setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
       } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
         // This section shouldn't happen because we use Accept All Strategy
         LOG.error("Failed to start auto onboard for Pinot data source.");

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
@@ -75,8 +75,8 @@ public class AutoOnboardPinotMetricsUtils {
       try {
         // Accept all SSL certificate because we assume that the Pinot broker are setup in the same internal network
         SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(null, new AcceptAllTrustStrategy()).build();
-        //this.pinotControllerClient =
-        //    HttpClients.custom().setSSLContext(sslContext).setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
+        this.pinotControllerClient =
+            HttpClients.custom().setSSLContext(sslContext).setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
       } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
         // This section shouldn't happen because we use Accept All Strategy
         LOG.error("Failed to start auto onboard for Pinot data source.");

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.datalayer.bao;
 
+import java.util.Set;
 import org.apache.pinot.thirdeye.datalayer.pojo.MergedAnomalyResultBean;
 import java.util.List;
 
@@ -79,7 +80,7 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   MergedAnomalyResultBean convertMergeAnomalyDTO2Bean(MergedAnomalyResultDTO entity);
 
-  MergedAnomalyResultDTO convertMergedAnomalyBean2DTO(MergedAnomalyResultBean mergedAnomalyResultBean);
+  MergedAnomalyResultDTO convertMergedAnomalyBean2DTO(MergedAnomalyResultBean mergedAnomalyResultBean, Set<Long> visitedAnomalyIds);
 
   List<MergedAnomalyResultDTO> convertMergedAnomalyBean2DTO(List<MergedAnomalyResultBean> mergedAnomalyResultBeanList);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -184,7 +184,9 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     MergedAnomalyResultBean mergedAnomalyResultBean = genericPojoDao.get(id, MergedAnomalyResultBean.class);
     if (mergedAnomalyResultBean != null) {
       MergedAnomalyResultDTO mergedAnomalyResultDTO;
-      mergedAnomalyResultDTO = convertMergedAnomalyBean2DTO(mergedAnomalyResultBean);
+      Set<Long> visitedIds = new HashSet<>();
+      visitedIds.add(mergedAnomalyResultBean.getId());
+      mergedAnomalyResultDTO = convertMergedAnomalyBean2DTO(mergedAnomalyResultBean, visitedIds);
       return mergedAnomalyResultDTO;
     } else {
       return null;
@@ -373,7 +375,9 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
     if (CollectionUtils.isNotEmpty(list)) {
       MergedAnomalyResultBean mostRecentConflictMergedAnomalyResultBean = list.get(0);
-      return convertMergedAnomalyBean2DTO(mostRecentConflictMergedAnomalyResultBean);
+      Set<Long> visitedIds = new HashSet<>();
+      visitedIds.add(mostRecentConflictMergedAnomalyResultBean.getId());
+      return convertMergedAnomalyBean2DTO(mostRecentConflictMergedAnomalyResultBean, visitedIds);
     }
     return null;
   }
@@ -487,7 +491,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   @Override
-  public MergedAnomalyResultDTO convertMergedAnomalyBean2DTO(MergedAnomalyResultBean mergedAnomalyResultBean) {
+  public MergedAnomalyResultDTO convertMergedAnomalyBean2DTO(MergedAnomalyResultBean mergedAnomalyResultBean, Set<Long> visitedAnomalyIds) {
     MergedAnomalyResultDTO mergedAnomalyResultDTO;
     mergedAnomalyResultDTO = MODEL_MAPPER.map(mergedAnomalyResultBean, MergedAnomalyResultDTO.class);
 
@@ -503,21 +507,22 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
       mergedAnomalyResultDTO.setFeedback(anomalyFeedbackDTO);
     }
 
-    mergedAnomalyResultDTO.setChildren(getChildAnomalies(mergedAnomalyResultBean));
+    mergedAnomalyResultDTO.setChildren(getChildAnomalies(mergedAnomalyResultBean, visitedAnomalyIds));
 
     return mergedAnomalyResultDTO;
   }
 
-  private Set<MergedAnomalyResultDTO> getChildAnomalies(MergedAnomalyResultBean mergedAnomalyResultBean) {
+  private Set<MergedAnomalyResultDTO> getChildAnomalies(MergedAnomalyResultBean mergedAnomalyResultBean, Set<Long> visitedAnomalyIds) {
     Set<MergedAnomalyResultDTO> children = new HashSet<>();
     if (mergedAnomalyResultBean.getChildIds() != null) {
       for (Long id : mergedAnomalyResultBean.getChildIds()) {
-        if (id == null) {
+        if (id == null || visitedAnomalyIds.contains(id)) {
           continue;
         }
 
+        visitedAnomalyIds.add(id);
         MergedAnomalyResultBean childBean = genericPojoDao.get(id, MergedAnomalyResultBean.class);
-        MergedAnomalyResultDTO child = convertMergedAnomalyBean2DTO(childBean);
+        MergedAnomalyResultDTO child = convertMergedAnomalyBean2DTO(childBean, visitedAnomalyIds);
         children.add(child);
       }
     }
@@ -532,7 +537,9 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
       Future<MergedAnomalyResultDTO> future =
           EXECUTOR_SERVICE.submit(new Callable<MergedAnomalyResultDTO>() {
             @Override public MergedAnomalyResultDTO call() throws Exception {
-              return MergedAnomalyResultManagerImpl.this.convertMergedAnomalyBean2DTO(mergedAnomalyResultBean);
+              Set<Long> visitedIds = new HashSet<>();
+              visitedIds.add(mergedAnomalyResultBean.getId());
+              return MergedAnomalyResultManagerImpl.this.convertMergedAnomalyBean2DTO(mergedAnomalyResultBean, visitedIds);
             }
           });
       mergedAnomalyResultDTOFutureList.add(future);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -184,9 +184,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     MergedAnomalyResultBean mergedAnomalyResultBean = genericPojoDao.get(id, MergedAnomalyResultBean.class);
     if (mergedAnomalyResultBean != null) {
       MergedAnomalyResultDTO mergedAnomalyResultDTO;
-      Set<Long> visitedIds = new HashSet<>();
-      visitedIds.add(mergedAnomalyResultBean.getId());
-      mergedAnomalyResultDTO = convertMergedAnomalyBean2DTO(mergedAnomalyResultBean, visitedIds);
+      mergedAnomalyResultDTO = convertMergedAnomalyBean2DTO(mergedAnomalyResultBean, new HashSet<>());
       return mergedAnomalyResultDTO;
     } else {
       return null;
@@ -375,9 +373,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
     if (CollectionUtils.isNotEmpty(list)) {
       MergedAnomalyResultBean mostRecentConflictMergedAnomalyResultBean = list.get(0);
-      Set<Long> visitedIds = new HashSet<>();
-      visitedIds.add(mostRecentConflictMergedAnomalyResultBean.getId());
-      return convertMergedAnomalyBean2DTO(mostRecentConflictMergedAnomalyResultBean, visitedIds);
+      return convertMergedAnomalyBean2DTO(mostRecentConflictMergedAnomalyResultBean, new HashSet<>());
     }
     return null;
   }
@@ -507,6 +503,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
       mergedAnomalyResultDTO.setFeedback(anomalyFeedbackDTO);
     }
 
+    visitedAnomalyIds.add(mergedAnomalyResultBean.getId());
     mergedAnomalyResultDTO.setChildren(getChildAnomalies(mergedAnomalyResultBean, visitedAnomalyIds));
 
     return mergedAnomalyResultDTO;
@@ -520,7 +517,6 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
           continue;
         }
 
-        visitedAnomalyIds.add(id);
         MergedAnomalyResultBean childBean = genericPojoDao.get(id, MergedAnomalyResultBean.class);
         MergedAnomalyResultDTO child = convertMergedAnomalyBean2DTO(childBean, visitedAnomalyIds);
         children.add(child);
@@ -537,9 +533,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
       Future<MergedAnomalyResultDTO> future =
           EXECUTOR_SERVICE.submit(new Callable<MergedAnomalyResultDTO>() {
             @Override public MergedAnomalyResultDTO call() throws Exception {
-              Set<Long> visitedIds = new HashSet<>();
-              visitedIds.add(mergedAnomalyResultBean.getId());
-              return MergedAnomalyResultManagerImpl.this.convertMergedAnomalyBean2DTO(mergedAnomalyResultBean, visitedIds);
+              return MergedAnomalyResultManagerImpl.this.convertMergedAnomalyBean2DTO(mergedAnomalyResultBean, new HashSet<>());
             }
           });
       mergedAnomalyResultDTOFutureList.add(future);


### PR DESCRIPTION
Found some anomalies have itself as child anomalies (reasons unknown) which will cause stackoverflow when retrieving anomalies.
This PR is a hot fix which will check for loop when retrieving anomalies.