### PR TITLE
Support Aggregation functions with multiple arguments.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -71,7 +71,7 @@ import org.apache.pinot.common.utils.helix.TableCache;
 import org.apache.pinot.core.query.reduce.BrokerReduceService;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.util.QueryOptions;
-import org.apache.pinot.pql.parsers.pql2.ast.FunctionCallAstNode;
+import org.apache.pinot.parsers.CompilerConstants;
 import org.apache.pinot.spi.config.TableType;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -443,15 +443,15 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       for (AggregationInfo info : brokerRequest.getAggregationsInfo()) {
         if (info.getAggregationParams() != null && !info.getAggregationType()
             .equalsIgnoreCase(AggregationFunctionType.COUNT.getName())) {
-          String column = info.getAggregationParams().get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO);
-          String[] expressions = column.split(FunctionCallAstNode.DISTINCT_MULTI_COLUMN_SEPARATOR);
+          String column = info.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO);
+          String[] expressions = column.split(CompilerConstants.AGGREGATION_FUNCTION_ARG_SEPARATOR);
           String[] newExpressions = new String[expressions.length];
           for (int i = 0; i < expressions.length; i++) {
             String expression = expressions[i];
             newExpressions[i] = fixColumnNameCase(tableCache, actualTableName, expression);
           }
-          String newColumns = StringUtil.join(FunctionCallAstNode.DISTINCT_MULTI_COLUMN_SEPARATOR, newExpressions);
-          info.getAggregationParams().put(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO, newColumns);
+          String newColumns = StringUtil.join(CompilerConstants.AGGREGATION_FUNCTION_ARG_SEPARATOR, newExpressions);
+          info.getAggregationParams().put(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, newColumns);
         }
       }
       if (brokerRequest.isSetGroupBy()) {
@@ -714,8 +714,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
           }
           if (brokerRequest.isSetOrderBy()) {
             String column =
-                aggregationInfo.getAggregationParams().get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO);
-            String[] columns = column.split(FunctionCallAstNode.DISTINCT_MULTI_COLUMN_SEPARATOR);
+                aggregationInfo.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO);
+            String[] columns = column.split(CompilerConstants.AGGREGATION_FUNCTION_ARG_SEPARATOR);
             Set<String> set = new HashSet<>(Arrays.asList(columns));
             List<SelectionSort> orderByColumns = brokerRequest.getOrderBy();
             for (SelectionSort selectionSort : orderByColumns) {

--- a/pinot-common/src/main/java/org/apache/pinot/parsers/CompilerConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/parsers/CompilerConstants.java
@@ -16,23 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.query.aggregation.function;
+package org.apache.pinot.parsers;
 
-import org.apache.pinot.common.function.AggregationFunctionType;
+/**
+ * Class to host compiler related constants
+ */
+public class CompilerConstants {
+  public static final String AGGREGATION_FUNCTION_ARG_SEPARATOR = ":";
+  public static final String COLUMN_KEY_IN_AGGREGATION_INFO = "column";
 
+  // Private constructor to prevent instantiation
+  private CompilerConstants() {
 
-public class DistinctCountRawHLLMVAggregationFunction extends DistinctCountRawHLLAggregationFunction {
-
-  /**
-   * Constructor for the class.
-   * @param column Column name to aggregate on.
-   */
-  public DistinctCountRawHLLMVAggregationFunction(String column) {
-    super(new DistinctCountHLLMVAggregationFunction(column), column);
-  }
-
-  @Override
-  public AggregationFunctionType getType() {
-    return AggregationFunctionType.DISTINCTCOUNTRAWHLLMV;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/Pql2Compiler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/Pql2Compiler.java
@@ -70,8 +70,6 @@ public class Pql2Compiler implements AbstractCompiler {
       Boolean.valueOf(System.getProperty("pinot.query.converter.validate", "false"));
   public static boolean FAIL_ON_CONVERSION_ERROR =
       Boolean.valueOf(System.getProperty("pinot.query.converter.fail_on_error", "false"));
-  public static String ENABLE_DISTINCT_KEY = "pinot.distinct.enabled";
-  public static boolean ENABLE_DISTINCT = Boolean.valueOf(System.getProperty(ENABLE_DISTINCT_KEY, "true"));
   private static class ErrorListener extends BaseErrorListener {
 
     @Override

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -52,7 +52,6 @@ import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -450,9 +449,6 @@ public class CalciteSqlParser {
 
   private static List<Expression> convertDistinctSelectList(SqlNodeList selectList) {
     List<Expression> selectExpr = new ArrayList<>();
-    if (!Pql2Compiler.ENABLE_DISTINCT) {
-      throw new SqlCompilationException("Support for DISTINCT is currently disabled in Pinot");
-    }
     selectExpr.add(convertDistinctAndSelectListToFunctionExpression(selectList));
     return selectExpr;
   }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -33,9 +33,9 @@ import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.parsers.CompilerConstants;
 import org.apache.pinot.pql.parsers.PinotQuery2BrokerRequestConverter;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
-import org.apache.pinot.pql.parsers.pql2.ast.FunctionCallAstNode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -601,8 +601,6 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testSqlDistinctQueryCompilation() {
-    Pql2Compiler.ENABLE_DISTINCT = true;
-
     // test single column DISTINCT
     String sql = "SELECT DISTINCT c1 FROM foo";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
@@ -624,7 +622,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(aggregationInfos.size(), 1);
     AggregationInfo aggregationInfo = aggregationInfos.get(0);
     Assert.assertEquals(aggregationInfo.getAggregationType(), AggregationFunctionType.DISTINCT.getName());
-    Assert.assertEquals(aggregationInfo.getAggregationParams().get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO),
+    Assert.assertEquals(aggregationInfo.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO),
         "c1");
 
     // test multi column DISTINCT
@@ -650,7 +648,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(aggregationInfos.size(), 1);
     aggregationInfo = aggregationInfos.get(0);
     Assert.assertEquals(aggregationInfo.getAggregationType(), AggregationFunctionType.DISTINCT.getName());
-    Assert.assertEquals(aggregationInfo.getAggregationParams().get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO),
+    Assert.assertEquals(aggregationInfo.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO),
         "c1:c2");
 
     // test multi column DISTINCT with filter
@@ -684,7 +682,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(aggregationInfos.size(), 1);
     aggregationInfo = aggregationInfos.get(0);
     Assert.assertEquals(aggregationInfo.getAggregationType(), AggregationFunctionType.DISTINCT.getName());
-    Assert.assertEquals(aggregationInfo.getAggregationParams().get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO),
+    Assert.assertEquals(aggregationInfo.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO),
         "c1:c2:c3");
 
     // not supported by Calcite SQL (this is in compliance with SQL standard)
@@ -811,7 +809,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(aggregationInfos.size(), 1);
     aggregationInfo = aggregationInfos.get(0);
     Assert.assertEquals(aggregationInfo.getAggregationType(), AggregationFunctionType.DISTINCT.getName());
-    Assert.assertEquals(aggregationInfo.getAggregationParams().get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO),
+    Assert.assertEquals(aggregationInfo.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO),
         "add(col1,col2)");
 
     // multi-column distinct with multiple transform functions
@@ -865,7 +863,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(aggregationInfos.size(), 1);
     aggregationInfo = aggregationInfos.get(0);
     Assert.assertEquals(aggregationInfo.getAggregationType(), AggregationFunctionType.DISTINCT.getName());
-    Assert.assertEquals(aggregationInfo.getAggregationParams().get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO),
+    Assert.assertEquals(aggregationInfo.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO),
         "add(div(col1,col2),mul(col3,col4)):sub(col3,col4)");
 
     // multi-column distinct with multiple transform columns and additional identifiers
@@ -926,7 +924,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(aggregationInfos.size(), 1);
     aggregationInfo = aggregationInfos.get(0);
     Assert.assertEquals(aggregationInfo.getAggregationType(), AggregationFunctionType.DISTINCT.getName());
-    Assert.assertEquals(aggregationInfo.getAggregationParams().get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO),
+    Assert.assertEquals(aggregationInfo.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO),
         "add(div(col1,col2),mul(col3,col4)):sub(col3,col4):col5:col6");
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
@@ -31,7 +31,7 @@ import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
-import org.apache.pinot.pql.parsers.pql2.ast.FunctionCallAstNode;
+import org.apache.pinot.parsers.CompilerConstants;
 import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +67,7 @@ public class TransformPlanNode implements PlanNode {
         if (aggregationInfo.getAggregationType().equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
           // 'DISTINCT(col1, col2 ...)' is modeled as one single aggregation function
           String[] distinctColumns = AggregationFunctionUtils.getColumn(aggregationInfo)
-              .split(FunctionCallAstNode.DISTINCT_MULTI_COLUMN_SEPARATOR);
+              .split(CompilerConstants.AGGREGATION_FUNCTION_ARG_SEPARATOR);
           columns.addAll(Arrays.asList(distinctColumns));
         } else if (!aggregationInfo.getAggregationType().equalsIgnoreCase(AggregationFunctionType.COUNT.getName())) {
           columns.add(AggregationFunctionUtils.getColumn(aggregationInfo));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -71,21 +72,21 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   /**
    * Performs aggregation on the given block value sets (aggregation only).
    */
-  void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets);
+  void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap);
 
   /**
    * Performs aggregation on the given group key array and block value sets (aggregation group-by on single-value
    * columns).
    */
   void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets);
+      Map<String, BlockValSet> blockValSets);
 
   /**
    * Performs aggregation on the given group keys array and block value sets (aggregation group-by on multi-value
    * columns).
    */
   void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets);
+      Map<String, BlockValSet> blockValSets);
 
   /**
    * Extracts the intermediate result from the aggregation result holder (aggregation only).

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import com.google.common.base.Preconditions;
 import com.google.common.math.DoubleMath;
 import java.io.Serializable;
 import java.util.List;
@@ -27,9 +28,8 @@ import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.query.aggregation.AggregationFunctionContext;
-import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
-import org.apache.pinot.pql.parsers.pql2.ast.FunctionCallAstNode;
+import org.apache.pinot.parsers.CompilerConstants;
 
 
 /**
@@ -39,13 +39,11 @@ public class AggregationFunctionUtils {
   private AggregationFunctionUtils() {
   }
 
-  public static final String COLUMN_KEY = FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO;
-
   /**
    * Extracts the aggregation column (could be column name or UDF expression) from the {@link AggregationInfo}.
    */
   public static String getColumn(AggregationInfo aggregationInfo) {
-    return aggregationInfo.getAggregationParams().get(COLUMN_KEY);
+    return aggregationInfo.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO);
   }
 
   /**
@@ -137,5 +135,18 @@ public class AggregationFunctionUtils {
     } else {
       return value.toString();
     }
+  }
+
+  /**
+   * Utility function to parse percentile value from string.
+   * Asserts that percentile value is within 0 and 100.
+   *
+   * @param percentileString Input String
+   * @return Percentile value parsed from String.
+   */
+  public static int parsePercentile(String percentileString) {
+    int percentile = Integer.parseInt(percentileString);
+    Preconditions.checkState(percentile >= 0 && percentile <= 100);
+    return percentile;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -25,6 +26,14 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
 public class AvgMVAggregationFunction extends AvgAggregationFunction {
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public AvgMVAggregationFunction(String column) {
+    super(column);
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -37,8 +46,8 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     double sum = 0.0;
     long count = 0L;
     for (int i = 0; i < length; i++) {
@@ -53,8 +62,8 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       aggregateOnGroupKey(groupKeyArray[i], groupByResultHolder, valuesArray[i]);
     }
@@ -62,8 +71,8 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -25,6 +26,14 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
 public class CountMVAggregationFunction extends CountAggregationFunction {
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public CountMVAggregationFunction(String column) {
+    super(column);
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -47,8 +56,8 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    int[] valueArray = blockValSets[0].getNumMVEntries();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    int[] valueArray = blockValSetMap.get(_column).getNumMVEntries();
     long count = 0L;
     for (int i = 0; i < length; i++) {
       count += valueArray[i];
@@ -58,8 +67,8 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    int[] valueArray = blockValSets[0].getNumMVEntries();
+      Map<String, BlockValSet> blockValSetMap) {
+    int[] valueArray = blockValSetMap.get(_column).getNumMVEntries();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + valueArray[i]);
@@ -68,8 +77,8 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    int[] valueArray = blockValSets[0].getNumMVEntries();
+      Map<String, BlockValSet> blockValSetMap) {
+    int[] valueArray = blockValSetMap.get(_column).getNumMVEntries();
     for (int i = 0; i < length; i++) {
       int value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import org.apache.pinot.spi.data.FieldSpec;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -27,9 +27,20 @@ import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class DistinctCountAggregationFunction implements AggregationFunction<IntOpenHashSet, Integer> {
+
+  protected final String _column;
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public DistinctCountAggregationFunction(String column) {
+    _column = column;
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -52,37 +63,38 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
     IntOpenHashSet valueSet = getValueSet(aggregationResultHolder);
 
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    FieldSpec.DataType valueType = blockValSet.getValueType();
     switch (valueType) {
       case INT:
-        int[] intValues = blockValSets[0].getIntValuesSV();
+        int[] intValues = blockValSet.getIntValuesSV();
         for (int i = 0; i < length; i++) {
           valueSet.add(intValues[i]);
         }
         break;
       case LONG:
-        long[] longValues = blockValSets[0].getLongValuesSV();
+        long[] longValues = blockValSet.getLongValuesSV();
         for (int i = 0; i < length; i++) {
           valueSet.add(Long.hashCode(longValues[i]));
         }
         break;
       case FLOAT:
-        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        float[] floatValues = blockValSet.getFloatValuesSV();
         for (int i = 0; i < length; i++) {
           valueSet.add(Float.hashCode(floatValues[i]));
         }
         break;
       case DOUBLE:
-        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        double[] doubleValues = blockValSet.getDoubleValuesSV();
         for (int i = 0; i < length; i++) {
           valueSet.add(Double.hashCode(doubleValues[i]));
         }
         break;
       case STRING:
-        String[] stringValues = blockValSets[0].getStringValuesSV();
+        String[] stringValues = blockValSet.getStringValuesSV();
         for (int i = 0; i < length; i++) {
           valueSet.add(stringValues[i].hashCode());
         }
@@ -94,35 +106,37 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+      Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    FieldSpec.DataType valueType = blockValSet.getValueType();
+
     switch (valueType) {
       case INT:
-        int[] intValues = blockValSets[0].getIntValuesSV();
+        int[] intValues = blockValSet.getIntValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKey(groupByResultHolder, groupKeyArray[i], intValues[i]);
         }
         break;
       case LONG:
-        long[] longValues = blockValSets[0].getLongValuesSV();
+        long[] longValues = blockValSet.getLongValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKey(groupByResultHolder, groupKeyArray[i], Long.hashCode(longValues[i]));
         }
         break;
       case FLOAT:
-        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        float[] floatValues = blockValSet.getFloatValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKey(groupByResultHolder, groupKeyArray[i], Float.hashCode(floatValues[i]));
         }
         break;
       case DOUBLE:
-        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        double[] doubleValues = blockValSet.getDoubleValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKey(groupByResultHolder, groupKeyArray[i], Double.hashCode(doubleValues[i]));
         }
         break;
       case STRING:
-        String[] stringValues = blockValSets[0].getStringValuesSV();
+        String[] stringValues = blockValSet.getStringValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKey(groupByResultHolder, groupKeyArray[i], stringValues[i].hashCode());
         }
@@ -134,35 +148,37 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+      Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+
+    FieldSpec.DataType valueType = blockValSet.getValueType();
     switch (valueType) {
       case INT:
-        int[] intValues = blockValSets[0].getIntValuesSV();
+        int[] intValues = blockValSet.getIntValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
         }
         break;
       case LONG:
-        long[] longValues = blockValSets[0].getLongValuesSV();
+        long[] longValues = blockValSet.getLongValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Long.hashCode(longValues[i]));
         }
         break;
       case FLOAT:
-        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        float[] floatValues = blockValSet.getFloatValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Float.hashCode(floatValues[i]));
         }
         break;
       case DOUBLE:
-        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        double[] doubleValues = blockValSet.getDoubleValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Double.hashCode(doubleValues[i]));
         }
         break;
       case STRING:
-        String[] stringValues = blockValSets[0].getStringValuesSV();
+        String[] stringValues = blockValSet.getStringValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i].hashCode());
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -20,7 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.base.Preconditions;
-import org.apache.pinot.spi.data.FieldSpec.DataType;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -29,10 +29,21 @@ import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class DistinctCountHLLAggregationFunction implements AggregationFunction<HyperLogLog, Long> {
+  protected final String _column;
+
   public static final int DEFAULT_LOG2M = 8;
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public DistinctCountHLLAggregationFunction(String column) {
+    _column = column;
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -55,37 +66,39 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    DataType valueType = blockValSets[0].getValueType();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    DataType valueType = blockValSet.getValueType();
+
     if (valueType != DataType.BYTES) {
       HyperLogLog hyperLogLog = getDefaultHyperLogLog(aggregationResultHolder);
       switch (valueType) {
         case INT:
-          int[] intValues = blockValSets[0].getIntValuesSV();
+          int[] intValues = blockValSet.getIntValuesSV();
           for (int i = 0; i < length; i++) {
             hyperLogLog.offer(intValues[i]);
           }
           break;
         case LONG:
-          long[] longValues = blockValSets[0].getLongValuesSV();
+          long[] longValues = blockValSet.getLongValuesSV();
           for (int i = 0; i < length; i++) {
             hyperLogLog.offer(longValues[i]);
           }
           break;
         case FLOAT:
-          float[] floatValues = blockValSets[0].getFloatValuesSV();
+          float[] floatValues = blockValSet.getFloatValuesSV();
           for (int i = 0; i < length; i++) {
             hyperLogLog.offer(floatValues[i]);
           }
           break;
         case DOUBLE:
-          double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+          double[] doubleValues = blockValSet.getDoubleValuesSV();
           for (int i = 0; i < length; i++) {
             hyperLogLog.offer(doubleValues[i]);
           }
           break;
         case STRING:
-          String[] stringValues = blockValSets[0].getStringValuesSV();
+          String[] stringValues = blockValSet.getStringValuesSV();
           for (int i = 0; i < length; i++) {
             hyperLogLog.offer(stringValues[i]);
           }
@@ -96,7 +109,7 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
       }
     } else {
       // Serialized HyperLogLog
-      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
         HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
         if (hyperLogLog != null) {
@@ -118,42 +131,44 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    DataType valueType = blockValSets[0].getValueType();
+      Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    DataType valueType = blockValSet.getValueType();
+
     switch (valueType) {
       case INT:
-        int[] intValues = blockValSets[0].getIntValuesSV();
+        int[] intValues = blockValSet.getIntValuesSV();
         for (int i = 0; i < length; i++) {
           getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(intValues[i]);
         }
         break;
       case LONG:
-        long[] longValues = blockValSets[0].getLongValuesSV();
+        long[] longValues = blockValSet.getLongValuesSV();
         for (int i = 0; i < length; i++) {
           getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(longValues[i]);
         }
         break;
       case FLOAT:
-        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        float[] floatValues = blockValSet.getFloatValuesSV();
         for (int i = 0; i < length; i++) {
           getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(floatValues[i]);
         }
         break;
       case DOUBLE:
-        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        double[] doubleValues = blockValSet.getDoubleValuesSV();
         for (int i = 0; i < length; i++) {
           getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(doubleValues[i]);
         }
         break;
       case STRING:
-        String[] stringValues = blockValSets[0].getStringValuesSV();
+        String[] stringValues = blockValSet.getStringValuesSV();
         for (int i = 0; i < length; i++) {
           getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(stringValues[i]);
         }
         break;
       case BYTES:
         // Serialized HyperLogLog
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
         try {
           for (int i = 0; i < length; i++) {
             HyperLogLog value = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]);
@@ -176,11 +191,13 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    DataType valueType = blockValSets[0].getValueType();
+      Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    DataType valueType = blockValSet.getValueType();
+
     switch (valueType) {
       case INT:
-        int[] intValues = blockValSets[0].getIntValuesSV();
+        int[] intValues = blockValSet.getIntValuesSV();
         for (int i = 0; i < length; i++) {
           int value = intValues[i];
           for (int groupKey : groupKeysArray[i]) {
@@ -189,7 +206,7 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
         }
         break;
       case LONG:
-        long[] longValues = blockValSets[0].getLongValuesSV();
+        long[] longValues = blockValSet.getLongValuesSV();
         for (int i = 0; i < length; i++) {
           long value = longValues[i];
           for (int groupKey : groupKeysArray[i]) {
@@ -198,7 +215,7 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
         }
         break;
       case FLOAT:
-        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        float[] floatValues = blockValSet.getFloatValuesSV();
         for (int i = 0; i < length; i++) {
           float value = floatValues[i];
           for (int groupKey : groupKeysArray[i]) {
@@ -207,7 +224,7 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
         }
         break;
       case DOUBLE:
-        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        double[] doubleValues = blockValSet.getDoubleValuesSV();
         for (int i = 0; i < length; i++) {
           double value = doubleValues[i];
           for (int groupKey : groupKeysArray[i]) {
@@ -216,7 +233,7 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
         }
         break;
       case STRING:
-        String[] stringValues = blockValSets[0].getStringValuesSV();
+        String[] stringValues = blockValSet.getStringValuesSV();
         for (int i = 0; i < length; i++) {
           String value = stringValues[i];
           for (int groupKey : groupKeysArray[i]) {
@@ -226,7 +243,7 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
         break;
       case BYTES:
         // Serialized HyperLogLog
-        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
         try {
           for (int i = 0; i < length; i++) {
             HyperLogLog value = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -19,14 +19,23 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
-import org.apache.pinot.spi.data.FieldSpec.DataType;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggregationFunction {
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public DistinctCountHLLMVAggregationFunction(String column) {
+    super(column);
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -39,13 +48,14 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
     HyperLogLog hyperLogLog = getDefaultHyperLogLog(aggregationResultHolder);
 
-    DataType valueType = blockValSets[0].getValueType();
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    DataType valueType = blockValSet.getValueType();
     switch (valueType) {
       case INT:
-        int[][] intValuesArray = blockValSets[0].getIntValuesMV();
+        int[][] intValuesArray = blockValSet.getIntValuesMV();
         for (int i = 0; i < length; i++) {
           for (int value : intValuesArray[i]) {
             hyperLogLog.offer(value);
@@ -53,7 +63,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case LONG:
-        long[][] longValuesArray = blockValSets[0].getLongValuesMV();
+        long[][] longValuesArray = blockValSet.getLongValuesMV();
         for (int i = 0; i < length; i++) {
           for (long value : longValuesArray[i]) {
             hyperLogLog.offer(value);
@@ -61,7 +71,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case FLOAT:
-        float[][] floatValuesArray = blockValSets[0].getFloatValuesMV();
+        float[][] floatValuesArray = blockValSet.getFloatValuesMV();
         for (int i = 0; i < length; i++) {
           for (float value : floatValuesArray[i]) {
             hyperLogLog.offer(value);
@@ -69,7 +79,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case DOUBLE:
-        double[][] doubleValuesArray = blockValSets[0].getDoubleValuesMV();
+        double[][] doubleValuesArray = blockValSet.getDoubleValuesMV();
         for (int i = 0; i < length; i++) {
           for (double value : doubleValuesArray[i]) {
             hyperLogLog.offer(value);
@@ -77,7 +87,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case STRING:
-        String[][] stringValuesArray = blockValSets[0].getStringValuesMV();
+        String[][] stringValuesArray = blockValSet.getStringValuesMV();
         for (int i = 0; i < length; i++) {
           for (String value : stringValuesArray[i]) {
             hyperLogLog.offer(value);
@@ -92,11 +102,13 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    DataType valueType = blockValSets[0].getValueType();
+      Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    DataType valueType = blockValSet.getValueType();
+
     switch (valueType) {
       case INT:
-        int[][] intValuesArray = blockValSets[0].getIntValuesMV();
+        int[][] intValuesArray = blockValSet.getIntValuesMV();
         for (int i = 0; i < length; i++) {
           HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
           for (int value : intValuesArray[i]) {
@@ -105,7 +117,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case LONG:
-        long[][] longValuesArray = blockValSets[0].getLongValuesMV();
+        long[][] longValuesArray = blockValSet.getLongValuesMV();
         for (int i = 0; i < length; i++) {
           HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
           for (long value : longValuesArray[i]) {
@@ -114,7 +126,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case FLOAT:
-        float[][] floatValuesArray = blockValSets[0].getFloatValuesMV();
+        float[][] floatValuesArray = blockValSet.getFloatValuesMV();
         for (int i = 0; i < length; i++) {
           HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
           for (float value : floatValuesArray[i]) {
@@ -123,7 +135,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case DOUBLE:
-        double[][] doubleValuesArray = blockValSets[0].getDoubleValuesMV();
+        double[][] doubleValuesArray = blockValSet.getDoubleValuesMV();
         for (int i = 0; i < length; i++) {
           HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
           for (double value : doubleValuesArray[i]) {
@@ -132,7 +144,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case STRING:
-        String[][] stringValuesArray = blockValSets[0].getStringValuesMV();
+        String[][] stringValuesArray = blockValSet.getStringValuesMV();
         for (int i = 0; i < length; i++) {
           HyperLogLog hyperLogLog = getDefaultHyperLogLog(groupByResultHolder, groupKeyArray[i]);
           for (String value : stringValuesArray[i]) {
@@ -148,11 +160,13 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    DataType valueType = blockValSets[0].getValueType();
+      Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    DataType valueType = blockValSet.getValueType();
+
     switch (valueType) {
       case INT:
-        int[][] intValuesArray = blockValSets[0].getIntValuesMV();
+        int[][] intValuesArray = blockValSet.getIntValuesMV();
         for (int i = 0; i < length; i++) {
           int[] intValues = intValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {
@@ -164,7 +178,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case LONG:
-        long[][] longValuesArray = blockValSets[0].getLongValuesMV();
+        long[][] longValuesArray = blockValSet.getLongValuesMV();
         for (int i = 0; i < length; i++) {
           long[] longValues = longValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {
@@ -176,7 +190,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case FLOAT:
-        float[][] floatValuesArray = blockValSets[0].getFloatValuesMV();
+        float[][] floatValuesArray = blockValSet.getFloatValuesMV();
         for (int i = 0; i < length; i++) {
           float[] floatValues = floatValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {
@@ -188,7 +202,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case DOUBLE:
-        double[][] doubleValuesArray = blockValSets[0].getDoubleValuesMV();
+        double[][] doubleValuesArray = blockValSet.getDoubleValuesMV();
         for (int i = 0; i < length; i++) {
           double[] doubleValues = doubleValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {
@@ -200,7 +214,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
         }
         break;
       case STRING:
-        String[][] stringValuesArray = blockValSets[0].getStringValuesMV();
+        String[][] stringValuesArray = blockValSet.getStringValuesMV();
         for (int i = 0; i < length; i++) {
           String[] stringValues = stringValuesArray[i];
           for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -30,12 +31,20 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 public class DistinctCountRawHLLAggregationFunction implements AggregationFunction<HyperLogLog, SerializedHLL> {
   private final DistinctCountHLLAggregationFunction _distinctCountHLLAggregationFunction;
 
-  public DistinctCountRawHLLAggregationFunction() {
-    this(new DistinctCountHLLAggregationFunction());
+  protected final String _column;
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public DistinctCountRawHLLAggregationFunction(String column) {
+    this(new DistinctCountHLLAggregationFunction(column), column);
   }
 
-  DistinctCountRawHLLAggregationFunction(DistinctCountHLLAggregationFunction distinctCountHLLAggregationFunction) {
+  DistinctCountRawHLLAggregationFunction(DistinctCountHLLAggregationFunction distinctCountHLLAggregationFunction,
+      String column) {
     _distinctCountHLLAggregationFunction = distinctCountHLLAggregationFunction;
+    _column = column;
   }
 
   @Override
@@ -59,20 +68,22 @@ public class DistinctCountRawHLLAggregationFunction implements AggregationFuncti
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    _distinctCountHLLAggregationFunction.aggregate(length, aggregationResultHolder, blockValSets);
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<String, BlockValSet> blockValSetMap) {
+    _distinctCountHLLAggregationFunction.aggregate(length, aggregationResultHolder, blockValSetMap);
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    _distinctCountHLLAggregationFunction.aggregateGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSets);
+      Map<String, BlockValSet> blockValSetMap) {
+    _distinctCountHLLAggregationFunction.aggregateGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap);
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    _distinctCountHLLAggregationFunction.aggregateGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSets);
+      Map<String, BlockValSet> blockValSetMap) {
+    _distinctCountHLLAggregationFunction
+        .aggregateGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.base.Preconditions;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -37,6 +38,16 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 public class FastHLLAggregationFunction implements AggregationFunction<HyperLogLog, Long> {
   public static final int DEFAULT_LOG2M = 8;
   private static final int BYTE_TO_CHAR_OFFSET = 129;
+
+  private final String _column;
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public FastHLLAggregationFunction(String column) {
+    _column = column;
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -59,8 +70,8 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    String[] values = blockValSets[0].getStringValuesSV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    String[] values = blockValSetMap.get(_column).getStringValuesSV();
     try {
       HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
       if (hyperLogLog != null) {
@@ -81,8 +92,8 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    String[] values = blockValSets[0].getStringValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    String[] values = blockValSetMap.get(_column).getStringValuesSV();
     try {
       for (int i = 0; i < length; i++) {
         HyperLogLog value = convertStringToHLL(values[i]);
@@ -101,8 +112,8 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    String[] values = blockValSets[0].getStringValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    String[] values = blockValSetMap.get(_column).getStringValuesSV();
     try {
       for (int i = 0; i < length; i++) {
         HyperLogLog value = convertStringToHLL(values[i]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -29,6 +30,16 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 public class MaxAggregationFunction implements AggregationFunction<Double, Double> {
   private static final double DEFAULT_INITIAL_VALUE = Double.NEGATIVE_INFINITY;
+
+  protected final String _column;
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public MaxAggregationFunction(String column) {
+    _column = column;
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -51,8 +62,8 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[] valueArray = blockValSetMap.get(_column).getDoubleValuesSV();
     double max = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
@@ -65,8 +76,8 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[] valueArray = blockValSetMap.get(_column).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       int groupKey = groupKeyArray[i];
@@ -78,8 +89,8 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[] valueArray = blockValSetMap.get(_column).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -25,6 +26,14 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
 public class MaxMVAggregationFunction extends MaxAggregationFunction {
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public MaxMVAggregationFunction(String column) {
+    super(column);
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -37,8 +46,8 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     double max = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
@@ -52,8 +61,8 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       double max = groupByResultHolder.getDoubleResult(groupKey);
@@ -68,8 +77,8 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -29,6 +30,16 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 public class MinAggregationFunction implements AggregationFunction<Double, Double> {
   private static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
+
+  protected final String _column;
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public MinAggregationFunction(String column) {
+    _column = column;
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -51,8 +62,8 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[] valueArray = blockValSetMap.get(_column).getDoubleValuesSV();
     double min = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
@@ -65,8 +76,8 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[] valueArray = blockValSetMap.get(_column).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       int groupKey = groupKeyArray[i];
@@ -78,8 +89,8 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[] valueArray = blockValSetMap.get(_column).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -25,6 +26,14 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
 public class MinMVAggregationFunction extends MinAggregationFunction {
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public MinMVAggregationFunction(String column) {
+    super(column);
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -37,8 +46,8 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     double min = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
@@ -52,8 +61,8 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       double min = groupByResultHolder.getDoubleResult(groupKey);
@@ -68,8 +77,8 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import org.apache.pinot.spi.data.FieldSpec.DataType;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -28,9 +28,20 @@ import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMaxRangePair, Double> {
+
+  protected final String _column;
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public MinMaxRangeAggregationFunction(String column) {
+    _column = column;
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -53,11 +64,13 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
-    if (blockValSets[0].getValueType() != DataType.BYTES) {
-      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    if (blockValSet.getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSet.getDoubleValuesSV();
       for (int i = 0; i < length; i++) {
         double value = doubleValues[i];
         if (value < min) {
@@ -69,7 +82,7 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
       }
     } else {
       // Serialized MinMaxRangePair
-      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      byte[][] bytesValues = blockValSet.getBytesValuesSV();
       for (int i = 0; i < length; i++) {
         MinMaxRangePair minMaxRangePair = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
         double minValue = minMaxRangePair.getMin();
@@ -96,16 +109,17 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    if (blockValSets[0].getValueType() != DataType.BYTES) {
-      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    if (blockValSet.getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSet.getDoubleValuesSV();
       for (int i = 0; i < length; i++) {
         double value = doubleValues[i];
         setGroupByResult(groupKeyArray[i], groupByResultHolder, value, value);
       }
     } else {
       // Serialized MinMaxRangePair
-      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      byte[][] bytesValues = blockValSet.getBytesValuesSV();
       for (int i = 0; i < length; i++) {
         MinMaxRangePair minMaxRangePair = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
         setGroupByResult(groupKeyArray[i], groupByResultHolder, minMaxRangePair.getMin(), minMaxRangePair.getMax());
@@ -115,9 +129,10 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    if (blockValSets[0].getValueType() != DataType.BYTES) {
-      double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_column);
+    if (blockValSet.getValueType() != DataType.BYTES) {
+      double[] doubleValues = blockValSet.getDoubleValuesSV();
       for (int i = 0; i < length; i++) {
         double value = doubleValues[i];
         for (int groupKey : groupKeysArray[i]) {
@@ -126,7 +141,7 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
       }
     } else {
       // Serialized MinMaxRangePair
-      byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+      byte[][] bytesValues = blockValSet.getBytesValuesSV();
       for (int i = 0; i < length; i++) {
         MinMaxRangePair minMaxRangePair = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
         double min = minMaxRangePair.getMin();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -25,6 +26,14 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
 public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunction {
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public MinMaxRangeMVAggregationFunction(String column) {
+    super(column);
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -37,8 +46,8 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
     for (int i = 0; i < length; i++) {
@@ -57,8 +66,8 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       aggregateOnGroupKey(groupKeyArray[i], groupByResultHolder, valuesArray[i]);
     }
@@ -66,8 +75,8 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -27,8 +29,17 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 public class PercentileEstMVAggregationFunction extends PercentileEstAggregationFunction {
 
-  public PercentileEstMVAggregationFunction(int percentile) {
-    super(percentile);
+  /**
+   * Constructor for the class.
+   *
+   * @param arguments List of arguments.
+   *                  <ul>
+   *                  <li> Arg 0: Column name to aggregate.</li>
+   *                  <li> Arg 1: Percentile to compute. </li>
+   *                  </ul>
+   */
+  public PercentileEstMVAggregationFunction(List<String> arguments) {
+    super(arguments);
   }
 
   @Override
@@ -52,8 +63,8 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    long[][] valuesArray = blockValSets[0].getLongValuesMV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    long[][] valuesArray = blockValSetMap.get(_column).getLongValuesMV();
     QuantileDigest quantileDigest = getDefaultQuantileDigest(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
       for (long value : valuesArray[i]) {
@@ -64,8 +75,8 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    long[][] valuesArray = blockValSets[0].getLongValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    long[][] valuesArray = blockValSetMap.get(_column).getLongValuesMV();
     for (int i = 0; i < length; i++) {
       QuantileDigest quantileDigest = getDefaultQuantileDigest(groupByResultHolder, groupKeyArray[i]);
       for (long value : valuesArray[i]) {
@@ -76,8 +87,8 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    long[][] valuesArray = blockValSets[0].getLongValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    long[][] valuesArray = blockValSetMap.get(_column).getLongValuesMV();
     for (int i = 0; i < length; i++) {
       long[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -27,8 +29,17 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 public class PercentileMVAggregationFunction extends PercentileAggregationFunction {
 
-  public PercentileMVAggregationFunction(int percentile) {
-    super(percentile);
+  /**
+   * Constructor for the class.
+   *
+   * @param arguments List of arguments.
+   *                  <ul>
+   *                  <li> Arg 0: Column name to aggregate.</li>
+   *                  <li> Arg 1: Percentile to compute. </li>
+   *                  </ul>
+   */
+  public PercentileMVAggregationFunction(List<String> arguments) {
+    super(arguments);
   }
 
   @Override
@@ -52,8 +63,8 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     DoubleArrayList valueList = getValueList(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
@@ -64,8 +75,8 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       DoubleArrayList valueList = getValueList(groupByResultHolder, groupKeyArray[i]);
       for (double value : valuesArray[i]) {
@@ -76,8 +87,8 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import com.tdunning.math.stats.TDigest;
+import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -27,8 +29,17 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAggregationFunction {
 
-  public PercentileTDigestMVAggregationFunction(int percentile) {
-    super(percentile);
+  /**
+   * Constructor for the class.
+   *
+   * @param arguments List of arguments.
+   *                  <ul>
+   *                  <li> Arg 0: Column name to aggregate.</li>
+   *                  <li> Arg 1: Percentile to compute. </li>
+   *                  </ul>
+   */
+  public PercentileTDigestMVAggregationFunction(List<String> arguments) {
+    super(arguments);
   }
 
   @Override
@@ -52,8 +63,8 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     TDigest tDigest = getDefaultTDigest(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
@@ -64,8 +75,8 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       TDigest tDigest = getDefaultTDigest(groupByResultHolder, groupKeyArray[i]);
       for (double value : valuesArray[i]) {
@@ -76,8 +87,8 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -29,6 +30,15 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 public class SumAggregationFunction implements AggregationFunction<Double, Double> {
   private static final double DEFAULT_VALUE = 0.0;
+  protected final String _column;
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public SumAggregationFunction(String column) {
+    _column = column;
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -51,8 +61,8 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[] valueArray = blockValSetMap.get(_column).getDoubleValuesSV();
     double sum = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       sum += valueArray[i];
@@ -62,8 +72,8 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[] valueArray = blockValSetMap.get(_column).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + valueArray[i]);
@@ -72,8 +82,8 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[] valueArray = blockValSetMap.get(_column).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -25,6 +26,14 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
 public class SumMVAggregationFunction extends SumAggregationFunction {
+
+  /**
+   * Constructor for the class.
+   * @param column Column name to aggregate on.
+   */
+  public SumMVAggregationFunction(String column) {
+    super(column);
+  }
 
   @Override
   public AggregationFunctionType getType() {
@@ -37,8 +46,8 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     double sum = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
@@ -50,8 +59,8 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       double sum = groupByResultHolder.getDoubleResult(groupKey);
@@ -64,8 +73,8 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet... blockValSets) {
-    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
+      Map<String, BlockValSet> blockValSetMap) {
+    double[][] valuesArray = blockValSetMap.get(_column).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.core.query.aggregation.groupby;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.request.GroupBy;
@@ -153,16 +155,18 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
 
     if (function.getType() == AggregationFunctionType.COUNT) {
       if (_hasMVGroupByExpression) {
-        function.aggregateGroupByMV(length, _mvGroupKeys, resultHolder);
+        function.aggregateGroupByMV(length, _mvGroupKeys, resultHolder, Collections.emptyMap());
       } else {
-        function.aggregateGroupBySV(length, _svGroupKeys, resultHolder);
+        function.aggregateGroupBySV(length, _svGroupKeys, resultHolder, Collections.emptyMap());
       }
     } else {
-      BlockValSet blockValueSet = transformBlock.getBlockValueSet(_aggregationExpressions[functionIndex]);
+      TransformExpressionTree aggregationExpression = _aggregationExpressions[functionIndex];
+      Map<String, BlockValSet> blockValSetMap = Collections
+          .singletonMap(aggregationExpression.toString(), transformBlock.getBlockValueSet(aggregationExpression));
       if (_hasMVGroupByExpression) {
-        function.aggregateGroupByMV(length, _mvGroupKeys, resultHolder, blockValueSet);
+        function.aggregateGroupByMV(length, _mvGroupKeys, resultHolder, blockValSetMap);
       } else {
-        function.aggregateGroupBySV(length, _svGroupKeys, resultHolder, blockValueSet);
+        function.aggregateGroupBySV(length, _svGroupKeys, resultHolder, blockValSetMap);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -40,7 +40,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.util.QueryOptions;
-import org.apache.pinot.pql.parsers.pql2.ast.FunctionCallAstNode;
+import org.apache.pinot.parsers.CompilerConstants;
 
 
 /**
@@ -164,8 +164,8 @@ public class DistinctDataTableReducer implements DataTableReducer {
 
   private String[] getDistinctColumns() {
     return _brokerRequest.getAggregationsInfo().get(0).getAggregationParams()
-        .get(FunctionCallAstNode.COLUMN_KEY_IN_AGGREGATION_INFO)
-        .split(FunctionCallAstNode.DISTINCT_MULTI_COLUMN_SEPARATOR);
+        .get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO)
+        .split(CompilerConstants.AGGREGATION_FUNCTION_ARG_SEPARATOR);
   }
 
   private DataSchema getEmptyResultTableDataSchema() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Collections;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.parsers.CompilerConstants;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -33,9 +35,12 @@ public class AggregationFunctionFactoryTest {
     AggregationFunction aggregationFunction;
 
     BrokerRequest brokerRequest = new BrokerRequest();
+    String column = "testColumn";
 
     AggregationInfo aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("CoUnT");
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof CountAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNT);
@@ -43,171 +48,243 @@ public class AggregationFunctionFactoryTest {
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("MiN");
+    column = "min_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof MinAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MIN);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "min_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("MaX");
+    column = "max_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof MaxAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAX);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "max_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("SuM");
+    column = "sum_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof SumAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUM);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "sum_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("AvG");
+    column = "avg_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof AvgAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVG);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "avg_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("MiNmAxRaNgE");
+    column = "minMaxRange_column";
+    aggregationInfo.setAggregationParams(
+        Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof MinMaxRangeAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGE);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "minMaxRange_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("DiStInCtCoUnT");
+    column = "distinctCount_column";
+    aggregationInfo.setAggregationParams(
+        Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof DistinctCountAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNT);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "distinctCount_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("DiStInCtCoUnThLl");
+    column = "distinctCountHLL_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof DistinctCountHLLAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLL);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "distinctCountHLL_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("DiStInCtCoUnTrAwHlL");
+    column = "distinctCountRawHLL_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof DistinctCountRawHLLAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLL);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "distinctCountRawHLL_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
     ;
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("FaStHlL");
+    column = "fastHLL_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof FastHLLAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.FASTHLL);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "fastHLL_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("PeRcEnTiLe5");
+    column = "percentile5_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "percentile5_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("PeRcEnTiLeEsT50");
+    column = "percentileEst50_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "percentileEst50_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("PeRcEnTiLeTdIgEsT99");
+    column = "percentileTDigest99_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "percentileTDigest99_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("CoUnTmV");
+    column = "countMV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof CountMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNTMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "countMV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("MiNmV");
+    column = "minMV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof MinMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "minMV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("MaXmV");
+    column = "maxMV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof MaxMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAXMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "maxMV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("SuMmV");
+    column = "sumMV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof SumMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUMMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "sumMV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("AvGmV");
+    column = "avgMV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof AvgMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVGMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "avgMV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("MiNmAxRaNgEmV");
+    column = "minMaxRangeMV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof MinMaxRangeMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGEMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "minMaxRangeMV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("DiStInCtCoUnTmV");
+    column = "distinctCountMV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof DistinctCountMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "distinctCountMV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("DiStInCtCoUnThLlMv");
+    column = "distinctCountHLLMV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof DistinctCountHLLMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "distinctCountHLLMV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("DiStInCtCoUnTrAwHlLmV");
+    column = "distinctCountRawHLLMV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof DistinctCountRawHLLMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLLMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "distinctCountRawHLLMV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("PeRcEnTiLe10Mv");
+    column = "percentile10MV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof PercentileMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "percentile10MV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("PeRcEnTiLeEsT90mV");
+    column = "percentileEst90MV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof PercentileEstMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEESTMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "percentileEst90MV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
 
     aggregationInfo = new AggregationInfo();
     aggregationInfo.setAggregationType("PeRcEnTiLeTdIgEsT95mV");
+    column = "percentileTDigest95MV_column";
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
     Assert.assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), "percentileTDigest95MV_column");
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMN), column);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -273,9 +273,10 @@ public class DistinctQueriesTest extends BaseQueriesTest {
         assertEquals(actualValues, expectedValues);
       }
       {
-        // Test selecting some columns with transform, filter, order-by and limit
+        // Test selecting some columns with transform, filter, order-by and limit. Spaces in 'add' are intentional
+        // to ensure that AggregationFunction arguments are standardized (to remove spaces).
         String query =
-            "SELECT DISTINCT(ADD(intColumn, floatColumn), stringColumn) FROM testTable WHERE longColumn < 60 ORDER BY stringColumn DESC, ADD(intColumn, floatColumn) ASC LIMIT 10";
+            "SELECT DISTINCT(ADD ( intColumn,  floatColumn  ), stringColumn) FROM testTable WHERE longColumn < 60 ORDER BY stringColumn DESC, ADD(intColumn, floatColumn) ASC LIMIT 10";
 
         // Check data schema
         DistinctTable distinctTable = getDistinctTableInnerSegment(query);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
@@ -21,13 +21,11 @@ package org.apache.pinot.queries;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.query.aggregation.DistinctTable;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -175,7 +173,6 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
    */
   @Test
   public void testSingleColumnDistinct() {
-    Pql2Compiler.ENABLE_DISTINCT = true;
     String query = "SELECT DISTINCT(column1) FROM testTable LIMIT 1000000";
     AggregationOperator aggregationOperator = getOperatorForQuery(query);
     IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
@@ -208,7 +205,6 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
    */
   @Test
   public void testMultiColumnDistinct() {
-    Pql2Compiler.ENABLE_DISTINCT = true;
     String query = "SELECT DISTINCT(column1, column3) FROM testTable LIMIT 1000000";
     AggregationOperator aggregationOperator = getOperatorForQuery(query);
     IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
@@ -24,7 +24,6 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.SelectionResults;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -424,7 +423,6 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
    */
   @Test
   public void testInterSegmentDistinctSingleColumn() {
-    Pql2Compiler.ENABLE_DISTINCT = true;
     final String query = "SELECT DISTINCT(column1) FROM testTable LIMIT 1000000";
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     final SelectionResults selectionResults = brokerResponse.getSelectionResults();
@@ -441,7 +439,6 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
    */
   @Test
   public void testInterSegmentDistinctMultiColumn() {
-    Pql2Compiler.ENABLE_DISTINCT = true;
     final String query = "SELECT DISTINCT(column1, column3) FROM testTable LIMIT 1000000";
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     final SelectionResults selectionResults = brokerResponse.getSelectionResults();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
@@ -30,7 +30,6 @@ import org.apache.pinot.common.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.common.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -849,7 +848,6 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
    */
   @Test
   public void testInterSegmentDistinct() {
-    Pql2Compiler.ENABLE_DISTINCT = true;
     String query = "SELECT DISTINCT(column1) FROM testTable LIMIT 1000000";
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/AggregationGroupByTrimmingServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/AggregationGroupByTrimmingServiceTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.aggregation.groupby;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -34,6 +35,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.parsers.CompilerConstants;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -44,10 +46,9 @@ public class AggregationGroupByTrimmingServiceTest {
   private static final Random RANDOM = new Random(RANDOM_SEED);
   private static final String ERROR_MESSAGE = "Random seed: " + RANDOM_SEED;
 
-  private AggregationInfo aggregationInfo = new AggregationInfo().setAggregationType("SUM");
-  private static final AggregationFunction SUM = AggregationFunctionFactory.getAggregationFunction(new AggregationInfo().setAggregationType("SUM"), new BrokerRequest());
-  private static final AggregationFunction DISTINCTCOUNT =
-      AggregationFunctionFactory.getAggregationFunction(new AggregationInfo().setAggregationType("DISTINCTCOUNT"), new BrokerRequest());
+  private static final AggregationFunction SUM = createAggregationFunction("SUM", "sumColumn");
+  private static final AggregationFunction DISTINCTCOUNT = createAggregationFunction("DISTINCTCOUNT", "distinctColumn");
+
   private static final AggregationFunction[] AGGREGATION_FUNCTIONS = {SUM, DISTINCTCOUNT};
   private static final int NUM_GROUP_KEYS = 3;
   private static final int GROUP_BY_TOP_N = 100;
@@ -141,5 +142,13 @@ public class AggregationGroupByTrimmingServiceTest {
       groupStringBuilder.append(group.get(i));
     }
     return groupStringBuilder.toString();
+  }
+
+  private static AggregationFunction createAggregationFunction(String aggregationType, String column) {
+    AggregationInfo aggregationInfo = new AggregationInfo();
+    aggregationInfo.setAggregationType(aggregationType);
+    aggregationInfo
+        .setAggregationParams(Collections.singletonMap(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO, column));
+    return AggregationFunctionFactory.getAggregationFunction(aggregationInfo, new BrokerRequest());
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -39,7 +39,6 @@ import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.config.QueryConfig;
 import org.apache.pinot.spi.config.TableConfig;
 import org.apache.pinot.spi.config.TableType;
@@ -851,7 +850,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   @Test
   public void testDistinctQuery()
       throws Exception {
-    Pql2Compiler.ENABLE_DISTINCT = true;
     // by default 10 rows will be returned, so use high limit
     String pql = "SELECT DISTINCT(Carrier) FROM mytable LIMIT 1000000";
     String sql = "SELECT DISTINCT Carrier FROM mytable";


### PR DESCRIPTION
The current implementation assumes that all AggregationFunctions take one argument
with the exception of DistinctAggregationFunction. This PR handles changes related
to supporting AggregationFunctions with multiple arguments, as we anticipate new
aggregation functions to be added that take multiple arguments.

1. Enhanced parser to allow multiple arguments for aggregation functions.
2. AggregationFunctionFactory provides the right set of arguments when instantiating
   individual aggregation functions.
3. AggregationFunctions now store their arguments, as opposed to assuming that the right
   BlockValSet is passed to the aggregate() api's.
4. AggregationFunction.aggregate() api's now take a Map<String, BlockValSet> where the key
   is the argument expression (columnName for simple case), as opposed to a variable array
   as that interface does not provide a way to associate BlockValSet with the argument.
5. Cleanup: Removed env variable to enable/disable Distinct, as there is no need for it to be
   disabled anymore.