### PR TITLE
Disbale text query realtime integration test

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
@@ -55,6 +55,7 @@ import org.testng.annotations.Test;
 /**
  * Cluster integration test for near realtime text search
  */
+@Test(enabled=false)
 public class LuceneRealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSet {
 
   private static final String TABLE_NAME = "mytable";
@@ -165,7 +166,10 @@ public class LuceneRealtimeClusterIntegrationTest extends BaseClusterIntegration
     return outputAvroFile;
   }
 
-  @Test
+
+  // we need to make this more deterministic. internal release builds
+  // are failing intermittently. disable until we make it reasonably deterministic
+  @Test(enabled=false)
   public void testTextSearchCountQuery() throws Exception {
     String pqlQuery =
         "SELECT count(*) FROM " + TABLE_NAME + " WHERE text_match(SKILLS_TEXT_COL, '\"machine learning\" AND spark') LIMIT 1000000";


### PR DESCRIPTION
We need to make this more deterministic. internal release builds are failing intermittently. Disable until we make it reasonably deterministic. 

It has got to do with timing -- how soon do we start seeing > 0 hits for the text query on realtime segments which is internally dependent on ingestion and how quickly they are refreshed.