### PR TITLE
QueryServer need not be a Runnable

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -85,11 +85,7 @@ public class QueryRoutingTest {
 
     // Start the server
     QueryServer queryServer = getQueryServer(0, responseBytes);
-    Thread thread = new Thread(queryServer);
-    thread.start();
-    while (queryServer.isNotReady()) {
-      Thread.sleep(100L);
-    }
+    queryServer.start();
 
     // OFFLINE only
     AsyncQueryResponse asyncQueryResponse =
@@ -127,7 +123,6 @@ public class QueryRoutingTest {
 
     // Shut down the server
     queryServer.shutDown();
-    thread.join();
   }
 
   @Test
@@ -137,11 +132,7 @@ public class QueryRoutingTest {
 
     // Start the server
     QueryServer queryServer = getQueryServer(0, new byte[0]);
-    Thread thread = new Thread(queryServer);
-    thread.start();
-    while (queryServer.isNotReady()) {
-      Thread.sleep(100L);
-    }
+    queryServer.start();
 
     long startTimeMs = System.currentTimeMillis();
     AsyncQueryResponse asyncQueryResponse =
@@ -159,7 +150,6 @@ public class QueryRoutingTest {
 
     // Shut down the server
     queryServer.shutDown();
-    thread.join();
   }
 
   @Test
@@ -172,11 +162,7 @@ public class QueryRoutingTest {
 
     // Start the server
     QueryServer queryServer = getQueryServer(0, responseBytes);
-    Thread thread = new Thread(queryServer);
-    thread.start();
-    while (queryServer.isNotReady()) {
-      Thread.sleep(100L);
-    }
+    queryServer.start();
 
     long startTimeMs = System.currentTimeMillis();
     AsyncQueryResponse asyncQueryResponse =
@@ -194,7 +180,6 @@ public class QueryRoutingTest {
 
     // Shut down the server
     queryServer.shutDown();
-    thread.join();
   }
 
   @Test
@@ -207,11 +192,7 @@ public class QueryRoutingTest {
 
     // Start the server
     QueryServer queryServer = getQueryServer(500, responseBytes);
-    Thread thread = new Thread(queryServer);
-    thread.start();
-    while (queryServer.isNotReady()) {
-      Thread.sleep(100L);
-    }
+    queryServer.start();
 
     long startTimeMs = System.currentTimeMillis();
     AsyncQueryResponse asyncQueryResponse =
@@ -219,7 +200,6 @@ public class QueryRoutingTest {
 
     // Shut down the server before getting the response
     queryServer.shutDown();
-    thread.join();
 
     Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getResponse();
     assertEquals(response.size(), 1);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -117,7 +117,7 @@ public class ServerInstance {
     LOGGER.info("Starting query scheduler");
     _queryScheduler.start();
     LOGGER.info("Starting query server");
-    new Thread(_queryServer).start();
+    _queryServer.start();
 
     _started = true;
     LOGGER.info("Finish starting server instance");


### PR DESCRIPTION
QueryServer (the Netty server on pinot-server to accept incoming connections from broker) is wrapped around a Runnable and the thread is just blocked waiting for the channel's close future to be completed.

By channel, I am referring to the one created during bootstrapping after bind() is completed to the local port and the server is ready to accept incoming connections (and create child channels).

A thread is not really needed since the shutdown method (called during ServerInstance shutdown) will anyway close the channel. 

Looks like the purpose of wrapping it around a thread was to prevent the caller who is starting the QueryServer from blocking since the latter would do channel.closeFuture().sync() and get blocked until we close the channel and the closeFuture is completed.