### PR TITLE
Add Azure Data Lake Gen2 connector for PinotFS

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -38,6 +38,12 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-data-lake-store-sdk</artifactId>
+      <version>2.1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-storage-file-datalake</artifactId>
+      <version>12.0.0-beta.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzureGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzureGen2PinotFS.java
@@ -63,6 +63,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Azure Data Lake Storage Gen2 implementation for the PinotFS interface.
+ *
+ * TODO: add the unit test
  */
 public class AzureGen2PinotFS extends PinotFS {
   private static final Logger LOGGER = LoggerFactory.getLogger(AzureGen2PinotFS.class);
@@ -115,7 +117,7 @@ public class AzureGen2PinotFS extends PinotFS {
     _blobServiceClient =
         new BlobServiceClientBuilder().credential(sharedKeyCredential).endpoint(blobServiceEndpointUrl).buildClient();
     _fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    LOGGER.error("AzureGen2PinotFS is initialized (accountName={}, fileSystemName={}, dfsServiceEndpointUrl={}, "
+    LOGGER.info("AzureGen2PinotFS is initialized (accountName={}, fileSystemName={}, dfsServiceEndpointUrl={}, "
             + "blobServiceEndpointUrl={}, enableChecksum={})", accountName, fileSystemName, dfsServiceEndpointUrl,
         blobServiceEndpointUrl, _enableChecksum);
   }
@@ -135,7 +137,7 @@ public class AzureGen2PinotFS extends PinotFS {
       if (e.getStatusCode() == ALREADY_EXISTS_STATUS_CODE && e.getErrorCode().equals(PATH_ALREADY_EXISTS_ERROR_CODE)) {
         return true;
       }
-      LOGGER.error("Exception thrown while calling mkdir (uri = {})", uri, e);
+      LOGGER.error("Exception thrown while calling mkdir (uri={}, errorStatus ={})", uri, e.getStatusCode(), e);
       throw new IOException(e);
     }
   }
@@ -197,7 +199,7 @@ public class AzureGen2PinotFS extends PinotFS {
       // In case we are copying a directory, we need to recursively look into the directory and copy all the files and
       // directories accordingly
       try {
-        boolean copySucceeded = false;
+        boolean copySucceeded = true;
         Path srcPath = Paths.get(srcUri.getPath());
         for (String path : listFiles(srcUri, true)) {
           // Compute the src path for the given path
@@ -213,7 +215,7 @@ public class AzureGen2PinotFS extends PinotFS {
             mkdir(newDst);
           } else {
             // If src is a file, we need to copy.
-            copySucceeded |= copySrcToDst(currentSrc, newDst);
+            copySucceeded &= copySrcToDst(currentSrc, newDst);
           }
         }
         return copySucceeded;

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzureGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzureGen2PinotFS.java
@@ -1,0 +1,460 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.filesystem;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.util.Context;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.common.Utility;
+import com.azure.storage.file.datalake.DataLakeDirectoryClient;
+import com.azure.storage.file.datalake.DataLakeFileClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+import com.azure.storage.file.datalake.models.DataLakeRequestConditions;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.ListPathsOptions;
+import com.azure.storage.file.datalake.models.PathHttpHeaders;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.models.PathProperties;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Map;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Azure Data Lake Storage Gen2 implementation for the PinotFS interface.
+ */
+public class AzureGen2PinotFS extends PinotFS {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AzureGen2PinotFS.class);
+
+  private static final String ACCOUNT_NAME = "accountName";
+  private static final String ACCESS_KEY = "accessKey";
+  private static final String FILE_SYSTEM_NAME = "fileSystemName";
+  private static final String ENABLE_CHECKSUM = "enableChecksum";
+
+  private static final String HTTPS_URL_PREFIX = "https://";
+
+  private static final String AZURE_STORAGE_DNS_SUFFIX = ".dfs.core.windows.net";
+  private static final String AZURE_BLOB_DNS_SUFFIX = ".blob.core.windows.net";
+  private static final String PATH_ALREADY_EXISTS_ERROR_CODE = "PathAlreadyExists";
+  private static final String IS_DIRECTORY_KEY = "hdi_isfolder";
+
+  private static final int NOT_FOUND_STATUS_CODE = 404;
+  private static final int ALREADY_EXISTS_STATUS_CODE = 409;
+
+  // Azure Data Lake Gen2's block size is 4MB
+  private static final int BUFFER_SIZE = 4 * 1024 * 1024;
+
+  private DataLakeFileSystemClient _fileSystemClient;
+  private BlobServiceClient _blobServiceClient;
+
+  // If enabled, pinotFS implementation will guarantee that the bits you've read are the same as the ones you wrote.
+  // However, there's some overhead in computing hash. (Adds roughly 3 seconds for 1GB file)
+  private boolean _enableChecksum;
+
+  @Override
+  public void init(Configuration config) {
+    _enableChecksum = config.getBoolean(ENABLE_CHECKSUM, false);
+
+    // Azure storage account name
+    String accountName = config.getString(ACCOUNT_NAME);
+
+    // TODO: consider to add the encryption of the following config
+    String accessKey = config.getString(ACCESS_KEY);
+    String fileSystemName = config.getString(FILE_SYSTEM_NAME);
+
+    String dfsServiceEndpointUrl = HTTPS_URL_PREFIX + accountName + AZURE_STORAGE_DNS_SUFFIX;
+    String blobServiceEndpointUrl = HTTPS_URL_PREFIX + accountName + AZURE_BLOB_DNS_SUFFIX;
+
+    StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(accountName, accessKey);
+
+    DataLakeServiceClient serviceClient = new DataLakeServiceClientBuilder().credential(sharedKeyCredential)
+        .endpoint(dfsServiceEndpointUrl)
+        .buildClient();
+
+    _blobServiceClient =
+        new BlobServiceClientBuilder().credential(sharedKeyCredential).endpoint(blobServiceEndpointUrl).buildClient();
+    _fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
+    LOGGER.error("AzureGen2PinotFS is initialized (accountName={}, fileSystemName={}, dfsServiceEndpointUrl={}, "
+            + "blobServiceEndpointUrl={}, enableChecksum={})", accountName, fileSystemName, dfsServiceEndpointUrl,
+        blobServiceEndpointUrl, _enableChecksum);
+  }
+
+  @Override
+  public boolean mkdir(URI uri) throws IOException {
+    LOGGER.debug("mkdir is called with uri='{}'", uri);
+    try {
+      // By default, create directory call will overwrite if the path already exists. Setting IfNoneMatch = "*" to
+      // prevent overwrite. https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
+      DataLakeRequestConditions requestConditions = new DataLakeRequestConditions().setIfNoneMatch("*");
+      _fileSystemClient.createDirectoryWithResponse(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(uri), null,
+          null, null, null, requestConditions, null, null);
+      return true;
+    } catch (DataLakeStorageException e) {
+      // If the path already exists, doing nothing and return true
+      if (e.getStatusCode() == ALREADY_EXISTS_STATUS_CODE && e.getErrorCode().equals(PATH_ALREADY_EXISTS_ERROR_CODE)) {
+        return true;
+      }
+      LOGGER.error("Exception thrown while calling mkdir (uri = {})", uri, e);
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public boolean delete(URI segmentUri, boolean forceDelete) throws IOException {
+    LOGGER.debug("delete is called with segmentUri='{}', forceDelete='{}'", segmentUri, forceDelete);
+    try {
+      boolean isDirectory = isDirectory(segmentUri);
+      if (isDirectory && listFiles(segmentUri, false).length > 0 && !forceDelete) {
+        return false;
+      }
+
+      String path = AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(segmentUri);
+      if (isDirectory) {
+        _fileSystemClient.deleteDirectoryWithResponse(path, true, null, null, Context.NONE).getValue();
+      } else {
+        _fileSystemClient.deleteFile(path);
+      }
+      return true;
+    } catch (DataLakeStorageException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public boolean doMove(URI srcUri, URI dstUri) throws IOException {
+    LOGGER.debug("doMove is called with srcUri='{}', dstUri='{}'", srcUri, dstUri);
+    try {
+      // TODO: currently, azure-sdk has a bug in "rename" when the path includes some special characters that gets
+      // changed during the url encoding (e.g '%' -> '%25', ' ' -> '%20')
+      // https://github.com/Azure/azure-sdk-for-java/issues/8761
+      DataLakeDirectoryClient directoryClient =
+          _fileSystemClient.getDirectoryClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(srcUri));
+      directoryClient.rename(null, AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(dstUri));
+      return true;
+    } catch (DataLakeStorageException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public boolean copy(URI srcUri, URI dstUri) throws IOException {
+    LOGGER.debug("copy is called with srcUri='{}', dstUri='{}'", srcUri, dstUri);
+    // If src and dst are the same, do nothing.
+    if (srcUri.equals(dstUri)) {
+      return true;
+    }
+
+    // Remove the destination directory or file
+    if (exists(dstUri)) {
+      delete(dstUri, true);
+    }
+
+    if (!isDirectory(srcUri)) {
+      // If source is a file, we can simply copy the file from src to dst
+      return copySrcToDst(srcUri, dstUri);
+    } else {
+      // In case we are copying a directory, we need to recursively look into the directory and copy all the files and
+      // directories accordingly
+      try {
+        boolean copySucceeded = false;
+        Path srcPath = Paths.get(srcUri.getPath());
+        for (String path : listFiles(srcUri, true)) {
+          // Compute the src path for the given path
+          URI currentSrc = new URI(srcUri.getScheme(), srcUri.getHost(), path, null);
+
+          // Compute the destination path for the current path.
+          String relativeSrcPath = srcPath.relativize(Paths.get(path)).toString();
+          String newDstPath = Paths.get(dstUri.getPath(), relativeSrcPath).toString();
+          URI newDst = new URI(dstUri.getScheme(), dstUri.getHost(), newDstPath, null);
+
+          if (isDirectory(currentSrc)) {
+            // If src is directory, create one.
+            mkdir(newDst);
+          } else {
+            // If src is a file, we need to copy.
+            copySucceeded |= copySrcToDst(currentSrc, newDst);
+          }
+        }
+        return copySucceeded;
+      } catch (DataLakeStorageException | URISyntaxException e) {
+        throw new IOException(e);
+      }
+    }
+  }
+
+  @Override
+  public boolean exists(URI fileUri) throws IOException {
+    try {
+      _fileSystemClient.getDirectoryClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(fileUri))
+          .getProperties();
+      return true;
+    } catch (DataLakeStorageException e) {
+      if (e.getStatusCode() == NOT_FOUND_STATUS_CODE) {
+        return false;
+      }
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public long length(URI fileUri) throws IOException {
+    try {
+      PathProperties pathProperties =
+          _fileSystemClient.getDirectoryClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(fileUri))
+              .getProperties();
+      return pathProperties.getFileSize();
+    } catch (DataLakeStorageException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public String[] listFiles(URI fileUri, boolean recursive) throws IOException {
+    LOGGER.debug("listFiles is called with fileUri='{}', recursive='{}'", fileUri, recursive);
+    try {
+      // Unlike other Azure SDK APIs that takes url encoded path, ListPathsOptions takes decoded url
+      // e.g) 'path/segment' instead of 'path%2Fsegment'
+      String pathForListPathsOptions =
+          Utility.urlDecode(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(fileUri));
+      ListPathsOptions options = new ListPathsOptions().setPath(pathForListPathsOptions).setRecursive(recursive);
+      PagedIterable<PathItem> iter = _fileSystemClient.listPaths(options, null);
+      return iter.stream()
+          .map(p -> AzurePinotFSUtil.convertAzureStylePathToUriStylePath(p.getName()))
+          .toArray(String[]::new);
+    } catch (DataLakeStorageException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public void copyToLocalFile(URI srcUri, File dstFile) throws Exception {
+    LOGGER.debug("copyToLocalFile is called with srcUri='{}', dstFile='{}'", srcUri, dstFile);
+    if (dstFile.exists()) {
+      if (dstFile.isDirectory()) {
+        FileUtils.deleteDirectory(dstFile);
+      } else {
+        FileUtils.deleteQuietly(dstFile);
+      }
+    }
+    int bytesRead;
+    byte[] buffer = new byte[BUFFER_SIZE];
+    try (InputStream inputStream = open(srcUri)) {
+      try (OutputStream outputStream = new FileOutputStream(dstFile)) {
+        while ((bytesRead = inputStream.read(buffer)) != -1) {
+          outputStream.write(buffer, 0, bytesRead);
+        }
+      }
+    }
+    // If MD5 hash is available as part of path properties, verify it with the local file
+    if (_enableChecksum) {
+      DataLakeFileClient fileClient =
+          _fileSystemClient.getFileClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(srcUri));
+      byte[] md5ContentFromMetadata = fileClient.getProperties().getContentMd5();
+      if (md5ContentFromMetadata != null && md5ContentFromMetadata.length > 0) {
+        byte[] md5FromLocalFile = computeContentMd5(dstFile);
+        if (!Arrays.equals(md5FromLocalFile, md5ContentFromMetadata)) {
+          // Clean up the corrupted file
+          FileUtils.deleteQuietly(dstFile);
+          throw new IOException("Computed MD5 and MD5 from metadata do not match");
+        }
+      }
+    }
+  }
+
+  @Override
+  public void copyFromLocalFile(File srcFile, URI dstUri) throws Exception {
+    LOGGER.debug("copyFromLocalFile is called with srcFile='{}', dstUri='{}'", srcFile, dstUri);
+    byte[] contentMd5 = computeContentMd5(srcFile);
+    try (InputStream fileInputStream = new FileInputStream(srcFile)) {
+      copyInputStreamToDst(fileInputStream, dstUri, contentMd5);
+    }
+  }
+
+  @Override
+  public boolean isDirectory(URI uri) throws IOException {
+    try {
+      PathProperties pathProperties = getPathProperties(uri);
+      Map<String, String> metadata = pathProperties.getMetadata();
+      // TODO: need to find the other ways to check the directory if it becomes available. listFiles API returns
+      // PathInfo, which includes "isDirectory" field; however, there's no API available for fetching PathInfo directly
+      // from target uri.
+      return Boolean.valueOf(metadata.get(IS_DIRECTORY_KEY));
+    } catch (DataLakeStorageException e) {
+      throw new IOException("Failed while checking isDirectory for : " + uri, e);
+    }
+  }
+
+  @Override
+  public long lastModified(URI uri) throws IOException {
+    try {
+      PathProperties pathProperties = getPathProperties(uri);
+      OffsetDateTime offsetDateTime = pathProperties.getLastModified();
+      Timestamp timestamp = Timestamp.valueOf(offsetDateTime.atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+      return timestamp.getTime();
+    } catch (DataLakeStorageException e) {
+      throw new IOException("Failed while checking lastModified time for : " + uri, e);
+    }
+  }
+
+  @Override
+  public boolean touch(URI uri) throws IOException {
+    // The following data lake gen2 API provides a way to update file properties including last modified time.
+    // https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update
+    // However, action = "setProperties" is available in REST API but not available in Java SDK yet.
+    //
+    // For now, directly use Blob service's API to get the same effect.
+    // https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-properties
+    try {
+      DataLakeFileClient fileClient =
+          _fileSystemClient.getFileClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(uri));
+      PathProperties pathProperties = fileClient.getProperties();
+      fileClient.setHttpHeaders(getPathHttpHeaders(pathProperties));
+      return true;
+    } catch (DataLakeStorageException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public InputStream open(URI uri) throws IOException {
+    // Use Blob API since read() function from Data Lake Client currently takes "OutputStream" as an input and
+    // flush bytes to an output stream. This needs to be piped back into input stream to implement this function.
+    // On the other hand, Blob API directly allow you to open the input stream.
+    BlobClient blobClient = _blobServiceClient.getBlobContainerClient(_fileSystemClient.getFileSystemName())
+        .getBlobClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(uri));
+
+    return blobClient.openInputStream();
+    // Another approach is to download the file to the local disk to a temp path and return the file input stream. In
+    // this case, we need to override "close()" and delete temp file.
+  }
+
+  private boolean copySrcToDst(URI srcUri, URI dstUri) throws IOException {
+    PathProperties pathProperties =
+        _fileSystemClient.getFileClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(srcUri)).getProperties();
+    try (InputStream inputStream = open(srcUri)) {
+      return copyInputStreamToDst(inputStream, dstUri, pathProperties.getContentMd5());
+    }
+  }
+
+  /**
+   * Helper function to copy input stream to destination URI.
+   *
+   * NOTE: the caller has to close the input stream.
+   *
+   * @param inputStream input stream that will be written to dstUri
+   * @param dstUri destination URI
+   * @return true if the copy succeeds
+   */
+  private boolean copyInputStreamToDst(InputStream inputStream, URI dstUri, byte[] contentMd5)
+      throws IOException {
+    int bytesRead;
+    long totalBytesRead = 0;
+    byte[] buffer = new byte[BUFFER_SIZE];
+    DataLakeFileClient fileClient =
+        _fileSystemClient.createFile(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(dstUri));
+
+    // Update MD5 metadata
+    if (contentMd5 != null) {
+      PathHttpHeaders pathHttpHeaders = getPathHttpHeaders(fileClient.getProperties());
+      pathHttpHeaders.setContentMd5(contentMd5);
+      fileClient.setHttpHeaders(pathHttpHeaders);
+    }
+
+    try {
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        byte[] md5BlockHash = null;
+        if (_enableChecksum) {
+          // Compute md5 for the current block
+          MessageDigest md5Block = MessageDigest.getInstance("MD5");
+          md5Block.update(buffer, 0, bytesRead);
+          md5BlockHash = md5Block.digest();
+        }
+        // Upload 4MB at a time since Azure's limit for each append call is 4MB.
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(buffer, 0, bytesRead);
+        fileClient.appendWithResponse(byteArrayInputStream, totalBytesRead, bytesRead, md5BlockHash, null, null,
+            Context.NONE);
+        byteArrayInputStream.close();
+        totalBytesRead += bytesRead;
+      }
+      // Call flush on ADLS Gen 2
+      fileClient.flush(totalBytesRead);
+
+      return true;
+    } catch (DataLakeStorageException | NoSuchAlgorithmException e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Compute md5 hash from the file
+   * @param file input file
+   * @return byte array of md5 hash
+   * @throws Exception
+   */
+  private byte[] computeContentMd5(File file) throws Exception{
+    MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+    int bytesRead;
+    byte[] buffer = new byte[BUFFER_SIZE];
+    try (InputStream inputStream = new FileInputStream(file)) {
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        messageDigest.update(buffer, 0, bytesRead);
+      }
+    }
+    return messageDigest.digest();
+  }
+
+  private PathProperties getPathProperties(URI uri) throws IOException {
+    return _fileSystemClient.getDirectoryClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(uri))
+        .getProperties();
+  }
+
+  private PathHttpHeaders getPathHttpHeaders(PathProperties pathProperties) {
+    return new PathHttpHeaders().setCacheControl(pathProperties.getCacheControl())
+        .setContentDisposition(pathProperties.getContentDisposition())
+        .setContentEncoding(pathProperties.getContentEncoding())
+        .setContentMd5(pathProperties.getContentMd5())
+        .setContentLanguage(pathProperties.getContentLanguage())
+        .setContentType(pathProperties.getContentType());
+  }
+}

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFSUtil.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFSUtil.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.filesystem;
+
+import com.azure.storage.common.Utility;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+
+
+/**
+ * Util class for Azure related PinotFS
+ */
+public class AzurePinotFSUtil {
+  private static final String DIRECTORY_DELIMITER = File.separator;
+
+  private AzurePinotFSUtil() {
+  }
+
+  /**
+   * Extract Azure Data Lake Gen2 style path from uri
+   *
+   * NOTE: returning path 'should not be' url encoded. (e.g. should return 'a/segment' instead of 'a%2Fsegment')
+   *
+   * @param uri a uri path
+   * @return path in Azure Data Lake Gen2 format
+   * @throws IOException
+   */
+  public static String convertUriToAzureStylePath(URI uri) throws IOException {
+    // Pinot side code uses `URLEncoder` when building uri
+    String path = URLDecoder.decode(uri.getRawPath(), "UTF-8");
+    if (path.startsWith(DIRECTORY_DELIMITER)) {
+      path = path.substring(1);
+    }
+    if (path.endsWith(DIRECTORY_DELIMITER)) {
+      path = path.substring(0, path.length() - 1);
+    }
+    // We need to use azure's url encoder to be compatible
+    return path;
+  }
+
+  /**
+   * Extract 'url encoded' Azure Data Lake Gen2 style path from uri
+   *
+   * NOTE: returning path 'should be' url encoded. (e.g. should return 'a%2Fsegment' instead of 'a/segment')
+   *
+   * @param uri a uri path
+   * @return url encoded path in Azure Data Lake Gen2 format
+   * @throws IOException
+   */
+  public static String convertUriToUrlEncodedAzureStylePath(URI uri) throws IOException {
+    return Utility.urlEncode(convertUriToAzureStylePath(uri));
+  }
+
+  /**
+   * Convert Azure Data Lake Gen2 style path into uri format.
+   *
+   * NOTE: returning path 'should not be' url encoded. (e.g. should return 'a/segment' instead of 'a%2Fsegment')
+   *
+   * @param path Azure data lake gen2 style path
+   * @return path in uri format
+   */
+  public static String convertAzureStylePathToUriStylePath(String path) {
+    if (!path.startsWith(DIRECTORY_DELIMITER)) {
+      path = DIRECTORY_DELIMITER + path;
+    }
+    if (path.endsWith(DIRECTORY_DELIMITER)) {
+      path = path.substring(0, path.length() - 1);
+    }
+    return path;
+  }
+}

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/AzurePinotFSUtilTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/AzurePinotFSUtilTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.filesystem.test;
+
+import com.azure.storage.common.Utility;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import org.apache.pinot.plugin.filesystem.AzurePinotFSUtil;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AzurePinotFSUtilTest {
+  private static final String BASE_PATH = "abfss://test.dfs.core.windows.net";
+
+  @Test
+  public void testConvertUriToAzureStylePath() throws Exception {
+    testUriToAzureStylePath("table_0", "segment_1", false);
+    testUriToAzureStylePath("table_0", "segment %", false);
+    testUriToAzureStylePath("table %", "segment_1", false);
+    testUriToAzureStylePath("table %", "segment %", false);
+  }
+
+  @Test
+  public void testConvertUriToUrlEncodedAzureStylePath() throws Exception {
+    testUriToAzureStylePath("table_0", "segment_1", true);
+    testUriToAzureStylePath("table_0", "segment %", true);
+    testUriToAzureStylePath("table %", "segment_1", true);
+    testUriToAzureStylePath("table %", "segment %", true);
+  }
+
+  @Test
+  public void testConvertAzureStylePathToUriStylePath() throws Exception {
+    Assert.assertEquals(AzurePinotFSUtil.convertAzureStylePathToUriStylePath("a/b"), "/a/b");
+    Assert.assertEquals(AzurePinotFSUtil.convertAzureStylePathToUriStylePath("a/b/"), "/a/b");
+    Assert.assertEquals(AzurePinotFSUtil.convertAzureStylePathToUriStylePath("/a/b"), "/a/b");
+    Assert.assertEquals(AzurePinotFSUtil.convertAzureStylePathToUriStylePath("/a/b/"), "/a/b");
+
+    Assert.assertEquals(AzurePinotFSUtil.convertAzureStylePathToUriStylePath("table/segment %"), "/table/segment %");
+    Assert.assertEquals(AzurePinotFSUtil.convertAzureStylePathToUriStylePath("table/segment %/"), "/table/segment %");
+    Assert.assertEquals(AzurePinotFSUtil.convertAzureStylePathToUriStylePath("/table/segment %"), "/table/segment %");
+    Assert.assertEquals(AzurePinotFSUtil.convertAzureStylePathToUriStylePath("/table/segment %/"), "/table/segment %");
+  }
+
+  public void testUriToAzureStylePath(String tableName, String segmentName, boolean urlEncoded) throws Exception {
+    // "/encode(dir)/encode(segment)"
+    String expectedPath = String.join(File.separator, tableName, segmentName);
+    URI uri = createUri(URLEncoder.encode(tableName, "UTF-8"), URLEncoder.encode(segmentName, "UTF-8"));
+    checkUri(uri, expectedPath, urlEncoded);
+
+    // "/encode(dir/segment)"
+    uri = createUri(URLEncoder.encode(String.join(File.separator, tableName, segmentName), "UTF-8"));
+    checkUri(uri, expectedPath, urlEncoded);
+
+    // "/encode(dir/segment)"
+    uri = createUri(Utility.urlEncode(String.join(File.separator, tableName, segmentName)));
+    checkUri(uri, expectedPath, urlEncoded);
+
+    // Using a URI constructor. In this case, we don't need to encode
+    // /dir/segment
+    uri = new URI(uri.getScheme(), uri.getHost(), File.separator + String.join(File.separator, tableName, segmentName),
+        null);
+    checkUri(uri, expectedPath, urlEncoded);
+  }
+
+  private void checkUri(URI uri, String expectedPath, boolean urlEncoded) throws IOException {
+    if (urlEncoded) {
+      Assert.assertEquals(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(uri), Utility.urlEncode(expectedPath));
+    } else {
+      Assert.assertEquals(AzurePinotFSUtil.convertUriToAzureStylePath(uri), expectedPath);
+    }
+  }
+
+  private URI createUri(String tableName, String segmentName) {
+    String fullUriPath = String.join(File.separator, BASE_PATH, tableName, segmentName);
+    return URI.create(fullUriPath);
+  }
+
+  private URI createUri(String path) {
+    String fullUriPath = String.join(File.separator, BASE_PATH, path);
+    return URI.create(fullUriPath);
+  }
+}

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -261,13 +261,13 @@ public class GcsPinotFS  extends PinotFS {
     ImmutableList.Builder<URI> builder = ImmutableList.builder();
     Path srcPath = Paths.get(srcUri.getPath());
     try {
-      boolean copySucceeded = false;
+      boolean copySucceeded = true;
       for (String directoryEntry : listFiles(srcUri, true)) {
         URI src = new URI(srcUri.getScheme(), srcUri.getHost(), directoryEntry, null);
         String relativeSrcPath = srcPath.relativize(Paths.get(directoryEntry)).toString();
         String dstPath = dstUri.resolve(relativeSrcPath).getPath();
         URI dst = new URI(dstUri.getScheme(), dstUri.getHost(), dstPath, null);
-        copySucceeded |= copyFile(src, dst);
+        copySucceeded &= copyFile(src, dst);
       }
       return copySucceeded;
     } catch (URISyntaxException e) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -120,6 +120,14 @@ public class LocalPinotFSTest {
     Assert.assertTrue(localPinotFS.exists(new File(newAbsoluteTempDirPath3, "testDir").toURI()));
     Assert.assertTrue(localPinotFS.exists(new File(new File(newAbsoluteTempDirPath3, "testDir"), "testFile").toURI()));
 
+    // Check if using a different scheme on URI still works
+    URI uri = URI.create("hdfs://localhost:9999" + newAbsoluteTempDirPath.getPath());
+    localPinotFS.move(newAbsoluteTempDirPath3.toURI(), uri, true);
+    Assert.assertFalse(localPinotFS.exists(newAbsoluteTempDirPath3.toURI()));
+    Assert.assertTrue(localPinotFS.exists(newAbsoluteTempDirPath.toURI()));
+    Assert.assertTrue(localPinotFS.exists(new File(newAbsoluteTempDirPath, "testDir").toURI()));
+    Assert.assertTrue(localPinotFS.exists(new File(new File(newAbsoluteTempDirPath, "testDir"), "testFile").toURI()));
+
     // Check file copy to location where something already exists still works
     localPinotFS.copy(testFileUri, thirdTestFile.toURI());
     // Check length of file

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
     <commons-logging.version>1.2</commons-logging.version>
     <snappy-java.version>1.1.1.7</snappy-java.version>
     <log4j.version>2.11.2</log4j.version>
+    <netty.version>4.1.42.Final</netty.version>
 
     <!-- Sets the VM argument line used when unit tests are run. -->
     <argLine>-Xms4g -Xmx4g -XX:MaxPermSize=512m -XX:MaxDirectMemorySize=10g</argLine>
@@ -357,11 +358,6 @@
         <version>20.0</version>
       </dependency>
       <dependency>
-        <groupId>com.microsoft.azure</groupId>
-        <artifactId>azure-data-lake-store-sdk</artifactId>
-        <version>2.1.5</version>
-      </dependency>
-      <dependency>
         <groupId>com.yammer.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>2.2.0</version>
@@ -391,17 +387,48 @@
         <artifactId>commons-io</artifactId>
         <version>2.4</version>
       </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-all</artifactId>
-        <version>4.1.28.Final</version>
-      </dependency>
+
       <!-- zkclient & helix-core use netty -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty</artifactId>
         <version>3.9.6.Final</version>
       </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-all</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <!-- this part is for resolving dependency convergence error for pinot-adls -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>${netty.version}</version>
+        <classifier>linux-x86_64</classifier>
+      </dependency>
+
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>


### PR DESCRIPTION
1. Testing have been done by attaching ADLS Gen2 to the local deployment.
2. move() is implemented by copy & delete because of azure sdk issue with rename() API.
   https://github.com/Azure/azure-sdk-for-java/issues/8761