### PR TITLE
Update pinot assembly scripts for release 0.3.0

### DIFF
--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -43,10 +43,74 @@
     <file>
       <source>${pinot.root}/DISCLAIMER</source>
     </file>
+    <!-- Include Pinot All-in-one jar -->
     <file>
       <source>${pinot.root}/pinot-distribution/target/pinot-distribution-${project.version}-shaded.jar</source>
       <destName>lib/pinot-all-${project.version}-jar-with-dependencies.jar</destName>
     </file>
+    <!-- Start Include Pinot Plugins-->
+    <!-- Start Include Pinot Stream Ingestion Plugins-->
+    <!-- Only Include Specified Kafka Version Plugin-->
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kafka-${kafka.version}/target/pinot-kafka-${kafka.version}-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-stream-ingestion/pinot-kafka-${kafka.version}/pinot-kafka-${kafka.version}-${project.version}-shaded.jar</destName>
+    </file>
+    <!-- End Include Pinot Stream Ingestion Plugins-->
+    <!-- Start Include Pinot Batch Ingestion Plugins-->
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/target/pinot-batch-ingestion-standalone-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pinot-batch-ingestion-standalone-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/target/pinot-batch-ingestion-hadoop-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pinot-batch-ingestion-hadoop-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/target/pinot-batch-ingestion-spark-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pinot-batch-ingestion-spark-${project.version}-shaded.jar</destName>
+    </file>
+    <!-- End Include Pinot Batch Ingestion Plugins-->
+    <!-- Start Include Pinot File System Plugins-->
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-adls/target/pinot-adls-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-file-system/pinot-adls/pinot-adls-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-gcs/target/pinot-gcs-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-file-system/pinot-gcs/pinot-gcs-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-hdfs/target/pinot-hdfs-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-file-system/pinot-hdfs/pinot-hdfs-${project.version}-shaded.jar</destName>
+    </file>
+    <!-- End Include Pinot File System Plugins-->
+    <!-- Start Include Pinot Input Format Plugins-->
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-avro/target/pinot-avro-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-input-format/pinot-avro/pinot-avro-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-csv/target/pinot-csv-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-input-format/pinot-csv/pinot-csv-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-json/target/pinot-json-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-input-format/pinot-json/pinot-json-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-orc/target/pinot-orc-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-input-format/pinot-orc/pinot-orc-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-parquet/target/pinot-parquet-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-input-format/pinot-parquet/pinot-parquet-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-thrift/target/pinot-thrift-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-input-format/pinot-thrift/pinot-thrift-${project.version}-shaded.jar</destName>
+    </file>
+    <!-- End Include Pinot Input Format Plugins-->
+    <!-- End Include Pinot Plugins-->
   </files>
   <fileSets>
     <!-- Rename licenses-binary directory to licenses and include it to a distribution tarbell -->
@@ -85,30 +149,6 @@
       <directory>${pinot.root}/pinot-tools/target/pinot-tools-pkg/bin</directory>
       <outputDirectory>bin</outputDirectory>
       <fileMode>0755</fileMode>
-    </fileSet>
-    <fileSet>
-      <useDefaultExcludes>false</useDefaultExcludes>
-      <directory>${pinot.root}/pinot-plugins/target/plugins/</directory>
-      <outputDirectory>plugins</outputDirectory>
-      <excludes>
-        <exclude>**/*.pom</exclude>
-        <exclude>**/pinot-plugins/**</exclude>
-        <exclude>**/pinot-file-system/pinot-file-system/**</exclude>
-        <exclude>**/pinot-input-format/pinot-input-format/**</exclude>
-        <exclude>**/pinot-stream-ingestion/pinot-stream-ingestion/**</exclude>
-        <exclude>**/pinot-stream-ingestion/pinot-kafka-*/**</exclude>
-        <exclude>**/pinot-batch-ingestion/pinot-batch-ingestion/**</exclude>
-        <exclude>**/pinot-batch-ingestion/pinot-batch-ingestion-common/**</exclude>
-        <exclude>**/pinot-batch-ingestion/pinot-ingestion-common/**</exclude>
-        <exclude>**/pinot-batch-ingestion/pinot-hadoop/**</exclude>
-        <exclude>**/pinot-batch-ingestion/pinot-spark/**</exclude>
-        <exclude>**/pinot-batch-ingestion/v0_deprecated/**</exclude>
-      </excludes>
-    </fileSet>
-    <fileSet>
-      <useDefaultExcludes>false</useDefaultExcludes>
-      <directory>${pinot.root}/pinot-plugins/target/plugins/pinot-stream-ingestion/pinot-kafka-${kafka.version}</directory>
-      <outputDirectory>plugins/pinot-stream-ingestion/pinot-kafka-${kafka.version}</outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -102,7 +102,6 @@
                       <shadedPattern>shaded.org.apache.http</shadedPattern>
                     </relocation>
                   </relocations>
-                  <outputDirectory>${pinot.root}/pinot-plugins/target/plugins/${plugin.type}/${project.artifactId}</outputDirectory>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
This is required for release 0.3.0
`mvn release` command doesn't honor output relocation, so we need to manually specify those in assembly scripts for `pinot-plugins`.