### PR TITLE
Support creation of inverted index on a new column in V1 segment format as part of segment reload

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
@@ -89,6 +89,7 @@ public class SegmentPreProcessor implements AutoCloseable {
             DefaultColumnHandlerFactory.getDefaultColumnHandler(_indexDir, _schema, _segmentMetadata, segmentWriter);
         defaultColumnHandler.updateDefaultColumns();
         _segmentMetadata = new SegmentMetadataImpl(_indexDir);
+        _segmentDirectory.reloadMetadata();
       }
 
       // Create column inverted indices according to the index config.

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentDirectory.java
@@ -120,6 +120,8 @@ public abstract class SegmentDirectory implements Closeable {
     return SegmentLocalFSDirectory.loadSegmentMetadata(directory);
   }
 
+  public abstract void reloadMetadata() throws Exception;
+
   /**
    * Get the path/URL for the directory
    * @return

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentLocalFSDirectory.java
@@ -84,6 +84,12 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
     }
   }
 
+  @Override
+  public void reloadMetadata() throws Exception {
+    this.segmentMetadata = loadSegmentMetadata(segmentDirectory);
+    columnIndexDirectory.metadata = this.segmentMetadata;
+  }
+
   private File getSegmentPath(File segmentDirectory, SegmentVersion segmentVersion) {
     if (segmentVersion == SegmentVersion.v1 || segmentVersion == SegmentVersion.v2) {
       return segmentDirectory;

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
@@ -26,8 +26,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
@@ -42,6 +40,8 @@ import org.apache.pinot.core.segment.store.ColumnIndexType;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
 import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.segments.v1.creator.SegmentTestUtils;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -58,6 +58,7 @@ public class SegmentPreProcessorTest {
   private static final String COLUMN7_NAME = "column7";
   private static final String COLUMN13_NAME = "column13";
   private static final String NO_SUCH_COLUMN_NAME = "noSuchColumn";
+  private static final String NEW_COLUMN_INVERTED_INDEX = "newStringMVDimension";
 
   // For update default value tests.
   private static final String NEW_COLUMNS_SCHEMA1 = "data/newColumnsSchema1.json";
@@ -268,7 +269,10 @@ public class SegmentPreProcessorTest {
   public void testV1UpdateDefaultColumns()
       throws Exception {
     constructV1Segment();
-    checkUpdateDefaultColumns();
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+    indexLoadingConfig.setInvertedIndexColumns(new HashSet<>(
+        Arrays.asList(COLUMN1_NAME, COLUMN7_NAME, COLUMN13_NAME, NO_SUCH_COLUMN_NAME, NEW_COLUMN_INVERTED_INDEX)));
+    checkUpdateDefaultColumns(indexLoadingConfig);
 
     // Try to use the third schema and update default value again.
     // For the third schema, we changed the default value for column 'newStringMVDimension' to 'notSameLength', which
@@ -289,10 +293,10 @@ public class SegmentPreProcessorTest {
         "0000000141ba085ee15d2f3241ba085ee15d2f324059000000000000000000013ff000000000000041ba085ee15d2f32");
   }
 
-  private void checkUpdateDefaultColumns()
+  private void checkUpdateDefaultColumns(IndexLoadingConfig indexLoadingConfig)
       throws Exception {
     // Update default value.
-    try (SegmentPreProcessor processor = new SegmentPreProcessor(_indexDir, _indexLoadingConfig, _newColumnsSchema1)) {
+    try (SegmentPreProcessor processor = new SegmentPreProcessor(_indexDir, indexLoadingConfig, _newColumnsSchema1)) {
       processor.process();
     }
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);


### PR DESCRIPTION
This is a bug fix. As part of working on PR https://github.com/apache/incubator-pinot/pull/5074, I was adding tests for supporting segment reload of text indexes for both V1 and V3 segment formats. The test was constantly failing when the format is V1, a new column is added and text index is enabled. 

There is an underlying bug due to which this was happening and the exact same scenario doesn't seem to work with inverted index as well. Very easily reproducible in SegmentPreprocessorTest. The existing tests didn't catch it because although they were testing for adding new columns with V1, they didn't test the scenario of enabling inverted index after adding a new column in V1.

This is the stack trace:

`java.lang.NullPointerException
	at org.apache.pinot.core.segment.index.SegmentMetadataImpl.getForwardIndexFileName(SegmentMetadataImpl.java:507)
	at org.apache.pinot.core.segment.store.FilePerIndexDirectory.getFileFor(FilePerIndexDirectory.java:171)
	at org.apache.pinot.core.segment.store.FilePerIndexDirectory.getReadBufferFor(FilePerIndexDirectory.java:145)
	at org.apache.pinot.core.segment.store.FilePerIndexDirectory.getForwardIndexBufferFor(FilePerIndexDirectory.java:62)
	at org.apache.pinot.core.segment.store.SegmentLocalFSDirectory.getIndexForColumn(SegmentLocalFSDirectory.java:237)
	at org.apache.pinot.core.segment.store.SegmentLocalFSDirectory.access$000(SegmentLocalFSDirectory.java:42)
	at org.apache.pinot.core.segment.store.SegmentLocalFSDirectory$Writer.getIndexFor(SegmentLocalFSDirectory.java:470)
	at org.apache.pinot.core.segment.index.loader.invertedindex.InvertedIndexHandler.getForwardIndexReader(InvertedIndexHandler.java:145)
	at org.apache.pinot.core.segment.index.loader.invertedindex.InvertedIndexHandler.createInvertedIndexForColumn(InvertedIndexHandler.java:110)
	at org.apache.pinot.core.segment.index.loader.invertedindex.InvertedIndexHandler.createInvertedIndices(InvertedIndexHandler.java:73)
	at org.apache.pinot.core.segment.index.loader.SegmentPreProcessor.process(SegmentPreProcessor.java:97)
	at org.apache.pinot.core.segment.index.loader.SegmentPreProcessorTest.checkUpdateDefaultColumns(SegmentPreProcessorTest.java:300)
	at org.apache.pinot.core.segment.index.loader.SegmentPreProcessorTest.testV1UpdateDefaultColumns(SegmentPreProcessorTest.java:275)`

In InvertedIndexHandler, when we are trying to create the inverted index for newly created column, it gets the forward index which should already exist since SegmentPreprocessor would have already updated default column values using V1DefaultColumnHandler.

The problem happens in **FilePerIndexDirectory.getForwardIndexBufferFor (column)** as it tries to get ColumnMetadata for the column from segment metadata.

ColumnMetadata is null since the segment metadata that this code is working with is stale (new columns have been added but preprocessor code didn't reload the metadata for directory). 

The fix is to reload the metadata in SegmentPreprocessor for the SegmentDirectory. 