### PR TITLE
Updated Pinot doc links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Because of the design choices we made to achieve these goals, there are certain 
 Pinot works very well for querying time series data with lots of Dimensions and Metrics. Example - Query (profile views, ad campaign performance, etc.) in an analytical fashion (who viewed this profile in the last weeks, how many ads were clicked per campaign). 
 
 ## Instructions to build Pinot
-More detailed instructions can be found at [Quick Demo](https://apache-pinot.gitbook.io/apache-pinot-cookbook/getting-started) section in the documentation.
+More detailed instructions can be found at [Quick Demo](https://docs.pinot.apache.org/getting-started) section in the documentation.
 ```
 # Clone a repo
 $ git clone https://github.com/apache/incubator-pinot.git
@@ -83,10 +83,10 @@ Pinot also provides k8s integration with interactive query engine [Presto](kuber
  - Apache Pinot Meetup Group: https://www.meetup.com/apache-pinot/
 
 ## Documentation
-Check out [Pinot documentation](https://apache-pinot.gitbook.io/apache-pinot-cookbook/) for a complete description of Pinot's features.
-- [Quick Demo](https://apache-pinot.gitbook.io/apache-pinot-cookbook/getting-started/running-pinot-locally)
-- [Pinot Architecture](https://apache-pinot.gitbook.io/apache-pinot-cookbook/concepts/architecture)
-- [Pinot Query Language](https://apache-pinot.gitbook.io/apache-pinot-cookbook/pinot-user-guide/pinot-query-language)
+Check out [Pinot documentation](https://docs.pinot.apache.org/) for a complete description of Pinot's features.
+- [Quick Demo](https://docs.pinot.apache.org/getting-started/running-pinot-locally)
+- [Pinot Architecture](https://docs.pinot.apache.org/concepts/architecture)
+- [Pinot Query Language](https://docs.pinot.apache.org/pinot-user-guide/pinot-query-language)
 
 ## Pinot Query Clients
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@
 Pinot
 #####
 
-.. note::  The documentation has moved to `Apache Pinot Cookbook <https://apache-pinot.gitbook.io/apache-pinot-cookbook/>`_.
+.. note::  The documentation has moved to `Apache Pinot Docs <https://docs.pinot.apache.org/>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/README.md
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/README.md
@@ -21,4 +21,4 @@
 # Pinot connector for kafka 0.9.x
 
 This is an implementation of the kafka stream for kafka versions 0.9.x. The version used in this implementation is kafka 0.9.0.1. This module compiles with version 0.9.0.0 as well, however we have not tested if it runs with the older versions.
-A stream plugin for another version of kafka, or another stream, can be added in a similar fashion. Refer to documentation on (Pluggable Streams)[https://apache-pinot.gitbook.io/apache-pinot-cookbook/developers-and-contributors/extending-pinot/pluggable-streams] for the specfic interfaces to implement.
+A stream plugin for another version of kafka, or another stream, can be added in a similar fashion. Refer to documentation on (Pluggable Streams)[https://docs.pinot.apache.org/developers-and-contributors/extending-pinot/pluggable-streams] for the specfic interfaces to implement.

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/README.md
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/README.md
@@ -22,7 +22,7 @@
 
 This is an implementation of the kafka stream for kafka versions 2.x The version used in this implementation is kafka 2.0.0.
 
-A stream plugin for another version of kafka, or another stream, can be added in a similar fashion. Refer to documentation on (Pluggable Streams)[https://apache-pinot.gitbook.io/apache-pinot-cookbook/developers-and-contributors/extending-pinot/pluggable-streams] for the specfic interfaces to implement.
+A stream plugin for another version of kafka, or another stream, can be added in a similar fashion. Refer to documentation on (Pluggable Streams)[https://docs.pinot.apache.org/developers-and-contributors/extending-pinot/pluggable-streams] for the specfic interfaces to implement.
 
 * How to build and release Pinot package with Kafka 2.x connector
 ```$xslt


### PR DESCRIPTION
Move doc link reference from `https://apache-pinot.gitbook.io/apache-pinot-cookbook` to `https://docs.pinot.apache.org`