### PR TITLE
[TE] added a couple of validations to check if detection is subscribed & valid; cleaned up other validations

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -63,7 +63,7 @@ import static org.apache.pinot.thirdeye.notification.commons.SmtpConfiguration.S
 public class DetectionEmailAlerter extends DetectionAlertScheme {
   private static final Logger LOG = LoggerFactory.getLogger(DetectionEmailAlerter.class);
 
-  private static final String PROP_RECIPIENTS = "recipients";
+  public static final String PROP_RECIPIENTS = "recipients";
   private static final String PROP_TO = "to";
   private static final String PROP_CC = "cc";
   private static final String PROP_BCC = "bcc";

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/SubscriptionConfigValidator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/SubscriptionConfigValidator.java
@@ -24,10 +24,12 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.util.Predicate;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
 import org.quartz.CronExpression;
 
+import static org.apache.pinot.thirdeye.detection.alert.scheme.DetectionEmailAlerter.PROP_RECIPIENTS;
 import static org.apache.pinot.thirdeye.detection.yaml.translator.SubscriptionConfigTranslator.*;
 
 
@@ -36,21 +38,17 @@ public class SubscriptionConfigValidator implements ConfigValidator<DetectionAle
   private static final String PROP_CLASS_NAME = "className";
 
   /**
-   * Perform validation on the alert config like verifying if all the required fields are set
+   * Perform validation on the parsed & constructed subscription config
    */
   @Override
   public void validateConfig(DetectionAlertConfigDTO alertConfig) throws IllegalArgumentException {
     Preconditions.checkNotNull(alertConfig);
 
     // Check for all the required fields in the alert
-    Preconditions.checkArgument(!StringUtils.isEmpty(alertConfig.getName()), "Subscription group name field cannot be left empty.");
-    Preconditions.checkArgument(!StringUtils.isEmpty(alertConfig.getApplication()), "Application field cannot be left empty");
-
-    // Empty subscription properties
-    Preconditions.checkArgument((alertConfig.getProperties() != null
-            && alertConfig.getProperties().get(PROP_CLASS_NAME) != null
-            && StringUtils.isNotEmpty((alertConfig.getProperties().get(PROP_CLASS_NAME).toString()))),
-        "'Type' field cannot be left empty.");
+    Preconditions.checkArgument(!StringUtils.isEmpty(alertConfig.getName()),
+        "Subscription group name field cannot be left empty.");
+    Preconditions.checkArgument(!StringUtils.isEmpty(alertConfig.getApplication()),
+        "Application field cannot be left empty");
 
     // Application name should be valid
     Preconditions.checkArgument(!DAORegistry.getInstance().getApplicationDAO().findByName(alertConfig.getApplication()).isEmpty(),
@@ -61,7 +59,13 @@ public class SubscriptionConfigValidator implements ConfigValidator<DetectionAle
     // Cron Validator
     Preconditions.checkArgument(CronExpression.isValidExpression(alertConfig.getCronExpression()),
         "The subscription cron specified is incorrect. Please verify your cron expression using online cron"
-            + " makers.");
+        + " makers.");
+
+    // Empty subscription properties
+    Preconditions.checkArgument((alertConfig.getProperties() != null
+            && alertConfig.getProperties().get(PROP_CLASS_NAME) != null
+            && StringUtils.isNotEmpty((alertConfig.getProperties().get(PROP_CLASS_NAME).toString()))),
+        "'Type' field cannot be left empty.");
 
     // At least one alertScheme is required
     Preconditions.checkArgument((alertConfig.getAlertSchemes() != null && !alertConfig.getAlertSchemes().isEmpty()),
@@ -74,17 +78,35 @@ public class SubscriptionConfigValidator implements ConfigValidator<DetectionAle
 
     // detectionConfigIds cannot be empty
     List<Long> detectionIds = ConfigUtils.getLongs(alertConfig.getProperties().get(PROP_DETECTION_CONFIG_IDS));
-    Preconditions.checkArgument((detectionIds != null && !detectionIds.isEmpty()),
-        "A notification group should subscribe to at least one alert. If you wish to unsubscribe, set active"
-            + " to false.");
+    Preconditions.checkArgument(!detectionIds.isEmpty(),
+        "A notification group should subscribe to at least one alert. If you wish to unsubscribe, set"
+            + " active to false.");
 
     // TODO add more checks like email validity, alert type check, scheme type check etc.
   }
 
-  // Validate the raw subscription yaml configuration
+  /**
+   * Checks to ensure the fields adhere to the syntax
+   */
   @Override
   public void validateYaml(Map<String, Object> config) throws IllegalArgumentException {
-    // Add validations
+    // Make sure recipients are configured at the right place
+    Preconditions.checkArgument(!config.containsKey(PROP_RECIPIENTS),
+        "Recipients should be configured under the EMAIL alertScheme within params");
+
+    // Subscription group must subscribe to at least one alert
+    List<String> detectionNames = ConfigUtils.getList(config.get(PROP_DETECTION_NAMES));
+    Preconditions.checkArgument(!detectionNames.isEmpty(),
+        "A subscription group should subscribe to at least one alert. If you wish to unsubscribe, set"
+            + " active to false in the subscription config.");
+
+    // Make sure the subscribed detections are valid
+    for (String detectionName : detectionNames) {
+      Preconditions.checkArgument(!DAORegistry.getInstance().getDetectionConfigManager()
+              .findByPredicate(Predicate.EQ("name", detectionName)).isEmpty(),
+          "Cannot find detection " + detectionName + " - Please ensure the detections listed under "
+              + PROP_DETECTION_NAMES + " exist and are correctly configured.");
+    }
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/translator/DetectionConfigTranslator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/translator/DetectionConfigTranslator.java
@@ -288,9 +288,7 @@ public class DetectionConfigTranslator extends ConfigTranslator<DetectionConfigD
     yamlConfigMap.put(PROP_NAME, alertName);
 
     // By default if 'type' is not specified, we assume it as a METRIC_ALERT
-    if (!yamlConfigMap.containsKey(PROP_TYPE)) {
-      yamlConfigMap.put(PROP_TYPE, METRIC_ALERT);
-    }
+    yamlConfigMap.putIfAbsent(PROP_TYPE, METRIC_ALERT);
 
     // Translate config depending on the type (METRIC_ALERT OR COMPOSITE_ALERT)
     Map<String, Object> properties;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/translator/SubscriptionConfigTranslator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/translator/SubscriptionConfigTranslator.java
@@ -58,6 +58,7 @@ public class SubscriptionConfigTranslator extends ConfigTranslator<DetectionAler
   public static final String PROP_TYPE = "type";
   public static final String PROP_CLASS_NAME = "className";
   public static final String PROP_PARAM = "params";
+  public static final String DEFAULT_ALERTER_PIPELINE = "DEFAULT_ALERTER_PIPELINE";
 
   static final String PROP_ALERT_SUPPRESSORS = "alertSuppressors";
   static final String PROP_REFERENCE_LINKS = "referenceLinks";
@@ -92,7 +93,7 @@ public class SubscriptionConfigTranslator extends ConfigTranslator<DetectionAler
     Map<String, Object> properties = new HashMap<>();
 
     // Default subscription type is "DEFAULT_ALERTER_PIPELINE"
-    alertYamlConfigs.putIfAbsent(PROP_TYPE, "DEFAULT_ALERTER_PIPELINE");
+    alertYamlConfigs.putIfAbsent(PROP_TYPE, DEFAULT_ALERTER_PIPELINE);
 
     for (Map.Entry<String, Object> entry : alertYamlConfigs.entrySet()) {
       if (entry.getKey().equals(PROP_TYPE)) {

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/validators/DetectionConfigValidatorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/validators/DetectionConfigValidatorTest.java
@@ -199,13 +199,4 @@ public class DetectionConfigValidatorTest {
     DetectionConfigValidator detectionConfigValidator = new DetectionConfigValidator(provider);
     detectionConfigValidator.validateYaml(this.yamlConfig2);
   }
-
-  // type is a compulsory field at sub-alert levels
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testNoTypeUnderAlertsValidation() {
-    ((Map<String, Object>) ConfigUtils.getList(this.yamlConfig2.get("alerts")).get(0)).remove("type");
-
-    DetectionConfigValidator detectionConfigValidator = new DetectionConfigValidator(provider);
-    detectionConfigValidator.validateYaml(this.yamlConfig2);
-  }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/yaml/YamlResourceTest.java
@@ -72,7 +72,7 @@ public class YamlResourceTest {
   public void testValidateCreateAlertYaml() throws IOException {
     // No validation error should be thrown for valid yaml payload
     String detectionPayload = IOUtils.toString(this.getClass().getResourceAsStream("detection/detection-config-2.yaml"));
-    String subscriptionPayload = IOUtils.toString(this.getClass().getResourceAsStream("alertconfig/alert-config-5.yaml"));
+    String subscriptionPayload = IOUtils.toString(this.getClass().getResourceAsStream("subscription/subscription-config-5.yaml"));
     Map<String, String> config = new HashMap<>();
     config.put("detection", detectionPayload);
     config.put("subscription", subscriptionPayload);
@@ -85,7 +85,7 @@ public class YamlResourceTest {
 
     // Throw error if the subscription group is not subscribed to the detection
     detectionPayload = IOUtils.toString(this.getClass().getResourceAsStream("detection/detection-config-2.yaml"));
-    subscriptionPayload = IOUtils.toString(this.getClass().getResourceAsStream("alertconfig/alert-config-2.yaml"));
+    subscriptionPayload = IOUtils.toString(this.getClass().getResourceAsStream("subscription/subscription-config-2.yaml"));
     config.put("detection", detectionPayload);
     config.put("subscription", subscriptionPayload);
     try {
@@ -178,7 +178,8 @@ public class YamlResourceTest {
       this.yamlResource.createSubscriptionConfig(blankYaml);
       Assert.fail("Exception not thrown on empty yaml");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "Subscription group name field cannot be left empty.");
+      Assert.assertEquals(e.getMessage(), "A subscription group should subscribe to at least one alert."
+          + " If you wish to unsubscribe, set active to false in the subscription config.");
     }
 
     String inValidYaml = "application:test:application";
@@ -273,7 +274,8 @@ public class YamlResourceTest {
       this.yamlResource.updateSubscriptionGroup(user, oldId, blankYaml);
       Assert.fail("Exception not thrown on empty yaml");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "Subscription group name field cannot be left empty.");
+      Assert.assertEquals(e.getMessage(), "A subscription group should subscribe to at least one alert."
+          + " If you wish to unsubscribe, set active to false in the subscription config.");
     }
 
     String inValidYaml = "application:test:application";

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/detection/detection-config-1.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/detection/detection-config-1.yaml
@@ -1,4 +1,4 @@
-detectionName: testPipeline
+detectionName: test_detection_1
 description: My test pipeline
 type: METRIC_ALERT
 metric: test_metric

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/detection/detection-config-2.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/detection/detection-config-2.yaml
@@ -1,4 +1,4 @@
-detectionName: testPipeline
+detectionName: test_detection_2
 description: My modified pipeline
 type: METRIC_ALERT
 metric: test_metric

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-1.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-1.yaml
@@ -10,16 +10,17 @@ dimensionRecipients:
   - "ios-thirdeye@thirdeye.com"
 dimension: app_name
 
-fromAddress: thirdeye-dev@linkedin.com
-
-recipients:
- to:
-  - "thirdeye@thirdeye.com"
- cc:
-  - "thirdeye-developers@thirdeye.com"
+subscribedDetections:
+- test_detection_1
 
 alertSchemes:
 - type: EMAIL
+  params:
+    recipients:
+      to:
+        - "thirdeye@thirdeye.com"
+      cc:
+        - "thirdeye-developers@thirdeye.com"
 - type: IRIS
   params:
     plan: thirdye_test_plan

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-2.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-2.yaml
@@ -12,16 +12,14 @@ dimensionRecipients:
   - "ios-thirdeye@thirdeye.com"
 dimension: app_name
 
-fromAddress: thirdeye-dev@linkedin.com
-
-recipients:
- to:
-  - "thirdeye@thirdeye.com"
- cc:
-  - "thirdeye-developers@thirdeye.com"
-
 alertSchemes:
 - type: EMAIL
+  params:
+    recipients:
+      to:
+        - "thirdeye@thirdeye.com"
+      cc:
+        - "thirdeye-developers@thirdeye.com"
 - type: IRIS
   params:
     plan: thirdye_test_plan

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-3.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-3.yaml
@@ -13,16 +13,14 @@ dimensionRecipients:
   - "ios-thirdeye@thirdeye.com"
 dimension: app_name
 
-fromAddress: thirdeye-dev@linkedin.com
-
-recipients:
- to:
-  - "thirdeye@thirdeye.com"
- cc:
-  - "thirdeye-developers@thirdeye.com"
-
 alertSchemes:
 - type: EMAIL
+  params:
+    recipients:
+      to:
+        - "thirdeye@thirdeye.com"
+      cc:
+        - "thirdeye-developers@thirdeye.com"
 - type: IRIS
   params:
     plan: thirdye_test_plan

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-4.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-4.yaml
@@ -13,16 +13,14 @@ dimensionRecipients:
   - "ios-thirdeye@thirdeye.com"
 dimension: app_name
 
-fromAddress: thirdeye-dev@linkedin.com
-
-recipients:
- to:
-  - "thirdeye@thirdeye.com"
- cc:
-  - "thirdeye-developers@thirdeye.com"
-
 alertSchemes:
 - type: EMAIL
+  params:
+    recipients:
+      to:
+        - "thirdeye@thirdeye.com"
+      cc:
+        - "thirdeye-developers@thirdeye.com"
 - type: IRIS
   params:
     plan: thirdye_test_plan

--- a/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-5.yaml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/org/apache/pinot/thirdeye/detection/yaml/subscription/subscription-config-5.yaml
@@ -13,19 +13,16 @@ dimensionRecipients:
   - "ios-thirdeye@thirdeye.com"
 dimension: app_name
 
-fromAddress: thirdeye-dev@linkedin.com
-
-recipients:
- to:
-  - "thirdeye@thirdeye.com"
- cc:
-  - "thirdeye-developers@thirdeye.com"
-
 alertSchemes:
 - type: EMAIL
   params:
     template: ENTITY_GROUPBY_REPORT
     subject: METRICS
+    recipients:
+      to:
+        - "thirdeye@thirdeye.com"
+      cc:
+        - "thirdeye-developers@thirdeye.com"
 - type: IRIS
   params:
     plan: thirdye_test_plan

--- a/thirdeye/thirdeye-pinot/src/test/resources/sample-alert-config.yml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/sample-alert-config.yml
@@ -14,13 +14,13 @@ subscribedDetections:
 # or for advanced critical use-cases setup Iris alert by referring to the documentation
 alertSchemes:
   - type: EMAIL
-recipients:
-  to:
-    - "me@company.com"          # Specify alert recipient email address here
-    - "me@company.com"
-  cc:
-    - "cc_email@company.com"
-fromAddress: email@domain.com
+    params:
+      recipients:
+        to:
+          - "me@company.com"          # Specify alert recipient email address here
+          - "me@company.com"
+        cc:
+          - "cc_email@company.com"
 
 # The below links will appear in the email alerts. This will help alert recipients to quickly refer and act on.
 referenceLinks:


### PR DESCRIPTION
Validations added:
* Make sure subscription group subscribes to the detectionName while creating an alert
* Make sure all the subscribed detections are valid
* recipients should be configured under the EMAIL scheme params and not at the root level

Validations removed:
* type is not compulsory in subscription group
* type is not compulsory for sub-entity alerts.

Added unit tests for newly added validations