### PR TITLE
Add tests for VALUEIN

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/request/PqlAndCalciteSqlCompatibilityTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/request/PqlAndCalciteSqlCompatibilityTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.request.FilterQueryMap;
 import org.apache.pinot.common.request.GroupBy;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.Selection;
+import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.parsers.utils.BrokerRequestComparisonUtils;
 import org.apache.pinot.pql.parsers.PinotQuery2BrokerRequestConverter;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
@@ -147,5 +148,54 @@ public class PqlAndCalciteSqlCompatibilityTest {
         throw e;
       }
     }
+  }
+
+  @Test
+  public void testPqlSqlOrderByCompatibility() {
+    String pql = "SELECT count(*) FROM Foo GROUP BY VALUEIN(mv_col, 10790, 16344) TOP 10";
+    String sql = "SELECT VALUEIN(mv_col, 10790, 16344), count(*) FROM Foo GROUP BY VALUEIN(mv_col, 10790, 16344) ORDER BY count(*) LIMIT 10";
+    testPqlSqlOrderByCompatibilityHelper(pql, sql, "count(*)");
+
+    pql = "SELECT sum(col1) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') TOP 10";
+    sql = "SELECT TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS'), sum(col1) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') ORDER BY sum(col1) LIMIT 10";
+    testPqlSqlOrderByCompatibilityHelper(pql, sql, "sum(col1)");
+
+    pql = "SELECT max(add(col1,col2)) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') TOP 10";
+    sql = "SELECT DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES'), max(add(col1,col2)) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') ORDER BY max(add(col1,col2)) LIMIT 10";
+    testPqlSqlOrderByCompatibilityHelper(pql, sql, "max(add(col1,col2))");
+
+    pql = "SELECT max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS')";
+    sql = "SELECT TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS'), max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') ORDER BY max(div(col1,col2)) LIMIT 10";
+    testPqlSqlOrderByCompatibilityHelper(pql, sql, "max(div(col1,col2))");
+
+    pql = "SELECT count(*) FROM Foo GROUP BY VALUEIN(time, 10790, 16344) TOP 10";
+    sql = "SELECT VALUEIN(\"time\", 10790, 16344), count(*) FROM Foo GROUP BY VALUEIN(\"time\", 10790, 16344) ORDER BY count(*) LIMIT 10";
+    testPqlSqlOrderByCompatibilityHelper(pql, sql, "count(*)");
+
+    pql = "SELECT count(*) FROM Foo GROUP BY TIMECONVERT(time, 'MILLISECONDS', 'SECONDS') TOP 10";
+    sql = "SELECT TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS'), count(*) FROM Foo GROUP BY TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS') ORDER BY count(*) LIMIT 10";
+    testPqlSqlOrderByCompatibilityHelper(pql, sql, "count(*)");
+
+    pql = "SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT(time, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') TOP 10";
+    sql = "SELECT DATETIMECONVERT(\"time\", '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES'), count(*) FROM Foo GROUP BY DATETIMECONVERT(\"time\", '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') ORDER BY count(*) LIMIT 10";
+    testPqlSqlOrderByCompatibilityHelper(pql, sql, "count(*)");
+
+    pql = "SELECT max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(time, 'MILLISECONDS', 'SECONDS') TOP 10";
+    sql = "SELECT TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS'), max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS') ORDER BY max(div(col1,col2)) LIMIT 10";
+    testPqlSqlOrderByCompatibilityHelper(pql, sql, "max(div(col1,col2))");
+  }
+
+  private void testPqlSqlOrderByCompatibilityHelper(String pql, String sql, String orderByColumn) {
+    final BrokerRequest brokerRequestFromPQL = OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(pql), null);
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    final BrokerRequest brokerRequestFromSQL =
+        OPTIMIZER.optimize(new PinotQuery2BrokerRequestConverter().convert(pinotQuery), null);
+    Assert.assertTrue(BrokerRequestComparisonUtils.validate(brokerRequestFromPQL, brokerRequestFromSQL, /*ignoreOrderBy*/true));
+    // validate ORDER BY here since brokerRequest from PQL will have order by as NULL and
+    // brokerRequest from SQL will have valid ORDER BY
+    List<SelectionSort> orderBy = brokerRequestFromSQL.getOrderBy();
+    Assert.assertEquals(orderBy.size(), 1);
+    SelectionSort sort = orderBy.get(0);
+    Assert.assertEquals(sort.getColumn(), orderByColumn);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/parsers/utils/BrokerRequestComparisonUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/parsers/utils/BrokerRequestComparisonUtils.java
@@ -35,6 +35,10 @@ public class BrokerRequestComparisonUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(BrokerRequestComparisonUtils.class);
 
   public static boolean validate(BrokerRequest br1, BrokerRequest br2) {
+    return validate(br1, br2, false);
+  }
+
+  public static boolean validate(BrokerRequest br1, BrokerRequest br2, boolean ignoreOrderBy) {
     boolean result = br1.equals(br2);
     if (!result) {
       StringBuilder sb = new StringBuilder();
@@ -101,17 +105,19 @@ public class BrokerRequestComparisonUtils {
             br2.getAggregationsInfo());
         return false;
       }
-      if (br1.getOrderBy() != null) {
-        if (!validateOrderBys(br1.getOrderBy(), br2.getOrderBy())) {
-          sb.append("br1.getOrderBy() = ").append(br1.getOrderBy()).append("\n").append("br2.getOrderBy() = ")
-              .append(br2.getOrderBy());
-          LOGGER.error("Order By did not match conversion:{}", sb);
+      if (!ignoreOrderBy) {
+        if (br1.getOrderBy() != null) {
+          if (!validateOrderBys(br1.getOrderBy(), br2.getOrderBy())) {
+            sb.append("br1.getOrderBy() = ").append(br1.getOrderBy()).append("\n").append("br2.getOrderBy() = ")
+                .append(br2.getOrderBy());
+            LOGGER.error("Order By did not match conversion:{}", sb);
+            return false;
+          }
+        } else if (br2.getOrderBy() != null) {
+          LOGGER.error("OrderBy did not match, br1.getOrderBy() = null, br2.getOrderBy() = {}",
+              br2.getOrderBy());
           return false;
         }
-      } else if (br2.getOrderBy() != null) {
-        LOGGER.error("OrderBy did not match, br1.getOrderBy() = null, br2.getOrderBy() = {}",
-            br2.getOrderBy());
-        return false;
       }
     }
     return true;

--- a/pinot-common/src/test/resources/pql_queries.list
+++ b/pinot-common/src/test/resources/pql_queries.list
@@ -817,14 +817,6 @@ select COUNT(*) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKeys(mapField) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKey(mapField,k1) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'
-SELECT count(*) FROM Foo GROUP BY VALUEIN(mv_col, 10790, 16344) LIMIT 10
-SELECT count(*) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') LIMIT 10
-SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') LIMIT 10
-SELECT MAX(DIV(col1, col2)) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS')
-SELECT count(*) FROM Foo GROUP BY VALUEIN(time, 10790, 16344) LIMIT 10
-SELECT count(*) FROM Foo GROUP BY TIMECONVERT(time, 'MILLISECONDS', 'SECONDS') LIMIT 10
-SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT(time, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') LIMIT 10
-SELECT MAX(DIV(col1, col2)) FROM Foo GROUP BY TIMECONVERT(time, 'MILLISECONDS', 'SECONDS')
 SELECT count(c1), sum(c1), min(c1), max(c1), avg(c1), minmaxrange(c1), distinctcount(c1), distinctcounthll(c1) FROM foo
 SELECT distinctcountrawhll(c1), fasthll(c1), percentile(c1), percentileest(c1), percentiletdigest(c1) FROM foo
 SELECT countmv(c1), summv(c1), minmv(c1), maxmv(c1), avgmv(c1), minmaxrangemv(c1), distinctcountmv(c1), distinctcounthllmv(c1) FROM foo

--- a/pinot-common/src/test/resources/pql_queries.list
+++ b/pinot-common/src/test/resources/pql_queries.list
@@ -817,3 +817,19 @@ select COUNT(*) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKeys(mapField) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKey(mapField,k1) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'
+SELECT count(*) FROM Foo GROUP BY VALUEIN(mv_col, 10790, 16344) LIMIT 10
+SELECT count(*) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') LIMIT 10
+SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') LIMIT 10
+SELECT MAX(DIV(col1, col2)) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS')
+SELECT count(*) FROM Foo GROUP BY VALUEIN(time, 10790, 16344) LIMIT 10
+SELECT count(*) FROM Foo GROUP BY TIMECONVERT(time, 'MILLISECONDS', 'SECONDS') LIMIT 10
+SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT(time, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') LIMIT 10
+SELECT MAX(DIV(col1, col2)) FROM Foo GROUP BY TIMECONVERT(time, 'MILLISECONDS', 'SECONDS')
+SELECT count(c1), sum(c1), min(c1), max(c1), avg(c1), minmaxrange(c1), distinctcount(c1), distinctcounthll(c1) FROM foo
+SELECT distinctcountrawhll(c1), fasthll(c1), percentile(c1), percentileest(c1), percentiletdigest(c1) FROM foo
+SELECT countmv(c1), summv(c1), minmv(c1), maxmv(c1), avgmv(c1), minmaxrangemv(c1), distinctcountmv(c1), distinctcounthllmv(c1) FROM foo
+SELECT distinctcountrawhllmv(c1), fasthllmv(c1), percentilemv(c1), percentileestmv(c1), percentiletdigestmv(c1) FROM foo
+SELECT count(c1), sum(add(c1,c2)), min(div(c1,c2)), max(sub(c1,c2)), avg(add(c1,c2)), minmaxrange(add(c1,c2)), distinctcount(sub(c1,c2)), distinctcounthll(c1) FROM foo
+SELECT distinctcountrawhll(sub(c1,c2)), fasthll(div(c1,c2)), percentile(sub(c1,c2)), percentileest(add(c1,c2)), percentiletdigest(add(c1,c2)) FROM foo
+SELECT countmv(c1), summv(add(c1,c2)), minmv(div(c1,c2)), maxmv(sub(c1,c2)), avgmv(add(c1,c2)), minmaxrangemv(min(c1,c2)), distinctcountmv(add(c1,c2)), distinctcounthllmv(min(c1,c2)) FROM foo
+SELECT distinctcountrawhllmv(c1), fasthllmv(add(sub(c1,c2),div(c1,c2))), percentilemv(min(c1,c2)), percentileestmv(add(c1,c2)), percentiletdigestmv(min(c1,c2)) FROM foo

--- a/pinot-common/src/test/resources/sql_queries.list
+++ b/pinot-common/src/test/resources/sql_queries.list
@@ -817,14 +817,6 @@ select COUNT(*) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKeys(mapField) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKey(mapField,k1) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'
-SELECT count(*) FROM Foo GROUP BY VALUEIN(mv_col, 10790, 16344) LIMIT 10
-SELECT count(*) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') LIMIT 10
-SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') LIMIT 10
-SELECT MAX(DIV(col1, col2)) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS')
-SELECT count(*) FROM Foo GROUP BY VALUEIN("time", 10790, 16344) LIMIT 10
-SELECT count(*) FROM Foo GROUP BY TIMECONVERT("time", 'MILLISECONDS', 'SECONDS') LIMIT 10
-SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT("time", '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') LIMIT 10
-SELECT MAX(DIV(col1, col2)) FROM Foo GROUP BY TIMECONVERT("time", 'MILLISECONDS', 'SECONDS')
 SELECT count(c1), sum(c1), min(c1), max(c1), avg(c1), minmaxrange(c1), distinctcount(c1), distinctcounthll(c1) FROM foo
 SELECT distinctcountrawhll(c1), fasthll(c1), percentile(c1), percentileest(c1), percentiletdigest(c1) FROM foo
 SELECT countmv(c1), summv(c1), minmv(c1), maxmv(c1), avgmv(c1), minmaxrangemv(c1), distinctcountmv(c1), distinctcounthllmv(c1) FROM foo

--- a/pinot-common/src/test/resources/sql_queries.list
+++ b/pinot-common/src/test/resources/sql_queries.list
@@ -817,3 +817,19 @@ select COUNT(*) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKeys(mapField) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKey(mapField,k1) from baseballStats where DIV(numberOfGames,10) = 100
 select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'
+SELECT count(*) FROM Foo GROUP BY VALUEIN(mv_col, 10790, 16344) LIMIT 10
+SELECT count(*) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') LIMIT 10
+SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') LIMIT 10
+SELECT MAX(DIV(col1, col2)) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS')
+SELECT count(*) FROM Foo GROUP BY VALUEIN("time", 10790, 16344) LIMIT 10
+SELECT count(*) FROM Foo GROUP BY TIMECONVERT("time", 'MILLISECONDS', 'SECONDS') LIMIT 10
+SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT("time", '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') LIMIT 10
+SELECT MAX(DIV(col1, col2)) FROM Foo GROUP BY TIMECONVERT("time", 'MILLISECONDS', 'SECONDS')
+SELECT count(c1), sum(c1), min(c1), max(c1), avg(c1), minmaxrange(c1), distinctcount(c1), distinctcounthll(c1) FROM foo
+SELECT distinctcountrawhll(c1), fasthll(c1), percentile(c1), percentileest(c1), percentiletdigest(c1) FROM foo
+SELECT countmv(c1), summv(c1), minmv(c1), maxmv(c1), avgmv(c1), minmaxrangemv(c1), distinctcountmv(c1), distinctcounthllmv(c1) FROM foo
+SELECT distinctcountrawhllmv(c1), fasthllmv(c1), percentilemv(c1), percentileestmv(c1), percentiletdigestmv(c1) FROM foo
+SELECT count(c1), sum(add(c1,c2)), min(div(c1,c2)), max(sub(c1,c2)), avg(add(c1,c2)), minmaxrange(add(c1,c2)), distinctcount(sub(c1,c2)), distinctcounthll(c1) FROM foo
+SELECT distinctcountrawhll(sub(c1,c2)), fasthll(div(c1,c2)), percentile(sub(c1,c2)), percentileest(add(c1,c2)), percentiletdigest(add(c1,c2)) FROM foo
+SELECT countmv(c1), summv(add(c1,c2)), minmv(div(c1,c2)), maxmv(sub(c1,c2)), avgmv(add(c1,c2)), minmaxrangemv(min(c1,c2)), distinctcountmv(add(c1,c2)), distinctcounthllmv(min(c1,c2)) FROM foo
+SELECT distinctcountrawhllmv(c1), fasthllmv(add(sub(c1,c2),div(c1,c2))), percentilemv(min(c1,c2)), percentileestmv(add(c1,c2)), percentiletdigestmv(min(c1,c2)) FROM foo

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.queries;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.utils.DataSchema;
@@ -28,6 +30,7 @@ import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.collections.Lists;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -57,6 +60,44 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY);
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"199896"});
+
+    query = "SELECT VALUEIN(column7, 363, 469, 246, 100000), COUNTMV(column6) FROM testTable GROUP BY VALUEIN(column7, 363, 469, 246, 100000)";
+    brokerResponse = getBrokerResponseForPqlQuery(query);
+    List<String[]> groupKeys = new ArrayList<>();
+    groupKeys.add(new String[]{"363"});
+    groupKeys.add(new String[]{"469"});
+    groupKeys.add(new String[]{"246"});
+    List<String[]> aggregations = new ArrayList<>();
+    aggregations.add(new String[]{"35436"});
+    aggregations.add(new String[]{"33576"});
+    aggregations.add(new String[]{"24300"});
+    QueriesTestUtils
+        .testInterSegmentAggregationGroupByResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
+            groupKeys, aggregations);
+
+    query = "SELECT VALUEIN(column7, 363, 469, 246, 100000), COUNTMV(column6) FROM testTable GROUP BY VALUEIN(column7, 363, 469, 246, 100000)";
+    brokerResponse = getBrokerResponseForSqlQuery(query);
+    DataSchema expectedDataSchema =
+        new DataSchema(new String[]{"valuein(column7,'363','469','246','100000')", "countmv(column6)"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG});
+    QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L,
+        Lists.newArrayList(new Object[]{469, (long)33576}, new Object[]{246, (long)24300}, new Object[]{363, (long)35436}), 3, expectedDataSchema);
+
+    query = "SELECT VALUEIN(column7, 363, 469, 246, 100000), COUNTMV(column6) FROM testTable GROUP BY VALUEIN(column7, 363, 469, 246, 100000) ORDER BY COUNTMV(column6)";
+    brokerResponse = getBrokerResponseForSqlQuery(query);
+    QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L,
+        Lists.newArrayList(new Object[]{246, (long)24300}, new Object[]{469, (long)33576}, new Object[]{363, (long)35436}), 3, expectedDataSchema);
+
+    query = "SELECT VALUEIN(column7, 363, 469, 246, 100000), COUNTMV(column6) FROM testTable GROUP BY VALUEIN(column7, 363, 469, 246, 100000) ORDER BY COUNTMV(column6) DESC";
+    brokerResponse = getBrokerResponseForSqlQuery(query);
+    QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L,
+        Lists.newArrayList(new Object[]{363, (long)35436}, new Object[]{469, (long)33576}, new Object[]{246, (long)24300}), 3, expectedDataSchema);
+
+    query = "SELECT VALUEIN(column7, 363, 469, 246, 100000) AS value_in_col, COUNTMV(column6) FROM testTable GROUP BY value_in_col ORDER BY COUNTMV(column6) DESC";
+    expectedDataSchema =
+        new DataSchema(new String[]{"value_in_col", "countmv(column6)"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG});
+    brokerResponse = getBrokerResponseForSqlQuery(query);
+    QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L,
+        Lists.newArrayList(new Object[]{363, (long)35436}, new Object[]{469, (long)33576}, new Object[]{246, (long)24300}), 3, expectedDataSchema);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
@@ -61,7 +61,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     QueriesTestUtils
         .testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L, new String[]{"199896"});
 
-    query = "SELECT VALUEIN(column7, 363, 469, 246, 100000), COUNTMV(column6) FROM testTable GROUP BY VALUEIN(column7, 363, 469, 246, 100000)";
+    query = "SELECT COUNTMV(column6) FROM testTable GROUP BY VALUEIN(column7, 363, 469, 246, 100000)";
     brokerResponse = getBrokerResponseForPqlQuery(query);
     List<String[]> groupKeys = new ArrayList<>();
     groupKeys.add(new String[]{"363"});
@@ -98,6 +98,44 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     brokerResponse = getBrokerResponseForSqlQuery(query);
     QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L,
         Lists.newArrayList(new Object[]{363, (long)35436}, new Object[]{469, (long)33576}, new Object[]{246, (long)24300}), 3, expectedDataSchema);
+
+    query = "SELECT COUNTMV(column6) FROM testTable GROUP BY daysSinceEpoch";
+    brokerResponse = getBrokerResponseForPqlQuery(query);
+    groupKeys = new ArrayList<>();
+    groupKeys.add(new String[]{"1756015683"});
+    aggregations = new ArrayList<>();
+    aggregations.add(new String[]{"426752"});
+    QueriesTestUtils
+        .testInterSegmentAggregationGroupByResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
+            groupKeys, aggregations);
+
+    query = "SELECT daysSinceEpoch, COUNTMV(column6) FROM testTable GROUP BY daysSinceEpoch ORDER BY COUNTMV(column6) DESC";
+    expectedDataSchema =
+        new DataSchema(new String[]{"daysSinceEpoch", "countmv(column6)"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG});
+    brokerResponse = getBrokerResponseForSqlQuery(query);
+    List<Object[]> result = new ArrayList<>();
+    result.add(new Object[]{1756015683, (long)426752});
+    QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L,
+        result, 1, expectedDataSchema);
+
+    query = "SELECT COUNTMV(column6) FROM testTable GROUP BY timeconvert(daysSinceEpoch, 'DAYS', 'HOURS')";
+    brokerResponse = getBrokerResponseForPqlQuery(query);
+    groupKeys = new ArrayList<>();
+    groupKeys.add(new String[]{"42144376392"});
+    aggregations = new ArrayList<>();
+    aggregations.add(new String[]{"426752"});
+    QueriesTestUtils
+        .testInterSegmentAggregationGroupByResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
+            groupKeys, aggregations);
+
+    query = "SELECT timeconvert(daysSinceEpoch, 'DAYS', 'HOURS'), COUNTMV(column6) FROM testTable GROUP BY timeconvert(daysSinceEpoch, 'DAYS', 'HOURS') ORDER BY COUNTMV(column6) DESC";
+    expectedDataSchema =
+        new DataSchema(new String[]{"timeconvert(daysSinceEpoch,'DAYS','HOURS')", "countmv(column6)"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
+    brokerResponse = getBrokerResponseForSqlQuery(query);
+    result = new ArrayList<>();
+    result.add(new Object[]{42144376392L, (long)426752});
+    QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L,
+        result, 1, expectedDataSchema);
   }
 
   @Test


### PR DESCRIPTION
As we plan to migrate our internal users to SQL, adding few tests for non-SQL functions (VALUEIN etc) to ensure they are supported by SQL and the result is same as what we see in PQL.

- Add Calcite SQL parser tests for native Pinot functions, transform functions, valuein etc

- Also, add tests for resuult comparison for VALUEIN between PQL and SQL with/without ORDER BY
