### PR TITLE
Add override option to be 1 to force publishing the jars to bintray

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <repository>
       <id>bintray-linkedin-maven</id>
       <name>linkedin-maven</name>
-      <url>https://api.bintray.com/maven/linkedin/maven/pinot/;publish=1</url>
+      <url>https://api.bintray.com/maven/linkedin/maven/pinot/;publish=1;override=1</url>
     </repository>
   </distributionManagement>
 


### PR DESCRIPTION
We noticed the build failed at publishing jars to bintray with 405.
https://travis-ci.org/github/apache/incubator-pinot/jobs/669365299?utm_medium=notification&utm_source=email

In order to improve the fault tolerance of the build, this PR adds override option to be 1 to force publishing the jars to bintray. In Pinot it doesn't matter to override the version since every time there will be a new version generated.
