### PR TITLE
Update quota manager to reduce zk access

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/QueryQuotaConfig.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/QueryQuotaConfig.java
@@ -20,16 +20,21 @@ package org.apache.pinot.broker.queryquota;
 
 import com.google.common.util.concurrent.RateLimiter;
 import javax.annotation.Nonnull;
+import org.apache.pinot.common.utils.CommonConstants;
 
 
 public class QueryQuotaConfig {
 
   private RateLimiter _rateLimiter;
   private HitCounter _hitCounter;
+  private int _numOnlineBrokers;
+  private int _tableConfigStatVersion;
 
-  public QueryQuotaConfig(@Nonnull RateLimiter rateLimiter, @Nonnull HitCounter hitCounter) {
+  public QueryQuotaConfig(@Nonnull RateLimiter rateLimiter, @Nonnull HitCounter hitCounter, @Nonnull int numOnlineBrokers, @Nonnull int tableConfigStatVersion) {
     _rateLimiter = rateLimiter;
     _hitCounter = hitCounter;
+    _numOnlineBrokers = numOnlineBrokers;
+    _tableConfigStatVersion = tableConfigStatVersion;
   }
 
   public RateLimiter getRateLimiter() {
@@ -38,5 +43,21 @@ public class QueryQuotaConfig {
 
   public HitCounter getHitCounter() {
     return _hitCounter;
+  }
+
+  public int getNumOnlineBrokers() {
+    return _numOnlineBrokers;
+  }
+
+  public void setNumOnlineBrokers(int numOnlineBrokers) {
+    _numOnlineBrokers = numOnlineBrokers;
+  }
+
+  public int getTableConfigStatVersion() {
+    return _tableConfigStatVersion;
+  }
+
+  public void setTableConfigStatVersion(int tableConfigStatVersion) {
+    _tableConfigStatVersion = tableConfigStatVersion;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/QueryQuotaEntity.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/QueryQuotaEntity.java
@@ -19,21 +19,22 @@
 package org.apache.pinot.broker.queryquota;
 
 import com.google.common.util.concurrent.RateLimiter;
-import javax.annotation.Nonnull;
-import org.apache.pinot.common.utils.CommonConstants;
 
 
-public class QueryQuotaConfig {
+public class QueryQuotaEntity {
 
   private RateLimiter _rateLimiter;
   private HitCounter _hitCounter;
   private int _numOnlineBrokers;
+  private double _overallRate;
   private int _tableConfigStatVersion;
 
-  public QueryQuotaConfig(@Nonnull RateLimiter rateLimiter, @Nonnull HitCounter hitCounter, @Nonnull int numOnlineBrokers, @Nonnull int tableConfigStatVersion) {
+  public QueryQuotaEntity(RateLimiter rateLimiter, HitCounter hitCounter, int numOnlineBrokers, double overallRate,
+      int tableConfigStatVersion) {
     _rateLimiter = rateLimiter;
     _hitCounter = hitCounter;
     _numOnlineBrokers = numOnlineBrokers;
+    _overallRate = overallRate;
     _tableConfigStatVersion = tableConfigStatVersion;
   }
 
@@ -51,6 +52,14 @@ public class QueryQuotaConfig {
 
   public void setNumOnlineBrokers(int numOnlineBrokers) {
     _numOnlineBrokers = numOnlineBrokers;
+  }
+
+  public double getOverallRate() {
+    return _overallRate;
+  }
+
+  public void setOverallRate(double overallRate) {
+    _overallRate = overallRate;
   }
 
   public int getTableConfigStatVersion() {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
@@ -117,6 +117,8 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
+    ZKMetadataProvider
+        .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, tableConfig.toZNRecord());
     setQps(tableConfig);
     _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
@@ -224,6 +226,25 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
+    ZKMetadataProvider
+        .setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, tableConfig.toZNRecord());
+    setQps(tableConfig);
+    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
+
+    runQueries(70, 10L);
+
+    _queryQuotaManager.dropTableQueryQuota(REALTIME_TABLE_NAME);
+    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
+  }
+
+  @Test
+  public void testRealtimeTableNotnullQuotaStat()
+      throws Exception {
+    ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
+    TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
+    ZKMetadataProvider
+        .setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, tableConfig.toZNRecord());
     setQps(tableConfig);
     _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
@@ -313,6 +334,8 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     ExternalView brokerResource = new ExternalView(BROKER_RESOURCE_INSTANCE);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
+    ZKMetadataProvider
+        .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, tableConfig.toZNRecord());
     setQps(tableConfig);
     _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
@@ -324,6 +347,8 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ExternalView brokerResource = new ExternalView(BROKER_RESOURCE_INSTANCE);
     brokerResource.setState(OFFLINE_TABLE_NAME, "broker_instance_2", "OFFLINE");
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
+    ZKMetadataProvider
+        .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, tableConfig.toZNRecord());
     setQps(tableConfig);
     _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.config.QuotaConfig;
 import org.apache.pinot.common.config.TableConfig;
 import org.apache.pinot.common.config.TableNameBuilder;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.testng.Assert;
@@ -39,9 +40,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-
-import static org.apache.pinot.common.utils.CommonConstants.Helix.BROKER_RESOURCE_INSTANCE;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
 
 
 public class HelixExternalViewBasedQueryQuotaManagerTest {
@@ -117,8 +115,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
-    ZKMetadataProvider
-        .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, tableConfig.toZNRecord());
+    ZKMetadataProvider.setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, tableConfig.toZNRecord());
     setQps(tableConfig);
     _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
@@ -144,9 +141,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     QuotaConfig quotaConfig = new QuotaConfig("6G", null);
     TableConfig realtimeTableConfig =
-        new TableConfig.Builder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
-            .setBrokerTenant("testBroker").setServerTenant("testServer").build();
+        new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME).setTableName(RAW_TABLE_NAME)
+            .setQuotaConfig(quotaConfig).setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
+            .setSegmentPushType("APPEND").setBrokerTenant("testBroker").setServerTenant("testServer").build();
     ZKMetadataProvider
         .setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, realtimeTableConfig.toZNRecord());
 
@@ -165,9 +162,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     QuotaConfig quotaConfig = new QuotaConfig("6G", "100.00");
     TableConfig realtimeTableConfig =
-        new TableConfig.Builder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
-            .setBrokerTenant("testBroker").setServerTenant("testServer").build();
+        new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME).setTableName(RAW_TABLE_NAME)
+            .setQuotaConfig(quotaConfig).setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
+            .setSegmentPushType("APPEND").setBrokerTenant("testBroker").setServerTenant("testServer").build();
     ZKMetadataProvider
         .setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, realtimeTableConfig.toZNRecord());
 
@@ -190,13 +187,13 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
 
     QuotaConfig quotaConfig = new QuotaConfig("6G", "100.00");
     TableConfig realtimeTableConfig =
-        new TableConfig.Builder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
-            .setBrokerTenant("testBroker").setServerTenant("testServer").build();
+        new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME).setTableName(RAW_TABLE_NAME)
+            .setQuotaConfig(quotaConfig).setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
+            .setSegmentPushType("APPEND").setBrokerTenant("testBroker").setServerTenant("testServer").build();
     TableConfig offlineTableConfig =
-        new TableConfig.Builder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
-            .setBrokerTenant("testBroker").setServerTenant("testServer").build();
+        new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+            .setQuotaConfig(quotaConfig).setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
+            .setSegmentPushType("APPEND").setBrokerTenant("testBroker").setServerTenant("testServer").build();
 
     ZKMetadataProvider
         .setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, realtimeTableConfig.toZNRecord());
@@ -226,8 +223,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
-    ZKMetadataProvider
-        .setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, tableConfig.toZNRecord());
+    ZKMetadataProvider.setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, tableConfig.toZNRecord());
     setQps(tableConfig);
     _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
@@ -239,19 +235,19 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
   }
 
   @Test
-  public void testRealtimeTableNotnullQuotaStat()
+  public void testRealtimeTableNotnullQuotaWhileTableConfigGetsDeleted()
       throws Exception {
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
-    ZKMetadataProvider
-        .setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, tableConfig.toZNRecord());
+    ZKMetadataProvider.setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, tableConfig.toZNRecord());
     setQps(tableConfig);
     _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
 
     runQueries(70, 10L);
 
-    _queryQuotaManager.dropTableQueryQuota(REALTIME_TABLE_NAME);
+    ZKMetadataProvider.removeResourceConfigFromPropertyStore(_testPropertyStore, REALTIME_TABLE_NAME);
+    _queryQuotaManager.processQueryQuotaChange(brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
   }
 
@@ -269,9 +265,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     QuotaConfig quotaConfig = new QuotaConfig("6G", null);
     TableConfig offlineTableConfig =
-        new TableConfig.Builder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
-            .setBrokerTenant("testBroker").setServerTenant("testServer").build();
+        new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+            .setQuotaConfig(quotaConfig).setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
+            .setSegmentPushType("APPEND").setBrokerTenant("testBroker").setServerTenant("testServer").build();
     ZKMetadataProvider.setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, offlineTableConfig.toZNRecord());
 
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
@@ -285,9 +281,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     QuotaConfig quotaConfig = new QuotaConfig("6G", "100.00");
     TableConfig offlineTableConfig =
-        new TableConfig.Builder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
-            .setBrokerTenant("testBroker").setServerTenant("testServer").build();
+        new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+            .setQuotaConfig(quotaConfig).setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
+            .setSegmentPushType("APPEND").setBrokerTenant("testBroker").setServerTenant("testServer").build();
     ZKMetadataProvider.setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, offlineTableConfig.toZNRecord());
 
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
@@ -332,10 +328,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
   @Test
   public void testNoBrokerServiceOnBrokerResource()
       throws Exception {
-    ExternalView brokerResource = new ExternalView(BROKER_RESOURCE_INSTANCE);
+    ExternalView brokerResource = new ExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
-    ZKMetadataProvider
-        .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, tableConfig.toZNRecord());
+    ZKMetadataProvider.setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, tableConfig.toZNRecord());
     setQps(tableConfig);
     _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
@@ -344,11 +339,10 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
   @Test
   public void testNoOnlineBrokerServiceOnBrokerResource()
       throws Exception {
-    ExternalView brokerResource = new ExternalView(BROKER_RESOURCE_INSTANCE);
+    ExternalView brokerResource = new ExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
     brokerResource.setState(OFFLINE_TABLE_NAME, "broker_instance_2", "OFFLINE");
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
-    ZKMetadataProvider
-        .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, tableConfig.toZNRecord());
+    ZKMetadataProvider.setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, tableConfig.toZNRecord());
     setQps(tableConfig);
     _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
 
@@ -358,7 +352,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
   }
 
   private TableConfig generateDefaultTableConfig(String tableName) {
-    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+    CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
     TableConfig.Builder builder = new TableConfig.Builder(tableType);
     builder.setTableName(tableName);
     return builder.build();
@@ -370,7 +364,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
   }
 
   private ExternalView generateBrokerResource(String tableName) {
-    ExternalView brokerResource = new ExternalView(BROKER_RESOURCE_INSTANCE);
+    ExternalView brokerResource = new ExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
     brokerResource.setState(tableName, BROKER_INSTANCE_ID, "ONLINE");
     brokerResource.setState(tableName, "broker_instance_2", "OFFLINE");
     return brokerResource;


### PR DESCRIPTION
This PR updates quota manager to reduce zk access.

Currently when a broker resource gets changed, all the tables which contains qps quota will be re-calculated. This PR reduces the zk reads.