### PR TITLE
Add forceDelete option for task queue deletion

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -181,12 +182,9 @@ public class PinotTaskRestletResource {
   @Path("/tasks/taskqueue/{taskType}")
   @ApiOperation("Delete a task queue")
   public SuccessResponse deleteTaskQueue(
-      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
-    try {
-      _pinotHelixTaskResourceManager.deleteTaskQueue(taskType);
-      return new SuccessResponse("Successfully deleted task queue for task type: " + taskType);
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,
+      @ApiParam(value = "Whether to force delete the task queue (expert only option, enable with cautious") @DefaultValue("false") @QueryParam("forceDelete") boolean forceDelete) {
+    _pinotHelixTaskResourceManager.deleteTaskQueue(taskType, forceDelete);
+    return new SuccessResponse("Successfully deleted task queue for task type: " + taskType);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -102,8 +102,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
   }
 
   @Test
-  public void testStopAndResumeTaskQueue()
-      throws Exception {
+  public void testStopResumeDeleteTaskQueue() {
     // Hold the task
     HOLD.set(true);
 
@@ -174,10 +173,12 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     }, 60_000L, "Failed to get all tasks COMPLETED");
 
     // Delete the task queue
-    // Note: Comment out the api for now since there is a known race condition
-    // where helix controller might write a deleted workflow back to ZK because it's still caching it.
-    // TODO: revert this after merging the fix
-//    _helixTaskResourceManager.deleteTaskQueue(TestTaskGenerator.TASK_TYPE);
+    _helixTaskResourceManager.deleteTaskQueue(TestTaskGenerator.TASK_TYPE, false);
+
+    // Wait at most 60 seconds for task queue to be deleted
+    TestUtils.waitForCondition(input -> {
+      return !_helixTaskResourceManager.getTaskTypes().contains(TestTaskGenerator.TASK_TYPE);
+    }, 60_000L, "Failed to delete the task queue");
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -64,6 +64,8 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
   private static final String TABLE_NAME_2 = "testTable2";
   private static final String TABLE_NAME_3 = "testTable3";
   private static final int NUM_MINIONS = 1;
+  private static final long STATE_TRANSITION_TIMEOUT_MS = 60_000L;  // 1 minute
+
   private static final AtomicBoolean HOLD = new AtomicBoolean();
   private static final AtomicBoolean TASK_START_NOTIFIED = new AtomicBoolean();
   private static final AtomicBoolean TASK_SUCCESS_NOTIFIED = new AtomicBoolean();
@@ -131,7 +133,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
       assertFalse(TASK_CANCELLED_NOTIFIED.get());
       assertFalse(TASK_ERROR_NOTIFIED.get());
       return true;
-    }, 60_000L, "Failed to get all tasks IN_PROGRESS");
+    }, STATE_TRANSITION_TIMEOUT_MS, "Failed to get all tasks IN_PROGRESS");
 
     // Stop the task queue
     _helixTaskResourceManager.stopTaskQueue(TestTaskGenerator.TASK_TYPE);
@@ -150,7 +152,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
       assertTrue(TASK_CANCELLED_NOTIFIED.get());
       assertFalse(TASK_ERROR_NOTIFIED.get());
       return true;
-    }, 60_000L, "Failed to get all tasks STOPPED");
+    }, STATE_TRANSITION_TIMEOUT_MS, "Failed to get all tasks STOPPED");
 
     // Resume the task queue, and let the task complete
     _helixTaskResourceManager.resumeTaskQueue(TestTaskGenerator.TASK_TYPE);
@@ -170,7 +172,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
       assertTrue(TASK_CANCELLED_NOTIFIED.get());
       assertFalse(TASK_ERROR_NOTIFIED.get());
       return true;
-    }, 60_000L, "Failed to get all tasks COMPLETED");
+    }, STATE_TRANSITION_TIMEOUT_MS, "Failed to get all tasks COMPLETED");
 
     // Delete the task queue
     _helixTaskResourceManager.deleteTaskQueue(TestTaskGenerator.TASK_TYPE, false);
@@ -178,7 +180,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     // Wait at most 60 seconds for task queue to be deleted
     TestUtils.waitForCondition(input -> {
       return !_helixTaskResourceManager.getTaskTypes().contains(TestTaskGenerator.TASK_TYPE);
-    }, 60_000L, "Failed to delete the task queue");
+    }, STATE_TRANSITION_TIMEOUT_MS, "Failed to delete the task queue");
   }
 
   @AfterClass


### PR DESCRIPTION
By default, force delete is set to false as it can corrupt the Helix
Task Framework cache. We keep this as an expert only option to force
deleting the task queue without going through the Helix transitions
in case we need to perform some cleanups. In normal case, this flag
should always be false.