### PR TITLE
Shuffle the segments when rebalancing the table to avoid creating hotspot servers

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
@@ -20,11 +20,12 @@ package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import org.apache.commons.configuration.Configuration;
@@ -214,10 +215,16 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
         Preconditions.checkState(instancePartitions.getNumPartitions() == 1,
             "Instance partitions: %s should contain 1 partition without partition column",
             instancePartitions.getInstancePartitionsName());
+
+        // NOTE: Shuffle the segments within the current assignment to avoid moving only new segments to the new added
+        //       servers, which might cause hotspot servers because queries tend to hit the new segments. Use the table
+        //       name hash as the random seed for the shuffle so that the result is deterministic.
+        List<String> segments = new ArrayList<>(currentAssignment.keySet());
+        Collections.shuffle(segments, new Random(_offlineTableName.hashCode()));
+
         newAssignment = new TreeMap<>();
         SegmentAssignmentUtils
-            .rebalanceReplicaGroupBasedPartition(currentAssignment, instancePartitions, 0, currentAssignment.keySet(),
-                newAssignment);
+            .rebalanceReplicaGroupBasedPartition(currentAssignment, instancePartitions, 0, segments, newAssignment);
       } else {
         LOGGER.info("Rebalancing table: {} with partition column: {}", _offlineTableName, _partitionColumn);
         newAssignment = rebalanceTableWithPartition(currentAssignment, instancePartitions);
@@ -238,10 +245,18 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
     for (OfflineSegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
       segmentZKMetadataMap.put(segmentZKMetadata.getSegmentName(), segmentZKMetadata);
     }
-    Map<Integer, Set<String>> partitionIdToSegmentsMap = new HashMap<>();
+    Map<Integer, List<String>> partitionIdToSegmentsMap = new HashMap<>();
     for (String segmentName : currentAssignment.keySet()) {
       int partitionId = getPartitionId(segmentZKMetadataMap.get(segmentName));
-      partitionIdToSegmentsMap.computeIfAbsent(partitionId, k -> new HashSet<>()).add(segmentName);
+      partitionIdToSegmentsMap.computeIfAbsent(partitionId, k -> new ArrayList<>()).add(segmentName);
+    }
+
+    // NOTE: Shuffle the segments within the current assignment to avoid moving only new segments to the new added
+    //       servers, which might cause hotspot servers because queries tend to hit the new segments. Use the table
+    //       name hash as the random seed for the shuffle so that the result is deterministic.
+    Random random = new Random(_offlineTableName.hashCode());
+    for (List<String> segments : partitionIdToSegmentsMap.values()) {
+      Collections.shuffle(segments, random);
     }
 
     return SegmentAssignmentUtils

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -20,11 +20,11 @@ package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Random;
 import java.util.TreeMap;
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.HelixManager;
@@ -202,11 +202,20 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
               _realtimeTableName, numReplicaGroups);
         }
 
-        Map<Integer, Set<String>> partitionIdToSegmentsMap = new HashMap<>();
+        Map<Integer, List<String>> partitionIdToSegmentsMap = new HashMap<>();
         for (String segmentName : completedSegmentAssignment.keySet()) {
           int partitionId = new LLCSegmentName(segmentName).getPartitionId();
-          partitionIdToSegmentsMap.computeIfAbsent(partitionId, k -> new HashSet<>()).add(segmentName);
+          partitionIdToSegmentsMap.computeIfAbsent(partitionId, k -> new ArrayList<>()).add(segmentName);
         }
+
+        // NOTE: Shuffle the segments within the current assignment to avoid moving only new segments to the new added
+        //       servers, which might cause hotspot servers because queries tend to hit the new segments. Use the table
+        //       name hash as the random seed for the shuffle so that the result is deterministic.
+        Random random = new Random(_realtimeTableName.hashCode());
+        for (List<String> segments : partitionIdToSegmentsMap.values()) {
+          Collections.shuffle(segments, random);
+        }
+
         newAssignment = SegmentAssignmentUtils
             .rebalanceReplicaGroupBasedTable(completedSegmentAssignment, completedInstancePartitions,
                 partitionIdToSegmentsMap);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtilsTest.java
@@ -21,10 +21,8 @@ package org.apache.pinot.controller.helix.core.assignment.segment;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
@@ -207,7 +205,7 @@ public class SegmentAssignmentUtilsTest {
 
     int numSegments = 90;
     List<String> segments = SegmentAssignmentTestUtils.getNameList(SEGMENT_NAME_PREFIX, numSegments);
-    Map<Integer, Set<String>> partitionIdToSegmentsMap = Collections.singletonMap(0, new HashSet<>(segments));
+    Map<Integer, List<String>> partitionIdToSegmentsMap = Collections.singletonMap(0, segments);
     int numInstances = 9;
     List<String> instances = SegmentAssignmentTestUtils.getNameList(INSTANCE_NAME_PREFIX, numInstances);
 


### PR DESCRIPTION
When new servers are added to an existing replica-group based table
and rebalance is triggered, current behavior will assign segments
in alphabetical order, which might move only the new segments to
the new added servers. Because queries tend to query the most recent
segments, this behavior might cause new added servers to become the
hotspot servers.
To address this issue, we shuffle the segments so that old and new
segments can be balanced assigned.
We use the hash of the table name as the random seed to shuffle the
segments so that the result is deterministic.

It is a little bit tricky to write a test case for this. Since the
change is straight-forward and the existing tests already have
pretty good coverage, after manually verified the expected behavior,
no new test is added.