### PR TITLE
Add a new server api for download of segments.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -213,5 +213,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   @Override
-  public String getTableDataDir() { return _tableDataDir; }
+  public String getTableDataDir() {
+    return _tableDataDir;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -213,7 +213,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   @Override
-  public String getTableDataDir() {
-    return _tableDataDir;
+  public File getTableDataDir() {
+    return new File(_tableDataDir);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -211,4 +211,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   public String getTableName() {
     return _tableNameWithType;
   }
+
+  @Override
+  public String getTableDataDir() { return _tableDataDir; }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -214,6 +214,6 @@ public abstract class BaseTableDataManager implements TableDataManager {
 
   @Override
   public File getTableDataDir() {
-    return new File(_tableDataDir);
+    return _indexDir;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
@@ -116,4 +116,9 @@ public interface TableDataManager {
    * Returns the table name managed by this instance.
    */
   String getTableName();
+
+  /**
+   * Returns the dir which contains the data segments.
+   */
+  String getTableDataDir();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
@@ -119,6 +119,7 @@ public interface TableDataManager {
 
   /**
    * Returns the dir which contains the data segments.
+   * @return
    */
-  String getTableDataDir();
+  File getTableDataDir();
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -190,7 +190,7 @@ public class TablesResource {
   @GET
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   @Path("/segments/{tableNameWithType}/{segmentName}")
-  @ApiOperation(value = "Download a segment", notes = "Download a segment in zipped tar format")
+  @ApiOperation(value = "Download an immutable segment", notes = "Download an immutable segment in zipped tar format")
   public Response downloadSegment(
       @ApiParam(value = "Name of the table with type REALTIME OR OFFLINE", required = true, example = "myTable_OFFLINE") @PathParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -203,10 +203,11 @@ public class TablesResource {
           Response.Status.NOT_FOUND);
     }
     try {
-      String tableDir = tableDataManager.getTableDataDir();
+      String tableDir = tableDataManager.getTableDataDir().getAbsolutePath();
       // TODO Limit the number of concurrent downloads of segments because compression is an expensive operation.
       String tarFilePath = TarGzCompressionUtils.createTarGzOfDirectory(tableDir + File.separator + segmentName);
       File tarFile = new File(tarFilePath);
+      tarFile.deleteOnExit();
       Response.ResponseBuilder builder = Response.ok();
       builder.entity((StreamingOutput) output -> {
         try {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -190,7 +190,7 @@ public class TablesResource {
   @GET
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   @Path("/segments/{tableNameWithType}/{segmentName}")
-  @ApiOperation(value = "Download an immutable segment", notes = "Download an immutable segment in zipped tar format")
+  @ApiOperation(value = "Download an immutable segment", notes = "Download an immutable segment in zipped tar format.")
   public Response downloadSegment(
       @ApiParam(value = "Name of the table with type REALTIME OR OFFLINE", required = true, example = "myTable_OFFLINE") @PathParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -205,7 +205,12 @@ public class TablesResource {
     try {
       String tableDir = tableDataManager.getTableDataDir().getAbsolutePath();
       // TODO Limit the number of concurrent downloads of segments because compression is an expensive operation.
-      String tarFilePath = TarGzCompressionUtils.createTarGzOfDirectory(tableDir + File.separator + segmentName);
+      // Store the tar.gz segment file in the server's segmentTarDir folder with a unique file name.
+      // Note that two clients asking the same segment file will result in the same tar.gz files being created twice.
+      // Will revisit for optimization if performance becomes an issue.
+      String tarFilePath = TarGzCompressionUtils.createTarGzOfDirectory(tableDir + File.separator + segmentName,
+          serverInstance.getInstanceDataManager().getSegmentFileDirectory() + File.separator + segmentName + "-"
+              + System.currentTimeMillis());
       File tarFile = new File(tarFilePath);
       tarFile.deleteOnExit();
       Response.ResponseBuilder builder = Response.ok();

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -56,8 +56,7 @@ import static org.mockito.Mockito.when;
 public abstract class BaseResourceTest {
   private static final String AVRO_DATA_PATH = "data/test_data-mv.avro";
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "BaseResourceTest");
-  protected static final String REALTIME_TABLE_NAME = "testTable_REALTIME";
-  protected static final String OFFLINE_TABLE_NAME = "testTable_OFFLINE";
+  protected static final String TABLE_NAME = "testTable";
 
   private final Map<String, TableDataManager> _tableDataManagerMap = new HashMap<>();
   protected final List<ImmutableSegment> _realtimeIndexSegments = new ArrayList<>();
@@ -87,10 +86,13 @@ public abstract class BaseResourceTest {
     when(serverInstance.getInstanceDataManager()).thenReturn(instanceDataManager);
 
     // Add the default tables and segments.
-    addTable(REALTIME_TABLE_NAME);
-    addTable(OFFLINE_TABLE_NAME);
-    setUpSegment(REALTIME_TABLE_NAME, "default", _realtimeIndexSegments);
-    setUpSegment(OFFLINE_TABLE_NAME, "default", _offlineIndexSegments);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME);
+
+    addTable(realtimeTableName);
+    addTable(offlineTableName);
+    setUpSegment(realtimeTableName, "default", _realtimeIndexSegments);
+    setUpSegment(offlineTableName, "default", _offlineIndexSegments);
 
     _adminApiApplication = new AdminApiApplication(serverInstance);
     _adminApiApplication.start(CommonConstants.Server.DEFAULT_ADMIN_API_PORT);

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -84,6 +84,7 @@ public abstract class BaseResourceTest {
     // Mock the server instance
     ServerInstance serverInstance = mock(ServerInstance.class);
     when(serverInstance.getInstanceDataManager()).thenReturn(instanceDataManager);
+    when(serverInstance.getInstanceDataManager().getSegmentFileDirectory()).thenReturn(FileUtils.getTempDirectoryPath());
 
     // Add the default tables and segments.
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME);

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -104,6 +105,9 @@ public abstract class BaseResourceTest {
   public void tearDown() {
     _adminApiApplication.stop();
     for (ImmutableSegment immutableSegment : _realtimeIndexSegments) {
+      immutableSegment.destroy();
+    }
+    for (ImmutableSegment immutableSegment : _offlineIndexSegments) {
       immutableSegment.destroy();
     }
     FileUtils.deleteQuietly(INDEX_DIR);

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TableSizeResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TableSizeResourceTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 
 
 public class TableSizeResourceTest extends BaseResourceTest {
-  private static final String TABLE_SIZE_PATH = "/tables/" + TABLE_NAME + "/size";
+  private static final String TABLE_SIZE_PATH = "/tables/" + REALTIME_TABLE_NAME + "/size";
 
   @Test
   public void testTableSizeNotFound() {
@@ -37,9 +37,9 @@ public class TableSizeResourceTest extends BaseResourceTest {
   @Test
   public void testTableSizeDetailed() {
     TableSizeInfo tableSizeInfo = _webTarget.path(TABLE_SIZE_PATH).request().get(TableSizeInfo.class);
-    ImmutableSegment defaultSegment = _indexSegments.get(0);
+    ImmutableSegment defaultSegment = _realtimeIndexSegments.get(0);
 
-    Assert.assertEquals(tableSizeInfo.tableName, TABLE_NAME);
+    Assert.assertEquals(tableSizeInfo.tableName, REALTIME_TABLE_NAME);
     Assert.assertEquals(tableSizeInfo.diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
     Assert.assertEquals(tableSizeInfo.segments.size(), 1);
     Assert.assertEquals(tableSizeInfo.segments.get(0).segmentName, defaultSegment.getSegmentName());
@@ -51,19 +51,19 @@ public class TableSizeResourceTest extends BaseResourceTest {
   public void testTableSizeNoDetails() {
     TableSizeInfo tableSizeInfo =
         _webTarget.path(TABLE_SIZE_PATH).queryParam("detailed", "false").request().get(TableSizeInfo.class);
-    ImmutableSegment defaultSegment = _indexSegments.get(0);
+    ImmutableSegment defaultSegment = _realtimeIndexSegments.get(0);
 
-    Assert.assertEquals(tableSizeInfo.tableName, TABLE_NAME);
+    Assert.assertEquals(tableSizeInfo.tableName, REALTIME_TABLE_NAME);
     Assert.assertEquals(tableSizeInfo.diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
     Assert.assertEquals(tableSizeInfo.segments.size(), 0);
   }
 
   @Test
   public void testTableSizeOld() {
-    TableSizeInfo tableSizeInfo = _webTarget.path("/table/" + TABLE_NAME + "/size").request().get(TableSizeInfo.class);
-    ImmutableSegment defaultSegment = _indexSegments.get(0);
+    TableSizeInfo tableSizeInfo = _webTarget.path("/table/" + REALTIME_TABLE_NAME + "/size").request().get(TableSizeInfo.class);
+    ImmutableSegment defaultSegment = _realtimeIndexSegments.get(0);
 
-    Assert.assertEquals(tableSizeInfo.tableName, TABLE_NAME);
+    Assert.assertEquals(tableSizeInfo.tableName, REALTIME_TABLE_NAME);
     Assert.assertEquals(tableSizeInfo.diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
     Assert.assertEquals(tableSizeInfo.segments.size(), 1);
     Assert.assertEquals(tableSizeInfo.segments.get(0).segmentName, defaultSegment.getSegmentName());

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TableSizeResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TableSizeResourceTest.java
@@ -21,13 +21,12 @@ package org.apache.pinot.server.api;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.common.restlet.resources.TableSizeInfo;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class TableSizeResourceTest extends BaseResourceTest {
-  private static final String TABLE_SIZE_PATH = "/tables/" + REALTIME_TABLE_NAME + "/size";
-
   @Test
   public void testTableSizeNotFound() {
     Response response = _webTarget.path("table/unknownTable/size").request().get(Response.class);
@@ -36,38 +35,54 @@ public class TableSizeResourceTest extends BaseResourceTest {
 
   @Test
   public void testTableSizeDetailed() {
-    TableSizeInfo tableSizeInfo = _webTarget.path(TABLE_SIZE_PATH).request().get(TableSizeInfo.class);
-    ImmutableSegment defaultSegment = _realtimeIndexSegments.get(0);
+    verifyTableSizeDetailedImpl(TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME), _realtimeIndexSegments.get(0));
+    verifyTableSizeDetailedImpl(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME), _offlineIndexSegments.get(0));
+  }
 
-    Assert.assertEquals(tableSizeInfo.tableName, REALTIME_TABLE_NAME);
-    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
+  private void verifyTableSizeDetailedImpl(String expectedTableName, ImmutableSegment segment) {
+    String path = "/tables/" + expectedTableName + "/size";
+    TableSizeInfo tableSizeInfo = _webTarget.path(path).request().get(TableSizeInfo.class);
+
+    Assert.assertEquals(tableSizeInfo.tableName, expectedTableName);
+    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, segment.getSegmentSizeBytes());
     Assert.assertEquals(tableSizeInfo.segments.size(), 1);
-    Assert.assertEquals(tableSizeInfo.segments.get(0).segmentName, defaultSegment.getSegmentName());
-    Assert.assertEquals(tableSizeInfo.segments.get(0).diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
-    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
+    Assert.assertEquals(tableSizeInfo.segments.get(0).segmentName, segment.getSegmentName());
+    Assert.assertEquals(tableSizeInfo.segments.get(0).diskSizeInBytes, segment.getSegmentSizeBytes());
+    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, segment.getSegmentSizeBytes());
   }
 
   @Test
   public void testTableSizeNoDetails() {
-    TableSizeInfo tableSizeInfo =
-        _webTarget.path(TABLE_SIZE_PATH).queryParam("detailed", "false").request().get(TableSizeInfo.class);
-    ImmutableSegment defaultSegment = _realtimeIndexSegments.get(0);
+    verifyTableSizeNoDetailsImpl(TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME),
+        _realtimeIndexSegments.get(0));
+    verifyTableSizeNoDetailsImpl(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME), _offlineIndexSegments.get(0));
+  }
 
-    Assert.assertEquals(tableSizeInfo.tableName, REALTIME_TABLE_NAME);
-    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
+  private void verifyTableSizeNoDetailsImpl(String expectedTableName, ImmutableSegment segment) {
+    String path = "/tables/" + expectedTableName + "/size";
+    TableSizeInfo tableSizeInfo =
+        _webTarget.path(path).queryParam("detailed", "false").request().get(TableSizeInfo.class);
+
+    Assert.assertEquals(tableSizeInfo.tableName, expectedTableName);
+    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, segment.getSegmentSizeBytes());
     Assert.assertEquals(tableSizeInfo.segments.size(), 0);
   }
 
   @Test
   public void testTableSizeOld() {
-    TableSizeInfo tableSizeInfo = _webTarget.path("/table/" + REALTIME_TABLE_NAME + "/size").request().get(TableSizeInfo.class);
-    ImmutableSegment defaultSegment = _realtimeIndexSegments.get(0);
+    verifyTableSizeOldImpl(TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME), _realtimeIndexSegments.get(0));
+    verifyTableSizeOldImpl(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME), _offlineIndexSegments.get(0));
+  }
 
-    Assert.assertEquals(tableSizeInfo.tableName, REALTIME_TABLE_NAME);
-    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
+  private void verifyTableSizeOldImpl(String expectedTableName, ImmutableSegment segment) {
+    String path = "/table/" + expectedTableName + "/size";
+    TableSizeInfo tableSizeInfo = _webTarget.path(path).request().get(TableSizeInfo.class);
+
+    Assert.assertEquals(tableSizeInfo.tableName, expectedTableName);
+    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, segment.getSegmentSizeBytes());
     Assert.assertEquals(tableSizeInfo.segments.size(), 1);
-    Assert.assertEquals(tableSizeInfo.segments.get(0).segmentName, defaultSegment.getSegmentName());
-    Assert.assertEquals(tableSizeInfo.segments.get(0).diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
-    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, defaultSegment.getSegmentSizeBytes());
+    Assert.assertEquals(tableSizeInfo.segments.get(0).segmentName, segment.getSegmentName());
+    Assert.assertEquals(tableSizeInfo.segments.get(0).diskSizeInBytes, segment.getSegmentSizeBytes());
+    Assert.assertEquals(tableSizeInfo.diskSizeInBytes, segment.getSegmentSizeBytes());
   }
 }

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -19,14 +19,23 @@
 package org.apache.pinot.server.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.util.List;
 import javax.ws.rs.core.Response;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.restlet.resources.TableSegments;
 import org.apache.pinot.common.restlet.resources.TablesList;
+import org.apache.pinot.common.utils.TarGzCompressionUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
-import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -45,10 +54,11 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertNotNull(tablesList);
     List<String> tables = tablesList.getTables();
     Assert.assertNotNull(tables);
-    Assert.assertEquals(tables.size(), 1);
-    Assert.assertEquals(tables.get(0), TABLE_NAME);
+    Assert.assertEquals(tables.size(), 2);
+    Assert.assertEquals(tables.get(0), REALTIME_TABLE_NAME);
+    Assert.assertEquals(tables.get(1), OFFLINE_TABLE_NAME);
 
-    String secondTable = "secondTable";
+    String secondTable = "secondTable_REALTIME";
     addTable(secondTable);
     response = _webTarget.path(tablesPath).request().get(Response.class);
     responseBody = response.readEntity(String.class);
@@ -57,25 +67,26 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertNotNull(tablesList);
     tables = tablesList.getTables();
     Assert.assertNotNull(tables);
-    Assert.assertEquals(tables.size(), 2);
-    Assert.assertTrue(tables.contains(TABLE_NAME));
+    Assert.assertEquals(tables.size(), 3);
+    Assert.assertTrue(tables.contains(REALTIME_TABLE_NAME));
     Assert.assertTrue(tables.contains(secondTable));
+    Assert.assertTrue(tables.contains(OFFLINE_TABLE_NAME));
   }
 
   @Test
   public void getSegments()
       throws Exception {
-    String segmentsPath = "/tables/" + TABLE_NAME + "/segments";
-    IndexSegment defaultSegment = _indexSegments.get(0);
+    String segmentsPath = "/tables/" + REALTIME_TABLE_NAME + "/segments";
+    IndexSegment defaultSegment = _realtimeIndexSegments.get(0);
 
     TableSegments tableSegments = _webTarget.path(segmentsPath).request().get(TableSegments.class);
     Assert.assertNotNull(tableSegments);
     List<String> segmentNames = tableSegments.getSegments();
     Assert.assertNotNull(segmentNames);
     Assert.assertEquals(segmentNames.size(), 1);
-    Assert.assertEquals(segmentNames.get(0), _indexSegments.get(0).getSegmentName());
+    Assert.assertEquals(segmentNames.get(0), _realtimeIndexSegments.get(0).getSegmentName());
 
-    IndexSegment secondSegment = setUpSegment("0");
+    IndexSegment secondSegment = setUpSegment(REALTIME_TABLE_NAME, "0", _realtimeIndexSegments);
     tableSegments = _webTarget.path(segmentsPath).request().get(TableSegments.class);
     Assert.assertNotNull(tableSegments);
     segmentNames = tableSegments.getSegments();
@@ -93,8 +104,8 @@ public class TablesResourceTest extends BaseResourceTest {
   @Test
   public void testSegmentMetadata()
       throws Exception {
-    IndexSegment defaultSegment = _indexSegments.get(0);
-    String segmentMetadataPath = "/tables/" + TABLE_NAME + "/segments/" + defaultSegment.getSegmentName() + "/metadata";
+    IndexSegment defaultSegment = _realtimeIndexSegments.get(0);
+    String segmentMetadataPath = "/tables/" + REALTIME_TABLE_NAME + "/segments/" + defaultSegment.getSegmentName() + "/metadata";
 
     JsonNode jsonResponse =
         JsonUtils.stringToJsonNode(_webTarget.path(segmentMetadataPath).request().get(String.class));
@@ -126,17 +137,17 @@ public class TablesResourceTest extends BaseResourceTest {
         .get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
 
-    response = _webTarget.path("/tables/" + TABLE_NAME + "/segments/UNKNOWN_SEGMENT").request().get(Response.class);
+    response = _webTarget.path("/tables/" + REALTIME_TABLE_NAME + "/segments/UNKNOWN_SEGMENT").request().get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
   }
 
   @Test
   public void testSegmentCrcMetadata()
       throws Exception {
-    String segmentsCrcPath = "/tables/" + TABLE_NAME + "/segments/crc";
+    String segmentsCrcPath = "/tables/" + REALTIME_TABLE_NAME + "/segments/crc";
 
     // Upload segments
-    List<ImmutableSegment> immutableSegments = setUpSegments(2);
+    List<ImmutableSegment> immutableSegments = setUpSegments(REALTIME_TABLE_NAME,2, _realtimeIndexSegments);
 
     // Trigger crc api to fetch crc information
     String response = _webTarget.path(segmentsCrcPath).request().get(String.class);
@@ -147,6 +158,64 @@ public class TablesResourceTest extends BaseResourceTest {
       String segmentName = immutableSegment.getSegmentName();
       String crc = immutableSegment.getSegmentMetadata().getCrc();
       Assert.assertEquals(segmentsCrc.get(segmentName).asText(), crc);
+    }
+  }
+
+  @Test
+  public void testDownloadSegments()
+      throws Exception {
+    // Verify the content of the downloaded segment from a realtime table.
+    Assert.assertTrue(downLoadAndVerifySegmentContent(REALTIME_TABLE_NAME, _realtimeIndexSegments.get(0)));
+    // Verify the content of the downloaded segment from an offline table.
+    Assert.assertTrue(downLoadAndVerifySegmentContent(OFFLINE_TABLE_NAME, _offlineIndexSegments.get(0)));
+
+    // Verify non-existent table and segment download return NOT_FOUND status.
+    Response response = _webTarget.path("/tables/UNKNOWN_REALTIME/segments/segmentname").request()
+        .get(Response.class);
+    Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+
+    response = _webTarget.path("/tables/" + REALTIME_TABLE_NAME + "/segments/UNKNOWN_SEGMENT").request().get(Response.class);
+    Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+  }
+
+  // Verify metadata file from segments.
+  private boolean downLoadAndVerifySegmentContent(String tableNameWithType, IndexSegment segment) {
+    String segmentPath = "/tables/" + tableNameWithType + "/segments/" + segment.getSegmentName();
+
+    // Download the segment and save to a temp local file.
+    Response response = _webTarget.path(segmentPath).request().get(Response.class);
+    Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    File segmentFile = response.readEntity(File.class);
+
+    File tempMetadataDir = new File(FileUtils.getTempDirectory(), "segment_metadata");
+    try (// Extract metadata.properties
+        InputStream metadataPropertiesInputStream = TarGzCompressionUtils
+            .unTarOneFile(new FileInputStream(segmentFile), V1Constants.MetadataKeys.METADATA_FILE_NAME);
+        // Extract creation.meta
+        InputStream creationMetaInputStream = TarGzCompressionUtils
+            .unTarOneFile(new FileInputStream(segmentFile), V1Constants.SEGMENT_CREATION_META)) {
+      Preconditions
+          .checkState(tempMetadataDir.mkdirs(), "Failed to create directory: %s", tempMetadataDir.getAbsolutePath());
+
+      Preconditions.checkNotNull(metadataPropertiesInputStream, "%s does not exist",
+          V1Constants.MetadataKeys.METADATA_FILE_NAME);
+      java.nio.file.Path metadataPropertiesPath = FileSystems.getDefault()
+          .getPath(tempMetadataDir.getAbsolutePath(), V1Constants.MetadataKeys.METADATA_FILE_NAME);
+      Files.copy(metadataPropertiesInputStream, metadataPropertiesPath);
+
+      Preconditions.checkNotNull(creationMetaInputStream, "%s does not exist", V1Constants.SEGMENT_CREATION_META);
+      java.nio.file.Path creationMetaPath =
+          FileSystems.getDefault().getPath(tempMetadataDir.getAbsolutePath(), V1Constants.SEGMENT_CREATION_META);
+      Files.copy(creationMetaInputStream, creationMetaPath);
+      // Load segment metadata
+      SegmentMetadataImpl metadata = new SegmentMetadataImpl(tempMetadataDir);
+
+      Assert.assertEquals(tableNameWithType, metadata.getTableName());
+      return true;
+    } catch (Exception e) {
+      return false;
+    } finally {
+      FileUtils.deleteQuietly(tempMetadataDir);
     }
   }
 }


### PR DESCRIPTION
Add segment download api to the Pinot server as discussed in step 1 of [deep store bypss for LLC](https://cwiki.apache.org/confluence/display/PINOT/By-passing+deep-store+requirement+for+Realtime+segment+completion) as discussed in this [POC](https://github.com/apache/incubator-pinot/pull/4914).

The API supports download of both realtime and offline table segments.  The relevant unit tests are modified to reflect both realtime and offline segment downloads. 

@mcvsubbu 