### PR TITLE
Fix selection early termination test

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineOperator.java
@@ -126,8 +126,12 @@ public class CombineOperator extends BaseOperator<IntermediateResultsBlock> {
         }
       });
     }
+    // TODO: we can track a volatile variable "desiredLimitReached"
+    // which can be set to true before we break out from the if check.
+    // check the volatile variable here and cancel the remaining futures
 
     // Submit operator groups merge job
+    // this is single-threaded merge across all segments.
     Future<IntermediateResultsBlock> mergedBlockFuture =
         _executorService.submit(new TraceCallable<IntermediateResultsBlock>() {
           @Override

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -62,7 +63,8 @@ public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTes
       assertNull(brokerResponse.getResultTable());
       assertEquals(brokerResponse.getNumSegmentsProcessed(), numSegmentsPerServer * NUM_SERVERS);
       assertEquals(brokerResponse.getNumSegmentsMatched(), numThreadsPerServer * NUM_SERVERS);
-      assertEquals(brokerResponse.getNumDocsScanned(), numThreadsPerServer * NUM_SERVERS * limit);
+      long numDocsScanned = brokerResponse.getNumDocsScanned();
+      assertTrue(limit <= numDocsScanned && numDocsScanned <= numThreadsPerServer * NUM_SERVERS * limit);
       assertEquals(brokerResponse.getNumEntriesScannedInFilter(), 0);
       assertEquals(brokerResponse.getNumEntriesScannedPostFilter(),
           numThreadsPerServer * NUM_SERVERS * limit * numColumnsInSelection);
@@ -73,7 +75,8 @@ public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTes
       assertNotNull(brokerResponse.getResultTable());
       assertEquals(brokerResponse.getNumSegmentsProcessed(), numSegmentsPerServer * NUM_SERVERS);
       assertEquals(brokerResponse.getNumSegmentsMatched(), numThreadsPerServer * NUM_SERVERS);
-      assertEquals(brokerResponse.getNumDocsScanned(), numThreadsPerServer * NUM_SERVERS * limit);
+      numDocsScanned = brokerResponse.getNumDocsScanned();
+      assertTrue(limit <= numDocsScanned && numDocsScanned <= numThreadsPerServer * NUM_SERVERS * limit);
       assertEquals(brokerResponse.getNumEntriesScannedInFilter(), 0);
       assertEquals(brokerResponse.getNumEntriesScannedPostFilter(),
           numThreadsPerServer * NUM_SERVERS * limit * numColumnsInSelection);


### PR DESCRIPTION
We are seeing some failures in our automation jobs where Selection Early termination test is failing spuriously when verifying the numDocsScanned.

The test assumes that each single thread would have done it's part of the work inside SelectionOnlyOperator.nextBlock() and returned from there.

Take an example:

LIMIT: 20480
threads per server: 5
num servers: 2
num segments (operators) per thread: 2
docs per segment: 30000

So as per the changes made in early termination PR, each thread will break out immediately after finishing the nextBlock() call on the first operator/segment.

We check for numDocsScanned as limit * num servers * num threads per server => 20480 * 2 * 5 = 204800

Now consider the fact that 5th thread is a bit slow -- it is still executing the SelectionOnlyOperator.nextBlock() code and continuously updating it's local numDocsScanned

The root thread in CombineOperator has already broken out because it has found a mergedBlock across all worker threads that has records >= LIMIT

Next we compute total numDocsScanned across all operators (10) for statistics so it adds up something like this:

20480 + 20480 + 20480 + 20480 + X (X is slightly less than 20480) + 0 + 0 + 0 + 0 + 0 => something just under 204800

In the test we should assert for expected range of numDocsScanned considering the max would be when each of the 5 threads finished the first segment thus leading to a perfect total of 204800

Also added a TODO for a small optimization in CombineOperator