### PR TITLE
fixing presto-coordinator k8s yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 bin/
 */bin/
 .idea
+.vscode
 *.iml
 .settings/
 out/

--- a/kubernetes/helm/presto-coordinator.yaml
+++ b/kubernetes/helm/presto-coordinator.yaml
@@ -87,6 +87,7 @@ spec:
       securityContext:
         runAsGroup: 1000
         fsGroup: 1000
+        runAsUser: 1000
       containers:
         - image: apachepinot/pinot-presto:latest
           imagePullPolicy: Always


### PR DESCRIPTION
Fix the missing `runAsUser` config in `presto-coordinator.yaml`.

Credit to: Dan Hill