### PR TITLE
Sql query endpoint

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -104,7 +104,7 @@ public class PinotClientRequest {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("sql")
-  @ApiOperation(value = "Querying pinot in sql")
+  @ApiOperation(value = "Querying pinot using sql")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Query response"), @ApiResponse(code = 500, message = "Internal Server Error")})
   public String processSqlQueryGet(@ApiParam(value = "Query", required = true) @QueryParam("sql") String query,
       @ApiParam(value = "Trace enabled") @QueryParam(Request.TRACE) String traceEnabled,
@@ -132,7 +132,7 @@ public class PinotClientRequest {
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Path("sql")
-  @ApiOperation(value = "Querying pinot")
+  @ApiOperation(value = "Querying pinot using sql")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Query response"), @ApiResponse(code = 500, message = "Internal Server Error")})
   public String processSqlQueryPost(String query) {
     try {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -103,7 +103,7 @@ public class PinotClientRequest {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("sql")
+  @Path("query/sql")
   @ApiOperation(value = "Querying pinot using sql")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Query response"), @ApiResponse(code = 500, message = "Internal Server Error")})
   public String processSqlQueryGet(@ApiParam(value = "Query", required = true) @QueryParam("sql") String query,
@@ -131,7 +131,7 @@ public class PinotClientRequest {
 
   @POST
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("sql")
+  @Path("query/sql")
   @ApiOperation(value = "Querying pinot using sql")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Query response"), @ApiResponse(code = 500, message = "Internal Server Error")})
   public String processSqlQueryPost(String query) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -42,10 +42,7 @@ import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.DEBUG_OPTIONS;
-import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.PQL;
-import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.TRACE;
+import org.apache.pinot.common.utils.CommonConstants.Broker.Request;
 
 
 @Api(tags = "Query")
@@ -67,16 +64,16 @@ public class PinotClientRequest {
   public String processQueryGet(
       // Query param "bql" is for backward compatibility
       @ApiParam(value = "Query", required = true) @QueryParam("bql") String query,
-      @ApiParam(value = "Trace enabled") @QueryParam(TRACE) String traceEnabled,
-      @ApiParam(value = "Debug options") @QueryParam(DEBUG_OPTIONS) String debugOptions) {
+      @ApiParam(value = "Trace enabled") @QueryParam(Request.TRACE) String traceEnabled,
+      @ApiParam(value = "Debug options") @QueryParam(Request.DEBUG_OPTIONS) String debugOptions) {
     try {
       ObjectNode requestJson = JsonUtils.newObjectNode();
-      requestJson.put(PQL, query);
+      requestJson.put(Request.PQL, query);
       if (traceEnabled != null) {
-        requestJson.put(TRACE, traceEnabled);
+        requestJson.put(Request.TRACE, traceEnabled);
       }
       if (debugOptions != null) {
-        requestJson.put(DEBUG_OPTIONS, debugOptions);
+        requestJson.put(Request.DEBUG_OPTIONS, debugOptions);
       }
       BrokerResponse brokerResponse = requestHandler.handleRequest(requestJson, null, new RequestStatistics());
       return brokerResponse.toJsonString();
@@ -102,5 +99,61 @@ public class PinotClientRequest {
       brokerMetrics.addMeteredGlobalValue(BrokerMeter.UNCAUGHT_POST_EXCEPTIONS, 1L);
       throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("sql")
+  @ApiOperation(value = "Querying pinot in sql")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Query response"), @ApiResponse(code = 500, message = "Internal Server Error")})
+  public String processSqlQueryGet(@ApiParam(value = "Query", required = true) @QueryParam("sql") String query,
+      @ApiParam(value = "Trace enabled") @QueryParam(Request.TRACE) String traceEnabled,
+      @ApiParam(value = "Debug options") @QueryParam(Request.DEBUG_OPTIONS) String debugOptions) {
+    try {
+      ObjectNode requestJson = JsonUtils.newObjectNode();
+      requestJson.put(Request.SQL, query);
+      String queryOptions = constructSqlQueryOptions();
+      requestJson.put(Request.QUERY_OPTIONS, queryOptions);
+      if (traceEnabled != null) {
+        requestJson.put(Request.TRACE, traceEnabled);
+      }
+      if (debugOptions != null) {
+        requestJson.put(Request.DEBUG_OPTIONS, debugOptions);
+      }
+      BrokerResponse brokerResponse = requestHandler.handleRequest(requestJson, null, new RequestStatistics());
+      return brokerResponse.toJsonString();
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while processing GET request", e);
+      brokerMetrics.addMeteredGlobalValue(BrokerMeter.UNCAUGHT_GET_EXCEPTIONS, 1L);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("sql")
+  @ApiOperation(value = "Querying pinot")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Query response"), @ApiResponse(code = 500, message = "Internal Server Error")})
+  public String processSqlQueryPost(String query) {
+    try {
+      JsonNode requestJson = JsonUtils.stringToJsonNode(query);
+      if (!requestJson.has(Request.SQL)) {
+        throw new IllegalStateException("Payload is missing the query string field 'sql'");
+      }
+      String queryOptions = constructSqlQueryOptions();
+      // the only query options as of now are sql related. do not allow any custom query options in sql endpoint
+      ObjectNode sqlRequestJson = ((ObjectNode) requestJson).put(Request.QUERY_OPTIONS, queryOptions);
+      BrokerResponse brokerResponse = requestHandler.handleRequest(sqlRequestJson, null, new RequestStatistics());
+      return brokerResponse.toJsonString();
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while processing POST request", e);
+      brokerMetrics.addMeteredGlobalValue(BrokerMeter.UNCAUGHT_POST_EXCEPTIONS, 1L);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private String constructSqlQueryOptions() {
+    return Request.QueryOptionKey.GROUP_BY_MODE + "=" + Request.SQL + ";" + Request.QueryOptionKey.RESPONSE_FORMAT + "="
+        + Request.SQL;
   }
 }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 class BrokerResponse {
   private JsonNode _aggregationResults;
   private JsonNode _selectionResults;
+  private JsonNode _resultTable;
   private JsonNode _exceptions;
 
   private BrokerResponse() {
@@ -36,6 +37,7 @@ class BrokerResponse {
     _aggregationResults = brokerResponse.get("aggregationResults");
     _exceptions = brokerResponse.get("exceptions");
     _selectionResults = brokerResponse.get("selectionResults");
+    _resultTable = brokerResponse.get("resultTable");
   }
 
   boolean hasExceptions() {
@@ -52,6 +54,10 @@ class BrokerResponse {
 
   JsonNode getSelectionResults() {
     return _selectionResults;
+  }
+
+  JsonNode getResultTable() {
+    return _resultTable;
   }
 
   int getAggregationResultsSize() {

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -67,9 +67,16 @@ class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
   public Future<BrokerResponse> executePinotQueryAsync(String brokerAddress, final Request request) {
     try {
       ObjectNode json = JsonNodeFactory.instance.objectNode();
-      json.put(request.getQueryFormat(), request.getQuery());
+      String queryFormat = request.getQueryFormat();
+      json.put(queryFormat, request.getQuery());
 
-      final String url = "http://" + brokerAddress + "/query";
+      final String url;
+      if (queryFormat.equalsIgnoreCase("sql")) {
+        url = "http://" + brokerAddress + "/sql";
+        json.put("queryOptions", "groupByMode=sql;responseFormat=sql");
+      } else {
+        url = "http://" + brokerAddress + "/query";
+      }
 
       AsyncHttpClient.BoundRequestBuilder requestBuilder = _httpClient.preparePost(url);
 

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -72,7 +72,7 @@ class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
 
       final String url;
       if (queryFormat.equalsIgnoreCase("sql")) {
-        url = "http://" + brokerAddress + "/sql";
+        url = "http://" + brokerAddress + "/query/sql";
         json.put("queryOptions", "groupByMode=sql;responseFormat=sql");
       } else {
         url = "http://" + brokerAddress + "/query";

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultSetGroup.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultSetGroup.java
@@ -32,19 +32,24 @@ public class ResultSetGroup {
   ResultSetGroup(BrokerResponse brokerResponse) {
     _resultSets = new ArrayList<>();
 
-    if (brokerResponse.getSelectionResults() != null) {
-      _resultSets.add(new SelectionResultSet(brokerResponse.getSelectionResults()));
-    }
+    if (brokerResponse.getResultTable() != null) {
+      _resultSets.add(new ResultTableResultSet(brokerResponse.getResultTable()));
+    } else {
 
-    int aggregationResultCount = brokerResponse.getAggregationResultsSize();
-    for (int i = 0; i < aggregationResultCount; i++) {
-      JsonNode aggregationResult = brokerResponse.getAggregationResults().get(i);
-      if (aggregationResult.has("value")) {
-        _resultSets.add(new AggregationResultSet(aggregationResult));
-      } else if (aggregationResult.has("groupByResult")) {
-        _resultSets.add(new GroupByResultSet(aggregationResult));
-      } else {
-        throw new PinotClientException("Unrecognized result group, neither a value nor group by result");
+      if (brokerResponse.getSelectionResults() != null) {
+        _resultSets.add(new SelectionResultSet(brokerResponse.getSelectionResults()));
+      }
+
+      int aggregationResultCount = brokerResponse.getAggregationResultsSize();
+      for (int i = 0; i < aggregationResultCount; i++) {
+        JsonNode aggregationResult = brokerResponse.getAggregationResults().get(i);
+        if (aggregationResult.has("value")) {
+          _resultSets.add(new AggregationResultSet(aggregationResult));
+        } else if (aggregationResult.has("groupByResult")) {
+          _resultSets.add(new GroupByResultSet(aggregationResult));
+        } else {
+          throw new PinotClientException("Unrecognized result group, neither a value nor group by result");
+        }
       }
     }
   }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultTableResultSet.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultTableResultSet.java
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.databind.JsonNode;
  * ResultSet which contains the ResultTable from the broker response of a sql query.
  */
 class ResultTableResultSet extends AbstractResultSet {
-  private JsonNode _rowsArray;
-  private JsonNode _columnNamesArray;
-  private JsonNode _columnDataTypesArray;
+  private final JsonNode _rowsArray;
+  private final JsonNode _columnNamesArray;
+  private final JsonNode _columnDataTypesArray;
 
   public ResultTableResultSet(JsonNode resultTable) {
     _rowsArray = resultTable.get("rows");

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultTableResultSet.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultTableResultSet.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+
+/**
+ * ResultSet which contains the ResultTable from the broker response of a sql query.
+ */
+class ResultTableResultSet extends AbstractResultSet {
+  private JsonNode _rowsArray;
+  private JsonNode _columnNamesArray;
+  private JsonNode _columnDataTypesArray;
+
+  public ResultTableResultSet(JsonNode resultTable) {
+    _rowsArray = resultTable.get("rows");
+    JsonNode dataSchema = resultTable.get("dataSchema");
+    _columnNamesArray = dataSchema.get("columnNames");
+    _columnDataTypesArray = dataSchema.get("columnDataTypes");
+  }
+
+  @Override
+  public int getRowCount() {
+    return _rowsArray.size();
+  }
+
+  @Override
+  public int getColumnCount() {
+    return _columnNamesArray.size();
+  }
+
+  @Override
+  public String getColumnName(int columnIndex) {
+    return _columnNamesArray.get(columnIndex).asText();
+  }
+
+  @Override
+  public String getString(int rowIndex, int columnIndex) {
+    JsonNode jsonValue = _rowsArray.get(rowIndex).get(columnIndex);
+    if (jsonValue.isTextual()) {
+      return jsonValue.textValue();
+    } else {
+      return jsonValue.toString();
+    }
+  }
+
+  @Override
+  public int getGroupKeyLength() {
+    return 0;
+  }
+
+  @Override
+  public String getGroupKeyString(int rowIndex, int groupKeyColumnIndex) {
+    throw new AssertionError("No group key string for result table");
+  }
+
+  @Override
+  public String getGroupKeyColumnName(int groupKeyColumnIndex) {
+    throw new AssertionError("No group key column name for result table");
+  }
+
+  @Override
+  public String toString() {
+    int numColumns = getColumnCount();
+    TextTable table = new TextTable();
+    String[] columnNames = new String[numColumns];
+    String[] columnDataTypes = new String[numColumns];
+    for (int c = 0; c < numColumns; c++) {
+      columnNames[c] = _columnNamesArray.get(c).asText();
+      columnDataTypes[c] = _columnDataTypesArray.get(c).asText();
+    }
+    table.addHeader(columnNames);
+    table.addHeader(columnDataTypes);
+
+    int numRows = getRowCount();
+    for (int r = 0; r < numRows; r++) {
+      String[] columnValues = new String[numColumns];
+      for (int c = 0; c < numColumns; c++) {
+        try {
+          columnValues[c] = getString(r, c);
+        } catch (Exception e) {
+          columnNames[c] = "ERROR";
+        }
+      }
+      table.addRow(columnValues);
+    }
+    return table.toString();
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -379,16 +379,16 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   /**
-   * Run equivalent Pinot and H2 query and compare the results.
+   * Run equivalent Pinot SQL and H2 query and compare the results.
    *
-   * @param sqlQuery Pinot query
+   * @param pinotQuery Pinot query
    * @param sqlQueries H2 query
    * @throws Exception
    */
-  protected void testSqlQuery(String sqlQuery, @Nullable List<String> sqlQueries)
+  protected void testSqlQuery(String pinotQuery, @Nullable List<String> sqlQueries)
       throws Exception {
     ClusterIntegrationTestUtils
-        .testQuery(sqlQuery, "sql", _brokerBaseApiUrl, getPinotConnection(), sqlQueries, getH2Connection());
+        .testSqlQuery(pinotQuery, _brokerBaseApiUrl, getPinotConnection(), sqlQueries, getH2Connection());
   }
 
   protected void setUpRealtimeTable(File avroFile, int numReplicas, boolean useLLC, String tableName)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -146,40 +146,32 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
    *     Eg. <code>SELECT a FROM table LIMIT 15 -> [SELECT a FROM table LIMIT 10000]</code>
    *   </li>
    * </ul>
-   * <p>For queries with multiple aggregation functions, need to split each of them into a separate H2 SQL query.
-   * <ul>
-   *   <li>
-   *     Eg. <code>SELECT SUM(a), MAX(b) FROM table -> [SELECT SUM(a) FROM table, SELECT MAX(b) FROM table]</code>
-   *   </li>
-   * </ul>
    * <p>For group-by queries, need to add group-by columns to the select clause for H2 SQL query.
    * <ul>
    *   <li>
    *     Eg. <code>SELECT SUM(a) FROM table GROUP BY b -> [SELECT b, SUM(a) FROM table GROUP BY b]</code>
    *   </li>
    * </ul>
-   *
-   * @throws Exception
+   * TODO: Selection queries, Aggregation Group By queries, Order By, Distinct
+   *  This list is very basic right now (aggregations only) and needs to be enriched
    */
   public void testHardcodedSqlQueries()
       throws Exception {
-    // Here are some sample queries.
     String query;
     query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch = 16312 AND Carrier = 'DL'";
     testSqlQuery(query, Collections.singletonList(query));
-    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = 'DL'";
+    query = "SELECT SUM(ArrTime) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = 'DL'";
     testSqlQuery(query, Collections.singletonList(query));
-    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch > 16312 AND Carrier = 'DL'";
+    query = "SELECT MAX(ArrTime) FROM mytable WHERE DaysSinceEpoch > 16312 AND Carrier = 'DL'";
     testSqlQuery(query, Collections.singletonList(query));
-    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch >= 16312 AND Carrier = 'DL'";
+    query = "SELECT MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 16312 AND Carrier = 'DL'";
     testSqlQuery(query, Collections.singletonList(query));
     query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch < 16312 AND Carrier = 'DL'";
     testSqlQuery(query, Collections.singletonList(query));
-    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL'";
+    query = "SELECT MAX(ArrTime), MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL'";
     testSqlQuery(query, Collections.singletonList(query));
-    query = "SELECT MAX(ArrTime), MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 16312";
-    testSqlQuery(query, Arrays.asList("SELECT MAX(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 15312",
-        "SELECT MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 15312"));
+    query = "SELECT COUNT(*), MAX(ArrTime), MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 16312";
+    testSqlQuery(query, Collections.singletonList(query));
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
 import com.google.common.math.DoubleMath;
 import com.google.common.primitives.Longs;
 import java.io.ByteArrayOutputStream;
@@ -50,7 +51,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.util.Utf8;
-import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.pinot.broker.requesthandler.PinotQueryParserFactory;
 import org.apache.pinot.broker.requesthandler.PinotQueryRequest;
 import org.apache.pinot.client.Request;
@@ -58,16 +59,17 @@ import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.utils.CommonConstants;
-import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
-import org.apache.pinot.spi.stream.StreamDataProducer;
-import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.core.startree.v2.builder.StarTreeV2BuilderConfig;
+import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.server.util.SegmentTestUtils;
+import org.apache.pinot.spi.stream.StreamDataProducer;
+import org.apache.pinot.spi.stream.StreamDataProvider;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
 import org.testng.Assert;
 
@@ -827,6 +829,99 @@ public class ClusterIntegrationTestUtils {
       // Neither aggregation or selection results
       String failureMessage = "No aggregation or selection results found for query: " + pinotQuery;
       failure(pinotQuery, sqlQueries, failureMessage);
+    }
+  }
+
+  /**
+   * Run equivalent Pinot SQL and H2 query and compare the results.
+   *
+   * @param pinotQuery Pinot sql query
+   * @param brokerUrl Pinot broker URL
+   * @param pinotConnection Pinot connection
+   * @param sqlQueries H2 SQL query
+   * @param h2Connection H2 connection
+   * @throws Exception
+   */
+  static void testSqlQuery(String pinotQuery, String brokerUrl, org.apache.pinot.client.Connection pinotConnection,
+      @Nullable List<String> sqlQueries, @Nullable Connection h2Connection)
+      throws Exception {
+    if (pinotQuery == null || sqlQueries == null) {
+      return;
+    }
+
+    // broker response
+    JsonNode pinotResponse = ClusterTest.postSqlQuery(pinotQuery, brokerUrl);
+    JsonNode brokerResponseRows = pinotResponse.get("resultTable").get("rows");
+    long pinotNumRecordsSelected = pinotResponse.get("numDocsScanned").asLong();
+
+    // connection response
+    Request pinotClientRequest = new Request("sql", pinotQuery);
+    ResultSetGroup pinotResultSetGroup = pinotConnection.execute(pinotClientRequest);
+    org.apache.pinot.client.ResultSet resultTableResultSet = pinotResultSetGroup.getResultSet(0);
+    int numRows = resultTableResultSet.getRowCount();
+    int numColumns = resultTableResultSet.getColumnCount();
+
+    // h2 response
+    String sqlQuery = sqlQueries.get(0);
+    Assert.assertNotNull(h2Connection);
+    Statement h2statement = h2Connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+    h2statement.execute(sqlQuery);
+    ResultSet h2ResultSet = h2statement.getResultSet();
+
+    // compare results
+    BrokerRequest brokerRequest =
+        PinotQueryParserFactory.get(CommonConstants.Broker.Request.SQL).compileToBrokerRequest(pinotQuery);
+    if (brokerRequest.getSelections() != null) { // selection
+
+      // TODO: compare results for selection queries, w/ and w/o order by
+    } else { // aggregation
+      if (!brokerRequest.isSetGroupBy()) { // aggregation only
+        // compare the single row
+        h2ResultSet.first();
+        for (int c = 0; c < numColumns; c++) {
+
+          String h2Value = h2ResultSet.getString(c + 1);
+
+          // If H2 value is null, it means no record selected in H2
+          if (h2Value == null) {
+            if (pinotNumRecordsSelected != 0) {
+              String failureMessage =
+                  "No record selected in H2 but " + pinotNumRecordsSelected + " records selected in Pinot";
+              failure(pinotQuery, Lists.newArrayList(sqlQuery), failureMessage);
+            }
+
+            // Skip further comparison
+            return;
+          }
+
+          String brokerValue = brokerResponseRows.get(0).get(c).asText();
+          String connectionValue = resultTableResultSet.getString(0, c);
+
+          // Fuzzy compare expected value and actual value
+          boolean error = false;
+          if (NumberUtils.isParsable(h2Value)) {
+            double expectedValue = Double.parseDouble(h2Value);
+            double actualValueBroker = Double.parseDouble(brokerValue);
+            double actualValueConnection = Double.parseDouble(connectionValue);
+            if (!DoubleMath.fuzzyEquals(actualValueBroker, expectedValue, 1.0) || !DoubleMath
+                .fuzzyEquals(actualValueConnection, expectedValue, 1.0)) {
+              error = true;
+            }
+          } else {
+            if (!h2Value.equals(brokerValue) || !h2Value.equals(connectionValue)) {
+              error = true;
+            }
+          }
+          if (error) {
+            String failureMessage =
+                "Value: " + c + " does not match, expected: " + h2Value + ", got broker value: " + brokerValue
+                    + ", got client value:" + connectionValue;
+            failure(pinotQuery, Lists.newArrayList(sqlQuery), failureMessage);
+          }
+        }
+      } else { // aggregation group by
+        // TODO: compare results for aggregation group by queries, w/ and w/o order by
+      }
     }
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -522,7 +522,7 @@ public abstract class ClusterTest extends ControllerTest {
     payload.put("sql", query);
     payload.put("queryOptions", "groupByMode=sql;responseFormat=sql");
 
-    return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/sql", payload.toString()));
+    return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/query/sql", payload.toString()));
   }
 
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -486,16 +486,25 @@ public abstract class ClusterTest extends ControllerTest {
     return JsonUtils.stringToJsonNode(sendGetRequest(_brokerBaseApiUrl + "/" + uri));
   }
 
+  /**
+   * Queries the broker's pql query endpoint (/query)
+   */
   protected JsonNode postQuery(String query)
       throws Exception {
     return postQuery(new PinotQueryRequest("pql", query), _brokerBaseApiUrl);
   }
 
+  /**
+   * Queries the broker's pql query endpoint (/query)
+   */
   public static JsonNode postQuery(PinotQueryRequest r, String brokerBaseApiUrl)
       throws Exception {
     return postQuery(r.getQuery(), brokerBaseApiUrl, false, r.getQueryFormat());
   }
 
+  /**
+   * Queries the broker's pql query endpoint (/query)
+   */
   public static JsonNode postQuery(String query, String brokerBaseApiUrl, boolean enableTrace, String queryType)
       throws Exception {
     ObjectNode payload = JsonUtils.newObjectNode();
@@ -504,4 +513,16 @@ public abstract class ClusterTest extends ControllerTest {
 
     return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/query", payload.toString()));
   }
+
+  /**
+   * Queries the broker's sql query endpoint (/sql)
+   */
+  static JsonNode postSqlQuery(String query, String brokerBaseApiUrl) throws Exception {
+    ObjectNode payload = JsonUtils.newObjectNode();
+    payload.put("sql", query);
+    payload.put("queryOptions", "groupByMode=sql;responseFormat=sql");
+
+    return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/sql", payload.toString()));
+  }
+
 }


### PR DESCRIPTION
https://github.com/apache/incubator-pinot/issues/4962

Query the port using
```
curl -H "Content-Type: application/json" -X POST -d '{"sql":"select count(*) from testTable group by foo order by foo desc"}' http://localhost:8099/sql
```
Please not: the functionality will be limited right now by what's accepted by the parsing layer.
For instance, `TOP` will not parse for group by queries, but `LIMIT` - which will parse - hasn't been wired in yet.