### PR TITLE
Fix the backward-compatible issue for `PartitionAwareRealtime` routing

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
@@ -32,15 +32,18 @@ public class InstanceSelectorFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceSelectorFactory.class);
 
-  public static final String LEGACY_REPLICA_GROUP_ROUTING = "PartitionAwareOffline";
+  public static final String LEGACY_REPLICA_GROUP_OFFLINE_ROUTING = "PartitionAwareOffline";
+  public static final String LEGACY_REPLICA_GROUP_REALTIME_ROUTING = "PartitionAwareRealtime";
 
   public static InstanceSelector getInstanceSelector(TableConfig tableConfig, BrokerMetrics brokerMetrics) {
     String tableNameWithType = tableConfig.getTableName();
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
     if (routingConfig != null && (
         RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(routingConfig.getInstanceSelectorType())
-            || (tableConfig.getTableType() == TableType.OFFLINE && LEGACY_REPLICA_GROUP_ROUTING
-            .equalsIgnoreCase(routingConfig.getRoutingTableBuilderName())))) {
+            || (tableConfig.getTableType() == TableType.OFFLINE && LEGACY_REPLICA_GROUP_OFFLINE_ROUTING
+            .equalsIgnoreCase(routingConfig.getRoutingTableBuilderName())) || (
+            tableConfig.getTableType() == TableType.REALTIME && LEGACY_REPLICA_GROUP_REALTIME_ROUTING
+                .equalsIgnoreCase(routingConfig.getRoutingTableBuilderName())))) {
       LOGGER.info("Using ReplicaGroupInstanceSelector for table: {}", tableNameWithType);
       return new ReplicaGroupInstanceSelector(tableNameWithType, brokerMetrics);
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
@@ -63,8 +63,8 @@ public class SegmentPrunerFactory {
         // Handle legacy configs for backward-compatibility
         TableType tableType = tableConfig.getTableType();
         String routingTableBuilderName = routingConfig.getRoutingTableBuilderName();
-        if (tableType == TableType.OFFLINE && LEGACY_PARTITION_AWARE_OFFLINE_ROUTING
-            .equalsIgnoreCase(routingTableBuilderName) || (tableType == TableType.REALTIME
+        if ((tableType == TableType.OFFLINE && LEGACY_PARTITION_AWARE_OFFLINE_ROUTING
+            .equalsIgnoreCase(routingTableBuilderName)) || (tableType == TableType.REALTIME
             && LEGACY_PARTITION_AWARE_REALTIME_ROUTING.equalsIgnoreCase(routingTableBuilderName))) {
           PartitionSegmentPruner partitionSegmentPruner = getPartitionSegmentPruner(tableConfig, propertyStore);
           if (partitionSegmentPruner != null) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -67,7 +67,13 @@ public class InstanceSelectorTest {
     // Should be backward-compatible with legacy config
     when(routingConfig.getInstanceSelectorType()).thenReturn(null);
     when(tableConfig.getTableType()).thenReturn(CommonConstants.Helix.TableType.OFFLINE);
-    when(routingConfig.getRoutingTableBuilderName()).thenReturn(InstanceSelectorFactory.LEGACY_REPLICA_GROUP_ROUTING);
+    when(routingConfig.getRoutingTableBuilderName())
+        .thenReturn(InstanceSelectorFactory.LEGACY_REPLICA_GROUP_OFFLINE_ROUTING);
+    assertTrue(InstanceSelectorFactory
+        .getInstanceSelector(tableConfig, brokerMetrics) instanceof ReplicaGroupInstanceSelector);
+    when(tableConfig.getTableType()).thenReturn(CommonConstants.Helix.TableType.REALTIME);
+    when(routingConfig.getRoutingTableBuilderName())
+        .thenReturn(InstanceSelectorFactory.LEGACY_REPLICA_GROUP_REALTIME_ROUTING);
     assertTrue(InstanceSelectorFactory
         .getInstanceSelector(tableConfig, brokerMetrics) instanceof ReplicaGroupInstanceSelector);
   }


### PR DESCRIPTION
Legacy `PartitionAwareRealtime` is using replica-group based routing