### PR TITLE
Make text index query cache a configurable option

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
@@ -132,7 +132,8 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       _dictionary = null;
       _bloomFilterReader = null;
       if (loadTextIndex) {
-        _invertedIndex = new LuceneTextIndexReader(columnName, segmentIndexDir, metadata.getTotalDocs());
+        _invertedIndex = new LuceneTextIndexReader(columnName, segmentIndexDir, metadata.getTotalDocs(),
+            indexLoadingConfig.getColumnsWithProperties().get(columnName));
       } else {
         _invertedIndex = null;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.segment.index.column;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 import org.apache.pinot.core.io.reader.DataFileReader;
 import org.apache.pinot.core.io.reader.SingleColumnSingleValueReader;
 import org.apache.pinot.core.io.reader.impl.v1.FixedBitMultiValueReader;
@@ -132,8 +133,9 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       _dictionary = null;
       _bloomFilterReader = null;
       if (loadTextIndex) {
+        Map<String, Map<String, String>> columnProperties = indexLoadingConfig.getColumnProperties();
         _invertedIndex = new LuceneTextIndexReader(columnName, segmentIndexDir, metadata.getTotalDocs(),
-            indexLoadingConfig.getColumnsWithProperties().get(columnName));
+            columnProperties.get(columnName));
       } else {
         _invertedIndex = null;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -61,7 +61,7 @@ public class IndexLoadingConfig {
   private boolean _enableSplitCommitEndWithMetadata;
 
   // constructed from FieldConfig
-  private Map<String, Map<String, String>> _columnsWithProperties;
+  private Map<String, Map<String, String>> _columnProperties = new HashMap<>();
 
   public IndexLoadingConfig(@Nonnull InstanceDataManagerConfig instanceDataManagerConfig,
       @Nonnull TableConfig tableConfig) {
@@ -96,7 +96,13 @@ public class IndexLoadingConfig {
       _noDictionaryColumns.addAll(noDictionaryColumns);
     }
 
-    _columnsWithProperties = new HashMap<>();
+    List<FieldConfig> fieldConfigList = tableConfig.getFieldConfigList();
+    if (fieldConfigList != null) {
+      for (FieldConfig fieldConfig : fieldConfigList) {
+        _columnProperties.put(fieldConfig.getName(), fieldConfig.getProperties());
+      }
+    }
+
     extractTextIndexColumnsFromTableConfig(tableConfig);
 
     Map<String, String> noDictionaryConfig = indexingConfig.getNoDictionaryConfig();
@@ -145,7 +151,6 @@ public class IndexLoadingConfig {
           }
           _textIndexColumns.add(column);
         }
-        _columnsWithProperties.put(column, fieldConfig.getProperties());
       }
     }
   }
@@ -202,8 +207,8 @@ public class IndexLoadingConfig {
   }
 
   @Nonnull
-  public Map<String, Map<String, String>> getColumnsWithProperties() {
-    return _columnsWithProperties;
+  public Map<String, Map<String, String>> getColumnProperties() {
+    return _columnProperties;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -60,6 +60,9 @@ public class IndexLoadingConfig {
   private boolean _isDirectRealtimeOffheapAllocation;
   private boolean _enableSplitCommitEndWithMetadata;
 
+  // constructed from FieldConfig
+  private Map<String, Map<String, String>> _columnsWithProperties;
+
   public IndexLoadingConfig(@Nonnull InstanceDataManagerConfig instanceDataManagerConfig,
       @Nonnull TableConfig tableConfig) {
     extractFromInstanceConfig(instanceDataManagerConfig);
@@ -93,6 +96,7 @@ public class IndexLoadingConfig {
       _noDictionaryColumns.addAll(noDictionaryColumns);
     }
 
+    _columnsWithProperties = new HashMap<>();
     extractTextIndexColumnsFromTableConfig(tableConfig);
 
     Map<String, String> noDictionaryConfig = indexingConfig.getNoDictionaryConfig();
@@ -136,11 +140,12 @@ public class IndexLoadingConfig {
       for (FieldConfig fieldConfig : fieldConfigList) {
         String column = fieldConfig.getName();
         if (fieldConfig.getIndexType() == FieldConfig.IndexType.TEXT) {
-          if (fieldConfig.getEncodingType() != FieldConfig.EncodingType.RAW || !_noDictionaryColumns.contains(fieldConfig.getName())) {
+          if (fieldConfig.getEncodingType() != FieldConfig.EncodingType.RAW || !_noDictionaryColumns.contains(column)) {
             throw new UnsupportedOperationException("Text index is currently not supported on dictionary encoded column: " + column);
           }
-          _textIndexColumns.add(fieldConfig.getName());
+          _textIndexColumns.add(column);
         }
+        _columnsWithProperties.put(column, fieldConfig.getProperties());
       }
     }
   }
@@ -194,6 +199,11 @@ public class IndexLoadingConfig {
   @Nonnull
   public Set<String> getInvertedIndexColumns() {
     return _invertedIndexColumns;
+  }
+
+  @Nonnull
+  public Map<String, Map<String, String>> getColumnsWithProperties() {
+    return _columnsWithProperties;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
@@ -77,8 +77,7 @@ public class LuceneTextIndexReader implements InvertedIndexReader<MutableRoaring
       _indexDirectory = FSDirectory.open(indexFile.toPath());
       _indexReader = DirectoryReader.open(_indexDirectory);
       _indexSearcher = new IndexSearcher(_indexReader);
-      if (textIndexProperties == null || textIndexProperties.get(FieldConfig.TEXT_INDEX_ENABLE_QUERY_CACHE) == null
-          || !textIndexProperties.get(FieldConfig.TEXT_INDEX_ENABLE_QUERY_CACHE).equalsIgnoreCase("true")) {
+      if (textIndexProperties == null || !Boolean.parseBoolean(textIndexProperties.get(FieldConfig.TEXT_INDEX_ENABLE_QUERY_CACHE))) {
         // Disable Lucene query result cache. While it helps a lot with performance for
         // repeated queries, on the downside it cause heap issues.
         _indexSearcher.setQueryCache(null);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
@@ -22,6 +22,9 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
@@ -36,7 +39,7 @@ import org.apache.pinot.core.segment.creator.impl.inv.text.LuceneTextIndexCreato
 import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
-import org.roaringbitmap.IntIterator;
+import org.apache.pinot.spi.config.FieldConfig;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.LoggerFactory;
 
@@ -67,16 +70,20 @@ public class LuceneTextIndexReader implements InvertedIndexReader<MutableRoaring
    * @param indexDir segment index directory
    * @param numDocs number of documents in the segment
    */
-  public LuceneTextIndexReader(String column, File indexDir, int numDocs) {
+  public LuceneTextIndexReader(String column, File indexDir, int numDocs,
+      @Nullable Map<String, String> textIndexProperties) {
     _column = column;
     try {
       File indexFile = getTextIndexFile(indexDir);
       _indexDirectory = FSDirectory.open(indexFile.toPath());
       _indexReader = DirectoryReader.open(_indexDirectory);
       _indexSearcher = new IndexSearcher(_indexReader);
-      // Disable Lucene query result cache. While it helps a lot with performance for
-      // repeated queries, on the downside it cause heap issues.
-      _indexSearcher.setQueryCache(null);
+      if (textIndexProperties == null || textIndexProperties.get(FieldConfig.TEXT_INDEX_ENABLE_QUERY_CACHE) == null
+          || !textIndexProperties.get(FieldConfig.TEXT_INDEX_ENABLE_QUERY_CACHE).equalsIgnoreCase("true")) {
+        // Disable Lucene query result cache. While it helps a lot with performance for
+        // repeated queries, on the downside it cause heap issues.
+        _indexSearcher.setQueryCache(null);
+      }
       // TODO: consider using a threshold of num docs per segment to decide between building
       // mapping file upfront on segment load v/s on-the-fly during query processing
       _docIdTranslator = new DocIdTranslator(indexDir, _column, numDocs, _indexSearcher);
@@ -85,8 +92,7 @@ public class LuceneTextIndexReader implements InvertedIndexReader<MutableRoaring
           .error("Failed to instantiate Lucene text index reader for column {}, exception {}", column, e.getMessage());
       throw new RuntimeException(e);
     }
-    StandardAnalyzer analyzer = new StandardAnalyzer();
-    _queryParser = new QueryParser(column, analyzer);
+    _queryParser = new QueryParser(column, new StandardAnalyzer());
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -26,7 +26,6 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/FieldConfig.java
@@ -31,10 +31,14 @@ public class FieldConfig extends BaseJsonConfig {
   private final IndexType _indexType;
   private final Map<String, String> _properties;
 
-  public static String BLOOM_FILTER_COLUMN_KEY = "field.config.bloom.filter";
-  public static String ON_HEAP_DICTIONARY_COLUMN_KEY = "field.config.onheap.dictionary";
-  public static String TEXT_INDEX_REALTIME_READER_REFRESH_KEY = "field.config.realtime.reader.refresh";
-  public static String VAR_LENGTH_DICTIONARY_COLUMN_KEY = "field.config.var.length.dictionary";
+  public static String BLOOM_FILTER_COLUMN_KEY = "bloom.filter";
+  public static String ON_HEAP_DICTIONARY_COLUMN_KEY = "onheap.dictionary";
+  public static String VAR_LENGTH_DICTIONARY_COLUMN_KEY = "var.length.dictionary";
+
+  public static String TEXT_INDEX_REALTIME_READER_REFRESH_KEY = "text.index.realtime.reader.refresh";
+  // Lucene creates a query result cache if this option is enabled
+  // the cache improves performance of repeatable queries
+  public static String TEXT_INDEX_ENABLE_QUERY_CACHE = "text.index.enable.query.cache";
 
   @JsonCreator
   public FieldConfig(@JsonProperty(value = "name", required = true) String name,


### PR DESCRIPTION
During design of text index feature, we had done some heap overhead experiments. As part of that we had determined that while Lucene's internal query cache helps with performance significantly for repeatable queries, it adds heap overhead. Therefore, it was disabled during index loading.

It is worthwhile to make this configurable on per-index basis for users to enable it. Of course, they need to know the downside of more heap overhead (which could potentially negate the perf improvements due to more GC).

As part of ongoing internal user acceptance testing, we learned that most of the queries are repeatable. The UI will more or less keep the text search filter constant and tweak the other filters. For such cases, it is good to see the performance improvements by enabling the query cache and if the heap overhead is not significantly high, user might want to keep it enabled.

Note: By default it is still disabled. So nothing really changed in the existing behavior.