### PR TITLE
Fix a NullPointerException that can occur if an Exception is raised when reading a JSON Record file.

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordReader.java
@@ -53,7 +53,9 @@ public class JSONRecordReader implements RecordReader {
       _iterator = JsonUtils.DEFAULT_READER.forType(new TypeReference<Map<String, Object>>() {
       }).readValues(_dataFile);
     } catch (Exception e) {
-      _iterator.close();
+      if (_iterator != null) {
+        _iterator.close();
+      }
       throw e;
     }
   }


### PR DESCRIPTION
_iterator will be null if an Exception is raised.  _iterator.close() causes an NPE.