### PR TITLE
[TE] Use upper and lower bounds as predicted for threshold algorithm

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
@@ -86,13 +86,12 @@ public class ThresholdRuleDetector implements AnomalyDetector<ThresholdRuleDetec
     if (!Double.isNaN(this.min)) {
       df.addSeries(COL_TOO_LOW, df.getDoubles(COL_CURRENT).lt(this.min));
     }
-    // predicted value is the same as the current value
-    df.addSeries(COL_VALUE, df.get(COL_CURRENT));
     df.mapInPlace(BooleanSeries.HAS_TRUE, COL_ANOMALY, COL_TOO_HIGH, COL_TOO_LOW);
     DatasetConfigDTO datasetConfig = data.getDatasetForMetricId().get(me.getId());
     List<MergedAnomalyResultDTO> anomalies = DetectionUtils.makeAnomalies(slice, df, COL_ANOMALY, endTime,
         DetectionUtils.getMonitoringGranularityPeriod(monitoringGranularity, datasetConfig), datasetConfig);
-    DataFrame baselineWithBoundaries = constructThresholdBoundaries(df);
+    DataFrame baselineWithBoundaries = constructBaselineAndBoundaries(df);
+
     return DetectionResult.from(anomalies, TimeSeries.fromDataFrame(baselineWithBoundaries));
   }
 
@@ -101,15 +100,24 @@ public class ThresholdRuleDetector implements AnomalyDetector<ThresholdRuleDetec
     InputData data =
         this.dataFetcher.fetchData(new InputDataSpec().withTimeseriesSlices(Collections.singletonList(slice)));
     DataFrame df = data.getTimeseries().get(slice);
-    return TimeSeries.fromDataFrame(constructThresholdBoundaries(df));
+    return TimeSeries.fromDataFrame(constructBaselineAndBoundaries(df));
   }
 
-  private DataFrame constructThresholdBoundaries(DataFrame df) {
+  /**
+   * Populate the dataframe with upper/lower boundaries and baseline
+   */
+  private DataFrame constructBaselineAndBoundaries(DataFrame df) {
+    // Set default baseline as the actual value
+    df.addSeries(COL_VALUE, df.getDoubles(COL_CURRENT));
     if (!Double.isNaN(this.min)) {
       df.addSeries(COL_LOWER_BOUND, DoubleSeries.fillValues(df.size(), this.min));
+      // set baseline value as the lower bound when actual value across below the mark
+      df.mapInPlace(DoubleSeries.MAX, COL_VALUE, COL_LOWER_BOUND, COL_VALUE);
     }
     if (!Double.isNaN(this.max)) {
       df.addSeries(COL_UPPER_BOUND, DoubleSeries.fillValues(df.size(), this.max));
+      // set baseline value as the upper bound when actual value across above the mark
+      df.mapInPlace(DoubleSeries.MIN, COL_VALUE, COL_UPPER_BOUND, COL_VALUE);
     }
     return df;
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetectorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetectorTest.java
@@ -102,7 +102,7 @@ public class ThresholdRuleDetectorTest {
     TimeSeries ts = result.getTimeseries();
     Assert.assertEquals(ts.getPredictedUpperBound(), DoubleSeries.fillValues(ts.size(), 500));
     Assert.assertEquals(ts.getPredictedLowerBound(), DoubleSeries.fillValues(ts.size(), 100));
-    Assert.assertEquals(ts.getPredictedBaseline(), ts.getCurrent());
+    Assert.assertEquals(ts.getPredictedBaseline().values(), new double[]{100, 100L, 200L, 500L, 500L});
   }
 
   @Test

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
@@ -441,23 +441,32 @@ public class RunAdhocDatabaseQueriesTool {
     }
   }
 
-  private void disableAllActiveFunction() {
-    disableAllActiveFunction(null);
+  private void disableAllActiveDetections() {
+    disableAllActiveDetections(null);
   }
 
-  private void disableAllActiveFunction(Collection<Long> excludeIds){
-    List<AnomalyFunctionDTO> functionSpecs = anomalyFunctionDAO.findAllActiveFunctions();
-    for (AnomalyFunctionDTO functionSpec : functionSpecs) {
-      if (functionSpec.getIsActive() && (CollectionUtils.isEmpty(excludeIds) || !excludeIds
-          .contains(functionSpec.getId()))) {
-        functionSpec.setActive(false);
-        anomalyFunctionDAO.update(functionSpec);
+  /**
+   * Disable all detections and activate the exclusion list
+   */
+  private void disableAllActiveDetections(Collection<Long> excludeIds){
+    List<DetectionConfigDTO> detections = detectionConfigDAO.findAll();
+    for (DetectionConfigDTO detection : detections) {
+      // Activate the whitelisted detections
+      if (excludeIds.contains(detection.getId())) {
+        detection.setActive(true);
+        detectionConfigDAO.update(detection);
+      } else {
+        // Disable other configs
+        if (detection.isActive()) {
+          detection.setActive(false);
+          detectionConfigDAO.update(detection);
+        }
       }
     }
   }
 
   /**
-   * Disable all subscription groups except groups with id in excludeIds
+   * Disable all subscription groups and activate the exclusion list
    */
   private void disableAllActiveSubsGroups(Collection<Long> excludeIds){
     List<DetectionAlertConfigDTO> subsConfigs = detectionAlertConfigDAO.findAll();
@@ -618,7 +627,7 @@ public class RunAdhocDatabaseQueriesTool {
       System.exit(1);
     }
     RunAdhocDatabaseQueriesTool dq = new RunAdhocDatabaseQueriesTool(persistenceFile);
-    dq.disableAllActiveSubsGroups(Collections.singleton(142644400L));
+    dq.disableAllActiveDetections(Collections.singleton(142644400L));
     LOG.info("DONE");
   }
 


### PR DESCRIPTION
Issue: The baseline/predicted value for Threshold Algorithms are currently set to be the actual value of the metric (likely a hack). This is quite misleading as the emails show anomalies with 0% change.

Fix: This PR addresses the issue by setting the predicted value to be the upper/lower bound whenever there is an anomaly.
* When the value cross the upper threshold, predicted/baseline  = upper threshold.
* When the value cross the lower threshold, predicted/baseline  = lower threshold.
