### PR TITLE
[TE] frontend - harleyjj/alert-details - put correct tail value in an…

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-details/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-details/component.js
@@ -935,6 +935,7 @@ export default Component.extend({
       let anomalyEdgeTimestamps = [];
       for (let i = 0; i < series.Current.timestamps.length; ++i) {
         const anomalyValue = useValue ? series.Current.values[i] : 1.0;
+        const anomalyValueMinusOne = useValue ? series.Current.values[i-1] : 1.0;
         if (!inAnomalyRange) {
           currentAnomaly = filteredAnomalies.find(anomaly => {
             return anomaly.startTime === series.Current.timestamps[i];
@@ -959,7 +960,7 @@ export default Component.extend({
             anomalyEdgeValues.push(anomalyValue);
             anomalyEdgeTimestamps.push(series.Current.timestamps[i]);
           } else if (i > 0) {
-            anomalyEdgeValues.push(series.Current.values[i-1]);
+            anomalyEdgeValues.push(anomalyValueMinusOne);
             anomalyEdgeTimestamps.push(series.Current.timestamps[i-1]);
             valuesCurrent.push(null);
           }
@@ -1130,7 +1131,7 @@ export default Component.extend({
    * @param anomalies - an array of anomaly objects
    * @param metricUrn - the metricUrn currently selected for time series chart
    * @param showRules - whether we are showing detection rules and bounds in time series chart
-   * @param selectedRule - which detection rule selected for time series chart 
+   * @param selectedRule - which detection rule selected for time series chart
    * @return {Array}
    */
   _filterAnomalies(anomalies, metricUrn, showRules, selectedRule) {


### PR DESCRIPTION
…omaly for graphing

The alert-details page was not putting the correct edge value in for anomalies which are displayed overhead in Preview Comparison.  This PR fixes the problem.  