### PR TITLE
Adding quickstart into Pinot admin command

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
@@ -47,9 +47,6 @@ public class HybridQuickstart {
   private File _dataFile;
   private File _ingestionJobSpecFile;
 
-  private HybridQuickstart() {
-  }
-
   public static void main(String[] args)
       throws Exception {
     // TODO: Explicitly call below method to load dependencies from pinot-plugins libs which are excluded from pinot-tools packaging.

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -30,8 +30,6 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 
 public class Quickstart {
-  private Quickstart() {
-  }
 
   private static final String TAB = "\t\t";
   private static final String NEW_LINE = "\n";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -39,9 +39,6 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 public class RealtimeQuickStart {
   private StreamDataServerStartable _kafkaStarter;
 
-  private RealtimeQuickStart() {
-  }
-
   public static void main(String[] args)
       throws Exception {
     PluginManager.get().init();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -36,6 +36,7 @@ import org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand;
 import org.apache.pinot.tools.admin.command.MoveReplicaGroup;
 import org.apache.pinot.tools.admin.command.OfflineSegmentIntervalCheckerCommand;
 import org.apache.pinot.tools.admin.command.PostQueryCommand;
+import org.apache.pinot.tools.admin.command.QuickStartCommand;
 import org.apache.pinot.tools.admin.command.RealtimeProvisioningHelperCommand;
 import org.apache.pinot.tools.admin.command.RebalanceTableCommand;
 import org.apache.pinot.tools.admin.command.ShowClusterInfoCommand;
@@ -87,6 +88,7 @@ public class PinotAdministrator {
   //@formatter:off
   @Argument(handler = SubCommandHandler.class, metaVar = "<subCommand>")
   @SubCommands({
+      @SubCommand(name = "QuickStart", impl = QuickStartCommand.class),
       @SubCommand(name = "GenerateData", impl = GenerateDataCommand.class),
       @SubCommand(name = "LaunchDataIngestionJob", impl = LaunchDataIngestionJobCommand.class),
       @SubCommand(name = "CreateSegment", impl = CreateSegmentCommand.class),

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.HybridQuickstart;
 import org.apache.pinot.tools.Quickstart;
@@ -69,20 +70,21 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
   @Override
   public boolean execute()
       throws Exception {
+    PluginManager.get().init();
     switch (_type.toUpperCase()) {
       case "OFFLINE":
       case "BATCH":
-        Quickstart.main(new String[]{});
+        new Quickstart().execute();
         break;
       case "REALTIME":
       case "STREAM":
-        RealtimeQuickStart.main(new String[]{});
+        new RealtimeQuickStart().execute();
         break;
       case "HYBRID":
-        HybridQuickstart.main(new String[]{});
+        new HybridQuickstart().execute();
         break;
       default:
-        throw new UnsupportedOperationException("Unsupported quickstart type: " + _type);
+        throw new UnsupportedOperationException("Unsupported QuickStart type: " + _type);
     }
     return true;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command;
+
+import org.apache.pinot.tools.Command;
+import org.apache.pinot.tools.HybridQuickstart;
+import org.apache.pinot.tools.Quickstart;
+import org.apache.pinot.tools.RealtimeQuickStart;
+import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class QuickStartCommand extends AbstractBaseAdminCommand implements Command {
+  private static final Logger LOGGER = LoggerFactory.getLogger(QuickStartCommand.class.getName());
+
+  @Option(name = "-type", required = false, metaVar = "<String>", usage = "Type of quickstart, supported: STREAM/BATCH/HYBRID")
+  private String _type;
+
+  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
+  private boolean _help = false;
+
+  @Override
+  public boolean getHelp() {
+    return _help;
+  }
+
+  @Override
+  public String getName() {
+    return "QuickStart";
+  }
+
+  public QuickStartCommand setType(String type) {
+    _type = type;
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return ("QuickStart -type " + _type);
+  }
+
+  @Override
+  public void cleanup() {
+
+  }
+
+  @Override
+  public String description() {
+    return "Run Pinot QuickStart.";
+  }
+
+  @Override
+  public boolean execute()
+      throws Exception {
+    switch (_type.toUpperCase()) {
+      case "OFFLINE":
+      case "BATCH":
+        Quickstart.main(new String[]{});
+        break;
+      case "REALTIME":
+      case "STREAM":
+        RealtimeQuickStart.main(new String[]{});
+        break;
+      case "HYBRID":
+        HybridQuickstart.main(new String[]{});
+        break;
+      default:
+        throw new UnsupportedOperationException("Unsupported quickstart type: " + _type);
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
With type options: for batch/stream/hybrid

So we can run quickstart in docker.