### PR TITLE
[TE] Adjust dectection window using expected delay

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskScheduler.java
@@ -154,7 +154,7 @@ public class DataAvailabilityTaskScheduler implements Runnable {
     List<DetectionConfigDTO> detectionConfigs = detectionConfigDAO.findAllActive()
         .stream().filter(DetectionConfigBean::isDataAvailabilitySchedule).collect(Collectors.toList());
     for (DetectionConfigDTO detectionConfig : detectionConfigs) {
-      List<String> metricUrns = DetectionConfigFormatter
+      Set<String> metricUrns = DetectionConfigFormatter
           .extractMetricUrnsFromProperties(detectionConfig.getProperties());
       Set<String> datasets = new HashSet<>();
       for (String urn : metricUrns) {
@@ -196,17 +196,9 @@ public class DataAvailabilityTaskScheduler implements Runnable {
     return res;
   }
 
-  private DetectionPipelineTaskInfo getDetectionPipelineTaskInfo(DetectionConfigDTO detectionConfig, long end) {
-    // Make sure start time is not out of DETECTION_TASK_MAX_LOOKBACK_WINDOW
-    long start = Math.max(detectionConfig.getLastTimestamp(),
-        end - ThirdEyeUtils.DETECTION_TASK_MAX_LOOKBACK_WINDOW);
-
-    return new DetectionPipelineTaskInfo(detectionConfig.getId(), start, end);
-  }
-
   private long createTask(TaskConstants.TaskType taskType, DetectionConfigDTO detectionConfig, long end)
       throws JsonProcessingException {
-    DetectionPipelineTaskInfo taskInfo = getDetectionPipelineTaskInfo(detectionConfig, end);
+    DetectionPipelineTaskInfo taskInfo = TaskUtils.buildTaskInfoFromDetectionConfig(detectionConfig, end);
     String taskInfoJson = OBJECT_MAPPER.writeValueAsString(taskInfo);
     TaskDTO taskDTO = TaskUtils.buildTask(detectionConfig.getId(), taskInfoJson, taskType);
     long id = taskDAO.save(taskDTO);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/DataAvailabilityTaskScheduler.java
@@ -52,6 +52,7 @@ import org.apache.pinot.thirdeye.util.ThirdEyeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * This class is to schedule detection tasks based on data availability events.
  */

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DatasetTriggerInfoRepo.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/detection/trigger/utils/DatasetTriggerInfoRepo.java
@@ -103,7 +103,7 @@ public class DatasetTriggerInfoRepo {
     List<DetectionConfigDTO> detectionConfigs = detectionConfigDAO.findAllActive();
     LOG.info(String.format("Found %d active detection configs", detectionConfigs.size()));
     for (DetectionConfigDTO detectionConfig : detectionConfigs) {
-      List<String> metricUrns = DetectionConfigFormatter
+      Set<String> metricUrns = DetectionConfigFormatter
           .extractMetricUrnsFromProperties(detectionConfig.getProperties());
       for (String urn : metricUrns) {
         MetricEntity me = MetricEntity.fromURN(urn);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -37,8 +37,10 @@ public class DatasetConfigBean extends AbstractBean {
 
   public static final String DEFAULT_COMPLETENESS_ALGORITHM = Wo4WAvgDataCompletenessAlgorithm.class.getName();
   public static String DEFAULT_PREAGGREGATED_DIMENSION_VALUE = "all";
-  public static TimeGranularity DEFAULT_HOURLY_EXPECTED_DELAY = new TimeGranularity(8, TimeUnit.HOURS);
-  public static TimeGranularity DEFAULT_DAILY_EXPECTED_DELAY = new TimeGranularity(36, TimeUnit.HOURS);
+  // This is the expected delay for the hourly/daily data source.
+  // 1 hour delay means we always expect to have 1 hour's before's data.
+  public static TimeGranularity DEFAULT_HOURLY_EXPECTED_DELAY = new TimeGranularity(1, TimeUnit.HOURS);
+  public static TimeGranularity DEFAULT_DAILY_EXPECTED_DELAY = new TimeGranularity(24, TimeUnit.HOURS);
 
   private String dataset;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineJob.java
@@ -21,24 +21,13 @@ package org.apache.pinot.thirdeye.detection;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.pinot.thirdeye.anomaly.task.TaskConstants;
-import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.TaskManager;
-import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.TaskDTO;
-import org.apache.pinot.thirdeye.datalayer.util.Predicate;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
-import org.apache.pinot.thirdeye.util.ThirdEyeUtils;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.quartz.JobKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/TaskUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/TaskUtils.java
@@ -33,6 +33,8 @@ import org.apache.pinot.thirdeye.util.ThirdEyeUtils;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
 
+import static org.apache.pinot.thirdeye.util.ThirdEyeUtils.getDetectionExpectedDelay;
+
 
 /**
  * Holds utility functions related to ThirdEye Tasks
@@ -86,9 +88,12 @@ public class TaskUtils {
     Long id = getIdFromJobKey(jobKey.getName());
     DetectionConfigDTO configDTO = DAORegistry.getInstance().getDetectionConfigManager().findById(id);
 
-    // Make sure start time is not out of DETECTION_TASK_MAX_LOOKBACK_WINDOW
-    long end = System.currentTimeMillis();
-    long start = Math.max(configDTO.getLastTimestamp(), end  - ThirdEyeUtils.DETECTION_TASK_MAX_LOOKBACK_WINDOW);
+    return buildTaskInfoFromDetectionConfig(configDTO, System.currentTimeMillis());
+  }
+
+  public static DetectionPipelineTaskInfo buildTaskInfoFromDetectionConfig(DetectionConfigDTO configDTO, long end) {
+    long delay = getDetectionExpectedDelay(configDTO);
+    long start = Math.max(configDTO.getLastTimestamp(), end  - ThirdEyeUtils.DETECTION_TASK_MAX_LOOKBACK_WINDOW - delay);
     return new DetectionPipelineTaskInfo(configDTO.getId(), start, end);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/formatter/DetectionConfigFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/formatter/DetectionConfigFormatter.java
@@ -23,10 +23,12 @@ package org.apache.pinot.thirdeye.formatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.MapUtils;
@@ -77,6 +79,7 @@ public class DetectionConfigFormatter implements DTOFormatter<DetectionConfigDTO
   static final String ATTR_GRANULARITY = "monitoringGranularity";
   static final String ATTR_HEALTH = "health";
 
+  private static final String PROP_METRIC_URNS_KEY = "metricUrn";
   private static final String PROP_NESTED_METRIC_URNS_KEY = "nestedMetricUrns";
   private static final String PROP_NESTED_PROPERTIES_KEY = "nested";
   private static final String PROP_MONITORING_GRANULARITY = "monitoringGranularity";
@@ -122,7 +125,7 @@ public class DetectionConfigFormatter implements DTOFormatter<DetectionConfigDTO
     output.put(ATTR_LAST_TIMESTAMP, config.getLastTimestamp());
     output.put(ATTR_HEALTH, getDetectionHealth(config));
 
-    List<String> metricUrns = extractMetricUrnsFromProperties(config.getProperties());
+    Set<String> metricUrns = extractMetricUrnsFromProperties(config.getProperties());
 
     Map<String, MetricConfigDTO> metricUrnToMetricDTOs = new HashMap<>();
     for (String metricUrn : metricUrns) {
@@ -157,8 +160,11 @@ public class DetectionConfigFormatter implements DTOFormatter<DetectionConfigDTO
    * @param properties the detection config properties
    * @return the list of metric urns
    */
-  public static List<String> extractMetricUrnsFromProperties(Map<String, Object> properties) {
-    List<String> metricUrns = new ArrayList<>();
+  public static Set<String> extractMetricUrnsFromProperties(Map<String, Object> properties) {
+    Set<String> metricUrns = new HashSet<>();
+    if (properties.containsKey(PROP_METRIC_URNS_KEY)) {
+      metricUrns.add((String)properties.get(PROP_METRIC_URNS_KEY));
+    }
     if (properties.containsKey(PROP_NESTED_METRIC_URNS_KEY)) {
       metricUrns.addAll(ConfigUtils.getList(properties.get(PROP_NESTED_METRIC_URNS_KEY)));
     }


### PR DESCRIPTION
Add detection expected delay when setting the detection window.
This is useful since some datasets have pretty large delay (e.g, 8 days). Using the default look back window can't catch the data.