### PR TITLE
Add error for empty instance list for tenant API

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTenantTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTenantTest.java
@@ -106,6 +106,16 @@ public class ControllerTenantTest extends ControllerTest {
   }
 
   @Test
+  public void testEmptyServerTenant() {
+    try {
+      sendGetRequest(_controllerRequestURLBuilder.forServerTenantGet("doesn't_exist"));
+      Assert.fail();
+    } catch (Exception e) {
+
+    }
+  }
+
+  @Test
   public void testServerTenant()
       throws IOException {
     // Create server tenants


### PR DESCRIPTION
* Currently, we return an empty list when no instances are tagged with the particular tag corresponding to a tenant. I have changed this to throw an exception.