### PR TITLE
Improvements to data anonymizer tool

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AnonymizeDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AnonymizeDataCommand.java
@@ -24,7 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.tools.Command;
-import org.apache.pinot.tools.PinotDataAndQueryAnonymizer;
+import org.apache.pinot.tools.anonymizer.PinotDataAndQueryAnonymizer;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 import org.slf4j.Logger;
@@ -116,7 +116,8 @@ public class AnonymizeDataCommand extends AbstractBaseAdminCommand implements Co
           _outputDir,
           _avroFileNamePrefix,
           filterColumnCardinalityMap,
-          columnsToRetainDataFor);
+          columnsToRetainDataFor,
+          true);
       // first build global dictionaries
       pinotDataGenerator.buildGlobalDictionaries();
       // use global dictionaries to generate Avro files

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AnonymizeDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AnonymizeDataCommand.java
@@ -63,6 +63,9 @@ public class AnonymizeDataCommand extends AbstractBaseAdminCommand implements Co
   @Option(name = "-filterColumns", handler = StringArrayOptionHandler.class, usage = "Set of filter columns and their cardinalities. Global dictionaries will be built for these columns. Use -help option to see usage example")
   private String[] _columnsParticipatingInFilter;
 
+  @Option(name = "-mapBasedGlobalDictionaries", metaVar = "<boolean>", usage = "Whether to use map based global dictionary for improved performance of building global dictionary but with additional heap overhead. True by default")
+  private boolean _mapBasedGlobalDictionaries = true;
+
   @Option(name = "-help", help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message")
   private boolean _help = false;
 
@@ -117,7 +120,7 @@ public class AnonymizeDataCommand extends AbstractBaseAdminCommand implements Co
           _avroFileNamePrefix,
           filterColumnCardinalityMap,
           columnsToRetainDataFor,
-          true);
+          _mapBasedGlobalDictionaries);
       // first build global dictionaries
       pinotDataGenerator.buildGlobalDictionaries();
       // use global dictionaries to generate Avro files

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/ArrayBasedGlobalDictionaries.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/ArrayBasedGlobalDictionaries.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.tools.anonymizer;
 
 import com.google.common.base.Preconditions;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/ArrayBasedGlobalDictionaries.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/ArrayBasedGlobalDictionaries.java
@@ -1,0 +1,367 @@
+package org.apache.pinot.tools.anonymizer;
+
+import com.google.common.base.Preconditions;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.pinot.core.segment.index.ColumnMetadata;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.ByteArray;
+
+
+public class ArrayBasedGlobalDictionaries implements GlobalDictionaries {
+  private final static int INT_BASE_VALUE = 1000;
+  private final static long LONG_BASE_VALUE = 100000;
+  private static final float FLOAT_BASE_VALUE = 100.23f;
+  private static final double DOUBLE_BASE_VALUE = 1000.2375;
+
+  private final Map<String, OrigAndDerivedValueHolder> _columnToGlobalDictionary;
+
+  ArrayBasedGlobalDictionaries() {
+    _columnToGlobalDictionary = new HashMap<>();
+  }
+
+  /**
+   * First step towards building global dictionary
+   * by inserting the original values from segments
+   * into global dictionary
+   * @param origValue original value
+   * @param column column name
+   * @param columnMetadata column metadata
+   * @param cardinality total cardinality of column
+   */
+  @Override
+  public void addOrigValueToGlobalDictionary(
+      Object origValue,
+      String column,
+      ColumnMetadata columnMetadata,
+      int cardinality) {
+    _columnToGlobalDictionary.putIfAbsent(column, new OrigAndDerivedValueHolder(columnMetadata.getDataType(), cardinality));
+    OrigAndDerivedValueHolder holder = _columnToGlobalDictionary.get(column);
+    if (columnMetadata.getDataType() == FieldSpec.DataType.BYTES) {
+      holder.addOrigValue(new ByteArray((byte[])origValue));
+    } else {
+      holder.addOrigValue(origValue);
+    }
+  }
+
+  /**
+   * This is the second step where we complete the global dictionaries
+   * by sorting the original values to get sort order across all segments
+   */
+  @Override
+  public void sortOriginalValuesInGlobalDictionaries() {
+    for (Map.Entry<String, OrigAndDerivedValueHolder> entry : _columnToGlobalDictionary.entrySet()) {
+      OrigAndDerivedValueHolder valueHolder = entry.getValue();
+      valueHolder.sort();
+    }
+  }
+
+  /**
+   * This is the third and final step where we complete the global
+   * dictionaries by generating values:
+   *
+   * For numeric columns, we generate in order since
+   * we start with a base value.
+   * For string column, we first generate and then sort
+   */
+  @Override
+  public void addDerivedValuesToGlobalDictionaries() {
+    // update global dictionary for each column by adding
+    // the corresponding generated value for each orig value
+    for (Map.Entry<String, OrigAndDerivedValueHolder> entry : _columnToGlobalDictionary.entrySet()) {
+      OrigAndDerivedValueHolder valueHolder = entry.getValue();
+      generateDerivedValuesForGlobalDictionary(valueHolder);
+    }
+  }
+
+  @Override
+  public void serialize(String outputDir) throws Exception {
+    // write global dictionary for each column
+    for (String column : _columnToGlobalDictionary.keySet()) {
+      PrintWriter dictionaryWriter = new PrintWriter(new BufferedWriter(new FileWriter(outputDir + "/" + column + DICT_FILE_EXTENSION)));
+      OrigAndDerivedValueHolder holder = _columnToGlobalDictionary.get(column);
+      for (int i = 0; i < holder._index; i++) {
+        dictionaryWriter.println(holder._origValues[i]);
+        dictionaryWriter.println(holder._derivedValues[i]);
+      }
+      dictionaryWriter.flush();
+    }
+  }
+
+  @Override
+  public Object getDerivedValueForOrigValueSV(String column, Object origValue) {
+    OrigAndDerivedValueHolder valueHolder = _columnToGlobalDictionary.get(column);
+    return valueHolder.getDerivedValueForOrigValue(origValue);
+  }
+
+  @Override
+  public Object[] getDerivedValuesForOrigValuesMV(String column, Object[] origMultiValues) {
+    OrigAndDerivedValueHolder valueHolder = _columnToGlobalDictionary.get(column);
+    int length = origMultiValues.length;
+    Object[] derivedMultiValues = new Object[length];
+    for (int i = 0; i < length; i++) {
+      derivedMultiValues[i] = valueHolder.getDerivedValueForOrigValue(origMultiValues[i]);
+    }
+    return derivedMultiValues;
+  }
+
+  /**
+   * Per column holder to store both original values and corresponding
+   * derived values in global dictionary.
+   */
+  private static class OrigAndDerivedValueHolder {
+    FieldSpec.DataType _dataType;
+    Object[] _origValues;
+    Object[] _derivedValues;
+    int _index;
+    Comparator _comparator;
+
+    OrigAndDerivedValueHolder(
+        FieldSpec.DataType dataType,
+        int totalCardinality) {
+      _dataType = dataType;
+      // user specified cardinality might be slightly inaccurate depending
+      // on when the user determined the cardinality and when the source
+      // segments were given to this tool so just provision 10% additional
+      // capacity
+      _origValues = new Object[totalCardinality + (int)(0.1 * totalCardinality)];
+      // we will use index value as the actual total cardinality based
+      // on total number of values read from dictionary of each segment
+      _index = 0;
+      buildComparator();
+    }
+
+    void buildComparator() {
+      switch (_dataType) {
+        case INT:
+          _comparator = new Comparator() {
+            @Override
+            public int compare(Object o1, Object o2) {
+              return ((Integer)o1).compareTo((Integer)o2);
+            }
+          };
+          break;
+        case LONG:
+          _comparator = new Comparator() {
+            @Override
+            public int compare(Object o1, Object o2) {
+              return ((Long)o1).compareTo((Long)o2);
+            }
+          };
+          break;
+        case FLOAT:
+          _comparator = new Comparator() {
+            @Override
+            public int compare(Object o1, Object o2) {
+              return ((Float)o1).compareTo((Float) o2);
+            }
+          };
+          break;
+        case DOUBLE:
+          _comparator = new Comparator() {
+            @Override
+            public int compare(Object o1, Object o2) {
+              return ((Double)o1).compareTo((Double) o2);
+            }
+          };
+        case STRING:
+          _comparator = new Comparator() {
+            @Override
+            public int compare(Object o1, Object o2) {
+              return ((String)o1).compareTo((String) o2);
+            }
+          };
+          break;
+        case BYTES:
+          _comparator = new Comparator() {
+            @Override
+            public int compare(Object o1, Object o2) {
+              return ((ByteArray)o1).compareTo((ByteArray) o2);
+            }
+          };
+          break;
+        default:
+          throw new UnsupportedOperationException("global dictionary currently does not support: " + _dataType.name());
+      }
+    }
+
+    void sort() {
+      Arrays.sort(_origValues, 0, _index, _comparator);
+    }
+
+    void addOrigValue(Object origValue) {
+      if (!linearSearch(origValue)) {
+        _origValues[_index++] = origValue;
+      }
+    }
+
+    void setDerivedValues(Object[] derivedValues) {
+      Preconditions.checkState(derivedValues.length == _index);
+      _derivedValues = derivedValues;
+    }
+
+    Object getDerivedValueForOrigValue(Object origValue) {
+      int index = binarySearch(0, _index - 1, origValue);
+      Preconditions.checkState(index >= 0, "Expecting origValue: " + origValue);
+      return _derivedValues[index];
+    }
+
+    // used during building global dictionary phase
+    // to prevent adding original values already
+    // seen from previous segments
+    boolean linearSearch(Object key) {
+      for (int i = 0; i < _index; i++) {
+        if (key == null) {
+          if (_origValues[i] == null) {
+            return true;
+          }
+        } else {
+          if (_origValues[i].equals(key)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    // used during data generation phase.
+    // since the global dictionary is fully built
+    // and sorted, we can do binary search
+    // TODO: make this iterative
+    int binarySearch(int low, int high, Object key) {
+      if (low > high) return -1;
+
+      int mid = (low + high)/2;
+
+      if (_origValues[mid].equals(key)) {
+        return mid;
+      }
+
+      if (isLessThan(_origValues[mid], key) < 0) {
+        return binarySearch(mid + 1, high, key);
+      }
+
+      return binarySearch(low, mid - 1, key);
+    }
+
+    private int isLessThan(Object o1, Object o2) {
+      switch (_dataType) {
+        case INT:
+          return ((Integer) o1).compareTo((Integer)o2);
+        case LONG:
+          return ((Long) o1).compareTo((Long)o2);
+        case DOUBLE:
+          return ((Double) o1).compareTo((Double) o2);
+        case FLOAT:
+          return ((Float) o1).compareTo((Float) o2);
+        case STRING:
+          return ((String) o1).compareTo((String) o2);
+        case BYTES:
+          return ((ByteArray) o1).compareTo((ByteArray) o2);
+        default:
+          throw new IllegalStateException("unexpected data type: " + _dataType);
+      }
+    }
+  }
+
+  private void generateDerivedValuesForGlobalDictionary(OrigAndDerivedValueHolder valueHolder) {
+    int cardinality = valueHolder._index;
+    switch (valueHolder._dataType) {
+      case INT:
+        valueHolder.setDerivedValues(generateDerivedIntValuesForGD(cardinality));
+        break;
+      case LONG:
+        valueHolder.setDerivedValues(generateDerivedLongValuesForGD(cardinality));
+        break;
+      case FLOAT:
+        valueHolder.setDerivedValues(generateDerivedFloatValuesForGD(cardinality));
+        break;
+      case DOUBLE:
+        valueHolder.setDerivedValues(generateDerivedDoubleValuesForGD(cardinality));
+        break;
+      case STRING:
+        valueHolder.setDerivedValues(generateDerivedStringValuesForGD(valueHolder));
+        break;
+      case BYTES:
+        valueHolder.setDerivedValues(generateDerivedByteValuesForGD(valueHolder));
+        break;
+      default:
+        throw new UnsupportedOperationException("global dictionary currently does not support: " + valueHolder._dataType.name());
+    }
+  }
+
+  private Integer[] generateDerivedIntValuesForGD(int cardinality) {
+    Integer[] values = new Integer[cardinality];
+    for (int i = 0; i < cardinality; i++) {
+      values[i] = INT_BASE_VALUE + i;
+    }
+    return values;
+  }
+
+  private Long[] generateDerivedLongValuesForGD(int cardinality) {
+    Long[] values = new Long[cardinality];
+    for (int i = 0; i < cardinality; i++) {
+      values[i] = LONG_BASE_VALUE + (long)i;
+    }
+    return values;
+  }
+
+  private Float[] generateDerivedFloatValuesForGD(int cardinality) {
+    Float[] values = new Float[cardinality];
+    for (int i = 0; i < cardinality; i++) {
+      values[i] = FLOAT_BASE_VALUE + (float)i;
+    }
+    return values;
+  }
+
+  private Double[] generateDerivedDoubleValuesForGD(int cardinality) {
+    Double[] values = new Double[cardinality];
+    for (int i = 0; i < cardinality; i++) {
+      values[i] = DOUBLE_BASE_VALUE + (double)i;
+    }
+    return values;
+  }
+
+  private String[] generateDerivedStringValuesForGD(OrigAndDerivedValueHolder valueHolder) {
+    int cardinality = valueHolder._index;
+    String[] values = new String[cardinality];
+    for (int i = 0; i < cardinality; i++) {
+      String val = (String)valueHolder._origValues[i];
+      if (val == null || val.equals("") || val.equals(" ") || val.equals("null")) {
+        values[i] = "null";
+      } else {
+        int origValLength = val.length();
+        values[i] = RandomStringUtils.randomAlphanumeric(origValLength);
+      }
+    }
+    Arrays.sort(values);
+    return values;
+  }
+
+  private ByteArray[] generateDerivedByteValuesForGD(OrigAndDerivedValueHolder valueHolder) {
+    int cardinality = valueHolder._index;
+    ByteArray[] values = new ByteArray[cardinality];
+    Random random = new Random();
+    for (int i = 0; i < cardinality; i++) {
+      ByteArray byteArray = (ByteArray)valueHolder._origValues[i];
+      if (byteArray == null || byteArray.length() == 0) {
+        values[i] = new ByteArray(new byte[0]);
+      } else {
+        int origValLength = byteArray.length();
+        byte[] generated = new byte[origValLength];
+        random.nextBytes(generated);
+        values[i] = new ByteArray(generated);
+      }
+    }
+    Arrays.sort(values);
+    return values;
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/GlobalDictionaries.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/GlobalDictionaries.java
@@ -1,0 +1,21 @@
+package org.apache.pinot.tools.anonymizer;
+
+import org.apache.pinot.core.segment.index.ColumnMetadata;
+
+
+public interface GlobalDictionaries {
+
+  String DICT_FILE_EXTENSION = ".dict";
+
+  void addOrigValueToGlobalDictionary(Object origValue, String column, ColumnMetadata columnMetadata, int cardinality);
+
+  void sortOriginalValuesInGlobalDictionaries();
+
+  void addDerivedValuesToGlobalDictionaries();
+
+  void serialize(String outputDir) throws Exception;
+
+  Object getDerivedValueForOrigValueSV(String column, Object origValue);
+
+  Object[] getDerivedValuesForOrigValuesMV(String column, Object[] origValues);
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/GlobalDictionaries.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/GlobalDictionaries.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.tools.anonymizer;
 
 import org.apache.pinot.core.segment.index.ColumnMetadata;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/MapBasedGlobalDictionaries.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/MapBasedGlobalDictionaries.java
@@ -1,0 +1,260 @@
+package org.apache.pinot.tools.anonymizer;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.pinot.core.segment.index.ColumnMetadata;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.ByteArray;
+
+
+public class MapBasedGlobalDictionaries implements GlobalDictionaries {
+  private final static int INT_BASE_VALUE = 1000;
+  private final static long LONG_BASE_VALUE = 100000;
+  private static final float FLOAT_BASE_VALUE = 100.23f;
+  private static final double DOUBLE_BASE_VALUE = 1000.2375;
+
+  private final Map<String, OrigAndDerivedValueHolder> _columnToGlobalDictionary;
+
+  MapBasedGlobalDictionaries() {
+    _columnToGlobalDictionary = new HashMap<>();
+  }
+
+  /**
+   * First step towards building global dictionary
+   * by inserting the original values from segments
+   * into global dictionary
+   * @param origValue original value
+   * @param column column name
+   * @param columnMetadata column metadata
+   * @param cardinality total cardinality of column
+   */
+  @Override
+  public void addOrigValueToGlobalDictionary(
+      Object origValue,
+      String column,
+      ColumnMetadata columnMetadata,
+      int cardinality) {
+    FieldSpec.DataType dataType = columnMetadata.getDataType();
+    _columnToGlobalDictionary.putIfAbsent(column, new OrigAndDerivedValueHolder(dataType));
+    OrigAndDerivedValueHolder origAndDerivedValueHolder = _columnToGlobalDictionary.get(column);
+    if (dataType == FieldSpec.DataType.BYTES) {
+      origAndDerivedValueHolder.setOrigValue(new ByteArray((byte[])origValue));
+    } else {
+      origAndDerivedValueHolder.setOrigValue(origValue);
+    }
+  }
+
+  /**
+   * This is the second step where we complete the global dictionaries
+   * by sorting the original values to get sort order across all segments
+   */
+  @Override
+  public void sortOriginalValuesInGlobalDictionaries() {
+    // NO-OP since we use a sorted map so the global dictionary
+    // is already sorted
+  }
+
+  /**
+   * This is the third and final step where we complete the global
+   * dictionaries by generating values:
+   *
+   * For numeric columns, we generate in order since
+   * we start with a base value.
+   * For string column, we first generate and then sort
+   */
+  @Override
+  public void addDerivedValuesToGlobalDictionaries() {
+    // update global dictionary for each column by adding
+    // the corresponding generated value for each orig value
+    for (Map.Entry<String, OrigAndDerivedValueHolder> entry : _columnToGlobalDictionary.entrySet()) {
+      OrigAndDerivedValueHolder origAndDerivedValueHolder = entry.getValue();
+      generateDerivedValuesForGlobalDictionary(origAndDerivedValueHolder);
+    }
+  }
+
+  @Override
+  public void serialize(String outputDir) throws Exception {
+    // write global dictionary for each column
+    for (String column : _columnToGlobalDictionary.keySet()) {
+      PrintWriter dictionaryWriter = new PrintWriter(new BufferedWriter(new FileWriter(outputDir + "/" + column + DICT_FILE_EXTENSION)));
+      OrigAndDerivedValueHolder origAndDerivedValueHolder = _columnToGlobalDictionary.get(column);
+      Set<Map.Entry<Object, DerivedValue>> entries = origAndDerivedValueHolder._origAndDerivedValues.entrySet();
+      Iterator<Map.Entry<Object, DerivedValue>> sortedIterator = entries.iterator();
+      while (sortedIterator.hasNext()) {
+        Map.Entry<Object, DerivedValue> entry = sortedIterator.next();
+        dictionaryWriter.println(entry.getKey());
+        dictionaryWriter.println(entry.getValue()._derivedValue);
+      }
+      dictionaryWriter.flush();
+    }
+  }
+
+  @Override
+  public Object getDerivedValueForOrigValueSV(String column, Object origValue) {
+    OrigAndDerivedValueHolder origAndDerivedValueHolder = _columnToGlobalDictionary.get(column);
+    TreeMap<Object, DerivedValue> sortedMap = origAndDerivedValueHolder._origAndDerivedValues;
+    return sortedMap.get(origValue)._derivedValue;
+  }
+
+  @Override
+  public Object[] getDerivedValuesForOrigValuesMV(String column, Object[] origMultiValues) {
+    OrigAndDerivedValueHolder origAndDerivedValueHolder = _columnToGlobalDictionary.get(column);
+    TreeMap<Object, DerivedValue> sortedMap = origAndDerivedValueHolder._origAndDerivedValues;
+    int length = origMultiValues.length;
+    Object[] derivedMultiValues = new Object[length];
+    for (int i = 0; i < length; i++) {
+      derivedMultiValues[i] = sortedMap.get(origMultiValues[i]);
+    }
+    return derivedMultiValues;
+  }
+
+  private static class OrigAndDerivedValueHolder {
+    FieldSpec.DataType _dataType;
+    TreeMap<Object, DerivedValue> _origAndDerivedValues;
+
+    OrigAndDerivedValueHolder(FieldSpec.DataType dataType) {
+      _dataType = dataType;
+      _origAndDerivedValues = new TreeMap<>();
+    }
+
+    void setOrigValue(Object origValue) {
+     if (!_origAndDerivedValues.containsKey(origValue)) {
+       _origAndDerivedValues.put(origValue, new DerivedValue());
+     }
+    }
+  }
+
+  private static class DerivedValue {
+    Object _derivedValue;
+    DerivedValue() { }
+  }
+
+  private void generateDerivedValuesForGlobalDictionary(OrigAndDerivedValueHolder origAndDerivedValueHolder) {
+    switch (origAndDerivedValueHolder._dataType) {
+      case INT:
+        generateDerivedIntValuesForGD(origAndDerivedValueHolder._origAndDerivedValues);
+        break;
+      case LONG:
+        generateDerivedLongValuesForGD(origAndDerivedValueHolder._origAndDerivedValues);
+        break;
+      case FLOAT:
+        generateDerivedFloatValuesForGD(origAndDerivedValueHolder._origAndDerivedValues);
+        break;
+      case DOUBLE:
+        generateDerivedDoubleValuesForGD(origAndDerivedValueHolder._origAndDerivedValues);
+        break;
+      case STRING:
+        generateDerivedStringValuesForGD(origAndDerivedValueHolder._origAndDerivedValues);
+        break;
+      case BYTES:
+        generateDerivedByteValuesForGD(origAndDerivedValueHolder._origAndDerivedValues);
+        break;
+      default:
+        throw new UnsupportedOperationException("global dictionary currently does not support: " + origAndDerivedValueHolder._dataType.name());
+    }
+  }
+
+  private void generateDerivedIntValuesForGD(TreeMap<Object, DerivedValue> sortedMap) {
+    Iterator<Map.Entry<Object, DerivedValue>> sortedIterator = sortedMap.entrySet().iterator();
+    int i = 0;
+    while (sortedIterator.hasNext()) {
+      Map.Entry<Object, DerivedValue> entry = sortedIterator.next();
+      DerivedValue derivedValue = entry.getValue();
+      derivedValue._derivedValue = INT_BASE_VALUE + i;
+    }
+  }
+
+  private void generateDerivedLongValuesForGD(TreeMap<Object, DerivedValue> sortedMap) {
+    Iterator<Map.Entry<Object, DerivedValue>> sortedIterator = sortedMap.entrySet().iterator();
+    int i = 0;
+    while (sortedIterator.hasNext()) {
+      Map.Entry<Object, DerivedValue> entry = sortedIterator.next();
+      DerivedValue derivedValue = entry.getValue();
+      derivedValue._derivedValue = LONG_BASE_VALUE + i;
+    }
+  }
+
+  private void generateDerivedFloatValuesForGD(TreeMap<Object, DerivedValue> sortedMap) {
+    Iterator<Map.Entry<Object, DerivedValue>> sortedIterator = sortedMap.entrySet().iterator();
+    int i = 0;
+    while (sortedIterator.hasNext()) {
+      Map.Entry<Object, DerivedValue> entry = sortedIterator.next();
+      DerivedValue derivedValue = entry.getValue();
+      derivedValue._derivedValue = FLOAT_BASE_VALUE + i;
+    }
+  }
+
+  private void generateDerivedDoubleValuesForGD(TreeMap<Object, DerivedValue> sortedMap) {
+    Iterator<Map.Entry<Object, DerivedValue>> sortedIterator = sortedMap.entrySet().iterator();
+    int i = 0;
+    while (sortedIterator.hasNext()) {
+      Map.Entry<Object, DerivedValue> entry = sortedIterator.next();
+      DerivedValue derivedValue = entry.getValue();
+      derivedValue._derivedValue = DOUBLE_BASE_VALUE + i;
+    }
+  }
+
+  private String[] generateDerivedStringValuesForGD(TreeMap<Object, DerivedValue> sortedMap) {
+    Iterator<Map.Entry<Object, DerivedValue>> sortedIterator = sortedMap.entrySet().iterator();
+    int cardinality = sortedMap.size();
+    String[] values = new String[cardinality];
+    int i = 0;
+    while (sortedIterator.hasNext()) {
+      Map.Entry<Object, DerivedValue> entry = sortedIterator.next();
+      String val = (String)entry.getKey();
+      if (val == null || val.equals("") || val.equals(" ") || val.equals("null")) {
+        values[i++] = "null";
+      } else {
+        int origValLength = val.length();
+        values[i++] = RandomStringUtils.randomAlphanumeric(origValLength);
+      }
+    }
+    Arrays.sort(values);
+    sortedIterator = sortedMap.entrySet().iterator();
+    i = 0;
+    while (sortedIterator.hasNext()) {
+      Map.Entry<Object, DerivedValue> entry = sortedIterator.next();
+      DerivedValue derivedValue = entry.getValue();
+      derivedValue._derivedValue = values[i++];
+    }
+    return values;
+  }
+
+  private ByteArray[] generateDerivedByteValuesForGD(TreeMap<Object, DerivedValue> sortedMap) {
+    Iterator<Map.Entry<Object, DerivedValue>> sortedIterator = sortedMap.entrySet().iterator();
+    int cardinality = sortedMap.size();
+    ByteArray[] values = new ByteArray[cardinality];
+    Random random = new Random();
+    int i = 0;
+    while (sortedIterator.hasNext()) {
+      Map.Entry<Object, DerivedValue> entry = sortedIterator.next();
+      ByteArray byteArray = (ByteArray)entry.getKey();
+      if (byteArray == null || byteArray.length() == 0) {
+        values[i++] = new ByteArray(new byte[0]);
+      } else {
+        int origValLength = byteArray.length();
+        byte[] generated = new byte[origValLength];
+        random.nextBytes(generated);
+        values[i++] = new ByteArray(generated);
+      }
+    }
+    Arrays.sort(values);
+    sortedIterator = sortedMap.entrySet().iterator();
+    i = 0;
+    while (sortedIterator.hasNext()) {
+      Map.Entry<Object, DerivedValue> entry = sortedIterator.next();
+      DerivedValue derivedValue = entry.getValue();
+      derivedValue._derivedValue = values[i++];
+    }
+    return values;
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/MapBasedGlobalDictionaries.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/MapBasedGlobalDictionaries.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.tools.anonymizer;
 
 import java.io.BufferedWriter;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/MapBasedGlobalDictionaries.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/MapBasedGlobalDictionaries.java
@@ -151,6 +151,16 @@ public class MapBasedGlobalDictionaries implements GlobalDictionaries {
     }
   }
 
+  /**
+   * This wrapper is needed so that we can set the derived values in global dictionary
+   * in sorted order while iterating over it. When we iterate over TreeMap, we get the
+   * map's entries as a set. Since doing a put() while iteration is not going to work,
+   * we create a wrapper and simply set the derived value to whatever the generated
+   * value is as we iterate on the sorted map to go over all original dictionary values.
+   *
+   * TODO: May be if we can do entry.setValue() on Map.Entry, then we don't need this wrapper
+   * and we can safely update the TreeMap during iteration.
+   */
   private static class DerivedValue {
     Object _derivedValue;
     DerivedValue() { }

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/TestDataAndQueryAnonymizer.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/TestDataAndQueryAnonymizer.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
+import org.apache.pinot.tools.anonymizer.PinotDataAndQueryAnonymizer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
Following improvements are made based on the the latest usage to enhance an internal test framework

- The global dictionary code was taking too long since the initial implementation was array based and used linear search while building the global dictionary. We had earlier avoided use of map/set to minimize the heap overhead as opposed to optimizing for performance. But it turns out that for higher cardinalities, linear search is significantly slowing down this tool. This PR implements a Map based global dictionary to keep the bound to O(logN).

- Fixed bug for multi-value support. Avro API needs Object[] to be casted as Arrays.asList

- Users of this tool might use a partial production dataset (as we are planning to do so) to workaround the memory requirements of this tool. In this case, the global dictionary will not have each and every value from the dictionary of original segment. So the query generator needs to be aware of this and should ignore such queries for which it is not able to rewrite the predicate since the original value never made it to the global dictionary as it was not a part of the chosen subset of segments.

A new global dictionary interface is implemented. Existing array based implementation is kept intact and a new map based concrete implementation is written. By default, the tool will now use map based global dictionaries.