### PR TITLE
Reduce the non-determinism in Lucene integration test

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
@@ -108,7 +108,7 @@ public class LuceneRealtimeClusterIntegrationTest extends BaseClusterIntegration
         null, null, getTaskConfig(), getStreamConsumerFactoryClassName(),
         1, textIndexColumns);
 
-    // just wait for 1sec for few docs to be loaded
+    // just wait for 2sec for few docs to be loaded
     waitForDocsLoaded(2000L, false );
   }
 
@@ -182,6 +182,7 @@ public class LuceneRealtimeClusterIntegrationTest extends BaseClusterIntegration
         Assert.assertTrue(result >= prevResult);
       }
       prevResult = result;
+      Thread.sleep(10);
     }
   }
 }


### PR DESCRIPTION
The lucene cluster integration test is written to test both offline and realtime (primarily) text index functionality. The goal of the test is to be able to see an increasingly number of hits/matches in the index for the same query (run in a tight loop 2000 times).

The test runs the query 2000 times and starts checking for more than 0 hits from 300th query onwards. It also compares the number of hits (count *) with that of previous query. However, based on how fast the queries are completed, how quickly the documents are ingested and how quickly the realtime segments get refreshed, the check fails and we start to see greater than 0 hits a little after 300th query.

The current PR puts a 10ms sleep time between queries to reduce the non-determinism. 

The test has blocked our internal release builds. I'd like to think about to how to make this more deterministic and address that in a follow-up. For now, this fix should get us going.

My original desired goal with the test is to see the final total number of hits (17k) only for the last few hundred queries. Until then we should only be seeing an increasing number of hits. The sleep time compromises this goal since we are going to see the total number of hits sooner. I will address this later.