### PR TITLE
[TE] Fix over-scheduling tasks in data availability scheduler

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -194,7 +194,8 @@ public class ThirdEyeAnomalyApplication
         if (config.isDataAvailabilityTaskScheduler()) {
           dataAvailabilityTaskScheduler = new DataAvailabilityTaskScheduler(
               config.getDataAvailabilitySchedulingConfiguration().getSchedulerDelayInSec(),
-              config.getDataAvailabilitySchedulingConfiguration().getTaskTriggerFallBackTimeInSec());
+              config.getDataAvailabilitySchedulingConfiguration().getTaskTriggerFallBackTimeInSec(),
+              config.getDataAvailabilitySchedulingConfiguration().getSchedulingWindowInSec());
           dataAvailabilityTaskScheduler.start();
         }
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListener.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityEventListener.java
@@ -79,8 +79,8 @@ public class DataAvailabilityEventListener implements Runnable {
           LOG.info("Processing event: " + event.getDatasetName() + " with watermark " + event.getHighWatermark());
           String dataset = event.getDatasetName();
           datasetTriggerInfoRepo.setLastUpdateTimestamp(dataset, event.getHighWatermark());
-          //Note: Batch update the timestamps of dataset if the event traffic spike
-          datasetConfigManager.updateLastRefreshTime(dataset, event.getHighWatermark());
+          //Note: Batch update the timestamps of dataset if the event traffic spikes
+          datasetConfigManager.updateLastRefreshTime(dataset, event.getHighWatermark(), System.currentTimeMillis());
           ThirdeyeMetricsUtil.processedTriggerEventCounter.inc();
           LOG.debug("Finished processing event: " + event.getDatasetName());
         } catch (Exception e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DataAvailabilitySchedulingConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DataAvailabilitySchedulingConfiguration.java
@@ -20,6 +20,8 @@
 package org.apache.pinot.thirdeye.anomaly.detection.trigger.utils;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 
 /**
  * Configuration class for DataAvailabilityListener.
@@ -37,11 +39,11 @@ public class DataAvailabilitySchedulingConfiguration {
   private List<String> dataSourceWhitelist;
   private List<String> filterClassList;
   // delay time after each run for the scheduler to reduce DB polling
-  private long schedulerDelayInSec = 300; // 5 minutes
+  private long schedulerDelayInSec = TimeUnit.MINUTES.toSeconds(5);
   // default threshold if detection level threshold is not set
-  private long taskTriggerFallBackTimeInSec = 24 * 60 * 60; // 1 day
-  // scheduling window for data availability scheduling
-  private long schedulingWindowInSec = 15 * 60; // 15 minutes
+  private long taskTriggerFallBackTimeInSec = TimeUnit.DAYS.toSeconds(1);
+  // scheduling window for data availability scheduling to avoid over-scheduling if watermarks do not move forward
+  private long schedulingWindowInSec = TimeUnit.MINUTES.toSeconds(15);
 
   public String getConsumerClass() {
     return consumerClass;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DataAvailabilitySchedulingConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DataAvailabilitySchedulingConfiguration.java
@@ -37,9 +37,11 @@ public class DataAvailabilitySchedulingConfiguration {
   private List<String> dataSourceWhitelist;
   private List<String> filterClassList;
   // delay time after each run for the scheduler to reduce DB polling
-  private long schedulerDelayInSec = 300; // 5 minute
+  private long schedulerDelayInSec = 300; // 5 minutes
   // default threshold if detection level threshold is not set
   private long taskTriggerFallBackTimeInSec = 24 * 60 * 60; // 1 day
+  // scheduling window for data availability scheduling
+  private long schedulingWindowInSec = 15 * 60; // 15 minutes
 
   public String getConsumerClass() {
     return consumerClass;
@@ -143,5 +145,13 @@ public class DataAvailabilitySchedulingConfiguration {
 
   public void setTaskTriggerFallBackTimeInSec(long taskTriggerFallBackTimeInSec) {
     this.taskTriggerFallBackTimeInSec = taskTriggerFallBackTimeInSec;
+  }
+
+  public long getSchedulingWindowInSec() {
+    return schedulingWindowInSec;
+  }
+
+  public void setSchedulingWindowInSec(long schedulingWindowInSec) {
+    this.schedulingWindowInSec = schedulingWindowInSec;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/DatasetConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/DatasetConfigManager.java
@@ -31,6 +31,6 @@ public interface DatasetConfigManager extends AbstractManager<DatasetConfigDTO> 
 
   List<DatasetConfigDTO> findActiveRequiresCompletenessCheck();
 
-  void updateLastRefreshTime(String dataset, long lastRefreshTime);
+  void updateLastRefreshTime(String dataset, long lastRefreshTime, long lastEventTime);
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/DatasetConfigManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/DatasetConfigManagerImpl.java
@@ -62,9 +62,10 @@ public class DatasetConfigManagerImpl extends AbstractManagerImpl<DatasetConfigD
   }
 
   @Override
-  public void updateLastRefreshTime(String dataset, long refreshTime) {
+  public void updateLastRefreshTime(String dataset, long refreshTime, long eventTime) {
     DatasetConfigDTO datasetConfigDTO = findByDataset(dataset);
     datasetConfigDTO.setLastRefreshTime(refreshTime);
+    datasetConfigDTO.setLastRefreshEventTime(eventTime);
     update(datasetConfigDTO);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -97,6 +97,9 @@ public class DatasetConfigBean extends AbstractBean {
   private double expectedCompleteness = Wo4WAvgDataCompletenessAlgorithm.DEFAULT_EXPECTED_COMPLETENESS;
   // latest timestamp of the dataset updated by external events
   private long lastRefreshTime;
+  // timestamp of receiving the last update event
+  private long lastRefreshEventTime = 0;
+
 
   private Map<String, String> properties = new HashMap<>();
 
@@ -303,6 +306,14 @@ public class DatasetConfigBean extends AbstractBean {
 
   public void setLastRefreshTime(long lastRefreshTime) {
     this.lastRefreshTime = lastRefreshTime;
+  }
+
+  public long getLastRefreshEventTime() {
+    return lastRefreshEventTime;
+  }
+
+  public void setLastRefreshEventTime(long lastRefreshEventTime) {
+    this.lastRefreshEventTime = lastRefreshEventTime;
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskSchedulerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskSchedulerTest.java
@@ -79,7 +79,8 @@ public class DataAvailabilityTaskSchedulerTest {
     metric1.setDerived(false);
     metric2.setAlias("");
     metricId2 = metricConfigManager.save(metric2);
-    dataAvailabilityTaskScheduler = new DataAvailabilityTaskScheduler(60, 24 * 60 * 60, 15 * 60);
+    dataAvailabilityTaskScheduler = new DataAvailabilityTaskScheduler(60,
+        TimeUnit.DAYS.toSeconds(1), TimeUnit.MINUTES.toSeconds(15));
   }
 
   @AfterMethod

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskSchedulerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskSchedulerTest.java
@@ -79,7 +79,7 @@ public class DataAvailabilityTaskSchedulerTest {
     metric1.setDerived(false);
     metric2.setAlias("");
     metricId2 = metricConfigManager.save(metric2);
-    dataAvailabilityTaskScheduler = new DataAvailabilityTaskScheduler(60, 24 * 60 * 60);
+    dataAvailabilityTaskScheduler = new DataAvailabilityTaskScheduler(60, 24 * 60 * 60, 15 * 60);
   }
 
   @AfterMethod
@@ -91,8 +91,8 @@ public class DataAvailabilityTaskSchedulerTest {
   public void testCreateOneTask() {
     List<Long> metrics = Arrays.asList(metricId1, metricId2);
     long detectionId = createDetection(1, metrics, TEST_TIME - TimeUnit.DAYS.toMillis(1),0);
-    createDataset(1, TEST_TIME);
-    createDataset(2, TEST_TIME);
+    createDataset(1, TEST_TIME, TEST_TIME);
+    createDataset(2, TEST_TIME, TEST_TIME);
     dataAvailabilityTaskScheduler.run();
     TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
     List<TaskDTO> tasks = taskManager.findAll();
@@ -110,8 +110,8 @@ public class DataAvailabilityTaskSchedulerTest {
     long detection2 = createDetection(2, metrics1, oneDayAgo, 0);
     List<Long> singleMetric = Collections.singletonList(metricId2);
     long detection3 = createDetection(3, singleMetric, oneDayAgo, 0);
-    createDataset(1, TEST_TIME);
-    createDataset(2, TEST_TIME);
+    createDataset(1, TEST_TIME, TEST_TIME);
+    createDataset(2, TEST_TIME, TEST_TIME);
     dataAvailabilityTaskScheduler.run();
     TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
     List<TaskDTO> tasks = taskManager.findAll();
@@ -131,8 +131,8 @@ public class DataAvailabilityTaskSchedulerTest {
     List<Long> metrics1 = Arrays.asList(metricId1, metricId2);
     long detection1 = createDetection(1, metrics1, TEST_TIME, 0);
     long detection2 = createDetection(2, Collections.singletonList(metricId2), TEST_TIME, 0);
-    createDataset(1, TEST_TIME + TimeUnit.HOURS.toMillis(1)); // updated dataset
-    createDataset(2, TEST_TIME - TimeUnit.HOURS.toMillis(1)); // not updated dataset
+    createDataset(1, TEST_TIME + TimeUnit.HOURS.toMillis(1), TEST_TIME); // updated dataset
+    createDataset(2, TEST_TIME - TimeUnit.HOURS.toMillis(1), TEST_TIME); // not updated dataset
     createDetectionTask(detection1, TEST_TIME - 60_000, TaskConstants.TaskStatus.COMPLETED);
     createDetectionTask(detection2, TEST_TIME - 60_000, TaskConstants.TaskStatus.COMPLETED);
     DetectionConfigManager detectionConfigManager = DAORegistry.getInstance().getDetectionConfigManager();
@@ -151,8 +151,8 @@ public class DataAvailabilityTaskSchedulerTest {
     long detection1 = createDetection(1, metrics1, oneDayAgo, 0);
     long detection2 = createDetection(2, Collections.singletonList(metricId2), oneDayAgo, 0);
     long detection3 = createDetection(3, Collections.singletonList(metricId2), oneDayAgo, 2 * 24 * 60 * 60);
-    createDataset(1, oneDayAgo - 60_000); // not updated dataset
-    createDataset(2, oneDayAgo - 60_000); // not updated dataset
+    createDataset(1, oneDayAgo - 60_000, TEST_TIME); // not updated dataset
+    createDataset(2, oneDayAgo - 60_000, TEST_TIME); // not updated dataset
     createDetectionTask(detection1, oneDayAgo - 60_000, TaskConstants.TaskStatus.COMPLETED);
     createDetectionTask(detection2, oneDayAgo - 60_000, TaskConstants.TaskStatus.COMPLETED);
     createDetectionTask(detection3, oneDayAgo - 60_000, TaskConstants.TaskStatus.COMPLETED);
@@ -172,8 +172,8 @@ public class DataAvailabilityTaskSchedulerTest {
     long detection2 = createDetection(2, metrics1, oneDayAgo, 0);
     List<Long> singleMetric = Collections.singletonList(metricId2);
     long detection3 = createDetection(3, singleMetric, oneDayAgo, 0);
-    createDataset(1, TEST_TIME);
-    createDataset(2, TEST_TIME);
+    createDataset(1, TEST_TIME, TEST_TIME);
+    createDataset(2, TEST_TIME, TEST_TIME);
     createDetectionTask(detection1, oneDayAgo, TaskConstants.TaskStatus.RUNNING);
     dataAvailabilityTaskScheduler.run();
     TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
@@ -190,11 +190,31 @@ public class DataAvailabilityTaskSchedulerTest {
         new HashSet<>(Arrays.asList(tasks.get(1).getJobName(), tasks.get(2).getJobName())));
   }
 
-  private long createDataset(int intSuffix, long refreshTime) {
+  @Test
+  public void testScheduleOutOfSchedulingWindow() {
+    List<Long> metrics1 = Collections.singletonList(metricId1);
+    long oneDayAgo = TEST_TIME - TimeUnit.DAYS.toMillis(1);
+    long detection1 = createDetection(1, metrics1, oneDayAgo, 0);
+    long halfHourAgo = TEST_TIME - TimeUnit.MINUTES.toMillis(30);
+    List<Long> metrics2 = Arrays.asList(metricId1, metricId2);
+    long detection2 = createDetection(2, metrics2, oneDayAgo, 0);
+    createDataset(1, TEST_TIME, halfHourAgo);
+    createDataset(2, TEST_TIME, TEST_TIME);
+    TaskManager taskManager = DAORegistry.getInstance().getTaskDAO();
+    Assert.assertEquals(taskManager.findAll().size(), 0);
+    dataAvailabilityTaskScheduler.run();
+    List<TaskDTO> tasks = taskManager.findAll();
+    Assert.assertEquals(tasks.size(), 1);
+    Assert.assertEquals(TaskConstants.TaskType.DETECTION.toString() + "_" + detection2,
+        tasks.get(0).getJobName());
+  }
+
+  private long createDataset(int intSuffix, long refreshTime, long refreshEventTime) {
     DatasetConfigManager datasetConfigDAO = DAORegistry.getInstance().getDatasetConfigDAO();
     DatasetConfigDTO ds1 = new DatasetConfigDTO();
     ds1.setDataset(TEST_DATASET_PREFIX + intSuffix);
     ds1.setLastRefreshTime(refreshTime);
+    ds1.setLastRefreshEventTime(refreshEventTime);
     return datasetConfigDAO.save(ds1);
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/rootcause/MockDatasetConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/rootcause/MockDatasetConfigManager.java
@@ -84,7 +84,7 @@ public class MockDatasetConfigManager extends AbstractMockManager<DatasetConfigD
   }
 
   @Override
-  public void updateLastRefreshTime(String dataset, long lastRefreshTime) {
+  public void updateLastRefreshTime(String dataset, long lastRefreshTime, long lastEventTime) {
     throw new AssertionError("not implemented");
   }
 }


### PR DESCRIPTION
This PR is to fix the issue when detection jobs doesn't move the watermark forward and the data availability keeps scheduling detection tasks for the same detection. To solve it, we add scheduling window logic in which the scheduler only schedule new detection tasks. If the watermark does not move forward for any reason after the detection job runs, the scheduler will try scheduling it a few times and stop due to being out of the scheduling window. 