### PR TITLE
Fix docker compose & quick start

### DIFF
--- a/docker/images/pinot/README.md
+++ b/docker/images/pinot/README.md
@@ -131,12 +131,12 @@ docker-compose -f docker-compose.yml up
 
 Below is the script to create airlineStats table
 ```SHELL
-docker run --network=docker_default apachepinot/pinot:0.3.0-SNAPSHOT AddTable -schemaFile examples/stream/airlineStats/airlineStats_schema.json -tableConfigFile examples/stream/airlineStats/docker/airlineStats_realtime_table_config.json -controllerHost pinot-controller -controllerPort 9000 -exec
+docker run --network=pinot_default apachepinot/pinot:0.3.0-SNAPSHOT AddTable -schemaFile examples/stream/airlineStats/airlineStats_schema.json -tableConfigFile examples/stream/airlineStats/docker/airlineStats_realtime_table_config.json -controllerHost pinot-controller -controllerPort 9000 -exec
 ```
 
 Below is the script to ingest airplane stats data to Kafka
 ```SHELL
-docker run --network=docker_default apachepinot/pinot:0.3.0-SNAPSHOT StreamAvroIntoKafka -avroFile examples/stream/airlineStats/sample_data/airlineStats_data.avro -kafkaTopic flights-realtime -kafkaBrokerList kafka:9092 -zkAddress zookeeper:2181
+docker run --network=pinot_default apachepinot/pinot:0.3.0-SNAPSHOT StreamAvroIntoKafka -avroFile examples/stream/airlineStats/sample_data/airlineStats_data.avro -kafkaTopic flights-realtime -kafkaBrokerList kafka:9092 -zkAddress zookeeper:2181
 ```
 
 In order to query pinot, try to open `localhost:9000/query` from your browser.

--- a/docker/images/pinot/docker-compose.yml
+++ b/docker/images/pinot/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       ZOO_MY_ID: 1
       ZOO_PORT: 2181
-      ZOO_SERVERS: server.1=zookeeper:2888:3888
+      ZOO_SERVERS: server.1=zookeeper:2888:3888;2181
     volumes:
       - ./pinot-docker-demo/zookeeper/data:/data
       - ./pinot-docker-demo/zookeeper/datalog:/datalog


### PR DESCRIPTION
Quick start for docker does not currently work.
1. default network created by compose starts with the name of the parent dir. So it is "pinot_default", not "docker_default". Scripts in README were fixed according to that.
2. docker-compose -f docker-compose up does not start the stack properly. Services complain about connectivity issues, which trace back to zookeeper. Turns out (probably a change in the newer version, as docker-compose users "latest" tag) ZOO_SERVERS need a listening port at the end. This is also now fixed.

Now users can simply follow Quick Start instructions and all will work "out of the box".