### PR TITLE
Change console loggers to non-async for pinot-tools

### DIFF
--- a/pinot-tools/src/main/resources/conf/pinot-admin-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-admin-log4j2.xml
@@ -39,15 +39,15 @@
     </RandomAccessFile>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="info" additivity="false">
+    <Root level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
-    <AsyncLogger name="org.apache.pinot.controller.ControllerStarter" level="info" additivity="false">
+    </Root>
+    <Logger name="org.apache.pinot.controller.ControllerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncLogger>
-    <AsyncLogger name="org.apache.pinot.tools.admin" level="info" additivity="false">
+    </Logger>
+    <Logger name="org.apache.pinot.tools.admin" level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncLogger>
+    </Logger>
     <AsyncLogger name="org.reflections" level="error" additivity="false"/>
     <AsyncLogger name="org.apache.pinot.spi.plugin" level="error" additivity="false">
       <AppenderRef ref="console"/>

--- a/pinot-tools/src/main/resources/conf/pinot-broker-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-broker-log4j2.xml
@@ -33,16 +33,16 @@
     </RandomAccessFile>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="info" additivity="false">
+    <Root level="info" additivity="false">
       <!-- Display warnings on the console -->
       <AppenderRef ref="console" level="warn"/>
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="brokerLog"/>
-    </AsyncRoot>
+    </Root>
     <!-- Output broker starter logs to the console -->
-    <AsyncLogger name="org.apache.pinot.broker.broker.helix.HelixBrokerStarter" level="info" additivity="false">
+    <Logger name="org.apache.pinot.broker.broker.helix.HelixBrokerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncLogger>
+    </Logger>
     <AsyncLogger name="org.reflections" level="error" additivity="false"/>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/pinot-controller-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-controller-log4j2.xml
@@ -33,16 +33,16 @@
     </RandomAccessFile>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="info" additivity="false">
+    <Root level="info" additivity="false">
       <!-- Display warnings on the console -->
       <AppenderRef ref="console" level="warn"/>
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="controllerLog"/>
-    </AsyncRoot>
+    </Root>
     <!-- Output controller starter logs to the console -->
-    <AsyncLogger name="org.apache.pinot.controller.ControllerStarter" level="info" additivity="false">
+    <Logger name="org.apache.pinot.controller.ControllerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncLogger>
+    </Logger>
     <AsyncLogger name="org.reflections" level="error" additivity="false"/>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/pinot-ingestion-job-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-ingestion-job-log4j2.xml
@@ -34,13 +34,13 @@
 
   </Appenders>
   <Loggers>
-    <AsyncRoot level="error" additivity="false">
+    <Root level="error" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
-    <AsyncLogger name="org.apache.pinot" level="info" additivity="false">
+    </Root>
+    <Logger name="org.apache.pinot" level="info" additivity="false">
       <AppenderRef ref="console"/>
       <AppenderRef ref="ingestionJobLog"/>
-    </AsyncLogger>
+    </Logger>
     <AsyncLogger name="org.reflections" level="error" additivity="false"/>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/pinot-server-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-server-log4j2.xml
@@ -33,16 +33,16 @@
     </RandomAccessFile>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="info" additivity="false">
+    <Root level="info" additivity="false">
       <!-- Display warnings on the console -->
       <AppenderRef ref="console" level="warn"/>
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="serverLog"/>
-    </AsyncRoot>
+    </Root>
     <!-- Output server starter logs to the console -->
-    <AsyncLogger name="org.apache.pinot.server.starter.helix.HelixServerStarter" level="info" additivity="false">
+    <Logger name="org.apache.pinot.server.starter.helix.HelixServerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncLogger>
+    </Logger>
     <AsyncLogger name="org.reflections" level="error" additivity="false"/>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/conf/pinot-tools-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-tools-log4j2.xml
@@ -40,13 +40,13 @@
 
   </Appenders>
   <Loggers>
-    <AsyncRoot level="info" additivity="false">
+    <Root level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
-    <AsyncLogger name="org.apache.pinot" level="info" additivity="false"/>
-    <AsyncLogger name="org.apache.pinot.tools" level="info" additivity="false">
+    </Root>
+    <Logger name="org.apache.pinot" level="info" additivity="false"/>
+    <Logger name="org.apache.pinot.tools" level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncLogger>
+    </Logger>
 
     <!-- Direct controller package log to the controller log file -->
     <AsyncLogger name="org.apache.pinot.controller" level="info" additivity="false">

--- a/pinot-tools/src/main/resources/conf/quickstart-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/quickstart-log4j2.xml
@@ -40,13 +40,13 @@
 
   </Appenders>
   <Loggers>
-    <AsyncRoot level="error" additivity="false">
+    <Root level="error" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
-    <AsyncLogger name="org.apache.pinot" level="error" additivity="false"/>
-    <AsyncLogger name="org.apache.pinot.tools.admin" level="info" additivity="false">
+    </Root>
+    <Logger name="org.apache.pinot" level="error" additivity="false"/>
+    <Logger name="org.apache.pinot.tools.admin" level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncLogger>
+    </Logger>
 
     <!-- Direct controller package log to the controller log file -->
     <AsyncLogger name="org.apache.pinot.controller" level="info" additivity="false">

--- a/pinot-tools/src/main/resources/log4j2.xml
+++ b/pinot-tools/src/main/resources/log4j2.xml
@@ -44,13 +44,13 @@
 
   </Appenders>
   <Loggers>
-    <AsyncRoot level="error" additivity="false">
+    <Root level="error" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
-    <AsyncLogger name="org.apache.pinot" level="info" additivity="false"/>
-    <AsyncLogger name="org.apache.pinot.tools" level="info" additivity="false">
+    </Root>
+    <Logger name="org.apache.pinot" level="info" additivity="false"/>
+    <Logger name="org.apache.pinot.tools" level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncLogger>
+    </Logger>
 
     <!-- Direct controller package log to the controller log file -->
     <AsyncLogger name="org.apache.pinot.controller" level="info" additivity="false">


### PR DESCRIPTION
Someone reached out to us on the slack channel that they were trying out quickstart, but cannot see any logs when running the pinot-admin commands. Specifically, the issues were for AddTable and LaunchDataIngestionJob.
I was able to reproduce the issue. I setup the quick-start-batch cluster, and then `AddTable` command with missing table config file.
```
# checkout and build, and then
bin/quick-start-batch.sh
bin/pinot-admin.sh AddTable -tableConfigFile /tmp/pinot-quick-start/transcript-table.json -exec
```
There's just 1 line of log, and the program exits
```
2020/03/06 17:08:19.205 INFO [AddTableCommand] [main] Executing command: AddTable -tableConfigFile /tmp/pinot-quick-start/transcript-table-offline.json -schemaFile /tmp/pinot-quick-start/transcript-schema.json -controllerHost xxxx -controllerPort 9000 -exec
```

Possible suspect is the AsyncLogger. On changing `s/AsyncLogger/Logger` for those using AppenderRef=console, this worked for me. We should be fine changing AsyncLogger to Logger for `pinot-tools` module. 
Other suggestions welcome.