### PR TITLE
[TE] add rate limiter to batch alert onboarding

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -191,7 +191,7 @@ public class ThirdEyeDashboardApplication
         DAO_REGISTRY.getDetectionConfigManager(), DAO_REGISTRY.getDetectionAlertConfigManager()));
     env.jersey().register(new DetectionResource());
     env.jersey().register(new DetectionAlertResource(DAO_REGISTRY.getDetectionAlertConfigManager()));
-    env.jersey().register(new YamlResource(config.getDetectionPreviewConfig()));
+    env.jersey().register(new YamlResource(config.getDetectionPreviewConfig(), config.getAlertOnboardingPermitPerSecond()));
     env.jersey().register(new SqlDataSourceResource());
 
     TimeSeriesLoader timeSeriesLoader = new DefaultTimeSeriesLoader(

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardConfiguration.java
@@ -27,10 +27,15 @@ import java.util.List;
 
 
 public class ThirdEyeDashboardConfiguration extends ThirdEyeConfiguration {
+  private static final double PROP_DEFAULT_ALERT_ONBOARDING_PERMIT_PER_SECOND = 2;
+
   AuthConfiguration authConfig;
   RootCauseConfiguration rootCause;
   List<ResourceConfiguration> resourceConfig;
   DetectionPreviewConfiguration detectionPreviewConfig = new DetectionPreviewConfiguration();
+
+  // the maximum number of onboarding requests allowed per second
+  double alertOnboardingPermitPerSecond = PROP_DEFAULT_ALERT_ONBOARDING_PERMIT_PER_SECOND;
 
   public DetectionPreviewConfiguration getDetectionPreviewConfig() {
     return detectionPreviewConfig;
@@ -38,6 +43,14 @@ public class ThirdEyeDashboardConfiguration extends ThirdEyeConfiguration {
 
   public void setDetectionPreviewConfig(DetectionPreviewConfiguration detectionPreviewConfig) {
     this.detectionPreviewConfig = detectionPreviewConfig;
+  }
+
+  public double getAlertOnboardingPermitPerSecond() {
+    return alertOnboardingPermitPerSecond;
+  }
+
+  public void setAlertOnboardingPermitPerSecond(double alertOnoardingPermitPerSecond) {
+    this.alertOnboardingPermitPerSecond = alertOnoardingPermitPerSecond;
   }
 
   public List<ResourceConfiguration> getResourceConfig() {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
@@ -371,7 +371,8 @@ public class YamlResource {
   long createDetectionConfig(@NotNull String payload, long startTime, long endTime) throws Exception {
     // if can't acquire alert onboarding QPS permit, throw an exception
     if (!this.onboardingRateLimiter.tryAcquire()) {
-      throw new RuntimeException("Server is busy handling create detection requests. Please retry later.");
+      throw new RuntimeException(
+          String.format("Server is busy handling create detection requests. Please retry later. QPS quota: %f", this.onboardingRateLimiter.getRate()));
     }
 
     DetectionConfigDTO detectionConfig = buildDetectionConfigFromYaml(startTime, endTime, payload, null);


### PR DESCRIPTION
Add a rate limiter to the create alert API. The QPS permit can be set in Thirdeye configs. If the QPS is above the permit, it will return an error message to the users. This is to prevent the users who are using API to create alerts at a high throughput which could bring down the system.