### PR TITLE
[TE] Retain the original last success task execution time if we can't…

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorTaskRunner.java
@@ -137,6 +137,7 @@ public class MonitorTaskRunner implements TaskRunner {
             .addAnomalyCoverageStatus(DAO_REGISTRY.getMergedAnomalyResultDAO())
             .addDetectionTaskStatus(DAO_REGISTRY.getTaskDAO())
             .addOverallHealth()
+            .addOriginalDetectionHealth(config.getHealth())
             .build();
         // fetch the config again before saving to DB to avoid overriding config that is updated by other threads
         config = detectionDAO.findById(config.getId());

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DetectionConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DetectionConfigBean.java
@@ -162,6 +162,12 @@ public class DetectionConfigBean extends AbstractBean {
   }
 
   public void setHealth(DetectionHealth health) {
+    // If there is no success execution in the current window then the last success task execution time would be -1L.
+    // We should keep the original last success task execution time if we have.
+    long lastSuccessTaskExecutionTime = this.health.getDetectionTaskStatus().getLastSuccessTaskExecutionTime();
+   if (health.getDetectionTaskStatus().getLastSuccessTaskExecutionTime() == -1L) {
+      health.setLastSuccessTaskExecutionTime(lastSuccessTaskExecutionTime);
+    }
     this.health = health;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DetectionConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/pojo/DetectionConfigBean.java
@@ -162,12 +162,6 @@ public class DetectionConfigBean extends AbstractBean {
   }
 
   public void setHealth(DetectionHealth health) {
-    // If there is no success execution in the current window then the last success task execution time would be -1L.
-    // We should keep the original last success task execution time if we have.
-    long lastSuccessTaskExecutionTime = this.health.getDetectionTaskStatus().getLastSuccessTaskExecutionTime();
-   if (health.getDetectionTaskStatus().getLastSuccessTaskExecutionTime() == -1L) {
-      health.setLastSuccessTaskExecutionTime(lastSuccessTaskExecutionTime);
-    }
     this.health = health;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionHealth.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionHealth.java
@@ -83,10 +83,6 @@ public class DetectionHealth {
     return detectionTaskStatus;
   }
 
-  public void setLastSuccessTaskExecutionTime(long lastSuccessTaskExecutionTime) {
-    detectionTaskStatus.setLastSuccessTaskExecutionTime(lastSuccessTaskExecutionTime);
-  }
-
   /**
    * Builder for the detection health
    */

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionHealth.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionHealth.java
@@ -83,6 +83,10 @@ public class DetectionHealth {
     return detectionTaskStatus;
   }
 
+  public void setLastSuccessTaskExecutionTime(long lastSuccessTaskExecutionTime) {
+    detectionTaskStatus.setLastSuccessTaskExecutionTime(lastSuccessTaskExecutionTime);
+  }
+
   /**
    * Builder for the detection health
    */

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionTaskStatus.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionTaskStatus.java
@@ -46,10 +46,14 @@ public class DetectionTaskStatus {
 
   // the time stamp of last successfully finishing task
   @JsonProperty
-  private final Long lastTaskExecutionTime;
+  private Long lastSuccessTaskExecutionTime;
 
-  public Long getLastTaskExecutionTime() {
-    return lastTaskExecutionTime;
+  public Long getLastSuccessTaskExecutionTime() {
+    return lastSuccessTaskExecutionTime;
+  }
+
+  public void setLastSuccessTaskExecutionTime(long lastSuccessTaskExecutionTime) {
+    this.lastSuccessTaskExecutionTime = lastSuccessTaskExecutionTime;
   }
 
   // the counting for detection task status
@@ -68,12 +72,12 @@ public class DetectionTaskStatus {
   private static final double TASK_SUCCESS_RATE_BAD_THRESHOLD = 0.2;
   private static final double TASK_SUCCESS_RATE_MODERATE_THRESHOLD = 0.8;
 
-  public DetectionTaskStatus(double taskSuccessRate, HealthStatus healthStatus, Map<TaskConstants.TaskStatus, Long> counts, List<TaskDTO> tasks, long lastTaskExecutionTime) {
+  public DetectionTaskStatus(double taskSuccessRate, HealthStatus healthStatus, Map<TaskConstants.TaskStatus, Long> counts, List<TaskDTO> tasks, long lastSuccessTaskExecutionTime) {
     this.taskSuccessRate = taskSuccessRate;
     this.healthStatus = healthStatus;
     this.tasks = tasks;
     this.taskCounts.putAll(counts);
-    this.lastTaskExecutionTime = lastTaskExecutionTime;
+    this.lastSuccessTaskExecutionTime = lastSuccessTaskExecutionTime;
   }
 
   // default constructor for deserialization
@@ -81,7 +85,7 @@ public class DetectionTaskStatus {
     this.taskSuccessRate = Double.NaN;
     this.healthStatus = HealthStatus.UNKNOWN;
     this.tasks = Collections.emptyList();
-    this.lastTaskExecutionTime = -1L;
+    this.lastSuccessTaskExecutionTime = -1L;
   }
 
   public double getTaskSuccessRate() {
@@ -106,8 +110,8 @@ public class DetectionTaskStatus {
     Map<TaskConstants.TaskStatus, Long> counts =
         tasks.stream().collect(Collectors.groupingBy(TaskBean::getStatus, Collectors.counting()));
     double taskSuccessRate = getTaskSuccessRate(counts);
-    long lastTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
-    return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks, lastTaskExecutionTime);
+    long lastSuccessTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
+    return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks, lastSuccessTaskExecutionTime);
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionTaskStatus.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionTaskStatus.java
@@ -100,32 +100,35 @@ public class DetectionTaskStatus {
     return taskCounts;
   }
 
-  public static DetectionTaskStatus fromTasks(List<TaskDTO> tasks) {
+  public static DetectionTaskStatus fromTasks(List<TaskDTO> tasks, long lastTaskExecutionTime) {
     // count the number of tasks by task status
     tasks.sort(Comparator.comparingLong(TaskBean::getStartTime).reversed());
     Map<TaskConstants.TaskStatus, Long> counts =
         tasks.stream().collect(Collectors.groupingBy(TaskBean::getStatus, Collectors.counting()));
     double taskSuccessRate = getTaskSuccessRate(counts);
-    long lastTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
-    return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks, lastTaskExecutionTime);
+    long newTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
+    newTaskExecutionTime = newTaskExecutionTime == -1L ? lastTaskExecutionTime : newTaskExecutionTime;
+    return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks, newTaskExecutionTime);
   }
 
   /**
    * Create a Detection task status from a list of tasks
    * @param tasks the list of tasks
+   * @param lastTaskExecutionTime the last task exeuction time
    * @param taskLimit the number of tasks should be returned in the task status
    * @return the DetectionTaskStatus
    */
-  public static DetectionTaskStatus fromTasks(List<TaskDTO> tasks, long taskLimit) {
+  public static DetectionTaskStatus fromTasks(List<TaskDTO> tasks, long lastTaskExecutionTime, long taskLimit) {
     // count the number of tasks by task status
     tasks.sort(Comparator.comparingLong(TaskBean::getStartTime).reversed());
     Map<TaskConstants.TaskStatus, Long> counts =
         tasks.stream().collect(Collectors.groupingBy(TaskBean::getStatus, Collectors.counting()));
     double taskSuccessRate = getTaskSuccessRate(counts);
-    long lastTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
+    long newTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
+    newTaskExecutionTime = newTaskExecutionTime == -1L ? lastTaskExecutionTime : newTaskExecutionTime;
     tasks = tasks.stream().limit(taskLimit).collect(Collectors.toList());
     return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks,
-        lastTaskExecutionTime);
+        newTaskExecutionTime);
   }
 
   private static Long getLastSuccessTaskExecutionTime(List<TaskDTO> tasks) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionTaskStatus.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/health/DetectionTaskStatus.java
@@ -46,14 +46,10 @@ public class DetectionTaskStatus {
 
   // the time stamp of last successfully finishing task
   @JsonProperty
-  private Long lastSuccessTaskExecutionTime;
+  private final Long lastTaskExecutionTime;
 
-  public Long getLastSuccessTaskExecutionTime() {
-    return lastSuccessTaskExecutionTime;
-  }
-
-  public void setLastSuccessTaskExecutionTime(long lastSuccessTaskExecutionTime) {
-    this.lastSuccessTaskExecutionTime = lastSuccessTaskExecutionTime;
+  public Long getLastTaskExecutionTime() {
+    return lastTaskExecutionTime;
   }
 
   // the counting for detection task status
@@ -72,12 +68,12 @@ public class DetectionTaskStatus {
   private static final double TASK_SUCCESS_RATE_BAD_THRESHOLD = 0.2;
   private static final double TASK_SUCCESS_RATE_MODERATE_THRESHOLD = 0.8;
 
-  public DetectionTaskStatus(double taskSuccessRate, HealthStatus healthStatus, Map<TaskConstants.TaskStatus, Long> counts, List<TaskDTO> tasks, long lastSuccessTaskExecutionTime) {
+  public DetectionTaskStatus(double taskSuccessRate, HealthStatus healthStatus, Map<TaskConstants.TaskStatus, Long> counts, List<TaskDTO> tasks, long lastTaskExecutionTime) {
     this.taskSuccessRate = taskSuccessRate;
     this.healthStatus = healthStatus;
     this.tasks = tasks;
     this.taskCounts.putAll(counts);
-    this.lastSuccessTaskExecutionTime = lastSuccessTaskExecutionTime;
+    this.lastTaskExecutionTime = lastTaskExecutionTime;
   }
 
   // default constructor for deserialization
@@ -85,7 +81,7 @@ public class DetectionTaskStatus {
     this.taskSuccessRate = Double.NaN;
     this.healthStatus = HealthStatus.UNKNOWN;
     this.tasks = Collections.emptyList();
-    this.lastSuccessTaskExecutionTime = -1L;
+    this.lastTaskExecutionTime = -1L;
   }
 
   public double getTaskSuccessRate() {
@@ -110,8 +106,8 @@ public class DetectionTaskStatus {
     Map<TaskConstants.TaskStatus, Long> counts =
         tasks.stream().collect(Collectors.groupingBy(TaskBean::getStatus, Collectors.counting()));
     double taskSuccessRate = getTaskSuccessRate(counts);
-    long lastSuccessTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
-    return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks, lastSuccessTaskExecutionTime);
+    long lastTaskExecutionTime = getLastSuccessTaskExecutionTime(tasks);
+    return new DetectionTaskStatus(taskSuccessRate, classifyTaskStatus(taskSuccessRate), counts, tasks, lastTaskExecutionTime);
   }
 
   /**


### PR DESCRIPTION
… find success tasks
There are several alerts that failed for more than 30 days, and thus we can't get the last success task execution from this window.
However we should keep the original last success task execution time.