### PR TITLE
Default tenant and example queries for hybrid quickstart 

### DIFF
--- a/docker/images/pinot/table-configs/airlineStats_realtime_table_config.json
+++ b/docker/images/pinot/table-configs/airlineStats_realtime_table_config.json
@@ -12,10 +12,7 @@
     "replication": "1",
     "replicasPerPartition": "1"
   },
-  "tenants": {
-    "broker": "airline_broker",
-    "server": "airline"
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
     "streamConfigs": {

--- a/kubernetes/helm/pinot-realtime-quickstart.yml
+++ b/kubernetes/helm/pinot-realtime-quickstart.yml
@@ -38,10 +38,7 @@ data:
         "replication": "1",
         "replicasPerPartition": "1"
       },
-      "tenants": {
-        "broker": "airline_broker",
-        "server": "airline"
-      },
+      "tenants": {},
       "tableIndexConfig": {
         "loadMode": "MMAP",
         "streamConfigs": {
@@ -78,10 +75,7 @@ data:
         "replication": "1",
         "replicasPerPartition": "1"
       },
-      "tenants": {
-        "broker": "airline_broker",
-        "server": "airline"
-      },
+      "tenants": {},
       "tableIndexConfig": {
         "loadMode": "MMAP",
         "streamConfigs": {

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
@@ -8,10 +8,7 @@
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
-  "tenants": {
-    "broker": "airline_broker",
-    "server": "airline"
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP"
   },

--- a/pinot-tools/src/main/resources/examples/stream/airlineStats/airlineStats_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/airlineStats/airlineStats_realtime_table_config.json
@@ -12,10 +12,7 @@
     "replication": "1",
     "replicasPerPartition": "1"
   },
-  "tenants": {
-    "broker": "airline_broker",
-    "server": "airline"
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
     "streamConfigs": {

--- a/pinot-tools/src/main/resources/examples/stream/airlineStats/docker/airlineStats_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/airlineStats/docker/airlineStats_realtime_table_config.json
@@ -12,10 +12,7 @@
     "replication": "1",
     "replicasPerPartition": "1"
   },
-  "tenants": {
-    "broker": "airline_broker",
-    "server": "airline"
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
     "streamConfigs": {

--- a/pinot-tools/src/main/resources/examples/stream/airlineStats/kafka_0.9/airlineStats_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/airlineStats/kafka_0.9/airlineStats_realtime_table_config.json
@@ -12,10 +12,7 @@
     "replication": "1",
     "replicasPerPartition": "1"
   },
-  "tenants": {
-    "broker": "airline_broker",
-    "server": "airline"
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
     "streamConfigs": {

--- a/pinot-tools/src/main/resources/examples/stream/airlineStats/kafka_2.0/airlineStats_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/airlineStats/kafka_2.0/airlineStats_realtime_table_config.json
@@ -12,10 +12,7 @@
     "replication": "1",
     "replicasPerPartition": "1"
   },
-  "tenants": {
-    "broker": "airline_broker",
-    "server": "airline"
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
     "streamConfigs": {


### PR DESCRIPTION
Change the tenant name used in the hybrid quickstart to DefaultTenants. This will make the documentation consistent across all 3 quickstart, and the followup example will not need special cases: https://apache-pinot.gitbook.io/apache-pinot-cookbook/getting-started/pushing-your-data-to-pinot

