### PR TITLE
Bugfixing the issue for ThreadLocal DocIdSet in ExpressionFilterOperator

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
@@ -49,11 +49,17 @@ public class DocIdSetOperator extends BaseOperator<DocIdSetBlock> {
   private FilterBlockDocIdSet _filterBlockDocIdSet;
   private BlockDocIdIterator _blockDocIdIterator;
   private int _currentDocId = 0;
+  private boolean _threadLocal = true;
 
   public DocIdSetOperator(@Nonnull BaseFilterOperator filterOperator, int maxSizeOfDocIdSet) {
+    this(filterOperator, maxSizeOfDocIdSet, true);
+  }
+
+  public DocIdSetOperator(@Nonnull BaseFilterOperator filterOperator, int maxSizeOfDocIdSet, boolean threadLocal) {
     Preconditions.checkArgument(maxSizeOfDocIdSet > 0 && maxSizeOfDocIdSet <= DocIdSetPlanNode.MAX_DOC_PER_CALL);
     _filterOperator = filterOperator;
     _maxSizeOfDocIdSet = maxSizeOfDocIdSet;
+    _threadLocal = threadLocal;
   }
 
   @Override
@@ -69,7 +75,7 @@ public class DocIdSetOperator extends BaseOperator<DocIdSetBlock> {
     }
 
     int pos = 0;
-    int[] docIds = THREAD_LOCAL_DOC_IDS.get();
+    int[] docIds = _threadLocal? THREAD_LOCAL_DOC_IDS.get(): new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     for (int i = 0; i < _maxSizeOfDocIdSet; i++) {
       _currentDocId = _blockDocIdIterator.next();
       if (_currentDocId == Constants.EOF) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
@@ -75,7 +75,7 @@ public class DocIdSetOperator extends BaseOperator<DocIdSetBlock> {
     }
 
     int pos = 0;
-    int[] docIds = _threadLocal? THREAD_LOCAL_DOC_IDS.get(): new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int[] docIds = _threadLocal? THREAD_LOCAL_DOC_IDS.get(): new int[_maxSizeOfDocIdSet];
     for (int i = 0; i < _maxSizeOfDocIdSet; i++) {
       _currentDocId = _blockDocIdIterator.next();
       if (_currentDocId == Constants.EOF) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
@@ -151,7 +151,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
         throw new UnsupportedOperationException("Filter on expressions that return multi-values is not yet supported");
       }
       _blockDocIdIterator.setStartDocId(0);
-      _blockDocIdIterator.setEndDocId(_expressionFilterOperator._numDocs - 1);
+      _blockDocIdIterator.setEndDocId(_expressionFilterOperator._numDocs);
     }
 
     @Override
@@ -196,7 +196,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
       int _endDocId;
       //used only in next() and advance methods
       int _currentBlockStartDocId = -1;
-      int _currentBlockEndDocId = -1;
+      int _currentBlockEndDocId = 0;
       private int _currentDocId = -1;
       IntIterator _intIterator = null;
 
@@ -219,12 +219,13 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
         }
         while (_currentDocId < _endDocId) {
           if (_intIterator == null) {
-            _currentBlockStartDocId = _currentBlockEndDocId + 1;
+            _currentBlockStartDocId = _currentBlockEndDocId;
             _currentBlockEndDocId = _currentBlockStartDocId + DocIdSetPlanNode.MAX_DOC_PER_CALL;
             _currentBlockEndDocId = Math.min(_currentBlockEndDocId, _endDocId);
             MutableRoaringBitmap bitmapRange = new MutableRoaringBitmap();
-            bitmapRange.add(_currentBlockStartDocId, _currentBlockEndDocId + 1);
+            bitmapRange.add(_currentBlockStartDocId, _currentBlockEndDocId);
             MutableRoaringBitmap matchedBitmap = evaluate(bitmapRange);
+
             _intIterator = matchedBitmap.getIntIterator();
             _numDocsScanned += (_currentBlockEndDocId - _currentBlockStartDocId);
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
@@ -196,7 +196,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
       int _endDocId;
       //used only in next() and advance methods
       int _currentBlockStartDocId = -1;
-      int _currentBlockEndDocId = 0;
+      int _currentBlockEndDocId = -1;
       private int _currentDocId = -1;
       IntIterator _intIterator = null;
 
@@ -219,7 +219,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
         }
         while (_currentDocId < _endDocId) {
           if (_intIterator == null) {
-            _currentBlockStartDocId = _currentBlockEndDocId;
+            _currentBlockStartDocId = _currentBlockEndDocId + 1;
             _currentBlockEndDocId = _currentBlockStartDocId + DocIdSetPlanNode.MAX_DOC_PER_CALL;
             _currentBlockEndDocId = Math.min(_currentBlockEndDocId, _endDocId);
             MutableRoaringBitmap bitmapRange = new MutableRoaringBitmap();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
@@ -290,7 +290,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
 
       private MutableRoaringBitmap evaluate(MutableRoaringBitmap answer) {
         BaseFilterOperator filterOperator = new BitmapWrappedFilterOperator(answer);
-        DocIdSetOperator docIdSetOperator = new DocIdSetOperator(filterOperator, DocIdSetPlanNode.MAX_DOC_PER_CALL);
+        DocIdSetOperator docIdSetOperator = new DocIdSetOperator(filterOperator, DocIdSetPlanNode.MAX_DOC_PER_CALL, false);
         ProjectionOperator projectionOperator =
             new ProjectionOperator(_expressionFilterOperator._dataSourceMap, docIdSetOperator);
         TransformOperator operator =

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -170,6 +170,18 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     String query;
     List<String> h2queries;
     query =
+        "SELECT COUNT(*) FROM mytable WHERE CarrierDelay=15 AND ArrDelay > CarrierDelay LIMIT 1";
+    testSqlQuery(query, Collections.singletonList(query));
+    query =
+        "SELECT ArrDelay, CarrierDelay, (ArrDelay - CarrierDelay) AS diff FROM mytable WHERE CarrierDelay=15 AND ArrDelay > CarrierDelay ORDER BY diff, ArrDelay, CarrierDelay LIMIT 100000";
+    testSqlQuery(query, Collections.singletonList(query));
+    query =
+        "SELECT COUNT(*) FROM mytable WHERE ArrDelay > CarrierDelay LIMIT 1";
+    testSqlQuery(query, Collections.singletonList(query));
+    query =
+        "SELECT ArrDelay, CarrierDelay, (ArrDelay - CarrierDelay) AS diff FROM mytable WHERE ArrDelay > CarrierDelay ORDER BY diff, ArrDelay, CarrierDelay LIMIT 100000";
+    testSqlQuery(query, Collections.singletonList(query));
+    query =
         "SELECT count(*) FROM mytable WHERE AirlineID > 20355 AND OriginState BETWEEN 'PA' AND 'DE' AND DepTime <> 2202 LIMIT 21";
     testSqlQuery(query, Collections.singletonList(query));
     query =


### PR DESCRIPTION
Bug fixing for: https://github.com/apache/incubator-pinot/issues/5103

Root cause is that we use `THREAD_LOCAL_DOC_IDS` in `DocIdSetOperator`.
However expression evaluation through `ExpressionFilterOperator` will construct `DocIdSetOperator` multiple times with FilterOperator to reset the `THREAD_LOCAL_DOC_IDS` values.