### PR TITLE
Make PQL case insensitive

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -172,7 +172,7 @@ public class HelixBrokerStarter {
     _helixExternalViewBasedQueryQuotaManager = new HelixExternalViewBasedQueryQuotaManager();
     _helixExternalViewBasedQueryQuotaManager.init(_spectatorHelixManager);
     _brokerServerBuilder = new BrokerServerBuilder(_brokerConf, _helixExternalViewBasedRouting,
-        _helixExternalViewBasedRouting.getTimeBoundaryService(), _helixExternalViewBasedQueryQuotaManager);
+        _helixExternalViewBasedRouting.getTimeBoundaryService(), _helixExternalViewBasedQueryQuotaManager, _propertyStore);
     BrokerRequestHandler brokerRequestHandler = _brokerServerBuilder.getBrokerRequestHandler();
     BrokerMetrics brokerMetrics = _brokerServerBuilder.getBrokerMetrics();
     _helixExternalViewBasedRouting.setBrokerMetrics(brokerMetrics);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixConstants.ChangeType;
 import org.apache.helix.HelixDataAccessor;
@@ -35,9 +36,12 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Message;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModelFactory;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -163,6 +167,7 @@ public class HelixBrokerStarter {
     _helixAdmin = _spectatorHelixManager.getClusterManagmentTool();
     _propertyStore = _spectatorHelixManager.getHelixPropertyStore();
     _helixDataAccessor = _spectatorHelixManager.getHelixDataAccessor();
+    ConfigAccessor configAccessor = _spectatorHelixManager.getConfigAccessor();
 
     // Set up the broker server builder
     LOGGER.info("Setting up broker server builder");
@@ -171,6 +176,13 @@ public class HelixBrokerStarter {
     _helixExternalViewBasedRouting.init(_spectatorHelixManager);
     _helixExternalViewBasedQueryQuotaManager = new HelixExternalViewBasedQueryQuotaManager();
     _helixExternalViewBasedQueryQuotaManager.init(_spectatorHelixManager);
+
+    //should we enable case_insensitive_pql
+    HelixConfigScope helixConfigScope =
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(_clusterName).build();
+    String enableCaseInsensitivePql = configAccessor.get(helixConfigScope, Helix.ENABLE_CASE_INSENSITIVE_PQL_KEY);
+    _brokerConf.setProperty(Helix.ENABLE_CASE_INSENSITIVE_PQL_KEY, Boolean.valueOf(enableCaseInsensitivePql));
+
     _brokerServerBuilder = new BrokerServerBuilder(_brokerConf, _helixExternalViewBasedRouting,
         _helixExternalViewBasedRouting.getTimeBoundaryService(), _helixExternalViewBasedQueryQuotaManager, _propertyStore);
     BrokerRequestHandler brokerRequestHandler = _brokerServerBuilder.getBrokerRequestHandler();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -358,8 +358,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       Collection<FilterQuery> values = brokerRequest.getFilterSubQueryMap().getFilterQueryMap().values();
       for (FilterQuery filterQuery : values) {
         if (filterQuery.getNestedFilterQueryIdsSize() == 0) {
-          String actualColumnName = _tableCache.getActualColumnName(actualTableName, filterQuery.getColumn());
-          filterQuery.setColumn(actualColumnName);
+          String expression = filterQuery.getColumn();
+          filterQuery.setColumn(fixColumnNameCase(actualTableName, expression));
         }
       }
     }
@@ -389,7 +389,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       List<String> selectionColumns = selection.getSelectionColumns();
       for (int i = 0; i < selectionColumns.size(); i++) {
         String expression = selectionColumns.get(i);
-        if (expression.trim().equalsIgnoreCase("*")) {
+        if (!expression.trim().equalsIgnoreCase("*")) {
           selectionColumns.set(i, fixColumnNameCase(actualTableName, expression));
         }
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.broker.api.RequestStatistics;
 import org.apache.pinot.broker.broker.AccessControlFactory;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
@@ -55,8 +57,8 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
   public SingleConnectionBrokerRequestHandler(Configuration config, RoutingTable routingTable,
       TimeBoundaryService timeBoundaryService, AccessControlFactory accessControlFactory,
-      QueryQuotaManager queryQuotaManager, BrokerMetrics brokerMetrics) {
-    super(config, routingTable, timeBoundaryService, accessControlFactory, queryQuotaManager, brokerMetrics);
+      QueryQuotaManager queryQuotaManager, BrokerMetrics brokerMetrics, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    super(config, routingTable, timeBoundaryService, accessControlFactory, queryQuotaManager, brokerMetrics, propertyStore);
     _queryRouter = new QueryRouter(_brokerId, brokerMetrics);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/transform/TransformExpressionTree.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/transform/TransformExpressionTree.java
@@ -81,7 +81,7 @@ public class TransformExpressionTree {
   }
 
   private final ExpressionType _expressionType;
-  private final String _value;
+  private String _value;
   private final List<TransformExpressionTree> _children;
 
   public TransformExpressionTree(AstNode root) {
@@ -130,6 +130,14 @@ public class TransformExpressionTree {
   }
 
   /**
+   * allows value to be set (needed to fix the case)
+   * @param value
+   */
+  public void setValue(String value) {
+    _value = value;
+  }
+
+  /**
    * Returns the children of the node.
    *
    * @return List of children
@@ -145,6 +153,14 @@ public class TransformExpressionTree {
    */
   public boolean isColumn() {
     return _expressionType == ExpressionType.IDENTIFIER;
+  }
+
+  public boolean isFunction() {
+    return _expressionType == ExpressionType.FUNCTION;
+  }
+
+  public boolean isLiteral() {
+    return _expressionType == ExpressionType.LITERAL;
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -41,6 +41,9 @@ public class CommonConstants {
     public static final String LEAD_CONTROLLER_RESOURCE_NAME = "leadControllerResource";
 
     public static final String LEAD_CONTROLLER_RESOURCE_ENABLED_KEY = "RESOURCE_ENABLED";
+    public static final String ENABLE_CASE_INSENSITIVE_PQL_KEY = "enable.case.insensitive.pql";
+
+
 
     // More information on why these numbers are set can be found in the following doc:
     // https://cwiki.apache.org/confluence/display/PINOT/Controller+Separation+between+Helix+and+Pinot

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
@@ -71,7 +71,12 @@ public class TableCache {
   public String getActualColumnName(String tableName, String columnName) {
     String schemaName = _tableConfigChangeListener._table2SchemaConfigMap.get(tableName.toLowerCase());
     if (schemaName != null) {
-      return _schemaChangeListener.getColumnName(schemaName, columnName);
+      String actualColumnName = _schemaChangeListener.getColumnName(schemaName, columnName);
+      // If actual column name doesn't exist in schema, then return the origin column name.
+      if (actualColumnName == null) {
+        return columnName;
+      }
+      return actualColumnName;
     }
     return columnName;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.helix;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.I0Itec.zkclient.IZkChildListener;
+import org.I0Itec.zkclient.IZkDataListener;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.HelixPropertyListener;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.utils.SchemaUtils;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+
+
+public class TableCache {
+  private static final String PROPERTYSTORE_SCHEMAS_PREFIX = "/SCHEMAS";
+  private static final String PROPERTYSTORE_TABLE_CONFIGS_PREFIX = "/CONFIGS/TABLE";
+
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  TableConfigChangeListener _tableConfigChangeListener;
+  SchemaChangeListener _schemaChangeListener;
+
+  public TableCache(ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _propertyStore = propertyStore;
+    _schemaChangeListener = new SchemaChangeListener();
+    _schemaChangeListener.refresh();
+    _tableConfigChangeListener = new TableConfigChangeListener();
+    _tableConfigChangeListener.refresh();
+  }
+
+  public String getActualTableName(String tableName) {
+    return _tableConfigChangeListener._tableNameMap.getOrDefault(tableName.toLowerCase(), tableName);
+  }
+
+  public String getActualColumnName(String tableName, String columnName) {
+    String schemaName = _tableConfigChangeListener._table2SchemaConfigMap.get(tableName.toLowerCase());
+    if (schemaName != null) {
+      return _schemaChangeListener.getColumnName(schemaName, columnName);
+    }
+    return columnName;
+  }
+
+  class TableConfigChangeListener implements IZkChildListener, IZkDataListener {
+
+    Map<String, TableConfig> _tableConfigMap = new ConcurrentHashMap<>();
+    Map<String, String> _tableNameMap = new ConcurrentHashMap<>();
+    Map<String, String> _table2SchemaConfigMap = new ConcurrentHashMap<>();
+
+    public synchronized void refresh() {
+      try {
+        //always subscribe first before reading, so that we dont miss any changes
+        _propertyStore.subscribeChildChanges(PROPERTYSTORE_TABLE_CONFIGS_PREFIX, _tableConfigChangeListener);
+        _propertyStore.subscribeDataChanges(PROPERTYSTORE_TABLE_CONFIGS_PREFIX, _tableConfigChangeListener);
+        List<ZNRecord> children =
+            _propertyStore.getChildren(PROPERTYSTORE_TABLE_CONFIGS_PREFIX, null, AccessOption.PERSISTENT);
+        if (children != null) {
+          for (ZNRecord znRecord : children) {
+            try {
+              TableConfig tableConfig = TableConfig.fromZnRecord(znRecord);
+              String tableNameWithType = tableConfig.getTableName();
+              _tableConfigMap.put(tableNameWithType, tableConfig);
+              String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+              //create case insensitive mapping
+              _tableNameMap.put(tableNameWithType.toLowerCase(), tableNameWithType);
+              _tableNameMap.put(rawTableName.toLowerCase(), rawTableName);
+              //create case insensitive mapping between table name and schemaName
+              _table2SchemaConfigMap.put(tableNameWithType.toLowerCase(), rawTableName);
+              _table2SchemaConfigMap.put(rawTableName.toLowerCase(), rawTableName);
+            } catch (IOException e) {
+              e.printStackTrace();
+              //ignore
+            }
+          }
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+        //ignore
+      }
+    }
+
+    @Override
+    public void handleChildChange(String s, List<String> list)
+        throws Exception {
+      refresh();
+    }
+
+    @Override
+    public void handleDataChange(String s, Object o)
+        throws Exception {
+      refresh();
+    }
+
+    @Override
+    public void handleDataDeleted(String s)
+        throws Exception {
+      refresh();
+    }
+  }
+
+  class SchemaChangeListener implements IZkChildListener, IZkDataListener {
+    Map<String, Schema> _schemaMap = new ConcurrentHashMap<>();
+    Map<String, Map<String, String>> _schemaColumnMap = new ConcurrentHashMap<>();
+
+    public synchronized void refresh() {
+      try {
+        //always subscribe first before reading, so that we dont miss any changes
+        _propertyStore.subscribeChildChanges(PROPERTYSTORE_SCHEMAS_PREFIX, _schemaChangeListener);
+        _propertyStore.subscribeDataChanges(PROPERTYSTORE_SCHEMAS_PREFIX, _schemaChangeListener);
+        List<ZNRecord> children =
+            _propertyStore.getChildren(PROPERTYSTORE_SCHEMAS_PREFIX, null, AccessOption.PERSISTENT);
+        if (children != null) {
+          for (ZNRecord znRecord : children) {
+            try {
+              Schema schema = SchemaUtils.fromZNRecord(znRecord);
+              String schemaNameLowerCase = schema.getSchemaName().toLowerCase();
+              _schemaMap.put(schemaNameLowerCase, schema);
+              Collection<FieldSpec> allFieldSpecs = schema.getAllFieldSpecs();
+              ConcurrentHashMap<String, String> columnNameMap = new ConcurrentHashMap<>();
+              _schemaColumnMap.put(schemaNameLowerCase, columnNameMap);
+              for (FieldSpec fieldSpec : allFieldSpecs) {
+                columnNameMap.put(fieldSpec.getName().toLowerCase(), fieldSpec.getName());
+              }
+            } catch (IOException e) {
+              //ignore
+            }
+          }
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+        //ignore
+      }
+    }
+
+    Schema getSchema(String schemaName) {
+      return _schemaMap.get(schemaName.toLowerCase());
+    }
+
+    String getColumnName(String schemaName, String columnName) {
+      Map<String, String> columnNameMap = _schemaColumnMap.get(schemaName.toLowerCase());
+      if (columnNameMap != null) {
+        return columnNameMap.get(columnName.toLowerCase());
+      }
+      return columnName;
+    }
+
+    @Override
+    public void handleChildChange(String s, List<String> list)
+        throws Exception {
+      refresh();
+    }
+
+    @Override
+    public void handleDataChange(String s, Object o)
+        throws Exception {
+      refresh();
+    }
+
+    @Override
+    public void handleDataDeleted(String s)
+        throws Exception {
+      refresh();
+    }
+  }
+}
+

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
@@ -134,12 +134,11 @@ public class TableCache {
   }
 
   class SchemaChangeListener implements IZkChildListener, IZkDataListener {
-    Map<String, Schema> _schemaMap = new ConcurrentHashMap<>();
     Map<String, Map<String, String>> _schemaColumnMap = new ConcurrentHashMap<>();
 
     public synchronized void refresh() {
       try {
-        //always subscribe first before reading, so that we dont miss any changes
+        //always subscribe first before reading, so that we dont miss any changes between reading and setting the watcher again
         _propertyStore.subscribeChildChanges(PROPERTYSTORE_SCHEMAS_PREFIX, _schemaChangeListener);
         _propertyStore.subscribeDataChanges(PROPERTYSTORE_SCHEMAS_PREFIX, _schemaChangeListener);
         List<ZNRecord> children =
@@ -149,7 +148,6 @@ public class TableCache {
             try {
               Schema schema = SchemaUtils.fromZNRecord(znRecord);
               String schemaNameLowerCase = schema.getSchemaName().toLowerCase();
-              _schemaMap.put(schemaNameLowerCase, schema);
               Collection<FieldSpec> allFieldSpecs = schema.getAllFieldSpecs();
               ConcurrentHashMap<String, String> columnNameMap = new ConcurrentHashMap<>();
               _schemaColumnMap.put(schemaNameLowerCase, columnNameMap);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PqlQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PqlQueryResource.java
@@ -108,6 +108,8 @@ public class PqlQueryResource {
     BrokerRequest brokerRequest;
     try {
       brokerRequest = REQUEST_COMPILER.compileToBrokerRequest(pqlQuery);
+      String inputTableName = brokerRequest.getQuerySource().getTableName();
+      brokerRequest.getQuerySource().setTableName(_pinotHelixResourceManager.getActualTableName(inputTableName));
     } catch (Exception e) {
       LOGGER.info("Caught exception while compiling PQL query: {}, {}", pqlQuery, e.getMessage());
       return QueryException.getException(QueryException.PQL_PARSING_ERROR, e).toString();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -141,8 +140,6 @@ public class PinotHelixResourceManager {
   private Builder _keyBuilder;
   private SegmentDeletionManager _segmentDeletionManager;
   private PinotLLCRealtimeSegmentManager _pinotLLCRealtimeSegmentManager;
-  Map<String, String> _tableNameCaseInsensitiveMap = new ConcurrentHashMap<>();
-  Map<String, String> _columnNameCaseInsensitiveMap = new ConcurrentHashMap<>();
   private TableCache _tableCache;
 
   public PinotHelixResourceManager(String zkURL, String helixClusterName, @Nullable String dataDir,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -43,6 +43,7 @@ import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.model.builder.CustomModeISBuilder;
 import org.apache.helix.model.builder.FullAutoModeISBuilder;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.controller.helix.core.PinotHelixBrokerResourceOnlineOfflineStateModelGenerator;
 import org.apache.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineStateModelGenerator;
@@ -75,6 +76,7 @@ public class HelixSetupUtils {
       HelixConfigScope configScope =
           new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(helixClusterName).build();
       admin.setConfig(configScope, Collections.singletonMap(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true"));
+      admin.setConfig(configScope, Collections.singletonMap(ENABLE_CASE_INSENSITIVE_PQL_KEY, Boolean.FALSE.toString()));
       LOGGER.info("New Helix cluster: {} created", helixClusterName);
     }
   }

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -98,7 +98,7 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-    <dependency>
+    <!--<dependency>
       <groupId>org.apache.helix</groupId>
       <artifactId>helix-core</artifactId>
       <exclusions>
@@ -107,7 +107,7 @@
           <artifactId>netty</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
+    </dependency>-->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -833,7 +833,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     for (String query : queries) {
       query = query.replace("mytable", "MYTABLE").replace("DaysSinceEpoch", "DAYSSinceEpOch");
       JsonNode response = postQuery(query);
-      System.out.println("response = " + response);
       Assert.assertTrue(response.get("numSegmentsProcessed").asLong() >= 1, query + " failed");
     }
   }


### PR DESCRIPTION

This PR will handle remove the restriction that table names and column names in the query must match what is defined in TableConfig and Schema.

The idea is to fix the broker request object in the beginning so that the rest of the code does not require any change.

Adding option to enable this via cluster config ```enable.case.insensitive.pql```
https://github.com/apache/incubator-pinot/issues/4902
