### PR TITLE
[TE] detection health - generate task status in monitoring task

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionHealth.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionHealth.java
@@ -93,6 +93,7 @@ public class DetectionHealth {
     private EvaluationManager evaluationDAO;
     private MergedAnomalyResultManager anomalyDAO;
     private TaskManager taskDAO;
+    // the number of task DTO returned in the detectionHealth
     private long taskLimit;
     private boolean provideOverallHealth;
 
@@ -243,11 +244,7 @@ public class DetectionHealth {
               Predicate.IN(COL_NAME_TASK_STATUS, new String[]{TaskConstants.TaskStatus.COMPLETED.toString(),
                   TaskConstants.TaskStatus.FAILED.toString(), TaskConstants.TaskStatus.TIMEOUT.toString(),
                   TaskConstants.TaskStatus.WAITING.toString()})));
-      tasks.sort(Comparator.comparingLong(TaskBean::getStartTime).reversed());
-      // limit the task size
-      tasks = tasks.stream().limit(this.taskLimit).collect(Collectors.toList());
-
-      return DetectionTaskStatus.fromTasks(tasks);
+      return DetectionTaskStatus.fromTasks(tasks, this.taskLimit);
     }
 
     private static HealthStatus classifyOverallHealth(DetectionHealth health) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionTaskStatus.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionTaskStatus.java
@@ -22,6 +22,7 @@ package org.apache.pinot.thirdeye.detection.health;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,16 +68,12 @@ public class DetectionTaskStatus {
   private static final double TASK_SUCCESS_RATE_BAD_THRESHOLD = 0.2;
   private static final double TASK_SUCCESS_RATE_MODERATE_THRESHOLD = 0.8;
 
-  public DetectionTaskStatus(double taskSuccessRate, HealthStatus healthStatus, Map<TaskConstants.TaskStatus, Long> counts, List<TaskDTO> tasks) {
+  public DetectionTaskStatus(double taskSuccessRate, HealthStatus healthStatus, Map<TaskConstants.TaskStatus, Long> counts, List<TaskDTO> tasks, long lastTaskExecutionTime) {
     this.taskSuccessRate = taskSuccessRate;
     this.healthStatus = healthStatus;
     this.tasks = tasks;
     this.taskCounts.putAll(counts);
-    this.lastTaskExecutionTime = tasks.stream()
-        .filter(task -> task.getStatus().equals(TaskConstants.TaskStatus.COMPLETED))
-        .map(TaskBean::getEndTime)
-        .findFirst()
-        .orElse(-1L);
+    this.lastTaskExecutionTime = lastTaskExecutionTime;
   }
 
   // default constructor for deserialization
@@ -104,20 +101,52 @@ public class DetectionTaskStatus {
   }
 
   public static DetectionTaskStatus fromTasks(List<TaskDTO> tasks) {
-    double taskSuccessRate = Double.NaN;
     // count the number of tasks by task status
+    tasks.sort(Comparator.comparingLong(TaskBean::getStartTime).reversed());
     Map<TaskConstants.TaskStatus, Long> counts =
         tasks.stream().collect(Collectors.groupingBy(TaskBean::getStatus, Collectors.counting()));
+    double taskSuccessRate = getTaskSuccessRate(counts);
+    long lastTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
+    return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks, lastTaskExecutionTime);
+  }
 
+  /**
+   * Create a Detection task status from a list of tasks
+   * @param tasks the list of tasks
+   * @param taskLimit the number of tasks should be returned in the task status
+   * @return the DetectionTaskStatus
+   */
+  public static DetectionTaskStatus fromTasks(List<TaskDTO> tasks, long taskLimit) {
+    // count the number of tasks by task status
+    tasks.sort(Comparator.comparingLong(TaskBean::getStartTime).reversed());
+    Map<TaskConstants.TaskStatus, Long> counts =
+        tasks.stream().collect(Collectors.groupingBy(TaskBean::getStatus, Collectors.counting()));
+    double taskSuccessRate = getTaskSuccessRate(counts);
+    long lastTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
+    tasks = tasks.stream().limit(taskLimit).collect(Collectors.toList());
+    return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks,
+        lastTaskExecutionTime);
+  }
+
+  private static Long getLastSuccessTaskExecutionTime(List<TaskDTO> tasks) {
+    return tasks.stream()
+        .filter(task -> task.getStatus().equals(TaskConstants.TaskStatus.COMPLETED))
+        .map(TaskBean::getEndTime)
+        .findFirst()
+        .orElse(-1L);
+  }
+
+  private static double getTaskSuccessRate(Map<TaskConstants.TaskStatus, Long> counts) {
     if (counts.size() != 0) {
       long completedTasks = counts.getOrDefault(TaskConstants.TaskStatus.COMPLETED, 0L);
-      long failedTasks = counts.getOrDefault(
-          TaskConstants.TaskStatus.FAILED, 0L);
+      long failedTasks = counts.getOrDefault(TaskConstants.TaskStatus.FAILED, 0L);
       long timeoutTasks = counts.getOrDefault(TaskConstants.TaskStatus.TIMEOUT, 0L);
-      taskSuccessRate = (double) completedTasks / (failedTasks +  timeoutTasks + completedTasks);
+      long waitingTasks = counts.getOrDefault(TaskConstants.TaskStatus.WAITING, 0L);
+      return (double) completedTasks / (failedTasks + timeoutTasks + completedTasks + waitingTasks);
     }
-    return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks);
+    return Double.NaN;
   }
+
 
   private static HealthStatus classifyTaskStatus(double taskSuccessRate) {
     if (Double.isNaN(taskSuccessRate)) {


### PR DESCRIPTION
This PR fixes the incorrect detection health issue on the alerts page. Previously, the detection health that is shown on the alerts page won't include correct task status. This fix allows the monitoring task to generate the task status correctly.