### PR TITLE
Remove the construction of second bitmap in text index reader to improve performance

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeLuceneDocIdCollector.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeLuceneDocIdCollector.java
@@ -35,10 +35,10 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  */
 public class RealtimeLuceneDocIdCollector implements Collector {
 
-  private final MutableRoaringBitmap _docIDs;
+  private final MutableRoaringBitmap _docIds;
 
-  public RealtimeLuceneDocIdCollector(MutableRoaringBitmap docIDs) {
-    _docIDs = docIDs;
+  public RealtimeLuceneDocIdCollector(MutableRoaringBitmap docIds) {
+    _docIds = docIds;
   }
 
   @Override
@@ -57,7 +57,7 @@ public class RealtimeLuceneDocIdCollector implements Collector {
 
       @Override
       public void collect(int doc) throws IOException {
-        _docIDs.add(doc);
+        _docIds.add(doc);
       }
     };
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeLuceneDocIdCollector.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeLuceneDocIdCollector.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.segment.index.readers.text;
+package org.apache.pinot.core.realtime.impl.invertedindex;
 
 import java.io.IOException;
 import org.apache.lucene.index.LeafReaderContext;
@@ -26,29 +26,19 @@ import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
-
 /**
- * A simple collector created to bypass all the heap heavy process
- * of collecting the results in Lucene. Lucene by default will
- * create a {@link org.apache.lucene.search.TopScoreDocCollector}
- * which internally uses a {@link org.apache.lucene.search.TopDocsCollector}
- * and uses a PriorityQueue to maintain the top results. From the heap usage
- * experiments (please see the design doc), we found out that this was
- * substantially contributing to heap whereas we currently don't need any
- * scoring or top doc collecting.
- * Every time Lucene finds a matching document for the text search query,
- * a callback is invoked into this collector that simply collects the
- * matching doc's docID. We store the docID in a bitmap to be traversed later
- * as part of doc id iteration etc.
+ * DocID collector for Lucene search query. We have optimized
+ * the lucene search on offline segments by maintaining
+ * a pre-built luceneDocId -> pinotDocId mapping. Since that solution
+ * is not directly applicable to realtime, we will separate the collector
+ * for the time-being. Once we have optimized the realtime, we can
  */
-public class LuceneDocIdCollector implements Collector {
+public class RealtimeLuceneDocIdCollector implements Collector {
 
   private final MutableRoaringBitmap _docIDs;
-  private final LuceneTextIndexReader.DocIdTranslator _docIdTranslator;
 
-  public LuceneDocIdCollector(MutableRoaringBitmap docIDs, LuceneTextIndexReader.DocIdTranslator docIdTranslator) {
+  public RealtimeLuceneDocIdCollector(MutableRoaringBitmap docIDs) {
     _docIDs = docIDs;
-    _docIdTranslator = docIdTranslator;
   }
 
   @Override
@@ -67,7 +57,7 @@ public class LuceneDocIdCollector implements Collector {
 
       @Override
       public void collect(int doc) throws IOException {
-        _docIDs.add(_docIdTranslator.getPinotDocId(doc));
+        _docIDs.add(doc);
       }
     };
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeLuceneTextIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/invertedindex/RealtimeLuceneTextIndexReader.java
@@ -99,7 +99,7 @@ public class RealtimeLuceneTextIndexReader implements InvertedIndexReader<Mutabl
   public MutableRoaringBitmap getDocIds(Object value) {
     String searchQuery = (String) value;
     MutableRoaringBitmap docIDs = new MutableRoaringBitmap();
-    Collector docIDCollector = new LuceneDocIdCollector(docIDs);
+    Collector docIDCollector = new RealtimeLuceneDocIdCollector(docIDs);
     IndexSearcher indexSearcher = null;
     try {
       Query query = _queryParser.parse(searchQuery);
@@ -123,6 +123,9 @@ public class RealtimeLuceneTextIndexReader implements InvertedIndexReader<Mutabl
     }
   }
 
+  // TODO: Optimize this similar to how we have done for offline/completed segments.
+  // Pre-built mapping will not work for realtime. We need to build an on-the-fly cache
+  // as queries are coming in.
   private MutableRoaringBitmap getPinotDocIds(IndexSearcher indexSearcher, MutableRoaringBitmap luceneDocIds) {
     IntIterator luceneDocIDIterator = luceneDocIds.getIntIterator();
     MutableRoaringBitmap actualDocIDs = new MutableRoaringBitmap();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneDocIdCollector.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneDocIdCollector.java
@@ -43,11 +43,11 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  */
 public class LuceneDocIdCollector implements Collector {
 
-  private final MutableRoaringBitmap _docIDs;
+  private final MutableRoaringBitmap _docIds;
   private final LuceneTextIndexReader.DocIdTranslator _docIdTranslator;
 
-  public LuceneDocIdCollector(MutableRoaringBitmap docIDs, LuceneTextIndexReader.DocIdTranslator docIdTranslator) {
-    _docIDs = docIDs;
+  public LuceneDocIdCollector(MutableRoaringBitmap docIds, LuceneTextIndexReader.DocIdTranslator docIdTranslator) {
+    _docIds = docIds;
     _docIdTranslator = docIdTranslator;
   }
 
@@ -67,7 +67,7 @@ public class LuceneDocIdCollector implements Collector {
 
       @Override
       public void collect(int doc) throws IOException {
-        _docIDs.add(_docIdTranslator.getPinotDocId(doc));
+        _docIds.add(_docIdTranslator.getPinotDocId(doc));
       }
     };
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
@@ -126,12 +126,12 @@ public class LuceneTextIndexReader implements InvertedIndexReader<MutableRoaring
   @Override
   public MutableRoaringBitmap getDocIds(Object value) {
     String searchQuery = (String) value;
-    MutableRoaringBitmap docIDs = new MutableRoaringBitmap();
-    Collector docIDCollector = new LuceneDocIdCollector(docIDs, _docIdTranslator);
+    MutableRoaringBitmap docIds = new MutableRoaringBitmap();
+    Collector docIDCollector = new LuceneDocIdCollector(docIds, _docIdTranslator);
     try {
       Query query = _queryParser.parse(searchQuery);
       _indexSearcher.search(query, docIDCollector);
-      return docIDs;
+      return docIds;
     } catch (Exception e) {
       String msg = "Caught excepttion while searching the text index for column:" + _column + " search query:" + searchQuery;
       throw new RuntimeException(msg, e);


### PR DESCRIPTION
This is a follow-up to optimization implemented in PR https://github.com/apache/incubator-pinot/pull/5177.

Since we now have pre-built mapping of luceneDocId to pinotDocId, we can directly build the result bitmap with pinotDocId. This PR removes the construction of second bitmap since earlier we had to do build the result in two phases -- (1) run search query to get luceneDocIDs in a bitmap. Iterate over this bitmap and build a second bitmap with corresponding pinotDocIds.

Now in our Lucene collector callback, we can directly build the final bitmap.

This change along with previous PR provides significant performance improvements.

Ran an increasingQPS test on real data (single segment with 10million docs and a text index). QPS was increased from 1 to 40

```
REPORT FOR TARGET QPS: 1.0
Current Target QPS: 1.0, Time Passed: 30084ms, Queries Executed: 30, Average QPS: 0.997207818109294, Average Broker Time: 44.6ms, Average Client Time: 50.1ms, Queries Queued: 0.

REPORT FOR TARGET QPS: 3.0
Current Target QPS: 3.0, Time Passed: 30255ms, Queries Executed: 90, Average QPS: 2.974714923153198, Average Broker Time: 50.3ms, Average Client Time: 53.24444444444445ms, Queries Queued: 0.

REPORT FOR TARGET QPS: 5.0
Current Target QPS: 5.0, Time Passed: 30412ms, Queries Executed: 150, Average QPS: 4.932263580165724, Average Broker Time: 41.44ms, Average Client Time: 44.1ms, Queries Queued: 0.

REPORT FOR TARGET QPS: 7.0
Current Target QPS: 7.0, Time Passed: 30489ms, Queries Executed: 210, Average QPS: 6.887730000983961, Average Broker Time: 41.82857142857143ms, Average Client Time: 44.00476190476191ms, Queries Queued: 0.

REPORT FOR TARGET QPS: 9.0
Current Target QPS: 9.0, Time Passed: 30868ms, Queries Executed: 270, Average QPS: 8.746922379162887, Average Broker Time: 43.385185185185186ms, Average Client Time: 45.27037037037037ms, Queries Queued: 0.

REPORT FOR TARGET QPS: 25.0
Current Target QPS: 25.0, Time Passed: 30233ms, Queries Executed: 694, Average QPS: 22.955049118512882, Average Broker Time: 37.27089337175793ms, Average Client Time: 38.53746397694525ms, Queries Queued: 0.

REPORT FOR TARGET QPS: 27.0
Current Target QPS: 27.0, Time Passed: 30254ms, Queries Executed: 740, Average QPS: 24.459575593309975, Average Broker Time: 39.71351351351351ms, Average Client Time: 40.87837837837838ms, Queries Queued: 0.

REPORT FOR TARGET QPS: 29.0
Current Target QPS: 29.0, Time Passed: 30147ms, Queries Executed: 798, Average QPS: 26.4702955517962, Average Broker Time: 37.06516290726817ms, Average Client Time: 38.22431077694235ms, Queries Queued: 0.

REPORT FOR TARGET QPS: 31.0
Current Target QPS: 31.0, Time Passed: 30160ms, Queries Executed: 843, Average QPS: 27.950928381962864, Average Broker Time: 37.79359430604982ms, Average Client Time: 38.86476868327402ms, Queries Queued: 0.

FINAL REPORT:
Current Target QPS: 39.0, Time Passed: 27344ms, Queries Executed: 947, Average QPS: 34.632826214160325, Average Broker Time: 36.91024287222809ms, Average Client Time: 37.91129883843717ms.

10th percentile: 4.0
25th percentile: 26.0
50th percentile: 37.0
90th percentile: 68.0
95th percentile: 75.0
99th percentile: 129.0
99.9th percentile: 150.0
```

The optimizations implemented in this and previous PR are not directly applicable to realtime (we have the exact same performance overhead in realtime too) since we can't have a pre-built mapping there. We mostly need to build a cache on-the-fly as queries are processed on realtime lucene index. A solution is in progress. Will put PR soon