### PR TITLE
Make PQL use LIMIT N if TOP N is not set

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/SelectAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/SelectAstNode.java
@@ -136,10 +136,14 @@ public class SelectAstNode extends BaseAstNode {
     }
 
     // If there is a topN clause, set it on the group by
+    // if topN is not present, set it with LIMIT;
+    // if Limit is not present, set it with DEFAULT.
     GroupBy groupBy = brokerRequest.getGroupBy();
     if (groupBy != null) {
       if (_topN != -1) {
         groupBy.setTopN(_topN);
+      } else if (_recordLimit != -1) {
+        groupBy.setTopN(_recordLimit);
       } else {
         // Pinot quirk: default to top 10
         groupBy.setTopN(DEFAULT_RECORD_LIMIT);

--- a/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
@@ -183,6 +183,25 @@ public class Pql2CompilerTest {
   }
 
   @Test
+  public void testGroupByTopLimitBehavior() {
+    boolean previousFailOnConversionErrorValue = Pql2Compiler.FAIL_ON_CONVERSION_ERROR;
+    Pql2Compiler.FAIL_ON_CONVERSION_ERROR = false;
+    BrokerRequest brokerRequest =
+        COMPILER.compileToBrokerRequest("select count(*) from myTable group by dimA top 200");
+    Assert.assertEquals(brokerRequest.getGroupBy().getTopN(), 200);
+    brokerRequest =
+        COMPILER.compileToBrokerRequest("select count(*) from myTable group by dimA limit 300");
+    Assert.assertEquals(brokerRequest.getGroupBy().getTopN(), 300);
+    brokerRequest =
+        COMPILER.compileToBrokerRequest("select count(*) from myTable group by dimA");
+    Assert.assertEquals(brokerRequest.getGroupBy().getTopN(), 10);
+    brokerRequest =
+        COMPILER.compileToBrokerRequest("select count(*) from myTable group by dimA top 200 LIMIT 300");
+    Assert.assertEquals(brokerRequest.getGroupBy().getTopN(), 200);
+    Pql2Compiler.FAIL_ON_CONVERSION_ERROR = previousFailOnConversionErrorValue;
+  }
+
+  @Test
   public void testRejectInvalidLexerToken() {
     assertCompilationFails("select foo from bar where baz ?= 2");
     assertCompilationFails("select foo from bar where baz =! 2");


### PR DESCRIPTION
Make group by query to use `LIMIT N` to set _topN field if `TOP N` is not present.
