### PR TITLE
[TE][subscription] update subscription watermarks to use anomaly create time instead of end time

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -63,7 +63,7 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   List<MergedAnomalyResultDTO> findByStartEndTimeInRangeAndDetectionConfigId(long startTime, long endTime, long detectionConfigId);
 
-  List<MergedAnomalyResultDTO> findByStartTimeInRangeAndDetectionConfigId(long startTime, long endTime, long detectionConfigId);
+  List<MergedAnomalyResultDTO> findByCreatedTimeInRangeAndDetectionConfigId(long startTime, long endTime, long detectionConfigId);
 
   List<MergedAnomalyResultDTO> findByTime(long startTime, long endTime);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -21,6 +21,7 @@ package org.apache.pinot.thirdeye.datalayer.bao.jdbc;
 
 import com.google.common.base.Preconditions;
 import com.google.inject.Singleton;
+import java.sql.Timestamp;
 import org.apache.pinot.thirdeye.datalayer.dto.AnomalyFeedbackDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
@@ -269,9 +270,11 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findByStartTimeInRangeAndDetectionConfigId(long startTime, long endTime, long detectionConfigId) {
+  public List<MergedAnomalyResultDTO> findByCreatedTimeInRangeAndDetectionConfigId(long startTime, long endTime, long detectionConfigId) {
     Predicate predicate =
-        Predicate.AND(Predicate.GE("startTime", startTime), Predicate.LT("startTime", endTime),
+        Predicate.AND(
+            Predicate.GE("createTime", new Timestamp(startTime)),
+            Predicate.LT("createTime", new Timestamp(endTime)),
             Predicate.EQ("detectionConfigId", detectionConfigId));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
     return convertMergedAnomalyBean2DTO(list);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DetectionAlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DetectionAlertConfigBean.java
@@ -46,7 +46,6 @@ public class DetectionAlertConfigBean extends AbstractBean {
   AlertConfigBean.SubjectType subjectType = AlertConfigBean.SubjectType.ALERT;
 
   Map<Long, Long> vectorClocks;
-  Long highWaterMark;
 
   Map<String, Object> properties;
 
@@ -117,14 +116,6 @@ public class DetectionAlertConfigBean extends AbstractBean {
     this.application = application;
   }
 
-  public Long getHighWaterMark() {
-    return highWaterMark;
-  }
-
-  public void setHighWaterMark(Long highWaterMark) {
-    this.highWaterMark = highWaterMark;
-  }
-
   public AlertConfigBean.SubjectType getSubjectType() {
     return subjectType;
   }
@@ -176,15 +167,15 @@ public class DetectionAlertConfigBean extends AbstractBean {
     DetectionAlertConfigBean that = (DetectionAlertConfigBean) o;
     return active == that.active && Objects.equals(name, that.name) && Objects.equals(from, that.from)
         && Objects.equals(cronExpression, that.cronExpression) && Objects.equals(application, that.application)
-        && subjectType == that.subjectType && Objects.equals(vectorClocks, that.vectorClocks) && Objects.equals(
-        highWaterMark, that.highWaterMark) && Objects.equals(properties, that.properties)
-        && Objects.equals(alertSchemes, that.alertSchemes) && Objects.equals(alertSuppressors, that.alertSuppressors)
-        && Objects.equals(refLinks, that.refLinks) && Objects.equals(yaml, that.yaml);
+        && subjectType == that.subjectType && Objects.equals(vectorClocks, that.vectorClocks)
+        && Objects.equals(properties, that.properties) && Objects.equals(alertSchemes, that.alertSchemes)
+        && Objects.equals(alertSuppressors, that.alertSuppressors) && Objects.equals(refLinks, that.refLinks)
+        && Objects.equals(yaml, that.yaml);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(active, name, from, cronExpression, application, subjectType, vectorClocks,
-        highWaterMark, properties, alertSchemes, alertSuppressors, refLinks, yaml);
+    return Objects.hash(active, name, from, cronExpression, application, subjectType, vectorClocks, properties,
+        alertSchemes, alertSuppressors, refLinks, yaml);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DefaultDataProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DefaultDataProvider.java
@@ -145,6 +145,9 @@ public class DefaultDataProvider implements DataProvider {
     }
   }
 
+  /**
+   * Fetch all anomalies based on the request Anomaly Slices (overlap with slice window)
+   */
   @Override
   public Multimap<AnomalySlice, MergedAnomalyResultDTO> fetchAnomalies(Collection<AnomalySlice> slices) {
     Multimap<AnomalySlice, MergedAnomalyResultDTO> output = ArrayListMultimap.create();

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/AlertUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/AlertUtils.java
@@ -82,17 +82,10 @@ public class AlertUtils {
         });
   }
 
-  public static long getHighWaterMark(Collection<MergedAnomalyResultDTO> anomalies) {
-    if (anomalies.isEmpty()) {
-      return 0;
-    }
-    return Collections.max(Collections2.transform(anomalies, mergedAnomalyResultDTO -> mergedAnomalyResultDTO.getId()));
-  }
-
   private static long getLastTimeStamp(Collection<MergedAnomalyResultDTO> anomalies, long startTime) {
     long lastTimeStamp = startTime;
     for (MergedAnomalyResultDTO anomaly : anomalies) {
-      lastTimeStamp = Math.max(anomaly.getEndTime(), lastTimeStamp);
+      lastTimeStamp = Math.max(anomaly.getCreatedTime(), lastTimeStamp);
     }
     return lastTimeStamp;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/DetectionAlertJob.java
@@ -118,8 +118,13 @@ public class DetectionAlertJob implements Job {
     for (Map.Entry<Long, Long> vectorLock : vectorLocks.entrySet()) {
       long configId = vectorLock.getKey();
       long lastNotifiedTime = vectorLock.getValue();
-      if (anomalyDAO.findByStartTimeInRangeAndDetectionConfigId(lastNotifiedTime, System.currentTimeMillis(), configId)
-          .stream().anyMatch(x -> !x.isChild())) {
+
+      Predicate predicate = Predicate.AND(
+          Predicate.GE("createdTime", lastNotifiedTime),
+          Predicate.LT("createdTime", System.currentTimeMillis()),
+          Predicate.EQ("detectionConfigId", configId));
+
+      if (anomalyDAO.findByPredicate(predicate).stream().anyMatch(x -> !x.isChild())) {
         return true;
       }
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsRecipientAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/DimensionsRecipientAlertFilter.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.collections4.MapUtils;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.detection.ConfigUtils;
@@ -73,25 +72,21 @@ public class DimensionsRecipientAlertFilter extends StatefulDetectionAlertFilter
   public static final String PROP_NOTIFY = "notify";
   public static final String PROP_REF_LINKS = "referenceLinks";
   public static final String PROP_DIMENSION_RECIPIENTS = "dimensionRecipients";
-  private static final String PROP_SEND_ONCE = "sendOnce";
 
   final List<Map<String, Object>> dimensionRecipients;
   final List<Long> detectionConfigIds;
-  final boolean sendOnce;
 
   public DimensionsRecipientAlertFilter(DataProvider provider, DetectionAlertConfigDTO config, long endTime) {
     super(provider, config, endTime);
     this.dimensionRecipients = ConfigUtils.getList(this.config.getProperties().get(PROP_DIMENSION_RECIPIENTS));
     this.detectionConfigIds = ConfigUtils.getLongs(this.config.getProperties().get(PROP_DETECTION_CONFIG_IDS));
-    this.sendOnce = MapUtils.getBoolean(this.config.getProperties(), PROP_SEND_ONCE, true);
   }
 
   @Override
-  public DetectionAlertFilterResult run(Map<Long, Long> vectorClocks, long highWaterMark) {
+  public DetectionAlertFilterResult run(Map<Long, Long> vectorClocks) {
     DetectionAlertFilterResult result = new DetectionAlertFilterResult();
-    final long minId = getMinId(highWaterMark);
 
-    Set<MergedAnomalyResultDTO> anomalies = this.filter(this.makeVectorClocks(this.detectionConfigIds), minId);
+    Set<MergedAnomalyResultDTO> anomalies = this.filter(this.makeVectorClocks(this.detectionConfigIds));
 
     // Prepare mapping from dimension-recipients to anomalies
     for (Map<String, Object> dimensionRecipient : this.dimensionRecipients) {
@@ -126,13 +121,5 @@ public class DimensionsRecipientAlertFilter extends StatefulDetectionAlertFilter
     }
 
     return result;
-  }
-
-  private long getMinId(long highWaterMark) {
-    if (this.sendOnce) {
-      return highWaterMark + 1;
-    } else {
-      return 0;
-    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/PerUserDimensionAlertFilter.java
@@ -59,12 +59,10 @@ public class PerUserDimensionAlertFilter extends StatefulDetectionAlertFilter {
   private static final String PROP_DETECTION_CONFIG_IDS = "detectionConfigIds";
   private static final String PROP_DIMENSION = "dimension";
   private static final String PROP_DIMENSION_RECIPIENTS = "dimensionRecipients";
-  private static final String PROP_SEND_ONCE = "sendOnce";
 
   final String dimension;
   final SetMultimap<String, String> dimensionRecipients;
   final List<Long> detectionConfigIds;
-  final boolean sendOnce;
 
   public PerUserDimensionAlertFilter(DataProvider provider, DetectionAlertConfigDTO config, long endTime) {
     super(provider, config, endTime);
@@ -73,16 +71,12 @@ public class PerUserDimensionAlertFilter extends StatefulDetectionAlertFilter {
     this.dimension = MapUtils.getString(this.config.getProperties(), PROP_DIMENSION);
     this.dimensionRecipients = HashMultimap.create(ConfigUtils.<String, String>getMultimap(this.config.getProperties().get(PROP_DIMENSION_RECIPIENTS)));
     this.detectionConfigIds = ConfigUtils.getLongs(this.config.getProperties().get(PROP_DETECTION_CONFIG_IDS));
-    this.sendOnce = MapUtils.getBoolean(this.config.getProperties(), PROP_SEND_ONCE, true);
   }
 
   @Override
-  public DetectionAlertFilterResult run(Map<Long, Long> vectorClocks, long highWaterMark) {
+  public DetectionAlertFilterResult run(Map<Long, Long> vectorClocks) {
     DetectionAlertFilterResult result = new DetectionAlertFilterResult();
-
-    final long minId = getMinId(highWaterMark);
-
-    Set<MergedAnomalyResultDTO> anomalies = this.filter(this.makeVectorClocks(this.detectionConfigIds), minId);
+    Set<MergedAnomalyResultDTO> anomalies = this.filter(this.makeVectorClocks(this.detectionConfigIds));
 
     // group anomalies by dimensions value
     Multimap<String, MergedAnomalyResultDTO> grouped = Multimaps.index(anomalies, new Function<MergedAnomalyResultDTO, String>() {
@@ -142,13 +136,5 @@ public class PerUserDimensionAlertFilter extends StatefulDetectionAlertFilter {
 
     recipients.add(newUser);
     return recipients;
-  }
-
-  private long getMinId(long highWaterMark) {
-    if (this.sendOnce) {
-      return highWaterMark + 1;
-    } else {
-      return 0;
-    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/SubscriptionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/SubscriptionUtils.java
@@ -52,7 +52,6 @@ public class SubscriptionUtils {
     subsConfig.setSubjectType(parentConfig.getSubjectType());
     subsConfig.setProperties(parentConfig.getProperties());
     subsConfig.setVectorClocks(parentConfig.getVectorClocks());
-    subsConfig.setHighWaterMark(parentConfig.getHighWaterMark());
 
     subsConfig.setAlertSchemes(alertSchemes);
     subsConfig.setReferenceLinks(refLinks);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilter.java
@@ -21,7 +21,6 @@ package org.apache.pinot.thirdeye.detection.alert.filter;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
-import java.util.Collections;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
@@ -33,10 +32,7 @@ import org.apache.pinot.thirdeye.detection.alert.StatefulDetectionAlertFilter;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.collections4.MapUtils;
 import org.apache.pinot.thirdeye.detection.annotation.AlertFilter;
-
-import static org.apache.pinot.thirdeye.detection.alert.scheme.DetectionEmailAlerter.*;
 
 
 /**
@@ -50,28 +46,23 @@ public class ToAllRecipientsDetectionAlertFilter extends StatefulDetectionAlertF
   public static final String PROP_CC = "cc";
   public static final String PROP_BCC = "bcc";
   private static final String PROP_DETECTION_CONFIG_IDS = "detectionConfigIds";
-  private static final String PROP_SEND_ONCE = "sendOnce";
 
   final SetMultimap<String, String> recipients;
   List<Long> detectionConfigIds;
-  boolean sendOnce;
 
   public ToAllRecipientsDetectionAlertFilter(DataProvider provider, DetectionAlertConfigDTO config, long endTime) {
     super(provider, config, endTime);
 
     this.recipients = HashMultimap.create(ConfigUtils.<String, String>getMultimap(this.config.getProperties().get(PROP_RECIPIENTS)));
     this.detectionConfigIds = ConfigUtils.getLongs(this.config.getProperties().get(PROP_DETECTION_CONFIG_IDS));
-    this.sendOnce = MapUtils.getBoolean(this.config.getProperties(), PROP_SEND_ONCE, true);
   }
 
   @Override
-  public DetectionAlertFilterResult run(Map<Long, Long> vectorClocks, long highWaterMark) {
+  public DetectionAlertFilterResult run(Map<Long, Long> vectorClocks) {
     DetectionAlertFilterResult result = new DetectionAlertFilterResult();
 
-    final long minId = getMinId(highWaterMark);
-
     // Fetch all the anomalies to be notified to the recipients
-    Set<MergedAnomalyResultDTO> anomalies = this.filter(this.makeVectorClocks(this.detectionConfigIds), minId);
+    Set<MergedAnomalyResultDTO> anomalies = this.filter(this.makeVectorClocks(this.detectionConfigIds));
 
     // Handle legacy recipients yaml syntax
     if (SubscriptionUtils.isEmptyEmailRecipients(this.config) && CollectionUtils.isNotEmpty(this.recipients.get(PROP_TO))) {
@@ -85,13 +76,4 @@ public class ToAllRecipientsDetectionAlertFilter extends StatefulDetectionAlertF
 
     return result.addMapping(new DetectionAlertFilterNotification(this.config), anomalies);
   }
-
-  private long getMinId(long highWaterMark) {
-    if (this.sendOnce) {
-      return highWaterMark + 1;
-    } else {
-      return 0;
-    }
-  }
-
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/components/ThresholdRuleDetector.java
@@ -108,7 +108,7 @@ public class ThresholdRuleDetector implements AnomalyDetector<ThresholdRuleDetec
    */
   private DataFrame constructBaselineAndBoundaries(DataFrame df) {
     // Set default baseline as the actual value
-    df.addSeries(COL_VALUE, df.getDoubles(COL_CURRENT));
+    df.addSeries(COL_VALUE, df.get(COL_CURRENT));
     if (!Double.isNaN(this.min)) {
       df.addSeries(COL_LOWER_BOUND, DoubleSeries.fillValues(df.size(), this.min));
       // set baseline value as the lower bound when actual value across below the mark

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/SubscriptionConfigValidator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/validators/SubscriptionConfigValidator.java
@@ -116,11 +116,6 @@ public class SubscriptionConfigValidator implements ConfigValidator<DetectionAle
     Preconditions.checkNotNull(oldAlertConfig);
 
     Preconditions.checkArgument(updatedAlertConfig.getId().equals(oldAlertConfig.getId()));
-    Long newHighWatermark = updatedAlertConfig.getHighWaterMark();
-    Long oldHighWatermark = oldAlertConfig.getHighWaterMark();
-    if (newHighWatermark != null && oldHighWatermark != null && newHighWatermark.longValue() != oldHighWatermark) {
-      throw new IllegalArgumentException("HighWaterMark has been modified. This is not allowed");
-    }
     if (updatedAlertConfig.getVectorClocks() != null) {
       for (Map.Entry<Long, Long> vectorClock : updatedAlertConfig.getVectorClocks().entrySet()) {
         if (!oldAlertConfig.getVectorClocks().containsKey(vectorClock.getKey())

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/translator/SubscriptionConfigTranslator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/translator/SubscriptionConfigTranslator.java
@@ -195,7 +195,6 @@ public class SubscriptionConfigTranslator extends ConfigTranslator<DetectionAler
 
     alertConfigDTO.setAlertSchemes(buildAlertSchemes(yamlConfigMap));
     alertConfigDTO.setAlertSuppressors(buildAlertSuppressors(yamlConfigMap));
-    alertConfigDTO.setHighWaterMark(0L);
 
     // NOTE: The below fields will/should be hidden from the YAML/UI. They will only be updated by the backend pipeline.
     List<Long> detectionConfigIds = new ArrayList<>();

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/SendAlertTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/SendAlertTest.java
@@ -16,6 +16,8 @@
 
 package org.apache.pinot.thirdeye.detection.alert;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import org.apache.pinot.thirdeye.anomaly.task.TaskContext;
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
@@ -33,6 +35,7 @@ import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pinot.thirdeye.detection.MockDataProvider;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -95,7 +98,6 @@ public class SendAlertTest {
     this.alertConfigDTO.setName(ALERT_NAME_VALUE);
     Map<Long, Long> vectorClocks = new HashMap<>();
     this.alertConfigDTO.setVectorClocks(vectorClocks);
-
     this.alertConfigId = this.alertConfigDAO.save(this.alertConfigDTO);
 
     MergedAnomalyResultDTO anomalyResultDTO = new MergedAnomalyResultDTO();
@@ -139,6 +141,6 @@ public class SendAlertTest {
     taskRunner.execute(alertTaskInfo, taskContext);
 
     DetectionAlertConfigDTO alert = alertConfigDAO.findById(this.alertConfigId);
-    Assert.assertEquals((long) alert.getVectorClocks().get(this.detectionConfigId), 2000L);
+    Assert.assertTrue((long) alert.getVectorClocks().get(this.detectionConfigId) > 0);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilterTest.java
@@ -188,22 +188,22 @@ public class ToAllRecipientsDetectionAlertFilterTest {
 
   @Test
   public void testAlertFilterNoResend() throws Exception {
+    // Assume below 2 anomalies have already been notified
     MergedAnomalyResultDTO existingOld = makeAnomaly(1001L, 1000, 1100);
-    existingOld.setId(5L);
-
+    existingOld.setCreatedTime(1100L);
     MergedAnomalyResultDTO existingNew = makeAnomaly(1001L, 1100, 1200);
-    existingNew.setId(6L);
+    existingNew.setCreatedTime(1200L);
 
+    // This newly detected anomaly needs to be notified to the user
     MergedAnomalyResultDTO existingFuture = makeAnomaly(1001L, 1200, 1300);
-    existingFuture.setId(7L);
+    existingFuture.setCreatedTime(1300L);
 
     this.detectedAnomalies.clear();
     this.detectedAnomalies.add(existingOld);
     this.detectedAnomalies.add(existingNew);
     this.detectedAnomalies.add(existingFuture);
 
-    this.alertConfig.setHighWaterMark(6L);
-    this.alertConfig.setVectorClocks(Collections.singletonMap(1001L, 1100L));
+    this.alertConfig.setVectorClocks(Collections.singletonMap(1001L, 1200L));
 
     this.alertFilter = new ToAllRecipientsDetectionAlertFilter(this.provider, this.alertConfig,2500L);
 
@@ -219,20 +219,19 @@ public class ToAllRecipientsDetectionAlertFilterTest {
   @Test
   public void testAlertFilterResend() throws Exception {
     MergedAnomalyResultDTO existingOld = makeAnomaly(1001L, 1000, 1100);
-    existingOld.setId(5L);
+    existingOld.setCreatedTime(1100L);
 
     MergedAnomalyResultDTO existingNew = makeAnomaly(1001L, 1100, 1200);
-    existingNew.setId(6L);
+    existingNew.setCreatedTime(1200L);
 
     MergedAnomalyResultDTO existingFuture = makeAnomaly(1001L, 1200, 1300);
-    existingFuture.setId(7L);
+    existingFuture.setCreatedTime(1300L);
 
     this.detectedAnomalies.clear();
     this.detectedAnomalies.add(existingOld);
     this.detectedAnomalies.add(existingNew);
     this.detectedAnomalies.add(existingFuture);
 
-    this.alertConfig.setHighWaterMark(5L);
     this.alertConfig.setVectorClocks(Collections.singletonMap(1001L, 1100L));
     this.alertConfig.getProperties().put(PROP_SEND_ONCE, false);
 


### PR DESCRIPTION
Problem Statement: 
The current subscription watermarks are designed to notify an anomaly only once (even if merged) and we maintain this by keeping track of the last notified anomaly end time (watermark). However, the assumption here was that newer anomalies will always be detected on newer data (that is, newer anomalies can never have start time < watermark). This puts the restriction when dealing with backfilled data and also in the case of missing data where the actual deviation anomalies on the data might be detected later. This PR tries to remove this restriction by leveraging the anomaly create time in the watermark.

Proposed changes:
* Replace the anomaly end time with the anomaly create time in the vector clock.
* Remove highWaterMark field from subscription config - As of today, we maintain 2 watermarks, namely the last notified anomaly ID(highWaterMark) and the anomaly end time watermark(vector clocks) to ensure that each anomaly is notified only once. The main purpose of the highWaterMark is to filter out merged anomalies from the time window. This is no longer required once we start relying on the anomaly create time.