### PR TITLE
Enhance TableRebalancer to support reassigning COMPLETED segments when instances changed

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitions.java
@@ -39,6 +39,11 @@ import org.apache.pinot.spi.utils.JsonUtils;
  *   <li>
  *     Partition: a set of instances that contains the segments of the same partition (value partition for offline
  *     table, or stream partition for real-time table)
+ *     <p>NOTE: For real-time table CONSUMING instance partitions, partition cannot be explicitly configured (number of
+ *     partitions must be 1), but has to be derived from the index of the instance. Each instance will contain all the
+ *     segments from a stream partition before them getting relocated to the COMPLETED instance partitions. The stream
+ *     partitions will be evenly spread over all instances (within each replica-group if replica-group is configured).
+ *     <p>TODO: Support explicit partition configuration for CONSUMING instance partitions
  *   </li>
  *   <li>
  *     Replica-group: a set of instances that contains one replica of all the segments

--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitionsUtils.java
@@ -52,27 +52,18 @@ public class InstancePartitionsUtils {
   }
 
   /**
-   * Fetches the instance partitions from Helix property store if exists, or computes it for backward-compatibility.
+   * Fetches the instance partitions from Helix property store if it exists, or computes it for backward-compatibility.
    */
   public static InstancePartitions fetchOrComputeInstancePartitions(HelixManager helixManager, TableConfig tableConfig,
       InstancePartitionsType instancePartitionsType) {
     String tableNameWithType = tableConfig.getTableName();
 
-    // Fetch the instance partitions from property store if exists
+    // Fetch the instance partitions from property store if it exists
     ZkHelixPropertyStore<ZNRecord> propertyStore = helixManager.getHelixPropertyStore();
     InstancePartitions instancePartitions =
         fetchInstancePartitions(propertyStore, getInstancePartitionsName(tableNameWithType, instancePartitionsType));
     if (instancePartitions != null) {
       return instancePartitions;
-    }
-
-    // Use the CONSUMING instance partitions for COMPLETED segments if exists
-    if (instancePartitionsType == InstancePartitionsType.COMPLETED) {
-      InstancePartitions consumingInstancePartitions = fetchInstancePartitions(propertyStore,
-          getInstancePartitionsName(tableNameWithType, InstancePartitionsType.CONSUMING));
-      if (consumingInstancePartitions != null) {
-        return consumingInstancePartitions;
-      }
     }
 
     // Compute the default instance partitions (for backward-compatibility)

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
@@ -165,8 +165,17 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
       assertEquals(instanceStateMap.size(), NUM_REPLICAS);
     }
 
-    // Rebalance should relocate all COMPLETED (ONLINE) segments to the COMPLETED instances
-    Map<String, Map<String, String>> newAssignment =
+    // Rebalance without COMPLETED instance partitions should not change the segment assignment
+    Map<InstancePartitionsType, InstancePartitions> noRelocationInstancePartitionsMap = new TreeMap<>();
+    noRelocationInstancePartitionsMap
+        .put(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
+    Map<String, Map<String, String>> newAssignment = _segmentAssignment
+        .rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, new BaseConfiguration());
+    assertEquals(newAssignment, currentAssignment);
+
+    // Rebalance with COMPLETED instance partitions should relocate all COMPLETED (ONLINE) segments to the COMPLETED
+    // instances
+    newAssignment =
         _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, new BaseConfiguration());
     assertEquals(newAssignment.size(), NUM_SEGMENTS);
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
@@ -194,10 +203,15 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
     Arrays.fill(expectedNumSegmentsAssignedPerInstance, numSegmentsPerInstance);
     assertEquals(numSegmentsAssignedPerInstance, expectedNumSegmentsAssignedPerInstance);
 
-    // Rebalance all segments (including CONSUMING) should give the same assignment
+    // Rebalance with COMPLETED instance partitions including CONSUMING segments should give the same assignment
     BaseConfiguration config = new BaseConfiguration();
     config.setProperty(RebalanceConfigConstants.INCLUDE_CONSUMING, true);
     assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, config), newAssignment);
+
+    // Rebalance without COMPLETED instance partitions again should change the segment assignment back
+    assertEquals(
+        _segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, new BaseConfiguration()),
+        currentAssignment);
 
     // Rebalance should not change the assignment for the OFFLINE segments
     String offlineSegmentName = "offlineSegment";


### PR DESCRIPTION
Motivation:
Currently when we change the instances for a LLC realtime table,
there is no way to reassign COMPLETED segments to align with the
partitions of the CONSUMING segments. This feature is especially
important when partition-aware routing is enabled for the table.
Right now we manually calculate the assignment and replace it in
ZK, which is both troublesome and risky, and we cannot leverage
the no-downtime rebalance.

Change:
When COMPLETED instance partitions are not provided (do not
relocate COMPLETED segments), reassign COMPLETED segments the same
way as CONSUMING segments so that partitions can be aligned.
Enhance TableRebalancer to support aligning the partitions for
COMPLETED segments without downtime.