### PR TITLE
Support text index load for V1 segment format

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.segment.creator.impl.inv.text;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.logging.Logger;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -30,10 +29,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
-import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.segment.creator.InvertedIndexCreator;
-import org.apache.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator;
-import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.slf4j.LoggerFactory;
 
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
@@ -30,8 +30,10 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.segment.creator.InvertedIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator;
+import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.slf4j.LoggerFactory;
 
 
@@ -79,7 +81,9 @@ public class LuceneTextIndexCreator implements InvertedIndexCreator {
   public LuceneTextIndexCreator(String column, File segmentIndexDir, boolean commit) {
     _textColumn = column;
     try {
-      File indexFile = new File(segmentIndexDir.getPath() + "/" + _textColumn + LUCENE_TEXT_INDEX_FILE_EXTENSION);
+      // segment generation is always in V1 and later we convert (as part of post creation processing)
+      // to V3 if segmentVersion is set to V3 in SegmentGeneratorConfig.
+      File indexFile = getV1TextIndexFile(segmentIndexDir);
       _indexDirectory = FSDirectory.open(indexFile.toPath());
       StandardAnalyzer standardAnalyzer = new StandardAnalyzer();
       IndexWriterConfig indexWriterConfig = new IndexWriterConfig(standardAnalyzer);
@@ -154,5 +158,10 @@ public class LuceneTextIndexCreator implements InvertedIndexCreator {
   @Override
   public void add(int[] dictIds, int length) {
     throw new IllegalStateException("Lucene text inverted index is not dictionary based");
+  }
+
+  private File getV1TextIndexFile(File indexDir) {
+    String luceneIndexDirectory = _textColumn + LuceneTextIndexCreator.LUCENE_TEXT_INDEX_FILE_EXTENSION;
+    return new File(indexDir, luceneIndexDirectory);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
@@ -33,6 +33,7 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.segment.creator.impl.inv.text.LuceneTextIndexCreator;
 import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
+import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.roaringbitmap.IntIterator;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.LoggerFactory;
@@ -63,8 +64,7 @@ public class LuceneTextIndexReader implements InvertedIndexReader<MutableRoaring
   public LuceneTextIndexReader(String column, File segmentIndexDir) {
     _column = column;
     try {
-      File indexFile = new File(segmentIndexDir.getPath() + "/" + SegmentVersion.v3.name() + "/" + column
-          + LuceneTextIndexCreator.LUCENE_TEXT_INDEX_FILE_EXTENSION);
+      File indexFile = getTextIndexFile(segmentIndexDir);
       _indexDirectory = FSDirectory.open(indexFile.toPath());
       _indexReader = DirectoryReader.open(_indexDirectory);
       _indexSearcher = new IndexSearcher(_indexReader);
@@ -78,6 +78,28 @@ public class LuceneTextIndexReader implements InvertedIndexReader<MutableRoaring
     }
     StandardAnalyzer analyzer = new StandardAnalyzer();
     _queryParser = new QueryParser(column, analyzer);
+  }
+
+  /**
+   * CASE 1: If IndexLoadingConfig specifies a segment version to load and if it is different then
+   * the on-disk version of the segment, then {@link org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader}
+   * will take care of up-converting the on-disk segment to v3 before load. The converter
+   * already has support for converting v1 text index to v3. So the text index can be
+   * loaded from segmentIndexDir/v3/ since v3 sub-directory would have already been created
+   *
+   * CASE 2: However, if IndexLoadingConfig doesn't specify the segment version to load or if the specified
+   * version is same as the on-disk version of the segment, then ImmutableSegmentLoader will load
+   * whatever the version of segment is on disk.
+   * @param segmentIndexDir top-level segment index directory
+   * @return text index file
+   */
+  private File getTextIndexFile(File segmentIndexDir) {
+    // will return null if file does not exist
+    File file = SegmentDirectoryPaths.findTextIndexIndexFile(segmentIndexDir, _column);
+    if (file == null) {
+      throw new IllegalStateException("Failed to find text index file for column: " + _column);
+    }
+    return file;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
@@ -30,7 +30,6 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
-import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.segment.creator.impl.inv.text.LuceneTextIndexCreator;
 import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
 import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentDirectoryPaths.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentDirectoryPaths.java
@@ -24,6 +24,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
+import org.apache.pinot.core.segment.creator.impl.inv.text.LuceneTextIndexCreator;
 
 
 public class SegmentDirectoryPaths {
@@ -76,6 +77,18 @@ public class SegmentDirectoryPaths {
   @Nullable
   public static File findStarTreeFile(@Nonnull File indexDir) {
     return findFormatFile(indexDir, V1Constants.STAR_TREE_INDEX_FILE);
+  }
+
+  /**
+   * Find text index file in top-level segment index directory
+   * @param indexDir top-level segment index directory
+   * @param column text column name
+   * @return text index directory (if exists in V3, V1 or V2 format), null if index file does not exit
+   */
+  @Nullable
+  public static File findTextIndexIndexFile(File indexDir, String column) {
+    String luceneIndexDirectory = column + LuceneTextIndexCreator.LUCENE_TEXT_INDEX_FILE_EXTENSION;
+    return findFormatFile(indexDir, luceneIndexDirectory);
   }
 
   /**


### PR DESCRIPTION
Currently in Pinot, the segments are always generated in V1 and later during post-creation processing, if SegmentGeneratorConfig has segmentVersion as V3, we convert it to V3. This is also true for text indexes in segments. The converter already supports V1 -> V3 for text indexes.

Upon segment load, we need to address the following scenarios:

**CASE 1:**  If IndexLoadingConfig specifies a segment version to load and if it is different than
the on-disk version of the segment, then ImmutableSegmentLoader will take care of up-converting the on-disk segment to V3 before load. The converter already has support for converting V1 text index to V3. So the text index can be loaded from segmentIndexDir/V3/ since V3 sub-directory would have already been created

**CASE 2**: However, if IndexLoadingConfig doesn't specify the segment version to load or if the specified version is same as the on-disk version of the segment (could be either V1, V2 or V3), then ImmutableSegmentLoader will load whatever the version of segment is on disk.

The text index reader created as part of segment load should be agnostic of above cases.

Added a test to cover all cases in LoaderTest