### PR TITLE
Close Kafka consumer before building or downloading immutable segment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -209,7 +209,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final Semaphore _partitionConsumerSemaphore;
   // A boolean flag to check whether the current thread has acquired the semaphore.
   // This boolean is needed because the semaphore is shared by threads; every thread holding this semaphore can
-  // modify the permit. This boolean make sure the semaphore gets released only once within the same thread.
+  // modify the permit. This boolean make sure the semaphore gets released only once when the partition stops consuming.
   private final AtomicBoolean _acquiredConsumerSemaphore;
   private final String _metricKeyName;
   private final ServerMetrics _serverMetrics;
@@ -1149,7 +1149,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       _partitionConsumerSemaphore.acquire();
       _acquiredConsumerSemaphore.set(true);
     } catch (InterruptedException e) {
-      String errorMsg = "InterruptedException when acquiring semaphore for Segment: " + _segmentNameStr;
+      String errorMsg = "InterruptedException when acquiring the partitionConsumerSemaphore";
       segmentLogger.error(errorMsg);
       throw new RuntimeException(errorMsg);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1151,7 +1151,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     } catch (InterruptedException e) {
       String errorMsg = "InterruptedException when acquiring the partitionConsumerSemaphore";
       segmentLogger.error(errorMsg);
-      throw new RuntimeException(errorMsg);
+      throw new RuntimeException(errorMsg + " for segment: " + _segmentNameStr);
     }
     makeStreamConsumer("Starting");
     makeStreamMetadataProvider("Starting");

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -63,8 +63,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   private SegmentBuildTimeLeaseExtender _leaseExtender;
   private RealtimeSegmentStatsHistory _statsHistory;
   private final Semaphore _segmentBuildSemaphore;
-  // Maintains a map for the partitionIds and its related semaphores, which is to prevent two different Kafka consumers
-  // from consuming with the same partitionId in parallel in the same host.
+  // Maintains a map of partitionIds to semaphores.
+  // The semaphore ensures that exactly one PartitionConsumer instance consumes from any stream partition.
+  // In some streams, it's possible that having multiple consumers (with the same consumer name on the same host) consuming from the same stream partition can lead to bugs.
   // The semaphores will stay in the hash map even if the consuming partitions move to a different host.
   // We expect that there will be a small number of semaphores, but that may be ok.
   private final Map<Integer, Semaphore> _partitionIdToSemaphoreMap = new ConcurrentHashMap<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -22,8 +22,11 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -60,6 +63,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   private SegmentBuildTimeLeaseExtender _leaseExtender;
   private RealtimeSegmentStatsHistory _statsHistory;
   private final Semaphore _segmentBuildSemaphore;
+  private Map<Integer, Semaphore> _partitionIdToSemaphoreMap = new ConcurrentHashMap<>();
 
   // The old name of the stats file used to be stats.ser which we changed when we moved all packages
   // from com.linkedin to org.apache because of not being able to deserialize the old files using the newer classes
@@ -242,7 +246,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
           return;
         }
         manager = new LLRealtimeSegmentDataManager(realtimeSegmentZKMetadata, tableConfig, instanceZKMetadata, this,
-            _indexDir.getAbsolutePath(), indexLoadingConfig, schema, _serverMetrics);
+            _indexDir.getAbsolutePath(), indexLoadingConfig, schema, _partitionIdToSemaphoreMap, _serverMetrics);
       }
       _logger.info("Initialize RealtimeSegmentDataManager - " + segmentName);
       _segmentDataManagerMap.put(segmentName, manager);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -63,7 +63,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   private SegmentBuildTimeLeaseExtender _leaseExtender;
   private RealtimeSegmentStatsHistory _statsHistory;
   private final Semaphore _segmentBuildSemaphore;
-  private Map<Integer, Semaphore> _partitionIdToSemaphoreMap = new ConcurrentHashMap<>();
+  // Maintains a map for the partitionIds and its related semaphores, which is to prevent two different Kafka consumers
+  // from consuming with the same partitionId in parallel in the same host.
+  // The semaphores will stay in the hash map even if the consuming partitions move to a different host.
+  // We expect that there will be a small number of semaphores, but that may be ok.
+  private final Map<Integer, Semaphore> _partitionIdToSemaphoreMap = new ConcurrentHashMap<>();
 
   // The old name of the stats file used to be stats.ser which we changed when we moved all packages
   // from com.linkedin to org.apache because of not being able to deserialize the old files using the newer classes

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -647,7 +647,7 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     long timeout = 2_000L;
     FakeLLRealtimeSegmentDataManager firstSegmentDataManager = createFakeSegmentManager();
-    Assert.assertTrue(firstSegmentDataManager.getAcquireConsumerSemaphore().get());
+    Assert.assertTrue(firstSegmentDataManager.getAcquiredConsumerSemaphore().get());
     Assert.assertEquals(firstSegmentDataManager.getPartitionConsumerSemaphore().availablePermits(), 0);
 
     // Release semaphore after timeout.
@@ -666,7 +666,7 @@ public class LLRealtimeSegmentDataManagerTest {
     FakeLLRealtimeSegmentDataManager secondSegmentDataManager = createFakeSegmentManager();
     Assert.assertEquals(firstSegmentDataManager.getPartitionConsumerSemaphore(),
         secondSegmentDataManager.getPartitionConsumerSemaphore());
-    Assert.assertTrue(secondSegmentDataManager.getAcquireConsumerSemaphore().get());
+    Assert.assertTrue(secondSegmentDataManager.getAcquiredConsumerSemaphore().get());
     Assert.assertEquals(firstSegmentDataManager.getPartitionConsumerSemaphore().availablePermits(), 0);
 
     // Call destroy method the 2nd time on the first segment manager, the permits in semaphore won't increase.

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -50,7 +50,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 
@@ -121,8 +120,8 @@ public class LLRealtimeSegmentDataManagerTest {
     RealtimeTableDataManager tableDataManager = mock(RealtimeTableDataManager.class);
     when(tableDataManager.getServerInstance()).thenReturn(instanceId);
     RealtimeSegmentStatsHistory statsHistory = mock(RealtimeSegmentStatsHistory.class);
-    when(statsHistory.getEstimatedCardinality(any(String.class))).thenReturn(200);
-    when(statsHistory.getEstimatedAvgColSize(any(String.class))).thenReturn(32);
+    when(statsHistory.getEstimatedCardinality(anyString())).thenReturn(200);
+    when(statsHistory.getEstimatedAvgColSize(anyString())).thenReturn(32);
     when(tableDataManager.getStatsHistory()).thenReturn(statsHistory);
     return tableDataManager;
   }
@@ -669,7 +668,14 @@ public class LLRealtimeSegmentDataManagerTest {
         secondSegmentDataManager.getPartitionConsumerSemaphore());
     Assert.assertTrue(secondSegmentDataManager.getAcquireConsumerSemaphore().get());
     Assert.assertEquals(firstSegmentDataManager.getPartitionConsumerSemaphore().availablePermits(), 0);
+
+    // Call destroy method the 2nd time on the first segment manager, the permits in semaphore won't increase.
+    firstSegmentDataManager.destroy();
+    Assert.assertEquals(firstSegmentDataManager.getPartitionConsumerSemaphore().availablePermits(), 0);
+
+    // The permit finally gets released in the Semaphore.
     secondSegmentDataManager.destroy();
+    Assert.assertEquals(secondSegmentDataManager.getPartitionConsumerSemaphore().availablePermits(), 1);
   }
 
   public static class FakeLLRealtimeSegmentDataManager extends LLRealtimeSegmentDataManager {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -924,8 +924,4 @@ public class LLRealtimeSegmentDataManagerTest {
       }
     }
   }
-
-//  public static class FakeSemaphore extends Semaphore {
-//
-//  }
 }


### PR DESCRIPTION
When realtime immutable segment needs to be built or downloaded, there is a short period of time that the new consuming segment has already started the Kafka consumption before the immutable segment finishes building or downloading. 
This leads to a scenario that two unclosed consumers exist for the same partitionId at the same time. And this will also cause the metric system having two consumers with the same metric name.

When an immutable segment needs to be built or downloaded, it means this segment has already done the Kafka consumption. Thus, it's ok to close the Kafka consumer.