### PR TITLE
Support order-by on BYTES column

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.pinot.common.response.ProcessingException;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
 /**
@@ -62,6 +63,8 @@ public interface DataTable {
   double getDouble(int rowId, int colId);
 
   String getString(int rowId, int colId);
+
+  ByteArray getBytes(int rowId, int colId);
 
   <T> T getObject(int rowId, int colId);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/RowBasedBlockValueFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/RowBasedBlockValueFetcher.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.common;
 
-import java.io.Serializable;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
 public class RowBasedBlockValueFetcher {
@@ -33,9 +33,9 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  public Serializable[] getRow(int docId) {
+  public Object[] getRow(int docId) {
     int numColumns = _valueFetchers.length;
-    Serializable[] row = new Serializable[numColumns];
+    Object[] row = new Object[numColumns];
     for (int i = 0; i < numColumns; i++) {
       row[i] = _valueFetchers[i].getValue(docId);
     }
@@ -80,10 +80,10 @@ public class RowBasedBlockValueFetcher {
   }
 
   private interface ValueFetcher {
-    Serializable getValue(int docId);
+    Object getValue(int docId);
   }
 
-  private class IntSingleValueFetcher implements ValueFetcher {
+  private static class IntSingleValueFetcher implements ValueFetcher {
     private final int[] _values;
 
     IntSingleValueFetcher(int[] values) {
@@ -95,7 +95,7 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  private class LongSingleValueFetcher implements ValueFetcher {
+  private static class LongSingleValueFetcher implements ValueFetcher {
     private final long[] _values;
 
     LongSingleValueFetcher(long[] values) {
@@ -107,7 +107,7 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  private class FloatSingleValueFetcher implements ValueFetcher {
+  private static class FloatSingleValueFetcher implements ValueFetcher {
     private final float[] _values;
 
     FloatSingleValueFetcher(float[] values) {
@@ -119,7 +119,7 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  private class DoubleSingleValueFetcher implements ValueFetcher {
+  private static class DoubleSingleValueFetcher implements ValueFetcher {
     private final double[] _values;
 
     DoubleSingleValueFetcher(double[] values) {
@@ -131,7 +131,7 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  private class StringSingleValueFetcher implements ValueFetcher {
+  private static class StringSingleValueFetcher implements ValueFetcher {
     private final String[] _values;
 
     StringSingleValueFetcher(String[] values) {
@@ -143,19 +143,19 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  private class BytesValueFetcher implements ValueFetcher {
+  private static class BytesValueFetcher implements ValueFetcher {
     private final byte[][] _values;
 
     BytesValueFetcher(byte[][] values) {
       _values = values;
     }
 
-    public byte[] getValue(int docId) {
-      return _values[docId];
+    public ByteArray getValue(int docId) {
+      return new ByteArray(_values[docId]);
     }
   }
 
-  private class IntMultiValueFetcher implements ValueFetcher {
+  private static class IntMultiValueFetcher implements ValueFetcher {
     private final int[][] _values;
 
     IntMultiValueFetcher(int[][] values) {
@@ -167,7 +167,7 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  private class LongMultiValueFetcher implements ValueFetcher {
+  private static class LongMultiValueFetcher implements ValueFetcher {
     private final long[][] _values;
 
     LongMultiValueFetcher(long[][] values) {
@@ -179,7 +179,7 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  private class FloatMultiValueFetcher implements ValueFetcher {
+  private static class FloatMultiValueFetcher implements ValueFetcher {
     private final float[][] _values;
 
     FloatMultiValueFetcher(float[][] values) {
@@ -191,7 +191,7 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  private class DoubleMultiValueFetcher implements ValueFetcher {
+  private static class DoubleMultiValueFetcher implements ValueFetcher {
     private final double[][] _values;
 
     DoubleMultiValueFetcher(double[][] values) {
@@ -203,7 +203,7 @@ public class RowBasedBlockValueFetcher {
     }
   }
 
-  private class StringMultiValueFetcher implements ValueFetcher {
+  private static class StringMultiValueFetcher implements ValueFetcher {
     private final String[][] _values;
 
     StringMultiValueFetcher(String[][] values) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableImplV2.java
@@ -33,6 +33,8 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
 
 
 public class DataTableImplV2 implements DataTable {
@@ -386,6 +388,12 @@ public class DataTableImplV2 implements DataTable {
     _fixedSizeData.position(rowId * _rowSizeInBytes + _columnOffsets[colId]);
     int dictId = _fixedSizeData.getInt();
     return _dictionaryMap.get(_dataSchema.getColumnName(colId)).get(dictId);
+  }
+
+  @Override
+  public ByteArray getBytes(int rowId, int colId) {
+    // NOTE: DataTable V2 uses String to store BYTES value
+    return BytesUtils.toByteArray(getString(rowId, colId));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
@@ -22,33 +22,36 @@ import java.util.Arrays;
 
 
 /**
- * Defines the key component of the record
+ * Defines the key component of the record.
+ * <p>Key can be used as the key in a map, and may only contain single-value columns.
+ * <p>For each data type, the value should be stored as:
+ * <ul>
+ *   <li>INT: Integer</li>
+ *   <li>LONG: Long</li>
+ *   <li>FLOAT: Float</li>
+ *   <li>DOUBLE: Double</li>
+ *   <li>STRING: String</li>
+ *   <li>BYTES: ByteArray</li>
+ * </ul>
+ *
+ * TODO: Consider replacing Key with Record as the concept is very close and the implementation is the same
  */
 public class Key {
-  private Object[] _columns;
+  private final Object[] _values;
 
-  public Key(Object[] columns) {
-    _columns = columns;
+  public Key(Object[] values) {
+    _values = values;
   }
 
-  public Object[] getColumns() {
-    return _columns;
-  }
-
+  // NOTE: Not check class for performance concern
+  @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
   @Override
   public boolean equals(Object o) {
-    Key that = (Key) o;
-    return Arrays.deepEquals(_columns, that._columns);
+    return Arrays.equals(_values, ((Key) o)._values);
   }
 
   @Override
   public int hashCode() {
-    return Arrays.deepHashCode(_columns);
+    return Arrays.hashCode(_values);
   }
-
-  @Override
-  public String toString() {
-    return Arrays.deepToString(_columns);
-  }
-
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
@@ -22,35 +22,46 @@ import java.util.Arrays;
 
 
 /**
- * Defines a single record in Pinot
+ * Defines a single record in Pinot.
+ * <p>Record may contain both single-value and multi-value columns. In order to use the record as the key in a map, it
+ * can only contain single-value columns (to avoid using Arrays.deepEquals() and Arrays.deepHashCode() for performance
+ * concern).
+ * <p>For each data type, the value should be stored as:
+ * <ul>
+ *   <li>INT: Integer</li>
+ *   <li>LONG: Long</li>
+ *   <li>FLOAT: Float</li>
+ *   <li>DOUBLE: Double</li>
+ *   <li>STRING: String</li>
+ *   <li>BYTES: ByteArray</li>
+ *   <li>OBJECT (intermediate aggregation result): Object</li>
+ *   <li>INT_ARRAY: int[]</li>
+ *   <li>LONG_ARRAY: long[]</li>
+ *   <li>FLOAT_ARRAY: float[]</li>
+ *   <li>DOUBLE_ARRAY: double[]</li>
+ *   <li>STRING_ARRAY: String[]</li>
+ * </ul>
  */
 public class Record {
-  private Object[] _values;
+  private final Object[] _values;
 
   public Record(Object[] values) {
     _values = values;
   }
 
-  /**
-   * Returns the column values contained in the Record
-   */
   public Object[] getValues() {
     return _values;
   }
 
-  @Override
-  public String toString() {
-    return Arrays.deepToString(_values);
-  }
-
+  // NOTE: Not check class for performance concern
+  @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
   @Override
   public boolean equals(Object o) {
-    Record that = (Record) o;
-    return Arrays.deepEquals(_values, that._values);
+    return Arrays.equals(_values, ((Record) o)._values);
   }
 
   @Override
   public int hashCode() {
-    return Arrays.deepHashCode(_values);
+    return Arrays.hashCode(_values);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
@@ -245,30 +245,23 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
   }
 
   private Function<String, Object> getConverterFunction(DataSchema.ColumnDataType columnDataType) {
-    Function<String, Object> function;
     switch (columnDataType) {
-
       case INT:
-        function = Integer::valueOf;
-        break;
+        return Integer::valueOf;
       case LONG:
-        function = Long::valueOf;
-        break;
+        return Long::valueOf;
       case FLOAT:
-        function = Float::valueOf;
-        break;
+        return Float::valueOf;
       case DOUBLE:
-        function = Double::valueOf;
-        break;
-      case BYTES:
-        function = BytesUtils::toByteArray;
-        break;
+        return Double::valueOf;
       case STRING:
+        return s -> s;
+      case BYTES:
+        return BytesUtils::toByteArray;
+      // Add other group-by column type supports here
       default:
-        function = s -> s;
-        break;
+        throw new IllegalStateException();
     }
-    return function;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineOperator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -214,7 +213,7 @@ public class CombineOperator extends BaseOperator<IntermediateResultsBlock> {
     Selection selections = brokerRequest.getSelections();
     if (selections != null && brokerRequest.getOrderBy() == null) {
       // Selection-only
-      Collection<Serializable[]> selectionResult = mergedBlock.getSelectionResult();
+      Collection<Object[]> selectionResult = mergedBlock.getSelectionResult();
       return selectionResult != null && selectionResult.size() >= selections.getSize();
     }
     return false;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.operator.blocks;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -43,6 +42,7 @@ import org.apache.pinot.core.data.table.Table;
 import org.apache.pinot.core.query.aggregation.AggregationFunctionContext;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
 /**
@@ -50,7 +50,7 @@ import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
  */
 public class IntermediateResultsBlock implements Block {
   private DataSchema _dataSchema;
-  private Collection<Serializable[]> _selectionResult;
+  private Collection<Object[]> _selectionResult;
   private AggregationFunctionContext[] _aggregationFunctionContexts;
   private List<Object> _aggregationResult;
   private AggregationGroupByResult _aggregationGroupByResult;
@@ -69,7 +69,7 @@ public class IntermediateResultsBlock implements Block {
   /**
    * Constructor for selection result.
    */
-  public IntermediateResultsBlock(DataSchema dataSchema, Collection<Serializable[]> selectionResult) {
+  public IntermediateResultsBlock(DataSchema dataSchema, Collection<Object[]> selectionResult) {
     _dataSchema = dataSchema;
     _selectionResult = selectionResult;
   }
@@ -139,11 +139,11 @@ public class IntermediateResultsBlock implements Block {
   }
 
   @Nullable
-  public Collection<Serializable[]> getSelectionResult() {
+  public Collection<Object[]> getSelectionResult() {
     return _selectionResult;
   }
 
-  public void setSelectionResult(@Nullable Collection<Serializable[]> rowEventsSet) {
+  public void setSelectionResult(@Nullable Collection<Object[]> rowEventsSet) {
     _selectionResult = rowEventsSet;
   }
 
@@ -274,29 +274,44 @@ public class IntermediateResultsBlock implements Block {
       Object value)
       throws IOException {
     switch (columnDataType) {
-
       case INT:
-        dataTableBuilder.setColumn(columnIndex, ((Number) value).intValue());
+        dataTableBuilder.setColumn(columnIndex, (int) value);
         break;
       case LONG:
-        dataTableBuilder.setColumn(columnIndex, ((Number) value).longValue());
+        dataTableBuilder.setColumn(columnIndex, (long) value);
         break;
       case FLOAT:
-        dataTableBuilder.setColumn(columnIndex, ((Number) value).floatValue());
+        dataTableBuilder.setColumn(columnIndex, (float) value);
         break;
       case DOUBLE:
-        dataTableBuilder.setColumn(columnIndex, ((Number) value).doubleValue());
+        dataTableBuilder.setColumn(columnIndex, (double) value);
         break;
       case STRING:
         dataTableBuilder.setColumn(columnIndex, (String) value);
         break;
       case BYTES:
-        // FIXME: support BYTES in DataTable instead of converting to string
-        dataTableBuilder.setColumn(columnIndex, value.toString()); // ByteArray::toString
+        dataTableBuilder.setColumn(columnIndex, (ByteArray) value);
         break;
-      default:
+      case OBJECT:
         dataTableBuilder.setColumn(columnIndex, value);
         break;
+      case INT_ARRAY:
+        dataTableBuilder.setColumn(columnIndex, (int[]) value);
+        break;
+      case LONG_ARRAY:
+        dataTableBuilder.setColumn(columnIndex, (long[]) value);
+        break;
+      case FLOAT_ARRAY:
+        dataTableBuilder.setColumn(columnIndex, (float[]) value);
+        break;
+      case DOUBLE_ARRAY:
+        dataTableBuilder.setColumn(columnIndex, (double[]) value);
+        break;
+      case STRING_ARRAY:
+        dataTableBuilder.setColumn(columnIndex, (String[]) value);
+        break;
+      default:
+        throw new IllegalStateException();
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator.query;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.request.Selection;
@@ -45,7 +44,7 @@ public class SelectionOnlyOperator extends BaseOperator<IntermediateResultsBlock
   private final BlockValSet[] _blockValSets;
   private final DataSchema _dataSchema;
   private final int _numRowsToKeep;
-  private final List<Serializable[]> _rows;
+  private final List<Object[]> _rows;
 
   private int _numDocsScanned = 0;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DistinctTable.java
@@ -36,7 +36,7 @@ import org.apache.pinot.core.common.datatable.DataTableFactory;
 import org.apache.pinot.core.data.table.BaseTable;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.core.data.table.Record;
-import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
 /**
@@ -120,8 +120,9 @@ public class DistinctTable extends BaseTable {
     return dataTable.toBytes();
   }
 
-  private void serializeColumns(final Object[] columns, final DataSchema.ColumnDataType[] columnDataTypes,
-      final DataTableBuilder dataTableBuilder) {
+  private void serializeColumns(Object[] columns, DataSchema.ColumnDataType[] columnDataTypes,
+      DataTableBuilder dataTableBuilder)
+      throws IOException {
     for (int colIndex = 0; colIndex < columns.length; colIndex++) {
       switch (columnDataTypes[colIndex]) {
         case INT:
@@ -140,7 +141,11 @@ public class DistinctTable extends BaseTable {
           dataTableBuilder.setColumn(colIndex, ((String) columns[colIndex]));
           break;
         case BYTES:
-          dataTableBuilder.setColumn(colIndex, BytesUtils.toHexString((byte[]) columns[colIndex]));
+          dataTableBuilder.setColumn(colIndex, (ByteArray) columns[colIndex]);
+          break;
+        // Add other distinct column type supports here
+        default:
+          throw new IllegalStateException();
       }
     }
   }
@@ -188,8 +193,9 @@ public class DistinctTable extends BaseTable {
             columnValues[colIndex] = dataTable.getString(rowIndex, colIndex);
             break;
           case BYTES:
-            columnValues[colIndex] = dataTable.getString(rowIndex, colIndex);
+            columnValues[colIndex] = dataTable.getBytes(rowIndex, colIndex);
             break;
+          // Add other distinct column type supports here
           default:
             throw new IllegalStateException(
                 "Unexpected column data type " + columnDataType + " while deserializing data table for DISTINCT query");

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
@@ -91,17 +91,13 @@ public class DistinctAggregationFunction implements AggregationFunction<Distinct
     // for DISTINCT queries without filter.
     RowBasedBlockValueFetcher blockValueFetcher = new RowBasedBlockValueFetcher(blockValSets);
 
-    int rowIndex = 0;
     // TODO: Do early termination in the operator itself which should
     // not call aggregate function at all if the limit has reached
     // that will require the interface change since this function
     // has to communicate back that required number of records have
     // been collected
-    while (rowIndex < length) {
-      Object[] columnData = blockValueFetcher.getRow(rowIndex);
-      Record record = new Record(columnData);
-      distinctTable.upsert(record);
-      rowIndex++;
+    for (int i = 0; i < length; i++) {
+      distinctTable.upsert(new Record(blockValueFetcher.getRow(i)));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
@@ -43,12 +43,11 @@ import org.apache.pinot.core.util.QueryOptions;
  * Helper class to reduce and set Aggregation results into the BrokerResponseNative
  */
 public class AggregationDataTableReducer implements DataTableReducer {
-
   private final AggregationFunction[] _aggregationFunctions;
   private final List<AggregationInfo> _aggregationInfos;
   private final int _numAggregationFunctions;
   private final boolean _preserveType;
-  private boolean _responseFormatSql;
+  private final boolean _responseFormatSql;
 
   AggregationDataTableReducer(BrokerRequest brokerRequest, AggregationFunction[] aggregationFunctions,
       QueryOptions queryOptions) {
@@ -112,8 +111,7 @@ public class AggregationDataTableReducer implements DataTableReducer {
     if (_responseFormatSql) {
       brokerResponseNative.setResultTable(reduceToResultTable(intermediateResults));
     } else {
-      brokerResponseNative
-          .setAggregationResults(reduceToAggregationResult(intermediateResults, dataSchema));
+      brokerResponseNative.setAggregationResults(reduceToAggregationResult(intermediateResults, dataSchema));
     }
   }
 
@@ -135,8 +133,7 @@ public class AggregationDataTableReducer implements DataTableReducer {
   /**
    * Sets aggregation results into AggregationResults
    */
-  private List<AggregationResult> reduceToAggregationResult(Object[] intermediateResults,
-      DataSchema dataSchema) {
+  private List<AggregationResult> reduceToAggregationResult(Object[] intermediateResults, DataSchema dataSchema) {
     // Extract final results and set them into the broker response.
     List<AggregationResult> reducedAggregationResults = new ArrayList<>(_numAggregationFunctions);
     for (int i = 0; i < _numAggregationFunctions; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/CombineService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/CombineService.java
@@ -18,11 +18,9 @@
  */
 package org.apache.pinot.core.query.reduce;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.PriorityQueue;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Selection;
@@ -45,8 +43,8 @@ public class CombineService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CombineService.class);
 
-  public static void mergeTwoBlocks(@Nonnull BrokerRequest brokerRequest, @Nonnull IntermediateResultsBlock mergedBlock,
-      @Nonnull IntermediateResultsBlock blockToMerge) {
+  public static void mergeTwoBlocks(BrokerRequest brokerRequest, IntermediateResultsBlock mergedBlock,
+      IntermediateResultsBlock blockToMerge) {
     // Combine processing exceptions.
     List<ProcessingException> mergedProcessingExceptions = mergedBlock.getProcessingExceptions();
     List<ProcessingException> processingExceptionsToMerge = blockToMerge.getProcessingExceptions();
@@ -95,8 +93,8 @@ public class CombineService {
       // Result set size will be zero if no row matches the predicate.
       DataSchema mergedBlockSchema = mergedBlock.getDataSchema();
       DataSchema blockToMergeSchema = blockToMerge.getDataSchema();
-      Collection<Serializable[]> mergedBlockResultSet = mergedBlock.getSelectionResult();
-      Collection<Serializable[]> blockToMergeResultSet = blockToMerge.getSelectionResult();
+      Collection<Object[]> mergedBlockResultSet = mergedBlock.getSelectionResult();
+      Collection<Object[]> blockToMergeResultSet = blockToMerge.getSelectionResult();
 
       if (mergedBlockSchema == null || mergedBlockResultSet.size() == 0) {
         // No data in merged block.
@@ -130,7 +128,7 @@ public class CombineService {
             if (isSelectionOrderBy) {
               // Combine selection order-by.
               SelectionOperatorUtils
-                  .mergeWithOrdering((PriorityQueue<Serializable[]>) mergedBlockResultSet, blockToMergeResultSet,
+                  .mergeWithOrdering((PriorityQueue<Object[]>) mergedBlockResultSet, blockToMergeResultSet,
                       selection.getOffset() + selectionSize);
             } else {
               // Combine selection only.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -55,7 +55,6 @@ import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmin
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.core.util.QueryOptions;
-import org.apache.pinot.spi.utils.BytesUtils;
 
 
 /**
@@ -315,7 +314,6 @@ public class GroupByDataTableReducer implements DataTableReducer {
         DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
         BiFunction<Integer, Integer, Object> function;
         switch (columnDataType) {
-
           case INT:
             function = dataTable::getInt;
             break;
@@ -332,11 +330,14 @@ public class GroupByDataTableReducer implements DataTableReducer {
             function = dataTable::getString;
             break;
           case BYTES:
-            // FIXME: support BYTES in DataTable instead of converting to string
-            function = (row, col) -> BytesUtils.toByteArray(dataTable.getString(row, col));
+            function = dataTable::getBytes;
             break;
-          default:
+          case OBJECT:
             function = dataTable::getObject;
+            break;
+          // Add other aggregation intermediate result / group-by column type supports here
+          default:
+            throw new IllegalStateException();
         }
         functions[i] = function;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.query.reduce;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -48,12 +47,11 @@ import org.slf4j.LoggerFactory;
  * Helper class to reduce and set Selection results into the BrokerResponseNative
  */
 public class SelectionDataTableReducer implements DataTableReducer {
-
   private static final Logger LOGGER = LoggerFactory.getLogger(SelectionDataTableReducer.class);
 
   private final Selection _selection;
-  private boolean _preserveType;
-  private boolean _responseFormatSql;
+  private final boolean _preserveType;
+  private final boolean _responseFormatSql;
 
   SelectionDataTableReducer(BrokerRequest brokerRequest, QueryOptions queryOptions) {
     _selection = brokerRequest.getSelections();
@@ -103,8 +101,6 @@ public class SelectionDataTableReducer implements DataTableReducer {
         SelectionOperatorService selectionService = new SelectionOperatorService(_selection, dataSchema);
         selectionService.reduceWithOrdering(dataTableMap.values());
         if (_responseFormatSql) {
-          // TODO: Selection uses Serializable[] in all its operations
-          //   Converting that to Object[] end to end would be a big change, and will be done in future PRs
           brokerResponseNative.setResultTable(selectionService.renderResultTableWithOrdering());
         } else {
           brokerResponseNative.setSelectionResults(selectionService.renderSelectionResultsWithOrdering(_preserveType));
@@ -113,11 +109,8 @@ public class SelectionDataTableReducer implements DataTableReducer {
         // Selection only
         List<String> selectionColumns =
             SelectionOperatorUtils.getSelectionColumns(_selection.getSelectionColumns(), dataSchema);
-        List<Serializable[]> reducedRows =
-            SelectionOperatorUtils.reduceWithoutOrdering(dataTableMap.values(), selectionSize);
+        List<Object[]> reducedRows = SelectionOperatorUtils.reduceWithoutOrdering(dataTableMap.values(), selectionSize);
         if (_responseFormatSql) {
-          // TODO: Selection uses Serializable[] in all its operations
-          //   Converting that to Object[] end to end would be a big change, and will be done in future PRs
           brokerResponseNative
               .setResultTable(SelectionOperatorUtils.renderResultTableWithoutOrdering(reducedRows, dataSchema));
         } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
@@ -63,7 +63,7 @@ public class SelectionOperatorService {
   private final DataSchema _dataSchema;
   private final int _offset;
   private final int _numRowsToKeep;
-  private final PriorityQueue<Serializable[]> _rows;
+  private final PriorityQueue<Object[]> _rows;
 
   /**
    * Constructor for <code>SelectionOperatorService</code> with {@link DataSchema}. (Inter segment)
@@ -87,7 +87,7 @@ public class SelectionOperatorService {
    *
    * @return flexible {@link Comparator} for selection rows.
    */
-  private Comparator<Serializable[]> getTypeCompatibleComparator(List<SelectionSort> sortSequence) {
+  private Comparator<Object[]> getTypeCompatibleComparator(List<SelectionSort> sortSequence) {
     // Compare all single-value columns
     int numOrderByExpressions = sortSequence.size();
     List<Integer> valueIndexList = new ArrayList<>(numOrderByExpressions);
@@ -112,13 +112,14 @@ public class SelectionOperatorService {
     return (o1, o2) -> {
       for (int i = 0; i < numValuesToCompare; i++) {
         int index = valueIndices[i];
-        Serializable v1 = o1[index];
-        Serializable v2 = o2[index];
+        Object v1 = o1[index];
+        Object v2 = o2[index];
         int result;
         if (isNumber[i]) {
           result = Double.compare(((Number) v1).doubleValue(), ((Number) v2).doubleValue());
         } else {
-          result = ((String) v1).compareTo((String) v2);
+          //noinspection unchecked
+          result = ((Comparable) v1).compareTo(v2);
         }
         if (result != 0) {
           return result * multipliers[i];
@@ -133,7 +134,7 @@ public class SelectionOperatorService {
    *
    * @return selection results.
    */
-  public PriorityQueue<Serializable[]> getRows() {
+  public PriorityQueue<Object[]> getRows() {
     return _rows;
   }
 
@@ -145,7 +146,7 @@ public class SelectionOperatorService {
     for (DataTable dataTable : dataTables) {
       int numRows = dataTable.getNumberOfRows();
       for (int rowId = 0; rowId < numRows; rowId++) {
-        Serializable[] row = SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId);
+        Object[] row = SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId);
         SelectionOperatorUtils.addToPriorityQueue(row, _rows, _numRowsToKeep);
       }
     }
@@ -161,21 +162,32 @@ public class SelectionOperatorService {
    */
   public SelectionResults renderSelectionResultsWithOrdering(boolean preserveType) {
     LinkedList<Serializable[]> rowsInSelectionResults = new LinkedList<>();
-
     int[] columnIndices = SelectionOperatorUtils.getColumnIndices(_selectionColumns, _dataSchema);
-    DataSchema.ColumnDataType[] columnDataTypes;
+    int numColumns = columnIndices.length;
+    DataSchema.ColumnDataType[] columnDataTypes = _dataSchema.getColumnDataTypes();
+
     if (preserveType) {
-      columnDataTypes = null;
-    } else {
-      int numColumns = _selectionColumns.size();
-      columnDataTypes = new DataSchema.ColumnDataType[numColumns];
-      for (int i = 0; i < numColumns; i++) {
-        columnDataTypes[i] = _dataSchema.getColumnDataType(columnIndices[i]);
+      while (_rows.size() > _offset) {
+        Object[] row = _rows.poll();
+        assert row != null;
+        Serializable[] extractedRow = new Serializable[numColumns];
+        for (int i = 0; i < numColumns; i++) {
+          int columnIndex = columnIndices[i];
+          extractedRow[i] = SelectionOperatorUtils.convertValueToType(row[columnIndex], columnDataTypes[columnIndex]);
+        }
+        rowsInSelectionResults.addFirst(extractedRow);
       }
-    }
-    while (_rows.size() > _offset) {
-      rowsInSelectionResults
-          .addFirst(SelectionOperatorUtils.extractColumns(_rows.poll(), columnIndices, columnDataTypes));
+    } else {
+      while (_rows.size() > _offset) {
+        Object[] row = _rows.poll();
+        assert row != null;
+        Serializable[] extractedRow = new Serializable[numColumns];
+        for (int i = 0; i < numColumns; i++) {
+          int columnIndex = columnIndices[i];
+          extractedRow[i] = SelectionOperatorUtils.getFormattedValue(row[columnIndex], columnDataTypes[columnIndex]);
+        }
+        rowsInSelectionResults.addFirst(extractedRow);
+      }
     }
 
     return new SelectionResults(_selectionColumns, rowsInSelectionResults);
@@ -193,18 +205,29 @@ public class SelectionOperatorService {
     LinkedList<Object[]> rowsInSelectionResults = new LinkedList<>();
     int[] columnIndices = SelectionOperatorUtils.getColumnIndices(_selectionColumns, _dataSchema);
     int numColumns = columnIndices.length;
+    DataSchema.ColumnDataType[] columnDataTypes = _dataSchema.getColumnDataTypes();
 
     while (_rows.size() > _offset) {
-      Serializable[] row = _rows.poll();
+      Object[] row = _rows.poll();
+      assert row != null;
       Object[] extractedRow = new Object[numColumns];
       for (int i = 0; i < numColumns; i++) {
-        extractedRow[i] = row[columnIndices[i]];
+        int columnIndex = columnIndices[i];
+        extractedRow[i] = SelectionOperatorUtils.convertValueToType(row[columnIndex], columnDataTypes[columnIndex]);
       }
       rowsInSelectionResults.addFirst(extractedRow);
     }
 
-    // final data schema in ResultTable should be created based on order in _selectionColumns
-    DataSchema finalDataSchema = SelectionOperatorUtils.getResultTableDataSchema(_dataSchema, _selectionColumns);
-    return new ResultTable(finalDataSchema, rowsInSelectionResults);
+    // Construct the result data schema
+    String[] columnNames = _dataSchema.getColumnNames();
+    String[] resultColumnNames = new String[numColumns];
+    DataSchema.ColumnDataType[] resultColumnDataTypes = new DataSchema.ColumnDataType[numColumns];
+    for (int i = 0; i < numColumns; i++) {
+      int columnIndex = columnIndices[i];
+      resultColumnNames[i] = columnNames[columnIndex];
+      resultColumnDataTypes[i] = columnDataTypes[columnIndex];
+    }
+    DataSchema resultDataSchema = new DataSchema(resultColumnNames, resultColumnDataTypes);
+    return new ResultTable(resultDataSchema, rowsInSelectionResults);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
@@ -18,11 +18,10 @@
  */
 package org.apache.pinot.queries;
 
-import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
+import java.util.PriorityQueue;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -103,9 +102,9 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    List<Serializable[]> selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
+    List<Object[]> selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
-    Serializable[] firstRow = selectionResult.get(0);
+    Object[] firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 10);
     Assert.assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 890282370);
     Assert.assertEquals(firstRow[columnIndexMap.get("column6")], new int[]{2147483647});
@@ -128,7 +127,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
+    selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 10);
@@ -158,9 +157,9 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    List<Serializable[]> selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
+    List<Object[]> selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
-    Serializable[] firstRow = selectionResult.get(0);
+    Object[] firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 3);
     Assert.assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 890282370);
     Assert.assertEquals(firstRow[columnIndexMap.get("column6")], new int[]{2147483647});
@@ -183,7 +182,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
+    selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 3);
@@ -213,9 +212,9 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    Queue<Serializable[]> selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
+    PriorityQueue<Object[]> selectionResult = (PriorityQueue<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
-    Serializable[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.peek();
     Assert.assertEquals(lastRow.length, 4);
     Assert.assertEquals((String) lastRow[columnIndexMap.get("column5")], "AKXcXcIqsqOJFsdwxZ");
     Assert.assertEquals(lastRow[columnIndexMap.get("column6")], new int[]{1252});
@@ -238,7 +237,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
+    selectionResult = (PriorityQueue<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     lastRow = selectionResult.peek();
     Assert.assertEquals(lastRow.length, 4);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
@@ -18,11 +18,10 @@
  */
 package org.apache.pinot.queries;
 
-import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
+import java.util.PriorityQueue;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -103,9 +102,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
         DataSchema.ColumnDataType.STRING);
-    List<Serializable[]> selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
+    List<Object[]> selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
-    Serializable[] firstRow = selectionResult.get(0);
+    Object[] firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 11);
     Assert.assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 1578964907);
     Assert.assertEquals((String) firstRow[columnIndexMap.get("column11")], "P");
@@ -128,7 +127,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
         DataSchema.ColumnDataType.STRING);
-    selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
+    selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 11);
@@ -158,9 +157,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
         DataSchema.ColumnDataType.STRING);
-    List<Serializable[]> selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
+    List<Object[]> selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
-    Serializable[] firstRow = selectionResult.get(0);
+    Object[] firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 3);
     Assert.assertEquals(((Integer) firstRow[0]).intValue(), 1578964907);
     Assert.assertEquals((String) firstRow[2], "P");
@@ -182,7 +181,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
         DataSchema.ColumnDataType.STRING);
-    selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
+    selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 3);
@@ -212,9 +211,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")),
         DataSchema.ColumnDataType.INT);
-    Queue<Serializable[]> selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
+    PriorityQueue<Object[]> selectionResult = (PriorityQueue<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
-    Serializable[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.peek();
     Assert.assertEquals(lastRow.length, 4);
     Assert.assertEquals(((Integer) lastRow[columnIndexMap.get("column6")]).intValue(), 6043515);
     Assert.assertEquals(((Integer) lastRow[columnIndexMap.get("column1")]).intValue(), 10542595);
@@ -237,7 +236,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")),
         DataSchema.ColumnDataType.INT);
-    selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
+    selectionResult = (PriorityQueue<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     lastRow = selectionResult.peek();
     Assert.assertEquals(lastRow.length, 4);
@@ -268,9 +267,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")),
         DataSchema.ColumnDataType.INT);
-    Queue<Serializable[]> selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
+    PriorityQueue<Object[]> selectionResult = (PriorityQueue<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
-    Serializable[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.peek();
     Assert.assertEquals(lastRow.length, 11);
     Assert.assertEquals(((Integer) lastRow[columnIndexMap.get("column6")]).intValue(), 6043515);
     Assert.assertEquals(((Integer) lastRow[columnIndexMap.get("column1")]).intValue(), 10542595);
@@ -294,7 +293,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
         DataSchema.ColumnDataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")),
         DataSchema.ColumnDataType.INT);
-    selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
+    selectionResult = (PriorityQueue<Object[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     lastRow = selectionResult.peek();
     Assert.assertEquals(lastRow.length, 11);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/RangePredicateWithSortedInvertedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/RangePredicateWithSortedInvertedIndexTest.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.queries;
 
 import java.io.File;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -37,7 +36,6 @@ import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -209,14 +207,14 @@ public class RangePredicateWithSortedInvertedIndexTest extends BaseQueriesTest {
   private void runQuery(String query, int count, List<Pairs.IntPair> intPairs, int numColumns) {
     SelectionOnlyOperator operator = getOperatorForQuery(query);
     IntermediateResultsBlock block = operator.nextBlock();
-    Collection<Serializable[]> rows = block.getSelectionResult();
+    Collection<Object[]> rows = block.getSelectionResult();
     Assert.assertNotNull(rows);
     Assert.assertEquals(rows.size(), count);
     if (count > 0) {
       Pairs.IntPair pair = intPairs.get(0);
       int startPos = pair.getLeft();
       int pairPos = 0;
-      for (Serializable[] row : rows) {
+      for (Object[] row : rows) {
         Assert.assertEquals(numColumns, row.length);
         Assert.assertEquals(row[0], stringValues[startPos]);
         Assert.assertEquals(row[1], startPos);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -1067,7 +1067,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
       throws Exception {
     SelectionOnlyOperator operator = getOperatorForQuery(query);
     IntermediateResultsBlock operatorResult = operator.nextBlock();
-    List<Serializable[]> resultset = (List<Serializable[]>) operatorResult.getSelectionResult();
+    List<Object[]> resultset = (List<Object[]>) operatorResult.getSelectionResult();
     Assert.assertNotNull(resultset);
     Assert.assertEquals(resultset.size(), expectedResultSize);
     if (compareGrepOutput) {
@@ -1076,8 +1076,8 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
     } else if (expectedResults != null) {
       // compare with expected result table
       for (int i = 0; i < expectedResultSize; i++) {
-        Serializable[] actualRow = resultset.get(i);
-        Serializable[] expectedRow = expectedResults.get(i);
+        Object[] actualRow = resultset.get(i);
+        Object[] expectedRow = expectedResults.get(i);
         Assert.assertEquals(actualRow.length, expectedRow.length);
         for (int j = 0; j < actualRow.length; j++) {
           Object actualColValue = actualRow[j];
@@ -1088,7 +1088,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
     }
   }
 
-  private void verifySearchOutputWithGrepResults(List<Serializable[]> actualResultSet)
+  private void verifySearchOutputWithGrepResults(List<Object[]> actualResultSet)
       throws Exception {
     URL resourceUrl = getClass().getClassLoader().getResource("data/text_search_data/group_by_grep_results.out");
     File file = new File(resourceUrl.getFile());
@@ -1098,7 +1098,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
     int counter = 0;
     while ((line = reader.readLine()) != null) {
       String[] expectedRow = line.split(":");
-      Serializable[] actualRow = actualResultSet.get(counter);
+      Object[] actualRow = actualResultSet.get(counter);
       int expectedIntColValue = Integer.valueOf(expectedRow[0]) + INT_BASE_VALUE - 1;
       Assert.assertEquals(expectedIntColValue, actualRow[0]);
       Assert.assertEquals(expectedRow[1], actualRow[1]);


### PR DESCRIPTION
In order to support order-by on BYTES column everywhere, inside the system we should always use ByteArray (comparable) to store the BYTES value.
Currently BYTES value are stored as byte[], ByteArray or String in different places, which is very confusing and could cause casting errors.

Changes:
- For DisctinctCount, fix the casting issue when ordering on BYTES column
- For selection order-by, order BYTES column using ByteArray instead of String for performance improvement
- Inside Record, always store BYTES as ByteArray for clarity and also performance improvement (avoid expensive deepEquals and deepHashCode)
- On broker side, store BYTES column using ByteArray instead of String for performance improvement
- On broker side, support type compatible merges for all selection queries

No format change on the query results.
TODO: We are still returning String for BYTES column when preserving the type. Consider changing it to byte[].