### PR TITLE
Re-design the broker routing

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/RoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/RoutingManager.java
@@ -1,0 +1,502 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.apache.helix.AccessOption;
+import org.apache.helix.BaseDataAccessor;
+import org.apache.helix.HelixConstants;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.broker.broker.helix.ClusterChangeHandler;
+import org.apache.pinot.broker.routing.v2.instanceselector.InstanceSelector;
+import org.apache.pinot.broker.routing.v2.instanceselector.InstanceSelectorFactory;
+import org.apache.pinot.broker.routing.v2.segmentpruner.SegmentPruner;
+import org.apache.pinot.broker.routing.v2.segmentpruner.SegmentPrunerFactory;
+import org.apache.pinot.broker.routing.v2.segmentselector.SegmentSelector;
+import org.apache.pinot.broker.routing.v2.segmentselector.SegmentSelectorFactory;
+import org.apache.pinot.broker.routing.v2.timeboundary.TimeBoundaryInfo;
+import org.apache.pinot.broker.routing.v2.timeboundary.TimeBoundaryManager;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metrics.BrokerMeter;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The {@code RoutingManager} manages the routing of all tables hosted by the broker instance. It listens to the cluster
+ * changes and updates the routing components accordingly.
+ * <p>The following methods are provided:
+ * <ul>
+ *   <li>{@link #buildRouting(String)}: Builds/rebuilds the routing for a table</li>
+ *   <li>{@link #removeRouting(String)}: Removes the routing for a table</li>
+ *   <li>{@link #refreshSegment(String, String): Refreshes the metadata for a segment}</li>
+ *   <li>{@link #routingExists(String)}: Returns whether the routing exists for a table</li>
+ *   <li>{@link #getRoutingTable(BrokerRequest)}: Returns the routing table for a query</li>
+ *   <li>{@link #getTimeBoundaryInfo(String)}: Returns the time boundary info for a table</li>
+ * </ul>
+ */
+public class RoutingManager implements ClusterChangeHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RoutingManager.class);
+
+  private final BrokerMetrics _brokerMetrics;
+  private final Map<String, RoutingEntry> _routingEntryMap = new ConcurrentHashMap<>();
+  private final Map<String, ServerInstance> _enabledServerInstanceMap = new ConcurrentHashMap<>();
+
+  private BaseDataAccessor<ZNRecord> _zkDataAccessor;
+  private String _externalViewPathPrefix;
+  private String _idealStatePathPrefix;
+  private String _instanceConfigsPath;
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  public RoutingManager(BrokerMetrics brokerMetrics) {
+    _brokerMetrics = brokerMetrics;
+  }
+
+  @Override
+  public void init(HelixManager helixManager) {
+    HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
+    _zkDataAccessor = helixDataAccessor.getBaseDataAccessor();
+    _externalViewPathPrefix = helixDataAccessor.keyBuilder().externalViews().getPath() + "/";
+    _idealStatePathPrefix = helixDataAccessor.keyBuilder().idealStates().getPath() + "/";
+    _instanceConfigsPath = helixDataAccessor.keyBuilder().instanceConfigs().getPath();
+    _propertyStore = helixManager.getHelixPropertyStore();
+  }
+
+  @Override
+  public synchronized void processClusterChange(HelixConstants.ChangeType changeType) {
+    Preconditions.checkState(changeType == HelixConstants.ChangeType.EXTERNAL_VIEW
+        || changeType == HelixConstants.ChangeType.INSTANCE_CONFIG, "Illegal change type: " + changeType);
+    if (changeType == HelixConstants.ChangeType.EXTERNAL_VIEW) {
+      processExternalViewChange();
+    } else {
+      processInstanceConfigChange();
+    }
+  }
+
+  private void processExternalViewChange() {
+    LOGGER.info("Processing external view change");
+    long startTimeMs = System.currentTimeMillis();
+
+    int numTables = _routingEntryMap.size();
+    if (numTables == 0) {
+      LOGGER.info("No table exists in the routing, skipping processing external view change");
+      return;
+    }
+
+    List<RoutingEntry> routingEntries = new ArrayList<>(numTables);
+    List<String> externalViewPaths = new ArrayList<>(numTables);
+    for (Map.Entry<String, RoutingEntry> entry : _routingEntryMap.entrySet()) {
+      String tableNameWithType = entry.getKey();
+      routingEntries.add(entry.getValue());
+      externalViewPaths.add(_externalViewPathPrefix + tableNameWithType);
+    }
+    Stat[] stats = _zkDataAccessor.getStats(externalViewPaths, AccessOption.PERSISTENT);
+    long fetchStatsEndTimeMs = System.currentTimeMillis();
+
+    int numRoutingEntriesToUpdate = 0;
+    for (int i = 0; i < numTables; i++) {
+      Stat stat = stats[i];
+      if (stat != null) {
+        RoutingEntry routingEntry = routingEntries.get(i);
+        if (stat.getVersion() != routingEntry.getLastUpdateExternalViewVersion()) {
+          numRoutingEntriesToUpdate++;
+          try {
+            updateRoutingEntryOnExternalViewChange(routingEntry);
+          } catch (Exception e) {
+            LOGGER
+                .error("Caught unexpected exception while updating routing entry on external view change for table: {}",
+                    routingEntry.getTableNameWithType(), e);
+          }
+        }
+      }
+    }
+    long updateRoutingEntriesEndTimeMs = System.currentTimeMillis();
+
+    LOGGER.info(
+        "Processed external view change in {}ms (fetch {} external view stats: {}ms, update {} routing entries: {}ms)",
+        updateRoutingEntriesEndTimeMs - startTimeMs, numTables, fetchStatsEndTimeMs - startTimeMs,
+        numRoutingEntriesToUpdate, updateRoutingEntriesEndTimeMs - fetchStatsEndTimeMs);
+  }
+
+  private void updateRoutingEntryOnExternalViewChange(RoutingEntry routingEntry) {
+    String tableNameWithType = routingEntry.getTableNameWithType();
+    ExternalView externalView = getExternalView(tableNameWithType);
+    if (externalView == null) {
+      LOGGER.warn("Failed to find external view for table: {}, skipping updating routing entry", tableNameWithType);
+      return;
+    }
+    Set<String> onlineSegments = getOnlineSegments(tableNameWithType);
+    if (onlineSegments == null) {
+      LOGGER.warn("Failed to find ideal state for table: {}, skipping updating routing entry", tableNameWithType);
+      return;
+    }
+    routingEntry.onExternalViewChange(externalView, onlineSegments);
+  }
+
+  @Nullable
+  private ExternalView getExternalView(String tableNameWithType) {
+    Stat stat = new Stat();
+    ZNRecord znRecord = _zkDataAccessor.get(_externalViewPathPrefix + tableNameWithType, stat, AccessOption.PERSISTENT);
+    if (znRecord != null) {
+      znRecord.setVersion(stat.getVersion());
+      return new ExternalView(znRecord);
+    } else {
+      return null;
+    }
+  }
+
+  @Nullable
+  private Set<String> getOnlineSegments(String tableNameWithType) {
+    ZNRecord znRecord = _zkDataAccessor.get(_idealStatePathPrefix + tableNameWithType, null, AccessOption.PERSISTENT);
+    if (znRecord != null) {
+      Map<String, Map<String, String>> segmentAssignment = znRecord.getMapFields();
+      Set<String> onlineSegments = new HashSet<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
+      for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
+        Map<String, String> instanceStateMap = entry.getValue();
+        if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.ONLINE) || instanceStateMap
+            .containsValue(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+          onlineSegments.add(entry.getKey());
+        }
+      }
+      return onlineSegments;
+    } else {
+      return null;
+    }
+  }
+
+  private void processInstanceConfigChange() {
+    LOGGER.info("Processing instance config change");
+    long startTimeMs = System.currentTimeMillis();
+
+    List<ZNRecord> instanceConfigZNRecords =
+        _zkDataAccessor.getChildren(_instanceConfigsPath, null, AccessOption.PERSISTENT);
+    long fetchInstanceConfigsEndTimeMs = System.currentTimeMillis();
+
+    // Calculate new enabled and disabled instances
+    Set<String> enabledInstances = new HashSet<>();
+    List<String> newEnabledInstances = new ArrayList<>();
+    for (ZNRecord instanceConfigZNRecord : instanceConfigZNRecords) {
+      String instance = instanceConfigZNRecord.getId();
+      if (isInstanceEnabled(instanceConfigZNRecord)) {
+        enabledInstances.add(instance);
+
+        // Always refresh the server instance with the latest instance config in case it changes
+        ServerInstance serverInstance = new ServerInstance(new InstanceConfig(instanceConfigZNRecord));
+        if (_enabledServerInstanceMap.put(instance, serverInstance) == null) {
+          newEnabledInstances.add(instance);
+        }
+      }
+    }
+    List<String> newDisabledInstances = new ArrayList<>();
+    for (String instance : _enabledServerInstanceMap.keySet()) {
+      if (!enabledInstances.contains(instance)) {
+        newDisabledInstances.add(instance);
+      }
+    }
+    List<String> changedInstances = new ArrayList<>(newEnabledInstances.size() + newDisabledInstances.size());
+    changedInstances.addAll(newEnabledInstances);
+    changedInstances.addAll(newDisabledInstances);
+    long calculateChangedInstancesEndTimeMs = System.currentTimeMillis();
+
+    // Update routing entry for all tables
+    for (RoutingEntry routingEntry : _routingEntryMap.values()) {
+      try {
+        routingEntry.onInstancesChange(enabledInstances, changedInstances);
+      } catch (Exception e) {
+        LOGGER.error("Caught unexpected exception while updating routing entry on instances change for table: {}",
+            routingEntry.getTableNameWithType(), e);
+      }
+    }
+    long updateRoutingEntriesEndTimeMs = System.currentTimeMillis();
+
+    // Remove new disabled instances from _enabledServerInstanceMap after updating all routing entries to ensure it
+    // always contains the selected instances
+    _enabledServerInstanceMap.keySet().removeAll(newDisabledInstances);
+
+    LOGGER.info(
+        "Processed instance config change in {}ms (fetch {} instance configs: {}ms, calculate changed instances: {}ms, update {} routing entries: {}ms), new enabled instances: {}, new disabled instances: {}",
+        updateRoutingEntriesEndTimeMs - startTimeMs, instanceConfigZNRecords.size(),
+        fetchInstanceConfigsEndTimeMs - startTimeMs, calculateChangedInstancesEndTimeMs - fetchInstanceConfigsEndTimeMs,
+        _routingEntryMap.size(), updateRoutingEntriesEndTimeMs - calculateChangedInstancesEndTimeMs,
+        newEnabledInstances, newDisabledInstances);
+  }
+
+  private static boolean isInstanceEnabled(ZNRecord instanceConfigZNRecord) {
+    if ("false"
+        .equals(instanceConfigZNRecord.getSimpleField(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name()))) {
+      return false;
+    }
+    if ("true".equals(instanceConfigZNRecord.getSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS))) {
+      return false;
+    }
+    if ("true".equals(instanceConfigZNRecord.getSimpleField(CommonConstants.Helix.QUERIES_DISABLED))) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Builds/rebuilds the routing for the given table.
+   */
+  public synchronized void buildRouting(String tableNameWithType) {
+    LOGGER.info("Building routing for table: {}", tableNameWithType);
+
+    TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: {}", tableNameWithType);
+    ExternalView externalView = getExternalView(tableNameWithType);
+    Preconditions.checkState(externalView != null, "Failed to find external view for table: {}", tableNameWithType);
+    Set<String> onlineSegments = getOnlineSegments(tableNameWithType);
+    Preconditions.checkState(onlineSegments != null, "Failed to find ideal state for table: {}", tableNameWithType);
+    Set<String> enabledInstances = _enabledServerInstanceMap.keySet();
+
+    SegmentSelector segmentSelector = SegmentSelectorFactory.getSegmentSelector(tableConfig);
+    segmentSelector.init(externalView, onlineSegments);
+    List<SegmentPruner> segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    for (SegmentPruner segmentPruner : segmentPruners) {
+      segmentPruner.init(externalView, onlineSegments);
+    }
+    InstanceSelector instanceSelector = InstanceSelectorFactory.getInstanceSelector(tableConfig, _brokerMetrics);
+    instanceSelector.init(enabledInstances, externalView, onlineSegments);
+    int externalViewVersion = externalView.getRecord().getVersion();
+
+    // Add time boundary manager if both offline and real-time part exist for a hybrid table
+    TimeBoundaryManager timeBoundaryManager = null;
+    String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    if (TableNameBuilder.isOfflineTableResource(tableNameWithType)) {
+      // Current table is offline
+      String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
+      if (_routingEntryMap.containsKey(realtimeTableName)) {
+        LOGGER.info("Adding time boundary manager for table: {}", tableNameWithType);
+        timeBoundaryManager = new TimeBoundaryManager(tableConfig, _propertyStore);
+        timeBoundaryManager.init(externalView, onlineSegments);
+      }
+    } else {
+      // Current table is real-time
+      String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+      RoutingEntry offlineTableRoutingEntry = _routingEntryMap.get(offlineTableName);
+      if (offlineTableRoutingEntry != null && offlineTableRoutingEntry.getTimeBoundaryManager() == null) {
+        LOGGER.info("Adding time boundary manager for table: {}", offlineTableName);
+
+        // NOTE: Add time boundary manager to the offline part before adding the routing for the real-time part to
+        // ensure no overlapping data getting queried
+        TableConfig offlineTableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, offlineTableName);
+        Preconditions
+            .checkState(offlineTableConfig != null, "Failed to find table config for table: {}", offlineTableName);
+        ExternalView offlineTableExternalView = getExternalView(offlineTableName);
+        Preconditions.checkState(offlineTableExternalView != null, "Failed to find external view for table: {}",
+            offlineTableName);
+        Set<String> offlineTableOnlineSegments = getOnlineSegments(offlineTableName);
+        Preconditions.checkState(offlineTableOnlineSegments != null, "Failed to find ideal state for table: {}",
+            offlineTableName);
+        TimeBoundaryManager offlineTableTimeBoundaryManager =
+            new TimeBoundaryManager(offlineTableConfig, _propertyStore);
+        offlineTableTimeBoundaryManager.init(offlineTableExternalView, offlineTableOnlineSegments);
+        offlineTableRoutingEntry.setTimeBoundaryManager(offlineTableTimeBoundaryManager);
+      }
+    }
+
+    RoutingEntry routingEntry =
+        new RoutingEntry(tableNameWithType, segmentSelector, segmentPruners, instanceSelector, externalViewVersion,
+            timeBoundaryManager);
+    if (_routingEntryMap.put(tableNameWithType, routingEntry) == null) {
+      LOGGER.info("Built routing for table: {}", tableNameWithType);
+    } else {
+      LOGGER.info("Rebuilt routing for table: {}", tableNameWithType);
+    }
+  }
+
+  /**
+   * Removes the routing for the given table.
+   */
+  public synchronized void removeRouting(String tableNameWithType) {
+    LOGGER.info("Removing routing for table: {}", tableNameWithType);
+    if (_routingEntryMap.remove(tableNameWithType) != null) {
+      LOGGER.info("Removed routing for table: {}", tableNameWithType);
+
+      // Remove time boundary manager for the offline part routing if the removed routing is the real-time part of a
+      // hybrid table
+      if (TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
+        String offlineTableName =
+            TableNameBuilder.OFFLINE.tableNameWithType(TableNameBuilder.extractRawTableName(tableNameWithType));
+        RoutingEntry routingEntry = _routingEntryMap.get(offlineTableName);
+        if (routingEntry != null) {
+          routingEntry.setTimeBoundaryManager(null);
+          LOGGER.info("Removed time boundary manager for table: {}", offlineTableName);
+        }
+      }
+    } else {
+      LOGGER.warn("Routing does not exist for table: {}, skipping removing routing", tableNameWithType);
+    }
+  }
+
+  /**
+   * Refreshes the metadata for the given segment (called when segment is getting refreshed).
+   */
+  public synchronized void refreshSegment(String tableNameWithType, String segment) {
+    LOGGER.info("Refreshing segment: {} for table: {}", segment, tableNameWithType);
+    RoutingEntry routingEntry = _routingEntryMap.get(tableNameWithType);
+    if (routingEntry != null) {
+      routingEntry.refreshSegment(segment);
+      LOGGER.info("Refreshed segment: {} for table: {}", segment, tableNameWithType);
+    } else {
+      LOGGER.warn("Routing does not exist for table: {}, skipping refreshing segment", tableNameWithType);
+    }
+  }
+
+  /**
+   * Returns {@code true} if the routing exists for the given table.
+   */
+  public boolean routingExists(String tableNameWithType) {
+    return _routingEntryMap.containsKey(tableNameWithType);
+  }
+
+  /**
+   * Returns the routing table (map from server instance to list of segments hosted by the server) based on the broker
+   * request.
+   * <p>NOTE: The broker request should already have the table suffix (_OFFLINE or _REALTIME) appended.
+   */
+  public Map<ServerInstance, List<String>> getRoutingTable(BrokerRequest brokerRequest) {
+    String tableNameWithType = brokerRequest.getQuerySource().getTableName();
+    RoutingEntry routingEntry = _routingEntryMap.get(tableNameWithType);
+    Preconditions.checkState(routingEntry != null, "Failed to find routing for table: %s", tableNameWithType);
+
+    Map<String, String> segmentToInstanceMap = routingEntry.calculateSegmentToInstanceMap(brokerRequest);
+    Map<ServerInstance, List<String>> routingTable = new HashMap<>();
+    for (Map.Entry<String, String> entry : segmentToInstanceMap.entrySet()) {
+      ServerInstance serverInstance = _enabledServerInstanceMap.get(entry.getValue());
+      if (serverInstance != null) {
+        routingTable.computeIfAbsent(serverInstance, k -> new ArrayList<>()).add(entry.getKey());
+      } else {
+        // Should not happen in normal case unless encountered unexpected exception when updating routing entries
+        _brokerMetrics.addMeteredTableValue(tableNameWithType, BrokerMeter.SERVER_MISSING_FOR_ROUTING, 1L);
+      }
+    }
+    return routingTable;
+  }
+
+  /**
+   * Returns the time boundary info for the given offline table.
+   * <p>NOTE: Time boundary info is only available for the offline part of the hybrid table.
+   */
+  @Nullable
+  public TimeBoundaryInfo getTimeBoundaryInfo(String offlineTableName) {
+    RoutingEntry routingEntry = _routingEntryMap.get(offlineTableName);
+    Preconditions.checkState(routingEntry != null, "Failed to find routing for table: %s", offlineTableName);
+    TimeBoundaryManager timeBoundaryManager = routingEntry.getTimeBoundaryManager();
+    return timeBoundaryManager != null ? timeBoundaryManager.getTimeBoundaryInfo() : null;
+  }
+
+  private static class RoutingEntry {
+    final String _tableNameWithType;
+    final SegmentSelector _segmentSelector;
+    final List<SegmentPruner> _segmentPruners;
+    final InstanceSelector _instanceSelector;
+
+    // Cache the ExternalView version for the last update
+    transient int _lastUpdateExternalViewVersion;
+    // Time boundary manager is only available for the offline part of the hybrid table
+    transient TimeBoundaryManager _timeBoundaryManager;
+
+    RoutingEntry(String tableNameWithType, SegmentSelector segmentSelector, List<SegmentPruner> segmentPruners,
+        InstanceSelector instanceSelector, int lastUpdateExternalViewVersion,
+        @Nullable TimeBoundaryManager timeBoundaryManager) {
+      _tableNameWithType = tableNameWithType;
+      _segmentSelector = segmentSelector;
+      _segmentPruners = segmentPruners;
+      _instanceSelector = instanceSelector;
+      _lastUpdateExternalViewVersion = lastUpdateExternalViewVersion;
+      _timeBoundaryManager = timeBoundaryManager;
+    }
+
+    String getTableNameWithType() {
+      return _tableNameWithType;
+    }
+
+    int getLastUpdateExternalViewVersion() {
+      return _lastUpdateExternalViewVersion;
+    }
+
+    void setTimeBoundaryManager(@Nullable TimeBoundaryManager timeBoundaryManager) {
+      _timeBoundaryManager = timeBoundaryManager;
+    }
+
+    @Nullable
+    TimeBoundaryManager getTimeBoundaryManager() {
+      return _timeBoundaryManager;
+    }
+
+    // NOTE: The change gets applied in sequence, and before change applied to all components, there could be some
+    // inconsistency between components, which is fine because the inconsistency only exists for the newly changed
+    // segments and only lasts for a very short time.
+    void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
+      _segmentSelector.onExternalViewChange(externalView, onlineSegments);
+      for (SegmentPruner segmentPruner : _segmentPruners) {
+        segmentPruner.onExternalViewChange(externalView, onlineSegments);
+      }
+      _instanceSelector.onExternalViewChange(externalView, onlineSegments);
+      if (_timeBoundaryManager != null) {
+        _timeBoundaryManager.onExternalViewChange(externalView, onlineSegments);
+      }
+      _lastUpdateExternalViewVersion = externalView.getStat().getVersion();
+    }
+
+    void onInstancesChange(Set<String> enabledInstances, List<String> changedInstances) {
+      _instanceSelector.onInstancesChange(enabledInstances, changedInstances);
+    }
+
+    void refreshSegment(String segment) {
+      for (SegmentPruner segmentPruner : _segmentPruners) {
+        segmentPruner.refreshSegment(segment);
+      }
+      if (_timeBoundaryManager != null) {
+        _timeBoundaryManager.refreshSegment(segment);
+      }
+    }
+
+    Map<String, String> calculateSegmentToInstanceMap(BrokerRequest brokerRequest) {
+      List<String> selectedSegments = _segmentSelector.select(brokerRequest);
+      for (SegmentPruner segmentPruner : _segmentPruners) {
+        selectedSegments = segmentPruner.prune(brokerRequest, selectedSegments);
+      }
+      return _instanceSelector.select(brokerRequest, selectedSegments);
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/BalancedInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/BalancedInstanceSelector.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.instanceselector;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.HashUtil;
+
+
+/**
+ * Instance selector to balance the number of segments served by each selected server instance.
+ * <p>The selection algorithm will always evenly distribute the traffic to all replicas of each segment, and will try
+ * to select different replica id for each segment. The algorithm is very light-weight and will do best effort to
+ * balance the number of segments served by each selected server instance.
+ */
+public class BalancedInstanceSelector extends BaseInstanceSelector {
+
+  public BalancedInstanceSelector(String tableNameWithType, BrokerMetrics brokerMetrics) {
+    super(tableNameWithType, brokerMetrics);
+  }
+
+  @Override
+  Map<String, String> select(List<String> segments, int requestId,
+      Map<String, List<String>> segmentToEnabledInstancesMap) {
+    Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+    for (String segment : segments) {
+      List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment);
+      // NOTE: enabledInstances can be null when there is no enabled instances for the segment, or the instance selector
+      // has not been updated (we update all components for routing in sequence)
+      if (enabledInstances != null) {
+        int numEnabledInstances = enabledInstances.size();
+        segmentToSelectedInstanceMap.put(segment, enabledInstances.get(requestId++ % numEnabledInstances));
+      }
+    }
+    return segmentToSelectedInstanceMap;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/BaseInstanceSelector.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.instanceselector;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
+import org.apache.helix.model.ExternalView;
+import org.apache.pinot.common.metrics.BrokerMeter;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.HashUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Base implementation of instance selector which maintains a map from segment to enabled server instances that serves
+ * the segment.
+ */
+abstract class BaseInstanceSelector implements InstanceSelector {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseInstanceSelector.class);
+
+  // To prevent int overflow, reset the request id once it reaches this value
+  private static final int MAX_REQUEST_ID = 1_000_000_000;
+
+  private final AtomicLong _requestId = new AtomicLong();
+  private final String _tableNameWithType;
+  private final BrokerMetrics _brokerMetrics;
+
+  private volatile Set<String> _enabledInstances;
+  private volatile Map<String, List<String>> _segmentToInstancesMap;
+  private volatile Map<String, List<String>> _instanceToSegmentsMap;
+  private volatile Map<String, List<String>> _segmentToEnabledInstancesMap;
+
+  BaseInstanceSelector(String tableNameWithType, BrokerMetrics brokerMetrics) {
+    _tableNameWithType = tableNameWithType;
+    _brokerMetrics = brokerMetrics;
+  }
+
+  @Override
+  public void init(Set<String> enabledInstances, ExternalView externalView, Set<String> onlineSegments) {
+    _enabledInstances = enabledInstances;
+    onExternalViewChange(externalView, onlineSegments);
+  }
+
+  @Override
+  public void onInstancesChange(Set<String> enabledInstances, List<String> changedInstances) {
+    _enabledInstances = enabledInstances;
+
+    // Update all segments served by the changed instances
+    Set<String> segmentsToUpdate = new HashSet<>();
+    Map<String, List<String>> instanceToSegmentsMap = _instanceToSegmentsMap;
+    for (String instance : changedInstances) {
+      List<String> segments = instanceToSegmentsMap.get(instance);
+      if (segments != null) {
+        segmentsToUpdate.addAll(segments);
+      }
+    }
+
+    // Directly return if no segment needs to be updated
+    if (segmentsToUpdate.isEmpty()) {
+      return;
+    }
+
+    // Update the map from segment to enabled instances
+    // NOTE: We can directly modify the map because we will only update the values without changing the map entries.
+    // Because the map is marked as volatile, the running queries (already accessed the map) might use the enabled
+    // instances either before or after the change, which is okay; the following queries (not yet accessed the map) will
+    // get the updated value.
+    Map<String, List<String>> segmentToInstancesMap = _segmentToInstancesMap;
+    Map<String, List<String>> segmentToEnabledInstancesMap = _segmentToEnabledInstancesMap;
+    for (Map.Entry<String, List<String>> entry : segmentToEnabledInstancesMap.entrySet()) {
+      String segment = entry.getKey();
+      if (segmentsToUpdate.contains(segment)) {
+        entry.setValue(
+            calculateEnabledInstancesForSegment(segment, segmentToInstancesMap.get(segment), enabledInstances));
+      }
+    }
+  }
+
+  @Override
+  public void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    Map<String, List<String>> segmentToInstancesMap =
+        new HashMap<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
+    Map<String, List<String>> instanceToSegmentsMap = new HashMap<>();
+
+    for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
+      String segment = entry.getKey();
+      Map<String, String> instanceStateMap = entry.getValue();
+      // NOTE: 'instances' will be sorted here because 'instanceStateMap' is a TreeMap
+      List<String> instances = new ArrayList<>(instanceStateMap.size());
+      segmentToInstancesMap.put(segment, instances);
+      for (Map.Entry<String, String> instanceStateEntry : instanceStateMap.entrySet()) {
+        String instance = instanceStateEntry.getKey();
+        String state = instanceStateEntry.getValue();
+        if (state.equals(RealtimeSegmentOnlineOfflineStateModel.ONLINE) || state
+            .equals(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+          instances.add(instance);
+          instanceToSegmentsMap.computeIfAbsent(instance, k -> new ArrayList<>()).add(segment);
+        }
+      }
+    }
+
+    // Generate a new map from segment to enabled instances
+    Set<String> enabledInstances = _enabledInstances;
+    Map<String, List<String>> segmentToEnabledInstancesMap =
+        new HashMap<>(HashUtil.getHashMapCapacity(segmentToInstancesMap.size()));
+    // NOTE: Put null as the value when there is no enabled instances for a segment so that segmentToEnabledInstancesMap
+    // always contains all segments. With this, in onInstancesChange() we can directly iterate over
+    // segmentToEnabledInstancesMap.entrySet() and modify the value without changing the map entries.
+    for (Map.Entry<String, List<String>> entry : segmentToInstancesMap.entrySet()) {
+      String segment = entry.getKey();
+      segmentToEnabledInstancesMap
+          .put(segment, calculateEnabledInstancesForSegment(segment, entry.getValue(), enabledInstances));
+    }
+
+    _segmentToInstancesMap = segmentToInstancesMap;
+    _instanceToSegmentsMap = instanceToSegmentsMap;
+    _segmentToEnabledInstancesMap = segmentToEnabledInstancesMap;
+  }
+
+  @Nullable
+  private List<String> calculateEnabledInstancesForSegment(String segment, List<String> instancesForSegment,
+      Set<String> enabledInstances) {
+    List<String> enabledInstancesForSegment = new ArrayList<>(instancesForSegment.size());
+    for (String instance : instancesForSegment) {
+      if (enabledInstances.contains(instance)) {
+        enabledInstancesForSegment.add(instance);
+      }
+    }
+    if (!enabledInstancesForSegment.isEmpty()) {
+      return enabledInstancesForSegment;
+    } else {
+      LOGGER.warn("Failed to find servers hosting segment: {} for table: {} (all online instances: {} are disabled)",
+          segment, _tableNameWithType, instancesForSegment);
+      _brokerMetrics.addMeteredTableValue(_tableNameWithType, BrokerMeter.NO_SERVING_HOST_FOR_SEGMENT, 1);
+      return null;
+    }
+  }
+
+  @Override
+  public Map<String, String> select(BrokerRequest brokerRequest, List<String> segments) {
+    int requestId = (int) (_requestId.getAndIncrement() % MAX_REQUEST_ID);
+    return select(segments, requestId, _segmentToEnabledInstancesMap);
+  }
+
+  /**
+   * Selects the server instances for the given segments based on the request id and segment to enabled instances map,
+   * returns a map from segment to selected server instance hosting the segment.
+   * <p>NOTE: {@code segmentToEnabledInstancesMap} might contain {@code null} values (segment with {@code null} enabled
+   * instances). If enabled instances are not {@code null}, they are sorted (in alphabetical order).
+   */
+  abstract Map<String, String> select(List<String> segments, int requestId,
+      Map<String, List<String>> segmentToEnabledInstancesMap);
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/InstanceSelector.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.instanceselector;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.model.ExternalView;
+import org.apache.pinot.common.request.BrokerRequest;
+
+
+/**
+ * The instance selector selects server instances to serve the query based on the selected segments.
+ */
+public interface InstanceSelector {
+
+  /**
+   * Initializes the instance selector with the enabled instances, external view and online segments (segments with
+   * ONLINE/CONSUMING instances in ideal state). Should be called only once before calling other methods.
+   * <p>NOTE: {@code onlineSegments} is unused, but intentionally passed in as argument in case it is needed in the
+   * future.
+   */
+  void init(Set<String> enabledInstances, ExternalView externalView, Set<String> onlineSegments);
+
+  /**
+   * Processes the instances change. Changed instances are pre-computed based on the current and previous enabled
+   * instances only once on the caller side and passed to all the instance selectors.
+   */
+  void onInstancesChange(Set<String> enabledInstances, List<String> changedInstances);
+
+  /**
+   * Processes the external view change based on the given online segments (segments with ONLINE/CONSUMING instances in
+   * ideal state).
+   * <p>NOTE: {@code onlineSegments} is unused, but intentionally passed in as argument in case it is needed in the
+   * future.
+   */
+  void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments);
+
+  /**
+   * Selects the server instances for the given segments queried by the given broker request, returns a map from segment
+   * to selected server instance hosting the segment.
+   */
+  Map<String, String> select(BrokerRequest brokerRequest, List<String> segments);
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/InstanceSelectorFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.instanceselector;
+
+import org.apache.pinot.common.config.RoutingConfig;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class InstanceSelectorFactory {
+  private InstanceSelectorFactory() {
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceSelectorFactory.class);
+
+  public static final String LEGACY_REPLICA_GROUP_ROUTING = "PartitionAwareOffline";
+
+  public static InstanceSelector getInstanceSelector(TableConfig tableConfig, BrokerMetrics brokerMetrics) {
+    String tableNameWithType = tableConfig.getTableName();
+    RoutingConfig routingConfig = tableConfig.getRoutingConfig();
+    if (routingConfig != null && (
+        RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(routingConfig.getInstanceSelectorType())
+            || (tableConfig.getTableType() == TableType.OFFLINE && LEGACY_REPLICA_GROUP_ROUTING
+            .equalsIgnoreCase(routingConfig.getRoutingTableBuilderName())))) {
+      LOGGER.info("Using ReplicaGroupInstanceSelector for table: {}", tableNameWithType);
+      return new ReplicaGroupInstanceSelector(tableNameWithType, brokerMetrics);
+    }
+    return new BalancedInstanceSelector(tableNameWithType, brokerMetrics);
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/instanceselector/ReplicaGroupInstanceSelector.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.instanceselector;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.HashUtil;
+
+
+/**
+ * Instance selector for replica-group routing strategy.
+ * <p>The selection algorithm will always evenly distribute the traffic to all replicas of each segment, and will select
+ * the same index of the enabled instances for all segments with the same number of replicas. The algorithm is very
+ * light-weight and will do best effort to select the least servers for the request.
+ * <p>The algorithm relies on the mirror segment assignment from replica-group segment assignment strategy. With mirror
+ * segment assignment, any server in one replica-group will always have a corresponding server in other replica-groups
+ * that have the same segments assigned. For an example, if S1 is a server in replica-group 1, and it has mirror server
+ * S2 in replica-group 2 and S3 in replica-group 3. All segments assigned to S1 will also be assigned to S2 and S3. In
+ * stable scenario (external view matches ideal state), all segments assigned to S1 will have the same enabled instances
+ * of [S1, S2, S3] sorted (in alphabetical order). If we always pick the same index of enabled instances for all
+ * segments, only one of S1, S2, S3 will be picked, so it is guaranteed that we pick the least server instances for the
+ * request (there is no guarantee on choosing servers from the same replica-group though). In transitioning/error
+ * scenario (external view does not match ideal state), there is no guarantee on picking the least server instances, but
+ * the traffic is guaranteed to be evenly distributed to all available instances to avoid overwhelming hotspot servers.
+ */
+public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
+
+  public ReplicaGroupInstanceSelector(String tableNameWithType, BrokerMetrics brokerMetrics) {
+    super(tableNameWithType, brokerMetrics);
+  }
+
+  @Override
+  Map<String, String> select(List<String> segments, int requestId,
+      Map<String, List<String>> segmentToEnabledInstancesMap) {
+    Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+    for (String segment : segments) {
+      List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment);
+      // NOTE: enabledInstances can be null when there is no enabled instances for the segment, or the instance selector
+      // has not been updated (we update all components for routing in sequence)
+      if (enabledInstances != null) {
+        int numEnabledInstances = enabledInstances.size();
+        segmentToSelectedInstanceMap.put(segment, enabledInstances.get(requestId % numEnabledInstances));
+      }
+    }
+    return segmentToSelectedInstanceMap;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentpruner/PartitionSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentpruner/PartitionSegmentPruner.java
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.segmentpruner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.request.FilterQueryTree;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.core.data.partition.PartitionFunction;
+import org.apache.pinot.core.data.partition.PartitionFunctionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The {@code PartitionSegmentPruner} prunes segments based on the their partition metadata stored in ZK. The pruner
+ * supports queries with filter (or nested filter) of EQUALITY and IN predicates.
+ */
+public class PartitionSegmentPruner implements SegmentPruner {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PartitionSegmentPruner.class);
+  private static final PartitionInfo INVALID_PARTITION_INFO = new PartitionInfo(null, null);
+
+  private final String _tableNameWithType;
+  private final String _partitionColumn;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final String _segmentZKMetadataPathPrefix;
+  private final Map<String, PartitionInfo> _partitionInfoMap = new ConcurrentHashMap<>();
+
+  public PartitionSegmentPruner(String tableNameWithType, String partitionColumn,
+      ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _tableNameWithType = tableNameWithType;
+    _partitionColumn = partitionColumn;
+    _propertyStore = propertyStore;
+    _segmentZKMetadataPathPrefix = ZKMetadataProvider.constructPropertyStorePathForResource(tableNameWithType) + "/";
+  }
+
+  @Override
+  public void init(ExternalView externalView, Set<String> onlineSegments) {
+    // Bulk load partition info for all online segments
+    int numSegments = onlineSegments.size();
+    List<String> segments = new ArrayList<>(onlineSegments);
+    List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
+    for (String segment : onlineSegments) {
+      segments.add(segment);
+      segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
+    }
+    List<ZNRecord> znRecords = _propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT);
+    for (int i = 0; i < numSegments; i++) {
+      String segment = segments.get(i);
+      _partitionInfoMap.put(segment, extractPartitionInfoFromSegmentZKMetadataZNRecord(segment, znRecords.get(i)));
+    }
+  }
+
+  private PartitionInfo extractPartitionInfoFromSegmentZKMetadataZNRecord(String segment, @Nullable ZNRecord znRecord) {
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, _tableNameWithType);
+      return INVALID_PARTITION_INFO;
+    }
+
+    String partitionMetadataJson = znRecord.getSimpleField(CommonConstants.Segment.PARTITION_METADATA);
+    if (partitionMetadataJson == null) {
+      LOGGER.warn("Failed to find segment partition metadata for segment: {}, table: {}", segment, _tableNameWithType);
+      return INVALID_PARTITION_INFO;
+    }
+
+    SegmentPartitionMetadata segmentPartitionMetadata;
+    try {
+      segmentPartitionMetadata = SegmentPartitionMetadata.fromJsonString(partitionMetadataJson);
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while extracting segment partition metadata for segment: {}, table: {}", segment,
+          _tableNameWithType, e);
+      return INVALID_PARTITION_INFO;
+    }
+
+    ColumnPartitionMetadata columnPartitionMetadata =
+        segmentPartitionMetadata.getColumnPartitionMap().get(_partitionColumn);
+    if (columnPartitionMetadata == null) {
+      LOGGER.warn("Failed to find column partition metadata for column: {}, segment: {}, table: {}", _partitionColumn,
+          segment, _tableNameWithType);
+      return INVALID_PARTITION_INFO;
+    }
+
+    return new PartitionInfo(PartitionFunctionFactory
+        .getPartitionFunction(columnPartitionMetadata.getFunctionName(), columnPartitionMetadata.getNumPartitions()),
+        columnPartitionMetadata.getPartitions());
+  }
+
+  @Override
+  public synchronized void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
+    // NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
+    //       ones. The refreshed segment ZK metadata change won't be picked up.
+    for (String segment : onlineSegments) {
+      _partitionInfoMap.computeIfAbsent(segment, k -> extractPartitionInfoFromSegmentZKMetadataZNRecord(k,
+          _propertyStore.get(_segmentZKMetadataPathPrefix + k, null, AccessOption.PERSISTENT)));
+    }
+    _partitionInfoMap.keySet().retainAll(onlineSegments);
+  }
+
+  @Override
+  public synchronized void refreshSegment(String segment) {
+    _partitionInfoMap.put(segment, extractPartitionInfoFromSegmentZKMetadataZNRecord(segment,
+        _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT)));
+  }
+
+  @Override
+  public List<String> prune(BrokerRequest brokerRequest, List<String> segments) {
+    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+    if (filterQueryTree == null) {
+      return segments;
+    }
+    List<String> selectedSegments = new ArrayList<>();
+    for (String segment : segments) {
+      PartitionInfo partitionInfo = _partitionInfoMap.get(segment);
+      if (partitionInfo == null || partitionInfo == INVALID_PARTITION_INFO || isPartitionMatch(filterQueryTree,
+          partitionInfo)) {
+        selectedSegments.add(segment);
+      }
+    }
+    return selectedSegments;
+  }
+
+  private boolean isPartitionMatch(FilterQueryTree filterQueryTree, PartitionInfo partitionInfo) {
+    switch (filterQueryTree.getOperator()) {
+      case AND:
+        for (FilterQueryTree child : filterQueryTree.getChildren()) {
+          if (!isPartitionMatch(child, partitionInfo)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (FilterQueryTree child : filterQueryTree.getChildren()) {
+          if (isPartitionMatch(child, partitionInfo)) {
+            return true;
+          }
+        }
+        return false;
+      case EQUALITY:
+      case IN:
+        if (filterQueryTree.getColumn().equals(_partitionColumn)) {
+          for (String value : filterQueryTree.getValue()) {
+            if (partitionInfo._partitions.contains(partitionInfo._partitionFunction.getPartition(value))) {
+              return true;
+            }
+          }
+          return false;
+        }
+      default:
+        return true;
+    }
+  }
+
+  private static class PartitionInfo {
+    final PartitionFunction _partitionFunction;
+    final Set<Integer> _partitions;
+
+    PartitionInfo(PartitionFunction partitionFunction, Set<Integer> partitions) {
+      _partitionFunction = partitionFunction;
+      _partitions = partitions;
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentpruner/SegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentpruner/SegmentPruner.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.segmentpruner;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.helix.model.ExternalView;
+import org.apache.pinot.common.request.BrokerRequest;
+
+
+/**
+ * The segment pruner prunes the selected segments based on the query.
+ */
+public interface SegmentPruner {
+
+  /**
+   * Initializes the segment pruner with the external view and online segments (segments with ONLINE/CONSUMING instances
+   * in ideal state). Should be called only once before calling other methods.
+   * <p>NOTE: {@code externalView} is unused, but intentionally passed in as argument in case it is needed in the
+   * future.
+   */
+  void init(ExternalView externalView, Set<String> onlineSegments);
+
+  /**
+   * Processes the external view change based on the given online segments (segments with ONLINE/CONSUMING instances in
+   * ideal state).
+   * <p>NOTE: {@code externalView} is unused, but intentionally passed in as argument in case it is needed in the
+   * future.
+   */
+  void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments);
+
+  /**
+   * Refreshes the metadata for the given segment (called when segment is getting refreshed).
+   */
+  void refreshSegment(String segment);
+
+  /**
+   * Prunes the segments queried by the given broker request, returns the selected segments to be queried.
+   */
+  List<String> prune(BrokerRequest brokerRequest, List<String> segments);
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentpruner/SegmentPrunerFactory.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.segmentpruner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.config.ColumnPartitionConfig;
+import org.apache.pinot.common.config.RoutingConfig;
+import org.apache.pinot.common.config.SegmentPartitionConfig;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class SegmentPrunerFactory {
+  private SegmentPrunerFactory() {
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPrunerFactory.class);
+
+  public static final String LEGACY_PARTITION_AWARE_OFFLINE_ROUTING = "PartitionAwareOffline";
+  public static final String LEGACY_PARTITION_AWARE_REALTIME_ROUTING = "PartitionAwareRealtime";
+
+  public static List<SegmentPruner> getSegmentPruners(TableConfig tableConfig,
+      ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    RoutingConfig routingConfig = tableConfig.getRoutingConfig();
+    if (routingConfig != null) {
+      List<String> segmentPrunerTypes = routingConfig.getSegmentPrunerTypes();
+      if (segmentPrunerTypes != null) {
+        List<SegmentPruner> segmentPruners = new ArrayList<>(segmentPrunerTypes.size());
+        for (String segmentPrunerType : segmentPrunerTypes) {
+          if (RoutingConfig.PARTITION_SEGMENT_PRUNER_TYPE.equalsIgnoreCase(segmentPrunerType)) {
+            PartitionSegmentPruner partitionSegmentPruner = getPartitionSegmentPruner(tableConfig, propertyStore);
+            if (partitionSegmentPruner != null) {
+              segmentPruners.add(partitionSegmentPruner);
+            }
+          }
+        }
+        return segmentPruners;
+      } else {
+        // Handle legacy configs for backward-compatibility
+        TableType tableType = tableConfig.getTableType();
+        String routingTableBuilderName = routingConfig.getRoutingTableBuilderName();
+        if (tableType == TableType.OFFLINE && LEGACY_PARTITION_AWARE_OFFLINE_ROUTING
+            .equalsIgnoreCase(routingTableBuilderName) || (tableType == TableType.REALTIME
+            && LEGACY_PARTITION_AWARE_REALTIME_ROUTING.equalsIgnoreCase(routingTableBuilderName))) {
+          PartitionSegmentPruner partitionSegmentPruner = getPartitionSegmentPruner(tableConfig, propertyStore);
+          if (partitionSegmentPruner != null) {
+            return Collections.singletonList(getPartitionSegmentPruner(tableConfig, propertyStore));
+          }
+        }
+      }
+    }
+    return Collections.emptyList();
+  }
+
+  @Nullable
+  private static PartitionSegmentPruner getPartitionSegmentPruner(TableConfig tableConfig,
+      ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    String tableNameWithType = tableConfig.getTableName();
+    SegmentPartitionConfig segmentPartitionConfig = tableConfig.getIndexingConfig().getSegmentPartitionConfig();
+    if (segmentPartitionConfig == null) {
+      LOGGER.warn("Cannot enable partition pruning without segment partition config for table: {}", tableNameWithType);
+      return null;
+    }
+    Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
+    if (columnPartitionMap.size() != 1) {
+      LOGGER.warn("Cannot enable partition pruning with other than exact one partition column for table: {}",
+          tableNameWithType);
+      return null;
+    } else {
+      String partitionColumn = columnPartitionMap.keySet().iterator().next();
+      LOGGER.info("Using PartitionSegmentPruner on partition column: {} for table: {}", partitionColumn,
+          tableNameWithType);
+      return new PartitionSegmentPruner(tableNameWithType, partitionColumn, propertyStore);
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentselector/OfflineSegmentSelector.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.segmentselector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.apache.helix.model.ExternalView;
+import org.apache.pinot.common.request.BrokerRequest;
+
+
+/**
+ * Segment selector for offline table.
+ */
+public class OfflineSegmentSelector implements SegmentSelector {
+  private volatile List<String> _segments;
+
+  @Override
+  public void init(ExternalView externalView, Set<String> onlineSegments) {
+    onExternalViewChange(externalView, onlineSegments);
+  }
+
+  @Override
+  public void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
+    // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
+    //       hotspot servers
+
+    _segments = Collections.unmodifiableList(new ArrayList<>(onlineSegments));
+  }
+
+  @Override
+  public List<String> select(BrokerRequest brokerRequest) {
+    return _segments;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentselector/RealtimeSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentselector/RealtimeSegmentSelector.java
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.segmentselector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.helix.model.ExternalView;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.HLCSegmentName;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.SegmentName;
+
+
+/**
+ * Segment selector for real-time table which handles the following scenarios:
+ * <ul>
+ *   <li>When HLC and LLC segments coexist (during LLC migration), select only HLC segments or LLC segments</li>
+ *   <li>For HLC segments, only select segments in one group</li>
+ *   <li>
+ *     For LLC segments, only select the first CONSUMING segment for each partition to avoid duplicate data because in
+ *     certain unlikely degenerate scenarios, we can consume overlapping data until segments are flushed (at which point
+ *     the overlapping data is discarded during the reconciliation process with the controller).
+ *   </li>
+ * </ul>
+ */
+public class RealtimeSegmentSelector implements SegmentSelector {
+  public static final String ROUTING_OPTIONS_KEY = "routingOptions";
+  public static final String FORCE_HLC = "FORCE_HLC";
+
+  private final AtomicLong _requestId = new AtomicLong();
+  private volatile List<List<String>> _hlcSegments;
+  private volatile List<String> _llcSegments;
+
+  @Override
+  public void init(ExternalView externalView, Set<String> onlineSegments) {
+    onExternalViewChange(externalView, onlineSegments);
+  }
+
+  @Override
+  public void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
+    // Group HLC segments by their group id
+    // NOTE: Use TreeMap so that group ids are sorted and the result is deterministic
+    Map<String, List<String>> groupIdToHLCSegmentsMap = new TreeMap<>();
+
+    List<String> completedLLCSegments = new ArrayList<>();
+    // Store the first CONSUMING segment for each partition
+    Map<Integer, LLCSegmentName> partitionIdToFirstConsumingLLCSegmentMap = new HashMap<>();
+
+    // Iterate over the external view instead of the online segments so that the map lookups are performed on the
+    // HashSet instead of the TreeSet for performance. For LLC segments, we need the external view to figure out whether
+    // the segments are in CONSUMING state. For the goal of segment selector, we should not exclude segments not in the
+    // external view, but it is okay to exclude them as there is no way to route them without instance states in
+    // external view.
+    // - New added segment might only exist in ideal state
+    // - New removed segment might only exist in external view
+    for (Map.Entry<String, Map<String, String>> entry : externalView.getRecord().getMapFields().entrySet()) {
+      String segment = entry.getKey();
+      if (!onlineSegments.contains(segment)) {
+        continue;
+      }
+
+      // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
+      //       hotspot servers
+
+      Map<String, String> instanceStateMap = entry.getValue();
+      if (SegmentName.isHighLevelConsumerSegmentName(segment)) {
+        HLCSegmentName hlcSegmentName = new HLCSegmentName(segment);
+        groupIdToHLCSegmentsMap.computeIfAbsent(hlcSegmentName.getGroupId(), k -> new ArrayList<>()).add(segment);
+      } else {
+        if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+          // Keep the first CONSUMING segment for each partition
+          LLCSegmentName llcSegmentName = new LLCSegmentName(segment);
+          partitionIdToFirstConsumingLLCSegmentMap.compute(llcSegmentName.getPartitionId(), (k, consumingSegment) -> {
+            if (consumingSegment == null) {
+              return llcSegmentName;
+            } else {
+              if (llcSegmentName.getSequenceNumber() < consumingSegment.getSequenceNumber()) {
+                return llcSegmentName;
+              } else {
+                return consumingSegment;
+              }
+            }
+          });
+        } else {
+          completedLLCSegments.add(segment);
+        }
+      }
+    }
+
+    int numHLCGroups = groupIdToHLCSegmentsMap.size();
+    if (numHLCGroups != 0) {
+      List<List<String>> hlcSegments = new ArrayList<>(numHLCGroups);
+      for (List<String> hlcSegmentsForGroup : groupIdToHLCSegmentsMap.values()) {
+        hlcSegments.add(Collections.unmodifiableList(hlcSegmentsForGroup));
+      }
+      _hlcSegments = hlcSegments;
+    } else {
+      _hlcSegments = null;
+    }
+
+    if (!completedLLCSegments.isEmpty() || !partitionIdToFirstConsumingLLCSegmentMap.isEmpty()) {
+      List<String> llcSegments =
+          new ArrayList<>(completedLLCSegments.size() + partitionIdToFirstConsumingLLCSegmentMap.size());
+      llcSegments.addAll(completedLLCSegments);
+      for (LLCSegmentName llcSegmentName : partitionIdToFirstConsumingLLCSegmentMap.values()) {
+        llcSegments.add(llcSegmentName.getSegmentName());
+      }
+      _llcSegments = Collections.unmodifiableList(llcSegments);
+    } else {
+      _llcSegments = null;
+    }
+  }
+
+  @Override
+  public List<String> select(BrokerRequest brokerRequest) {
+    if (_hlcSegments == null) {
+      return selectLLCSegments();
+    }
+    if (_llcSegments == null) {
+      return selectHLCSegments();
+    }
+
+    // Handle HLC and LLC coexisting scenario, select HLC segments only if it is forced in the routing options
+    Map<String, String> debugOptions = brokerRequest.getDebugOptions();
+    if (debugOptions != null) {
+      String routingOptions = debugOptions.get(ROUTING_OPTIONS_KEY);
+      if (routingOptions != null && routingOptions.toUpperCase().contains(FORCE_HLC)) {
+        return selectHLCSegments();
+      }
+    }
+    return selectLLCSegments();
+  }
+
+  private List<String> selectHLCSegments() {
+    List<List<String>> hlcSegments = _hlcSegments;
+    return hlcSegments.get((int) (_requestId.getAndIncrement() % hlcSegments.size()));
+  }
+
+  private List<String> selectLLCSegments() {
+    return _llcSegments;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentselector/SegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentselector/SegmentSelector.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.segmentselector;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.helix.model.ExternalView;
+import org.apache.pinot.common.request.BrokerRequest;
+
+
+/**
+ * The segment selector selects the segments for the query. The segments selected should cover the whole dataset (table)
+ * without overlap.
+ * <p>Segment selector examples:
+ * <ul>
+ *   <li>
+ *     For real-time table, when HLC and LLC segments coexist (during LLC migration), select only HLC segments or LLC
+ *     segments
+ *   </li>
+ *   <li>For HLC real-time table, select segments in one group</li>
+ *   <li>
+ *     For table with segment merge/rollup enabled, select the merged segments over the original segments with the same
+ *     data
+ *   </li>
+ * </ul>
+ */
+public interface SegmentSelector {
+
+  /**
+   * Initializes the segment selector with the external view and online segments (segments with ONLINE/CONSUMING
+   * instances in ideal state). Should be called only once before calling other methods.
+   */
+  void init(ExternalView externalView, Set<String> onlineSegments);
+
+  /**
+   * Processes the external view change based on the given online segments (segments with ONLINE/CONSUMING instances in
+   * ideal state).
+   */
+  void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments);
+
+  /**
+   * Selects the segments queried by the given broker request. The segments selected should cover the whole dataset
+   * (table) without overlap.
+   */
+  List<String> select(BrokerRequest brokerRequest);
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentselector/SegmentSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/segmentselector/SegmentSelectorFactory.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.segmentselector;
+
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
+
+
+public class SegmentSelectorFactory {
+  private SegmentSelectorFactory() {
+  }
+
+  public static SegmentSelector getSegmentSelector(TableConfig tableConfig) {
+    if (tableConfig.getTableType() == TableType.OFFLINE) {
+      return new OfflineSegmentSelector();
+    } else {
+      return new RealtimeSegmentSelector();
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/timeboundary/TimeBoundaryInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/timeboundary/TimeBoundaryInfo.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.timeboundary;
+
+public class TimeBoundaryInfo {
+  private final String _timeColumn;
+  private final String _timeValue;
+
+  public TimeBoundaryInfo(String timeColumn, String timeValue) {
+    _timeColumn = timeColumn;
+    _timeValue = timeValue;
+  }
+
+  public String getTimeColumn() {
+    return _timeColumn;
+  }
+
+  public String getTimeValue() {
+    return _timeValue;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/timeboundary/TimeBoundaryManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/v2/timeboundary/TimeBoundaryManager.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.timeboundary;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
+import org.apache.pinot.spi.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The {@code TimeBoundaryManager} class manages the time boundary information for a table.
+ * <p>TODO: Support SDF (simple date format) time column
+ */
+public class TimeBoundaryManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeBoundaryManager.class);
+  private static final long INVALID_END_TIME = -1;
+
+  private final String _offlineTableName;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final String _segmentZKMetadataPathPrefix;
+  private final String _timeColumn;
+  private final TimeUnit _timeUnit;
+  private final boolean _isHourlyTable;
+  private final Map<String, Long> _endTimeMap = new HashMap<>();
+
+  private volatile TimeBoundaryInfo _timeBoundaryInfo;
+
+  public TimeBoundaryManager(TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    Preconditions.checkState(tableConfig.getTableType() == TableType.OFFLINE,
+        "Cannot construct TimeBoundaryManager for real-time table: %s", tableConfig.getTableName());
+    _offlineTableName = tableConfig.getTableName();
+    _propertyStore = propertyStore;
+    _segmentZKMetadataPathPrefix = ZKMetadataProvider.constructPropertyStorePathForResource(_offlineTableName) + "/";
+
+    Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _offlineTableName);
+    Preconditions.checkState(schema != null, "Failed to find schema for table: %s", _offlineTableName);
+    _timeColumn = schema.getTimeColumnName();
+    _timeUnit = schema.getOutgoingTimeUnit();
+    Preconditions.checkState(_timeColumn != null && _timeUnit != null,
+        "Time column and time unit must be configured in the schema for table: %s", _offlineTableName);
+
+    // For HOURLY table with time unit other than DAYS, use (maxEndTime - 1 HOUR) as the time boundary; otherwise, use
+    // (maxEndTime - 1 DAY)
+    _isHourlyTable = "HOURLY".equalsIgnoreCase(tableConfig.getValidationConfig().getSegmentPushFrequency())
+        && _timeUnit != TimeUnit.DAYS;
+
+    LOGGER.info("Constructed TimeBoundaryManager with timeColumn: {}, timeUnit: {}, isHourlyTable: {} for table: {}",
+        _timeColumn, _timeUnit, _isHourlyTable, _offlineTableName);
+  }
+
+  /**
+   * Initializes the time boundary manager with the external view and online segments (segments with ONLINE/CONSUMING
+   * instances in ideal state). Should be called only once before calling other methods.
+   * <p>NOTE: {@code externalView} is unused, but intentionally passed in as argument in case it is needed in the
+   * future.
+   */
+  @SuppressWarnings("unused")
+  public void init(ExternalView externalView, Set<String> onlineSegments) {
+    // Bulk load time info for all online segments
+    int numSegments = onlineSegments.size();
+    List<String> segments = new ArrayList<>(numSegments);
+    List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
+    for (String segment : onlineSegments) {
+      segments.add(segment);
+      segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
+    }
+    List<ZNRecord> znRecords = _propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT);
+    long maxEndTime = INVALID_END_TIME;
+    for (int i = 0; i < numSegments; i++) {
+      String segment = segments.get(i);
+      long endTime = extractEndTimeFromSegmentZKMetadataZNRecord(segment, znRecords.get(i));
+      _endTimeMap.put(segment, endTime);
+      maxEndTime = Math.max(maxEndTime, endTime);
+    }
+    updateTimeBoundaryInfo(maxEndTime);
+  }
+
+  private long extractEndTimeFromSegmentZKMetadataZNRecord(String segment, @Nullable ZNRecord znRecord) {
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, _offlineTableName);
+      return INVALID_END_TIME;
+    }
+
+    long endTime = znRecord.getLongField(CommonConstants.Segment.END_TIME, INVALID_END_TIME);
+    if (endTime <= 0) {
+      LOGGER.warn("Failed to find valid end time for segment: {}, table: {}", segment, _offlineTableName);
+      return INVALID_END_TIME;
+    }
+
+    TimeUnit timeUnit = znRecord.getEnumField(CommonConstants.Segment.TIME_UNIT, TimeUnit.class, TimeUnit.DAYS);
+    return _timeUnit.convert(endTime, timeUnit);
+  }
+
+  private void updateTimeBoundaryInfo(long maxEndTime) {
+    if (maxEndTime > 0) {
+      long timeBoundary = getTimeBoundary(maxEndTime);
+      TimeBoundaryInfo currentTimeBoundaryInfo = _timeBoundaryInfo;
+      if (currentTimeBoundaryInfo == null || Long.parseLong(currentTimeBoundaryInfo.getTimeValue()) != timeBoundary) {
+        _timeBoundaryInfo = new TimeBoundaryInfo(_timeColumn, Long.toString(timeBoundary));
+        LOGGER.info("Updated time boundary to: {} for table: {}", timeBoundary, _offlineTableName);
+      }
+    } else {
+      LOGGER.warn("Failed to find segment with valid end time for table: {}, no time boundary generated",
+          _offlineTableName);
+      _timeBoundaryInfo = null;
+    }
+  }
+
+  /**
+   * Returns the time boundary based on the given maximum end time.
+   * <p>NOTE: For HOURLY table with time unit other than DAYS, use (maxEndTime - 1 HOUR) as the time boundary;
+   * otherwise, use (maxEndTime - 1 DAY).
+   */
+  private long getTimeBoundary(long maxEndTime) {
+    if (_isHourlyTable) {
+      return maxEndTime - _timeUnit.convert(1L, TimeUnit.HOURS);
+    } else {
+      return maxEndTime - _timeUnit.convert(1L, TimeUnit.DAYS);
+    }
+  }
+
+  /**
+   * Processes the external view change based on the given online segments (segments with ONLINE/CONSUMING instances in
+   * ideal state).
+   * <p>NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
+   * ones. The refreshed segment ZK metadata change won't be picked up.
+   * <p>NOTE: {@code externalView} is unused, but intentionally passed in as argument in case it is needed in the
+   * future.
+   */
+  @SuppressWarnings("unused")
+  public synchronized void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
+    for (String segment : onlineSegments) {
+      _endTimeMap.computeIfAbsent(segment, k -> extractEndTimeFromSegmentZKMetadataZNRecord(segment,
+          _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT)));
+    }
+    _endTimeMap.keySet().retainAll(onlineSegments);
+    updateTimeBoundaryInfo(getMaxEndTime());
+  }
+
+  private long getMaxEndTime() {
+    long maxEndTime = INVALID_END_TIME;
+    for (long endTime : _endTimeMap.values()) {
+      maxEndTime = Math.max(maxEndTime, endTime);
+    }
+    return maxEndTime;
+  }
+
+  /**
+   * Refreshes the metadata for the given segment (called when segment is getting refreshed).
+   */
+  public synchronized void refreshSegment(String segment) {
+    _endTimeMap.put(segment, extractEndTimeFromSegmentZKMetadataZNRecord(segment,
+        _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT)));
+    updateTimeBoundaryInfo(getMaxEndTime());
+  }
+
+  @Nullable
+  public TimeBoundaryInfo getTimeBoundaryInfo() {
+    return _timeBoundaryInfo;
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilderTest.java
@@ -77,8 +77,8 @@ public class BalancedRandomRoutingTableBuilderTest {
 
     TableConfig tableConfig = new TableConfig.Builder(TableType.OFFLINE).setTableName(tableNameWithType)
         .setRoutingConfig(
-            new RoutingConfig(null, Collections.singletonMap(RoutingConfig.ENABLE_DYNAMIC_COMPUTING_KEY, "true")))
-        .build();
+            new RoutingConfig(null, Collections.singletonMap(RoutingConfig.ENABLE_DYNAMIC_COMPUTING_KEY, "true"), null,
+                null)).build();
     routingTableBuilder.init(new BaseConfiguration(), tableConfig, null, null);
 
     // Create external view

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
@@ -377,7 +377,7 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig = new ReplicaGroupStrategyConfig(null, NUM_PARTITION);
 
     // Create the routing config
-    RoutingConfig routingConfig = new RoutingConfig("PartitionAwareOffline", null);
+    RoutingConfig routingConfig = new RoutingConfig("PartitionAwareOffline", null, null, null);
 
     // Create table config
     TableConfig tableConfig =

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
@@ -346,7 +346,7 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
     SegmentPartitionConfig partitionConfig = new SegmentPartitionConfig(metadataMap);
 
     // Create the routing config
-    RoutingConfig routingConfig = new RoutingConfig("PartitionAwareOffline", null);
+    RoutingConfig routingConfig = new RoutingConfig("PartitionAwareOffline", null, null, null);
 
     // Create table config
     TableConfig tableConfig =

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/v2/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/v2/instanceselector/InstanceSelectorTest.java
@@ -1,0 +1,402 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.instanceselector;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.helix.model.ExternalView;
+import org.apache.pinot.broker.routing.v2.segmentpruner.SegmentPrunerFactory;
+import org.apache.pinot.common.config.RoutingConfig;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ERROR;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class InstanceSelectorTest {
+
+  @Test
+  public void testInstanceSelectorFactory() {
+    TableConfig tableConfig = mock(TableConfig.class);
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+
+    // Routing config is missing
+    assertTrue(
+        InstanceSelectorFactory.getInstanceSelector(tableConfig, brokerMetrics) instanceof BalancedInstanceSelector);
+
+    // Instance selector type is not configured
+    RoutingConfig routingConfig = mock(RoutingConfig.class);
+    when(tableConfig.getRoutingConfig()).thenReturn(routingConfig);
+    assertTrue(
+        InstanceSelectorFactory.getInstanceSelector(tableConfig, brokerMetrics) instanceof BalancedInstanceSelector);
+
+    // Replica-group instance selector should be returned
+    when(routingConfig.getInstanceSelectorType()).thenReturn(RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE);
+    assertTrue(InstanceSelectorFactory
+        .getInstanceSelector(tableConfig, brokerMetrics) instanceof ReplicaGroupInstanceSelector);
+
+    // Should be backward-compatible with legacy config
+    when(routingConfig.getInstanceSelectorType()).thenReturn(null);
+    when(tableConfig.getTableType()).thenReturn(CommonConstants.Helix.TableType.OFFLINE);
+    when(routingConfig.getRoutingTableBuilderName())
+        .thenReturn(SegmentPrunerFactory.LEGACY_PARTITION_AWARE_OFFLINE_ROUTING);
+    assertTrue(InstanceSelectorFactory
+        .getInstanceSelector(tableConfig, brokerMetrics) instanceof ReplicaGroupInstanceSelector);
+  }
+
+  @Test
+  public void testInstanceSelector() {
+    String offlineTableName = "testTable_OFFLINE";
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    BalancedInstanceSelector balancedInstanceSelector = new BalancedInstanceSelector(offlineTableName, brokerMetrics);
+    ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
+        new ReplicaGroupInstanceSelector(offlineTableName, brokerMetrics);
+
+    Set<String> enabledInstances = new HashSet<>();
+    ExternalView externalView = new ExternalView(offlineTableName);
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    // NOTE: Online segments is not used in the current implementation
+    Set<String> onlineSegments = Collections.emptySet();
+
+    // 'instance0' and 'instance1' are in the same replica-group, 'instance2' and 'instance3' are in the same
+    // replica-group; 'instance0' and 'instance2' serve the same segments, 'instance1' and 'instance3' serve the same
+    // segments
+    String instance0 = "instance0";
+    String instance1 = "instance1";
+    String instance2 = "instance2";
+    String instance3 = "instance3";
+    enabledInstances.add(instance0);
+    enabledInstances.add(instance1);
+    enabledInstances.add(instance2);
+    enabledInstances.add(instance3);
+
+    // Add 2 instances with segments in ERROR state
+    String errorInstance0 = "errorInstance0";
+    String errorInstance1 = "errorInstance1";
+    enabledInstances.add(errorInstance0);
+    enabledInstances.add(errorInstance1);
+
+    // Add 2 segments to each instance
+    //   [segment0, segment1] -> [instance0, instance2, errorInstance0]
+    //   [segment2, segment3] -> [instance1, instance3, errorInstance1]
+    Map<String, String> instanceStateMap0 = new TreeMap<>();
+    instanceStateMap0.put(instance0, ONLINE);
+    instanceStateMap0.put(instance2, ONLINE);
+    instanceStateMap0.put(errorInstance0, ERROR);
+    String segment0 = "segment0";
+    String segment1 = "segment1";
+    segmentAssignment.put(segment0, instanceStateMap0);
+    segmentAssignment.put(segment1, instanceStateMap0);
+    Map<String, String> instanceStateMap1 = new TreeMap<>();
+    instanceStateMap1.put(instance1, ONLINE);
+    instanceStateMap1.put(instance3, ONLINE);
+    instanceStateMap1.put(errorInstance1, ERROR);
+    String segment2 = "segment2";
+    String segment3 = "segment3";
+    segmentAssignment.put(segment2, instanceStateMap1);
+    segmentAssignment.put(segment3, instanceStateMap1);
+    List<String> segments = Arrays.asList(segment0, segment1, segment2, segment3);
+
+    balancedInstanceSelector.init(enabledInstances, externalView, onlineSegments);
+    replicaGroupInstanceSelector.init(enabledInstances, externalView, onlineSegments);
+
+    // For the first request:
+    //   BalancedInstanceSelector:
+    //     segment0 -> instance0
+    //     segment1 -> instance2
+    //     segment2 -> instance1
+    //     segment3 -> instance3
+    //   ReplicaGroupInstanceSelector:
+    //     segment0 -> instance0
+    //     segment1 -> instance0
+    //     segment2 -> instance1
+    //     segment3 -> instance1
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    Map<String, String> expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment0, instance0);
+    expectedBalancedInstanceSelectorResult.put(segment1, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance1);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance3);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment0, instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+
+    // For the second request:
+    //   BalancedInstanceSelector:
+    //     segment0 -> instance2
+    //     segment1 -> instance0
+    //     segment2 -> instance3
+    //     segment3 -> instance1
+    //   ReplicaGroupInstanceSelector:
+    //     segment0 -> instance2
+    //     segment1 -> instance2
+    //     segment2 -> instance3
+    //     segment3 -> instance3
+    expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment0, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment1, instance0);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance3);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance1);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment0, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+
+    // Disable instance0
+    enabledInstances.remove(instance0);
+    balancedInstanceSelector.onInstancesChange(enabledInstances, Collections.singletonList(instance0));
+    replicaGroupInstanceSelector.onInstancesChange(enabledInstances, Collections.singletonList(instance0));
+
+    // For the third request:
+    //   BalancedInstanceSelector:
+    //     segment0 -> instance2
+    //     segment1 -> instance2
+    //     segment2 -> instance1
+    //     segment3 -> instance3
+    //   ReplicaGroupInstanceSelector:
+    //     segment0 -> instance2
+    //     segment1 -> instance2
+    //     segment2 -> instance1
+    //     segment3 -> instance1
+    expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment0, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment1, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance1);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance3);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment0, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+
+    // For the fourth request:
+    //   BalancedInstanceSelector:
+    //     segment0 -> instance2
+    //     segment1 -> instance2
+    //     segment2 -> instance3
+    //     segment3 -> instance1
+    //   ReplicaGroupInstanceSelector:
+    //     segment0 -> instance2
+    //     segment1 -> instance2
+    //     segment2 -> instance3
+    //     segment3 -> instance3
+    expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment0, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment1, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance3);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance1);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment0, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+
+    // Remove segment0 and add segment4
+    segmentAssignment.remove(segment0);
+    String segment4 = "segment4";
+    segmentAssignment.put(segment4, instanceStateMap0);
+    segments = Arrays.asList(segment1, segment2, segment3, segment4);
+
+    // Requests arrived before changes got picked up
+
+    // For the fifth request:
+    //   BalancedInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance3
+    //     segment3 -> instance1
+    //     segment4 -> null
+    //   ReplicaGroupInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance1
+    //     segment3 -> instance1
+    //     segment4 -> null
+    expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment1, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance3);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance1);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+
+    // For the sixth request:
+    //   BalancedInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance1
+    //     segment3 -> instance3
+    //     segment4 -> null
+    //   ReplicaGroupInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance3
+    //     segment3 -> instance3
+    //     segment4 -> null
+    expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment1, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance1);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance3);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+
+    // Process the changes
+    balancedInstanceSelector.onExternalViewChange(externalView, onlineSegments);
+    replicaGroupInstanceSelector.onExternalViewChange(externalView, onlineSegments);
+
+    // For the seventy request:
+    //   BalancedInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance3
+    //     segment3 -> instance1
+    //     segment4 -> instance2
+    //   ReplicaGroupInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance1
+    //     segment3 -> instance1
+    //     segment4 -> instance2
+    expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment1, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance3);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance1);
+    expectedBalancedInstanceSelectorResult.put(segment4, instance2);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment4, instance2);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+
+    // For the eighth request:
+    //   BalancedInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance1
+    //     segment3 -> instance3
+    //     segment4 -> instance2
+    //   ReplicaGroupInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance3
+    //     segment3 -> instance3
+    //     segment4 -> instance2
+    expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment1, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance1);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance3);
+    expectedBalancedInstanceSelectorResult.put(segment4, instance2);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
+    expectedReplicaGroupInstanceSelectorResult.put(segment4, instance2);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+
+    // Re-enable instance0
+    enabledInstances.add(instance0);
+    balancedInstanceSelector.onInstancesChange(enabledInstances, Collections.singletonList(instance0));
+    replicaGroupInstanceSelector.onInstancesChange(enabledInstances, Collections.singletonList(instance0));
+
+    // For the ninth request:
+    //   BalancedInstanceSelector:
+    //     segment1 -> instance0
+    //     segment2 -> instance3
+    //     segment3 -> instance1
+    //     segment4 -> instance2
+    //   ReplicaGroupInstanceSelector:
+    //     segment1 -> instance0
+    //     segment2 -> instance1
+    //     segment3 -> instance1
+    //     segment4 -> instance0
+    expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment1, instance0);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance3);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance1);
+    expectedBalancedInstanceSelectorResult.put(segment4, instance2);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment4, instance0);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+
+    // For the tenth request:
+    //   BalancedInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance1
+    //     segment3 -> instance3
+    //     segment4 -> instance0
+    //   ReplicaGroupInstanceSelector:
+    //     segment1 -> instance2
+    //     segment2 -> instance3
+    //     segment3 -> instance3
+    //     segment4 -> instance2
+    expectedBalancedInstanceSelectorResult = new HashMap<>();
+    expectedBalancedInstanceSelectorResult.put(segment1, instance2);
+    expectedBalancedInstanceSelectorResult.put(segment2, instance1);
+    expectedBalancedInstanceSelectorResult.put(segment3, instance3);
+    expectedBalancedInstanceSelectorResult.put(segment4, instance0);
+    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
+    expectedReplicaGroupInstanceSelectorResult.put(segment4, instance2);
+    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
+        expectedReplicaGroupInstanceSelectorResult);
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/v2/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/v2/segmentpruner/SegmentPrunerTest.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.segmentpruner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.manager.zk.ZNRecordSerializer;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.manager.zk.ZkClient;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.config.ColumnPartitionConfig;
+import org.apache.pinot.common.config.IndexingConfig;
+import org.apache.pinot.common.config.RoutingConfig;
+import org.apache.pinot.common.config.SegmentPartitionConfig;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
+import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
+import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class SegmentPrunerTest {
+  private static final String OFFLINE_TABLE_NAME = "testTable_OFFLINE";
+  private static final String PARTITION_COLUMN = "memberId";
+  private static final String QUERY_1 = "SELECT * FROM testTable";
+  private static final String QUERY_2 = "SELECT * FROM testTable where memberId = 0";
+  private static final String QUERY_3 = "SELECT * FROM testTable where memberId IN (1, 2)";
+
+  private ZkStarter.ZookeeperInstance _zkInstance;
+  private ZkClient _zkClient;
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  @BeforeClass
+  public void setUp() {
+    _zkInstance = ZkStarter.startLocalZkServer();
+    _zkClient =
+        new ZkClient(ZkStarter.DEFAULT_ZK_STR, ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
+            new ZNRecordSerializer());
+    _propertyStore =
+        new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), "/SegmentPrunerTest/PROPERTYSTORE", null);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _zkClient.close();
+    ZkStarter.stopLocalZkServer(_zkInstance);
+  }
+
+  @Test
+  public void testSegmentPrunerFactory() {
+    TableConfig tableConfig = mock(TableConfig.class);
+    IndexingConfig indexingConfig = mock(IndexingConfig.class);
+    when(tableConfig.getIndexingConfig()).thenReturn(indexingConfig);
+
+    // Routing config is missing
+    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptyList());
+
+    // Segment pruner type is not configured
+    RoutingConfig routingConfig = mock(RoutingConfig.class);
+    when(tableConfig.getRoutingConfig()).thenReturn(routingConfig);
+    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptyList());
+
+    // Segment partition config is missing
+    when(routingConfig.getSegmentPrunerTypes())
+        .thenReturn(Collections.singletonList(RoutingConfig.PARTITION_SEGMENT_PRUNER_TYPE));
+    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptyList());
+
+    // Column partition config is missing
+    Map<String, ColumnPartitionConfig> columnPartitionConfigMap = new HashMap<>();
+    when(indexingConfig.getSegmentPartitionConfig()).thenReturn(new SegmentPartitionConfig(columnPartitionConfigMap));
+    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptyList());
+
+    // Partition-aware segment pruner should be returned
+    columnPartitionConfigMap.put(PARTITION_COLUMN, new ColumnPartitionConfig("Modulo", 5));
+    List<SegmentPruner> segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof PartitionSegmentPruner);
+
+    // Do not allow multiple partition columns
+    columnPartitionConfigMap.put("anotherPartitionColumn", new ColumnPartitionConfig("Modulo", 5));
+    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptyList());
+
+    // Should be backward-compatible with legacy config
+    columnPartitionConfigMap.remove("anotherPartitionColumn");
+    when(routingConfig.getSegmentPrunerTypes()).thenReturn(null);
+    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptyList());
+    when(tableConfig.getTableType()).thenReturn(TableType.OFFLINE);
+    when(routingConfig.getRoutingTableBuilderName())
+        .thenReturn(SegmentPrunerFactory.LEGACY_PARTITION_AWARE_OFFLINE_ROUTING);
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof PartitionSegmentPruner);
+    when(tableConfig.getTableType()).thenReturn(TableType.REALTIME);
+    when(routingConfig.getRoutingTableBuilderName())
+        .thenReturn(SegmentPrunerFactory.LEGACY_PARTITION_AWARE_REALTIME_ROUTING);
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof PartitionSegmentPruner);
+  }
+
+  @Test
+  public void testPartitionAwareSegmentPruner() {
+    Pql2Compiler compiler = new Pql2Compiler();
+    BrokerRequest brokerRequest1 = compiler.compileToBrokerRequest(QUERY_1);
+    BrokerRequest brokerRequest2 = compiler.compileToBrokerRequest(QUERY_2);
+    BrokerRequest brokerRequest3 = compiler.compileToBrokerRequest(QUERY_3);
+    ExternalView externalView = Mockito.mock(ExternalView.class);
+
+    PartitionSegmentPruner segmentPruner =
+        new PartitionSegmentPruner(OFFLINE_TABLE_NAME, PARTITION_COLUMN, _propertyStore);
+    Set<String> onlineSegments = new HashSet<>();
+    segmentPruner.init(externalView, onlineSegments);
+    assertEquals(segmentPruner.prune(brokerRequest1, Collections.emptyList()), Collections.emptyList());
+    assertEquals(segmentPruner.prune(brokerRequest2, Collections.emptyList()), Collections.emptyList());
+    assertEquals(segmentPruner.prune(brokerRequest3, Collections.emptyList()), Collections.emptyList());
+
+    // Segments without metadata (not updated yet) should not be pruned
+    String newSegment = "newSegment";
+    assertEquals(segmentPruner.prune(brokerRequest1, Collections.singletonList(newSegment)),
+        Collections.singletonList(newSegment));
+    assertEquals(segmentPruner.prune(brokerRequest2, Collections.singletonList(newSegment)),
+        Collections.singletonList(newSegment));
+    assertEquals(segmentPruner.prune(brokerRequest3, Collections.singletonList(newSegment)),
+        Collections.singletonList(newSegment));
+
+    // Segments without partition metadata should not be pruned
+    String segmentWithoutPartitionMetadata = "segmentWithoutPartitionMetadata";
+    onlineSegments.add(segmentWithoutPartitionMetadata);
+    OfflineSegmentZKMetadata segmentZKMetadataWithoutPartitionMetadata = new OfflineSegmentZKMetadata();
+    segmentZKMetadataWithoutPartitionMetadata.setSegmentName(segmentWithoutPartitionMetadata);
+    ZKMetadataProvider
+        .setOfflineSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME, segmentZKMetadataWithoutPartitionMetadata);
+    segmentPruner.onExternalViewChange(externalView, onlineSegments);
+    assertEquals(segmentPruner.prune(brokerRequest1, Collections.singletonList(segmentWithoutPartitionMetadata)),
+        Collections.singletonList(segmentWithoutPartitionMetadata));
+    assertEquals(segmentPruner.prune(brokerRequest2, Collections.singletonList(segmentWithoutPartitionMetadata)),
+        Collections.singletonList(segmentWithoutPartitionMetadata));
+    assertEquals(segmentPruner.prune(brokerRequest3, Collections.singletonList(segmentWithoutPartitionMetadata)),
+        Collections.singletonList(segmentWithoutPartitionMetadata));
+
+    // Test different partition functions and number of partitions
+    // 0 % 5 = 0; 1 % 5 = 1; 2 % 5 = 2
+    String segment0 = "segment0";
+    onlineSegments.add(segment0);
+    setSegmentZKMetadata(segment0, "Modulo", 5, 0);
+    // Murmur(0) % 4 = 0; Murmur(1) % 4 = 3; Murmur(2) % 4 = 0
+    String segment1 = "segment1";
+    onlineSegments.add(segment1);
+    setSegmentZKMetadata(segment1, "Murmur", 4, 0);
+    segmentPruner.onExternalViewChange(externalView, onlineSegments);
+    assertEquals(segmentPruner.prune(brokerRequest1, Arrays.asList(segment0, segment1)),
+        Arrays.asList(segment0, segment1));
+    assertEquals(segmentPruner.prune(brokerRequest2, Arrays.asList(segment0, segment1)),
+        Arrays.asList(segment0, segment1));
+    assertEquals(segmentPruner.prune(brokerRequest3, Arrays.asList(segment0, segment1)),
+        Collections.singletonList(segment1));
+
+    // Update partition metadata without refreshing should have no effect
+    setSegmentZKMetadata(segment0, "Modulo", 4, 1);
+    segmentPruner.onExternalViewChange(externalView, onlineSegments);
+    assertEquals(segmentPruner.prune(brokerRequest1, Arrays.asList(segment0, segment1)),
+        Arrays.asList(segment0, segment1));
+    assertEquals(segmentPruner.prune(brokerRequest2, Arrays.asList(segment0, segment1)),
+        Arrays.asList(segment0, segment1));
+    assertEquals(segmentPruner.prune(brokerRequest3, Arrays.asList(segment0, segment1)),
+        Collections.singletonList(segment1));
+
+    // Refresh the changed segment should update the segment pruner
+    segmentPruner.refreshSegment(segment0);
+    assertEquals(segmentPruner.prune(brokerRequest1, Arrays.asList(segment0, segment1)),
+        Arrays.asList(segment0, segment1));
+    assertEquals(segmentPruner.prune(brokerRequest2, Arrays.asList(segment0, segment1)),
+        Collections.singletonList(segment1));
+    assertEquals(segmentPruner.prune(brokerRequest3, Arrays.asList(segment0, segment1)),
+        Arrays.asList(segment0, segment1));
+  }
+
+  private void setSegmentZKMetadata(String segment, String partitionFunction, int numPartitions, int partitionId) {
+    OfflineSegmentZKMetadata offlineSegmentZKMetadata = new OfflineSegmentZKMetadata();
+    offlineSegmentZKMetadata.setSegmentName(segment);
+    offlineSegmentZKMetadata.setPartitionMetadata(new SegmentPartitionMetadata(Collections
+        .singletonMap(PARTITION_COLUMN,
+            new ColumnPartitionMetadata(partitionFunction, numPartitions, Collections.singleton(partitionId)))));
+    ZKMetadataProvider.setOfflineSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME, offlineSegmentZKMetadata);
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/v2/segmentselector/SegmentSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/v2/segmentselector/SegmentSelectorTest.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.segmentselector;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.model.ExternalView;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
+import org.apache.pinot.common.utils.HLCSegmentName;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.broker.routing.v2.segmentselector.RealtimeSegmentSelector.FORCE_HLC;
+import static org.apache.pinot.broker.routing.v2.segmentselector.RealtimeSegmentSelector.ROUTING_OPTIONS_KEY;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEqualsNoOrder;
+import static org.testng.Assert.assertTrue;
+
+
+public class SegmentSelectorTest {
+
+  @Test
+  public void testSegmentSelectorFactory() {
+    TableConfig tableConfig = mock(TableConfig.class);
+
+    when(tableConfig.getTableType()).thenReturn(TableType.OFFLINE);
+    assertTrue(SegmentSelectorFactory.getSegmentSelector(tableConfig) instanceof OfflineSegmentSelector);
+
+    when(tableConfig.getTableType()).thenReturn(TableType.REALTIME);
+    assertTrue(SegmentSelectorFactory.getSegmentSelector(tableConfig) instanceof RealtimeSegmentSelector);
+  }
+
+  @Test
+  public void testRealtimeSegmentSelector() {
+    String realtimeTableName = "testTable_REALTIME";
+    ExternalView externalView = new ExternalView(realtimeTableName);
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    Map<String, String> onlineInstanceStateMap = Collections.singletonMap("server", ONLINE);
+    Map<String, String> consumingInstanceStateMap = Collections.singletonMap("server", CONSUMING);
+    Set<String> onlineSegments = new HashSet<>();
+
+    // For HLC segments, only one group of segments should be selected
+    int numHLCGroups = 3;
+    int numHLCSegmentsPerGroup = 5;
+    String[][] hlcSegments = new String[numHLCGroups][];
+    for (int i = 0; i < numHLCGroups; i++) {
+      String groupId = "testTable_REALTIME_" + i;
+      String[] hlcSegmentsForGroup = new String[numHLCSegmentsPerGroup];
+      for (int j = 0; j < numHLCSegmentsPerGroup; j++) {
+        String hlcSegment = new HLCSegmentName(groupId, "0", Integer.toString(j)).getSegmentName();
+        segmentAssignment.put(hlcSegment, onlineInstanceStateMap);
+        onlineSegments.add(hlcSegment);
+        hlcSegmentsForGroup[j] = hlcSegment;
+      }
+      hlcSegments[i] = hlcSegmentsForGroup;
+    }
+
+    RealtimeSegmentSelector segmentSelector = new RealtimeSegmentSelector();
+    segmentSelector.init(externalView, onlineSegments);
+
+    // Only HLC segments exist, should select the HLC segments from the first group
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), hlcSegments[0]);
+
+    // For LLC segments, only the first CONSUMING segment for each partition should be selected
+    int numLLCPartitions = 3;
+    int numLLCSegmentsPerPartition = 5;
+    int numOnlineLLCSegmentsPerPartition = 3;
+    String[] expectedSelectedLLCSegments = new String[numLLCPartitions * (numLLCSegmentsPerPartition - 1)];
+    for (int i = 0; i < numLLCPartitions; i++) {
+      for (int j = 0; j < numLLCSegmentsPerPartition; j++) {
+        String llcSegment = new LLCSegmentName(realtimeTableName, i, j, 0).getSegmentName();
+        if (j < numOnlineLLCSegmentsPerPartition) {
+          externalView.setStateMap(llcSegment, onlineInstanceStateMap);
+        } else {
+          externalView.setStateMap(llcSegment, consumingInstanceStateMap);
+        }
+        onlineSegments.add(llcSegment);
+        if (j < numLLCSegmentsPerPartition - 1) {
+          expectedSelectedLLCSegments[i * (numLLCSegmentsPerPartition - 1) + j] = llcSegment;
+        }
+      }
+    }
+
+    segmentSelector.onExternalViewChange(externalView, onlineSegments);
+
+    // Both HLC and LLC segments exist, should select the LLC segments
+    assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), expectedSelectedLLCSegments);
+
+    // When HLC is forced, should select the HLC segments from the second group
+    when(brokerRequest.getDebugOptions()).thenReturn(Collections.singletonMap(ROUTING_OPTIONS_KEY, FORCE_HLC));
+    assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), hlcSegments[1]);
+
+    // Remove all the HLC segments from ideal state, should select the LLC segments even when HLC is forced
+    for (String[] hlcSegmentsForGroup : hlcSegments) {
+      for (String hlcSegment : hlcSegmentsForGroup) {
+        onlineSegments.remove(hlcSegment);
+      }
+    }
+    segmentSelector.onExternalViewChange(externalView, onlineSegments);
+    assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), expectedSelectedLLCSegments);
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/v2/timeboundary/TimeBoundaryManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/v2/timeboundary/TimeBoundaryManagerTest.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.v2.timeboundary;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.manager.zk.ZNRecordSerializer;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.manager.zk.ZkClient;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.common.config.TableNameBuilder;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import org.apache.pinot.common.utils.CommonConstants.Helix.TableType;
+import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+
+public class TimeBoundaryManagerTest {
+  private static final String TIME_COLUMN = "time";
+
+  private ZkStarter.ZookeeperInstance _zkInstance;
+  private ZkClient _zkClient;
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  @BeforeClass
+  public void setUp() {
+    _zkInstance = ZkStarter.startLocalZkServer();
+    _zkClient =
+        new ZkClient(ZkStarter.DEFAULT_ZK_STR, ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
+            new ZNRecordSerializer());
+    _propertyStore =
+        new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), "/TimeBoundaryManagerTest/PROPERTYSTORE", null);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _zkClient.close();
+    ZkStarter.stopLocalZkServer(_zkInstance);
+  }
+
+  @Test
+  public void testTimeBoundaryManager() {
+    ExternalView externalView = Mockito.mock(ExternalView.class);
+
+    for (TimeUnit timeUnit : TimeUnit.values()) {
+      // Test DAILY push table
+      String rawTableName = "testTable_" + timeUnit + "_DAILY";
+      TableConfig tableConfig = getTableConfig(rawTableName, timeUnit, "DAILY");
+      setSchema(rawTableName, timeUnit);
+
+      // Start with no segment
+      TimeBoundaryManager timeBoundaryManager = new TimeBoundaryManager(tableConfig, _propertyStore);
+      Set<String> onlineSegments = new HashSet<>();
+      timeBoundaryManager.init(externalView, onlineSegments);
+      assertNull(timeBoundaryManager.getTimeBoundaryInfo());
+
+      // Add the first segment should update the time boundary
+      String segment0 = "segment0";
+      onlineSegments.add(segment0);
+      setSegmentZKMetadata(rawTableName, segment0, 2, timeUnit);
+      timeBoundaryManager.init(externalView, onlineSegments);
+      verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(1, TimeUnit.DAYS));
+
+      // Add a new segment with larger end time should update the time boundary
+      String segment1 = "segment1";
+      onlineSegments.add(segment1);
+      setSegmentZKMetadata(rawTableName, segment1, 4, timeUnit);
+      timeBoundaryManager.onExternalViewChange(externalView, onlineSegments);
+      verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(3, TimeUnit.DAYS));
+
+      // Add a new segment with smaller end time should not change the time boundary
+      String segment2 = "segment2";
+      onlineSegments.add(segment2);
+      setSegmentZKMetadata(rawTableName, segment2, 3, timeUnit);
+      timeBoundaryManager.onExternalViewChange(externalView, onlineSegments);
+      verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(3, TimeUnit.DAYS));
+
+      // Remove the segment with largest end time should update the time boundary
+      onlineSegments.remove(segment1);
+      timeBoundaryManager.onExternalViewChange(externalView, onlineSegments);
+      verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(2, TimeUnit.DAYS));
+
+      // Change segment ZK metadata without refreshing should not update the time boundary
+      setSegmentZKMetadata(rawTableName, segment2, 5, timeUnit);
+      timeBoundaryManager.onExternalViewChange(externalView, onlineSegments);
+      verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(2, TimeUnit.DAYS));
+
+      // Refresh the changed segment should update the time boundary
+      timeBoundaryManager.refreshSegment(segment2);
+      verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(4, TimeUnit.DAYS));
+
+      // Test HOURLY push table
+      rawTableName = "testTable_" + timeUnit + "_HOURLY";
+      tableConfig = getTableConfig(rawTableName, timeUnit, "HOURLY");
+      setSchema(rawTableName, timeUnit);
+      timeBoundaryManager = new TimeBoundaryManager(tableConfig, _propertyStore);
+      onlineSegments = new HashSet<>();
+      onlineSegments.add(segment0);
+      setSegmentZKMetadata(rawTableName, segment0, 2, timeUnit);
+      timeBoundaryManager.init(externalView, onlineSegments);
+      long expectedTimeValue;
+      if (timeUnit == TimeUnit.DAYS) {
+        // Time boundary should be endTime - 1 DAY when time unit is DAYS
+        expectedTimeValue = timeUnit.convert(1, TimeUnit.DAYS);
+      } else {
+        // Time boundary should be endTime - 1 HOUR when time unit is other than DAYS
+        expectedTimeValue = timeUnit.convert(47, TimeUnit.HOURS);
+      }
+      verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), expectedTimeValue);
+    }
+  }
+
+  private TableConfig getTableConfig(String rawTableName, TimeUnit timeUnit, String pushFrequency) {
+    return new TableConfig.Builder(TableType.OFFLINE).setTableName(rawTableName).setTimeColumnName(TIME_COLUMN)
+        .setTimeType(timeUnit.name()).setSegmentPushFrequency(pushFrequency).build();
+  }
+
+  private void setSchema(String rawTableName, TimeUnit timeUnit) {
+    ZKMetadataProvider.setSchema(_propertyStore,
+        new Schema.SchemaBuilder().setSchemaName(rawTableName).addTime(TIME_COLUMN, timeUnit, FieldSpec.DataType.LONG)
+            .build());
+  }
+
+  private void setSegmentZKMetadata(String rawTableName, String segment, int endTimeInDays, TimeUnit timeUnit) {
+    OfflineSegmentZKMetadata offlineSegmentZKMetadata = new OfflineSegmentZKMetadata();
+    offlineSegmentZKMetadata.setSegmentName(segment);
+    offlineSegmentZKMetadata.setEndTime(timeUnit.convert(endTimeInDays, TimeUnit.DAYS));
+    offlineSegmentZKMetadata.setTimeUnit(timeUnit);
+    ZKMetadataProvider
+        .setOfflineSegmentZKMetadata(_propertyStore, TableNameBuilder.OFFLINE.tableNameWithType(rawTableName),
+            offlineSegmentZKMetadata);
+  }
+
+  private void verifyTimeBoundaryInfo(TimeBoundaryInfo timeBoundaryInfo, long expectedTimeValue) {
+    assertNotNull(timeBoundaryInfo);
+    assertEquals(timeBoundaryInfo.getTimeColumn(), TIME_COLUMN);
+    assertEquals(Long.parseLong(timeBoundaryInfo.getTimeValue()), expectedTimeValue);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/RoutingConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/RoutingConfig.java
@@ -20,21 +20,32 @@ package org.apache.pinot.common.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
 
 public class RoutingConfig extends BaseJsonConfig {
+  public static final String PARTITION_SEGMENT_PRUNER_TYPE = "partition";
+  public static final String REPLICA_GROUP_INSTANCE_SELECTOR_TYPE = "replicaGroup";
+
   public static final String ENABLE_DYNAMIC_COMPUTING_KEY = "enableDynamicComputing";
 
   private final String _routingTableBuilderName;
   private final Map<String, String> _routingTableBuilderOptions;
 
+  private final List<String> _segmentPrunerTypes;
+  private final String _instanceSelectorType;
+
   @JsonCreator
   public RoutingConfig(@JsonProperty("routingTableBuilderName") @Nullable String routingTableBuilderName,
-      @JsonProperty("routingTableBuilderOptions") @Nullable Map<String, String> routingTableBuilderOptions) {
+      @JsonProperty("routingTableBuilderOptions") @Nullable Map<String, String> routingTableBuilderOptions,
+      @JsonProperty("segmentPrunerType") @Nullable List<String> segmentPrunerTypes,
+      @JsonProperty("instanceSelectorType") @Nullable String instanceSelectorType) {
     _routingTableBuilderName = routingTableBuilderName;
     _routingTableBuilderOptions = routingTableBuilderOptions;
+    _segmentPrunerTypes = segmentPrunerTypes;
+    _instanceSelectorType = instanceSelectorType;
   }
 
   @Nullable
@@ -45,5 +56,15 @@ public class RoutingConfig extends BaseJsonConfig {
   @Nullable
   public Map<String, String> getRoutingTableBuilderOptions() {
     return _routingTableBuilderOptions;
+  }
+
+  @Nullable
+  public List<String> getSegmentPrunerTypes() {
+    return _segmentPrunerTypes;
+  }
+
+  @Nullable
+  public String getInstanceSelectorType() {
+    return _instanceSelectorType;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -90,6 +90,9 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   // this is different from NO_SERVER_FOUND_EXCEPTIONS which tracks unavailability across all segments
   NO_SERVING_HOST_FOR_SEGMENT("badResponses", false),
 
+  // Track the case where selected server is missing in RoutingManager
+  SERVER_MISSING_FOR_ROUTING("badResponses", false),
+
   // Netty connection metrics
   NETTY_CONNECTION_REQUESTS_SENT("nettyConnection", true),
   NETTY_CONNECTION_BYTES_SENT("nettyConnection", true),


### PR DESCRIPTION
Motivation:
- De-couple the partition pruning from the replica-group routing
- Support real-time replica-group routing
- Handle the scenario of external view not matching instance partitions
- Reduce the number of ZK accesses when processing cluster changes
- Support segment refresh for routing purposr (time boundary info & partitioning info)
- Support routing rebuild without restarting broker

Added RoutingManager as the instance level entry of the routing with the following methods:
- buildRouting()
- removeRouting()
- refreshSegment()
- routingExists()
- getRoutingTable()
- getTimeBoundaryInfo()

Break the routing table calculation into 3 steps:
- Segment selection
- Segment pruning
- Instance selection

This PR includes the implementation and tests
Will plug the new broker routing in the following PR