### PR TITLE
[TE][subscription] Dimension alerter should be resilient to partial errors; Emit metrics to track emails and jiras

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/utils/ThirdeyeMetricsUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/utils/ThirdeyeMetricsUtil.java
@@ -173,6 +173,24 @@ public class ThirdeyeMetricsUtil {
   public static final Counter eventScheduledTaskFallbackCounter =
       metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "eventScheduledTaskFallbackCounter");
 
+  public static final Counter emailAlertsSucesssCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "emailAlertsSucesssCounter");
+
+  public static final Counter emailAlertsFailedCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "emailAlertsFailedCounter");
+
+  public static final Counter jiraAlertsSuccessCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "jiraAlertsSuccessCounter");
+
+  public static final Counter jiraAlertsFailedCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "jiraAlertsFailedCounter");
+
+  public static final Counter jiraAlertsNumTicketsCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "jiraAlertsNumTicketsCounter");
+
+  public static final Counter jiraAlertsNumCommentsCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "jiraAlertsNumCommentsCounter");
+
   public static MetricsRegistry getMetricsRegistry() {
     return metricsRegistry;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionAlertScheme.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionAlertScheme.java
@@ -85,12 +85,13 @@ public abstract class DetectionAlertScheme {
    * Fail the alert task if unable to notify owner. However, in case of dimensions recipient alerter,
    * do not fail the alert if a subset of recipients are invalid.
    */
-  void handleAlertFailure(int size, IllegalArgumentException e) {
+  void handleAlertFailure(int numOfAnomalies, Exception e) throws Exception {
+    // Dimension recipients not enabled
     if (this.result.getResult().size() == 1) {
       throw e;
     } else {
       LOG.warn("Skipping! Found illegal arguments while sending {} anomalies for alert {}." + " Exception message: ",
-          size, this.subsConfig.getId(), e);
+          numOfAnomalies, this.subsConfig.getId(), e);
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -35,6 +35,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.mail.DefaultAuthenticator;
 import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.HtmlEmail;
+import org.apache.pinot.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.notification.commons.SmtpConfiguration;
 import org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
@@ -218,8 +219,10 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
               new HashSet<>(ConfigUtils.getList(emailRecipients.get(PROP_CC))),
               new HashSet<>(ConfigUtils.getList(emailRecipients.get(PROP_BCC))));
           sendEmail(prepareEmailContent(subsConfig, emailClientConfigs, anomalyResultListOfGroup, recipients));
+          ThirdeyeMetricsUtil.emailAlertsSucesssCounter.inc();
         }
-      } catch (IllegalArgumentException e) {
+      } catch (Exception e) {
+        ThirdeyeMetricsUtil.emailAlertsFailedCounter.inc();
         super.handleAlertFailure(result.getValue().size(), e);
       }
     }


### PR DESCRIPTION
Current setup of dimension alerter has the following issue:
If one of the recipients under dimension recipients has an error(ex: assignee invalid) then,
1. We will mark the task as FAILED and not proceed with the remaining recipients even if they are correctly configured.
2. Along with marking the task as FAILED, we also do not update the watermarks. Hence the next time the alerter runs, a subset of the dimension recipients will be notified again until we reach the error.

Proposal:
* Made a minor change such that dimension alerter will not fail the pipeline if one of the dimension recipient has some issue.
* Also added counters to track the number of email and jira metrics along with breakdown.
