### PR TITLE
Support bootstrap mode for table rebalance

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -474,7 +474,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Whether to rebalance table in dry-run mode") @DefaultValue("false") @QueryParam("dryRun") boolean dryRun,
       @ApiParam(value = "Whether to reassign instances before reassigning segments") @DefaultValue("false") @QueryParam("reassignInstances") boolean reassignInstances,
       @ApiParam(value = "Whether to reassign CONSUMING segments for real-time table") @DefaultValue("false") @QueryParam("includeConsuming") boolean includeConsuming,
-      @ApiParam(value = "Whether to rebalance table in bootstrap mode (starting from an empty table and reassign all segments, where segments will be assigned in a round-robin fashion, but no minimum movement is guaranteed)") @DefaultValue("false") @QueryParam("bootstrap") boolean bootstrap,
+      @ApiParam(value = "Whether to rebalance table in bootstrap mode (regardless of minimum segment movement, reassign all segments in a round-robin fashion as if adding new segments to an empty table)") @DefaultValue("false") @QueryParam("bootstrap") boolean bootstrap,
       @ApiParam(value = "Whether to allow downtime for the rebalance") @DefaultValue("false") @QueryParam("downtime") boolean downtime,
       @ApiParam(value = "For no-downtime rebalance, minimum number of replicas to keep alive during rebalance, or maximum number of replicas allowed to be unavailable if value is negative") @DefaultValue("1") @QueryParam("minAvailableReplicas") int minAvailableReplicas,
       @ApiParam(value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime contract cannot be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -474,6 +474,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Whether to rebalance table in dry-run mode") @DefaultValue("false") @QueryParam("dryRun") boolean dryRun,
       @ApiParam(value = "Whether to reassign instances before reassigning segments") @DefaultValue("false") @QueryParam("reassignInstances") boolean reassignInstances,
       @ApiParam(value = "Whether to reassign CONSUMING segments for real-time table") @DefaultValue("false") @QueryParam("includeConsuming") boolean includeConsuming,
+      @ApiParam(value = "Whether to rebalance table in bootstrap mode (starting from an empty table and reassign all segments, where segments will be assigned in a round-robin fashion, but no minimum movement is guaranteed)") @DefaultValue("false") @QueryParam("bootstrap") boolean bootstrap,
       @ApiParam(value = "Whether to allow downtime for the rebalance") @DefaultValue("false") @QueryParam("downtime") boolean downtime,
       @ApiParam(value = "For no-downtime rebalance, minimum number of replicas to keep alive during rebalance, or maximum number of replicas allowed to be unavailable if value is negative") @DefaultValue("1") @QueryParam("minAvailableReplicas") int minAvailableReplicas,
       @ApiParam(value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime contract cannot be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts) {
@@ -490,6 +491,7 @@ public class PinotTableRestletResource {
     rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, dryRun);
     rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, reassignInstances);
     rebalanceConfig.addProperty(RebalanceConfigConstants.INCLUDE_CONSUMING, includeConsuming);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.BOOTSTRAP, bootstrap);
     rebalanceConfig.addProperty(RebalanceConfigConstants.DOWNTIME, downtime);
     rebalanceConfig.addProperty(RebalanceConfigConstants.MIN_REPLICAS_TO_KEEP_UP_FOR_NO_DOWNTIME, minAvailableReplicas);
     rebalanceConfig.addProperty(RebalanceConfigConstants.BEST_EFFORTS, bestEfforts);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
@@ -173,7 +173,7 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
     if (bootstrap) {
       LOGGER.info("Bootstrapping the table: {}", _offlineTableName);
 
-      // When bootstrap is enabled, start with an empty table add reassign all segments
+      // When bootstrap is enabled, start with an empty assignment and reassign all segments
       newAssignment = new TreeMap<>();
       for (String segment : currentAssignment.keySet()) {
         List<String> assignedInstances = assignSegment(segment, newAssignment, instancePartitions);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -102,20 +102,37 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
             instancePartitions.getInstancePartitionsName());
     LOGGER.info("Assigning segment: {} with instance partitions: {} for table: {}", segmentName, instancePartitions,
         _realtimeTableName);
+    checkReplication(instancePartitions);
 
-    List<String> instancesAssigned = assignSegment(segmentName, instancePartitions);
+    List<String> instancesAssigned = assignConsumingSegment(segmentName, instancePartitions);
+
     LOGGER.info("Assigned segment: {} to instances: {} for table: {}", segmentName, instancesAssigned,
         _realtimeTableName);
     return instancesAssigned;
   }
 
   /**
-   * Helper method to assign instances based on the segment partition id and instance partitions.
+   * Helper method to check whether the number of replica-groups matches the table replication for replica-group based
+   * instance partitions. Log a warning if they do not match.
    */
-  private List<String> assignSegment(String segmentName, InstancePartitions instancePartitions) {
+  private void checkReplication(InstancePartitions instancePartitions) {
+    int numReplicaGroups = instancePartitions.getNumReplicaGroups();
+    if (numReplicaGroups != 1 && numReplicaGroups != _replication) {
+      LOGGER.warn(
+          "Number of replica-groups in instance partitions {}: {} does not match replication in table config: {} for table: {}, use: {}",
+          instancePartitions.getInstancePartitionsName(), numReplicaGroups, _replication, _realtimeTableName,
+          numReplicaGroups);
+    }
+  }
+
+  /**
+   * Helper method to assign instances for CONSUMING segment based on the segment partition id and instance partitions.
+   */
+  private List<String> assignConsumingSegment(String segmentName, InstancePartitions instancePartitions) {
     int partitionId = new LLCSegmentName(segmentName).getPartitionId();
 
-    if (instancePartitions.getNumReplicaGroups() == 1) {
+    int numReplicaGroups = instancePartitions.getNumReplicaGroups();
+    if (numReplicaGroups == 1) {
       // Non-replica-group based assignment:
       // Uniformly spray the partitions and replicas across the instances.
       // E.g. (6 instances, 3 partitions, 4 replicas)
@@ -139,14 +156,6 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
       //         p0  p1  p2
       //         p3  p4  p5
 
-      int numReplicaGroups = instancePartitions.getNumReplicaGroups();
-      if (numReplicaGroups != _replication) {
-        LOGGER.warn(
-            "Number of replica-groups in instance partitions {}: {} does not match replication in table config: {} for table: {}, use: {}",
-            instancePartitions.getInstancePartitionsName(), numReplicaGroups, _replication, _realtimeTableName,
-            numReplicaGroups);
-      }
-
       List<String> instancesAssigned = new ArrayList<>(numReplicaGroups);
       for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
         List<String> instances = instancePartitions.getInstances(0, replicaGroupId);
@@ -167,9 +176,15 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
         "Instance partitions: %s should contain 1 partition", consumingInstancePartitions.getInstancePartitionsName());
     boolean includeConsuming = config
         .getBoolean(RebalanceConfigConstants.INCLUDE_CONSUMING, RebalanceConfigConstants.DEFAULT_INCLUDE_CONSUMING);
+    boolean bootstrap =
+        config.getBoolean(RebalanceConfigConstants.BOOTSTRAP, RebalanceConfigConstants.DEFAULT_BOOTSTRAP);
     LOGGER.info(
-        "Rebalancing table: {} with COMPLETED instance partitions: {}, CONSUMING instance partitions: {}, includeConsuming: {}",
-        _realtimeTableName, completedInstancePartitions, consumingInstancePartitions, includeConsuming);
+        "Rebalancing table: {} with COMPLETED instance partitions: {}, CONSUMING instance partitions: {}, includeConsuming: {}, bootstrap: {}",
+        _realtimeTableName, completedInstancePartitions, consumingInstancePartitions, includeConsuming, bootstrap);
+    if (completedInstancePartitions != null) {
+      checkReplication(completedInstancePartitions);
+    }
+    checkReplication(consumingInstancePartitions);
 
     SegmentAssignmentUtils.CompletedConsumingOfflineSegmentAssignment completedConsumingOfflineSegmentAssignment =
         new SegmentAssignmentUtils.CompletedConsumingOfflineSegmentAssignment(currentAssignment);
@@ -184,41 +199,45 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
       LOGGER
           .info("Reassigning COMPLETED segments with COMPLETED instance partitions for table: {}", _realtimeTableName);
 
-      if (completedInstancePartitions.getNumReplicaGroups() == 1) {
-        // Non-replica-group based assignment
+      if (bootstrap) {
+        LOGGER.info("Bootstrapping the COMPLETED segments for table: {}", _realtimeTableName);
 
-        List<String> instances = SegmentAssignmentUtils
-            .getInstancesForNonReplicaGroupBasedAssignment(completedInstancePartitions, _replication);
-        newAssignment = SegmentAssignmentUtils
-            .rebalanceTableWithHelixAutoRebalanceStrategy(completedSegmentAssignment, instances, _replication);
+        // When bootstrap is enabled, start with an empty table add reassign all segments
+        newAssignment = new TreeMap<>();
+        for (String segment : completedSegmentAssignment.keySet()) {
+          List<String> assignedInstances = assignCompletedSegment(segment, newAssignment, completedInstancePartitions);
+          newAssignment.put(segment, SegmentAssignmentUtils
+              .getInstanceStateMap(assignedInstances, RealtimeSegmentOnlineOfflineStateModel.ONLINE));
+        }
       } else {
-        // Replica-group based assignment
+        if (completedInstancePartitions.getNumReplicaGroups() == 1) {
+          // Non-replica-group based assignment
 
-        int numReplicaGroups = completedInstancePartitions.getNumReplicaGroups();
-        if (numReplicaGroups != _replication) {
-          LOGGER.warn(
-              "Number of replica-groups in instance partitions {}: {} does not match replication in table config: {} for table: {}, use: {}",
-              completedInstancePartitions.getInstancePartitionsName(), numReplicaGroups, _replication,
-              _realtimeTableName, numReplicaGroups);
+          List<String> instances = SegmentAssignmentUtils
+              .getInstancesForNonReplicaGroupBasedAssignment(completedInstancePartitions, _replication);
+          newAssignment = SegmentAssignmentUtils
+              .rebalanceTableWithHelixAutoRebalanceStrategy(completedSegmentAssignment, instances, _replication);
+        } else {
+          // Replica-group based assignment
+
+          Map<Integer, List<String>> partitionIdToSegmentsMap = new HashMap<>();
+          for (String segmentName : completedSegmentAssignment.keySet()) {
+            int partitionId = new LLCSegmentName(segmentName).getPartitionId();
+            partitionIdToSegmentsMap.computeIfAbsent(partitionId, k -> new ArrayList<>()).add(segmentName);
+          }
+
+          // NOTE: Shuffle the segments within the current assignment to avoid moving only new segments to the new added
+          //       servers, which might cause hotspot servers because queries tend to hit the new segments. Use the table
+          //       name hash as the random seed for the shuffle so that the result is deterministic.
+          Random random = new Random(_realtimeTableName.hashCode());
+          for (List<String> segments : partitionIdToSegmentsMap.values()) {
+            Collections.shuffle(segments, random);
+          }
+
+          newAssignment = SegmentAssignmentUtils
+              .rebalanceReplicaGroupBasedTable(completedSegmentAssignment, completedInstancePartitions,
+                  partitionIdToSegmentsMap);
         }
-
-        Map<Integer, List<String>> partitionIdToSegmentsMap = new HashMap<>();
-        for (String segmentName : completedSegmentAssignment.keySet()) {
-          int partitionId = new LLCSegmentName(segmentName).getPartitionId();
-          partitionIdToSegmentsMap.computeIfAbsent(partitionId, k -> new ArrayList<>()).add(segmentName);
-        }
-
-        // NOTE: Shuffle the segments within the current assignment to avoid moving only new segments to the new added
-        //       servers, which might cause hotspot servers because queries tend to hit the new segments. Use the table
-        //       name hash as the random seed for the shuffle so that the result is deterministic.
-        Random random = new Random(_realtimeTableName.hashCode());
-        for (List<String> segments : partitionIdToSegmentsMap.values()) {
-          Collections.shuffle(segments, random);
-        }
-
-        newAssignment = SegmentAssignmentUtils
-            .rebalanceReplicaGroupBasedTable(completedSegmentAssignment, completedInstancePartitions,
-                partitionIdToSegmentsMap);
       }
     } else {
       // When COMPLETED instance partitions are not provided, reassign COMPLETED segments the same way as CONSUMING
@@ -230,7 +249,7 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
 
       newAssignment = new TreeMap<>();
       for (String segmentName : completedSegmentAssignment.keySet()) {
-        List<String> instancesAssigned = assignSegment(segmentName, consumingInstancePartitions);
+        List<String> instancesAssigned = assignConsumingSegment(segmentName, consumingInstancePartitions);
         Map<String, String> instanceStateMap = SegmentAssignmentUtils
             .getInstanceStateMap(instancesAssigned, RealtimeSegmentOnlineOfflineStateModel.ONLINE);
         newAssignment.put(segmentName, instanceStateMap);
@@ -245,7 +264,7 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
           .info("Reassigning CONSUMING segments with CONSUMING instance partitions for table: {}", _realtimeTableName);
 
       for (String segmentName : consumingSegmentAssignment.keySet()) {
-        List<String> instancesAssigned = assignSegment(segmentName, consumingInstancePartitions);
+        List<String> instancesAssigned = assignConsumingSegment(segmentName, consumingInstancePartitions);
         Map<String, String> instanceStateMap = SegmentAssignmentUtils
             .getInstanceStateMap(instancesAssigned, RealtimeSegmentOnlineOfflineStateModel.CONSUMING);
         newAssignment.put(segmentName, instanceStateMap);
@@ -261,5 +280,27 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
     LOGGER.info("Rebalanced table: {}, number of segments to be moved to each instance: {}", _realtimeTableName,
         SegmentAssignmentUtils.getNumSegmentsToBeMovedPerInstance(currentAssignment, newAssignment));
     return newAssignment;
+  }
+
+  /**
+   * Helper method to assign instances for COMPLETED segment based on the current assignment and instance partitions.
+   */
+  private List<String> assignCompletedSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
+      InstancePartitions instancePartitions) {
+    int numReplicaGroups = instancePartitions.getNumReplicaGroups();
+    if (numReplicaGroups == 1) {
+      // Non-replica-group based assignment
+
+      return SegmentAssignmentUtils
+          .assignSegmentWithoutReplicaGroup(currentAssignment, instancePartitions, _replication);
+    } else {
+      // Replica-group based assignment
+
+      // Uniformly spray the segment partitions over the instance partitions
+      int segmentPartitionId = new LLCSegmentName(segmentName).getPartitionId();
+      int numPartitions = instancePartitions.getNumPartitions();
+      int partitionId = segmentPartitionId % numPartitions;
+      return SegmentAssignmentUtils.assignSegmentWithReplicaGroup(currentAssignment, instancePartitions, partitionId);
+    }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -202,7 +202,7 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
       if (bootstrap) {
         LOGGER.info("Bootstrapping the COMPLETED segments for table: {}", _realtimeTableName);
 
-        // When bootstrap is enabled, start with an empty table add reassign all segments
+        // When bootstrap is enabled, start with an empty assignment and reassign all segments
         newAssignment = new TreeMap<>();
         for (String segment : completedSegmentAssignment.keySet()) {
           List<String> assignedInstances = assignCompletedSegment(segment, newAssignment, completedInstancePartitions);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfigConstants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfigConstants.java
@@ -35,6 +35,11 @@ public class RebalanceConfigConstants {
   public static final String INCLUDE_CONSUMING = "includeConsuming";
   public static final boolean DEFAULT_INCLUDE_CONSUMING = false;
 
+  // Whether to rebalance table in bootstrap mode (starting from an empty table and reassign all the segments, where
+  // segments will be assigned in a round-robin fashion, but no minimum movement is guaranteed)
+  public static final String BOOTSTRAP = "bootstrap";
+  public static final boolean DEFAULT_BOOTSTRAP = false;
+
   // Whether to allow downtime for the rebalance
   public static final String DOWNTIME = "downtime";
   public static final boolean DEFAULT_DOWNTIME = false;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfigConstants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfigConstants.java
@@ -35,8 +35,8 @@ public class RebalanceConfigConstants {
   public static final String INCLUDE_CONSUMING = "includeConsuming";
   public static final boolean DEFAULT_INCLUDE_CONSUMING = false;
 
-  // Whether to rebalance table in bootstrap mode (starting from an empty table and reassign all the segments, where
-  // segments will be assigned in a round-robin fashion, but no minimum movement is guaranteed)
+  // Whether to rebalance table in bootstrap mode (regardless of minimum segment movement, reassign all segments in a
+  // round-robin fashion as if adding new segments to an empty table)
   public static final String BOOTSTRAP = "bootstrap";
   public static final boolean DEFAULT_BOOTSTRAP = false;
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -114,6 +114,8 @@ public class TableRebalancer {
         .getBoolean(RebalanceConfigConstants.REASSIGN_INSTANCES, RebalanceConfigConstants.DEFAULT_REASSIGN_INSTANCES);
     boolean includeConsuming = rebalanceConfig
         .getBoolean(RebalanceConfigConstants.INCLUDE_CONSUMING, RebalanceConfigConstants.DEFAULT_INCLUDE_CONSUMING);
+    boolean bootstrap =
+        rebalanceConfig.getBoolean(RebalanceConfigConstants.BOOTSTRAP, RebalanceConfigConstants.DEFAULT_BOOTSTRAP);
     boolean downtime =
         rebalanceConfig.getBoolean(RebalanceConfigConstants.DOWNTIME, RebalanceConfigConstants.DEFAULT_DOWNTIME);
     int minReplicasToKeepUpForNoDowntime = rebalanceConfig
@@ -122,9 +124,9 @@ public class TableRebalancer {
     boolean bestEfforts = rebalanceConfig
         .getBoolean(RebalanceConfigConstants.BEST_EFFORTS, RebalanceConfigConstants.DEFAULT_BEST_EFFORTS);
     LOGGER.info(
-        "Start rebalancing table: {} with dryRun: {}, reassignInstances: {}, includeConsuming: {}, downtime: {}, minReplicasToKeepUpForNoDowntime: {}, bestEfforts: {}",
-        tableNameWithType, dryRun, reassignInstances, includeConsuming, downtime, minReplicasToKeepUpForNoDowntime,
-        bestEfforts);
+        "Start rebalancing table: {} with dryRun: {}, reassignInstances: {}, includeConsuming: {}, bootstrap: {}, downtime: {}, minReplicasToKeepUpForNoDowntime: {}, bestEfforts: {}",
+        tableNameWithType, dryRun, reassignInstances, includeConsuming, bootstrap, downtime,
+        minReplicasToKeepUpForNoDowntime, bestEfforts);
 
     // Validate table config
     try {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -34,6 +36,7 @@ import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
 import org.apache.pinot.common.utils.CommonConstants.Segment.AssignmentStrategy;
+import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
 import org.apache.pinot.spi.config.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.TableConfig;
 import org.apache.pinot.spi.config.TableType;
@@ -261,7 +264,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     assertEquals(numSegmentsAssignedPerInstance, expectedNumSegmentsAssignedPerInstance);
     // Current assignment should already be balanced
     assertEquals(_segmentAssignmentWithoutPartition
-        .rebalanceTable(currentAssignment, _instancePartitionsMapWithoutPartition, null), currentAssignment);
+            .rebalanceTable(currentAssignment, _instancePartitionsMapWithoutPartition, new BaseConfiguration()),
+        currentAssignment);
   }
 
   @Test
@@ -288,8 +292,67 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     Arrays.fill(expectedNumSegmentsAssignedPerInstance, numSegmentsPerInstance);
     assertEquals(numSegmentsAssignedPerInstance, expectedNumSegmentsAssignedPerInstance);
     // Current assignment should already be balanced
-    assertEquals(
-        _segmentAssignmentWithPartition.rebalanceTable(currentAssignment, _instancePartitionsMapWithPartition, null),
+    assertEquals(_segmentAssignmentWithPartition
+            .rebalanceTable(currentAssignment, _instancePartitionsMapWithPartition, new BaseConfiguration()),
         currentAssignment);
+  }
+
+  @Test
+  public void testBootstrapTableWithoutPartition() {
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+    for (String segmentName : SEGMENTS) {
+      List<String> instancesAssigned = _segmentAssignmentWithoutPartition
+          .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithoutPartition);
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+    }
+
+    // Bootstrap table should reassign all segments based on their alphabetical order
+    Configuration rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
+    Map<String, Map<String, String>> newAssignment = _segmentAssignmentWithoutPartition
+        .rebalanceTable(currentAssignment, _instancePartitionsMapWithoutPartition, rebalanceConfig);
+    assertEquals(newAssignment.size(), NUM_SEGMENTS);
+    List<String> sortedSegments = new ArrayList<>(SEGMENTS);
+    sortedSegments.sort(null);
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      assertEquals(newAssignment.get(sortedSegments.get(i)), currentAssignment.get(SEGMENTS.get(i)));
+    }
+  }
+
+  @Test
+  public void testBootstrapTableWithPartition() {
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+    for (String segmentName : SEGMENTS) {
+      List<String> instancesAssigned = _segmentAssignmentWithPartition
+          .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithPartition);
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+    }
+
+    // Bootstrap table should reassign all segments based on their alphabetical order within the partition
+    Configuration rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
+    Map<String, Map<String, String>> newAssignment = _segmentAssignmentWithPartition
+        .rebalanceTable(currentAssignment, _instancePartitionsMapWithPartition, rebalanceConfig);
+    assertEquals(newAssignment.size(), NUM_SEGMENTS);
+    int numSegmentsPerPartition = NUM_SEGMENTS / NUM_PARTITIONS;
+    String[][] partitionIdToSegmentsMap = new String[NUM_PARTITIONS][numSegmentsPerPartition];
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      partitionIdToSegmentsMap[i % NUM_PARTITIONS][i / NUM_PARTITIONS] = SEGMENTS.get(i);
+    }
+    String[][] partitionIdToSortedSegmentsMap = new String[NUM_PARTITIONS][numSegmentsPerPartition];
+    for (int i = 0; i < NUM_PARTITIONS; i++) {
+      String[] sortedSegments = new String[numSegmentsPerPartition];
+      System.arraycopy(partitionIdToSegmentsMap[i], 0, sortedSegments, 0, numSegmentsPerPartition);
+      Arrays.sort(sortedSegments);
+      partitionIdToSortedSegmentsMap[i] = sortedSegments;
+    }
+    for (int i = 0; i < NUM_PARTITIONS; i++) {
+      for (int j = 0; j < numSegmentsPerPartition; j++) {
+        assertEquals(newAssignment.get(partitionIdToSortedSegmentsMap[i][j]),
+            currentAssignment.get(partitionIdToSegmentsMap[i][j]));
+      }
+    }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
@@ -141,19 +141,26 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
       assertEquals(instanceStateMap.size(), NUM_REPLICAS);
     }
 
+    // Add an OFFLINE segment on some bad instances
+    String offlineSegmentName = "offlineSegment";
+    Map<String, String> offlineSegmentInstanceStateMap = SegmentAssignmentUtils
+        .getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
+            RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
+    currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
+
     // Rebalance without COMPLETED instance partitions should not change the segment assignment
     Map<InstancePartitionsType, InstancePartitions> noRelocationInstancePartitionsMap = new TreeMap<>();
     noRelocationInstancePartitionsMap
         .put(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
-    Map<String, Map<String, String>> newAssignment = _segmentAssignment
-        .rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, new BaseConfiguration());
-    assertEquals(newAssignment, currentAssignment);
+    assertEquals(_segmentAssignment
+            .rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, new BaseConfiguration()),
+        currentAssignment);
 
     // Rebalance with COMPLETED instance partitions should relocate all COMPLETED (ONLINE) segments to the COMPLETED
     // instances
-    newAssignment =
+    Map<String, Map<String, String>> newAssignment =
         _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, new BaseConfiguration());
-    assertEquals(newAssignment.size(), NUM_SEGMENTS);
+    assertEquals(newAssignment.size(), NUM_SEGMENTS + 1);
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
       if (segmentId < NUM_SEGMENTS - NUM_PARTITIONS) {
         // COMPLETED (ONLINE) segments
@@ -181,23 +188,43 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
     }
 
     // Rebalance with COMPLETED instance partitions including CONSUMING segments should give the same assignment
-    BaseConfiguration config = new BaseConfiguration();
-    config.setProperty(RebalanceConfigConstants.INCLUDE_CONSUMING, true);
-    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, config), newAssignment);
+    BaseConfiguration rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.setProperty(RebalanceConfigConstants.INCLUDE_CONSUMING, true);
+    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, rebalanceConfig),
+        newAssignment);
 
     // Rebalance without COMPLETED instance partitions again should change the segment assignment back
+    currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
     assertEquals(
         _segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, new BaseConfiguration()),
         currentAssignment);
 
-    // Rebalance should not change the assignment for the OFFLINE segments
-    String offlineSegmentName = "offlineSegment";
-    Map<String, String> offlineSegmentInstanceStateMap = SegmentAssignmentUtils
-        .getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
-            RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
-    currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
-    newAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
-    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, config), newAssignment);
+    // Bootstrap table without COMPLETED instance partitions should be the same as regular rebalance
+    rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
+    assertEquals(
+        _segmentAssignment.rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, rebalanceConfig),
+        currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, rebalanceConfig),
+        currentAssignment);
+
+    // Bootstrap table with COMPLETED instance partitions should reassign all COMPLETED segments based on their
+    // alphabetical order
+    newAssignment = _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, rebalanceConfig);
+    int index = 0;
+    for (Map.Entry<String, Map<String, String>> entry : newAssignment.entrySet()) {
+      String segmentName = entry.getKey();
+      Map<String, String> instanceStateMap = entry.getValue();
+      if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+        for (int i = 0; i < NUM_REPLICAS; i++) {
+          String expectedInstance = COMPLETED_INSTANCES.get(index++ % NUM_COMPLETED_INSTANCES);
+          assertEquals(instanceStateMap.get(expectedInstance), RealtimeSegmentOnlineOfflineStateModel.ONLINE);
+        }
+      } else {
+        // CONSUMING and OFFLINE segments should not be reassigned
+        assertEquals(instanceStateMap, currentAssignment.get(segmentName));
+      }
+    }
   }
 
   private void addToAssignment(Map<String, Map<String, String>> currentAssignment, int segmentId,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
@@ -166,19 +166,26 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
       assertEquals(instanceStateMap.size(), NUM_REPLICAS);
     }
 
+    // Add an OFFLINE segment on some bad instances
+    String offlineSegmentName = "offlineSegment";
+    Map<String, String> offlineSegmentInstanceStateMap = SegmentAssignmentUtils
+        .getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
+            RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
+    currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
+
     // Rebalance without COMPLETED instance partitions should not change the segment assignment
     Map<InstancePartitionsType, InstancePartitions> noRelocationInstancePartitionsMap = new TreeMap<>();
     noRelocationInstancePartitionsMap
         .put(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
-    Map<String, Map<String, String>> newAssignment = _segmentAssignment
-        .rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, new BaseConfiguration());
-    assertEquals(newAssignment, currentAssignment);
+    assertEquals(_segmentAssignment
+            .rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, new BaseConfiguration()),
+        currentAssignment);
 
     // Rebalance with COMPLETED instance partitions should relocate all COMPLETED (ONLINE) segments to the COMPLETED
     // instances
-    newAssignment =
+    Map<String, Map<String, String>> newAssignment =
         _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, new BaseConfiguration());
-    assertEquals(newAssignment.size(), NUM_SEGMENTS);
+    assertEquals(newAssignment.size(), NUM_SEGMENTS + 1);
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
       if (segmentId < NUM_SEGMENTS - NUM_PARTITIONS) {
         // COMPLETED (ONLINE) segments
@@ -205,23 +212,45 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
     assertEquals(numSegmentsAssignedPerInstance, expectedNumSegmentsAssignedPerInstance);
 
     // Rebalance with COMPLETED instance partitions including CONSUMING segments should give the same assignment
-    BaseConfiguration config = new BaseConfiguration();
-    config.setProperty(RebalanceConfigConstants.INCLUDE_CONSUMING, true);
-    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, config), newAssignment);
+    BaseConfiguration rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.setProperty(RebalanceConfigConstants.INCLUDE_CONSUMING, true);
+    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, rebalanceConfig),
+        newAssignment);
 
     // Rebalance without COMPLETED instance partitions again should change the segment assignment back
     assertEquals(
         _segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, new BaseConfiguration()),
         currentAssignment);
 
-    // Rebalance should not change the assignment for the OFFLINE segments
-    String offlineSegmentName = "offlineSegment";
-    Map<String, String> offlineSegmentInstanceStateMap = SegmentAssignmentUtils
-        .getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
-            RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
-    currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
-    newAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
-    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, config), newAssignment);
+    // Bootstrap table without COMPLETED instance partitions should be the same as regular rebalance
+    rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
+    assertEquals(
+        _segmentAssignment.rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, rebalanceConfig),
+        currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, rebalanceConfig),
+        currentAssignment);
+
+    // Bootstrap table with COMPLETED instance partitions should reassign all COMPLETED segments based on their
+    // alphabetical order
+    newAssignment = _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, rebalanceConfig);
+    int numCompletedInstancesPerReplicaGroup = NUM_COMPLETED_INSTANCES / NUM_REPLICAS;
+    int index = 0;
+    for (Map.Entry<String, Map<String, String>> entry : newAssignment.entrySet()) {
+      String segmentName = entry.getKey();
+      Map<String, String> instanceStateMap = entry.getValue();
+      if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+        int expectedInstanceId = index++ % numCompletedInstancesPerReplicaGroup;
+        for (int i = 0; i < NUM_REPLICAS; i++) {
+          String expectedInstance =
+              COMPLETED_INSTANCES.get(expectedInstanceId + i * numCompletedInstancesPerReplicaGroup);
+          assertEquals(instanceStateMap.get(expectedInstance), RealtimeSegmentOnlineOfflineStateModel.ONLINE);
+        }
+      } else {
+        // CONSUMING and OFFLINE segments should not be reassigned
+        assertEquals(instanceStateMap, currentAssignment.get(segmentName));
+      }
+    }
   }
 
   private void addToAssignment(Map<String, Map<String, String>> currentAssignment, int segmentId,

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -35,11 +35,13 @@ public class PinotTableRebalancer extends PinotZKChanger {
   private final Configuration _rebalanceConfig = new BaseConfiguration();
 
   public PinotTableRebalancer(String zkAddress, String clusterName, boolean dryRun, boolean reassignInstances,
-      boolean includeConsuming, boolean downtime, int minReplicasToKeepUpForNoDowntime, boolean bestEffort) {
+      boolean includeConsuming, boolean bootstrap, boolean downtime, int minReplicasToKeepUpForNoDowntime,
+      boolean bestEffort) {
     super(zkAddress, clusterName);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, dryRun);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, reassignInstances);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.INCLUDE_CONSUMING, includeConsuming);
+    _rebalanceConfig.addProperty(RebalanceConfigConstants.BOOTSTRAP, bootstrap);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.DOWNTIME, downtime);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.MIN_REPLICAS_TO_KEEP_UP_FOR_NO_DOWNTIME,
         minReplicasToKeepUpForNoDowntime);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -52,6 +52,9 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
   @Option(name = "-includeConsuming", metaVar = "<boolean>", usage = "Whether to reassign CONSUMING segments for real-time table (false by default)")
   private boolean _includeConsuming = false;
 
+  @Option(name = "-bootstrap", metaVar = "<boolean>", usage = "Whether to rebalance table in bootstrap mode (starting from an empty table and reassign all segments, where segments will be assigned in a round-robin fashion, but no minimum movement is guaranteed, false by default)")
+  private boolean _bootstrap = false;
+
   @Option(name = "-downtime", metaVar = "<boolean>", usage = "Whether to allow downtime for the rebalance (false by default)")
   private boolean _downtime = false;
 
@@ -77,8 +80,8 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
   public boolean execute()
       throws Exception {
     PinotTableRebalancer tableRebalancer =
-        new PinotTableRebalancer(_zkAddress, _clusterName, _dryRun, _reassignInstances, _includeConsuming, _downtime,
-            _minAvailableReplicas, _bestEfforts);
+        new PinotTableRebalancer(_zkAddress, _clusterName, _dryRun, _reassignInstances, _includeConsuming, _bootstrap,
+            _downtime, _minAvailableReplicas, _bestEfforts);
     RebalanceResult rebalanceResult = tableRebalancer.rebalance(_tableNameWithType);
     LOGGER
         .info("Got rebalance result: {} for table: {}", JsonUtils.objectToString(rebalanceResult), _tableNameWithType);
@@ -112,6 +115,12 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
     System.out.println("Rebalance table with CONSUMING segments reassigned");
     System.out.println(
         "sh pinot-admin.sh RebalanceTable -zkAddress localhost:2191 -clusterName PinotCluster -tableName myTable_REALTIME -includeConsuming");
+    System.out.println();
+
+    System.out.println(
+        "Rebalance table in bootstrap mode. Rebalancer will start from an empty table and reassign all segments");
+    System.out.println(
+        "sh pinot-admin.sh RebalanceTable -zkAddress localhost:2191 -clusterName PinotCluster -tableName myTable_REALTIME -bootstrap");
     System.out.println();
 
     System.out.println("Rebalance table with downtime");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -52,7 +52,7 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
   @Option(name = "-includeConsuming", metaVar = "<boolean>", usage = "Whether to reassign CONSUMING segments for real-time table (false by default)")
   private boolean _includeConsuming = false;
 
-  @Option(name = "-bootstrap", metaVar = "<boolean>", usage = "Whether to rebalance table in bootstrap mode (starting from an empty table and reassign all segments, where segments will be assigned in a round-robin fashion, but no minimum movement is guaranteed, false by default)")
+  @Option(name = "-bootstrap", metaVar = "<boolean>", usage = "Whether to rebalance table in bootstrap mode (regardless of minimum segment movement, reassign all segments in a round-robin fashion as if adding new segments to an empty table, false by default)")
   private boolean _bootstrap = false;
 
   @Option(name = "-downtime", metaVar = "<boolean>", usage = "Whether to allow downtime for the rebalance (false by default)")
@@ -118,7 +118,7 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
     System.out.println();
 
     System.out.println(
-        "Rebalance table in bootstrap mode. Rebalancer will start from an empty table and reassign all segments");
+        "Rebalance table in bootstrap mode. Rebalancer will reassign all segments in a round-robin fashion as if adding new segments to an empty table");
     System.out.println(
         "sh pinot-admin.sh RebalanceTable -zkAddress localhost:2191 -clusterName PinotCluster -tableName myTable_REALTIME -bootstrap");
     System.out.println();


### PR DESCRIPTION
Add bootstrap mode where the rebalancer starts with an empty table and reassign all segments.
This mode can be used to rebalance table with hotspot servers.
All segments will be sorted alphabetically and assigned in a round-robin fashion, no minimum movement is guaranteed.

Other related changes:
- Extract some pieces of code for sharing between offline and real-time assignment
- Extract assign segment logic without logging to reduce the log for bootstrapping
- Add tests to cover the new feature