### PR TITLE
exclude jsr311 dependency to make pinot-quickstart work under pinot-tools lib

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -97,6 +97,20 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
+          <artifactId>jackson-jaxrs-json-provider</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-jaxb-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -139,6 +139,20 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
+          <artifactId>jackson-jaxrs-json-provider</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-jaxb-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -208,6 +208,10 @@
           <groupId>com.fasterxml.jackson.module</groupId>
           <artifactId>jackson-module-jaxb-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
```
➜  pinot-tools/target/pinot-tools-pkg/bin/quick-start-batch.sh
***** Starting Zookeeper, controller, broker and server *****
Executing command: StartZookeeper -zkPort 2123 -dataDir /var/folders/z2/hb8qkb3s1fz4sb3dczgml7200000gn/T//PinotAdmin/zkData
log4j:WARN No appenders could be found for logger (org.I0Itec.zkclient.ZkConnection).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
log4j:WARN No appenders could be found for logger (org.I0Itec.zkclient.ZkEventThread).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Start zookeeper at localhost:2123 in thread main
Executing command: StartController -clusterName QuickStartCluster -controllerHost 192.168.1.2 -controllerPort 9000 -dataDir /var/folders/z2/hb8qkb3s1fz4sb3dczgml7200000gn/T//PinotController -zkAddress localhost:2123
Invalid instance setup, missing znode path: /QuickStartCluster/CONFIGS/PARTICIPANT/Controller_192.168.1.2_9000
Invalid instance setup, missing znode path: /QuickStartCluster/INSTANCES/Controller_192.168.1.2_9000/MESSAGES
Invalid instance setup, missing znode path: /QuickStartCluster/INSTANCES/Controller_192.168.1.2_9000/CURRENTSTATES
Invalid instance setup, missing znode path: /QuickStartCluster/INSTANCES/Controller_192.168.1.2_9000/STATUSUPDATES
Invalid instance setup, missing znode path: /QuickStartCluster/INSTANCES/Controller_192.168.1.2_9000/ERRORS
Exception in thread "main" java.lang.NoSuchMethodError: javax.ws.rs.core.Application.getProperties()Ljava/util/Map;
	at org.glassfish.jersey.server.ApplicationHandler.initialize(ApplicationHandler.java:306)
	at org.glassfish.jersey.server.ApplicationHandler.lambda$initialize$1(ApplicationHandler.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.processWithException(Errors.java:232)
	at org.glassfish.jersey.server.ApplicationHandler.initialize(ApplicationHandler.java:291)
	at org.glassfish.jersey.server.ApplicationHandler.<init>(ApplicationHandler.java:258)
	at org.glassfish.jersey.server.ApplicationHandler.<init>(ApplicationHandler.java:245)
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.<init>(GrizzlyHttpContainer.java:310)
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory.createHttpServer(GrizzlyHttpServerFactory.java:93)
	at org.apache.pinot.controller.api.ControllerAdminApiApplication.start(ControllerAdminApiApplication.java:85)
	at org.apache.pinot.controller.ControllerStarter.setUpPinotController(ControllerStarter.java:359)
	at org.apache.pinot.controller.ControllerStarter.start(ControllerStarter.java:231)
	at org.apache.pinot.tools.admin.command.StartControllerCommand.execute(StartControllerCommand.java:163)
	at org.apache.pinot.tools.admin.command.QuickstartRunner.startControllers(QuickstartRunner.java:97)
	at org.apache.pinot.tools.admin.command.QuickstartRunner.startAll(QuickstartRunner.java:132)
	at org.apache.pinot.tools.Quickstart.execute(Quickstart.java:150)
	at org.apache.pinot.tools.Quickstart.main(Quickstart.java:209)
```