### PR TITLE
Fix Pinot website build script for local dev and build

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -35,6 +35,9 @@
     "svg.js": "^2.6.2",
     "yarn": "^1.22.4"
   },
+  "resolutions": {
+    "**/sharp": "^0.25.2"
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
Update package.json to resolve  `sharp` version to `^0.25.2` to fix the local build issue.
