### PR TITLE
Support default star-tree

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
 import org.apache.pinot.core.segment.name.FixedSegmentNameGenerator;
@@ -87,6 +86,7 @@ public class SegmentGeneratorConfig {
   private SegmentVersion _segmentVersion = SegmentVersion.v3;
   private Schema _schema = null;
   private RecordReaderConfig _readerConfig = null;
+  private boolean _enableDefaultStarTree = false;
   private List<StarTreeV2BuilderConfig> _starTreeV2BuilderConfigs = null;
   private String _creatorVersion = null;
   private SegmentNameGenerator _segmentNameGenerator = null;
@@ -150,6 +150,7 @@ public class SegmentGeneratorConfig {
       _segmentPartitionConfig = indexingConfig.getSegmentPartitionConfig();
 
       // Star-tree V2 configs
+      setEnableDefaultStarTree(indexingConfig.isEnableDefaultStarTree());
       List<StarTreeIndexConfig> starTreeIndexConfigs = indexingConfig.getStarTreeIndexConfigs();
       if (starTreeIndexConfigs != null && !starTreeIndexConfigs.isEmpty()) {
         List<StarTreeV2BuilderConfig> starTreeV2BuilderConfigs = new ArrayList<>(starTreeIndexConfigs.size());
@@ -508,6 +509,14 @@ public class SegmentGeneratorConfig {
 
   public void setReaderConfig(RecordReaderConfig readerConfig) {
     _readerConfig = readerConfig;
+  }
+
+  public boolean isEnableDefaultStarTree() {
+    return _enableDefaultStarTree;
+  }
+
+  public void setEnableDefaultStarTree(boolean enableDefaultStarTree) {
+    _enableDefaultStarTree = enableDefaultStarTree;
   }
 
   public List<StarTreeV2BuilderConfig> getStarTreeV2BuilderConfigs() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -23,6 +23,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -262,8 +263,15 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
 
   private void buildStarTreeV2IfNecessary(File indexDir)
       throws Exception {
-    List<StarTreeV2BuilderConfig> starTreeV2BuilderConfigs = config.getStarTreeV2BuilderConfigs();
-    if (starTreeV2BuilderConfigs != null && !starTreeV2BuilderConfigs.isEmpty()) {
+    List<StarTreeV2BuilderConfig> starTreeV2BuilderConfigs = new ArrayList<>();
+    if (config.getStarTreeV2BuilderConfigs() != null) {
+      starTreeV2BuilderConfigs.addAll(config.getStarTreeV2BuilderConfigs());
+    }
+    // Append the default star-tree after the customized star-trees if enabled
+    if (config.isEnableDefaultStarTree()) {
+      starTreeV2BuilderConfigs.add(null);
+    }
+    if (!starTreeV2BuilderConfigs.isEmpty()) {
       MultipleTreesBuilder.BuildMode buildMode =
           config.isOnHeap() ? MultipleTreesBuilder.BuildMode.ON_HEAP : MultipleTreesBuilder.BuildMode.OFF_HEAP;
       new MultipleTreesBuilder(starTreeV2BuilderConfigs, indexDir, buildMode).build();

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/StarTreeV2BuilderConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/StarTreeV2BuilderConfig.java
@@ -18,14 +18,21 @@
  */
 package org.apache.pinot.core.startree.v2.builder;
 
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 
 
 /**
@@ -33,6 +40,10 @@ import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
  */
 public class StarTreeV2BuilderConfig {
   public static final int DEFAULT_MAX_LEAF_RECORDS = 10_000;
+
+  // For default config, dimensions with cardinality smaller or equal to this threshold will be included into the split
+  // order
+  private static final int DIMENSION_CARDINALITY_THRESHOLD_FOR_DEFAULT_CONFIG = 10_000;
 
   private final List<String> _dimensionsSplitOrder;
   private final Set<String> _skipStarNodeCreationForDimensions;
@@ -56,6 +67,79 @@ public class StarTreeV2BuilderConfig {
       builder.setMaxLeafRecords(maxLeafRecords);
     }
     return builder.build();
+  }
+
+  /**
+   * Generates default config based on the segment metadata.
+   * <ul>
+   *   <li>
+   *     All dictionary-encoded single-value dimensions with cardinality smaller or equal to the threshold will be
+   *     included in the split order, sorted by their cardinality in descending order.
+   *   </li>
+   *   <li>
+   *     All dictionary-encoded Time/DateTime columns will be appended to the split order following the dimensions,
+   *     sorted by their cardinality in descending order. Here we assume that time columns will be included in most
+   *     queries as the range filter column and/or the group by column, so for better performance, we always include
+   *     them as the last elements in the split order.
+   *   </li>
+   *   <li>Use COUNT(*) and SUM for all numeric metrics as function column pairs</li>
+   *   <li>Use default value for max leaf records</li>
+   * </ul>
+   */
+  public static StarTreeV2BuilderConfig generateDefaultConfig(SegmentMetadataImpl segmentMetadata) {
+    Schema schema = segmentMetadata.getSchema();
+    List<ColumnMetadata> dimensionColumnMetadataList = new ArrayList<>();
+    List<ColumnMetadata> timeColumnMetadataList = new ArrayList<>();
+    List<String> numericMetrics = new ArrayList<>();
+
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isSingleValueField() || fieldSpec.isVirtualColumn()) {
+        continue;
+      }
+      String column = fieldSpec.getName();
+      switch (fieldSpec.getFieldType()) {
+        case DIMENSION:
+          ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(column);
+          if (columnMetadata.hasDictionary()
+              && columnMetadata.getCardinality() <= DIMENSION_CARDINALITY_THRESHOLD_FOR_DEFAULT_CONFIG) {
+            dimensionColumnMetadataList.add(columnMetadata);
+          }
+          break;
+        case DATE_TIME:
+        case TIME:
+          columnMetadata = segmentMetadata.getColumnMetadataFor(column);
+          if (columnMetadata.hasDictionary()) {
+            timeColumnMetadataList.add(columnMetadata);
+          }
+          break;
+        case METRIC:
+          if (fieldSpec.getDataType().isNumeric()) {
+            numericMetrics.add(column);
+          }
+      }
+    }
+
+    // Sort all dimensions/time columns with their cardinality in descending order
+    dimensionColumnMetadataList.sort((o1, o2) -> Integer.compare(o2.getCardinality(), o1.getCardinality()));
+    timeColumnMetadataList.sort((o1, o2) -> Integer.compare(o2.getCardinality(), o1.getCardinality()));
+
+    List<String> dimensionsSplitOrder = new ArrayList<>();
+    for (ColumnMetadata dimensionColumnMetadata : dimensionColumnMetadataList) {
+      dimensionsSplitOrder.add(dimensionColumnMetadata.getColumnName());
+    }
+    for (ColumnMetadata timeColumnMetadata : timeColumnMetadataList) {
+      dimensionsSplitOrder.add(timeColumnMetadata.getColumnName());
+    }
+    Preconditions.checkState(!dimensionsSplitOrder.isEmpty(), "No qualified dimension found for star-tree split order");
+
+    Set<AggregationFunctionColumnPair> functionColumnPairs = new HashSet<>();
+    functionColumnPairs.add(AggregationFunctionColumnPair.COUNT_STAR);
+    for (String numericMetric : numericMetrics) {
+      functionColumnPairs.add(new AggregationFunctionColumnPair(AggregationFunctionType.SUM, numericMetric));
+    }
+
+    return new StarTreeV2BuilderConfig(dimensionsSplitOrder, Collections.emptySet(), functionColumnPairs,
+        DEFAULT_MAX_LEAF_RECORDS);
   }
 
   private StarTreeV2BuilderConfig(List<String> dimensionsSplitOrder, Set<String> skipStarNodeCreationForDimensions,

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/builder/StarTreeV2BuilderConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/builder/StarTreeV2BuilderConfigTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.startree.v2.builder;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.core.common.Constants;
+import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class StarTreeV2BuilderConfigTest {
+
+  @Test
+  public void testDefaultConfig() {
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("d1", DataType.INT)
+        .addSingleValueDimension("d2", DataType.LONG).addSingleValueDimension("d3", DataType.FLOAT)
+        .addSingleValueDimension("d4", DataType.DOUBLE).addMultiValueDimension("d5", DataType.INT)
+        .addMetric("m1", DataType.DOUBLE).addMetric("m2", DataType.BYTES)
+        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "t"), null)
+        .addDateTime("dt", DataType.LONG, "1:MILLISECONDS:EPOCH", "1:HOURS").build();
+    SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
+    when(segmentMetadata.getSchema()).thenReturn(schema);
+    // Included
+    ColumnMetadata columnMetadata = getColumnMetadata("d1", true, 200);
+    when(segmentMetadata.getColumnMetadataFor("d1")).thenReturn(columnMetadata);
+    // Included
+    columnMetadata = getColumnMetadata("d2", true, 400);
+    when(segmentMetadata.getColumnMetadataFor("d2")).thenReturn(columnMetadata);
+    // Not included because the cardinality is too high
+    columnMetadata = getColumnMetadata("d3", true, 20000);
+    when(segmentMetadata.getColumnMetadataFor("d3")).thenReturn(columnMetadata);
+    // Not included because it is not dictionary-encoded
+    columnMetadata = getColumnMetadata("d4", false, 100);
+    when(segmentMetadata.getColumnMetadataFor("d4")).thenReturn(columnMetadata);
+    // Not included because it is multi-valued
+    columnMetadata = getColumnMetadata("d5", true, 100);
+    when(segmentMetadata.getColumnMetadataFor("d5")).thenReturn(columnMetadata);
+    // Included (metric does not have to be dictionary-encoded or have valid cardinality)
+    columnMetadata = getColumnMetadata("m1", false, Constants.UNKNOWN_CARDINALITY);
+    when(segmentMetadata.getColumnMetadataFor("m1")).thenReturn(columnMetadata);
+    // Not included because it is not numeric
+    columnMetadata = getColumnMetadata("m2", true, 100);
+    when(segmentMetadata.getColumnMetadataFor("m2")).thenReturn(columnMetadata);
+    // Included (do not check cardinality for time column)
+    columnMetadata = getColumnMetadata("t", true, 20000);
+    when(segmentMetadata.getColumnMetadataFor("t")).thenReturn(columnMetadata);
+    // Included (do not check cardinality for date time column)
+    columnMetadata = getColumnMetadata("dt", true, 30000);
+    when(segmentMetadata.getColumnMetadataFor("dt")).thenReturn(columnMetadata);
+
+    StarTreeV2BuilderConfig defaultConfig = StarTreeV2BuilderConfig.generateDefaultConfig(segmentMetadata);
+    // Sorted by cardinality in descending order, followed by the time column
+    assertEquals(defaultConfig.getDimensionsSplitOrder(), Arrays.asList("d2", "d1", "dt", "t"));
+    // No column should be skipped for star-node creation
+    assertTrue(defaultConfig.getSkipStarNodeCreationForDimensions().isEmpty());
+    // Should have COUNT(*) and SUM(m1) as the function column pairs
+    assertEquals(defaultConfig.getFunctionColumnPairs(), new HashSet<>(Arrays
+        .asList(AggregationFunctionColumnPair.COUNT_STAR,
+            new AggregationFunctionColumnPair(AggregationFunctionType.SUM, "m1"))));
+    assertEquals(defaultConfig.getMaxLeafRecords(), StarTreeV2BuilderConfig.DEFAULT_MAX_LEAF_RECORDS);
+  }
+
+  private ColumnMetadata getColumnMetadata(String column, boolean hasDictionary, int cardinality) {
+    ColumnMetadata columnMetadata = mock(ColumnMetadata.class);
+    when(columnMetadata.getColumnName()).thenReturn(column);
+    when(columnMetadata.hasDictionary()).thenReturn(hasDictionary);
+    when(columnMetadata.getCardinality()).thenReturn(cardinality);
+    return columnMetadata;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -18,11 +18,10 @@
  */
 package org.apache.pinot.spi.config.table;
 
-import org.apache.pinot.spi.config.BaseJsonConfig;
-
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 public class IndexingConfig extends BaseJsonConfig {
@@ -38,6 +37,7 @@ public class IndexingConfig extends BaseJsonConfig {
   private List<String> _noDictionaryColumns; // TODO: replace this with noDictionaryConfig.
   private Map<String, String> _noDictionaryConfig;
   private List<String> _onHeapDictionaryColumns;
+  private boolean _enableDefaultStarTree;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private SegmentPartitionConfig _segmentPartitionConfig;
   private boolean _aggregateMetrics;
@@ -163,6 +163,14 @@ public class IndexingConfig extends BaseJsonConfig {
 
   public void setVarLengthDictionaryColumns(List<String> varLengthDictionaryColumns) {
     _varLengthDictionaryColumns = varLengthDictionaryColumns;
+  }
+
+  public boolean isEnableDefaultStarTree() {
+    return _enableDefaultStarTree;
+  }
+
+  public void setEnableDefaultStarTree(boolean enableDefaultStarTree) {
+    _enableDefaultStarTree = enableDefaultStarTree;
   }
 
   @Nullable

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeIndexConfig.java
@@ -21,16 +21,19 @@ package org.apache.pinot.spi.config.table;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import org.apache.pinot.spi.config.BaseJsonConfig;
-
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 public class StarTreeIndexConfig extends BaseJsonConfig {
+  // Star-tree will be split with this order (time column is treated as dimension)
   private final List<String> _dimensionsSplitOrder;
+  // Do not create star-node for these dimensions
   private final List<String> _skipStarNodeCreationForDimensions;
+  // Function column pairs with delimiter "__", e.g. SUM__col1, MAX__col2, COUNT__*
   private final List<String> _functionColumnPairs;
+  // The upper bound of records to be scanned at the leaf node
   private final int _maxLeafRecords;
 
   @JsonCreator

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -381,6 +381,10 @@ public abstract class FieldSpec implements Comparable<FieldSpec> {
     public boolean isFixedWidth() {
       return this != STRING && this != BYTES;
     }
+
+    public boolean isNumeric() {
+      return this == INT || this == LONG || this == FLOAT || this == DOUBLE;
+    }
   }
 
   @Override


### PR DESCRIPTION
Support generating default star-tree config with the following rules:
- All dictionary-encoded single-value dimensions (including date-time columns) with cardinality smaller or equal to the threshold (10000) will be included in the split order, sorted by their cardinality in descending order
- Time column (if exists and dictionary-encoded) will be appended to the split order as the last element
- Use COUNT(*) and SUM for all numeric metrics as function column pairs
- Use default value (10000) for max leaf records