### PR TITLE
Make output schema to match selection list for aggregation groupbys

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -321,4 +321,33 @@ public class RequestUtils {
       throw new IllegalStateException("Cannot get expression from " + astNode.getClass().getSimpleName());
     }
   }
+
+  public static String prettyPrint(Expression expression) {
+    if (expression == null) {
+      return "null";
+    }
+    if (expression.getIdentifier() != null) {
+      return expression.getIdentifier().getName();
+    }
+    if (expression.getLiteral() != null) {
+      if (expression.getLiteral().isSetLongValue()) {
+        return Long.toString(expression.getLiteral().getLongValue());
+      }
+    }
+    if (expression.getFunctionCall() != null) {
+      String res = expression.getFunctionCall().getOperator() + "(";
+      boolean isFirstParam = true;
+      for (Expression operand : expression.getFunctionCall().getOperands()) {
+        res += prettyPrint(operand);
+        if (!isFirstParam) {
+          res += ", ";
+        } else {
+          isFirstParam = false;
+        }
+      }
+      res += ")";
+      return res;
+    }
+    return null;
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -71,10 +71,11 @@ public class PinotQuery2BrokerRequestConverter {
 
     //TODO: these should not be part of the query?
     //brokerRequest.setEnableTrace();
-    //brokerRequest.setDebugOptions();
+    brokerRequest.setDebugOptions(pinotQuery.getDebugOptions());
     brokerRequest.setQueryOptions(pinotQuery.getQueryOptions());
     //brokerRequest.setBucketHashKey();
     //brokerRequest.setDuration();
+    brokerRequest.setPinotQuery(pinotQuery);
 
     return brokerRequest;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.GroupBy;
 import org.apache.pinot.common.request.HavingFilterQuery;
 import org.apache.pinot.common.request.HavingFilterQueryMap;
@@ -42,6 +43,7 @@ import org.apache.pinot.common.response.broker.GroupByResult;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
 import org.apache.pinot.core.data.table.IndexedTable;
 import org.apache.pinot.core.data.table.Record;
@@ -53,12 +55,15 @@ import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.core.util.QueryOptions;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Helper class to reduce data tables and set group by results into the BrokerResponseNative
  */
 public class GroupByDataTableReducer implements DataTableReducer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GroupByDataTableReducer.class);
 
   private final BrokerRequest _brokerRequest;
   private final AggregationFunction[] _aggregationFunctions;
@@ -72,6 +77,8 @@ public class GroupByDataTableReducer implements DataTableReducer {
   private final boolean _preserveType;
   private final boolean _groupByModeSql;
   private final boolean _responseFormatSql;
+  private final List<Expression> _sqlSelectionList;
+  private final List<Expression> _groupByList;
 
   GroupByDataTableReducer(BrokerRequest brokerRequest, AggregationFunction[] aggregationFunctions,
       QueryOptions queryOptions) {
@@ -87,6 +94,13 @@ public class GroupByDataTableReducer implements DataTableReducer {
     _preserveType = queryOptions.isPreserveType();
     _groupByModeSql = queryOptions.isGroupByModeSQL();
     _responseFormatSql = queryOptions.isResponseFormatSQL();
+    if (_responseFormatSql && brokerRequest.getPinotQuery() != null) {
+      _sqlSelectionList = brokerRequest.getPinotQuery().getSelectList();
+      _groupByList = brokerRequest.getPinotQuery().getGroupByList();
+    } else {
+      _sqlSelectionList = null;
+      _groupByList = null;
+    }
   }
 
   /**
@@ -161,7 +175,6 @@ public class GroupByDataTableReducer implements DataTableReducer {
           resultSize = brokerResponseNative.getAggregationResults().get(0).getGroupByResult().size();
         }
       }
-
     }
 
     if (brokerMetrics != null && resultSize > 0) {
@@ -180,11 +193,14 @@ public class GroupByDataTableReducer implements DataTableReducer {
 
     IndexedTable indexedTable = getIndexedTable(dataSchema, dataTables);
 
+    int[] finalSchemaMapIdx = null;
+    if (_sqlSelectionList != null) {
+      finalSchemaMapIdx = getFinalSchemaMapIdx(dataSchema);
+    }
     List<Object[]> rows = new ArrayList<>();
     Iterator<Record> sortedIterator = indexedTable.iterator();
     int numRows = 0;
     while (numRows < _groupBy.getTopN() && sortedIterator.hasNext()) {
-
       Record nextRecord = sortedIterator.next();
       Object[] values = nextRecord.getValues();
 
@@ -194,12 +210,102 @@ public class GroupByDataTableReducer implements DataTableReducer {
         values[index] = _aggregationFunctions[aggNum++].extractFinalResult(values[index]);
         index++;
       }
-      rows.add(values);
+      if (_sqlSelectionList != null) {
+        Object[] finalValues = new Object[_sqlSelectionList.size()];
+        for (int i = 0; i < finalSchemaMapIdx.length; i++) {
+          if (finalSchemaMapIdx[i] == -1) {
+            finalValues[i] = null;
+          } else {
+            finalValues[i] = values[finalSchemaMapIdx[i]];
+          }
+        }
+        rows.add(finalValues);
+      } else {
+        rows.add(values);
+      }
       numRows++;
     }
 
     DataSchema finalDataSchema = getSQLResultTableSchema(dataSchema);
+    if (_sqlSelectionList != null) {
+      int columnSize = _sqlSelectionList.size();
+      String[] columns = new String[columnSize];
+      DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[columnSize];
+      for (int i = 0; i < columnSize; i++) {
+        if (finalSchemaMapIdx[i] == -1) {
+          columns[i] = RequestUtils.prettyPrint(_sqlSelectionList.get(i));
+          columnDataTypes[i] = DataSchema.ColumnDataType.STRING;
+        } else {
+          columns[i] = finalDataSchema.getColumnName(finalSchemaMapIdx[i]);
+          columnDataTypes[i] = finalDataSchema.getColumnDataType(finalSchemaMapIdx[i]);
+        }
+      }
+      finalDataSchema = new DataSchema(columns, columnDataTypes);
+    }
     brokerResponseNative.setResultTable(new ResultTable(finalDataSchema, rows));
+  }
+
+  /**
+   * Generate index mapping based on selection expression to DataTable schema, which is groupBy columns,
+   * then aggregation functions.
+   * @param dataSchema
+   *
+   * @return a mapping from final schema idx to corresponding idx in data table schema.
+   */
+  private int[] getFinalSchemaMapIdx(DataSchema dataSchema) {
+    int[] finalSchemaMapIdx = new int[_sqlSelectionList.size()];
+    int nextAggregationIdx = _numGroupBy;
+    for (int i = 0; i < _sqlSelectionList.size(); i++) {
+      finalSchemaMapIdx[i] = getExpressionMapIdx(dataSchema, _sqlSelectionList.get(i), nextAggregationIdx);
+      if (finalSchemaMapIdx[i] == nextAggregationIdx) {
+        nextAggregationIdx++;
+      }
+    }
+    return finalSchemaMapIdx;
+  }
+
+  private int getExpressionMapIdx(DataSchema dataSchema, Expression expression, int nextAggregationIdx) {
+    // Check if expression matches groupBy list.
+    int idxFromGroupByList = getGroupByIdx(_groupByList, expression);
+    if (idxFromGroupByList != -1) {
+      return idxFromGroupByList;
+    }
+    // Handle all functions
+    if (expression.getFunctionCall() != null) {
+      // handle AS
+      if (expression.getFunctionCall().getOperator().equalsIgnoreCase("AS")) {
+        return getExpressionMapIdx(dataSchema, expression.getFunctionCall().getOperands().get(0), nextAggregationIdx);
+      }
+      // Return next aggregation idx.
+      return nextAggregationIdx;
+    }
+    // Handle identifier, which is a column.
+    if (expression.getIdentifier() != null) {
+      String columnName = expression.getIdentifier().getName();
+      for (int i = 0; i < dataSchema.size(); i++) {
+        if (columnName.equalsIgnoreCase(dataSchema.getColumnName(i))) {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Trying to match an expression based on given groupByList.
+   *
+   * @param groupByList
+   * @param expression
+   * @return matched idx from groupByList
+   */
+  private int getGroupByIdx(List<Expression> groupByList, Expression expression) {
+    for (int i = 0; i < groupByList.size(); i++) {
+      Expression groupByExpr = groupByList.get(i);
+      if (groupByExpr.equals(expression)) {
+        return i;
+      }
+    }
+    return -1;
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -172,6 +172,10 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     testSqlQuery(query, Collections.singletonList(query));
     query = "SELECT COUNT(*), MAX(ArrTime), MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 16312";
     testSqlQuery(query, Collections.singletonList(query));
+    query = "SELECT COUNT(*), MAX(ArrTime), MIN(ArrTime), DaysSinceEpoch FROM mytable GROUP BY DaysSinceEpoch";
+    testSqlQuery(query, Collections.singletonList(query));
+    query = "SELECT DaysSinceEpoch, COUNT(*), MAX(ArrTime), MIN(ArrTime) FROM mytable GROUP BY DaysSinceEpoch";
+    testSqlQuery(query, Collections.singletonList(query));
   }
 
   /**


### PR DESCRIPTION
- Query results schema should match select list.
- Validate that non-aggregate expression in select list must be in group by expressions.
E.g. 
```
select group_id , count(*), sum(rsvp_count),count(rsvp_count), sum(rsvp_count),ADD(group_id,1)  from meetupRsvp group by  group_id , ADD(group_id,1)   limit 10
```
Results is 
```
{
    "resultTable": {
        "dataSchema": {
            "columnDataTypes": ["LONG", "LONG", "DOUBLE", "LONG", "DOUBLE", "DOUBLE"],
            "columnNames": ["group_id", "count(*)", "sum(rsvp_count)", "count(*)", "sum(rsvp_count)", "add(group_id,'1')"]
        },
        "rows": [
            [263790, 2, 2.0, 2, 2.0, 263791.0],
            [15915612, 1, 1.0, 1, 1.0, 1.5915613E7],
            [1516787, 1, 1.0, 1, 1.0, 1516788.0],
            [31461301, 1, 1.0, 1, 1.0, 3.1461302E7],
            [3315552, 2, 2.0, 2, 2.0, 3315553.0],
            [19068870, 1, 1.0, 1, 1.0, 1.9068871E7],
            [252197, 1, 1.0, 1, 1.0, 252198.0],
            [32449323, 1, 1.0, 1, 1.0, 3.2449324E7],
            [31525187, 1, 1.0, 1, 1.0, 3.1525188E7],
            [18402988, 1, 1.0, 1, 1.0, 1.8402989E7]
        ]
    },
    "exceptions": [],
    "numServersQueried": 1,
    "numServersResponded": 1,
    "numSegmentsQueried": 1,
    "numSegmentsProcessed": 1,
    "numSegmentsMatched": 1,
    "numConsumingSegmentsQueried": 1,
    "numDocsScanned": 163,
    "numEntriesScannedInFilter": 0,
    "numEntriesScannedPostFilter": 326,
    "numGroupsLimitReached": true,
    "totalDocs": 163,
    "timeUsedMs": 18,
    "segmentStatistics": [],
    "traceInfo": {},
    "minConsumingFreshnessTimeMs": 1580132510553
}
```