### PR TITLE
[TE] Remove fromAddress as a compulsory field from subscription group

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertTaskRunner.java
@@ -24,16 +24,11 @@ import org.apache.pinot.thirdeye.anomaly.task.TaskInfo;
 import org.apache.pinot.thirdeye.anomaly.task.TaskResult;
 import org.apache.pinot.thirdeye.anomaly.task.TaskRunner;
 import org.apache.pinot.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
-import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionAlertConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.MergedAnomalyResultManager;
-import org.apache.pinot.thirdeye.datalayer.bao.MetricConfigManager;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
-import org.apache.pinot.thirdeye.datasource.ThirdEyeCacheRegistry;
-import org.apache.pinot.thirdeye.datasource.loader.AggregationLoader;
-import org.apache.pinot.thirdeye.datasource.loader.DefaultAggregationLoader;
 import org.apache.pinot.thirdeye.detection.alert.scheme.DetectionAlertScheme;
 import org.apache.pinot.thirdeye.detection.alert.suppress.DetectionAlertSuppressor;
 import java.util.ArrayList;
@@ -58,12 +53,6 @@ public class DetectionAlertTaskRunner implements TaskRunner {
     this.detAlertTaskFactory = new DetectionAlertTaskFactory();
     this.alertConfigDAO = DAORegistry.getInstance().getDetectionAlertConfigManager();
     this.mergedAnomalyDAO = DAORegistry.getInstance().getMergedAnomalyResultDAO();
-
-    DatasetConfigManager datasetDAO = DAORegistry.getInstance().getDatasetConfigDAO();
-    MetricConfigManager metricDAO = DAORegistry.getInstance().getMetricConfigDAO();
-    AggregationLoader aggregationLoader =
-        new DefaultAggregationLoader(metricDAO, datasetDAO, ThirdEyeCacheRegistry.getInstance().getQueryCache(),
-            ThirdEyeCacheRegistry.getInstance().getDatasetMaxDataTimeCache());
   }
 
   private DetectionAlertConfigDTO loadDetectionAlertConfig(long detectionAlertConfigId) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.mail.DefaultAuthenticator;
 import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.HtmlEmail;
@@ -68,6 +69,7 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
 
   private static final String PROP_EMAIL_WHITELIST = "emailWhitelist";
   private static final String PROP_ADMIN_RECIPIENTS = "adminRecipients";
+  private static final String PROP_FROM_ADDRESS = "fromAddress";
 
   public static final String PROP_EMAIL_SCHEME = "emailScheme";
 
@@ -79,7 +81,7 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
   private SmtpConfiguration smtpConfig;
 
   public DetectionEmailAlerter(DetectionAlertConfigDTO subsConfig, ThirdEyeAnomalyConfiguration thirdeyeConfig,
-      DetectionAlertFilterResult result) throws Exception {
+      DetectionAlertFilterResult result) {
     super(subsConfig, result);
     this.teConfig = thirdeyeConfig;
     this.smtpConfig = SmtpConfiguration.createFromProperties(this.teConfig.getAlerterConfiguration().get(SMTP_CONFIG_KEY));
@@ -148,6 +150,7 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
     EmailEntity emailEntity = new EmailContentFormatter(emailClientConfigs, content, this.teConfig, subsConfig)
         .getEmailEntity(anomalies);
     if (Strings.isNullOrEmpty(this.subsConfig.getFrom())) {
+      this.subsConfig.setFrom(MapUtils.getString(this.teConfig.getAlerterConfiguration(), PROP_FROM_ADDRESS));
       throw new IllegalArgumentException("Invalid sender's email");
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -150,8 +150,11 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
     EmailEntity emailEntity = new EmailContentFormatter(emailClientConfigs, content, this.teConfig, subsConfig)
         .getEmailEntity(anomalies);
     if (Strings.isNullOrEmpty(this.subsConfig.getFrom())) {
-      this.subsConfig.setFrom(MapUtils.getString(this.teConfig.getAlerterConfiguration(), PROP_FROM_ADDRESS));
-      throw new IllegalArgumentException("Invalid sender's email");
+      String fromAddress = MapUtils.getString(this.teConfig.getAlerterConfiguration(), PROP_FROM_ADDRESS);
+      if (Strings.isNullOrEmpty(fromAddress)) {
+        throw new IllegalArgumentException("Invalid sender's email");
+      }
+      this.subsConfig.setFrom(fromAddress);
     }
 
     HtmlEmail email = emailEntity.getContent();

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/SubscriptionConfigValidator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/SubscriptionConfigValidator.java
@@ -45,7 +45,6 @@ public class SubscriptionConfigValidator implements ConfigValidator<DetectionAle
     // Check for all the required fields in the alert
     Preconditions.checkArgument(!StringUtils.isEmpty(alertConfig.getName()), "Subscription group name field cannot be left empty.");
     Preconditions.checkArgument(!StringUtils.isEmpty(alertConfig.getApplication()), "Application field cannot be left empty");
-    Preconditions.checkArgument(!StringUtils.isEmpty(alertConfig.getFrom()), "From address field cannot be left empty");
 
     // Empty subscription properties
     Preconditions.checkArgument((alertConfig.getProperties() != null


### PR DESCRIPTION
This PR removes the need to configure a `fromAddress` in the subscription config. Instead, it will load a default email address from the alerterConfiguration in `detector.yml`