### PR TITLE
changing pinot-avro dependency scope to test from compile

### DIFF
--- a/pinot-batch-ingestion/pinot-spark/pom.xml
+++ b/pinot-batch-ingestion/pinot-spark/pom.xml
@@ -124,6 +124,10 @@
           <groupId>org.apache.pinot</groupId>
           <artifactId>pinot-core</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.thoughtworks.paranamer</groupId>
+          <artifactId>paranamer</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pinot-connectors/pinot-connector-kafka-base/pom.xml
+++ b/pinot-connectors/pinot-connector-kafka-base/pom.xml
@@ -43,5 +43,9 @@
       <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-avro</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -66,11 +66,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-avro</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
     </dependency>
     <dependency>
@@ -181,6 +176,12 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-avro</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
-import org.apache.pinot.avro.data.readers.AvroUtils;
 import org.apache.pinot.common.config.IndexingConfig;
 import org.apache.pinot.common.config.SegmentPartitionConfig;
 import org.apache.pinot.common.config.SegmentsValidationAndRetentionConfig;
@@ -620,36 +619,7 @@ public class SegmentGeneratorConfig {
     return getQualifyingFields(FieldType.METRIC, true);
   }
 
-  /**
-   * @deprecated Load outside the class and use the setter for schema setting.
-   * @throws IOException
-   */
-  @Deprecated
-  public void loadConfigFiles()
-      throws IOException {
-    Schema schema;
-    if (_schemaFile != null) {
-      schema = Schema.fromFile(new File(_schemaFile));
-      setSchema(schema);
-    } else if (_format == FileFormat.AVRO) {
-      schema = AvroUtils.getPinotSchemaFromAvroDataFile(new File(_inputFilePath));
-      setSchema(schema);
-    } else {
-      throw new RuntimeException("Input format " + _format + " requires schema.");
-    }
-
-    if (_readerConfigFile != null) {
-      try {
-        setReaderConfig(RecordReaderFactory.getRecordReaderConfig(FileFormat.CSV, _readerConfigFile));
-      } catch (IOException e) {
-        throw e;
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-  }
-
-  @JsonIgnore
+   @JsonIgnore
   public String getDimensions() {
     return getQualifyingFields(FieldType.DIMENSION, true);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -66,6 +66,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderFactory;
 import org.apache.pinot.startree.hll.HllConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,7 +128,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
         LOGGER.warn("Using class: {} to read segment, ignoring configured file format: {}", recordReaderClassName,
             fileFormat);
       }
-      return org.apache.pinot.spi.data.readers.RecordReaderFactory
+      return RecordReaderFactory
           .getRecordReaderByClass(recordReaderClassName, dataFile, schema, segmentGeneratorConfig.getReaderConfig());
     }
 

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -225,6 +225,11 @@
     </dependency>
     <!-- test -->
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-avro</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>test</scope>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -66,6 +66,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-csv</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-connector-kafka-base</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -34,6 +34,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.pinot.csv.data.readers.CSVRecordReader;
+import org.apache.pinot.csv.data.readers.CSVRecordReaderConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.data.StarTreeIndexSpec;
 import org.apache.pinot.common.segment.ReadMode;
@@ -404,7 +406,6 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
               dataDirPath.getFileSystem(new Configuration()).copyToLocalFile(dataFilePath, localFilePath);
               config.setInputFilePath(localFile);
               config.setSegmentName(_segmentName + "_" + segCnt);
-              config.loadConfigFiles();
 
               final SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
               switch (config.getFormat()) {
@@ -417,6 +418,12 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
                   RecordReader orcRecordReader = new ORCRecordReader();
                   orcRecordReader.init(new File(localFile), Schema.fromFile(new File(_schemaFile)), null);
                   driver.init(config, orcRecordReader);
+                  break;
+                case CSV:
+                  RecordReader csvRecordReader = new CSVRecordReader();
+                  CSVRecordReaderConfig readerConfig = JsonUtils.fileToObject(new File(_readerConfigFile), CSVRecordReaderConfig.class);
+                  csvRecordReader.init(new File(localFile), Schema.fromFile(new File(_schemaFile)), readerConfig);
+                  driver.init(config, csvRecordReader);
                   break;
                 default:
                   driver.init(config);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -421,7 +421,10 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
                   break;
                 case CSV:
                   RecordReader csvRecordReader = new CSVRecordReader();
-                  CSVRecordReaderConfig readerConfig = JsonUtils.fileToObject(new File(_readerConfigFile), CSVRecordReaderConfig.class);
+                  CSVRecordReaderConfig readerConfig = null;
+                  if (_readerConfigFile != null) {
+                    readerConfig = JsonUtils.fileToObject(new File(_readerConfigFile), CSVRecordReaderConfig.class);
+                  }
                   csvRecordReader.init(new File(localFile), Schema.fromFile(new File(_schemaFile)), readerConfig);
                   driver.init(config, csvRecordReader);
                   break;


### PR DESCRIPTION
SegmentGenerationConfig depended on AvroUtils. Removed the usage and cleaned up the dependency. After this change, pinot modules dont depend on any specific implementations at compile time. We have some dependencies at test scope.

![Screen Shot 2019-12-17 at 3 18 20 PM](https://user-images.githubusercontent.com/850791/71042405-7d968100-20e0-11ea-833a-a5dc7bded796.png)


![Screen Shot 2019-12-17 at 3 18 13 PM](https://user-images.githubusercontent.com/850791/71042412-825b3500-20e0-11ea-817d-af374ecd690f.png)

