### PR TITLE
Enhance the task related rest APIs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -28,17 +28,33 @@ import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
 import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.config.PinotTaskConfig;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
 
 
+/**
+ * Task related rest APIs.
+ * <ul>
+ *   <li>GET '/tasks/tasktypes': List all task types</li>
+ *   <li>GET '/tasks/{taskType}/state': Get the state (task queue state) for the given task type</li>
+ *   <li>GET '/tasks/{taskType}/tasks': List all tasks for the given task type</li>
+ *   <li>GET '/tasks/{taskType}/taskstates': Get a map from task to task state for the given task type</li>
+ *   <li>GET '/tasks/task/{taskName}/state': Get the task state for the given task</li>
+ *   <li>GET '/tasks/task/{taskName}/config': Get the task config (a list of child task configs) for the given task</li>
+ *   <li>POST '/tasks/schedule': Schedule tasks</li>
+ *   <li>PUT '/tasks/{taskType}/cleanup': Clean up finished tasks (COMPLETED, FAILED) for the given task type</li>
+ *   <li>PUT '/tasks/{taskType}/stop': Stop all running/pending tasks (as well as the task queue) for the given task type</li>
+ *   <li>PUT '/tasks/{taskType}/resume': Resume all stopped tasks (as well as the task queue) for the given task type</li>
+ *   <li>DELETE '/tasks/{taskType}': Delete all tasks (as well as the task queue) for the given task type</li>
+ * </ul>
+ */
 @Api(tags = Constants.TASK_TAG)
 @Path("/")
 public class PinotTaskRestletResource {
@@ -55,132 +71,186 @@ public class PinotTaskRestletResource {
   @Path("/tasks/tasktypes")
   @ApiOperation("List all task types")
   public Set<String> listTaskTypes() {
-    try {
-      return _pinotHelixTaskResourceManager.getTaskTypes();
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
+    return _pinotHelixTaskResourceManager.getTaskTypes();
   }
 
-  @GET
-  @Path("/tasks/tasks/{taskType}")
-  @ApiOperation("List all tasks for the given task type")
-  public Set<String> getTasks(@ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
-    try {
-      return _pinotHelixTaskResourceManager.getTasks(taskType);
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
-  }
-
-  @GET
-  @Path("/tasks/taskconfig/{taskName}")
-  @ApiOperation("Get the child task configs for the given task name")
-  public List<PinotTaskConfig> getTaskConfigs(
-      @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
-    try {
-      return _pinotHelixTaskResourceManager.getTaskConfigs(taskName);
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
-  }
-
-  @GET
-  @Path("/tasks/taskstates/{taskType}")
-  @ApiOperation("Get a map from task name to task state for the given task type")
-  public Map<String, TaskState> getTaskStates(
-      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
-    try {
-      return _pinotHelixTaskResourceManager.getTaskStates(taskType);
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
-  }
-
-  @GET
-  @Path("/tasks/taskstate/{taskName}")
-  @ApiOperation("Get the task state for the given task name")
-  public StringResultResponse getTaskState(
-      @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
-    try {
-      return new StringResultResponse(_pinotHelixTaskResourceManager.getTaskState(taskName).toString());
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
-  }
-
+  @Deprecated
   @GET
   @Path("/tasks/taskqueues")
-  @ApiOperation("List all task queues")
+  @ApiOperation("List all task queues (deprecated)")
   public Set<String> getTaskQueues() {
-    try {
-      return _pinotHelixTaskResourceManager.getTaskQueues();
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
+    return _pinotHelixTaskResourceManager.getTaskQueues();
   }
 
   @GET
-  @Path("/tasks/taskqueuestate/{taskType}")
-  @ApiOperation("Get the task queue state for the given task type")
-  public StringResultResponse getTaskQueueState(
+  @Path("/tasks/{taskType}/state")
+  @ApiOperation("Get the state (task queue state) for the given task type")
+  public TaskState getTaskQueueState(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
-    try {
-      return new StringResultResponse(_pinotHelixTaskResourceManager.getTaskQueueState(taskType).toString());
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
+    return _pinotHelixTaskResourceManager.getTaskQueueState(taskType);
   }
 
-  @PUT
-  @Path("/tasks/scheduletasks")
+  @Deprecated
+  @GET
+  @Path("/tasks/taskqueuestate/{taskType}")
+  @ApiOperation("Get the state (task queue state) for the given task type (deprecated)")
+  public StringResultResponse getTaskQueueStateDeprecated(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
+    return new StringResultResponse(_pinotHelixTaskResourceManager.getTaskQueueState(taskType).toString());
+  }
+
+  @GET
+  @Path("/tasks/{taskType}/tasks")
+  @ApiOperation("List all tasks for the given task type")
+  public Set<String> getTasks(@ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
+    return _pinotHelixTaskResourceManager.getTasks(taskType);
+  }
+
+  @Deprecated
+  @GET
+  @Path("/tasks/tasks/{taskType}")
+  @ApiOperation("List all tasks for the given task type (deprecated)")
+  public Set<String> getTasksDeprecated(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
+    return _pinotHelixTaskResourceManager.getTasks(taskType);
+  }
+
+  @GET
+  @Path("/tasks/{taskType}/taskstates")
+  @ApiOperation("Get a map from task to task state for the given task type")
+  public Map<String, TaskState> getTaskStates(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
+    return _pinotHelixTaskResourceManager.getTaskStates(taskType);
+  }
+
+  @Deprecated
+  @GET
+  @Path("/tasks/taskstates/{taskType}")
+  @ApiOperation("Get a map from task to task state for the given task type (deprecated)")
+  public Map<String, TaskState> getTaskStatesDeprecated(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
+    return _pinotHelixTaskResourceManager.getTaskStates(taskType);
+  }
+
+  @GET
+  @Path("/tasks/task/{taskName}/state")
+  @ApiOperation("Get the task state for the given task")
+  public TaskState getTaskState(
+      @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
+    return _pinotHelixTaskResourceManager.getTaskState(taskName);
+  }
+
+  @Deprecated
+  @GET
+  @Path("/tasks/taskstate/{taskName}")
+  @ApiOperation("Get the task state for the given task (deprecated)")
+  public StringResultResponse getTaskStateDeprecated(
+      @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
+    return new StringResultResponse(_pinotHelixTaskResourceManager.getTaskState(taskName).toString());
+  }
+
+  @GET
+  @Path("/tasks/task/{taskName}/config")
+  @ApiOperation("Get the task config (a list of child task configs) for the given task")
+  public List<PinotTaskConfig> getTaskConfigs(
+      @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
+    return _pinotHelixTaskResourceManager.getTaskConfigs(taskName);
+  }
+
+  @Deprecated
+  @GET
+  @Path("/tasks/taskconfig/{taskName}")
+  @ApiOperation("Get the task config (a list of child task configs) for the given task (deprecated)")
+  public List<PinotTaskConfig> getTaskConfigsDeprecated(
+      @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
+    return _pinotHelixTaskResourceManager.getTaskConfigs(taskName);
+  }
+
+  @POST
+  @Path("/tasks/schedule")
   @ApiOperation("Schedule tasks")
   public Map<String, String> scheduleTasks() {
-    try {
-      return _pinotTaskManager.scheduleTasks();
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
+    return _pinotTaskManager.scheduleTasks();
+  }
+
+  @Deprecated
+  @PUT
+  @Path("/tasks/scheduletasks")
+  @ApiOperation("Schedule tasks (deprecated)")
+  public Map<String, String> scheduleTasksDeprecated() {
+    return _pinotTaskManager.scheduleTasks();
   }
 
   @PUT
-  @Path("/tasks/cleanuptasks/{taskType}")
-  @ApiOperation("Clean up tasks for the given task type")
+  @Path("/tasks/{taskType}/cleanup")
+  @ApiOperation("Clean up finished tasks (COMPLETED, FAILED) for the given task type")
   public SuccessResponse cleanUpTasks(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
-    try {
-      _pinotHelixTaskResourceManager.cleanUpTaskQueue(taskType);
-      return new SuccessResponse("Successfully cleaned up tasks for task type: " + taskType);
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
+    _pinotHelixTaskResourceManager.cleanUpTaskQueue(taskType);
+    return new SuccessResponse("Successfully cleaned up tasks for task type: " + taskType);
+  }
+
+  @Deprecated
+  @PUT
+  @Path("/tasks/cleanuptasks/{taskType}")
+  @ApiOperation("Clean up finished tasks (COMPLETED, FAILED) for the given task type (deprecated)")
+  public SuccessResponse cleanUpTasksDeprecated(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
+    _pinotHelixTaskResourceManager.cleanUpTaskQueue(taskType);
+    return new SuccessResponse("Successfully cleaned up tasks for task type: " + taskType);
   }
 
   @PUT
+  @Path("/tasks/{taskType}/stop")
+  @ApiOperation("Stop all running/pending tasks (as well as the task queue) for the given task type")
+  public SuccessResponse stopTasks(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
+    _pinotHelixTaskResourceManager.stopTaskQueue(taskType);
+    return new SuccessResponse("Successfully stopped tasks for task type: " + taskType);
+  }
+
+  @PUT
+  @Path("/tasks/{taskType}/resume")
+  @ApiOperation("Resume all stopped tasks (as well as the task queue) for the given task type")
+  public SuccessResponse resumeTasks(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
+    _pinotHelixTaskResourceManager.resumeTaskQueue(taskType);
+    return new SuccessResponse("Successfully resumed tasks for task type: " + taskType);
+  }
+
+  @Deprecated
+  @PUT
   @Path("/tasks/taskqueue/{taskType}")
-  @ApiOperation("Stop/resume a task queue")
+  @ApiOperation("Stop/resume a task queue (deprecated)")
   public SuccessResponse toggleTaskQueueState(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,
       @ApiParam(value = "state", required = true) @QueryParam("state") String state) {
-    try {
-      switch (state.toUpperCase()) {
-        case TASK_QUEUE_STATE_STOP:
-          _pinotHelixTaskResourceManager.stopTaskQueue(taskType);
-          return new SuccessResponse("Successfully stopped task queue for task type: " + taskType);
-        case TASK_QUEUE_STATE_RESUME:
-          _pinotHelixTaskResourceManager.resumeTaskQueue(taskType);
-          return new SuccessResponse("Successfully resumed task queue for task type: " + taskType);
-        default:
-          throw new IllegalArgumentException("Unsupported state: " + state);
-      }
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
+    switch (state.toUpperCase()) {
+      case TASK_QUEUE_STATE_STOP:
+        _pinotHelixTaskResourceManager.stopTaskQueue(taskType);
+        return new SuccessResponse("Successfully stopped task queue for task type: " + taskType);
+      case TASK_QUEUE_STATE_RESUME:
+        _pinotHelixTaskResourceManager.resumeTaskQueue(taskType);
+        return new SuccessResponse("Successfully resumed task queue for task type: " + taskType);
+      default:
+        throw new IllegalArgumentException("Unsupported state: " + state);
     }
   }
 
   @DELETE
+  @Path("/tasks/{taskType}")
+  @ApiOperation("Delete all tasks (as well as the task queue) for the given task type")
+  public SuccessResponse deleteTasks(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,
+      @ApiParam(value = "Whether to force deleting the tasks (expert only option, enable with cautious") @DefaultValue("false") @QueryParam("forceDelete") boolean forceDelete) {
+    _pinotHelixTaskResourceManager.deleteTaskQueue(taskType, forceDelete);
+    return new SuccessResponse("Successfully deleted tasks for task type: " + taskType);
+  }
+
+  @Deprecated
+  @DELETE
   @Path("/tasks/taskqueue/{taskType}")
-  @ApiOperation("Delete a task queue")
+  @ApiOperation("Delete a task queue (deprecated)")
   public SuccessResponse deleteTaskQueue(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,
       @ApiParam(value = "Whether to force delete the task queue (expert only option, enable with cautious") @DefaultValue("false") @QueryParam("forceDelete") boolean forceDelete) {


### PR DESCRIPTION
Enhance the task related rest APIs to follow the convention.
GET:
  `/tasks/tasktypes`: List all task types
  `/tasks/{taskType}/state`: Get the state (task queue state) for the given task type
  `/tasks/{taskType}/tasks`: List all tasks for the given task type
  `/tasks/{taskType}/taskstates`: Get a map from task to task state for the given task type
  `/tasks/task/{taskName}/state`: Get the task state for the given task
  `/tasks/task/{taskName}/config`: Get the task config (a list of child task configs) for the given task
POST:
  `/tasks/schedule`: Schedule tasks
PUT:
  `/tasks/{taskType}/cleanup`: Clean up finished tasks (COMPLETED, FAILED) for the given task type
  `/tasks/{taskType}/stop`: Stop all running/pending tasks (as well as the task queue) for the given task type
  `/tasks/{taskType}/resume`: Resume all stopped tasks (as well as the task queue) for the given task type
DELETE:
  `/tasks/{taskType}`: Delete all tasks (as well as the task queue) for the given task type

Deprecated APIs:
GET:
  `/tasks/taskqueues`: List all task queues
  `/tasks/taskqueuestate/{taskType}` -> `/tasks/{taskType}/state`
  `/tasks/tasks/{taskType}` -> `/tasks/{taskType}/tasks`
  `/tasks/taskstates/{taskType}` -> `/tasks/{taskType}/taskstates`
  `/tasks/taskstate/{taskName}` -> `/tasks/task/{taskName}/taskstate`
  `/tasks/taskconfig/{taskName}` -> `/tasks/task/{taskName}/taskconfig`
PUT:
  `/tasks/scheduletasks` -> POST `/tasks/schedule`
  `/tasks/cleanuptasks/{taskType}` -> `/tasks/{taskType}/cleanup`
  `/tasks/taskqueue/{taskType}`: Toggle a task queue
DELETE:
  `/tasks/taskqueue/{taskType}` -> `/tasks/{taskType}`