### PR TITLE
[TE] fix the merger issue that it can't merge historical anomaly generated by multiple rules

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/ChildKeepingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/ChildKeepingMergeWrapper.java
@@ -60,13 +60,8 @@ public class ChildKeepingMergeWrapper extends BaselineFillingMergeWrapper {
         this.provider.fetchAnomalies(Collections.singleton(effectiveSlice)).get(effectiveSlice);
 
     return anomalies.stream()
-        .filter(anomaly -> !anomaly.isChild() && isDetectedByMultipleComponents(anomaly))
+        .filter(anomaly -> !anomaly.isChild() && ThirdEyeUtils.isDetectedByMultipleComponents(anomaly))
         .collect(Collectors.toList());
-  }
-
-  private boolean isDetectedByMultipleComponents(MergedAnomalyResultDTO anomaly) {
-    String componentName = anomaly.getProperties().getOrDefault(PROP_DETECTOR_COMPONENT_NAME, "");
-    return componentName.contains(",");
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/ThirdEyeUtils.java
@@ -63,6 +63,7 @@ import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.MetricConfigManager;
 import org.apache.pinot.thirdeye.datalayer.dto.DatasetConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.datalayer.dto.MetricConfigDTO;
 import org.apache.pinot.thirdeye.datalayer.pojo.AlertConfigBean.COMPARE_MODE;
 import org.apache.pinot.thirdeye.datalayer.pojo.MetricConfigBean;
@@ -703,6 +704,16 @@ public abstract class ThirdEyeUtils {
         period = DEFAULT_CACHING_PERIOD_LOOKBACK;
     }
     return period;
+  }
+
+  /**
+   * Check if the anomaly is detected by multiple components
+   * @param anomaly the anomaly
+   * @return if the anomaly is detected by multiple components
+   */
+  public static boolean isDetectedByMultipleComponents(MergedAnomalyResultDTO anomaly) {
+    String componentName = anomaly.getProperties().getOrDefault(PROP_DETECTOR_COMPONENT_NAME, "");
+    return componentName.contains(",");
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/ThirdEyeUtils.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -95,6 +96,7 @@ public abstract class ThirdEyeUtils {
   private static final String TWO_DECIMALS_FORMAT = "#,###.##";
   private static final String MAX_DECIMALS_FORMAT = "#,###.#####";
   private static final String DECIMALS_FORMAT_TOKEN = "#";
+  private static final String PROP_DETECTOR_COMPONENT_NAME_DELIMETER = ",";
 
   private static final int DEFAULT_HEAP_PERCENTAGE_FOR_RESULTSETGROUP_CACHE = 50;
   private static final int DEFAULT_LOWER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB = 100;
@@ -713,7 +715,7 @@ public abstract class ThirdEyeUtils {
    */
   public static boolean isDetectedByMultipleComponents(MergedAnomalyResultDTO anomaly) {
     String componentName = anomaly.getProperties().getOrDefault(PROP_DETECTOR_COMPONENT_NAME, "");
-    return componentName.contains(",");
+    return componentName.contains(PROP_DETECTOR_COMPONENT_NAME_DELIMETER);
   }
 
   /**
@@ -726,13 +728,9 @@ public abstract class ThirdEyeUtils {
    */
   private static String combineComponents(String component1, String component2) {
     List<String> components = new ArrayList<>();
-    for (String component : component1.split(",")) {
-      components.add(component);
-    }
-    for (String component : component2.split(",")) {
-      components.add(component);
-    }
-    return String.join(",", components.stream().distinct().collect(Collectors.toList()));
+    components.addAll(Arrays.asList(component1.split(PROP_DETECTOR_COMPONENT_NAME_DELIMETER)));
+    components.addAll(Arrays.asList(component2.split(PROP_DETECTOR_COMPONENT_NAME_DELIMETER)));
+    return components.stream().distinct().collect(Collectors.joining(PROP_DETECTOR_COMPONENT_NAME_DELIMETER));
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/ChildKeepingMergeWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/wrapper/ChildKeepingMergeWrapperTest.java
@@ -103,7 +103,8 @@ public class ChildKeepingMergeWrapperTest {
     MockPipelineLoader mockLoader = new MockPipelineLoader(this.runs, this.outputs);
 
     this.provider = new MockDataProvider()
-        .setLoader(mockLoader);
+        .setLoader(mockLoader)
+        .setAnomalies(Collections.emptyList());
   }
 
   @Test
@@ -292,7 +293,7 @@ public class ChildKeepingMergeWrapperTest {
     MockPipelineLoader mockLoader = new MockPipelineLoader(this.runs, Collections.singletonList(new MockPipelineOutput(Collections.singletonList(anomaly), -1L)));
 
     DataProvider provider = new MockDataProvider()
-        .setLoader(mockLoader);
+        .setLoader(mockLoader).setAnomalies(Collections.emptyList());
 
     DetectionPipelineResult output = new ChildKeepingMergeWrapper(provider, config, 1000, 3000).run();
     List<MergedAnomalyResultDTO> anomalyResults = output.getAnomalies();


### PR DESCRIPTION
Issue: Child-keeping merge wrapper won't merge the historical anomaly generated by multiple rules.

Fix: Let the child-keeping merger retrieves the historical anomaly generated by multiple rules from the database and re-merges them. Previously this was ignored.