### PR TITLE
[TE] Change the jetty version to be compatible of loading the certificate for HTTPS

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -39,7 +39,7 @@
     <dropwizard.version>1.3.12</dropwizard.version>
     <dropwizard-auth.version>1.3.12</dropwizard-auth.version>
     <dropwizard.redirect.bundle.version>1.3.5</dropwizard.redirect.bundle.version>
-    <jetty.version>9.4.26.v20200117</jetty.version>
+    <jetty.version>9.4.18.v20190429</jetty.version>
     <jackson.version>2.9.9</jackson.version>
     <mysql.connector.version>5.1.44</mysql.connector.version>
     <quartz.version>2.2.1</quartz.version>


### PR DESCRIPTION
PR5095 upgraded the jetty version. However, it cannot loads the certificate correctly. This PR changes it to a version that's compatible. 