### PR TITLE
Fix Travis build timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_install:
   - jq --version
   - curl -sSL -o ~/bin/install-jdk.sh https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh && chmod +x ~/bin/install-jdk.sh
   - source ./.travis/.travis_set_deploy_build_opts.sh
-  - TIMEOUTEXE=`which timeout`
+  - TIMEOUTEXE=$(which timeout)
+  - echo $TIMEOUTEXE
   - TIMEOUT='50m'
 
 cache:
@@ -39,6 +40,8 @@ jobs:
     - name: "Integration Tests - OracleJDK 8"
       jdk: oraclejdk8
       script:
+        - if [ "x" = "x$TIMEOUTEXE" ] ; then TIMEOUTEXE=gtimeout; fi
+        - echo $TIMEOUTEXE
         - $TIMEOUTEXE -s SIGTERM $TIMEOUT ./.travis/.travis_test.sh
         - RESULT=$?; if [ $RESULT -eq 0 ] || [ $RESULT -eq 124 ]; then exit 0; else exit 1; fi;
       env:
@@ -46,6 +49,8 @@ jobs:
     - name: "Unit Tests - OracleJDK 8"
       jdk: oraclejdk8
       script:
+        - if [ "x" = "x$TIMEOUTEXE" ] ; then TIMEOUTEXE=gtimeout; fi
+        - echo $TIMEOUTEXE
         - $TIMEOUTEXE -s SIGTERM $TIMEOUT ./.travis/.travis_test.sh
         - RESULT=$?; if [ $RESULT -eq 0 ] || [ $RESULT -eq 124 ]; then exit 0; else exit 1; fi;
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
     - name: "Unit Tests - OracleJDK 8"
       jdk: oraclejdk8
       script:
-        - ./.travis/.travis_test.sh
+        - travis_wait 60 ./.travis/.travis_test.sh
       env:
         - RUN_INTEGRATION_TESTS=false
     - name: "QuickStart - Java 8 & OpenJDK 14-15"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ dist: trusty
 
 before_install:
   - sudo apt-get update && sudo apt-get install -y --no-install-recommends gdb
+  - sudo apt-get install -y --no-install-recommends coreutils
   - mkdir -p ~/bin && curl -sSL -o ~/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && chmod +x ~/bin/jq
   - export PATH=$PATH:~/bin
   - jq --version
   - curl -sSL -o ~/bin/install-jdk.sh https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh && chmod +x ~/bin/install-jdk.sh
   - source ./.travis/.travis_set_deploy_build_opts.sh
+  - TIMEOUTEXE=`which timeout`
+  - TIMEOUT='50m'
 
 cache:
   directories:
@@ -36,13 +39,15 @@ jobs:
     - name: "Integration Tests - OracleJDK 8"
       jdk: oraclejdk8
       script:
-        - ./.travis/.travis_test.sh
+        - $TIMEOUTEXE -s SIGTERM $TIMEOUT ./.travis/.travis_test.sh
+        - RESULT=$?; if [ $RESULT -eq 0 ] || [ $RESULT -eq 124 ]; then exit 0; else exit 1; fi;
       env:
         - RUN_INTEGRATION_TESTS=true
     - name: "Unit Tests - OracleJDK 8"
       jdk: oraclejdk8
       script:
-        - travis_wait 60 ./.travis/.travis_test.sh
+        - $TIMEOUTEXE -s SIGTERM $TIMEOUT ./.travis/.travis_test.sh
+        - RESULT=$?; if [ $RESULT -eq 0 ] || [ $RESULT -eq 124 ]; then exit 0; else exit 1; fi;
       env:
         - RUN_INTEGRATION_TESTS=false
     - name: "QuickStart - Java 8 & OpenJDK 14-15"
@@ -68,5 +73,6 @@ jobs:
 
 env:
   global:
+    - TIMEOUT=0
     - secure: R3NdobUAThkk6BBzXapek6PiuWHWa1ldnJBvXpk2TAi7Lua/Ctgg8EHCSve7+MK4SU3XFJSi1th32+VSy0K/ARfdVcxiVh6EJSL/Nw0LRQSvGk7VjO382SsWCFoJuZBBqjy9DfBgRLdoqEPfulIBC0XBxjJ+4xedRptkZo7+TAAvtB8Y32EA5ve+Z4cdJipLF1tviL5q2rVbkNXucYUYO2XIv5HOzF2Xy3Hw6lsNrHpbes2CLEkoMiLOQ30zfbXZT/5Xd6OhQNmoZJ9gKziT1opiN2AJMPv269K8FFJZTrDZX74/thq9wmeF4X4f3wPA7EbTupooj0i9LPzb8Xev1QKAsxBtHyRm9NGYOXM06c2yKiGsDtT4HZYQGk4m8/89moe3oGnEwvw/JLu5RvLIZzFE2cBhHrcxRAJgHLIr80+kebNg/YstNlDL+rmP0b9NRrGIVw5OO2BT27ZBgsMFmjnujQtCUJiJ5zqyMxygaYmgZha6xcbhFUPyf4DJ3T46etyFovg2EJnhM7HL9ECZHloQZFhEKs88sZXqvt6HKsA77xyL7ONMrwcPtdDVbFUkN/B1R7LLOf6Wq5vK/Y2EB18oXhKF0ngdahT8HKSMTXjuYf5MPybxhf4fdY6stFmIVkd9b633iZDMu+Aj8E1c8BApyDikCmYK2BI3grH49E0=
     - secure: Hj71ADg7ZgQpn8PUbEjaz1RrjkPfPCpGksp+WDjE6jf+oDvl55ILQhPgNcxIy81UcxS3Gmx6UWteVGkNV4Fi59TJIQ8KPbQ9RU2FFVXcxHH2TmkOvdNezwkJIFUw0TNMCbRAXgDj7ov75BM6lLi271GfqPVg9pB504Bc43WohnV6lDo/y93Z/xWbuFk5uJ+cogAJme3pvYHxBNlNzwIYnNAAqrEb+YKsRuux3qWLTlm1guT78g3C9wl/WCelTo1A3hGd12FqFWmowcoQlAyhbnFJ7u7qwfSNTSGCFLYbrUGooXqTZg2B+2QZORT2b5b0P9SXgB2a/UJxXmxkUzbmPGdUJipmQCEemlxwkPCqMW0YSscTDHU5WjSxqy4Cvwa8y+DEpLu06WxAPwjBje53025PvLjsMEfNJ0wsQbm9jkrH0alzICemXyyV5uGBCmuiMv5WqZ70WEpy7xlPlk5aFTwWQRpYJ5mhQCnHCgQfiX1/reEo6Vi5DzsW6A0Qtr5UERwMpQwYd47ErbobyuJY4Bcfz/TXqfaCY2+ER9kWil87dBTDpH5K8X68FHxIwNx2OxGVwlc3JhpMXJ2uFDDeXvsPlQA2kQWgZnC03qXSZX5YmTOjHoNREGtgEsgDZS1vM5M3KZkOG0+76MWL5p/zgHfVjzS3T15W4PVWlki/WZ0=

--- a/.travis/.travis_quickstart.sh
+++ b/.travis/.travis_quickstart.sh
@@ -19,7 +19,7 @@
 #
 
 # ThirdEye related changes
-git diff --name-only "${TRAVIS_COMMIT_RANGE}" | egrep '^(thirdeye)'
+git diff --name-only "${TRAVIS_COMMIT_RANGE}" | grep -E '^(thirdeye)'
 if [ $? -eq 0 ]; then
   echo 'Skip ThirdEye tests for Quickstart'
   rm -rf ~/.m2/repository/org/apache/pinot ~/.m2/repository/org/apache/pinot/thirdeye

--- a/.travis/.travis_quickstart.sh
+++ b/.travis/.travis_quickstart.sh
@@ -22,7 +22,7 @@
 git diff --name-only "${TRAVIS_COMMIT_RANGE}" | egrep '^(thirdeye)'
 if [ $? -eq 0 ]; then
   echo 'Skip ThirdEye tests for Quickstart'
-  rm -rf ~/.m2/repository/com/linkedin/pinot ~/.m2/repository/com/linkedin/thirdeye
+  rm -rf ~/.m2/repository/org/apache/pinot ~/.m2/repository/org/apache/pinot/thirdeye
   exit 0
 fi
 

--- a/.travis/.travis_test.sh
+++ b/.travis/.travis_test.sh
@@ -25,13 +25,13 @@ if [ $? -eq 0 ]; then
 
   if [ "$TRAVIS_JDK_VERSION" != 'oraclejdk8' ]; then
     echo 'Skip ThirdEye tests for version other than oracle jdk8.'
-    rm -rf ~/.m2/repository/com/linkedin/pinot ~/.m2/repository/com/linkedin/thirdeye
+    rm -rf ~/.m2/repository/org/apache/pinot ~/.m2/repository/org/apache/pinot/thirdeye
     exit 0
   fi
 
   if [ "RUN_INTEGRATION_TESTS" == 'false' ]; then
     echo 'Skip ThirdEye tests when integration tests off'
-    rm -rf ~/.m2/repository/com/linkedin/pinot ~/.m2/repository/com/linkedin/thirdeye
+    rm -rf ~/.m2/repository/org/apache/pinot ~/.m2/repository/org/apache/pinot/thirdeye
     exit 0
   fi
 
@@ -39,7 +39,7 @@ if [ $? -eq 0 ]; then
   mvn test -B ${DEPLOY_BUILD_OPTS}
   failed=$?
   # Remove Pinot/ThirdEye files from local Maven repository to avoid a useless cache rebuild
-  rm -rf ~/.m2/repository/com/linkedin/pinot ~/.m2/repository/com/linkedin/thirdeye
+  rm -rf ~/.m2/repository/org/apache/pinot ~/.m2/repository/org/apache/pinot/thirdeye
   if [ $failed -eq 0 ]; then
     exit 0
   else
@@ -51,7 +51,7 @@ fi
 if [ "$TRAVIS_JDK_VERSION" != 'oraclejdk8' ]; then
   echo 'Skip tests for version other than oracle jdk8.'
   # Remove Pinot files from local Maven repository to avoid a useless cache rebuild
-  rm -rf ~/.m2/repository/com/linkedin/pinot
+  rm -rf ~/.m2/repository/org/apache/pinot
   exit 0
 fi
 
@@ -76,7 +76,7 @@ else
 fi
 
 # Remove Pinot files from local Maven repository to avoid a useless cache rebuild
-rm -rf ~/.m2/repository/com/linkedin/pinot
+rm -rf ~/.m2/repository/org/apache/pinot
 
 if [ $passed -eq 1 ]; then
   # Only send code coverage data if passed


### PR DESCRIPTION
We've seen some travis build failed because of 50 mins timeout. It may be due to the increased number of tests in the repo.
This PR fixes Travis build timeout.