### PR TITLE
Fix hybrid quickstart

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
@@ -126,15 +126,11 @@ public class HybridQuickstart {
     File tempDir = new File("/tmp", String.valueOf(System.currentTimeMillis()));
     Preconditions.checkState(tempDir.mkdirs());
     final QuickstartRunner runner =
-        new QuickstartRunner(Lists.newArrayList(offlineRequest, realtimeTableRequest), 2, 2, 1, tempDir, false);
+        new QuickstartRunner(Lists.newArrayList(offlineRequest, realtimeTableRequest), 1, 1, 1, tempDir);
     printStatus(Color.YELLOW, "***** Starting Kafka  *****");
     startKafka();
-    printStatus(Color.YELLOW, "***** Starting Zookeeper, 2 servers, 2 brokers and 1 controller *****");
+    printStatus(Color.YELLOW, "***** Starting Zookeeper, 1 servers, 1 brokers and 1 controller *****");
     runner.startAll();
-    printStatus(Color.YELLOW, "***** Creating a server tenant with name 'DefaultTenant' *****");
-    runner.createServerTenantWith(1, 1, TagNameUtils.DEFAULT_TENANT_NAME);
-    printStatus(Color.YELLOW, "***** Creating a broker tenant with name 'DefaultTenant' *****");
-    runner.createBrokerTenantWith(2, TagNameUtils.DEFAULT_TENANT_NAME);
     printStatus(Color.YELLOW, "***** Adding airlineStats offline and realtime table *****");
     runner.addTable();
     printStatus(Color.YELLOW, "***** Launch data ingestion job to build index segments for airlineStats and push to controller *****");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AirlineDataStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AirlineDataStream.java
@@ -70,7 +70,7 @@ public class AirlineDataStream {
 
     service = Executors.newFixedThreadPool(1);
     Quickstart.printStatus(Quickstart.Color.YELLOW,
-        "***** Offine data has max time as 16101, realtime will start consuming from time 16102 and increment time every 3000 events *****");
+        "***** Offine data has max time as 16101, realtime will start consuming from time 16102 and increment time every 60 events (which is approximately 60 seconds) *****");
   }
 
   public void shutdown() {
@@ -82,10 +82,9 @@ public class AirlineDataStream {
   }
 
   private void createStream()
-      throws FileNotFoundException, IOException {
+      throws IOException {
     if (keepIndexing) {
-      avroDataStream =
-          new DataFileStream<GenericRecord>(new FileInputStream(avroFile), new GenericDatumReader<GenericRecord>());
+      avroDataStream = new DataFileStream<>(new FileInputStream(avroFile), new GenericDatumReader<>());
       return;
     }
     avroDataStream = null;
@@ -109,7 +108,7 @@ public class AirlineDataStream {
       public void run() {
         while (true) {
           while (avroDataStream.hasNext()) {
-            if (keepIndexing == false) {
+            if (!keepIndexing) {
               return;
             }
 
@@ -132,9 +131,10 @@ public class AirlineDataStream {
             try {
               publish(message);
               counter++;
-              if (counter % 3000 == 0) {
+              if (counter % 60 == 0) {
                 currentTimeValue = currentTimeValue + 1;
               }
+              Thread.sleep(1000);
             } catch (Exception e) {
               logger.error(e.getMessage());
             }


### PR DESCRIPTION
Hybrid quickstart consumes a lot of cpu and memory as soon it starts up and it keeps on increasing. If another hybrid table is created on it, it eventually runs out of memory and crashes. Possible reasons:
1. we're creating 2 servers, 2 brokers, which each take up a lot of resources by default
2. the airlineStats stream produces events continuously in a loop, with no rate limiting.

Fixes:
1. Creating just 1 server and 1 broker. This was initially designed with 2 because we didn't have support for the same server to be tagged with _OFFLINE and _REALTIME, which no longer holds true
2. Sleeping for 1 second after each event published to the stream, creating a steady ingestion rate