### PR TITLE
Decouple server instance id with hostname/port config.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -192,9 +192,6 @@ public class CommonConstants {
     public static final String CONFIG_OF_REQUEST_HANDLER_FACTORY_CLASS = "pinot.server.requestHandlerFactory.class";
     public static final String CONFIG_OF_NETTY_PORT = "pinot.server.netty.port";
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.server.adminapi.port";
-    // A logical instance id is one which does not contain server host name and/or port info. E.g., server1.
-    // It is by default disabled.
-    public static final String CONFIG_OF_USE_LOGICAL_INSTANCE_ID = "pinot.server.logical.instance.id.enabled";
 
     public static final String CONFIG_OF_SEGMENT_FORMAT_VERSION = "pinot.server.instance.segment.format.version";
     public static final String CONFIG_OF_ENABLE_SPLIT_COMMIT = "pinot.server.instance.enable.split.commit";

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -192,6 +192,9 @@ public class CommonConstants {
     public static final String CONFIG_OF_REQUEST_HANDLER_FACTORY_CLASS = "pinot.server.requestHandlerFactory.class";
     public static final String CONFIG_OF_NETTY_PORT = "pinot.server.netty.port";
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.server.adminapi.port";
+    // A logical instance id is one which does not contain server host name and/or port info. E.g., server1.
+    // It is by default disabled.
+    public static final String CONFIG_OF_USE_LOGICAL_INSTANCE_ID = "pinot.server.logical.instance.id.enabled";
 
     public static final String CONFIG_OF_SEGMENT_FORMAT_VERSION = "pinot.server.instance.segment.format.version";
     public static final String CONFIG_OF_ENABLE_SPLIT_COMMIT = "pinot.server.instance.enable.split.commit";

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 import static org.apache.pinot.common.utils.CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST;
 import static org.apache.pinot.common.utils.CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT;
 import static org.apache.pinot.common.utils.CommonConstants.Server.CONFIG_OF_INSTANCE_ID;
-import static org.apache.pinot.common.utils.CommonConstants.Server.CONFIG_OF_USE_LOGICAL_INSTANCE_ID;
 import static org.testng.Assert.assertEquals;
 
 
@@ -101,13 +100,11 @@ public class ServerStarterIntegrationTest extends ControllerTest {
   }
 
   @Test
-  public void testUsingLogicalServerID()
+  public void testInstanceIdWithHostPortInfo()
       throws Exception {
     // Test the behavior when logical server id and hostname/port are all specified in server conf.
-    // Note that we need to turn on the CONFIG_OF_USE_LOGICAL_INSTANCE_ID flag to overwrite the host port info.
+    // Unlike testInstanceIdOnly(), the host and port info will be overwritten with those in config.
     Configuration serverConf = new PropertiesConfiguration();
-    // Need to explicitly turn this flag on.
-    serverConf.setProperty(CONFIG_OF_USE_LOGICAL_INSTANCE_ID, true);
     serverConf.setProperty(CONFIG_OF_INSTANCE_ID, SERVER1);
     serverConf.setProperty(KEY_OF_SERVER_NETTY_HOST, "host1");
     serverConf.setProperty(KEY_OF_SERVER_NETTY_PORT, 10001);
@@ -120,13 +117,11 @@ public class ServerStarterIntegrationTest extends ControllerTest {
   }
 
   @Test
-  public void testDisableLogicalServerID()
+  public void testInstanceIdOnly()
       throws Exception {
     // If the CONFIG_OF_USE_LOGICAL_INSTANCE_ID flag is NOT on, no server host/port info overwrite will happen.
     Configuration serverConf = new PropertiesConfiguration();
     serverConf.setProperty(CONFIG_OF_INSTANCE_ID, SERVER1);
-    serverConf.setProperty(KEY_OF_SERVER_NETTY_HOST, "host1");
-    serverConf.setProperty(KEY_OF_SERVER_NETTY_PORT, 10001);
     // Start the server
     HelixServerStarter helixServerStarter =
         new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.server.starter.helix.HelixServerStarter;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.common.utils.CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT;
+import static org.apache.pinot.common.utils.CommonConstants.Server.CONFIG_OF_INSTANCE_ID;
+import static org.apache.pinot.common.utils.CommonConstants.Server.CONFIG_OF_USE_LOGICAL_INSTANCE_ID;
+import static org.testng.Assert.assertEquals;
+
+
+public class ServerStarterIntegrationTest extends ControllerTest {
+  public static final String DEFAULT_SERVER_ID = "Server_127.0.0.1_8098";
+  public static final String SERVER1 = "Server1";
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+    startController();
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    stopController();
+    stopZk();
+  }
+
+  @Test
+  public void testWithNoInstanceIdNoHostnamePort()
+      throws Exception {
+    // Test the behavior when no instance id nor hostname/port is specified in server conf.
+    Configuration serverConf = new PropertiesConfiguration();
+    // Start the server
+    HelixServerStarter helixServerStarter =
+        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
+
+    // Verify the serverId, host and port are set correctly in Zk.
+    HelixManager helixManager = helixServerStarter.getHelixManager();
+    PropertyKey.Builder keyBuilder = helixManager.getHelixDataAccessor().keyBuilder();
+    InstanceConfig config =  helixManager.getHelixDataAccessor().getProperty(keyBuilder.instanceConfig(DEFAULT_SERVER_ID));
+    helixServerStarter.stop();
+
+    assertEquals(config.getInstanceName(), DEFAULT_SERVER_ID);
+    // By default (auto joined instances), server instance name is of format: {@code Server_<hostname>_<port>}, e.g.
+    // {@code Server_localhost_12345}, hostname is of format: {@code Server_<hostname>}, e.g. {@code Server_localhost}.
+    // More details refer to the class ServerInstance.
+    assertEquals(config.getHostName(), "Server_127.0.0.1");
+    assertEquals(config.getPort(), "8098");
+  }
+
+  @Test
+  public void testWithNoInstanceIdButWithHostnamePort()
+      throws Exception {
+    // Test the behavior when no instance id specified but hostname/port is specified in server conf.
+    Configuration serverConf = new PropertiesConfiguration();
+    serverConf.setProperty(KEY_OF_SERVER_NETTY_HOST, "host1");
+    serverConf.setProperty(KEY_OF_SERVER_NETTY_PORT, 10001);
+    // Start the server
+    HelixServerStarter helixServerStarter =
+        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
+
+    // Verify the serverId, host and port are set correctly in Zk.
+    HelixManager helixManager = helixServerStarter.getHelixManager();
+    PropertyKey.Builder keyBuilder = helixManager.getHelixDataAccessor().keyBuilder();
+    InstanceConfig config =  helixManager.getHelixDataAccessor().getProperty(keyBuilder.instanceConfig("Server_host1_10001"));
+    helixServerStarter.stop();
+
+    assertEquals(config.getInstanceName(), "Server_host1_10001");
+    assertEquals(config.getHostName(), "Server_host1");
+    assertEquals(config.getPort(), "10001");
+  }
+
+  @Test
+  public void testUsingLogicalServerID()
+      throws Exception {
+    // Test the behavior when logical server id and hostname/port are all specified in server conf.
+    // Note that we need to turn on the CONFIG_OF_USE_LOGICAL_INSTANCE_ID flag to overwrite the host port info.
+    Configuration serverConf = new PropertiesConfiguration();
+    // Need to explicitly turn this flag on.
+    serverConf.setProperty(CONFIG_OF_USE_LOGICAL_INSTANCE_ID, true);
+    serverConf.setProperty(CONFIG_OF_INSTANCE_ID, SERVER1);
+    serverConf.setProperty(KEY_OF_SERVER_NETTY_HOST, "host1");
+    serverConf.setProperty(KEY_OF_SERVER_NETTY_PORT, 10001);
+    // Start the server
+    HelixServerStarter helixServerStarter =
+        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
+
+    // Verify the serverId, host and port are set correctly in Zk.
+    HelixManager helixManager = helixServerStarter.getHelixManager();
+    PropertyKey.Builder keyBuilder = helixManager.getHelixDataAccessor().keyBuilder();
+    InstanceConfig config =  helixManager.getHelixDataAccessor().getProperty(keyBuilder.instanceConfig(SERVER1));
+    helixServerStarter.stop();
+
+    assertEquals(config.getInstanceName(), SERVER1);
+    assertEquals(config.getHostName(), "host1");
+    assertEquals(config.getPort(), "10001");
+  }
+
+  @Test
+  public void testDisableLogicalServerID()
+      throws Exception {
+    // If the CONFIG_OF_USE_LOGICAL_INSTANCE_ID flag is NOT on, no server host/port info overwrite will happen.
+    Configuration serverConf = new PropertiesConfiguration();
+    serverConf.setProperty(CONFIG_OF_INSTANCE_ID, SERVER1);
+    serverConf.setProperty(KEY_OF_SERVER_NETTY_HOST, "host1");
+    serverConf.setProperty(KEY_OF_SERVER_NETTY_PORT, 10001);
+    // Start the server
+    HelixServerStarter helixServerStarter =
+        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
+
+    // Verify the serverId, host and port are set correctly in Zk.
+    HelixManager helixManager = helixServerStarter.getHelixManager();
+    PropertyKey.Builder keyBuilder = helixManager.getHelixDataAccessor().keyBuilder();
+    InstanceConfig config =  helixManager.getHelixDataAccessor().getProperty(keyBuilder.instanceConfig(SERVER1));
+    helixServerStarter.stop();
+
+    assertEquals(config.getInstanceName(), SERVER1);
+    // Note that helix will use INSTANCE_ID to extract the hostname instead of using netty host/port in config.
+    assertEquals(config.getHostName(), SERVER1);
+    assertEquals(config.getPort(), "");
+  }
+
+  @Test
+  public void testSetInstanceIdToHostname()
+      throws Exception {
+    // Test the behavior when no instance id nor hostname/port is specified in server conf.
+    // Compared with testWithNoInstanceIdNoHostnamePort(), here the server id use hostname (i.e., localhost) instead of
+    // host address (i.e., 127.0.0.1).
+    Configuration serverConf = new PropertiesConfiguration();
+    serverConf.setProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, true);
+    // Start the server
+    HelixServerStarter helixServerStarter =
+        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
+
+    // Verify the serverId, host and port are set correctly in Zk.
+    HelixManager helixManager = helixServerStarter.getHelixManager();
+    PropertyKey.Builder keyBuilder = helixManager.getHelixDataAccessor().keyBuilder();
+    InstanceConfig config =  helixManager.getHelixDataAccessor().getProperty(keyBuilder.instanceConfig("Server_localhost_8098"));
+    helixServerStarter.stop();
+
+    assertEquals(config.getInstanceName(), "Server_localhost_8098");
+    // By default (auto joined instances), server instance name is of format: {@code Server_<hostname>_<port>}, e.g.
+    // {@code Server_localhost_12345}, hostname is of format: {@code Server_<hostname>}, e.g. {@code Server_localhost}.
+    // More details refer to the class ServerInstance.
+    assertEquals(config.getHostName(), "Server_localhost");
+    assertEquals(config.getPort(), "8098");
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -119,7 +119,6 @@ public class ServerStarterIntegrationTest extends ControllerTest {
   @Test
   public void testInstanceIdOnly()
       throws Exception {
-    // If the CONFIG_OF_USE_LOGICAL_INSTANCE_ID flag is NOT on, no server host/port info overwrite will happen.
     Configuration serverConf = new PropertiesConfiguration();
     serverConf.setProperty(CONFIG_OF_INSTANCE_ID, SERVER1);
     // Start the server

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -80,8 +80,9 @@ public class ServerStarterIntegrationTest extends ControllerTest {
     // Start the server.
     HelixServerStarter helixServerStarter =
         new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
-    verifyZkConfigData(helixServerStarter, helixServerStarter.getHelixManager().getInstanceName(),
-        helixServerStarter.getHelixManager().getInstanceName(), "8098");
+    String expectedInstanceName = helixServerStarter.getHelixManager().getInstanceName();
+    String expectedHostname = expectedInstanceName.substring(0, expectedInstanceName.lastIndexOf('_'));
+    verifyZkConfigData(helixServerStarter, expectedInstanceName, expectedHostname, "8098");
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -80,8 +80,8 @@ public class ServerStarterIntegrationTest extends ControllerTest {
     // Start the server.
     HelixServerStarter helixServerStarter =
         new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
-    verifyZkConfigData(helixServerStarter, helixServerStarter.getHelixManager().getInstanceName(), "Server_127.0.0.1",
-        "8098");
+    verifyZkConfigData(helixServerStarter, helixServerStarter.getHelixManager().getInstanceName(),
+        helixServerStarter.getHelixManager().getInstanceName(), "8098");
   }
 
   @Test

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -288,8 +288,10 @@ public class HelixServerStarter {
       instanceConfig.setPort(Integer.toString(_serverConf.getInt(KEY_OF_SERVER_NETTY_PORT, DEFAULT_SERVER_NETTY_PORT)));
       // Use setProperty instead of _helixAdmin.setInstanceConfig because the latter explicitly forbids instance host
       // port modification.
-      if(!_helixManager.getHelixDataAccessor().setProperty(
+      if(_helixManager.getHelixDataAccessor().setProperty(
           _helixManager.getHelixDataAccessor().keyBuilder().instanceConfig(instanceName), instanceConfig)) {
+        LOGGER.info("Updated server hostname/port successfully for server id {} to {}:", instanceName, instanceConfig);
+      } else {
         LOGGER.error("Failed to update hostname/port for instance: {}", instanceName);
         // Treat this is as a fatal error.
         System.exit(1);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -31,6 +31,7 @@ import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
@@ -294,7 +295,7 @@ public class HelixServerStarter {
       } else {
         LOGGER.error("Failed to update hostname/port for instance: {}", instanceName);
         // Treat this is as a fatal error.
-        System.exit(1);
+        throw new HelixException("Failed to update hostname/port for instance " + instanceName);
       }
     }
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -287,15 +287,18 @@ public class HelixServerStarter {
     if (serverConf.containsKey(CONFIG_OF_INSTANCE_ID)) {
       // Internally, Helix use instanceId to derive Hostname and Port. To decouple them, explicitly set the hostname/port
       // field in zk.
-      String hostName = _serverConf.getString(KEY_OF_SERVER_NETTY_HOST);
+      String hostName = serverConf.getString(KEY_OF_SERVER_NETTY_HOST);
       if (hostName != null && !hostName.equals(instanceConfig.getHostName())) {
         instanceConfig.setHostName(hostName);
         toUpdateHelixRecord = true;
       }
-      String portStr = Integer.toString(_serverConf.getInt(KEY_OF_SERVER_NETTY_PORT, DEFAULT_SERVER_NETTY_PORT));
-      if (portStr!= null && !portStr.equals(instanceConfig.getPort())) {
-        instanceConfig.setPort(portStr);
-        toUpdateHelixRecord = true;
+
+      if (serverConf.containsKey(KEY_OF_SERVER_NETTY_PORT)) {
+        String portStr = Integer.toString(serverConf.getInt(KEY_OF_SERVER_NETTY_PORT));
+        if (portStr != null && !portStr.equals(instanceConfig.getPort())) {
+          instanceConfig.setPort(portStr);
+          toUpdateHelixRecord = true;
+        }
       }
     }
     if (!toUpdateHelixRecord) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -284,12 +284,19 @@ public class HelixServerStarter {
     // If the server config has both instance_id and host/port info, overwrite the host/port info in zk. Without the
     // overwrite, Helix will extract host/port from the instance_id instead of use those in config.
     // Use serverConf instead of _serverConf as the latter has been modified.
-    if (serverConf.containsKey(CONFIG_OF_INSTANCE_ID) && serverConf.containsKey(KEY_OF_SERVER_NETTY_HOST)) {
-      toUpdateHelixRecord = true;
+    if (serverConf.containsKey(CONFIG_OF_INSTANCE_ID)) {
       // Internally, Helix use instanceId to derive Hostname and Port. To decouple them, explicitly set the hostname/port
       // field in zk.
-      instanceConfig.setHostName(_serverConf.getString(KEY_OF_SERVER_NETTY_HOST));
-      instanceConfig.setPort(Integer.toString(_serverConf.getInt(KEY_OF_SERVER_NETTY_PORT, DEFAULT_SERVER_NETTY_PORT)));
+      String hostName = _serverConf.getString(KEY_OF_SERVER_NETTY_HOST);
+      if (hostName != null && !hostName.equals(instanceConfig.getHostName())) {
+        instanceConfig.setHostName(hostName);
+        toUpdateHelixRecord = true;
+      }
+      String port = _serverConf.getString(KEY_OF_SERVER_NETTY_PORT);
+      if (port != null && !port.equals(instanceConfig.getPort())) {
+        instanceConfig.setPort(port);
+        toUpdateHelixRecord = true;
+      }
     }
     if (!toUpdateHelixRecord) {
       return;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -292,9 +292,9 @@ public class HelixServerStarter {
         instanceConfig.setHostName(hostName);
         toUpdateHelixRecord = true;
       }
-      String port = _serverConf.getString(KEY_OF_SERVER_NETTY_PORT);
-      if (port != null && !port.equals(instanceConfig.getPort())) {
-        instanceConfig.setPort(port);
+      String portStr = Integer.toString(_serverConf.getInt(KEY_OF_SERVER_NETTY_PORT, DEFAULT_SERVER_NETTY_PORT));
+      if (portStr!= null && !portStr.equals(instanceConfig.getPort())) {
+        instanceConfig.setPort(portStr);
         toUpdateHelixRecord = true;
       }
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -146,8 +146,10 @@ public class HelixServerStarter {
 
     LOGGER.info("Connecting Helix manager");
     _helixManager.connect();
-    // Overwrite the server netty host and port.
-    if (_serverConf.getBoolean(CONFIG_OF_USE_LOGICAL_INSTANCE_ID, false)) {
+    // If the server config has both instance_id and host/port info, overwrite the host/port info in zk. Without the
+    // overwrite, Helix will extract host/port from the instance_id instead of use those in config.
+    // Use serverConf instead of _serverConf as the latter has been modified.
+    if (serverConf.containsKey(CONFIG_OF_INSTANCE_ID) && serverConf.containsKey(KEY_OF_SERVER_NETTY_HOST)) {
       overwriteServerHostInfo();
     }
 


### PR DESCRIPTION
Currently Helix will derived hostname/port from the server instanceId string (as demonstrated in the test _testDisableLogicalServerID()_) if the instance id is set in server config. This PR decouples the configuration of server instance id and hostname/port.  This allows Pinot user to set the following field independently:

- Instance ID

- server_netty_host

- server_netty_port

This is done by overwriting the Helix zk data after server connects to the zk cluster. It is hidden behind a flag now so the current use cases will not be affected.

Also added an integration test to test different configuration choices for servers.

@mayankshriv @Jackie-Jiang @icefury71 

Issue link #4525