### PR TITLE
Set alias name in resultTable schema names

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -120,6 +120,10 @@ public class PinotQuery2BrokerRequestConverter {
     List<AggregationInfo> aggregationInfoList = null;
     for (Expression expression : pinotQuery.getSelectList()) {
       ExpressionType type = expression.getType();
+      if (type == ExpressionType.FUNCTION && expression.getFunctionCall().getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
+        expression = expression.getFunctionCall().getOperands().get(0);
+        type = expression.getType();
+      }
       switch (type) {
         case LITERAL:
           if (selection == null) {
@@ -134,9 +138,6 @@ public class PinotQuery2BrokerRequestConverter {
           selection.addToSelectionColumns(expression.getIdentifier().getName());
           break;
         case FUNCTION:
-          if (expression.getFunctionCall().getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
-            expression = expression.getFunctionCall().getOperands().get(0);
-          }
           Function functionCall = expression.getFunctionCall();
           String functionName = functionCall.getOperator();
           if (FunctionDefinitionRegistry.isAggFunc(functionName)) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -465,9 +465,10 @@ public class CalciteSqlParser {
         return asFuncExpr;
       case OTHER:
         if (node instanceof SqlDataTypeSpec) {
+          // This is to handle expression like: CAST(col AS INT)
           return RequestUtils.getLiteralExpression(((SqlDataTypeSpec) node).getTypeName().getSimple());
         } else {
-          // Keep processing default logic.
+          // Move on to process default logic.
         }
       default:
         SqlBasicCall funcSqlNode = (SqlBasicCall) node;

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -990,13 +990,13 @@ public class CalciteSqlCompilerTest {
     sql = "SELECT C1 AS ALIAS_C1, C2 AS ALIAS_C2, ADD(C1, C2) FROM Foo";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), SqlKind.AS.toString());
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C1");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "ALIAS_C1");
 
-    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), SqlKind.AS.toString());
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C2");
     Assert.assertEquals(

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -32,16 +32,12 @@ import org.apache.pinot.common.metrics.BrokerTimer;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
-import org.apache.pinot.common.request.Identifier;
-import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.util.QueryOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -50,8 +46,6 @@ import org.slf4j.LoggerFactory;
  */
 @ThreadSafe
 public class BrokerReduceService {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerReduceService.class);
 
   public BrokerResponseNative reduceOnDataTable(BrokerRequest brokerRequest,
       Map<ServerRoutingInstance, DataTable> dataTableMap, @Nullable BrokerMetrics brokerMetrics) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.BiFunction;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.AggregationInfo;
@@ -263,7 +264,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
     // Handle all functions
     if (expression.getFunctionCall() != null) {
       // handle AS
-      if (expression.getFunctionCall().getOperator().equalsIgnoreCase("AS")) {
+      if (expression.getFunctionCall().getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
         return getExpressionMapIdx(expression.getFunctionCall().getOperands().get(0), nextAggregationIdx);
       }
       // Return next aggregation idx.

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -454,7 +454,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
    * @param expectedSize expected result size
    */
   private void interSegmentInterServerTestHelper(String query, int expectedSize) {
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     final SelectionResults selectionResults = brokerResponse.getSelectionResults();
 
     Assert.assertEquals(selectionResults.getColumns().size(), 4);
@@ -724,7 +724,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
   }
 
   private void runQueryInterSegmentWithOrderBy(String query, List<Record> orderedResults, String[] columnNames) {
-    BrokerResponseNative brokerResponseNative = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponseNative = getBrokerResponseForPqlQuery(query);
     final SelectionResults selectionResults = brokerResponseNative.getSelectionResults();
     Assert.assertEquals(selectionResults.getColumns(), Lists.newArrayList(columnNames));
     List<Serializable[]> rows = selectionResults.getRows();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -137,14 +137,14 @@ public class FastHllQueriesTest extends BaseQueriesTest {
     Assert.assertEquals(((HyperLogLog) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).cardinality(), 691L);
 
     // Test inter segments base query
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(BASE_QUERY);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(BASE_QUERY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 4L, 0L, 8L, 120000L, new String[]{"21", "1762"});
     // Test inter segments query with filter
-    brokerResponse = getBrokerResponseForQueryWithFilter(BASE_QUERY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(BASE_QUERY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 449916L, 49032L, 120000L,
         new String[]{"17", "1197"});
     // Test inter segments query with group-by
-    brokerResponse = getBrokerResponseForQuery(BASE_QUERY + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(BASE_QUERY + GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 18452L, 0L, 55356L, 120000L, new String[]{"21", "1762"});
 
@@ -185,15 +185,15 @@ public class FastHllQueriesTest extends BaseQueriesTest {
     Assert.assertEquals(((HyperLogLog) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).cardinality(), 691L);
 
     // Test inter segments base query
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(BASE_QUERY);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(BASE_QUERY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L, new String[]{"21", "1762"});
     // Test inter segments query with filter
-    brokerResponse = getBrokerResponseForQueryWithFilter(BASE_QUERY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(BASE_QUERY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"17", "1197"});
     // Test inter segments query with group-by
-    brokerResponse = getBrokerResponseForQuery(BASE_QUERY + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(BASE_QUERY + GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L, new String[]{"21", "1762"});
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
@@ -19,11 +19,17 @@
 package org.apache.pinot.queries;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.function.Function;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.startree.hll.HllUtil;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertFalse;
@@ -33,45 +39,71 @@ import static org.testng.Assert.assertTrue;
 public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValueQueriesTest {
   private static String SV_GROUP_BY = " group by column8";
   private static String MV_GROUP_BY = " group by column7";
+  private static String ORDER_BY_ALIAS = " order by cnt_column6 DESC";
 
   @Test
   public void testCountMV() {
     String query = "SELECT COUNTMV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"426752"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L, new String[]{"62480"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"231056"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"199896"});
+  }
+
+  @Test
+  public void testCastCountMV() {
+    String query = "SELECT COUNTMV(column6) as cnt_column6 FROM testTable";
+    BrokerResponseNative brokerResponse = getBrokerResponseForSqlQuery(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"cnt_column6"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, Arrays.asList(new Long[][]{new Long[]{426752L}}), 1, expectedDataSchema);
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), "cnt_column6");
+
+    brokerResponse = getBrokerResponseForSqlQueryWithFilter(query);
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 62480L, 869592L, 62480L, 400000L, Arrays.asList(new Long[][]{new Long[]{62480L}}), 1, expectedDataSchema);
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), "cnt_column6");
+
+    brokerResponse = getBrokerResponseForSqlQuery(query + SV_GROUP_BY + ORDER_BY_ALIAS);
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, Arrays.asList(new Long[][]{new Long[]{231056L}}), 10, expectedDataSchema);
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), "cnt_column6");
+
+    brokerResponse = getBrokerResponseForSqlQuery(query + MV_GROUP_BY + ORDER_BY_ALIAS);
+    QueriesTestUtils
+        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, Arrays.asList(new Long[][]{new Long[]{199896L}}), 10, expectedDataSchema);
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), "cnt_column6");
   }
 
   @Test
   public void testMaxMV() {
     String query = "SELECT MAXMV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
   }
@@ -80,19 +112,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testMinMV() {
     String query = "SELECT MINMV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"1001.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"1009.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"1001.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"1001.00000"});
   }
@@ -101,19 +133,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testSumMV() {
     String query = "SELECT SUMMV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
         new String[]{"484324601810280.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"114652613591912.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"402591409613620.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"393483780531788.00000"});
   }
@@ -122,19 +154,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testAvgMV() {
     String query = "SELECT AVGMV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
         new String[]{"1134908803.73210"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"1835029026.75916"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
   }
@@ -143,19 +175,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testMinMaxRangeMV() {
     String query = "SELECT MINMAXRANGEMV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
         new String[]{"2147482646.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147482638.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147482646.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147482646.00000"});
   }
@@ -164,19 +196,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testDistinctCountMV() {
     String query = "SELECT DISTINCTCOUNTMV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"18499"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L, new String[]{"1186"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"4784"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"3434"});
   }
@@ -185,19 +217,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testDistinctCountHLLMV() {
     String query = "SELECT DISTINCTCOUNTHLLMV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"20039"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L, new String[]{"1296"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"4715"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"3490"});
   }
@@ -208,22 +240,22 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     Function<Serializable, String> cardinalityExtractor =
         value -> String.valueOf(HllUtil.buildHllFromBytes(BytesUtils.toBytes((String) value)).cardinality());
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, cardinalityExtractor,
             new String[]{"20039"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L, cardinalityExtractor,
             new String[]{"1296"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, cardinalityExtractor,
             new String[]{"4715"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, cardinalityExtractor,
             new String[]{"3490"});
@@ -233,19 +265,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testPercentile50MV() {
     String query = "SELECT PERCENTILE50MV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
   }
@@ -254,19 +286,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testPercentile90MV() {
     String query = "SELECT PERCENTILE90MV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
   }
@@ -275,19 +307,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testPercentile95MV() {
     String query = "SELECT PERCENTILE95MV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
   }
@@ -296,19 +328,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testPercentile99MV() {
     String query = "SELECT PERCENTILE99MV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647.00000"});
   }
@@ -317,19 +349,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testPercentileEst50MV() {
     String query = "SELECT PERCENTILEEST50MV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
   }
@@ -338,19 +370,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testPercentileEst90MV() {
     String query = "SELECT PERCENTILEEST90MV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
   }
@@ -359,19 +391,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testPercentileEst95MV() {
     String query = "SELECT PERCENTILEEST95MV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
   }
@@ -380,19 +412,19 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testPercentileEst99MV() {
     String query = "SELECT PERCENTILEEST99MV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 400000L, 400000L, new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 62480L, 1089104L, 62480L, 400000L,
         new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"2147483647"});
   }
@@ -401,10 +433,10 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
   public void testNumGroupsLimit() {
     String query = "SELECT COUNT(*) FROM testTable GROUP BY column6";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     assertFalse(brokerResponse.isNumGroupsLimitReached());
 
-    brokerResponse = getBrokerResponseForQuery(query, new InstancePlanMakerImplV2(1000, 1000));
+    brokerResponse = getBrokerResponseForPqlQuery(query, new InstancePlanMakerImplV2(1000, 1000));
     assertTrue(brokerResponse.isNumGroupsLimitReached());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
@@ -40,19 +40,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testCount() {
     String query = "SELECT COUNT(*) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L, new String[]{"120000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 0L, 120000L, new String[]{"24516"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 120000L, 120000L, new String[]{"64420"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 24516L, 120000L, new String[]{"17080"});
   }
@@ -63,19 +63,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     // Query should be answered by MetadataBasedAggregationOperator, so check if numEntriesScannedInFilter and
     // numEntriesScannedPostFilter are 0
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L,
         new String[]{"2146952047.00000", "2147419555.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"2146952047.00000", "999813884.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146952047.00000", "2147419555.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2146952047.00000", "999813884.00000"});
   }
@@ -86,19 +86,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     // Query should be answered by MetadataBasedAggregationOperator, so check if numEntriesScannedInFilter and
     // numEntriesScannedPostFilter are 0
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L,
         new String[]{"240528.00000", "17891.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"101116473.00000", "20396372.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"240528.00000", "17891.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"101116473.00000", "20396372.00000"});
   }
@@ -107,19 +107,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testSum() {
     String query = "SELECT SUM(column1), SUM(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"129268741751388.00000", "129156636756600.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"27503790384288.00000", "12429178874916.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"69526727335224.00000", "69225631719808.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"19058003631876.00000", "8606725456500.00000"});
   }
@@ -128,19 +128,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testAvg() {
     String query = "SELECT AVG(column1), AVG(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"1077239514.59490", "1076305306.30500"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"1121871038.68037", "506982332.96280"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2142595699.00000", "2141451242.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2142595699.00000", "999309554.00000"});
   }
@@ -151,19 +151,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     // Query should be answered by MetadataBasedAggregationOperator, so check if numEntriesScannedInFilter and
     // numEntriesScannedPostFilter are 0
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L,
         new String[]{"2146711519.00000", "2147401664.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"2045835574.00000", "979417512.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146711519.00000", "2146612605.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2044094181.00000", "979417512.00000"});
   }
@@ -172,19 +172,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testDistinctCount() {
     String query = "SELECT DISTINCTCOUNT(column1), DISTINCTCOUNT(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"6582", "21910"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"1872", "4556"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"3495", "11961"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"1272", "3289"});
   }
@@ -193,19 +193,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testDistinctCountHLL() {
     String query = "SELECT DISTINCTCOUNTHLL(column1), DISTINCTCOUNTHLL(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"5977", "23825"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"1886", "4492"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"3592", "11889"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"1324", "3197"});
   }
@@ -216,22 +216,22 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     Function<Serializable, String> cardinalityExtractor =
         value -> String.valueOf(HllUtil.buildHllFromBytes(BytesUtils.toBytes((String) value)).cardinality());
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L, cardinalityExtractor,
             new String[]{"5977", "23825"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L, cardinalityExtractor,
             new String[]{"1886", "4492"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L, cardinalityExtractor,
             new String[]{"3592", "11889"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L, cardinalityExtractor,
             new String[]{"1324", "3197"});
@@ -241,19 +241,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testPercentile50() {
     String query = "SELECT PERCENTILE50(column1), PERCENTILE50(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"1107310944.00000", "1080136306.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"1139674505.00000", "505053732.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146791843.00000", "2141451242.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2142595699.00000", "999309554.00000"});
   }
@@ -262,19 +262,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testPercentile90() {
     String query = "SELECT PERCENTILE90(column1), PERCENTILE90(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"1943040511.00000", "1936611145.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"1936730975.00000", "899534534.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146791843.00000", "2147278341.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2142595699.00000", "999309554.00000"});
   }
@@ -283,19 +283,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testPercentile95() {
     String query = "SELECT PERCENTILE95(column1), PERCENTILE95(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"2071559385.00000", "2042409652.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"2096857943.00000", "947763150.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146791843.00000", "2147419555.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2142595699.00000", "999309554.00000"});
   }
@@ -304,19 +304,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testPercentile99() {
     String query = "SELECT PERCENTILE99(column1), PERCENTILE99(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"2139354437.00000", "2125299552.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"2146232405.00000", "990669195.00000"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146791843.00000", "2147419555.00000"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2146232405.00000", "999309554.00000"});
   }
@@ -325,19 +325,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testPercentileEst50() {
     String query = "SELECT PERCENTILEEST50(column1), PERCENTILEEST50(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"1107310944", "1082130431"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"1139674505", "509607935"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146791843", "2141451242"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2142595699", "999309554"});
   }
@@ -346,19 +346,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testPercentileEst90() {
     String query = "SELECT PERCENTILEEST90(column1), PERCENTILEEST90(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"1946157055", "1946157055"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"1939865599", "902299647"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146791843", "2147278341"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2142595699", "999309554"});
   }
@@ -367,19 +367,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testPercentileEst95() {
     String query = "SELECT PERCENTILEEST95(column1), PERCENTILEEST95(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"2080374783", "2051014655"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"2109734911", "950009855"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146791843", "2147419555"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2142595699", "999309554"});
   }
@@ -388,19 +388,19 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testPercentileEst99() {
     String query = "SELECT PERCENTILEEST99(column1), PERCENTILEEST99(column3) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
         new String[]{"2143289343", "2143289343"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
         new String[]{"2146232405", "991952895"});
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 360000L, 120000L,
         new String[]{"2146791843", "2147419555"});
 
-    brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2146232405", "999309554"});
   }
@@ -409,10 +409,10 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testNumGroupsLimit() {
     String query = "SELECT COUNT(*) FROM testTable GROUP BY column1";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     assertFalse(brokerResponse.isNumGroupsLimitReached());
 
-    brokerResponse = getBrokerResponseForQuery(query, new InstancePlanMakerImplV2(1000, 1000));
+    brokerResponse = getBrokerResponseForPqlQuery(query, new InstancePlanMakerImplV2(1000, 1000));
     assertTrue(brokerResponse.isNumGroupsLimitReached());
   }
 
@@ -426,7 +426,7 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testInterSegmentDistinctSingleColumn() {
     Pql2Compiler.ENABLE_DISTINCT = true;
     final String query = "SELECT DISTINCT(column1) FROM testTable LIMIT 1000000";
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     final SelectionResults selectionResults = brokerResponse.getSelectionResults();
     Assert.assertEquals(selectionResults.getColumns().size(), 1);
     Assert.assertEquals(selectionResults.getColumns().get(0), "column1");
@@ -443,7 +443,7 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   public void testInterSegmentDistinctMultiColumn() {
     Pql2Compiler.ENABLE_DISTINCT = true;
     final String query = "SELECT DISTINCT(column1, column3) FROM testTable LIMIT 1000000";
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     final SelectionResults selectionResults = brokerResponse.getSelectionResults();
     Assert.assertEquals(selectionResults.getColumns().size(), 2);
     Assert.assertEquals(selectionResults.getColumns().get(0), "column1");

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
@@ -41,7 +41,7 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(Request.QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(Request.QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0, expectedNumEntriesScannedPostFilter, 400000L,
             expectedResults, expectedResults.size(), expectedDataSchema);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
@@ -49,7 +49,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, expectedNumDocsScanned, expectedNumEntriesScannedInFilter,
             expectedNumEntriesScannedPostFilter, expectedNumTotalDocs, expectedResults, expectedResults.size(),
@@ -63,13 +63,13 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.PQL);
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     QueriesTestUtils.testInterSegmentGroupByOrderByResultPQL(brokerResponse, expectedNumDocsScanned,
         expectedNumEntriesScannedInFilter, expectedNumEntriesScannedPostFilter, expectedNumTotalDocs, expectedGroups,
         expectedValues, false);
 
     queryOptions.put(QueryOptionKey.PRESERVE_TYPE, "true");
-    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     QueriesTestUtils.testInterSegmentGroupByOrderByResultPQL(brokerResponse, expectedNumDocsScanned,
         expectedNumEntriesScannedInFilter, expectedNumEntriesScannedPostFilter, expectedNumTotalDocs, expectedGroups,
         expectedValues, true);
@@ -88,7 +88,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     Map<String, String> queryOptions = null;
 
     // default PQL, PQL
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     Assert.assertNotNull(brokerResponse.getAggregationResults());
     Assert.assertNull(brokerResponse.getResultTable());
 
@@ -96,7 +96,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.PQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.PQL);
-    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     Assert.assertNotNull(brokerResponse.getAggregationResults());
     Assert.assertNull(brokerResponse.getResultTable());
 
@@ -104,7 +104,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     query = "SELECT SUM(column1) FROM testTable GROUP BY column11 ORDER BY column11";
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.PQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
-    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     Assert.assertNull(brokerResponse.getAggregationResults());
     Assert.assertNotNull(brokerResponse.getResultTable());
 
@@ -112,7 +112,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     query = "SELECT SUM(column1), MIN(column6) FROM testTable GROUP BY column11 ORDER BY column11";
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.PQL);
-    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     Assert.assertNotNull(brokerResponse.getAggregationResults());
     Assert.assertNull(brokerResponse.getResultTable());
     List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
@@ -128,7 +128,7 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
     // SQL, SQL - execute order by, return resultsTable
     queryOptions.put(QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
-    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     Assert.assertNull(brokerResponse.getAggregationResults());
     Assert.assertNotNull(brokerResponse.getResultTable());
     DataSchema dataSchema = brokerResponse.getResultTable().getDataSchema();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
@@ -49,7 +49,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"countmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -59,14 +59,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{62480L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "countmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -76,7 +76,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "countmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -95,7 +95,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"maxmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -105,14 +105,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "maxmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -122,7 +122,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "maxmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -141,7 +141,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"minmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -151,14 +151,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1009.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "minmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -168,7 +168,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "minmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -187,7 +187,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"summv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -197,14 +197,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{114652613591912.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "summv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -214,7 +214,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "summv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -233,7 +233,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"avgmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -243,14 +243,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1835029026.759155});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "avgmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -260,7 +260,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "avgmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -279,7 +279,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"minmaxrangemv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -289,14 +289,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147482638.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "minmaxrangemv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -306,7 +306,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "minmaxrangemv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -325,7 +325,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"distinctcountmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
     rows = new ArrayList<>();
@@ -335,14 +335,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1186});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "distinctcountmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     rows = new ArrayList<>();
@@ -352,7 +352,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "distinctcountmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     rows = new ArrayList<>();
@@ -371,7 +371,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"distinctcounthllmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -381,14 +381,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1296L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "distinctcounthllmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -398,7 +398,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "distinctcounthllmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -417,7 +417,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
     String query = "SELECT DISTINCTCOUNTRAWHLLMV(column6) FROM testTable";
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"distinctcountrawhllmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING});
     rows = new ArrayList<>();
@@ -429,7 +429,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Object[] row0 = brokerResponse.getResultTable().getRows().get(0);
     Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[0].toString())).cardinality(), expectedRow0[0]);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     expectedRow0 = new Object[]{1296L};
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
@@ -437,7 +437,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     row0 = brokerResponse.getResultTable().getRows().get(0);
     Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[0].toString())).cardinality(), expectedRow0[0]);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "distinctcountrawhllmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
     expectedRow0 = new Object[]{"674022574", 4715L};
@@ -449,7 +449,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Assert.assertEquals(row0[0], expectedRow0[0]);
     Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "distinctcountrawhllmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
     expectedRow0 = new Object[]{"363", 3490L};
@@ -470,7 +470,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentile50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -480,14 +480,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "percentile50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -497,7 +497,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentile50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -516,7 +516,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentile90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -526,14 +526,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "percentile90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -543,7 +543,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentile90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -562,7 +562,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentile95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -572,14 +572,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "percentile95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -589,7 +589,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentile95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -608,7 +608,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentile99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -618,14 +618,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "percentile99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -635,7 +635,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentile99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -654,7 +654,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentileest50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -664,14 +664,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147483647L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "percentileest50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -681,7 +681,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentileest50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -700,7 +700,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentileest90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -710,14 +710,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147483647L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "percentileest90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -727,7 +727,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentileest90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -746,7 +746,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentileest95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -756,14 +756,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147483647L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "percentileest95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -773,7 +773,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentileest95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -792,7 +792,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentileest99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -802,14 +802,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 400000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2147483647L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 62480L, 1089104L, 62480L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + SV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + SV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column8", "percentileest99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -819,7 +819,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentileest99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -836,10 +836,10 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
   public void testSelection() {
     // select *
     String query = "SELECT * FROM testTable";
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     SelectionResults selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT * FROM testTable option(responseFormat=sql)";
-    BrokerResponseNative brokerResponseSQL = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     ResultTable resultTable = brokerResponseSQL.getResultTable();
 
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 10);
@@ -852,10 +852,10 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
 
     // select * limit infinite
     query = "SELECT * FROM testTable limit 50";
-    brokerResponse = getBrokerResponseForQuery(query);
+    brokerResponse = getBrokerResponseForPqlQuery(query);
     selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT * FROM testTable LIMIT 50 option(responseFormat=sql)";
-    brokerResponseSQL = getBrokerResponseForQuery(query);
+    brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     resultTable = brokerResponseSQL.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 10);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(),
@@ -865,10 +865,10 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
 
     // select 1
     query = "SELECT column6 FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query);
+    brokerResponse = getBrokerResponseForPqlQuery(query);
     selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT column6 FROM testTable option(responseFormat=sql)";
-    brokerResponseSQL = getBrokerResponseForQuery(query);
+    brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     resultTable = brokerResponseSQL.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 1);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column6"});
@@ -879,10 +879,10 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
 
     // select 3
     query = "SELECT column1, column6, column7 FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query);
+    brokerResponse = getBrokerResponseForPqlQuery(query);
     selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT column1, column6, column7 FROM testTable option(responseFormat=sql)";
-    brokerResponseSQL = getBrokerResponseForQuery(query);
+    brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     resultTable = brokerResponseSQL.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 3);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column6", "column7"});

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
@@ -52,7 +52,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema =
         new DataSchema(new String[]{"count(*)"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -62,7 +62,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 0L, 120000L, rows, expectedResultsSize, dataSchema);
 
     // filter
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{24516L});
     QueriesTestUtils
@@ -70,7 +70,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     // group by
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "count(*)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -81,7 +81,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     // filter + group by
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"296467636", 17080L});
     QueriesTestUtils
@@ -89,7 +89,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     // empty results
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + " where column5='non-existent-value'", queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + " where column5='non-existent-value'", queryOptions);
     rows = new ArrayList<>();
     expectedResultsSize = 0;
     QueriesTestUtils
@@ -109,7 +109,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
 
     // Query should be answered by MetadataBasedAggregationOperator, so check if numEntriesScannedInFilter and
     // numEntriesScannedPostFilter are 0
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"max(column1)", "max(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -118,7 +118,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 0L, 120000L, rows, expectedResultsSize, dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2146952047.0, 999813884.0});
     QueriesTestUtils
@@ -126,7 +126,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "select max(column1) from testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "max(column1)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -136,7 +136,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"296467636", 2146952047.0});
     QueriesTestUtils
@@ -155,7 +155,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
 
     // Query should be answered by MetadataBasedAggregationOperator, so check if numEntriesScannedInFilter and
     // numEntriesScannedPostFilter are 0
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"min(column1)", "min(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -164,7 +164,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 0L, 120000L, rows, expectedResultsSize, dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{101116473.0, 20396372.0});
     QueriesTestUtils
@@ -172,7 +172,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT MIN(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "min(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -182,7 +182,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"296467636", 20396372.0});
     QueriesTestUtils
@@ -199,7 +199,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"sum(column1)", "sum(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -209,7 +209,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{27503790384288.0, 12429178874916.0});
     QueriesTestUtils
@@ -217,7 +217,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT SUM(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "sum(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -227,7 +227,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"296467636", 8606725456500.0});
     QueriesTestUtils
@@ -244,7 +244,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"avg(column1)", "avg(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -254,7 +254,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1121871038.680372, 506982332.9627998});
     QueriesTestUtils
@@ -262,7 +262,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "select avg(column3) from testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "avg(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -272,7 +272,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"438926263", 999309554.0});
     QueriesTestUtils
@@ -290,7 +290,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"minmaxrange(column1)", "minmaxrange(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -299,7 +299,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 0L, 120000L, rows, expectedResultsSize, dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2045835574.0, 979417512.0});
     QueriesTestUtils
@@ -307,7 +307,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT MINMAXRANGE(column1) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "minmaxrange(column1)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -317,7 +317,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"296467636", 2044094181.0});
     QueriesTestUtils
@@ -334,7 +334,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"distinctcount(column1)", "distinctcount(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT});
     rows = new ArrayList<>();
@@ -344,7 +344,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1872, 4556});
     QueriesTestUtils
@@ -352,7 +352,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT DISTINCTCOUNT(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "distinctcount(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     rows = new ArrayList<>();
@@ -362,7 +362,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"296467636", 3289});
     QueriesTestUtils
@@ -379,7 +379,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"distinctcounthll(column1)", "distinctcounthll(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -389,7 +389,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1886L, 4492L});
     QueriesTestUtils
@@ -397,7 +397,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT DISTINCTCOUNTHLL(column1) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "distinctcounthll(column1)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -407,7 +407,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"296467636", 1324L});
     QueriesTestUtils
@@ -424,7 +424,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"distinctcountrawhll(column1)", "distinctcountrawhll(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
     rows = new ArrayList<>();
@@ -437,7 +437,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[0].toString())).cardinality(), expectedRow0[0]);
     Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     expectedRow0 = new Object[]{1886L, 4492L};
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
@@ -447,7 +447,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
 
     query = "SELECT DISTINCTCOUNTRAWHLL(column1) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "distinctcountrawhll(column1)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
     expectedRow0 = new Object[]{"296467636", 3592L};
@@ -459,7 +459,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Assert.assertEquals(row0[0], expectedRow0[0]);
     Assert.assertEquals(HllUtil.buildHllFromBytes(BytesUtils.toBytes(row0[1].toString())).cardinality(), expectedRow0[1]);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     expectedRow0 = new Object[]{"296467636", 1324L};
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 24516L, 336536L, 49032L, 120000L, rows, expectedResultsSize,
@@ -478,7 +478,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentile50(column1)", "percentile50(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -488,7 +488,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1139674505.0, 505053732.0});
     QueriesTestUtils
@@ -496,7 +496,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT PERCENTILE50(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "percentile50(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -506,7 +506,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"438926263", 999309554.0});
     QueriesTestUtils
@@ -523,7 +523,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentile90(column1)", "percentile90(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -533,7 +533,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1936730975.0, 899534534.0});
     QueriesTestUtils
@@ -541,7 +541,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT PERCENTILE90(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "percentile90(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -551,7 +551,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"438926263", 999309554.0});
     QueriesTestUtils
@@ -568,7 +568,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentile95(column1)", "percentile95(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -578,7 +578,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2096857943.0, 947763150.0});
     QueriesTestUtils
@@ -586,7 +586,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT PERCENTILE95(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "percentile95(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -596,7 +596,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"438926263", 999309554.0});
     QueriesTestUtils
@@ -613,7 +613,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentile99(column1)", "percentile99(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -623,7 +623,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2146232405.0, 990669195.0});
     QueriesTestUtils
@@ -631,7 +631,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT PERCENTILE99(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "percentile99(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
@@ -641,7 +641,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"438926263", 999309554.0});
     QueriesTestUtils
@@ -658,7 +658,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentileest50(column1)", "percentileest50(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -668,7 +668,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1139674505L, 509607935L});
     QueriesTestUtils
@@ -676,7 +676,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT PERCENTILEEST50(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "percentileest50(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -686,7 +686,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"438926263", 999309554L});
     QueriesTestUtils
@@ -703,7 +703,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentileest90(column1)", "percentileest90(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -713,7 +713,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{1939865599L, 902299647L});
     QueriesTestUtils
@@ -721,7 +721,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT PERCENTILEEST90(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "percentileest90(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -731,7 +731,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"438926263", 999309554L});
     QueriesTestUtils
@@ -748,7 +748,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentileest95(column1)", "percentileest95(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -758,7 +758,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2109734911L, 950009855L});
     QueriesTestUtils
@@ -766,7 +766,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT PERCENTILEEST95(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "percentileest95(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -776,7 +776,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"438926263", 999309554L});
     QueriesTestUtils
@@ -793,7 +793,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
 
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     dataSchema = new DataSchema(new String[]{"percentileest99(column1)", "percentileest99(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -803,7 +803,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{2146232405L, 991952895L});
     QueriesTestUtils
@@ -811,7 +811,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
             dataSchema);
 
     query = "SELECT PERCENTILEEST99(column3) FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column9", "percentileest99(column3)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
@@ -821,7 +821,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
         .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
-    brokerResponse = getBrokerResponseForQuery(query + GROUP_BY + getFilter(), queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query + GROUP_BY + getFilter(), queryOptions);
     rows = new ArrayList<>();
     rows.add(new Object[]{"438926263", 999309554L});
     QueriesTestUtils
@@ -841,7 +841,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     String query = "SELECT DISTINCT(column1) FROM testTable LIMIT 1000000";
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     ResultTable resultTable = brokerResponse.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().size(), 1);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1"});
@@ -850,7 +850,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Assert.assertEquals(resultTable.getRows().size(), 6582);
 
     query = "SELECT DISTINCT(column1, column3) FROM testTable LIMIT 1000000";
-    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     resultTable = brokerResponse.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().size(), 2);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column3"});
@@ -859,7 +859,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     Assert.assertEquals(resultTable.getRows().size(), 21968);
 
     query = "SELECT DISTINCT(column1, column5, column3) FROM testTable LIMIT 1000000";
-    brokerResponse = getBrokerResponseForQuery(query, queryOptions);
+    brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
     resultTable = brokerResponse.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().size(), 3);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column5", "column3"});
@@ -875,10 +875,10 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
   public void testSelection() {
     // select *
     String query = "SELECT * FROM testTable";
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     SelectionResults selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT * FROM testTable option(responseFormat=sql)";
-    BrokerResponseNative brokerResponseSQL = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     ResultTable resultTable = brokerResponseSQL.getResultTable();
 
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 11);
@@ -889,10 +889,10 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
 
     // select * limit infinite
     query = "SELECT * FROM testTable limit 50";
-    brokerResponse = getBrokerResponseForQuery(query);
+    brokerResponse = getBrokerResponseForPqlQuery(query);
     selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT * FROM testTable LIMIT 50 option(responseFormat=sql)";
-    brokerResponseSQL = getBrokerResponseForQuery(query);
+    brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     resultTable = brokerResponseSQL.getResultTable();
 
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 11);
@@ -903,10 +903,10 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
 
     // select 1
     query = "SELECT column3 FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query);
+    brokerResponse = getBrokerResponseForPqlQuery(query);
     selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT column3 FROM testTable option(responseFormat=sql)";
-    brokerResponseSQL = getBrokerResponseForQuery(query);
+    brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     resultTable = brokerResponseSQL.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 1);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column3"});
@@ -917,10 +917,10 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
 
     // select 3
     query = "SELECT column1, column3, column11 FROM testTable";
-    brokerResponse = getBrokerResponseForQuery(query);
+    brokerResponse = getBrokerResponseForPqlQuery(query);
     selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT column1, column3, column11 FROM testTable option(responseFormat=sql)";
-    brokerResponseSQL = getBrokerResponseForQuery(query);
+    brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     resultTable = brokerResponseSQL.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 3);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column3", "column11"});
@@ -931,10 +931,10 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
 
     // select + order by
     query = "SELECT column1, column3 FROM testTable ORDER BY column3 option(preserveType=true)";
-    brokerResponse = getBrokerResponseForQuery(query);
+    brokerResponse = getBrokerResponseForPqlQuery(query);
     selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT column1, column3 FROM testTable ORDER BY column3 option(responseFormat=sql)";
-    brokerResponseSQL = getBrokerResponseForQuery(query);
+    brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     resultTable = brokerResponseSQL.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 2);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column3"});
@@ -952,10 +952,10 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     }
 
     query = "SELECT column1, column3 FROM testTable ORDER BY column3 option(preserveType=true)";
-    brokerResponse = getBrokerResponseForQuery(query);
+    brokerResponse = getBrokerResponseForPqlQuery(query);
     selectionResults = brokerResponse.getSelectionResults();
     query = "SELECT column1, column3 FROM testTable ORDER BY column3 option(responseFormat=sql)";
-    brokerResponseSQL = getBrokerResponseForQuery(query);
+    brokerResponseSQL = getBrokerResponseForPqlQuery(query);
     resultTable = brokerResponseSQL.getResultTable();
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames().length, 2);
     Assert.assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"column1", "column3"});

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
@@ -176,7 +176,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
   @Test
   public void testInterSegmentAggregation() {
     for (int percentile = 0; percentile <= 100; percentile++) {
-      BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getAggregationQuery(percentile));
+      BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(getAggregationQuery(percentile));
       List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
       Assert.assertNotNull(aggregationResults);
       Assert.assertEquals(aggregationResults.size(), 3);
@@ -208,7 +208,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
   @Test
   public void testInterSegmentGroupBy() {
     for (int percentile = 0; percentile <= 100; percentile++) {
-      BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getGroupByQuery(percentile));
+      BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(getGroupByQuery(percentile));
       List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
       Assert.assertNotNull(aggregationResults);
       Assert.assertEquals(aggregationResults.size(), 3);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
@@ -284,7 +284,7 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
   @Test
   public void testInterSegmentAggregation()
       throws Exception {
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getAggregationQuery());
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(getAggregationQuery());
     List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
     assertNotNull(aggregationResults);
     assertEquals(aggregationResults.size(), 5);
@@ -450,7 +450,7 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
   @Test
   public void testInterSegmentSVGroupBy()
       throws Exception {
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getSVGroupByQuery());
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(getSVGroupByQuery());
     List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
     assertNotNull(aggregationResults);
     assertEquals(aggregationResults.size(), 5);
@@ -655,7 +655,7 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
   @Test
   public void testInterSegmentMVGroupBy()
       throws Exception {
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getMVGroupByQuery());
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(getMVGroupByQuery());
     List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
     assertNotNull(aggregationResults);
     assertEquals(aggregationResults.size(), 5);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
@@ -276,7 +276,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
   }
 
   private void runAndVerifyInterSegmentQuery(String query, String serialized) {
-    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
     Assert.assertEquals(aggregationResults.size(), 1);
     Serializable value = aggregationResults.get(0).getValue();


### PR DESCRIPTION
Sample query
```
select event_name, count(*) as cnt from meetupRsvp group by event_name limit 1
```

Old response:
```
{
    "resultTable": {
        "dataSchema": {
            "columnNames": ["event_name", "count(*)"],
            "columnDataTypes": ["STRING", "LONG"]
        },
        "rows": [
            ["Remote Pair Programming Session: Callbacks, Closures, & Higher-Order Functions", 1]
        ]
    },
    ...
}
```

New  response:
```
{
    "resultTable": {
        "dataSchema": {
            "columnNames": ["event_name", "cnt"],
            "columnDataTypes": ["STRING", "LONG"]
        },
        "rows": [
            ["Remote Pair Programming Session: Callbacks, Closures, & Higher-Order Functions", 1]
        ]
    },
   ...
}
```

Sample query and response:
```
select count(*) as cnt1, sum(rsvp_count) as sum_rsvp_count from meetupRsvp limit 10
```
```
{
    "resultTable": {
        "dataSchema": {
            "columnDataTypes": ["LONG", "DOUBLE"],
            "columnNames": ["cnt1", "sum_rsvp_count"]
        },
        "rows": [
            [1131, 1131.0]
        ]
    },
...
}
```