### PR TITLE
Minor fixes for queryType sql in PostQuery command and pinot-java-client

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -49,29 +49,45 @@ public class Connection {
   }
 
   /**
-   * Creates a prepared statement, to escape query parameters.
+   * Creates a prepared statement, to escape a PQL query parameters.
    *
-   * @param statement The statement for which to create a prepared statement.
+   * Deprecated as we will soon be removing support for pql endpoint
+   *
+   * @param query The PQL query for which to create a prepared statement.
    * @return A prepared statement for this connection.
    */
-  public PreparedStatement prepareStatement(String statement) {
-    return new PreparedStatement(this, statement);
+  @Deprecated
+  public PreparedStatement prepareStatement(String query) {
+    return new PreparedStatement(this, query);
   }
 
   /**
-   * Executes a PQL statement.
-   * @param statement The statement to execute
+   * Creates a prepared statement, to escape query parameters.
+   *
+   * @param request The request for which to create a prepared statement.
+   * @return A prepared statement for this connection.
+   */
+  public PreparedStatement prepareStatement(Request request) {
+    return new PreparedStatement(this, request);
+  }
+
+  /**
+   * Executes a PQL query.
+   *
+   * Deprecated as we will soon be removing support for pql endpoint
+   * @param query The query to execute
    * @return The result of the query
    * @throws PinotClientException If an exception occurs while processing the query
    */
-  public ResultSetGroup execute(String statement)
+  @Deprecated
+  public ResultSetGroup execute(String query)
       throws PinotClientException {
-    return execute(null, new Request("pql", statement));
+    return execute(null, new Request("pql", query));
   }
 
   /**
    * Executes a Pinot Request.
-   * @param request The statement to execute
+   * @param request The request to execute
    * @return The result of the query
    * @throws PinotClientException If an exception occurs while processing the query
    */
@@ -81,21 +97,23 @@ public class Connection {
   }
 
   /**
-   * Executes a PQL statement.
+   * Executes a PQL query.
    *
-   * @param statement The statement to execute
+   * Deprecated as we will soon be removing support for pql endpoint
+   * @param query The query to execute
    * @return The result of the query
    * @throws PinotClientException If an exception occurs while processing the query
    */
-  public ResultSetGroup execute(String tableName, String statement)
+  @Deprecated
+  public ResultSetGroup execute(String tableName, String query)
       throws PinotClientException {
-    return execute(tableName, new Request("pql", statement));
+    return execute(tableName, new Request("pql", query));
   }
 
   /**
    * Executes a Pinot Request.
    *
-   * @param request The statement to execute
+   * @param request The request to execute
    * @return The result of the query
    * @throws PinotClientException If an exception occurs while processing the query
    */
@@ -114,21 +132,24 @@ public class Connection {
   }
 
   /**
-   * Executes a PQL statement asynchronously.
+   * Executes a PQL query asynchronously.
    *
-   * @param statement The statement to execute
+   * Deprecated as we will soon be removing support for pql endpoint
+   *
+   * @param query The query to execute
    * @return A future containing the result of the query
    * @throws PinotClientException If an exception occurs while processing the query
    */
-  public Future<ResultSetGroup> executeAsync(String statement)
+  @Deprecated
+  public Future<ResultSetGroup> executeAsync(String query)
       throws PinotClientException {
-    return executeAsync(new Request("pql", statement));
+    return executeAsync(new Request("pql", query));
   }
 
   /**
    * Executes a Pinot Request asynchronously.
    *
-   * @param request The statement to execute
+   * @param request The request to execute
    * @return A future containing the result of the query
    * @throws PinotClientException If an exception occurs while processing the query
    */
@@ -140,7 +161,7 @@ public class Connection {
           "Could not find broker to query for statement: " + (request.getQuery() == null ? "null"
               : request.getQuery()));
     }
-    final Future<BrokerResponse> responseFuture = _transport.executeQueryAsync(brokerHostPort, request.getQuery());
+    final Future<BrokerResponse> responseFuture = _transport.executeQueryAsync(brokerHostPort, request);
     return new ResultSetGroupFuture(responseFuture);
   }
 

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/package-info.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/package-info.java
@@ -32,8 +32,8 @@
  *     ("some-server:1234", "some-other-server:1234", ...);}</pre>
  *
  * Queries can be sent directly to the Pinot cluster using the
- * {@link org.apache.pinot.client.Connection#execute(java.lang.String)} and
- * {@link org.apache.pinot.client.Connection#executeAsync(java.lang.String)} methods of
+ * {@link org.apache.pinot.client.Connection#execute(org.apache.pinot.client.Request)} and
+ * {@link org.apache.pinot.client.Connection#executeAsync(org.apache.pinot.client.Request)} methods of
  * {@link org.apache.pinot.client.Connection}.
  *
  * <pre>{@code ResultSetGroup resultSetGroup = connection.execute("select * from foo...");

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/PreparedStatementTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/PreparedStatementTest.java
@@ -37,7 +37,7 @@ public class PreparedStatementTest {
   public void testPreparedStatementEscaping() {
     // Create a prepared statement that has to quote a string appropriately
     Connection connection = ConnectionFactory.fromHostList("dummy");
-    PreparedStatement preparedStatement = connection.prepareStatement("SELECT foo FROM bar WHERE baz = ?");
+    PreparedStatement preparedStatement = connection.prepareStatement(new Request("sql", "SELECT foo FROM bar WHERE baz = ?"));
     preparedStatement.setString(0, "'hello'");
     preparedStatement.execute();
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -99,14 +99,16 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     }
     LOGGER.info("Executing command: " + toString());
 
-    String request = null;
+    String request;
+    String urlString = "http://" + _brokerHost + ":" + _brokerPort + "/query";
     if (_queryType.toLowerCase().equals(Request.SQL)) {
+      urlString += "/sql";
       request = JsonUtils.objectToString(Collections.singletonMap(Request.SQL, _query));
     } else {
       request = JsonUtils.objectToString(Collections.singletonMap(Request.PQL, _query));
     }
 
-    return sendPostRequest("http://" + _brokerHost + ":" + _brokerPort + "/query", request);
+    return sendPostRequest(urlString, request);
   }
 
   @Override


### PR DESCRIPTION
Making fixes to PostQuery to correctly handle queryType to match information in https://apache-pinot.gitbook.io/apache-pinot-cookbook/pinot-user-guide/querying-pinot-using-standard-sql#pinot-admin
Use Request in Connection and PreparedStatement to be able to execute sql, to match examples in https://apache-pinot.gitbook.io/apache-pinot-cookbook/pinot-user-guide/pinot-clients/java. Deprecating the pql-only ways of executing query