### PR TITLE
Add skipShade option

### DIFF
--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -61,7 +61,10 @@
     <profile>
       <id>build-shaded-jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
Add skipShade option, so that it is still activeByDefault, and can be turned off with `-DskipShade` or `-DskipShade=true`