### PR TITLE
fixing spark ingestion issue

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationUtils.java
@@ -16,23 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pinot.plugin.ingestion.batch.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.pinot.spi.config.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.utils.JsonUtils;
-
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 
 public class SegmentGenerationUtils {
 
@@ -146,5 +147,20 @@ public class SegmentGenerationUtils {
     outputDir = !outputDirStr.endsWith("/") ? URI.create(outputDirStr.concat("/")) : outputDir;
     URI relativeOutputURI = outputDir.resolve(relativePath).resolve(".");
     return relativeOutputURI;
+  }
+
+  /**
+   * Extract file name from a given URI.
+   *
+   * @param inputFileURI
+   * @return
+   */
+  public static String getFileName(URI inputFileURI) {
+    String scheme = inputFileURI.getScheme();
+    if (scheme != null && scheme.equalsIgnoreCase("file")) {
+      return new File(inputFileURI).getName();
+    }
+    String[] pathSplits = inputFileURI.getPath().split("/");
+    return pathSplits[pathSplits.length - 1];
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationUtils.java
@@ -22,18 +22,18 @@ package org.apache.pinot.plugin.ingestion.batch.common;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
-import org.apache.commons.io.IOUtils;
-import org.apache.pinot.spi.config.TableConfig;
-import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.filesystem.PinotFS;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
-import org.apache.pinot.spi.utils.JsonUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.apache.pinot.spi.config.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 public class SegmentGenerationUtils {
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationUtils.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.pinot.plugin.ingestion.batch.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,6 +33,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.utils.JsonUtils;
+
 
 public class SegmentGenerationUtils {
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/TestSegmentGenerationUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/TestSegmentGenerationUtils.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.plugin.ingestion.batch.common;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.net.URI;
+
+public class TestSegmentGenerationUtils {
+
+  @Test
+  public void testExtractFileNameFromURI() {
+    Assert.assertEquals(SegmentGenerationUtils.getFileName(URI.create("file:/var/data/myTable/2020/04/06/input.data")),
+        "input.data");
+    Assert.assertEquals(SegmentGenerationUtils.getFileName(URI.create("/var/data/myTable/2020/04/06/input.data")),
+        "input.data");
+    Assert.assertEquals(SegmentGenerationUtils
+            .getFileName(URI.create("dbfs:/mnt/mydb/mytable/pt_year=2020/pt_month=4/pt_date=2020-04-01/input.data")),
+        "input.data");
+    Assert.assertEquals(SegmentGenerationUtils.getFileName(URI.create("hdfs://var/data/myTable/2020/04/06/input.data")),
+        "input.data");
+  }
+}

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -42,6 +42,7 @@ import org.yaml.snakeyaml.Yaml;
 
 import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_DIR;
 import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
+import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.getFileName;
 import static org.apache.pinot.plugin.ingestion.batch.hadoop.HadoopSegmentGenerationJobRunner.SEGMENT_GENERATION_JOB_SPEC;
 import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_DIR_PROPERTY_NAME;
 import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
@@ -124,7 +125,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
       FileUtils.forceMkdir(localOutputTempDir);
 
       //copy input path to local
-      File localInputDataFile = new File(localInputTempDir, new File(inputFileURI).getName());
+      File localInputDataFile = new File(localInputTempDir, getFileName(inputFileURI));
       PinotFSFactory.create(inputFileURI.getScheme()).copyToLocalFile(inputFileURI, localInputDataFile);
 
       //create task spec

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -19,6 +19,16 @@
 
 package org.apache.pinot.plugin.ingestion.batch.spark;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -40,16 +50,6 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.net.URI;
-import java.nio.file.FileSystems;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_DIR;
 import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -16,18 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pinot.plugin.ingestion.batch.spark;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.net.URI;
-import java.nio.file.FileSystems;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -49,12 +40,22 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_DIR;
 import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
+import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.getFileName;
 import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_DIR_PROPERTY_NAME;
 import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
-
 
 public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Serializable {
 
@@ -203,13 +204,20 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       }
       JavaRDD<String> pathRDD = sparkContext.parallelize(pathAndIdxList, pathAndIdxList.size());
 
+      final String pluginsInclude =
+          (sparkContext.getConf().contains(PLUGINS_INCLUDE_PROPERTY_NAME)) ? sparkContext.getConf()
+              .get(PLUGINS_INCLUDE_PROPERTY_NAME) : null;
       final URI finalInputDirURI = inputDirURI;
       final URI finalOutputDirURI = (stagingDirURI == null) ? outputDirURI : stagingDirURI;
       pathRDD.foreach(pathAndIdx -> {
+        for (PinotFSSpec pinotFSSpec : _spec.getPinotFSSpecs()) {
+          Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
+          PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+        }
+        PinotFS finalOutputDirFS = PinotFSFactory.create(finalOutputDirURI.getScheme());
         String[] splits = pathAndIdx.split(" ");
         String path = splits[0];
         int idx = Integer.valueOf(splits[1]);
-
         // Load Pinot Plugins copied from Distributed cache.
         File localPluginsTarFile = new File(PINOT_PLUGINS_TAR_GZ);
         if (localPluginsTarFile.exists()) {
@@ -223,11 +231,9 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           LOGGER.info("Trying to set System Property: [{}={}]", PLUGINS_DIR_PROPERTY_NAME,
               pluginsDirFile.getAbsolutePath());
           System.setProperty(PLUGINS_DIR_PROPERTY_NAME, pluginsDirFile.getAbsolutePath());
-
-          final String pluginsIncludes = sparkContext.getConf().get(PLUGINS_INCLUDE_PROPERTY_NAME);
-          if (pluginsIncludes != null) {
-            LOGGER.info("Trying to set System Property: [{}={}]", PLUGINS_INCLUDE_PROPERTY_NAME, pluginsIncludes);
-            System.setProperty(PLUGINS_INCLUDE_PROPERTY_NAME, pluginsIncludes);
+          if (pluginsInclude != null) {
+            LOGGER.info("Trying to set System Property: [{}={}]", PLUGINS_INCLUDE_PROPERTY_NAME, pluginsInclude);
+            System.setProperty(PLUGINS_INCLUDE_PROPERTY_NAME, pluginsInclude);
           }
           LOGGER.info("Pinot plugins System Properties are set at [{}], plugins includes [{}]",
               System.getProperty(PLUGINS_DIR_PROPERTY_NAME), System.getProperty(PLUGINS_INCLUDE_PROPERTY_NAME));
@@ -248,7 +254,8 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         FileUtils.forceMkdir(localOutputTempDir);
 
         //copy input path to local
-        File localInputDataFile = new File(localInputTempDir, new File(inputFileURI).getName());
+        File localInputDataFile = new File(localInputTempDir, getFileName(inputFileURI));
+        LOGGER.info("Trying to copy input file from {} to {}", inputFileURI, localInputDataFile);
         PinotFSFactory.create(inputFileURI.getScheme()).copyToLocalFile(inputFileURI, localInputDataFile);
 
         //create task spec
@@ -282,9 +289,10 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         LOGGER.info("Trying to move segment tar file from: [{}] to [{}]", localSegmentTarFile, outputSegmentTarURI);
         if (!_spec.isOverwriteOutput() && PinotFSFactory.create(outputSegmentTarURI.getScheme())
             .exists(outputSegmentTarURI)) {
-          LOGGER.warn("Not overwrite existing output segment tar file: {}", outputDirFS.exists(outputSegmentTarURI));
+          LOGGER
+              .warn("Not overwrite existing output segment tar file: {}", finalOutputDirFS.exists(outputSegmentTarURI));
         } else {
-          outputDirFS.copyFromLocalFile(localSegmentTarFile, outputSegmentTarURI);
+          finalOutputDirFS.copyFromLocalFile(localSegmentTarFile, outputSegmentTarURI);
         }
         FileUtils.deleteQuietly(localSegmentDir);
         FileUtils.deleteQuietly(localSegmentTarFile);
@@ -325,6 +333,10 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
 
   protected void packPluginsToDistributedCache(JavaSparkContext sparkContext) {
     String pluginsRootDir = PluginManager.get().getPluginsRootDir();
+    if (pluginsRootDir == null) {
+      LOGGER.warn("Local Pinot plugins directory is null, skip packaging...");
+      return;
+    }
     if (new File(pluginsRootDir).exists()) {
       File pluginsTarGzFile = new File(PINOT_PLUGINS_TAR_GZ);
       try {

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.pinot.plugin.ingestion.batch.spark;
 
 import java.io.File;
@@ -56,6 +55,7 @@ import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUt
 import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.getFileName;
 import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_DIR_PROPERTY_NAME;
 import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
+
 
 public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Serializable {
 

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -172,7 +172,7 @@ public class HadoopPinotFS extends PinotFS {
       LOGGER.debug("copied {} from hdfs to {} in local for size {}, take {} ms", srcUri, dstFilePath, dstFile.length(),
           System.currentTimeMillis() - startMs);
     } catch (IOException e) {
-      LOGGER.warn("failed to fetch segment {} from hdfs, might retry", srcUri, e);
+      LOGGER.warn("failed to fetch segment {} from hdfs to {}, might retry", srcUri, dstFile, e);
       throw e;
     }
   }

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/sparkIngestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/sparkIngestionJobSpec.yaml
@@ -80,7 +80,9 @@ pinotFSSpecs:
     #   org.apache.pinot.spi.filesystem.LocalPinotFS is used for local filesystem
     #   org.apache.pinot.plugin.filesystem.AzurePinotFS is used for Azure Data Lake
     #   org.apache.pinot.plugin.filesystem.HadoopPinotFS is used for HDFS
-    className: org.apache.pinot.spi.filesystem.LocalPinotFS
+    className: org.apache.pinot.plugin.filesystem.HadoopPinotFS
+    configs:
+      'hadoop.conf.path': ''
 
 # recordReaderSpec: defines all record reader
 recordReaderSpec:

--- a/pinot-tools/src/main/resources/examples/batch/baseballStats/sparkIngestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/baseballStats/sparkIngestionJobSpec.yaml
@@ -76,7 +76,9 @@ pinotFSSpecs:
     #   org.apache.pinot.spi.filesystem.LocalPinotFS is used for local filesystem
     #   org.apache.pinot.plugin.filesystem.AzurePinotFS is used for Azure Data Lake
     #   org.apache.pinot.plugin.filesystem.HadoopPinotFS is used for HDFS
-    className: org.apache.pinot.spi.filesystem.LocalPinotFS
+    className: org.apache.pinot.plugin.filesystem.HadoopPinotFS
+    configs:
+      'hadoop.conf.path': ''
 
 # recordReaderSpec: defines all record reader
 recordReaderSpec:


### PR DESCRIPTION
- Object Serialization problem: sparkContext, pinotFs cannot be passing into the lambda function.
- Rewrite getFileName method for URI, new File(uri) only supports `file` scheme
- Don't always ask for plugins directory for spark function, as they are usually given by the classpath already.
- Update example spark ingestion spec to use hdfs