### PR TITLE
fixing converting PinotQuery to BrokerRequest for group by clause with selections

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/parsers/utils/BrokerRequestComparisonUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/parsers/utils/BrokerRequestComparisonUtils.java
@@ -60,6 +60,10 @@ public class BrokerRequestComparisonUtils {
           LOGGER.error("FilterSubQueryMap did not match after conversion. {}", sb);
           return false;
         }
+      } else if (br2.getFilterQuery() != null) {
+        LOGGER.error("Filter did not match, br1.getFilterQuery() = null, br2.getFilterQuery() = {}",
+            br2.getFilterQuery());
+        return false;
       }
       if (br1.getSelections() != null) {
         if (!validateSelections(br1.getSelections(), br2.getSelections())) {
@@ -68,6 +72,10 @@ public class BrokerRequestComparisonUtils {
           LOGGER.error("Selection did not match after conversion:{}", sb);
           return false;
         }
+      } else if (br2.getSelections() != null) {
+        LOGGER.error("Selection did not match, br1.getSelections() = null, br2.getSelections() = {}",
+            br2.getSelections());
+        return false;
       }
       if (br1.getGroupBy() != null) {
         if (!validateGroupBy(br1.getGroupBy(), br2.getGroupBy())) {
@@ -76,6 +84,10 @@ public class BrokerRequestComparisonUtils {
           LOGGER.error("Group By did not match conversion:{}", sb);
           return false;
         }
+      } else if (br2.getGroupBy() != null) {
+        LOGGER.error("tGroupBy did not match, br1.getGroupBy() = null, br2.getGroupBy() = {}",
+            br2.getGroupBy());
+        return false;
       }
       if (br1.getAggregationsInfo() != null) {
         if (!validateAggregations(br1.getAggregationsInfo(), br2.getAggregationsInfo())) {
@@ -84,6 +96,10 @@ public class BrokerRequestComparisonUtils {
           LOGGER.error("Group By did not match conversion:{}", sb);
           return false;
         }
+      } else if (br2.getAggregationsInfo() != null) {
+        LOGGER.error("AggregationsInfo did not match, br1.getAggregationsInfo() = null, br2.getAggregationsInfo() = {}",
+            br2.getAggregationsInfo());
+        return false;
       }
       if (br1.getOrderBy() != null) {
         if (!validateOrderBys(br1.getOrderBy(), br2.getOrderBy())) {
@@ -92,6 +108,10 @@ public class BrokerRequestComparisonUtils {
           LOGGER.error("Order By did not match conversion:{}", sb);
           return false;
         }
+      } else if (br2.getOrderBy() != null) {
+        LOGGER.error("OrderBy did not match, br1.getOrderBy() = null, br2.getOrderBy() = {}",
+            br2.getOrderBy());
+        return false;
       }
     }
     return true;

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -154,7 +154,9 @@ public class PinotQuery2BrokerRequestConverter {
       }
     }
 
-    if (selection != null) {
+    if (aggregationInfoList != null && aggregationInfoList.size() > 0) {
+      brokerRequest.setAggregationsInfo(aggregationInfoList);
+    } else if (selection != null) {
       if (pinotQuery.isSetOffset()) {
         selection.setOffset(pinotQuery.getOffset());
       }
@@ -162,10 +164,6 @@ public class PinotQuery2BrokerRequestConverter {
         selection.setSize(pinotQuery.getLimit());
       }
       brokerRequest.setSelections(selection);
-    }
-
-    if (aggregationInfoList != null && aggregationInfoList.size() > 0) {
-      brokerRequest.setAggregationsInfo(aggregationInfoList);
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -20,9 +20,11 @@ package org.apache.pinot.sql.parsers;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.calcite.config.Lex;
@@ -90,6 +92,34 @@ public class CalciteSqlParser {
     // Set Option statements to PinotQuery.
     setOptions(pinotQuery, options);
     return pinotQuery;
+  }
+
+  static void validate(PinotQuery pinotQuery)
+      throws SqlCompilationException {
+    // Sanity check group by query: All identifiers in selection list should be also included in group by list.
+    if (pinotQuery.getGroupByList() != null) {
+      Set<String> groupbyIdentifier = extractIdentifiers(pinotQuery.getGroupByList());
+      for (Expression selectExpresion : pinotQuery.getSelectList()) {
+        if (selectExpresion.getIdentifier() != null) {
+          String identifier = selectExpresion.getIdentifier().getName();
+          if (!groupbyIdentifier.contains(identifier)) {
+            throw new SqlCompilationException("'" + identifier + "' should appear in GROUP BY clause.");
+          }
+        }
+      }
+    }
+  }
+
+  private static Set<String> extractIdentifiers(List<Expression> expressions) {
+    Set<String> identifiers = new HashSet<>();
+    for (Expression expression : expressions) {
+      if (expression.getIdentifier() != null) {
+        identifiers.add(expression.getIdentifier().getName());
+      } else if (expression.getFunctionCall() != null) {
+        identifiers.addAll(extractIdentifiers(expression.getFunctionCall().getOperands()));
+      }
+    }
+    return identifiers;
   }
 
   private static void setOptions(PinotQuery pinotQuery, List<String> optionsStatements) {
@@ -174,6 +204,7 @@ public class CalciteSqlParser {
         throw new RuntimeException(
             "Unable to convert SqlNode: " + sqlNode + " to PinotQuery. Unknown node type: " + sqlNode.getKind());
     }
+    validate(pinotQuery);
     return pinotQuery;
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -218,6 +218,23 @@ public class CalciteSqlCompilerTest {
     PinotQuery pinotQuery;
     try {
       pinotQuery = CalciteSqlParser.compileToPinotQuery(
+          "select sum(rsvp_count), count(*), group_city from meetupRsvp group by group_city order by sum(rsvp_count) limit 10");
+    } catch (SqlCompilationException e) {
+      throw e;
+    }
+    // Test PinotQuery
+    Assert.assertTrue(pinotQuery.isSetGroupByList());
+    Assert.assertTrue(pinotQuery.isSetLimit());
+    Assert.assertTrue(pinotQuery.isSetOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getType(), ExpressionType.FUNCTION);
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "SUM");
+    Assert.assertEquals(10, pinotQuery.getLimit());
+
+
+    try {
+      pinotQuery = CalciteSqlParser.compileToPinotQuery(
           "select sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count) limit 10");
     } catch (SqlCompilationException e) {
       throw e;
@@ -831,5 +848,18 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(aggregationInfo.getAggregationType(), AggregationFunctionType.DISTINCT.getName());
     Assert.assertEquals(aggregationInfo.getAggregationParams().get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO),
         "add(div(col1,col2),mul(col3,col4)):sub(col3,col4):col5:col6");
+  }
+
+  @Test
+  public void testQueryValidationFailure() {
+    String sql;
+    try {
+      sql = "select group_city,group_country, sum(rsvp_count), count(*) from meetupRsvp group by group_country, sum(rsvp_count), count(*) limit 50";
+      CalciteSqlParser.compileToPinotQuery(sql);
+      Assert.fail("Query should have failed compilation");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof SqlCompilationException);
+      Assert.assertTrue(e.getMessage().contains("'group_city' should appear in GROUP BY clause."));
+    }
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -232,7 +232,6 @@ public class CalciteSqlCompilerTest {
         "SUM");
     Assert.assertEquals(10, pinotQuery.getLimit());
 
-
     try {
       pinotQuery = CalciteSqlParser.compileToPinotQuery(
           "select sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count) limit 10");
@@ -851,15 +850,41 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
-  public void testQueryValidationFailure() {
-    String sql;
+  public void testQueryValidation() {
+    // Valid: Selection fields are part of group by identifiers.
+    String sql =
+        "select group_country, sum(rsvp_count), count(*) from meetupRsvp group by group_city, group_country ORDER BY sum(rsvp_count), count(*) limit 50";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    Assert.assertEquals(pinotQuery.getGroupByListSize(), 2);
+    Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
+
+    // Invalid: Selection field 'group_city' is not part of group by identifiers.
     try {
-      sql = "select group_city,group_country, sum(rsvp_count), count(*) from meetupRsvp group by group_country, sum(rsvp_count), count(*) limit 50";
+      sql =
+          "select group_city, group_country, sum(rsvp_count), count(*) from meetupRsvp group by group_country ORDER BY sum(rsvp_count), count(*) limit 50";
       CalciteSqlParser.compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
       Assert.assertTrue(e.getMessage().contains("'group_city' should appear in GROUP BY clause."));
+    }
+
+    // Valid groupBy non-aggregate function should pass.
+    sql =
+        "select secondsSinceEpoch, sum(rsvp_count), count(*) from meetupRsvp group by dateConvert(secondsSinceEpoch) limit 50";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
+    Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
+
+    // Invalid groupBy clause shouldn't contain aggregate expression, like sum(rsvp_count), count(*).
+    try {
+      sql =
+          "select  sum(rsvp_count), count(*) from meetupRsvp group by group_country, sum(rsvp_count), count(*) limit 50";
+      CalciteSqlParser.compileToPinotQuery(sql);
+      Assert.fail("Query should have failed compilation");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof SqlCompilationException);
+      Assert.assertTrue(e.getMessage().contains("is not allowed in GROUP BY clause."));
     }
   }
 }


### PR DESCRIPTION
- Fixing the issue that for Aggregation Group by query, we don't set selection field in BrokerRequest.
- added a simple validation logic to fail query if selected field(s) not mentioned in group by clause.
E.g. `SELECT col_a, col_b FROM myTable GROUP BY col_a`
- added a validation logic to prevent aggregation expressions in group by clause.