### PR TITLE
Optimization for selection only queries: Allow early termination

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
@@ -213,10 +213,7 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       // Set the execution statistics.
       ExecutionStatistics executionStatistics = new ExecutionStatistics();
       for (Operator operator : _operators) {
-        ExecutionStatistics executionStatisticsToMerge = operator.getExecutionStatistics();
-        if (executionStatisticsToMerge != null) {
-          executionStatistics.merge(executionStatisticsToMerge);
-        }
+        executionStatistics.merge(operator.getExecutionStatistics());
       }
       mergedBlock.setNumDocsScanned(executionStatistics.getNumDocsScanned());
       mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
@@ -213,10 +213,7 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
       // Set the execution statistics.
       ExecutionStatistics executionStatistics = new ExecutionStatistics();
       for (Operator operator : _operators) {
-        ExecutionStatistics executionStatisticsToMerge = operator.getExecutionStatistics();
-        if (executionStatisticsToMerge != null) {
-          executionStatistics.merge(executionStatisticsToMerge);
-        }
+        executionStatistics.merge(operator.getExecutionStatistics());
       }
       mergedBlock.setNumDocsScanned(executionStatistics.getNumDocsScanned());
       mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
@@ -70,12 +70,12 @@ public class DocIdSetOperator extends BaseOperator<DocIdSetBlock> {
 
     // Initialize filter block document Id set
     if (_filterBlockDocIdSet == null) {
-      _filterBlockDocIdSet = (FilterBlockDocIdSet) _filterOperator.nextBlock().getBlockDocIdSet();
+      _filterBlockDocIdSet = _filterOperator.nextBlock().getBlockDocIdSet();
       _blockDocIdIterator = _filterBlockDocIdSet.iterator();
     }
 
     int pos = 0;
-    int[] docIds = _threadLocal? THREAD_LOCAL_DOC_IDS.get(): new int[_maxSizeOfDocIdSet];
+    int[] docIds = _threadLocal ? THREAD_LOCAL_DOC_IDS.get() : new int[_maxSizeOfDocIdSet];
     for (int i = 0; i < _maxSizeOfDocIdSet; i++) {
       _currentDocId = _blockDocIdIterator.next();
       if (_currentDocId == Constants.EOF) {
@@ -97,6 +97,8 @@ public class DocIdSetOperator extends BaseOperator<DocIdSetBlock> {
 
   @Override
   public ExecutionStatistics getExecutionStatistics() {
-    return new ExecutionStatistics(0L, _filterBlockDocIdSet.getNumEntriesScannedInFilter(), 0L, 0L);
+    long numEntriesScannedInFilter =
+        _filterBlockDocIdSet != null ? _filterBlockDocIdSet.getNumEntriesScannedInFilter() : 0;
+    return new ExecutionStatistics(0, numEntriesScannedInFilter, 0, 0);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -50,7 +50,6 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
   private final AggregationFunctionContext[] _aggregationFunctionContexts;
   private final Map<String, Dictionary> _dictionaryMap;
   private final long _numTotalDocs;
-  private ExecutionStatistics _executionStatistics;
 
   /**
    * Constructor for the class.
@@ -96,11 +95,6 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
       aggregationResults.add(function.extractAggregationResult(resultHolder));
     }
 
-    // Create execution statistics. Set numDocsScanned to numTotalDocs for backward compatibility.
-    _executionStatistics =
-        new ExecutionStatistics(_numTotalDocs, 0/* numEntriesScannedInFilter */, 0/* numEntriesScannedPostFilter */,
-            _numTotalDocs);
-
     // Build intermediate result block based on aggregation result from the executor.
     return new IntermediateResultsBlock(_aggregationFunctionContexts, aggregationResults, false);
   }
@@ -112,6 +106,7 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
 
   @Override
   public ExecutionStatistics getExecutionStatistics() {
-    return _executionStatistics;
+    // NOTE: Set numDocsScanned to numTotalDocs for backward compatibility.
+    return new ExecutionStatistics(_numTotalDocs, 0, 0, _numTotalDocs);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/MetadataBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/MetadataBasedAggregationOperator.java
@@ -40,7 +40,6 @@ public class MetadataBasedAggregationOperator extends BaseOperator<IntermediateR
   private final AggregationFunctionContext[] _aggregationFunctionContexts;
   private final Map<String, DataSource> _dataSourceMap;
   private final SegmentMetadata _segmentMetadata;
-  private ExecutionStatistics _executionStatistics;
 
   /**
    * Constructor for the class.
@@ -71,11 +70,6 @@ public class MetadataBasedAggregationOperator extends BaseOperator<IntermediateR
       aggregationResults.add(numTotalDocs);
     }
 
-    // Create execution statistics. Set numDocsScanned to numTotalDocs for backward compatibility.
-    _executionStatistics =
-        new ExecutionStatistics(numTotalDocs, 0/*numEntriesScannedInFilter*/, 0/*numEntriesScannedPostFilter*/,
-            numTotalDocs);
-
     // Build intermediate result block based on aggregation result from the executor.
     return new IntermediateResultsBlock(_aggregationFunctionContexts, aggregationResults, false);
   }
@@ -87,6 +81,8 @@ public class MetadataBasedAggregationOperator extends BaseOperator<IntermediateR
 
   @Override
   public ExecutionStatistics getExecutionStatistics() {
-    return _executionStatistics;
+    // NOTE: Set numDocsScanned to numTotalDocs for backward compatibility.
+    int numTotalDocs = _segmentMetadata.getTotalDocs();
+    return new ExecutionStatistics(numTotalDocs, 0, 0, numTotalDocs);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/CombineSlowOperatorsTest.java
@@ -144,7 +144,7 @@ public class CombineSlowOperatorsTest {
 
     @Override
     public ExecutionStatistics getExecutionStatistics() {
-      return null;
+      return new ExecutionStatistics();
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.queries;
 
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -182,7 +184,9 @@ public abstract class BaseQueriesTest {
     Map<ServerRoutingInstance, DataTable> dataTableMap = new HashMap<>();
     dataTableMap.put(new ServerRoutingInstance("localhost", 1234, TableType.OFFLINE), instanceResponse);
     dataTableMap.put(new ServerRoutingInstance("localhost", 1234, TableType.REALTIME), instanceResponse);
-    return brokerReduceService.reduceOnDataTable(brokerRequest, dataTableMap, null);
+    BrokerResponseNative brokerResponseNative =
+        brokerReduceService.reduceOnDataTable(brokerRequest, dataTableMap, null);
+    return brokerResponseNative;
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.queries;
 
-import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -184,9 +182,7 @@ public abstract class BaseQueriesTest {
     Map<ServerRoutingInstance, DataTable> dataTableMap = new HashMap<>();
     dataTableMap.put(new ServerRoutingInstance("localhost", 1234, TableType.OFFLINE), instanceResponse);
     dataTableMap.put(new ServerRoutingInstance("localhost", 1234, TableType.REALTIME), instanceResponse);
-    BrokerResponseNative brokerResponseNative =
-        brokerReduceService.reduceOnDataTable(brokerRequest, dataTableMap, null);
-    return brokerResponseNative;
+    return brokerReduceService.reduceOnDataTable(brokerRequest, dataTableMap, null);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -25,8 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.data.manager.SegmentDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
@@ -36,6 +34,8 @@ import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
@@ -123,7 +123,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
     ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     _indexSegment = immutableSegment;
     _segmentDataManagers = new ArrayList<>();
-    for (int i = 0; i< getNumSegmentDataManagers(); i++) {
+    for (int i = 0; i < getNumSegmentDataManagers(); i++) {
       _segmentDataManagers.add(new ImmutableSegmentDataManager(immutableSegment));
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -66,6 +66,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
   private static final String AVRO_DATA = "data" + File.separator + "test_data-sv.avro";
   private static final String SEGMENT_NAME = "testTable_126164076_167572854";
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "SingleValueQueriesTest");
+  private static final int NUM_SEGMENT_DATA_MANAGERS = 2;
 
   // Hard-coded query filter.
   private static final String QUERY_FILTER =
@@ -122,14 +123,15 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
       throws Exception {
     ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     _indexSegment = immutableSegment;
-    _segmentDataManagers = new ArrayList<>();
-    for (int i = 0; i < getNumSegmentDataManagers(); i++) {
+    int numSegmentDataManagers = getNumSegmentDataManagers();
+    _segmentDataManagers = new ArrayList<>(numSegmentDataManagers);
+    for (int i = 0; i < numSegmentDataManagers; i++) {
       _segmentDataManagers.add(new ImmutableSegmentDataManager(immutableSegment));
     }
   }
 
   protected int getNumSegmentDataManagers() {
-    return 2;
+    return NUM_SEGMENT_DATA_MANAGERS;
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.queries;
 
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -121,8 +122,14 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
       throws Exception {
     ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     _indexSegment = immutableSegment;
-    _segmentDataManagers = Arrays
-        .asList(new ImmutableSegmentDataManager(immutableSegment), new ImmutableSegmentDataManager(immutableSegment));
+    _segmentDataManagers = new ArrayList<>();
+    for (int i = 0; i< getNumSegmentDataManagers(); i++) {
+      _segmentDataManagers.add(new ImmutableSegmentDataManager(immutableSegment));
+    }
+  }
+
+  protected int getNumSegmentDataManagers() {
+    return 2;
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.queries;
 
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.core.operator.CombineOperator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,8 +33,9 @@ public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTes
    * In order to ensure each thread is executing more than 1 segment, this test is against
    * (2 * MAX_NUM_THREADS_PER_QUERY) segments.
    */
+  @Override
   protected int getNumSegmentDataManagers() {
-    return Math.max(1, Math.min(10, Runtime.getRuntime().availableProcessors() / 2)) * 2;
+    return CombineOperator.MAX_NUM_THREADS_PER_QUERY * 2;
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests selection only queries
+ */
+public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTest {
+
+  /**
+   * In order to ensure each thread is executing more than 1 segment, this test is against
+   * (2 * MAX_NUM_THREADS_PER_QUERY) segments.
+   */
+  protected int getNumSegmentDataManagers() {
+    return Math.max(1, Math.min(10, Runtime.getRuntime().availableProcessors() / 2)) * 2;
+  }
+
+  /**
+   * With early termination, Selection Only query is scheduled with getNumSegmentDataManagers() threads,
+   * total segment processed is same at num threads.
+   */
+  @Test
+  public void testSelectOnlyQuery() {
+    int numThreadsPerQuery = getNumSegmentDataManagers();
+    // LIMIT = 5,15,35,75,155,315,635
+    for (int limit = 5; limit < 1000; limit += (limit + 5)) {
+      String query = String.format("SELECT column1, column6 FROM testTable LIMIT %d", limit);
+      BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
+      Assert.assertNotNull(brokerResponse.getSelectionResults());
+      Assert.assertNull(brokerResponse.getResultTable());
+      Assert.assertEquals(brokerResponse.getNumSegmentsMatched(), numThreadsPerQuery);
+      Assert.assertEquals(brokerResponse.getNumSegmentsProcessed(), numThreadsPerQuery);
+      Assert.assertEquals(brokerResponse.getNumDocsScanned(), numThreadsPerQuery * limit);
+      Assert.assertEquals(brokerResponse.getTotalDocs(), numThreadsPerQuery / 2 * 60000);
+
+      brokerResponse = getBrokerResponseForSqlQuery(query);
+      Assert.assertNull(brokerResponse.getSelectionResults());
+      Assert.assertNotNull(brokerResponse.getResultTable());
+      Assert.assertEquals(brokerResponse.getNumSegmentsMatched(), numThreadsPerQuery);
+      Assert.assertEquals(brokerResponse.getNumSegmentsProcessed(), numThreadsPerQuery);
+      Assert.assertEquals(brokerResponse.getNumDocsScanned(), numThreadsPerQuery * limit);
+      Assert.assertEquals(brokerResponse.getTotalDocs(), numThreadsPerQuery / 2 * 60000);
+    }
+  }
+
+  /**
+   * Without early termination, Selection order by query should hit all segments.
+   */
+  @Test
+  public void testSelectWithOrderByQuery() {
+    int numSegments = getNumSegmentDataManagers() * 2;
+    String query = "SELECT column11, column1 FROM testTable ORDER BY column11";
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
+    Assert.assertNotNull(brokerResponse.getSelectionResults());
+    Assert.assertNull(brokerResponse.getResultTable());
+    Assert.assertEquals(brokerResponse.getNumSegmentsMatched(), numSegments);
+    Assert.assertEquals(brokerResponse.getNumSegmentsProcessed(), numSegments);
+    Assert.assertEquals(brokerResponse.getNumDocsScanned(), getNumSegmentDataManagers() * 60000);
+    Assert.assertEquals(brokerResponse.getTotalDocs(), getNumSegmentDataManagers() * 60000);
+  }
+}


### PR DESCRIPTION
In Pinot CombineOpearator,  queries are scheduled with at most 10 threads. For tables with many segments(say 10k), it means each thread will process 1k segments.
For selection only queries (e.g. select * from myTable limit 10), each thread may collect enough results to return after scan a few segments. There is no means to wait and scan all the segments.
This is extremely useful for people want to randomly browse a big table from query console clicks.