### PR TITLE
Calcite SQL compiler syntax support for order by expression and set LENIENT SQL conformance

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -80,7 +80,7 @@ public class PinotQuery2BrokerRequestConverter {
   }
 
   private void convertOrderBy(PinotQuery pinotQuery, BrokerRequest brokerRequest) {
-    if (brokerRequest.getSelections() == null || pinotQuery.getOrderByList() == null) {
+    if (pinotQuery.getOrderByList() == null) {
       return;
     }
     List<SelectionSort> sortSequenceList = new ArrayList<>();
@@ -94,7 +94,10 @@ public class PinotQuery2BrokerRequestConverter {
       sortSequenceList.add(selectionSort);
     }
     if (!sortSequenceList.isEmpty()) {
-      brokerRequest.getSelections().setSelectionSortSequence(sortSequenceList);
+      if (brokerRequest.getSelections() != null) {
+        brokerRequest.getSelections().setSelectionSortSequence(sortSequenceList);
+      }
+      brokerRequest.setOrderBy(sortSequenceList);
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -224,17 +224,16 @@ public class CalciteSqlParser {
     final SqlKind kind = node.getKind();
     Expression expression;
     switch (kind) {
-      case IDENTIFIER:
-        expression = RequestUtils.getFunctionExpression("ASC");
-        expression.getFunctionCall().addToOperands(toExpression(node));
-        break;
       case DESCENDING:
         SqlBasicCall basicCall = (SqlBasicCall) node;
         expression = RequestUtils.getFunctionExpression("DESC");
         expression.getFunctionCall().addToOperands(toExpression(basicCall.getOperands()[0]));
         break;
+      case IDENTIFIER:
       default:
-        throw new RuntimeException("Unknown node type: " + node.getKind());
+        expression = RequestUtils.getFunctionExpression("ASC");
+        expression.getFunctionCall().addToOperands(toExpression(node));
+        break;
     }
     return expression;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -38,6 +38,7 @@ import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSelectKeyword;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.function.FunctionDefinitionRegistry;
 import org.apache.pinot.common.request.DataSource;
@@ -111,6 +112,7 @@ public class CalciteSqlParser {
   private static PinotQuery compileCalciteSqlToPinotQuery(String sql) {
     SqlParser.ConfigBuilder parserBuilder = SqlParser.configBuilder();
     parserBuilder.setLex(PINOT_LEX);
+    parserBuilder.setConformance(SqlConformanceEnum.LENIENT);
     SqlParser sqlParser = SqlParser.create(sql, parserBuilder.build());
     final SqlNode sqlNode;
     try {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -185,12 +185,40 @@ public class CalciteSqlCompilerTest {
     testTopZeroFor("select count(*) from someTable where c = 5 group by X ORDER BY $1 LIMIT -1", -1, true);
   }
 
+  @Test
+  public void testLimitOffsets() {
+    PinotQuery pinotQuery;
+    try {
+      pinotQuery =
+          CalciteSqlParser.compileToPinotQuery("select a, b, c from meetupRsvp order by a, b, c limit 100 offset 200");
+    } catch (SqlCompilationException e) {
+      throw e;
+    }
+    // Test PinotQuery
+    Assert.assertTrue(pinotQuery.isSetLimit());
+    Assert.assertEquals(100, pinotQuery.getLimit());
+    Assert.assertTrue(pinotQuery.isSetOffset());
+    Assert.assertEquals(200, pinotQuery.getOffset());
+
+    try {
+      pinotQuery =
+          CalciteSqlParser.compileToPinotQuery("select a, b, c from meetupRsvp order by a, b, c limit 200,100");
+    } catch (SqlCompilationException e) {
+      throw e;
+    }
+    // Test PinotQuery
+    Assert.assertTrue(pinotQuery.isSetLimit());
+    Assert.assertEquals(100, pinotQuery.getLimit());
+    Assert.assertTrue(pinotQuery.isSetOffset());
+    Assert.assertEquals(200, pinotQuery.getOffset());
+  }
 
   @Test
   public void testGroupbys() {
     PinotQuery pinotQuery;
     try {
-      pinotQuery = CalciteSqlParser.compileToPinotQuery("select sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count) limit 10");
+      pinotQuery = CalciteSqlParser.compileToPinotQuery(
+          "select sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count) limit 10");
     } catch (SqlCompilationException e) {
       throw e;
     }
@@ -199,11 +227,14 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(pinotQuery.isSetLimit());
     Assert.assertTrue(pinotQuery.isSetOrderByList());
     Assert.assertEquals(pinotQuery.getOrderByList().get(0).getType(), ExpressionType.FUNCTION);
-    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "SUM");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "SUM");
     Assert.assertEquals(10, pinotQuery.getLimit());
 
     try {
-      pinotQuery = CalciteSqlParser.compileToPinotQuery("select group_city, sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count), count(*) limit 10");
+      pinotQuery = CalciteSqlParser.compileToPinotQuery(
+          "select group_city, sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count), count(*) limit 10");
     } catch (SqlCompilationException e) {
       throw e;
     }
@@ -212,10 +243,18 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(pinotQuery.isSetLimit());
     Assert.assertTrue(pinotQuery.isSetOrderByList());
     Assert.assertEquals(pinotQuery.getOrderByList().get(0).getType(), ExpressionType.FUNCTION);
-    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "SUM");
-    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "rsvp_count");
-    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "COUNT");
-    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "*");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "SUM");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
+            .getIdentifier().getName(), "rsvp_count");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "COUNT");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
+            .getIdentifier().getName(), "*");
     Assert.assertEquals(10, pinotQuery.getLimit());
   }
 
@@ -282,8 +321,8 @@ public class CalciteSqlCompilerTest {
         CalciteSqlParser.compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'");
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "NOT_EQUALS");
 
-    // Bang equal '!=' is not allowed under the current SQL conformance level
-    assertCompilationFails("select * from vegetables where name != 'Brussels sprouts'");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where name != 'Brussels sprouts'");
+    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "NOT_EQUALS");
   }
 
   @Test


### PR DESCRIPTION
1. To support query with order by expressions like:
```
select group_city, sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count), count(*) limit 10
```
2. Use LIMIT with GROUP BY to display records.

3. Set SQL conformance LENIENT to make below query syntax works:
- Support `LIMIT offset,count` in Calcite Parser
- Support `!=` as not equal in Calcite Parser