### PR TITLE
Supress runtime logging warnings for java 11

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -140,7 +140,6 @@
                 <maxMemorySize>1G</maxMemorySize>
                 <extraArguments>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-tools-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -153,7 +152,6 @@
                 <extraArguments>
                   <extraArgument>-XX:MaxDirectMemorySize=30g</extraArgument>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-admin-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -166,7 +164,6 @@
                 <extraArguments>
                   <extraArgument>-XX:MaxDirectMemorySize=30g</extraArgument>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-tools-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -179,7 +176,6 @@
                 <extraArguments>
                   <extraArgument>-XX:MaxDirectMemorySize=30g</extraArgument>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-tools-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -192,7 +188,6 @@
                 <extraArguments>
                   <extraArgument>-XX:MaxDirectMemorySize=30g</extraArgument>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-tools-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -204,7 +199,6 @@
                 <maxMemorySize>1G</maxMemorySize>
                 <extraArguments>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-tools-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -216,7 +210,6 @@
                 <maxMemorySize>1G</maxMemorySize>
                 <extraArguments>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-tools-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -228,7 +221,6 @@
                 <maxMemorySize>1G</maxMemorySize>
                 <extraArguments>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-controller-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -240,7 +232,6 @@
                 <maxMemorySize>1G</maxMemorySize>
                 <extraArguments>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-broker-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -252,7 +243,6 @@
                 <maxMemorySize>1G</maxMemorySize>
                 <extraArguments>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-server-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -264,7 +254,6 @@
                 <maxMemorySize>1G</maxMemorySize>
                 <extraArguments>
                   <extraArgument>-Dlog4j2.configurationFile=conf/quickstart-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -277,7 +266,6 @@
                 <extraArguments>
                   <extraArgument>-XX:MaxDirectMemorySize=6g</extraArgument>
                   <extraArgument>-Dlog4j2.configurationFile=conf/quickstart-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -289,7 +277,6 @@
                 <maxMemorySize>1G</maxMemorySize>
                 <extraArguments>
                   <extraArgument>-Dlog4j2.configurationFile=conf/quickstart-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>
@@ -301,7 +288,6 @@
                 <maxMemorySize>1G</maxMemorySize>
                 <extraArguments>
                   <extraArgument>-Dlog4j2.configurationFile=conf/pinot-ingestion-job-log4j2.xml</extraArgument>
-                  <extraJvmArguments>-Dplugins.dir=@BASEDIR@/plugins</extraJvmArguments>
                 </extraArguments>
               </jvmSettings>
             </program>

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -187,6 +187,11 @@ fi
 
 if [ -z "$JAVA_OPTS" ] ; then
   ALL_JAVA_OPTS="@EXTRA_JVM_ARGUMENTS@"
+
+  # For java 8, we set jvm system property `plugins.dir` to load Pinot plugins
+  if [[ "$JAVA_VER" -eq 8 ]] ; then
+    ALL_JAVA_OPTS="$ALL_JAVA_OPTS -Dplugins.dir=$BASEDIR/plugins"
+  fi
 else
   ALL_JAVA_OPTS=$JAVA_OPTS
 fi

--- a/pinot-tools/src/main/resources/conf/pinot-admin-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-admin-log4j2.xml
@@ -48,5 +48,9 @@
     <AsyncLogger name="org.apache.pinot.tools.admin" level="info" additivity="false">
       <AppenderRef ref="console"/>
     </AsyncLogger>
+    <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+    <AsyncLogger name="org.apache.pinot.spi.plugin" level="error" additivity="false">
+      <AppenderRef ref="console"/>
+    </AsyncLogger>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/pinot-broker-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-broker-log4j2.xml
@@ -43,5 +43,6 @@
     <AsyncLogger name="org.apache.pinot.broker.broker.helix.HelixBrokerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>
     </AsyncLogger>
+    <AsyncLogger name="org.reflections" level="error" additivity="false"/>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/pinot-controller-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-controller-log4j2.xml
@@ -43,5 +43,6 @@
     <AsyncLogger name="org.apache.pinot.controller.ControllerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>
     </AsyncLogger>
+    <AsyncLogger name="org.reflections" level="error" additivity="false"/>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/pinot-ingestion-job-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-ingestion-job-log4j2.xml
@@ -41,5 +41,6 @@
       <AppenderRef ref="console"/>
       <AppenderRef ref="ingestionJobLog"/>
     </AsyncLogger>
+    <AsyncLogger name="org.reflections" level="error" additivity="false"/>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/pinot-server-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-server-log4j2.xml
@@ -43,5 +43,6 @@
     <AsyncLogger name="org.apache.pinot.server.starter.helix.HelixServerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>
     </AsyncLogger>
+    <AsyncLogger name="org.reflections" level="error" additivity="false"/>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/pinot-tools-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-tools-log4j2.xml
@@ -71,5 +71,9 @@
     <AsyncLogger name="org.apache.pinot.core.query" level="info" additivity="false">
       <AppenderRef ref="serverLog"/>
     </AsyncLogger>
+    <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+    <AsyncLogger name="org.apache.pinot.spi.plugin" level="error" additivity="false">
+      <AppenderRef ref="console"/>
+    </AsyncLogger>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/quickstart-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/quickstart-log4j2.xml
@@ -71,5 +71,9 @@
     <AsyncLogger name="org.apache.pinot.core.query" level="info" additivity="false">
       <AppenderRef ref="serverLog"/>
     </AsyncLogger>
+    <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+    <AsyncLogger name="org.apache.pinot.spi.plugin" level="error" additivity="false">
+      <AppenderRef ref="console"/>
+    </AsyncLogger>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
1. Suppress logging level of package `org.reflections` to error
2. Append jvm system property to only java 8 `-Dplugins.dir=$BASEDIR/plugins`

here are sample stacktrace:
```
could not get type for name org.eclipse.jetty.npn.NextProtoNego$ClientProvider from any class loader
org.reflections.ReflectionsException: could not get type for name org.eclipse.jetty.npn.NextProtoNego$ClientProvider
	at org.reflections.ReflectionUtils.forName(ReflectionUtils.java:390) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at org.reflections.Reflections.expandSuperTypes(Reflections.java:381) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at org.reflections.Reflections.<init>(Reflections.java:126) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at io.swagger.jaxrs.config.BeanConfig.classes(BeanConfig.java:276) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at io.swagger.jaxrs.config.BeanConfig.scanAndRead(BeanConfig.java:240) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at io.swagger.jaxrs.config.BeanConfig.setScan(BeanConfig.java:221) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at org.apache.pinot.broker.broker.BrokerAdminApiApplication.setupSwagger(BrokerAdminApiApplication.java:76) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at org.apache.pinot.broker.broker.BrokerAdminApiApplication.start(BrokerAdminApiApplication.java:64) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at org.apache.pinot.broker.broker.BrokerServerBuilder.start(BrokerServerBuilder.java:92) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at org.apache.pinot.broker.broker.helix.HelixBrokerStarter.start(HelixBrokerStarter.java:192) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at org.apache.pinot.tools.admin.command.StartBrokerCommand.execute(StartBrokerCommand.java:126) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at org.apache.pinot.tools.admin.PinotAdministrator.execute(PinotAdministrator.java:148) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	at org.apache.pinot.tools.admin.PinotAdministrator.main(PinotAdministrator.java:160) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.npn.NextProtoNego$ClientProvider
	at jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581) ~[?:?]
	at jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:521) ~[?:?]
	at org.reflections.ReflectionUtils.forName(ReflectionUtils.java:388) ~[pinot-all-0.3.0-SNAPSHOT-jar-with-dependencies.jar:0.3.0-SNAPSHOT-604a8ab18af9e8f4b35c163f02cf57b3fcce25b4]
	... 12 more
```
Complete missing classes are:
```
org.reflections.ReflectionsException: could not get type for name org.osgi.framework.BundleListener
org.reflections.ReflectionsException: could not get type for name org.apache.log4j.EnhancedPatternLayout
org.reflections.ReflectionsException: could not get type for name org.conscrypt.BufferAllocator
org.reflections.ReflectionsException: could not get type for name shaded.com.fasterxml.jackson.dataformat.xml.JacksonXmlModule
org.reflections.ReflectionsException: could not get type for name org.glassfish.grizzly.connectionpool.Endpoint
org.reflections.ReflectionsException: could not get type for name shaded.com.fasterxml.jackson.dataformat.xml.XmlMapper
org.reflections.ReflectionsException: could not get type for name javax.mail.Authenticator
org.reflections.ReflectionsException: could not get type for name io.netty.internal.tcnative.SniHostNameMatcher
org.reflections.ReflectionsException: could not get type for name org.apache.commons.jxpath.ri.model.NodePointer
org.reflections.ReflectionsException: could not get type for name org.jctools.queues.MessagePassingQueue$Consumer
org.reflections.ReflectionsException: could not get type for name jersey.repackaged.com.google.common.base.Predicate
org.reflections.ReflectionsException: could not get type for name scala.util.parsing.combinator.RegexParsers
org.reflections.ReflectionsException: could not get type for name org.eclipse.jetty.alpn.ALPN$ClientProvider
org.reflections.ReflectionsException: could not get type for name org.conscrypt.HandshakeListener
org.reflections.ReflectionsException: could not get type for name org.pentaho.aggdes.model.Table
org.reflections.ReflectionsException: could not get type for name org.osgi.framework.BundleActivator
org.reflections.ReflectionsException: could not get type for name org.glassfish.grizzly.connectionpool.MultiEndpointPool$EndpointPoolCustomizer
org.reflections.ReflectionsException: could not get type for name org.jboss.marshalling.ByteOutput
org.reflections.ReflectionsException: could not get type for name org.osgi.framework.SynchronousBundleListener
org.reflections.ReflectionsException: could not get type for name org.jvnet.fastinfoset.VocabularyApplicationData
org.reflections.ReflectionsException: could not get type for name org.conscrypt.AllocatedBuffer
org.reflections.ReflectionsException: could not get type for name io.netty.internal.tcnative.CertificateRequestedCallback
org.reflections.ReflectionsException: could not get type for name io.netty.internal.tcnative.CertificateVerifier
org.reflections.ReflectionsException: could not get type for name shaded.com.fasterxml.jackson.dataformat.xml.util.DefaultXmlPrettyPrinter
org.reflections.ReflectionsException: could not get type for name org.apache.log4j.FileAppender
org.reflections.ReflectionsException: could not get type for name org.jboss.marshalling.ByteInput
org.reflections.ReflectionsException: could not get type for name org.osgi.util.tracker.ServiceTracker
org.reflections.ReflectionsException: could not get type for name org.eclipse.jetty.alpn.ALPN$ServerProvider
org.reflections.ReflectionsException: could not get type for name org.apache.commons.jxpath.ri.model.NodeIterator
org.reflections.ReflectionsException: could not get type for name org.eclipse.jetty.npn.NextProtoNego$ServerProvider
org.reflections.ReflectionsException: could not get type for name org.pentaho.aggdes.model.StatisticsProvider
org.reflections.ReflectionsException: could not get type for name org.jctools.queues.MpscArrayQueue
org.reflections.ReflectionsException: could not get type for name org.pentaho.aggdes.model.Schema
org.reflections.ReflectionsException: could not get type for name org.pentaho.aggdes.model.Attribute
org.reflections.ReflectionsException: could not get type for name org.apache.commons.jxpath.ri.model.NodePointerFactory
org.reflections.ReflectionsException: could not get type for name org.codehaus.janino.JavaSourceClassLoader
org.reflections.ReflectionsException: could not get type for name org.glassfish.grizzly.websockets.WebSocketListener
org.reflections.ReflectionsException: could not get type for name org.eclipse.jetty.npn.NextProtoNego$ClientProvider
```