### PR TITLE
Use getResourceAsStream to load test resource file packaged inside test jar

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
@@ -127,11 +127,9 @@ public class LuceneRealtimeClusterIntegrationTest extends BaseClusterIntegration
   private File createAvroFile()
       throws Exception {
     // read the skills file
-    URL resourceUrl = getClass().getClassLoader().getResource("data/text_search_data/skills.txt");
-    File skillFile = new File(resourceUrl.getFile());
     String[] skills = new String[100];
     int skillCount = 0;
-    try (InputStream inputStream = new FileInputStream(skillFile);
+    try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("data/text_search_data/skills.txt");
         BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
       String line;
       while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
Text search integration test which is in pinot-integrations tests module uses test data resources from pinot-core. pinot-core test jar is available to pinot-integration-tests module via pom dependency.

However, our internal release builds failed since the test file is actually present in pinot-core-VERSION-SNAPSHOT-tests.jar.

getClass().getClassLoader().getResource() works only if the resource is a physical file object. For resources available inside jars, the path as an "!" to denote that resource is actually inside a jar. getResourceAsStream() should be used in such cases.

I am not quite sure why travis succeeds and our internal build fails. I will look into it. Meanwhile, this fix should unblock our internal builds.  When comparing the logs of our internal build v/s travis, I see that in travis we don't really build the pinot-core-VERSION-SNAPSHOT-tests.jar at the end of building pinot-core module and running tests. But we do this in our internal builds.

We had seen this earlier as well when an integration test in pinot-hadoop module failed to read the resource inside a jar -- that is currently disabled.