### PR TITLE
Lucene DocId to PinotDocId cache

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
@@ -132,7 +132,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       _dictionary = null;
       _bloomFilterReader = null;
       if (loadTextIndex) {
-        _invertedIndex = new LuceneTextIndexReader(columnName, segmentIndexDir);
+        _invertedIndex = new LuceneTextIndexReader(columnName, segmentIndexDir, metadata.getTotalDocs());
       } else {
         _invertedIndex = null;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/invertedindex/TextIndexHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/invertedindex/TextIndexHandler.java
@@ -61,8 +61,26 @@ import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKey
 import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Column.getKeyFor;
 
 
+/**
+ * Helper class for text indexes used by {@link org.apache.pinot.core.segment.index.loader.SegmentPreProcessor}.
+ * to create text index for column during segment load time. Currently text index is always
+ * created (if enabled on a column) during segment generation
+ *
+ * (1) A new segment with text index is created/refreshed. Server loads the segment. The handler
+ * detects the existence of text index and returns.
+ *
+ * (2) A reload is issued on an existing segment with existing text index. The handler
+ * detects the existence of text index and returns.
+ *
+ * (3) A reload is issued on an existing segment after text index is enabled on an existing
+ * column. Read the forward index to create text index.
+ *
+ * (4) A reload is issued on an existing segment after text index is enabled on a newly
+ * added column. In this case, the default column handler would have taken care of adding
+ * forward index for the new column. Read the forward index to create text index.
+ */
 public class TextIndexHandler {
-  private static final Logger LOGGER = LoggerFactory.getLogger(InvertedIndexHandler.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(TextIndexHandler.class);
 
   private final File _indexDir;
   private final SegmentDirectory.Writer _segmentWriter;
@@ -85,26 +103,6 @@ public class TextIndexHandler {
     }
   }
 
-  /**
-   * Create text index for column during segment load time. Currently text index is always
-   * created (if enabled on a column) during segment generation (true for both offline
-   * and realtime segments). So this function is a NO-OP for case when a new segment is loaded
-   * after creation. However, when segment reload is issued in the following scenarios, we generate
-   * text index.
-   *
-   * SCENARIO 1: user enables text index on an existing column (table config change)
-   * SCENARIO 2: user adds a new column and enables text index (both schema and table config change)
-   *
-   * This function is a NO-OP for the above two cases. Later we can also add a segment generator
-   * config option to not necessarily generate text index during segment generation. When we do
-   * so, this function should be able to take care of that scenario too.
-   *
-   * For scenario 2, {@link org.apache.pinot.core.segment.index.loader.defaultcolumn.V3DefaultColumnHandler}
-   * would have already added the forward index for the column with default value. We use the forward
-   * index here to get the raw data and build text index.
-   *
-   * @throws IOException
-   */
   public void createTextIndexesOnSegmentLoad()
       throws Exception {
     for (ColumnMetadata columnMetadata : _textIndexColumns) {
@@ -125,21 +123,23 @@ public class TextIndexHandler {
   private void checkUnsupportedOperationsForTextIndex(ColumnMetadata columnMetadata) {
     String column = columnMetadata.getColumnName();
     if (columnMetadata.hasDictionary()) {
-      throw new UnsupportedOperationException("Text index is currently not supported on dictionary encoded column: "+column);
+      throw new UnsupportedOperationException(
+          "Text index is currently not supported on dictionary encoded column: " + column);
     }
 
     if (columnMetadata.isSorted()) {
       // since Pinot's current implementation doesn't support raw sorted columns,
       // we need to check for this too
-      throw new UnsupportedOperationException("Text index is currently not supported on sorted columns: "+column);
+      throw new UnsupportedOperationException("Text index is currently not supported on sorted columns: " + column);
     }
 
     if (!columnMetadata.isSingleValue()) {
-      throw new UnsupportedOperationException("Text index is currently not supported on multi-value columns: "+column);
+      throw new UnsupportedOperationException(
+          "Text index is currently not supported on multi-value columns: " + column);
     }
 
     if (columnMetadata.getDataType() != FieldSpec.DataType.STRING) {
-      throw new UnsupportedOperationException("Text index is currently only supported on STRING columns: "+column);
+      throw new UnsupportedOperationException("Text index is currently only supported on STRING columns: " + column);
     }
   }
 
@@ -153,8 +153,13 @@ public class TextIndexHandler {
     }
     int numDocs = columnMetadata.getTotalDocs();
     LOGGER.info("Creating new text index for column: {} in segment: {}", column, _segmentName);
-    File segmentIndexDir = SegmentDirectoryPaths.segmentDirectoryFor(_indexDir, _segmentVersion);
-    try (LuceneTextIndexCreator textIndexCreator = new LuceneTextIndexCreator(column, segmentIndexDir, true)) {
+    File segmentDirectory = SegmentDirectoryPaths.segmentDirectoryFor(_indexDir, _segmentVersion);
+    // The handlers are always invoked by the preprocessor. Before this ImmutableSegmentLoader would have already
+    // up-converted the segment from v1/v2 -> v3 (if needed). So based on the segmentVersion, whatever segment
+    // segmentDirectory is indicated to us by SegmentDirectoryPaths, we create lucene index there. There is no
+    // further need to move around the lucene index directory since it is created with correct directory structure
+    // based on segmentVersion.
+    try (LuceneTextIndexCreator textIndexCreator = new LuceneTextIndexCreator(column, segmentDirectory, true)) {
       try (DataFileReader forwardIndexReader = getForwardIndexReader(columnMetadata)) {
         VarByteChunkSingleValueReader forwardIndex = (VarByteChunkSingleValueReader) forwardIndexReader;
         for (int docID = 0; docID < numDocs; docID++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentDirectoryPaths.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentDirectoryPaths.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pinot.core.segment.store;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.creator.impl.inv.text.LuceneTextIndexCreator;
+import org.apache.pinot.core.segment.index.readers.text.LuceneTextIndexReader;
 
 
 public class SegmentDirectoryPaths {
@@ -81,6 +83,13 @@ public class SegmentDirectoryPaths {
   public static File findTextIndexIndexFile(File indexDir, String column) {
     String luceneIndexDirectory = column + LuceneTextIndexCreator.LUCENE_TEXT_INDEX_FILE_EXTENSION;
     return findFormatFile(indexDir, luceneIndexDirectory);
+  }
+
+  @Nullable
+  @VisibleForTesting
+  public static File findTextIndexDocIdMappingFile(File indexDir, String column) {
+    String file = column + LuceneTextIndexReader.LUCENE_TEXT_INDEX_DOCID_MAPPING_FILE_EXTENSION;
+    return findFormatFile(indexDir, file);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -56,7 +56,6 @@ import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -75,7 +74,7 @@ import org.testng.annotations.Test;
  * The test table has a SKILLS column and QUERY_LOG column. Text index is created
  * on each of these columns.
  */
-public class TestTextSearchQueries extends BaseQueriesTest {
+public class TextSearchQueriesTest extends BaseQueriesTest {
 
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "TextSearchQueries");
   private static final String TABLE_NAME = "MyTable";


### PR DESCRIPTION
Cache the lucene docID to pinot docID mapping per text index. This has to be thread safe since it is shared by all threads (query threads) reading the index.

Storing this mapping on-heap structures (concurrent hash map, atomic int array etc) will add significant heap overhead.  Take an example of 10million docs per segment and we store a 4 byte doc id. This leads to 40MB per indexes. If there are 100 text indexes across segments on a server, we are looking at 4GB of heap overhead.

So the mapping has to be in off-heap memory (direct or mmap'd). The current solution builds the mapping upfront during segment load in a memory mapped file. During query processing, we avoid all calls to indexSearcher.doc(int docID). 

We had noticed in our internal perf testing that as QPS is increased, performance degrades. The docID converter (lucene to Pinot) is a CPU hogger (confirmed through FlameGraphs in YourKit) and was becoming a bottleneck for QPS based testing. On the other hand, when running the same set of expensive queries as one-off, the execution time of the each query was drastically improved. 

This change should provide significant improvements for throughput testing.  Verified by running PerfBenchmarkRunner without and without the changes.