### PR TITLE
Remove the cache from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,6 @@ before_install:
   - curl -sSL -o ~/bin/install-jdk.sh https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh && chmod +x ~/bin/install-jdk.sh
   - source ./.travis/.travis_set_deploy_build_opts.sh
 
-before_cache:
-  - rm -rf $HOME/.m2/repository/org/apache/pinot
-
-cache:
-  directories:
-    - $HOME/.m2
-  yarn: true
-
 addons:
   firefox: latest
 


### PR DESCRIPTION
If cache does not provide much gain for the test performance, disable it to save the extra cost of managing it