### PR TITLE
Fixing java 11 runtime issues

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -93,6 +93,26 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
@@ -197,6 +197,18 @@
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-integration-tests</artifactId>
       <version>${project.version}</version>

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -107,6 +107,37 @@ if [ -n "$CLASSPATH_PREFIX" ] ; then
   CLASSPATH=$CLASSPATH_PREFIX:$CLASSPATH
 fi
 
+if [ -z "$PLUGINS_DIR" ] ; then
+  PLUGINS_DIR="$BASEDIR"/plugins
+fi
+
+if [[ -d "$PLUGINS_DIR" ]] ; then
+  if [ -n "$PLUGINS_INCLUDE" ] ; then
+    IFS=';' read -ra PLUGINS_ARR <<< "$PLUGINS_INCLUDE"
+    for PLUGIN_JAR in "${PLUGINS_ARR[@]}"; do
+        PLUGIN_JAR_PATH=$(find "$PLUGINS_DIR" -name "$PLUGIN_JAR.jar")
+        if [ -n "$PLUGINS_CLASSPATH" ] ; then
+          PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR_PATH
+        else
+          PLUGINS_CLASSPATH=$PLUGIN_JAR_PATH
+        fi
+    done
+  else
+    PLUGIN_JARS=$(find "$PLUGINS_DIR" -name \*.jar)
+    for PLUGIN_JAR in $PLUGIN_JARS ; do
+      if [ -n "$PLUGINS_CLASSPATH" ] ; then
+        PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR
+      else
+        PLUGINS_CLASSPATH=$PLUGIN_JAR
+      fi
+    done
+  fi
+fi
+
+if [ -n "$PLUGINS_CLASSPATH" ] ; then
+  CLASSPATH=$CLASSPATH:$PLUGINS_CLASSPATH
+fi
+
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
   [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
@@ -117,7 +148,7 @@ if $cygwin; then
 fi
 
 if [ -z "$JAVA_OPTS" ] ; then
-  ALL_JAVA_OPTS="@EXTRA_JVM_ARGUMENTS@"
+  ALL_JAVA_OPTS="--add-exports java.base/jdk.internal.ref=ALL-UNNAMED @EXTRA_JVM_ARGUMENTS@"
 else
   ALL_JAVA_OPTS=$JAVA_OPTS
 fi

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -18,6 +18,33 @@
 # under the License.
 #
 
+jdk_version() {
+  local result
+  local java_cmd='java'
+  local IFS=$'\n'
+  # remove \r for Cygwin
+  local lines=$("$java_cmd" -Xms32M -Xmx32M -version 2>&1 | tr '\r' '\n')
+  if [[ -z $java_cmd ]]
+  then
+    result=no_java
+  else
+    for line in $lines; do
+      if [[ (-z $result) && ($line = *"version \""*) ]]
+      then
+        local ver=$(echo $line | sed -e 's/.*version "\(.*\)"\(.*\)/\1/; 1q')
+        # on macOS, sed doesn't support '?'
+        if [[ $ver = "1."* ]]
+        then
+          result=$(echo $ver | sed -e 's/1\.\([0-9]*\)\(.*\)/\1/; 1q')
+        else
+          result=$(echo $ver | sed -e 's/\([0-9]*\)\(.*\)/\1/; 1q')
+        fi
+      fi
+    done
+  fi
+  echo "$result"
+}
+
 # resolve links - $0 may be a softlink
 PRG="$0"
 
@@ -107,35 +134,46 @@ if [ -n "$CLASSPATH_PREFIX" ] ; then
   CLASSPATH=$CLASSPATH_PREFIX:$CLASSPATH
 fi
 
-if [ -z "$PLUGINS_DIR" ] ; then
-  PLUGINS_DIR="$BASEDIR"/plugins
-fi
 
-if [[ -d "$PLUGINS_DIR" ]] ; then
-  if [ -n "$PLUGINS_INCLUDE" ] ; then
-    IFS=';' read -ra PLUGINS_ARR <<< "$PLUGINS_INCLUDE"
-    for PLUGIN_JAR in "${PLUGINS_ARR[@]}"; do
-        PLUGIN_JAR_PATH=$(find "$PLUGINS_DIR" -name "$PLUGIN_JAR.jar")
-        if [ -n "$PLUGINS_CLASSPATH" ] ; then
-          PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR_PATH
-        else
-          PLUGINS_CLASSPATH=$PLUGIN_JAR_PATH
-        fi
-    done
-  else
-    PLUGIN_JARS=$(find "$PLUGINS_DIR" -name \*.jar)
-    for PLUGIN_JAR in $PLUGIN_JARS ; do
-      if [ -n "$PLUGINS_CLASSPATH" ] ; then
-        PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR
+JAVA_VER="$(jdk_version)"
+
+# For java 9 and later version, we need to explicitly set Pinot Plugins directory into classpath.
+if [[ "$JAVA_VER" -gt 8 ]] ; then
+  # Set $PLUGINS_CLASSPATH for plugin jars to be put into classpath.
+  # $PLUGINS_DIR and $PLUGINS_INCLUDE are used if $PLUGINS_CLASSPATH is not set.
+  # $PLUGINS_DIR is the root directory of plugins directory, default to '"$BASEDIR"/plugins' if not set.
+  # $PLUGINS_INCLUDE is semi-colon separated plugins name, e.g. pinot-avro;pinot-batch-ingestion-standalone. Default is not set, which means load all the plugin jars.
+  if [ -z "$PLUGINS_CLASSPATH" ] ; then
+    if [ -z "$PLUGINS_DIR" ] ; then
+      PLUGINS_DIR="$BASEDIR"/plugins
+    fi
+    if [[ -d "$PLUGINS_DIR" ]] ; then
+      if [ -n "$PLUGINS_INCLUDE" ] ; then
+        IFS=';' read -ra PLUGINS_ARR <<< "$PLUGINS_INCLUDE"
+        for PLUGIN_JAR in "${PLUGINS_ARR[@]}"; do
+            PLUGIN_JAR_PATH=$(find "$PLUGINS_DIR" -path \*/"$PLUGIN_JAR"/"$PLUGIN_JAR"-\*.jar)
+            if [ -n "$PLUGINS_CLASSPATH" ] ; then
+              PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR_PATH
+            else
+              PLUGINS_CLASSPATH=$PLUGIN_JAR_PATH
+            fi
+        done
       else
-        PLUGINS_CLASSPATH=$PLUGIN_JAR
+        PLUGIN_JARS=$(find "$PLUGINS_DIR" -name \*.jar)
+        for PLUGIN_JAR in $PLUGIN_JARS ; do
+          if [ -n "$PLUGINS_CLASSPATH" ] ; then
+            PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR
+          else
+            PLUGINS_CLASSPATH=$PLUGIN_JAR
+          fi
+        done
       fi
-    done
+    fi
   fi
-fi
 
-if [ -n "$PLUGINS_CLASSPATH" ] ; then
-  CLASSPATH=$CLASSPATH:$PLUGINS_CLASSPATH
+  if [ -n "$PLUGINS_CLASSPATH" ] ; then
+    CLASSPATH=$CLASSPATH:$PLUGINS_CLASSPATH
+  fi
 fi
 
 # For Cygwin, switch paths to Windows format before running java
@@ -148,9 +186,14 @@ if $cygwin; then
 fi
 
 if [ -z "$JAVA_OPTS" ] ; then
-  ALL_JAVA_OPTS="--add-exports java.base/jdk.internal.ref=ALL-UNNAMED @EXTRA_JVM_ARGUMENTS@"
+  ALL_JAVA_OPTS="@EXTRA_JVM_ARGUMENTS@"
 else
   ALL_JAVA_OPTS=$JAVA_OPTS
+fi
+
+# For java 9 and later, we need to set extra java options to access JDK’s internal APIs.
+if [[ "$JAVA_VER" -gt 8 ]] ; then
+  ALL_JAVA_OPTS="--add-exports java.base/jdk.internal.ref=ALL-UNNAMED $ALL_JAVA_OPTS"
 fi
 
 exec "$JAVACMD" $ALL_JAVA_OPTS \

--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,26 @@
         <version>2.0.1.Final</version>
       </dependency>
       <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <version>1.1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.helix</groupId>
         <artifactId>helix-core</artifactId>
         <version>${helix.version}</version>


### PR DESCRIPTION
By running existing code with java 11, we are facing issues:
1. Missing several jars after packing, e.g. java.lang.NoClassDefFoundError: javax/activation/DataSource
2. java.base/jdk.internal.ref is not exported anymore after java 9
3. Plugins are not loaded during runtime from plugins load, so need to change start script to add plugins jars into classpath.
