### PR TITLE
[TE] add dependencies for enabling ThirdEye HTTPS connections

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -39,7 +39,7 @@
     <dropwizard.version>1.3.12</dropwizard.version>
     <dropwizard-auth.version>1.3.12</dropwizard-auth.version>
     <dropwizard.redirect.bundle.version>1.3.5</dropwizard.redirect.bundle.version>
-    <jetty.version>9.4.12.v20180830</jetty.version>
+    <jetty.version>9.4.26.v20200117</jetty.version>
     <jackson.version>2.9.9</jackson.version>
     <mysql.connector.version>5.1.39</mysql.connector.version>
     <quartz.version>2.2.1</quartz.version>

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -157,6 +157,11 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
     </dependency>


### PR DESCRIPTION
Upgrade jetty version and add the jetty-util package to include SSL classes for HTTPS connections.