### PR TITLE
Make pinot-client to query sql endpoint by default

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -32,6 +32,9 @@ import org.slf4j.LoggerFactory;
  */
 public class Connection {
   private static final Logger LOGGER = LoggerFactory.getLogger(Connection.class);
+  private static final String SQL = "sql";
+  private static final String PQL = "pql";
+
   private final PinotClientTransport _transport;
   private BrokerSelector _brokerSelector;
   private List<String> _brokerList;
@@ -59,14 +62,25 @@ public class Connection {
   }
 
   /**
-   * Executes a PQL statement.
+   * Executes a SQL statement.
    * @param statement The statement to execute
    * @return The result of the query
    * @throws PinotClientException If an exception occurs while processing the query
    */
   public ResultSetGroup execute(String statement)
       throws PinotClientException {
-    return execute(null, new Request("pql", statement));
+    return execute(null, new Request(SQL, statement));
+  }
+
+  /**
+   * Executes a PQL statement.
+   * @param statement The statement to execute
+   * @return The result of the query
+   * @throws PinotClientException If an exception occurs while processing the query
+   */
+  public ResultSetGroup executePql(String statement)
+      throws PinotClientException {
+    return execute(null, new Request(PQL, statement));
   }
 
   /**
@@ -81,7 +95,7 @@ public class Connection {
   }
 
   /**
-   * Executes a PQL statement.
+   * Executes a SQL statement.
    *
    * @param statement The statement to execute
    * @return The result of the query
@@ -89,7 +103,19 @@ public class Connection {
    */
   public ResultSetGroup execute(String tableName, String statement)
       throws PinotClientException {
-    return execute(tableName, new Request("pql", statement));
+    return execute(tableName, new Request(SQL, statement));
+  }
+
+  /**
+   * Executes a PQL statement.
+   *
+   * @param statement The statement to execute
+   * @return The result of the query
+   * @throws PinotClientException If an exception occurs while processing the query
+   */
+  public ResultSetGroup executePql(String tableName, String statement)
+      throws PinotClientException {
+    return execute(tableName, new Request(PQL, statement));
   }
 
   /**
@@ -114,7 +140,7 @@ public class Connection {
   }
 
   /**
-   * Executes a PQL statement asynchronously.
+   * Executes a SQL statement asynchronously.
    *
    * @param statement The statement to execute
    * @return A future containing the result of the query
@@ -122,7 +148,19 @@ public class Connection {
    */
   public Future<ResultSetGroup> executeAsync(String statement)
       throws PinotClientException {
-    return executeAsync(new Request("pql", statement));
+    return executeAsync(new Request(SQL, statement));
+  }
+
+  /**
+   * Executes a PQL statement asynchronously.
+   *
+   * @param statement The statement to execute
+   * @return A future containing the result of the query
+   * @throws PinotClientException If an exception occurs while processing the query
+   */
+  public Future<ResultSetGroup> executePqlAsync(String statement)
+      throws PinotClientException {
+    return executeAsync(new Request(PQL, statement));
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -340,7 +340,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
    */
   protected long getCurrentCountStarResult()
       throws Exception {
-    return getPinotConnection().execute("SELECT COUNT(*) FROM " + getTableName()).getResultSet(0).getLong(0);
+    return getPinotConnection().executePql("SELECT COUNT(*) FROM " + getTableName()).getResultSet(0).getLong(0);
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -216,7 +216,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
 
   public void testVirtualColumnQueries() {
     // Check that there are no virtual columns in the query results
-    ResultSetGroup resultSetGroup = getPinotConnection().execute("select * from mytable");
+    ResultSetGroup resultSetGroup = getPinotConnection().executePql("select * from mytable");
     ResultSet resultSet = resultSetGroup.getResultSet(0);
     for (int i = 0; i < resultSet.getColumnCount(); i++) {
       Assert.assertFalse(resultSet.getColumnName(i).startsWith("$"),
@@ -224,11 +224,11 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     }
 
     // Check that the virtual columns work as expected (throws no exceptions)
-    getPinotConnection().execute("select $docId, $segmentName, $hostName from mytable");
-    getPinotConnection().execute("select $docId, $segmentName, $hostName from mytable where $docId < 5 limit 50");
-    getPinotConnection().execute("select $docId, $segmentName, $hostName from mytable where $docId = 5 limit 50");
-    getPinotConnection().execute("select $docId, $segmentName, $hostName from mytable where $docId > 19998 limit 50");
-    getPinotConnection().execute("select max($docId) from mytable group by $segmentName");
+    getPinotConnection().executePql("select $docId, $segmentName, $hostName from mytable");
+    getPinotConnection().executePql("select $docId, $segmentName, $hostName from mytable where $docId < 5 limit 50");
+    getPinotConnection().executePql("select $docId, $segmentName, $hostName from mytable where $docId = 5 limit 50");
+    getPinotConnection().executePql("select $docId, $segmentName, $hostName from mytable where $docId > 19998 limit 50");
+    getPinotConnection().executePql("select max($docId) from mytable group by $segmentName");
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ChaosMonkeyIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ChaosMonkeyIntegrationTest.java
@@ -151,7 +151,7 @@ public class ChaosMonkeyIntegrationTest {
 
   private int countRecords() {
     Connection connection = ConnectionFactory.fromHostList("localhost:8099");
-    return connection.execute("select count(*) from myTable").getResultSet(0).getInt(0);
+    return connection.executePql("select count(*) from myTable").getResultSet(0).getInt(0);
   }
 
   @Test(enabled = false)


### PR DESCRIPTION
Note, backward- incompatible change.

- make default `Connection.execute(...)` methods to query `sql` endpoint instead of `pql` endpoint.
- create new APIs `Connection.executePql(...)` to support old users who are still using PQL.