### PR TITLE
Do not derive host/port from instance id in HelixServerStarter

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -18,13 +18,9 @@
  */
 package org.apache.pinot.integration.tests;
 
-import java.net.InetAddress;
+import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.helix.HelixManager;
-import org.apache.helix.PropertyKey;
 import org.apache.helix.model.InstanceConfig;
-import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.controller.helix.ControllerTest;
@@ -33,119 +29,95 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.common.utils.CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.*;
 import static org.apache.pinot.common.utils.CommonConstants.Server.CONFIG_OF_INSTANCE_ID;
 import static org.testng.Assert.assertEquals;
 
 
 public class ServerStarterIntegrationTest extends ControllerTest {
-  public static final String SERVER1 = "Server1";
+  private static final String CUSTOM_INSTANCE_ID = "CustomInstance";
+  private static final String CUSTOM_HOST = "CustomHost";
+  private static final int CUSTOM_PORT = 10001;
 
   @BeforeClass
-  public void setUp()
-      throws Exception {
+  public void setUp() {
     startZk();
     startController();
   }
 
   @AfterClass
-  public void tearDown()
-      throws Exception {
+  public void tearDown() {
     stopController();
     stopZk();
   }
 
-  private void verifyZkConfigData(HelixServerStarter helixServerStarter, String expectedInstanceName,
-      String expectedHostname, String expectedPort) {
-    // Verify the serverId, host and port are set correctly in Zk.
-    HelixManager helixManager = helixServerStarter.getHelixManager();
-    PropertyKey.Builder keyBuilder = helixManager.getHelixDataAccessor().keyBuilder();
-    InstanceConfig config = helixManager.getHelixDataAccessor().
-        getProperty(keyBuilder.instanceConfig(helixServerStarter.getHelixManager().getInstanceName()));
+  private void verifyInstanceConfig(Configuration serverConf, String expectedInstanceId, String expectedHost,
+      int expectedPort)
+      throws Exception {
+    HelixServerStarter helixServerStarter =
+        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
     helixServerStarter.stop();
 
-    assertEquals(config.getInstanceName(), expectedInstanceName);
-    // By default (auto joined instances), server instance name is of format: {@code Server_<hostname>_<port>}, e.g.
-    // {@code Server_localhost_12345}, hostname is of format: {@code Server_<hostname>}, e.g. {@code Server_localhost}.
-    // More details refer to the class ServerInstance.
-    assertEquals(config.getHostName(), expectedHostname);
-    assertEquals(config.getPort(), expectedPort);
+    assertEquals(helixServerStarter.getInstanceId(), expectedInstanceId);
+    InstanceConfig instanceConfig =
+        _helixDataAccessor.getProperty(_helixDataAccessor.keyBuilder().instanceConfig(expectedInstanceId));
+    assertEquals(instanceConfig.getHostName(), expectedHost);
+    assertEquals(Integer.parseInt(instanceConfig.getPort()), expectedPort);
   }
 
   @Test
-  public void testWithNoInstanceIdNoHostnamePort()
+  public void testDefaultServerConf()
       throws Exception {
-    // Test the behavior when no instance id nor hostname/port is specified in server conf.
-    Configuration serverConf = new PropertiesConfiguration();
-    // Start the server.
-    HelixServerStarter helixServerStarter =
-        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
-    String expectedInstanceName = helixServerStarter.getHelixManager().getInstanceName();
-    String expectedHostname = expectedInstanceName.substring(0, expectedInstanceName.lastIndexOf('_'));
-    verifyZkConfigData(helixServerStarter, expectedInstanceName, expectedHostname, "8098");
-  }
-
-  @Test
-  public void testWithNoInstanceIdButWithHostnamePort()
-      throws Exception {
-    // Test the behavior when no instance id specified but hostname/port is specified in server conf.
-    Configuration serverConf = new PropertiesConfiguration();
-    serverConf.setProperty(KEY_OF_SERVER_NETTY_HOST, "host1");
-    serverConf.setProperty(KEY_OF_SERVER_NETTY_PORT, 10001);
-    // Start the server
-    HelixServerStarter helixServerStarter =
-        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
-
-    // Verify the serverId, host and port are set correctly in Zk.
-    verifyZkConfigData(helixServerStarter, "Server_host1_10001", "Server_host1", "10001");
-  }
-
-  @Test
-  public void testInstanceIdWithHostPortInfo()
-      throws Exception {
-    // Test the behavior when logical server id and hostname/port are all specified in server conf.
-    // Unlike testInstanceIdOnly(), the host and port info will be overwritten with those in config.
-    Configuration serverConf = new PropertiesConfiguration();
-    serverConf.setProperty(CONFIG_OF_INSTANCE_ID, SERVER1);
-    serverConf.setProperty(KEY_OF_SERVER_NETTY_HOST, "host1");
-    serverConf.setProperty(KEY_OF_SERVER_NETTY_PORT, 10001);
-    // Start the server
-    HelixServerStarter helixServerStarter =
-        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
-
-    // Verify the serverId, host and port are set correctly in Zk.
-    verifyZkConfigData(helixServerStarter, SERVER1, "host1", "10001");
-  }
-
-  @Test
-  public void testInstanceIdOnly()
-      throws Exception {
-    Configuration serverConf = new PropertiesConfiguration();
-    serverConf.setProperty(CONFIG_OF_INSTANCE_ID, SERVER1);
-    // Start the server
-    HelixServerStarter helixServerStarter =
-        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
-
-    // Verify the serverId, host and port are set correctly in Zk.
-    // Note that helix will use INSTANCE_ID to extract the hostname instead of using netty host/port in config.
-    verifyZkConfigData(helixServerStarter, SERVER1, SERVER1, "");
+    Configuration serverConf = new BaseConfiguration();
+    String expectedHost = NetUtil.getHostAddress();
+    String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + DEFAULT_SERVER_NETTY_PORT;
+    verifyInstanceConfig(serverConf, expectedInstanceId, expectedHost, DEFAULT_SERVER_NETTY_PORT);
   }
 
   @Test
   public void testSetInstanceIdToHostname()
       throws Exception {
-    // Test the behavior when no instance id nor hostname/port is specified in server conf.
-    // Compared with testWithNoInstanceIdNoHostnamePort(), here the server id use hostname (i.e., localhost) instead of
-    // host address (i.e., 127.0.0.1).
-    Configuration serverConf = new PropertiesConfiguration();
-    serverConf.setProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, true);
-    // Start the server
-    HelixServerStarter helixServerStarter =
-        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
+    Configuration serverConf = new BaseConfiguration();
+    serverConf.addProperty(SET_INSTANCE_ID_TO_HOSTNAME_KEY, true);
+    String expectedHost = NetUtil.getHostnameOrAddress();
+    String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + DEFAULT_SERVER_NETTY_PORT;
+    verifyInstanceConfig(serverConf, expectedInstanceId, expectedHost, DEFAULT_SERVER_NETTY_PORT);
+  }
 
-    // Verify the serverId, host and port are set correctly in Zk.
-    String hostName = NetUtil.getHostnameOrAddress();
-    verifyZkConfigData(helixServerStarter, "Server_" + hostName + "_8098", "Server_" + hostName, "8098");
+  @Test
+  public void testCustomInstanceId()
+      throws Exception {
+    Configuration serverConf = new BaseConfiguration();
+    serverConf.addProperty(CONFIG_OF_INSTANCE_ID, CUSTOM_INSTANCE_ID);
+    verifyInstanceConfig(serverConf, CUSTOM_INSTANCE_ID, NetUtil.getHostAddress(), DEFAULT_SERVER_NETTY_PORT);
+  }
+
+  @Test
+  public void testCustomHost()
+      throws Exception {
+    Configuration serverConf = new BaseConfiguration();
+    serverConf.addProperty(KEY_OF_SERVER_NETTY_HOST, CUSTOM_HOST);
+    String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + CUSTOM_HOST + "_" + DEFAULT_SERVER_NETTY_PORT;
+    verifyInstanceConfig(serverConf, expectedInstanceId, CUSTOM_HOST, DEFAULT_SERVER_NETTY_PORT);
+  }
+
+  @Test
+  public void testCustomPort()
+      throws Exception {
+    Configuration serverConf = new BaseConfiguration();
+    serverConf.addProperty(KEY_OF_SERVER_NETTY_PORT, CUSTOM_PORT);
+    String expectedHost = NetUtil.getHostAddress();
+    String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + CUSTOM_PORT;
+    verifyInstanceConfig(serverConf, expectedInstanceId, expectedHost, CUSTOM_PORT);
+  }
+
+  @Test
+  public void testAllCustomServerConf()
+      throws Exception {
+    Configuration serverConf = new BaseConfiguration();
+    serverConf.addProperty(CONFIG_OF_INSTANCE_ID, CUSTOM_INSTANCE_ID);
+    serverConf.addProperty(KEY_OF_SERVER_NETTY_HOST, CUSTOM_HOST);
+    serverConf.addProperty(KEY_OF_SERVER_NETTY_PORT, CUSTOM_PORT);
+    verifyInstanceConfig(serverConf, CUSTOM_INSTANCE_ID, CUSTOM_HOST, CUSTOM_PORT);
   }
 }


### PR DESCRIPTION
Currently host/port can be derived from instance id, and instance id
can also be derived from host/port, which makes ServerConf hard to
config.

Instead, with the change:
- Host is always from config or generated by NetUtil
- Port is always from config or using default (8098)
- Instance id is always from config or of format `Server_<host>_<port>`
- Host will no longer have the `Server_` prefix in InstanceConfig

BACKWARD-INCOMPATIBLE CHANGE:
- Host/port will no longer be derived from the instance id configuration if they are not configured: please add host/port configuration
- Host will no longer have the `Server_` prefix in InstanceConfig: this has no impact for Pinot as both formats are supported, but might affect client side code that expects `Server_` prefix for host in InstanceConfig