### PR TITLE
Fix bug in DISTINCT for queries that return empty response 

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import com.google.common.base.Preconditions;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
@@ -139,6 +140,12 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
 
   @Override
   public DistinctTable extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    if (_distinctTable == null) {
+      ColumnDataType[] columnDataTypes = new ColumnDataType[_columnNames.length];
+      Arrays.fill(columnDataTypes, ColumnDataType.STRING);
+      DataSchema dataSchema = new DataSchema(_columnNames, columnDataTypes);
+      _distinctTable = new DistinctTable(dataSchema, _orderBy, _limit);
+    }
     return _distinctTable;
   }
 


### PR DESCRIPTION
The DistinctTable which is the IntermediateResult type of DistinctAggregationFunction was null in such cases. Since we use the same object to serialize the result of the function as a single object (to keep consistency with how other aggregation function results are sent to the broker), the broker reduce service was throwing exception upon seeing the DistinctTable as null.

The fix is to send an empty table.

Report by a user in open source