### PR TITLE
Upgrade Helix version to 0.9.4

### DIFF
--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -90,8 +90,6 @@
                 <exclude>**/RealtimeClusterIntegrationTest.java</exclude>
                 <!-- Covered by ConvertToRawIndexMinionClusterIntegrationTest -->
                 <exclude>**/HybridClusterIntegrationTest.java</exclude>
-                <!-- TODO: re-enable the Minion tests when upgrading to Helix 0.9.1 -->
-                <exclude>**/*MinionClusterIntegrationTest.java</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.7.6</avro.version>
     <parquet.version>1.8.0</parquet.version>
-    <helix.version>0.8.4</helix.version>
+    <helix.version>0.9.4</helix.version>
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.9.8</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
@@ -1121,8 +1121,6 @@
           <!-- Excludes integration tests when unit tests are run. -->
           <excludes>
             <exclude>**/*IT.java</exclude>
-            <!-- TODO: re-enable the Minion tests when upgrading to Helix 0.9.1 -->
-            <exclude>**/*MinionClusterIntegrationTest.java</exclude>
           </excludes>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>


### PR DESCRIPTION
This PR:
* upgrades Helix version to 0.9.4
*  re-enables two integration tests for pinot-minion