### PR TITLE
Adding profile goal to generate shaded jars for all plugins automatic…

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-base/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-base/pom.xml
@@ -35,56 +35,6 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
   </properties>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <!--
-                  Usually in hadoop environment, there are multiple jars with different versions.
-                  Most of the NoSuchMethodExceptions are caused by class loading conflicts.
-                  Class relocation ensures the reference of certain packages/classes in Pinot code to
-                  shaded libs, e.g. jackson or guava.
-                  Ref: https://maven.apache.org/plugins/maven-shade-plugin/examples/class-relocation.html
-                  -->
-                  <relocations>
-                    <relocation>
-                      <pattern>com.google.common.base</pattern>
-                      <shadedPattern>shaded.com.google.common.base</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.fasterxml.jackson</pattern>
-                      <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
-                    </relocation>
-                  </relocations>
-                  <transformers>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                      <mainClass>org.apache.pinot.ingestion.standalone.StandaloneIngestionJobLauncher</mainClass>
-                    </transformer>
-                  </transformers>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
@@ -54,23 +54,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <shadedArtifactAttached>false</shadedArtifactAttached>
-          <createDependencyReducedPom>false</createDependencyReducedPom>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
@@ -42,33 +42,6 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>target/plugins/record-readers/pinot-avro</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
@@ -42,33 +42,6 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>target/plugins/record-readers/pinot-csv</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pinot-plugins/pinot-input-format/pinot-json/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-json/pom.xml
@@ -42,33 +42,6 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>target/plugins/record-readers/pinot-json</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -43,33 +43,6 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>target/plugins/record-readers/pinot-orc</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.apache.orc</groupId>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -42,33 +42,6 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>target/plugins/record-readers/pinot-parquet</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
@@ -42,33 +42,6 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>target/plugins/record-readers/pinot-thrift</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pinot-plugins/pinot-input-format/pom.xml
+++ b/pinot-plugins/pinot-input-format/pom.xml
@@ -47,11 +47,6 @@
   </modules>
 
   <dependencies>
-    <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-spi</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <!-- test -->
     <dependency>
       <groupId>org.testng</groupId>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -56,5 +56,31 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>target/plugins/${artifactId}</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
…ally

This will generate a shaded plugin jar for every module under pinot-plugins.

```./pinot-file-system/pinot-gcs/target/plugins/pinot-gcs/pinot-gcs-0.3.0-SNAPSHOT-shaded.jar
./pinot-file-system/pinot-adls/target/plugins/pinot-adls/pinot-adls-0.3.0-SNAPSHOT-shaded.jar
./pinot-file-system/pinot-hdfs/target/plugins/pinot-hdfs/pinot-hdfs-0.3.0-SNAPSHOT-shaded.jar
./pinot-batch-ingestion/v0_deprecated/pinot-spark/target/plugins/pinot-spark/pinot-spark-0.3.0-SNAPSHOT-shaded.jar
./pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/target/plugins/pinot-ingestion-common/pinot-ingestion-common-0.3.0-SNAPSHOT-shaded.jar
./pinot-batch-ingestion/v0_deprecated/pinot-hadoop/target/plugins/pinot-hadoop/pinot-hadoop-0.3.0-SNAPSHOT-shaded.jar
./pinot-batch-ingestion/pinot-batch-ingestion-base/target/plugins/pinot-batch-ingestion-base/pinot-batch-ingestion-base-0.3.0-SNAPSHOT-shaded.jar
./pinot-input-format/pinot-orc/target/plugins/pinot-orc/pinot-orc-0.3.0-SNAPSHOT-shaded.jar
./pinot-input-format/pinot-csv/target/plugins/pinot-csv/pinot-csv-0.3.0-SNAPSHOT-shaded.jar
./pinot-input-format/pinot-parquet/target/plugins/pinot-parquet/pinot-parquet-0.3.0-SNAPSHOT-shaded.jar
./pinot-input-format/pinot-avro/target/plugins/pinot-avro/pinot-avro-0.3.0-SNAPSHOT-shaded.jar
./pinot-input-format/pinot-json/target/plugins/pinot-json/pinot-json-0.3.0-SNAPSHOT-shaded.jar
./pinot-input-format/pinot-thrift/target/plugins/pinot-thrift/pinot-thrift-0.3.0-SNAPSHOT-shaded.jar
./pinot-stream-ingestion/pinot-kafka-0.9/target/plugins/pinot-kafka-0.9/pinot-kafka-0.9-0.3.0-SNAPSHOT-shaded.jar
./pinot-stream-ingestion/pinot-kafka-base/target/plugins/pinot-kafka-base/pinot-kafka-base-0.3.0-SNAPSHOT-shaded.jar
./pinot-stream-ingestion/pinot-kafka-2.0/target/plugins/pinot-kafka-2.0/pinot-kafka-2.0-0.3.0-SNAPSHOT-shaded.jar
```

Few things that might need to be fixed but not a blocker
- avoiding version number in the plugin name. e.g. pinot-kafka-2.0 will generate pinot-kafka-2.0-0.3.0-SNAPSHOT-shaded.jar
- even base modules generated shaded jar. e.g. pinot-kafka-base-0.3.0-SNAPSHOT-shaded.jar 

