### PR TITLE
Add FieldConfig to encapsulate a column's encoding and indexing info

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/FieldConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/FieldConfig.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+
+public class FieldConfig extends BaseJsonConfig {
+  private final String _name;
+  private final EncodingType _encodingType;
+  private final IndexType _indexType;
+  private final Map<String, String> _properties;
+
+  public static String BLOOM_FILTER_COLUMN_KEY = "field.config.bloom.filter";
+  public static String ON_HEAP_DICTIONARY_COLUMN_KEY = "field.config.onheap.dictionary";
+  public static String TEXT_INDEX_REALTIME_READER_REFRESH_KEY = "field.config.realtime.reader.refresh";
+  public static String VAR_LENGTH_DICTIONARY_COLUMN_KEY = "field.config.var.length.dictionary";
+
+  @JsonCreator
+  public FieldConfig(@JsonProperty(value = "name", required = true) String name,
+      @JsonProperty(value = "encodingType") @Nullable EncodingType encodingType,
+      @JsonProperty(value = "indexType") @Nullable IndexType indexType,
+      @JsonProperty(value = "properties") @Nullable Map<String, String> properties) {
+    _name = name;
+    _encodingType = encodingType;
+    _indexType = indexType;
+    _properties = properties;
+  }
+
+  // If null, we will create dictionary encoded forward index by default
+  public enum EncodingType {
+    RAW, DICTIONARY
+  }
+
+  // If null, there won't be any index
+  public enum IndexType {
+    INVERTED, SORTED, TEXT
+  }
+
+  public EncodingType getEncodingType() {
+    return _encodingType;
+  }
+
+  public IndexType getIndexType() {
+    return _indexType;
+  }
+
+  public String getName() {
+    return _name;
+  }
+
+  public Map<String, String> getProperties() {
+    return _properties;
+  }
+}


### PR DESCRIPTION
TableConfig can take a list of FieldConfig to encapsulate storage, indexing and any other information for a field.

**Motivation:**

As part of [text search feature](https://github.com/apache/incubator-pinot/pull/4993), we need to add a new set of columns to IndexingConfig : something like TextIndexConfig and capture the information required for text indexes: column name and some additional properties used by the implementation.

While this is good and in accordance with the existing model for specifying the per column encoding and indexing info, it is not very clean and interspersed throughout the IndexingConfig.

This PR implements a new model to store the per column encoding and indexing info encapsulated into FieldConfig object. TableConfig can take a list of FieldConfig. A FieldConfig is self-descriptive about the encoding and indexing info for the column along with additional properties.

Please read this document (also shared in the open source community) to know more details, migration plan from existing model to new model etc.

https://docs.google.com/document/d/1PyULfbLOYa5OexZMqbP_MZgg-338flKETJOKWS5en3g/edit