### PR TITLE
Add PinotServiceManager to start Pinot components

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -116,7 +116,6 @@
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jersey2-jaxrs</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-log</artifactId>

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -273,7 +273,7 @@ public class HelixBrokerStarter {
         Broker.DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START);
 
     LOGGER.info("Registering service status handler");
-    ServiceStatus.setServiceStatusCallback(new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList
+    ServiceStatus.addServiceStatusCallback(HelixBrokerStarter.class.getName(), new ServiceStatus.MultipleCallbackServiceStatusCallback(ImmutableList
         .of(new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_participantHelixManager,
                 _clusterName, _brokerId, resourcesToMonitor, minResourcePercentForStartup),
             new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_participantHelixManager,

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -212,7 +212,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
   @AfterClass
   public void tearDown() {
     stopFakeInstances();
-    _brokerStarter.shutdown();
+    _brokerStarter.stop();
     stopController();
     stopZk();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -55,6 +55,10 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     this(metricPrefix, metricsRegistry, clazz, false);
   }
 
+  public MetricsRegistry getMetricsRegistry() {
+    return _metricsRegistry;
+  }
+
   public AbstractMetrics(String metricPrefix, MetricsRegistry metricsRegistry, Class clazz, boolean global) {
     _metricPrefix = metricPrefix;
     _metricsRegistry = metricsRegistry;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -111,6 +111,8 @@ public class CommonConstants {
     public static final String CONFIG_OF_SERVER_FLAPPING_TIME_WINDOW_MS = "pinot.server.flapping.timeWindowMs";
     public static final String CONFIG_OF_MINION_FLAPPING_TIME_WINDOW_MS = "pinot.minion.flapping.timeWindowMs";
     public static final String DEFAULT_FLAPPING_TIME_WINDOW_MS = "1";
+
+    public static final String PINOT_SERVICE_ROLE = "pinot.service.role";
   }
 
   public static class Broker {
@@ -242,6 +244,8 @@ public class CommonConstants {
     public static final long DEFAULT_SHUTDOWN_RESOURCE_CHECK_INTERVAL_MS = 10_000L;
 
     public static final String DEFAULT_COLUMN_MIN_MAX_VALUE_GENERATOR_MODE = "TIME";
+
+    public static final String PINOT_SERVER_METRICS_PREFIX = "pinot.server.metrics.prefix";
 
     public static class SegmentCompletionProtocol {
       public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "pinot.server.segment.uploader";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -241,7 +241,7 @@ public class ControllerStarter {
     }
 
     ServiceStatus
-        .setServiceStatusCallback(new ServiceStatus.MultipleCallbackServiceStatusCallback(_serviceStatusCallbackList));
+        .addServiceStatusCallback(ControllerStarter.class.getName(), new ServiceStatus.MultipleCallbackServiceStatusCallback(_serviceStatusCallbackList));
   }
 
   private void setUpHelixController() {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -151,7 +151,9 @@ public abstract class ClusterTest extends ControllerTest {
             .setProperty(Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, Server.DEFAULT_INSTANCE_SEGMENT_TAR_DIR + "-" + i);
         configuration.setProperty(Server.CONFIG_OF_ADMIN_API_PORT, baseAdminApiPort - i);
         configuration.setProperty(Server.CONFIG_OF_NETTY_PORT, baseNettyPort + i);
-        _serverStarters.add(new HelixServerStarter(getHelixClusterName(), zkStr, configuration));
+        HelixServerStarter helixServerStarter = new HelixServerStarter(getHelixClusterName(), zkStr, configuration);
+        _serverStarters.add(helixServerStarter);
+        helixServerStarter.start();
       }
     } catch (Exception e) {
       throw new RuntimeException(e);
@@ -196,7 +198,7 @@ public abstract class ClusterTest extends ControllerTest {
     assertNotNull(_brokerStarters, "Brokers are not started");
     for (HelixBrokerStarter brokerStarter : _brokerStarters) {
       try {
-        brokerStarter.shutdown();
+        brokerStarter.stop();
       } catch (Exception e) {
         LOGGER.error("Encountered exception while stopping broker {}", e.getMessage());
       }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -56,6 +56,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
       throws Exception {
     HelixServerStarter helixServerStarter =
         new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
+    helixServerStarter.start();
     helixServerStarter.stop();
 
     assertEquals(helixServerStarter.getInstanceId(), expectedInstanceId);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -169,7 +169,7 @@ public class MinionStarter {
 
     // Initialize health check callback
     LOGGER.info("Initializing health check callback");
-    ServiceStatus.setServiceStatusCallback(new ServiceStatus.ServiceStatusCallback() {
+    ServiceStatus.addServiceStatusCallback(MinionStarter.class.getName(), new ServiceStatus.ServiceStatusCallback() {
       @Override
       public ServiceStatus.Status getServiceStatus() {
         // TODO: add health check here

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -47,6 +47,8 @@ import org.apache.pinot.minion.metrics.MinionMetrics;
 import org.apache.pinot.minion.taskfactory.TaskFactoryRegistry;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.services.ServiceRole;
+import org.apache.pinot.spi.services.ServiceStartable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +57,7 @@ import org.slf4j.LoggerFactory;
  * The class <code>MinionStarter</code> provides methods to start and stop the Pinot Minion.
  * <p>Pinot Minion will automatically join the given Helix cluster as a participant.
  */
-public class MinionStarter {
+public class MinionStarter implements ServiceStartable {
   private static final Logger LOGGER = LoggerFactory.getLogger(MinionStarter.class);
 
   private static final String HTTPS_PROTOCOL = "https";
@@ -104,10 +106,26 @@ public class MinionStarter {
     _eventObserverFactoryRegistry.registerEventObserverFactory(taskType, eventObserverFactory);
   }
 
+  @Override
+  public ServiceRole getServiceRole() {
+    return ServiceRole.MINION;
+  }
+
+  @Override
+  public String getInstanceId() {
+    return _instanceId;
+  }
+
+  @Override
+  public Configuration getConfig() {
+    return _config;
+  }
+
   /**
    * Starts the Pinot Minion instance.
    * <p>Should be called after all classes of task executor get registered.
    */
+  @Override
   public void start()
       throws Exception {
     LOGGER.info("Starting Pinot minion: {}", _instanceId);
@@ -169,7 +187,7 @@ public class MinionStarter {
 
     // Initialize health check callback
     LOGGER.info("Initializing health check callback");
-    ServiceStatus.addServiceStatusCallback(MinionStarter.class.getName(), new ServiceStatus.ServiceStatusCallback() {
+    ServiceStatus.setServiceStatusCallback(_instanceId, new ServiceStatus.ServiceStatusCallback() {
       @Override
       public ServiceStatus.Status getServiceStatus() {
         // TODO: add health check here
@@ -189,6 +207,7 @@ public class MinionStarter {
   /**
    * Stops the Pinot Minion instance.
    */
+  @Override
   public void stop() {
     try {
       LOGGER.info("Closing PinotFS classes");
@@ -198,6 +217,8 @@ public class MinionStarter {
     }
     LOGGER.info("Stopping Pinot minion: " + _instanceId);
     _helixManager.disconnect();
+    LOGGER.info("Deregistering service status handler");
+    ServiceStatus.removeServiceStatusCallback(_instanceId);
     LOGGER.info("Pinot minion stopped");
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -135,7 +135,8 @@ public class ServerInstance {
     _queryExecutor.shutDown();
     LOGGER.info("Shutting down instance data manager");
     _instanceDataManager.shutDown();
-
+    LOGGER.info("Shutting down metrics registry");
+    _serverMetrics.getMetricsRegistry().shutdown();
     _started = false;
     LOGGER.info("Finish shutting down server instance");
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.server.starter.helix;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -66,6 +65,8 @@ import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.server.starter.ServerInstance;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.services.ServiceRole;
+import org.apache.pinot.spi.services.ServiceStartable;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,118 +94,38 @@ import static org.apache.pinot.common.utils.CommonConstants.Server.*;
  *   </li>
  * </ul>
  */
-public class HelixServerStarter {
+public class HelixServerStarter implements ServiceStartable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixServerStarter.class);
 
   private final String _helixClusterName;
   private final String _zkAddress;
   private final Configuration _serverConf;
+  private final String _host;
+  private final int _port;
   private final String _instanceId;
-  private final HelixManager _helixManager;
-  private final HelixAdmin _helixAdmin;
-  private final ServerInstance _serverInstance;
-  private final AdminApiApplication _adminApiApplication;
-  private final RealtimeLuceneIndexRefreshState _realtimeLuceneIndexRefreshState;
+  private HelixManager _helixManager;
+  private HelixAdmin _helixAdmin;
+  private ServerInstance _serverInstance;
+  private AdminApiApplication _adminApiApplication;
+  private RealtimeLuceneIndexRefreshState _realtimeLuceneIndexRefreshState;
 
   public HelixServerStarter(String helixClusterName, String zkAddress, Configuration serverConf)
       throws Exception {
-    LOGGER.info("Starting Pinot server");
-    long startTimeMs = System.currentTimeMillis();
-
     _helixClusterName = helixClusterName;
     _zkAddress = zkAddress;
     // Make a clone so that changes to the config won't propagate to the caller
     _serverConf = ConfigurationUtils.cloneConfiguration(serverConf);
 
-    String host = _serverConf.getString(KEY_OF_SERVER_NETTY_HOST,
+    _host = _serverConf.getString(KEY_OF_SERVER_NETTY_HOST,
         _serverConf.getBoolean(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtil
             .getHostnameOrAddress() : NetUtil.getHostAddress());
-    int port = _serverConf.getInt(KEY_OF_SERVER_NETTY_PORT, DEFAULT_SERVER_NETTY_PORT);
+    _port = _serverConf.getInt(KEY_OF_SERVER_NETTY_PORT, DEFAULT_SERVER_NETTY_PORT);
     if (_serverConf.containsKey(CONFIG_OF_INSTANCE_ID)) {
       _instanceId = _serverConf.getString(CONFIG_OF_INSTANCE_ID);
     } else {
-      _instanceId = PREFIX_OF_SERVER_INSTANCE + host + "_" + port;
+      _instanceId = PREFIX_OF_SERVER_INSTANCE + _host + "_" + _port;
       _serverConf.addProperty(CONFIG_OF_INSTANCE_ID, _instanceId);
     }
-
-    LOGGER.info("Initializing Helix manager with zkAddress: {}, clusterName: {}, instanceId: {}", _zkAddress,
-        _helixClusterName, _instanceId);
-    setupHelixSystemProperties();
-    _helixManager =
-        HelixManagerFactory.getZKHelixManager(helixClusterName, _instanceId, InstanceType.PARTICIPANT, _zkAddress);
-
-    LOGGER.info("Initializing server instance and registering state model factory");
-    Utils.logVersions();
-    ServerSegmentCompletionProtocolHandler
-        .init(_serverConf.subset(SegmentCompletionProtocol.PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER));
-    ServerConf serverInstanceConfig = DefaultHelixStarterServerConfig.getDefaultHelixServerConfig(_serverConf);
-    _serverInstance = new ServerInstance(serverInstanceConfig, _helixManager);
-    InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
-    SegmentFetcherAndLoader fetcherAndLoader = new SegmentFetcherAndLoader(_serverConf, instanceDataManager);
-    StateModelFactory<?> stateModelFactory =
-        new SegmentOnlineOfflineStateModelFactory(_instanceId, instanceDataManager, fetcherAndLoader);
-    _helixManager.getStateMachineEngine()
-        .registerStateModelFactory(SegmentOnlineOfflineStateModelFactory.getStateModelName(), stateModelFactory);
-    // Start the server instance as a pre-connect callback so that it starts after connecting to the ZK in order to
-    // access the property store, but before receiving state transitions
-    _helixManager.addPreConnectCallback(_serverInstance::start);
-
-    LOGGER.info("Connecting Helix manager");
-    _helixManager.connect();
-    _helixAdmin = _helixManager.getClusterManagmentTool();
-    updateInstanceConfigIfNeeded(host, port);
-
-    // Start restlet server for admin API endpoint
-    String accessControlFactoryClass =
-        _serverConf.getString(ACCESS_CONTROL_FACTORY_CLASS, DEFAULT_ACCESS_CONTROL_FACTORY_CLASS);
-    LOGGER.info("Using class: {} as the AccessControlFactory", accessControlFactoryClass);
-    final AccessControlFactory accessControlFactory;
-    try {
-      accessControlFactory = PluginManager.get().createInstance(accessControlFactoryClass);
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "Caught exception while creating new AccessControlFactory instance using class '" + accessControlFactoryClass
-              + "'", e);
-    }
-
-    int adminApiPort = _serverConf.getInt(CONFIG_OF_ADMIN_API_PORT, DEFAULT_ADMIN_API_PORT);
-    _adminApiApplication = new AdminApiApplication(_serverInstance, accessControlFactory);
-    _adminApiApplication.start(adminApiPort);
-    setAdminApiPort(adminApiPort);
-
-    ServerMetrics serverMetrics = _serverInstance.getServerMetrics();
-    // Register message handler factory
-    SegmentMessageHandlerFactory messageHandlerFactory =
-        new SegmentMessageHandlerFactory(fetcherAndLoader, instanceDataManager, serverMetrics);
-    _helixManager.getMessagingService()
-        .registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(), messageHandlerFactory);
-
-    serverMetrics.addCallbackGauge(INSTANCE_CONNECTED_METRIC_NAME, () -> _helixManager.isConnected() ? 1L : 0L);
-    _helixManager
-        .addPreConnectCallback(() -> serverMetrics.addMeteredGlobalValue(ServerMeter.HELIX_ZOOKEEPER_RECONNECTS, 1L));
-
-    // Register the service status handler
-    registerServiceStatusHandler();
-
-    ControllerLeaderLocator.create(_helixManager);
-
-    if (_serverConf
-        .getBoolean(CONFIG_OF_STARTUP_ENABLE_SERVICE_STATUS_CHECK, DEFAULT_STARTUP_ENABLE_SERVICE_STATUS_CHECK)) {
-      long endTimeMs = startTimeMs + _serverConf.getLong(CONFIG_OF_STARTUP_TIMEOUT_MS, DEFAULT_STARTUP_TIMEOUT_MS);
-      startupServiceStatusCheck(endTimeMs);
-    }
-    setShuttingDownStatus(false);
-    LOGGER.info("Pinot server ready");
-
-    // Create metrics for mmap stuff
-    serverMetrics.addCallbackGauge("memory.directBufferCount", PinotDataBuffer::getDirectBufferCount);
-    serverMetrics.addCallbackGauge("memory.directBufferUsage", PinotDataBuffer::getDirectBufferUsage);
-    serverMetrics.addCallbackGauge("memory.mmapBufferCount", PinotDataBuffer::getMmapBufferCount);
-    serverMetrics.addCallbackGauge("memory.mmapBufferUsage", PinotDataBuffer::getMmapBufferUsage);
-    serverMetrics.addCallbackGauge("memory.allocationFailureCount", PinotDataBuffer::getAllocationFailureCount);
-
-    _realtimeLuceneIndexRefreshState = RealtimeLuceneIndexRefreshState.getInstance();
-    _realtimeLuceneIndexRefreshState.start();
   }
 
   /**
@@ -264,7 +185,7 @@ public class HelixServerStarter {
               _instanceId, realtimeConsumptionCatchupWaitMs));
     }
     LOGGER.info("Registering service status handler");
-    ServiceStatus.addServiceStatusCallback(HelixServerStarter.class.getName(),
+    ServiceStatus.setServiceStatusCallback(_instanceId,
         new ServiceStatus.MultipleCallbackServiceStatusCallback(serviceStatusCallbackListBuilder.build()));
   }
 
@@ -377,6 +298,98 @@ public class HelixServerStarter {
         ServiceStatus.getStatusDescription());
   }
 
+  @Override
+  public ServiceRole getServiceRole() {
+    return ServiceRole.SERVER;
+  }
+
+  @Override
+  public void start()
+      throws Exception {
+    LOGGER.info("Starting Pinot server");
+    long startTimeMs = System.currentTimeMillis();
+
+    LOGGER.info("Initializing Helix manager with zkAddress: {}, clusterName: {}, instanceId: {}", _zkAddress,
+        _helixClusterName, _instanceId);
+    setupHelixSystemProperties();
+    _helixManager =
+        HelixManagerFactory.getZKHelixManager(_helixClusterName, _instanceId, InstanceType.PARTICIPANT, _zkAddress);
+
+    LOGGER.info("Initializing server instance and registering state model factory");
+    Utils.logVersions();
+    ServerSegmentCompletionProtocolHandler
+        .init(_serverConf.subset(SegmentCompletionProtocol.PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER));
+    ServerConf serverInstanceConfig = DefaultHelixStarterServerConfig.getDefaultHelixServerConfig(_serverConf);
+    _serverInstance = new ServerInstance(serverInstanceConfig, _helixManager);
+    InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
+    SegmentFetcherAndLoader fetcherAndLoader = new SegmentFetcherAndLoader(_serverConf, instanceDataManager);
+    StateModelFactory<?> stateModelFactory =
+        new SegmentOnlineOfflineStateModelFactory(_instanceId, instanceDataManager, fetcherAndLoader);
+    _helixManager.getStateMachineEngine()
+        .registerStateModelFactory(SegmentOnlineOfflineStateModelFactory.getStateModelName(), stateModelFactory);
+    // Start the server instance as a pre-connect callback so that it starts after connecting to the ZK in order to
+    // access the property store, but before receiving state transitions
+    _helixManager.addPreConnectCallback(_serverInstance::start);
+
+    LOGGER.info("Connecting Helix manager");
+    _helixManager.connect();
+    _helixAdmin = _helixManager.getClusterManagmentTool();
+    updateInstanceConfigIfNeeded(_host, _port);
+
+    // Start restlet server for admin API endpoint
+    String accessControlFactoryClass =
+        _serverConf.getString(ACCESS_CONTROL_FACTORY_CLASS, DEFAULT_ACCESS_CONTROL_FACTORY_CLASS);
+    LOGGER.info("Using class: {} as the AccessControlFactory", accessControlFactoryClass);
+    final AccessControlFactory accessControlFactory;
+    try {
+      accessControlFactory = PluginManager.get().createInstance(accessControlFactoryClass);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Caught exception while creating new AccessControlFactory instance using class '" + accessControlFactoryClass
+              + "'", e);
+    }
+
+    int adminApiPort = _serverConf.getInt(CONFIG_OF_ADMIN_API_PORT, DEFAULT_ADMIN_API_PORT);
+    _adminApiApplication = new AdminApiApplication(_serverInstance, accessControlFactory);
+    _adminApiApplication.start(adminApiPort);
+    setAdminApiPort(adminApiPort);
+
+    ServerMetrics serverMetrics = _serverInstance.getServerMetrics();
+    // Register message handler factory
+    SegmentMessageHandlerFactory messageHandlerFactory =
+        new SegmentMessageHandlerFactory(fetcherAndLoader, instanceDataManager, serverMetrics);
+    _helixManager.getMessagingService()
+        .registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(), messageHandlerFactory);
+
+    serverMetrics.addCallbackGauge(INSTANCE_CONNECTED_METRIC_NAME, () -> _helixManager.isConnected() ? 1L : 0L);
+    _helixManager
+        .addPreConnectCallback(() -> serverMetrics.addMeteredGlobalValue(ServerMeter.HELIX_ZOOKEEPER_RECONNECTS, 1L));
+
+    // Register the service status handler
+    registerServiceStatusHandler();
+
+    ControllerLeaderLocator.create(_helixManager);
+
+    if (_serverConf
+        .getBoolean(CONFIG_OF_STARTUP_ENABLE_SERVICE_STATUS_CHECK, DEFAULT_STARTUP_ENABLE_SERVICE_STATUS_CHECK)) {
+      long endTimeMs = startTimeMs + _serverConf.getLong(CONFIG_OF_STARTUP_TIMEOUT_MS, DEFAULT_STARTUP_TIMEOUT_MS);
+      startupServiceStatusCheck(endTimeMs);
+    }
+    setShuttingDownStatus(false);
+    LOGGER.info("Pinot server ready");
+
+    // Create metrics for mmap stuff
+    serverMetrics.addCallbackGauge("memory.directBufferCount", PinotDataBuffer::getDirectBufferCount);
+    serverMetrics.addCallbackGauge("memory.directBufferUsage", PinotDataBuffer::getDirectBufferUsage);
+    serverMetrics.addCallbackGauge("memory.mmapBufferCount", PinotDataBuffer::getMmapBufferCount);
+    serverMetrics.addCallbackGauge("memory.mmapBufferUsage", PinotDataBuffer::getMmapBufferUsage);
+    serverMetrics.addCallbackGauge("memory.allocationFailureCount", PinotDataBuffer::getAllocationFailureCount);
+
+    _realtimeLuceneIndexRefreshState = RealtimeLuceneIndexRefreshState.getInstance();
+    _realtimeLuceneIndexRefreshState.start();
+  }
+
+  @Override
   public void stop() {
     LOGGER.info("Shutting down Pinot server");
     long startTimeMs = System.currentTimeMillis();
@@ -400,6 +413,9 @@ public class HelixServerStarter {
       shutdownResourceCheck(endTimeMs);
     }
     _realtimeLuceneIndexRefreshState.stop();
+    LOGGER.info("Deregistering service status handler");
+    ServiceStatus.removeServiceStatusCallback(_instanceId);
+    LOGGER.info("Finish shutting down Pinot server for {}", _instanceId);
   }
 
   /**
@@ -562,9 +578,14 @@ public class HelixServerStarter {
     return true;
   }
 
-  @VisibleForTesting
+  @Override
   public String getInstanceId() {
     return _instanceId;
+  }
+
+  @Override
+  public Configuration getConfig() {
+    return _serverConf;
   }
 
   /**
@@ -578,7 +599,9 @@ public class HelixServerStarter {
     serverConf.addProperty(KEY_OF_SERVER_NETTY_PORT, port);
     serverConf.addProperty(CONFIG_OF_INSTANCE_DATA_DIR, "/tmp/PinotServer/test" + port + "/index");
     serverConf.addProperty(CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, "/tmp/PinotServer/test" + port + "/segmentTar");
-    return new HelixServerStarter("quickstart", "localhost:2191", serverConf);
+    HelixServerStarter serverStarter = new HelixServerStarter("quickstart", "localhost:2191", serverConf);
+    serverStarter.start();
+    return serverStarter;
   }
 
   public static void main(String[] args)

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -264,7 +264,7 @@ public class HelixServerStarter {
               _instanceId, realtimeConsumptionCatchupWaitMs));
     }
     LOGGER.info("Registering service status handler");
-    ServiceStatus.setServiceStatusCallback(
+    ServiceStatus.addServiceStatusCallback(HelixServerStarter.class.getName(),
         new ServiceStatus.MultipleCallbackServiceStatusCallback(serviceStatusCallbackListBuilder.build()));
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/services/ServiceRole.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/services/ServiceRole.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.services;
+
+/**
+ * ServiceRole defines a role that Pinot Service could start/stop.
+ */
+public enum ServiceRole {
+  CONTROLLER, BROKER, SERVER, MINION,
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/services/ServiceStartable.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/services/ServiceStartable.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.services;
+
+import org.apache.commons.configuration.Configuration;
+
+
+/**
+ * ServiceStartable is the general interface to manage a Pinot instance lifecycle for a specific ServiceRole.
+ * E.g. Controller/Broker/Server/Minion.
+ *
+ */
+public interface ServiceStartable {
+  ServiceRole getServiceRole();
+
+  String getInstanceId();
+
+  Configuration getConfig();
+
+  void start()
+      throws Exception;
+
+  void stop();
+}

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -248,6 +248,17 @@
               </jvmSettings>
             </program>
             <program>
+              <mainClass>org.apache.pinot.tools.admin.PinotServiceManagerStarter</mainClass>
+              <name>start-service-manager</name>
+              <jvmSettings>
+                <initialMemorySize>1G</initialMemorySize>
+                <maxMemorySize>1G</maxMemorySize>
+                <extraArguments>
+                  <extraArgument>-Dlog4j2.configurationFile=conf/pinot-service-log4j2.xml</extraArgument>
+                </extraArguments>
+              </jvmSettings>
+            </program>
+            <program>
               <mainClass>org.apache.pinot.tools.Quickstart</mainClass>
               <name>quick-start-batch</name>
               <jvmSettings>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -43,6 +43,7 @@ import org.apache.pinot.tools.admin.command.RebalanceTableCommand;
 import org.apache.pinot.tools.admin.command.ShowClusterInfoCommand;
 import org.apache.pinot.tools.admin.command.StartBrokerCommand;
 import org.apache.pinot.tools.admin.command.StartControllerCommand;
+import org.apache.pinot.tools.admin.command.StartServiceManagerCommand;
 import org.apache.pinot.tools.admin.command.StreamGitHubEventsCommand;
 import org.apache.pinot.tools.admin.command.StartKafkaCommand;
 import org.apache.pinot.tools.admin.command.StartServerCommand;
@@ -101,6 +102,7 @@ public class PinotAdministrator {
       @SubCommand(name = "StartController", impl = StartControllerCommand.class),
       @SubCommand(name = "StartBroker", impl = StartBrokerCommand.class),
       @SubCommand(name = "StartServer", impl = StartServerCommand.class),
+      @SubCommand(name = "StartServiceManager", impl = StartServiceManagerCommand.class),
       @SubCommand(name = "AddTable", impl = AddTableCommand.class),
       @SubCommand(name = "ChangeTableState", impl = ChangeTableState.class),
       @SubCommand(name = "AddTenant", impl = AddTenantCommand.class),

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotServiceManagerStarter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotServiceManagerStarter.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Simple shim so that jps -l shows StartServiceManager instead of PinotAdministrator
+ */
+public class PinotServiceManagerStarter {
+  public static void main(String[] args)
+      throws Exception {
+    List<String> arguments = new ArrayList<>();
+    arguments.add("StartServiceManager");
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -28,9 +28,11 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.tools.AbstractBaseCommand;
+import org.apache.pinot.tools.utils.PinotConfigUtils;
 
 
 /**
@@ -57,13 +59,6 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     return Integer.parseInt(processName.split("@")[0]);
   }
 
-  protected void savePID(String fileName)
-      throws IOException {
-    FileWriter pidFile = new FileWriter(fileName);
-    pidFile.write(getPID());
-    pidFile.close();
-  }
-
   public static String sendPostRequest(String urlString, String payload)
       throws IOException {
     return sendRequest("POST", urlString, payload);
@@ -82,7 +77,8 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     conn.setDoOutput(true);
     conn.setRequestMethod(requestMethod);
     if (payload != null) {
-      final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream(), "UTF-8"));
+      final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream(),
+          StandardCharsets.UTF_8));
       writer.write(payload, 0, payload.length());
       writer.flush();
     }
@@ -104,18 +100,15 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     return sb.toString();
   }
 
+  protected void savePID(String fileName)
+      throws IOException {
+    FileWriter pidFile = new FileWriter(fileName);
+    pidFile.write(getPID());
+    pidFile.close();
+  }
+
   PropertiesConfiguration readConfigFromFile(String configFileName)
       throws ConfigurationException {
-    if (configFileName != null) {
-      File configFile = new File(configFileName);
-
-      if (configFile.exists()) {
-        return new PropertiesConfiguration(configFile);
-      } else {
-        return null;
-      }
-    } else {
-      return null;
-    }
+    return PinotConfigUtils.readConfigFromFile(configFileName);
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/EnumArrayOptionHandler.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/EnumArrayOptionHandler.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command;
+
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionDef;
+import org.kohsuke.args4j.spi.OptionHandler;
+import org.kohsuke.args4j.spi.Parameters;
+import org.kohsuke.args4j.spi.Setter;
+
+
+public class EnumArrayOptionHandler<T extends Enum<T>> extends OptionHandler<T> {
+
+  public EnumArrayOptionHandler(CmdLineParser parser, OptionDef option, Setter<T> setter) {
+    super(parser, option, setter);
+  }
+
+  /**
+   * Returns {@code "T[]"}.
+   *
+   * @return return "T[]";
+   */
+  @Override
+  public String getDefaultMetaVariable() {
+    return setter.getType().getName() + "[]";
+  }
+
+  /**
+   * Tries to parse {@code String[]} argument from {@link Parameters}.
+   */
+  @Override
+  public int parseArguments(Parameters params)
+      throws CmdLineException {
+    int counter = 0;
+    for (; counter < params.size(); counter++) {
+      String param = params.getParameter(counter);
+
+      if (param.startsWith("-")) {
+        break;
+      }
+
+      for (String p : param.split(" ")) {
+        Class<T> t = (Class<T>) setter.getType();
+        setter.addValue(Enum.valueOf(t, p));
+      }
+    }
+
+    return counter;
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -19,12 +19,14 @@
 package org.apache.pinot.tools.admin.command;
 
 import java.io.File;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.common.utils.CommonConstants;
-import org.apache.pinot.common.utils.NetUtil;
-import org.apache.pinot.server.starter.helix.HelixServerStarter;
+import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.tools.Command;
+import org.apache.pinot.tools.utils.PinotConfigUtils;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,33 +38,24 @@ import org.slf4j.LoggerFactory;
  */
 public class StartServerCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StartServerCommand.class);
-
-  @Option(name = "-serverHost", required = false, metaVar = "<String>", usage = "Host name for controller.")
-  private String _serverHost;
-
-  @Option(name = "-serverPort", required = false, metaVar = "<int>", usage = "Port number to start the server at.")
-  private int _serverPort = CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
-
-  @Option(name = "-serverAdminPort", required = false, metaVar = "<int>", usage = "Port number to serve the server admin API at.")
-  private int _serverAdminPort = CommonConstants.Server.DEFAULT_ADMIN_API_PORT;
-
-  @Option(name = "-dataDir", required = false, metaVar = "<string>", usage = "Path to directory containing data.")
-  private String _dataDir = TMP_DIR + "pinotServerData";
-
-  @Option(name = "-segmentDir", required = false, metaVar = "<string>", usage = "Path to directory containing segments.")
-  private String _segmentDir = TMP_DIR + "pinotSegments";
-
-  @Option(name = "-zkAddress", required = false, metaVar = "<http>", usage = "Http address of Zookeeper.")
-  private String _zkAddress = DEFAULT_ZK_ADDRESS;
-
-  @Option(name = "-clusterName", required = false, metaVar = "<String>", usage = "Pinot cluster name.")
-  private String _clusterName = "PinotCluster";
-
-  @Option(name = "-configFileName", required = false, metaVar = "<Config File Name>", usage = "Broker Starter Config file.", forbids = {"-serverHost", "-serverPort", "-dataDir", "-segmentDir",})
-  private String _configFileName;
-
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
+  @Option(name = "-serverHost", required = false, metaVar = "<String>", usage = "Host name for controller.")
+  private String _serverHost;
+  @Option(name = "-serverPort", required = false, metaVar = "<int>", usage = "Port number to start the server at.")
+  private int _serverPort = CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
+  @Option(name = "-serverAdminPort", required = false, metaVar = "<int>", usage = "Port number to serve the server admin API at.")
+  private int _serverAdminPort = CommonConstants.Server.DEFAULT_ADMIN_API_PORT;
+  @Option(name = "-dataDir", required = false, metaVar = "<string>", usage = "Path to directory containing data.")
+  private String _dataDir = TMP_DIR + "pinotServerData";
+  @Option(name = "-segmentDir", required = false, metaVar = "<string>", usage = "Path to directory containing segments.")
+  private String _segmentDir = TMP_DIR + "pinotSegments";
+  @Option(name = "-zkAddress", required = false, metaVar = "<http>", usage = "Http address of Zookeeper.")
+  private String _zkAddress = DEFAULT_ZK_ADDRESS;
+  @Option(name = "-clusterName", required = false, metaVar = "<String>", usage = "Pinot cluster name.")
+  private String _clusterName = "PinotCluster";
+  @Option(name = "-configFileName", required = false, metaVar = "<Config File Name>", usage = "Broker Starter Config file.", forbids = {"-serverHost", "-serverPort", "-dataDir", "-segmentDir",})
+  private String _configFileName;
 
   @Override
   public boolean getHelp() {
@@ -136,28 +129,12 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
   public boolean execute()
       throws Exception {
     try {
-      if (_serverHost == null) {
-        _serverHost = NetUtil.getHostAddress();
-      }
-
-      Configuration configuration = readConfigFromFile(_configFileName);
-      if (configuration == null) {
-        if (_configFileName != null) {
-          LOGGER.error("Error: Unable to find file {}.", _configFileName);
-          return false;
-        }
-
-        configuration = new PropertiesConfiguration();
-        configuration.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, _serverHost);
-        configuration.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT, _serverPort);
-        configuration.addProperty(CommonConstants.Server.CONFIG_OF_ADMIN_API_PORT, _serverAdminPort);
-        configuration.addProperty("pinot.server.instance.dataDir", _dataDir + _serverPort + "/index");
-        configuration.addProperty("pinot.server.instance.segmentTarDir", _segmentDir + _serverPort + "/segmentTar");
-      }
-
       LOGGER.info("Executing command: " + toString());
-      new HelixServerStarter(_clusterName, _zkAddress, configuration);
-      String pidFile = ".pinotAdminServer-" + String.valueOf(System.currentTimeMillis()) + ".pid";
+      StartServiceManagerCommand startServiceManagerCommand =
+          new StartServiceManagerCommand().setZkAddress(_zkAddress).setClusterName(_clusterName).setPort(-1)
+              .setBootstrapServices(new String[0]).addBootstrapService(ServiceRole.SERVER, getServerConf());
+      startServiceManagerCommand.execute();
+      String pidFile = ".pinotAdminServer-" + System.currentTimeMillis() + ".pid";
       savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);
       return true;
     } catch (Exception e) {
@@ -165,5 +142,15 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
       System.exit(-1);
       return false;
     }
+  }
+
+
+  private Configuration getServerConf()
+      throws ConfigurationException, SocketException, UnknownHostException {
+    if (_configFileName != null) {
+      return PinotConfigUtils.readConfigFromFile(_configFileName);
+    }
+    return PinotConfigUtils
+        .generateServerConf(_serverHost, _serverPort, _serverAdminPort, _dataDir, _segmentDir);
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -1,0 +1,213 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command;
+
+import java.io.File;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.spi.services.ServiceRole;
+import org.apache.pinot.tools.Command;
+import org.apache.pinot.tools.service.PinotServiceManager;
+import org.apache.pinot.tools.utils.PinotConfigUtils;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.common.utils.CommonConstants.Helix.PINOT_SERVICE_ROLE;
+
+
+/**
+ * Class to implement StartPinotService command.
+ *
+ */
+public class StartServiceManagerCommand extends AbstractBaseAdminCommand implements Command {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StartServiceManagerCommand.class);
+  private final List<Configuration> _bootstrapConfigurations = new ArrayList<>();
+  private final String[] BOOTSTRAP_SERVICES = new String[]{"CONTROLLER", "BROKER", "SERVER"};
+
+  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
+  private boolean _help;
+  @Option(name = "-zkAddress", required = true, metaVar = "<http>", usage = "Http address of Zookeeper.")
+  private String _zkAddress = DEFAULT_ZK_ADDRESS;
+  @Option(name = "-clusterName", required = true, metaVar = "<String>", usage = "Pinot cluster name.")
+  private String _clusterName = DEFAULT_CLUSTER_NAME;
+  @Option(name = "-port", required = true, metaVar = "<int>", usage = "Pinot service manager admin port, -1 means disable, 0 means a random available port.")
+  private int _port;
+  @Option(name = "-bootstrapConfigPaths", handler = StringArrayOptionHandler.class, required = false, usage = "A list of Pinot service config file paths. Each config file requires an extra config: 'pinot.service.role' to indicate which service to start.", forbids = {"-bootstrapServices"})
+  private String[] _bootstrapConfigPaths;
+  @Option(name = "-bootstrapServices", handler = StringArrayOptionHandler.class, required = false, usage = "A list of Pinot service roles to start with default config. E.g. CONTROLLER/BROKER/SERVER", forbids = {"-bootstrapConfigPaths"})
+  private String[] _bootstrapServices = BOOTSTRAP_SERVICES;
+
+  private PinotServiceManager _pinotServiceManager;
+
+  public String getZkAddress() {
+    return _zkAddress;
+  }
+
+  public StartServiceManagerCommand setZkAddress(String zkAddress) {
+    _zkAddress = zkAddress;
+    return this;
+  }
+
+  public String getClusterName() {
+    return _clusterName;
+  }
+
+  public StartServiceManagerCommand setClusterName(String clusterName) {
+    _clusterName = clusterName;
+    return this;
+  }
+
+  public int getPort() {
+    return _port;
+  }
+
+  public StartServiceManagerCommand setPort(int port) {
+    _port = port;
+    return this;
+  }
+
+  public String[] getBootstrapConfigPaths() {
+    return _bootstrapConfigPaths;
+  }
+
+  public StartServiceManagerCommand setBootstrapConfigPaths(String[] bootstrapConfigPaths) {
+    _bootstrapConfigPaths = bootstrapConfigPaths;
+    return this;
+  }
+
+  public String[] getBootstrapServices() {
+    return _bootstrapServices;
+  }
+
+  public StartServiceManagerCommand setBootstrapServices(String[] bootstrapServices) {
+    _bootstrapServices = bootstrapServices;
+    return this;
+  }
+
+  @Override
+  public boolean getHelp() {
+    return _help;
+  }
+
+  public void setHelp(boolean help) {
+    _help = help;
+  }
+
+  @Override
+  public String getName() {
+    return "StartPinotService";
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder()
+        .append("StartServiceManager -clusterName " + _clusterName + " -zkAddress " + _zkAddress + " -port " + _port);
+    if (_bootstrapConfigPaths != null) {
+      sb.append(" -bootstrapConfigPaths " + Arrays.toString(_bootstrapConfigPaths));
+    } else if (_bootstrapServices != null) {
+      sb.append(" -bootstrapServices " + Arrays.toString(_bootstrapServices));
+    }
+
+    return sb.toString();
+  }
+
+  @Override
+  public void cleanup() {
+  }
+
+  @Override
+  public String description() {
+    return "Start the Pinot Service Process at the specified port.";
+  }
+
+  @Override
+  public boolean execute()
+      throws Exception {
+    try {
+      LOGGER.info("Executing command: " + toString());
+      _pinotServiceManager = new PinotServiceManager(_zkAddress, _clusterName, _port);
+      _pinotServiceManager.start();
+      if (_bootstrapConfigPaths != null) {
+        for (String configPath : _bootstrapConfigPaths) {
+          _bootstrapConfigurations.add(readConfigFromFile(configPath));
+        }
+      } else if (_bootstrapServices != null) {
+        for (String service : _bootstrapServices) {
+          ServiceRole serviceRole = ServiceRole.valueOf(service.toUpperCase());
+          addBootstrapService(serviceRole, getDefaultConfig(serviceRole));
+        }
+      }
+      for (Configuration conf : _bootstrapConfigurations) {
+        startPinotService(conf);
+      }
+      String pidFile = ".pinotAdminService-" + System.currentTimeMillis() + ".pid";
+      savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);
+      return true;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while starting pinot service, exiting.", e);
+      System.exit(-1);
+      return false;
+    }
+  }
+
+  private Configuration getDefaultConfig(ServiceRole serviceRole)
+      throws SocketException, UnknownHostException {
+    switch (serviceRole) {
+      case CONTROLLER:
+        return PinotConfigUtils.generateControllerConf(_zkAddress, _clusterName, null, DEFAULT_CONTROLLER_PORT, null,
+            ControllerConf.ControllerMode.DUAL, true);
+      case BROKER:
+        return PinotConfigUtils.generateBrokerConf(CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT);
+      case SERVER:
+        return PinotConfigUtils.generateServerConf(null, CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT,
+            CommonConstants.Server.DEFAULT_ADMIN_API_PORT, null, null);
+      default:
+        throw new RuntimeException("No default config found for service role: " + serviceRole);
+    }
+  }
+
+  private void startPinotService(Configuration conf) {
+    startPinotService(ServiceRole.valueOf(conf.getString(PINOT_SERVICE_ROLE)), conf);
+  }
+
+  public boolean startPinotService(ServiceRole role, Configuration conf) {
+    try {
+      String instanceId = _pinotServiceManager.startRole(role, conf);
+      LOGGER.info("Started Pinot [{}] Instance [{}].", role, instanceId);
+    } catch (Exception e) {
+      LOGGER.error(String.format("Failed to start a [ %s ] Service", role), e);
+      return false;
+    }
+    return true;
+  }
+
+  public StartServiceManagerCommand addBootstrapService(ServiceRole role, Configuration configuration) {
+    configuration.addProperty(PINOT_SERVICE_ROLE, role.toString());
+    _bootstrapConfigurations.add(configuration);
+    return this;
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -243,7 +243,8 @@ public class PerfBenchmarkDriver {
     }
     serverConfiguration.setProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_ID, _serverInstanceName);
     LOGGER.info("Starting server instance: {}", _serverInstanceName);
-    new HelixServerStarter(_clusterName, _zkAddress, serverConfiguration);
+    HelixServerStarter helixServerStarter = new HelixServerStarter(_clusterName, _zkAddress, serverConfiguration);
+    helixServerStarter.start();
   }
 
   private void startHelixResourceManager()

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
@@ -1,0 +1,229 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.service;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
+import org.apache.pinot.common.utils.NetUtil;
+import org.apache.pinot.common.utils.ServiceStatus;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.ControllerStarter;
+import org.apache.pinot.server.starter.helix.HelixServerStarter;
+import org.apache.pinot.spi.services.ServiceRole;
+import org.apache.pinot.spi.services.ServiceStartable;
+import org.apache.pinot.tools.service.api.resources.PinotInstanceStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.tools.utils.PinotConfigUtils.getAvailablePort;
+
+
+/**
+ * PinotServiceManager is a user entry point to start Pinot instances in one process.
+ *
+ */
+public class PinotServiceManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotServiceManager.class);
+
+  private final Map<String, ServiceStartable> _runningInstanceMap = new ConcurrentHashMap<>();
+
+  private final String _zkAddress;
+  private final String _clusterName;
+  private final int _port;
+  private final String _instanceId;
+  private PinotServiceManagerAdminApiApplication _pinotServiceManagerAdminApplication;
+  private boolean _isStarted = false;
+
+  public PinotServiceManager(String zkAddress, String clusterName) {
+    this(zkAddress, clusterName, 0);
+  }
+
+  public PinotServiceManager(String zkAddress, String clusterName, int port) {
+    this(zkAddress, clusterName, null, port);
+  }
+
+  public PinotServiceManager(String zkAddress, String clusterName, String hostname, int port) {
+    _zkAddress = zkAddress;
+    _clusterName = clusterName;
+    if (port == 0) {
+      port = getAvailablePort();
+    }
+    _port = port;
+    if (hostname == null || hostname.isEmpty()) {
+      hostname = NetUtil.getHostnameOrAddress();
+    }
+    _instanceId = String.format("ServiceManager_%s_%d", hostname, port);
+  }
+
+  public static void main(String[] args) {
+    PinotServiceManager pinotServiceManager = new PinotServiceManager("localhost:2181", "pinot-demo", 8085);
+    pinotServiceManager.start();
+  }
+
+  public String startRole(ServiceRole role, Configuration conf)
+      throws Exception {
+    switch (role) {
+      case CONTROLLER:
+        return startController((ControllerConf) conf);
+      case BROKER:
+        return startBroker(conf);
+      case SERVER:
+        return startServer(conf);
+    }
+    return null;
+  }
+
+  public String startController(ControllerConf controllerConf)
+      throws Exception {
+    LOGGER.info("Trying to start Pinot Controller...");
+    if (controllerConf.getHelixClusterName() == null) {
+      controllerConf.setHelixClusterName(_clusterName);
+    }
+    try {
+      if (controllerConf.getZkStr() == null) {
+        controllerConf.setZkStr(_zkAddress);
+      }
+    } catch (Exception e) {
+      controllerConf.setZkStr(_zkAddress);
+    }
+    ControllerStarter controllerStarter = new ControllerStarter(controllerConf);
+    controllerStarter.start();
+    String instanceId = controllerStarter.getInstanceId();
+    _runningInstanceMap.put(instanceId, controllerStarter);
+    LOGGER.info("Pinot Controller instance [{}] is Started...", instanceId);
+    return instanceId;
+  }
+
+  public String startBroker(Configuration brokerConf)
+      throws Exception {
+    LOGGER.info("Trying to start Pinot Broker...");
+    String brokerHost = brokerConf.getString("broker.host");
+    HelixBrokerStarter brokerStarter;
+    try {
+      brokerStarter = new HelixBrokerStarter(brokerConf, _clusterName, _zkAddress, brokerHost);
+    } catch (Exception e) {
+      LOGGER.error("Failed to initialize Pinot Broker Starter", e);
+      throw e;
+    }
+    try {
+      brokerStarter.start();
+    } catch (Exception e) {
+      LOGGER.error("Failed to start Pinot Broker", e);
+      throw e;
+    }
+    String instanceId = brokerStarter.getInstanceId();
+    _runningInstanceMap.put(instanceId, brokerStarter);
+    LOGGER.info("Pinot Broker instance [{}] is Started...", instanceId);
+    return instanceId;
+  }
+
+  public String startServer(Configuration serverConf)
+      throws Exception {
+    LOGGER.info("Trying to start Pinot Server...");
+    HelixServerStarter serverStarter = new HelixServerStarter(_clusterName, _zkAddress, serverConf);
+    serverStarter.start();
+
+    String instanceId = serverStarter.getInstanceId();
+    _runningInstanceMap.put(instanceId, serverStarter);
+    LOGGER.info("Pinot Server instance [{}] is Started...", instanceId);
+    return instanceId;
+  }
+
+  public boolean stopPinotInstance(ServiceStartable instance) {
+    if (instance == null) {
+      return false;
+    }
+    synchronized (instance) {
+      ServiceRole role = instance.getServiceRole();
+      String instanceId = instance.getInstanceId();
+      LOGGER.info("Trying to stop Pinot [{}] Instance [{}] ...", role, instanceId);
+      instance.stop();
+      LOGGER.info("Pinot [{}] Instance [{}] is Stopped...", role, instanceId);
+      _runningInstanceMap.remove(instanceId);
+      return true;
+    }
+  }
+
+  public void start() {
+    LOGGER.info("Registering service status handler");
+    ServiceStatus.setServiceStatusCallback(_instanceId, new PinotServiceManagerStatusCallback(this));
+
+    if (_port < 0) {
+      LOGGER.info("Skip Starting Pinot Service Manager admin application");
+    } else {
+      LOGGER.info("Starting Pinot Service Manager admin application on port: {}", _port);
+      _pinotServiceManagerAdminApplication = new PinotServiceManagerAdminApiApplication(this);
+      _pinotServiceManagerAdminApplication.start(_port);
+    }
+    _isStarted = true;
+  }
+
+  public void stop() {
+    LOGGER.info("Shutting down Pinot Service Manager admin application...");
+    _pinotServiceManagerAdminApplication.stop();
+    LOGGER.info("Deregistering service status handler");
+    ServiceStatus.removeServiceStatusCallback(_instanceId);
+  }
+
+  public boolean isStarted() {
+    return _isStarted;
+  }
+
+  public String getInstanceId() {
+    return _instanceId;
+  }
+
+  public int getServicePort() {
+    return _port;
+  }
+
+  public PinotInstanceStatus getInstanceStatus(String instanceName) {
+    ServiceStartable serviceStartable = _runningInstanceMap.get(instanceName);
+    if (serviceStartable == null) {
+      return null;
+    }
+    PinotInstanceStatus status =
+        new PinotInstanceStatus(serviceStartable.getServiceRole(), serviceStartable.getInstanceId(),
+            serviceStartable.getConfig(), ServiceStatus.getServiceStatus(instanceName),
+            ServiceStatus.getStatusDescription(instanceName));
+
+    return status;
+  }
+
+  public List<String> getRunningInstanceIds() {
+    return ImmutableList.copyOf(_runningInstanceMap.keySet());
+  }
+
+  public String getZkAddress() {
+    return _zkAddress;
+  }
+
+  public String getClusterName() {
+    return _clusterName;
+  }
+
+  public boolean stopPinotInstanceById(String instanceName) {
+    return stopPinotInstance(_runningInstanceMap.get(instanceName));
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.tools.service;
+
+import com.google.common.base.Preconditions;
+import io.swagger.jaxrs.config.BeanConfig;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
+import org.glassfish.grizzly.http.server.HttpHandler;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+
+
+public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
+  private static final String RESOURCE_PACKAGE = "org.apache.pinot.tools.service.api.resources";
+
+  private URI _baseUri;
+  private HttpServer _httpServer;
+
+  public PinotServiceManagerAdminApiApplication(PinotServiceManager pinotServiceManager) {
+    packages(RESOURCE_PACKAGE);
+    register(new AbstractBinder() {
+      @Override
+      protected void configure() {
+        bind(pinotServiceManager).to(PinotServiceManager.class);
+      }
+    });
+    register(JacksonFeature.class);
+    registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
+    registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+  }
+
+  public void start(int httpPort) {
+    Preconditions.checkArgument(httpPort > 0);
+    _baseUri = URI.create("http://0.0.0.0:" + httpPort + "/");
+    _httpServer = GrizzlyHttpServerFactory.createHttpServer(_baseUri, this);
+    setupSwagger();
+  }
+
+  private void setupSwagger() {
+    BeanConfig beanConfig = new BeanConfig();
+    beanConfig.setTitle("Pinot Starter API");
+    beanConfig.setDescription("APIs for accessing Pinot Starter information");
+    beanConfig.setContact("https://github.com/apache/incubator-pinot");
+    beanConfig.setVersion("1.0");
+    beanConfig.setSchemes(new String[]{"http"});
+    beanConfig.setBasePath(_baseUri.getPath());
+    beanConfig.setResourcePackage(RESOURCE_PACKAGE);
+    beanConfig.setScan(true);
+
+    HttpHandler httpHandler =
+        new CLStaticHttpHandler(PinotServiceManagerAdminApiApplication.class.getClassLoader(), "/api/");
+    // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
+    _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
+
+    URL swaggerDistLocation = PinotServiceManagerAdminApiApplication.class.getClassLoader()
+        .getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");
+    CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
+    _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
+  }
+
+  public void stop() {
+    if (_httpServer != null) {
+      _httpServer.shutdownNow();
+    }
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerStatusCallback.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerStatusCallback.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.service;
+
+import org.apache.pinot.common.utils.ServiceStatus;
+
+import static org.apache.pinot.common.utils.ServiceStatus.STATUS_DESCRIPTION_INIT;
+import static org.apache.pinot.common.utils.ServiceStatus.STATUS_DESCRIPTION_STARTED;
+
+
+public class PinotServiceManagerStatusCallback implements ServiceStatus.ServiceStatusCallback {
+  private final PinotServiceManager _pinotServiceManager;
+
+  public PinotServiceManagerStatusCallback(PinotServiceManager pinotServiceManager) {
+    _pinotServiceManager = pinotServiceManager;
+  }
+
+  @Override
+  public ServiceStatus.Status getServiceStatus() {
+    if (_pinotServiceManager.isStarted()) {
+      return ServiceStatus.Status.GOOD;
+    } else {
+      return ServiceStatus.Status.STARTING;
+    }
+  }
+
+  @Override
+  public String getStatusDescription() {
+    if (_pinotServiceManager.isStarted()) {
+      return STATUS_DESCRIPTION_STARTED;
+    } else {
+      return STATUS_DESCRIPTION_INIT;
+    }
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotInstanceStatus.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotInstanceStatus.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.service.api.resources;
+
+import java.util.Map;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationConverter;
+import org.apache.pinot.common.utils.ServiceStatus;
+import org.apache.pinot.spi.services.ServiceRole;
+
+
+public class PinotInstanceStatus {
+  private final ServiceRole _serviceRole;
+  private final String _instanceId;
+  private final Map _config;
+  private final ServiceStatus.Status _serviceStatus;
+  private final String _statusDescription;
+
+  public PinotInstanceStatus(ServiceRole serviceRole, String instanceId, Configuration config,
+      ServiceStatus.Status serviceStatus, String statusDescription) {
+    _serviceRole = serviceRole;
+    _instanceId = instanceId;
+    _config = ConfigurationConverter.getMap(config);
+    _serviceStatus = serviceStatus;
+    _statusDescription = statusDescription;
+  }
+
+  public String getStatusDescription() {
+    return _statusDescription;
+  }
+
+  public ServiceRole getServiceRole() {
+    return _serviceRole;
+  }
+
+  public String getInstanceId() {
+    return _instanceId;
+  }
+
+  public Map getConfig() {
+    return _config;
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerHealthCheck.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerHealthCheck.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.tools.service.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.common.utils.ServiceStatus;
+
+
+@Api(tags = "Health")
+@Path("/")
+public class PinotServiceManagerHealthCheck {
+
+  @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  @Path("health")
+  @ApiOperation(value = "Checking Pinot Service health")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Pinot Starter is healthy"), @ApiResponse(code = 503, message = "Pinot Starter is not healthy")})
+  public String getStarterHealth() {
+    ServiceStatus.Status status = ServiceStatus.getServiceStatus();
+    if (status == ServiceStatus.Status.GOOD) {
+      return "OK";
+    }
+    throw new WebApplicationException(String.format("Pinot starter status is [ %s ]", status),
+        Response.Status.SERVICE_UNAVAILABLE);
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/health/services")
+  @ApiOperation(value = "Checking all services health for a service")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Pinot Service is healthy"), @ApiResponse(code = 503, message = "Pinot Service is not healthy")})
+  public Map<String, Map<String, String>> getAllServicesHealth() {
+    return ServiceStatus.getServiceStatusMap();
+  }
+
+  @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  @Path("/health/services/{instanceName}")
+  @ApiOperation(value = "Checking service health for an instance")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Pinot Instance is healthy"), @ApiResponse(code = 503, message = "Pinot Instance is not healthy")})
+  public String getServiceHealth(
+      @ApiParam(value = "Name of the Instance") @PathParam("instanceName") String instanceName) {
+    ServiceStatus.Status status = ServiceStatus.getServiceStatus(instanceName);
+    if (status == ServiceStatus.Status.GOOD) {
+      return "OK";
+    }
+    throw new WebApplicationException(String.format("Pinot instance [ %s ] status is [ %s ]", instanceName, status),
+        Response.Status.SERVICE_UNAVAILABLE);
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerInstanceResource.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerInstanceResource.java
@@ -1,0 +1,241 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.tools.service.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.NetUtil;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.spi.services.ServiceRole;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.tools.service.PinotServiceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.common.utils.CommonConstants.Controller.CONFIG_OF_CONTROLLER_METRICS_PREFIX;
+import static org.apache.pinot.common.utils.CommonConstants.Controller.DEFAULT_METRICS_PREFIX;
+import static org.apache.pinot.tools.utils.PinotConfigUtils.TMP_DIR;
+import static org.apache.pinot.tools.utils.PinotConfigUtils.getAvailablePort;
+
+
+@Api(tags = "Startable")
+@Path("/")
+public class PinotServiceManagerInstanceResource {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotServiceManagerInstanceResource.class);
+
+  @Inject
+  private PinotServiceManager _pinotServiceManager;
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/instances")
+  @ApiOperation(value = "Get Pinot Instances Status")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Instance Status"), @ApiResponse(code = 500, message = "Internal server error")})
+  public Map<String, PinotInstanceStatus> getPinotAllInstancesStatus() {
+    Map<String, PinotInstanceStatus> results = new HashMap<>();
+    for (String instanceId : _pinotServiceManager.getRunningInstanceIds()) {
+      results.put(instanceId, _pinotServiceManager.getInstanceStatus(instanceId));
+    }
+    return results;
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/instances/{instanceName}")
+  @ApiOperation(value = "Get Pinot Instance Status")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Instance Status"), @ApiResponse(code = 404, message = "Instance Not Found"), @ApiResponse(code = 500, message = "Internal server error")})
+  public PinotInstanceStatus getPinotInstanceStatus(
+      @ApiParam(value = "Name of the instance") @PathParam("instanceName") String instanceName) {
+    List<String> instanceIds = _pinotServiceManager.getRunningInstanceIds();
+    if (instanceIds.contains(instanceName)) {
+      return _pinotServiceManager.getInstanceStatus(instanceName);
+    }
+    throw new WebApplicationException(String.format("Instance [%s] not found.", instanceName),
+        Response.Status.NOT_FOUND);
+  }
+
+  @DELETE
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/instances/{instanceName}")
+  @ApiOperation(value = "Stop a Pinot Instance")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Pinot Instance is Stopped"), @ApiResponse(code = 404, message = "Instance Not Found"), @ApiResponse(code = 500, message = "Internal server error")})
+  public Response stopPinotInstance(
+      @ApiParam(value = "Name of the instance") @PathParam("instanceName") String instanceName) {
+    List<String> instanceIds = _pinotServiceManager.getRunningInstanceIds();
+    if (instanceIds.contains(instanceName)) {
+      if (_pinotServiceManager.stopPinotInstanceById(instanceName)) {
+        return Response.ok().build();
+      } else {
+        throw new WebApplicationException(String.format("Failed to stop a Pinot instance [%s]", instanceName),
+            Response.Status.INTERNAL_SERVER_ERROR);
+      }
+    }
+    throw new WebApplicationException(String.format("Instance [%s] not found.", instanceName),
+        Response.Status.NOT_FOUND);
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/instances/{role}")
+  @ApiOperation(value = "Start a Pinot instance")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Pinot instance is started"), @ApiResponse(code = 400, message = "Bad Request"), @ApiResponse(code = 404, message = "Pinot Role Not Found"), @ApiResponse(code = 500, message = "Internal Server Error")})
+  public PinotInstanceStatus startPinotInstance(
+      @ApiParam(value = "A Role of Pinot Instance to start: CONTROLLER/BROKER/SERVER") @PathParam("role") String role,
+      @ApiParam(value = "true|false") @QueryParam("autoMode") boolean autoMode, String confStr) {
+    ServiceRole serviceRole;
+    try {
+      serviceRole = ServiceRole.valueOf(role.toUpperCase());
+    } catch (Exception e) {
+      throw new WebApplicationException("Unrecognized Role: " + role, Response.Status.NOT_FOUND);
+    }
+    Configuration configuration;
+    try {
+      configuration = JsonUtils.stringToObject(confStr, Configuration.class);
+    } catch (IOException e) {
+      if (autoMode) {
+        switch (serviceRole) {
+          case CONTROLLER:
+            configuration = new ControllerConf();
+            break;
+          default:
+            configuration = new PropertiesConfiguration();
+        }
+      } else {
+        throw new WebApplicationException("Unable to deserialize Conf String to Configuration Object",
+            Response.Status.BAD_REQUEST);
+      }
+    }
+    if (autoMode) {
+      updateConfiguration(serviceRole, configuration);
+    }
+    try {
+      String instanceName = _pinotServiceManager.startRole(serviceRole, configuration);
+      if (instanceName != null) {
+        LOGGER.info("Successfully started Pinot [{}] instance [{}]", serviceRole, instanceName);
+        return _pinotServiceManager.getInstanceStatus(instanceName);
+      }
+      throw new WebApplicationException(String.format("Unable to start a Pinot [%s]", serviceRole),
+          Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while processing POST request", e);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private void updateConfiguration(ServiceRole role, Configuration configuration) {
+    switch (role) {
+      case CONTROLLER:
+        ControllerConf controllerConf = (ControllerConf) configuration;
+        if (controllerConf.getControllerHost() == null) {
+          String hostname;
+          try {
+            hostname = NetUtil.getHostAddress();
+          } catch (Exception e) {
+            hostname = "localhost";
+          }
+          controllerConf.setControllerHost(hostname);
+        }
+        if (controllerConf.getControllerPort() == null) {
+          controllerConf.setControllerPort(Integer.toString(getAvailablePort()));
+        }
+        if (controllerConf.getDataDir() == null) {
+          controllerConf.setDataDir(TMP_DIR + String
+              .format("Controller_%s_%s/data", controllerConf.getControllerHost(), controllerConf.getControllerPort()));
+        }
+        if (!controllerConf.containsKey(CONFIG_OF_CONTROLLER_METRICS_PREFIX)) {
+          controllerConf.addProperty(CONFIG_OF_CONTROLLER_METRICS_PREFIX, String
+              .format("%s.%s_%s", DEFAULT_METRICS_PREFIX, controllerConf.getControllerHost(),
+                  controllerConf.getControllerPort()));
+        }
+        break;
+      case BROKER:
+        if (!configuration.containsKey(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT)) {
+          configuration.addProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, getAvailablePort());
+        }
+        if (!configuration.containsKey(CommonConstants.Broker.METRICS_CONFIG_PREFIX)) {
+          String hostname;
+          try {
+            hostname = NetUtil.getHostAddress();
+          } catch (Exception e) {
+            hostname = "localhost";
+          }
+          configuration.addProperty(CommonConstants.Broker.CONFIG_OF_METRICS_NAME_PREFIX, String
+              .format("%s%s_%d", CommonConstants.Broker.DEFAULT_METRICS_NAME_PREFIX, hostname,
+                  configuration.getInt(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT)));
+        }
+        return;
+      case SERVER:
+        if (!configuration.containsKey(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST)) {
+          String hostname;
+          try {
+            hostname = NetUtil.getHostAddress();
+          } catch (Exception e) {
+            hostname = "localhost";
+          }
+          configuration.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, hostname);
+        }
+        if (!configuration.containsKey(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT)) {
+          configuration.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT, getAvailablePort());
+        }
+        if (!configuration.containsKey(CommonConstants.Server.CONFIG_OF_ADMIN_API_PORT)) {
+          configuration.addProperty(CommonConstants.Server.CONFIG_OF_ADMIN_API_PORT, getAvailablePort());
+        }
+        if (!configuration.containsKey(CommonConstants.Server.CONFIG_OF_INSTANCE_DATA_DIR)) {
+          configuration.addProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_DATA_DIR, TMP_DIR + String
+              .format("Server_%s_%d/data", configuration.getString(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST),
+                  configuration.getInt(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT)));
+        }
+        if (!configuration.containsKey(CommonConstants.Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR)) {
+          configuration.addProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, TMP_DIR + String
+              .format("Server_%s_%d/segment", configuration.getString(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST),
+                  configuration.getInt(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT)));
+        }
+        if (!configuration.containsKey(CommonConstants.Server.PINOT_SERVER_METRICS_PREFIX)) {
+          configuration.addProperty(CommonConstants.Server.PINOT_SERVER_METRICS_PREFIX, String
+              .format("%s%s_%d", CommonConstants.Server.DEFAULT_METRICS_PREFIX,
+                  configuration.getString(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST),
+                  configuration.getInt(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT)));
+        }
+        return;
+    }
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.lang.StringUtils;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.NetUtil;
+import org.apache.pinot.controller.ControllerConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PinotConfigUtils {
+
+  public static final String TMP_DIR = System.getProperty("java.io.tmpdir") + File.separator;
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotConfigUtils.class);
+  private static final String CONTROLLER_CONFIG_VALIDATION_ERROR_MESSAGE_FORMAT =
+      "Pinot Controller Config Validation Error: %s";
+
+  public static ControllerConf generateControllerConf(String zkAddress, String clusterName, String controllerHost,
+      String controllerPort, String dataDir, ControllerConf.ControllerMode controllerMode, boolean tenantIsolation)
+      throws SocketException, UnknownHostException {
+    if (StringUtils.isEmpty(zkAddress)) {
+      throw new RuntimeException("zkAddress cannot be empty.");
+    }
+    if (StringUtils.isEmpty(clusterName)) {
+      throw new RuntimeException("clusterName cannot be empty.");
+    }
+    ControllerConf conf = new ControllerConf();
+    conf.setZkStr(zkAddress);
+    conf.setHelixClusterName(clusterName);
+    if (StringUtils.isEmpty(controllerHost)) {
+      controllerHost = NetUtil.getHostAddress();
+    }
+    conf.setControllerHost(controllerHost);
+    if (StringUtils.isEmpty(controllerPort)) {
+      controllerPort = Integer.toString(getAvailablePort());
+    }
+    conf.setControllerPort(controllerPort);
+
+    if (StringUtils.isEmpty(dataDir)) {
+      dataDir = TMP_DIR + String.format("Controller_%s_%s/controller/data", controllerHost, controllerPort);
+    }
+    conf.setDataDir(dataDir);
+    conf.setControllerVipHost(controllerHost);
+    conf.setTenantIsolationEnabled(tenantIsolation);
+
+    conf.setRetentionControllerFrequencyInSeconds(3600 * 6);
+    conf.setOfflineSegmentIntervalCheckerFrequencyInSeconds(3600);
+    conf.setRealtimeSegmentValidationFrequencyInSeconds(3600);
+    conf.setBrokerResourceValidationFrequencyInSeconds(3600);
+
+    conf.setControllerMode(controllerMode);
+    return conf;
+  }
+
+  public static ControllerConf generateControllerConf(String configFileName)
+      throws ConfigurationException {
+    ControllerConf conf = readControllerConfigFromFile(configFileName);
+    if (conf == null) {
+      throw new RuntimeException("Error: Unable to find controller config file " + configFileName);
+    }
+    return conf;
+  }
+
+  public static ControllerConf readControllerConfigFromFile(String configFileName)
+      throws ConfigurationException {
+    if (configFileName == null) {
+      return null;
+    }
+
+    File configFile = new File(configFileName);
+    if (!configFile.exists()) {
+      return null;
+    }
+
+    ControllerConf conf = new ControllerConf(configFile);
+    conf.setPinotFSFactoryClasses(null);
+    if (!validateControllerConfig(conf)) {
+      LOGGER.error("Failed to validate controller conf.");
+      throw new ConfigurationException("Pinot Controller Conf validation failure");
+    }
+    return (validateControllerConfig(conf)) ? conf : null;
+  }
+
+  public static boolean validateControllerConfig(ControllerConf conf)
+      throws ConfigurationException {
+    if (conf == null) {
+      throw new ConfigurationException(
+          String.format(CONTROLLER_CONFIG_VALIDATION_ERROR_MESSAGE_FORMAT, "null conf object."));
+    }
+    if (conf.getControllerPort() == null) {
+      throw new ConfigurationException(String.format(CONTROLLER_CONFIG_VALIDATION_ERROR_MESSAGE_FORMAT,
+          "missing controller port, please specify 'controller.port' property in config file."));
+    }
+    if (conf.getZkStr() == null) {
+      throw new ConfigurationException(String.format(CONTROLLER_CONFIG_VALIDATION_ERROR_MESSAGE_FORMAT,
+          "missing Zookeeper address, please specify 'controller.zk.str' property in config file."));
+    }
+    if (conf.getHelixClusterName() == null) {
+      throw new ConfigurationException(String.format(CONTROLLER_CONFIG_VALIDATION_ERROR_MESSAGE_FORMAT,
+          "missing helix cluster name, please specify 'controller.helix.cluster.name' property in config file."));
+    }
+    return true;
+  }
+
+  public static PropertiesConfiguration readConfigFromFile(String configFileName)
+      throws ConfigurationException {
+    if (configFileName == null) {
+      return null;
+    }
+    File configFile = new File(configFileName);
+    if (configFile.exists()) {
+      return new PropertiesConfiguration(configFile);
+    }
+    return null;
+  }
+
+  public static Configuration generateBrokerConf(int brokerPort) {
+    if (brokerPort == 0) {
+      brokerPort = getAvailablePort();
+    }
+    Configuration brokerConf = new BaseConfiguration();
+    brokerConf.addProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, brokerPort);
+    return brokerConf;
+  }
+
+  public static Configuration generateServerConf(String serverHost, int serverPort, int serverAdminPort,
+      String serverDataDir, String serverSegmentDir)
+      throws SocketException, UnknownHostException {
+    if (serverHost == null) {
+      serverHost = NetUtil.getHostAddress();
+    }
+    if (serverPort == 0) {
+      serverPort = getAvailablePort();
+    }
+    if (serverAdminPort == 0) {
+      serverAdminPort = getAvailablePort();
+    }
+    if (serverDataDir == null) {
+      serverDataDir = TMP_DIR + String.format("Server_%s_%d/server/data", serverHost, serverPort);
+    }
+    if (serverSegmentDir == null) {
+      serverSegmentDir = TMP_DIR + String.format("Server_%s_%d/server/segment", serverHost, serverPort);
+    }
+    Configuration serverConf = new PropertiesConfiguration();
+    serverConf.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, serverHost);
+    serverConf.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT, serverPort);
+    serverConf.addProperty(CommonConstants.Server.CONFIG_OF_ADMIN_API_PORT, serverAdminPort);
+    serverConf.addProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_DATA_DIR, serverDataDir);
+    serverConf.addProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, serverSegmentDir);
+    return serverConf;
+  }
+
+  public static int getAvailablePort() {
+    try {
+      try (ServerSocket socket = new ServerSocket(0)) {
+        return socket.getLocalPort();
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to find an available port to use", e);
+    }
+  }
+}

--- a/pinot-tools/src/main/resources/conf/pinot-service-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-service-log4j2.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<Configuration>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT"/>
+    <RandomAccessFile name="serviceManagerLog" fileName="pinotServiceManager.log" immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+    </RandomAccessFile>
+    <RandomAccessFile name="controllerLog" fileName="pinotController.log" immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+    </RandomAccessFile>
+    <RandomAccessFile name="brokerLog" fileName="pinotBroker.log" immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+    </RandomAccessFile>
+    <RandomAccessFile name="serverLog" fileName="pinotServer.log" immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+    </RandomAccessFile>
+
+  </Appenders>
+  <Loggers>
+    <Root level="info" additivity="false">
+      <AppenderRef ref="console"/>
+    </Root>
+    <Logger name="org.apache.pinot" level="info" additivity="false">
+      <AppenderRef ref="serviceManagerLog"/>
+    </Logger>
+    <Logger name="org.apache.pinot" level="error" additivity="false"/>
+    <Logger name="org.apache.pinot.tools.admin" level="info" additivity="false">
+      <AppenderRef ref="console"/>
+    </Logger>
+
+    <!-- Direct controller package log to the controller log file -->
+    <AsyncLogger name="org.apache.pinot.controller" level="info" additivity="false">
+      <AppenderRef ref="controllerLog"/>
+    </AsyncLogger>
+
+    <!-- Direct broker package log to the broker log file -->
+    <AsyncLogger name="org.apache.pinot.broker" level="info" additivity="false">
+      <AppenderRef ref="brokerLog"/>
+    </AsyncLogger>
+
+    <!-- Including server related package log to the server log file -->
+    <AsyncLogger name="org.apache.pinot.server" level="info" additivity="false">
+      <AppenderRef ref="serverLog"/>
+    </AsyncLogger>
+    <AsyncLogger name="org.apache.pinot.core.plan" level="info" additivity="false">
+      <AppenderRef ref="serverLog"/>
+    </AsyncLogger>
+    <AsyncLogger name="org.apache.pinot.core.realtime" level="info" additivity="false">
+      <AppenderRef ref="serverLog"/>
+    </AsyncLogger>
+    <AsyncLogger name="org.apache.pinot.core.query" level="info" additivity="false">
+      <AppenderRef ref="serverLog"/>
+    </AsyncLogger>
+    <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+    <AsyncLogger name="org.apache.pinot.spi.plugin" level="error" additivity="false">
+      <AppenderRef ref="console"/>
+    </AsyncLogger>
+  </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
     <jackson.version>2.9.8</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
     <jersey.version>2.28</jersey.version>
+    <grizzly.version>2.4.4</grizzly.version>
     <swagger.version>1.5.16</swagger.version>
     <hadoop.version>2.7.0</hadoop.version>
     <spark.version>2.2.0</spark.version>
@@ -991,6 +992,11 @@
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>jersey-container-grizzly2-http</artifactId>
         <version>${jersey.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.grizzly</groupId>
+        <artifactId>grizzly-http-server</artifactId>
+        <version>${grizzly.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
## Updates
1. Defines Enum ServiceRole: `CONTROLLER`/`BROKER`/`SERVER`/`MINION` for the Pinot Components to manage
2. Defines interface: `ServiceStartable`, so each role could implement its own way to start/stop it.
3. Make `ControllerStarter`,`HelixBrokerStarter`, `HelixServerStarter`, `MinionStarter` to implement interface `ServiceStartable`.
4. Implement `PinotServiceManagerStarter` as a new entry point to manage all pinot roles lifecycles.
5. Make `ServiceStatus` could handle multiple Pinot roles.
6. Provide REST API to start/stop Pinot Roles with default configs.
7. Move `ControllerStarter`/`BrokerStarter`/`ServerStarter` commands to use new `ServiceManagerStarer` command. Hence all Quickstarts will use it transparently.

## Sample Usage:
* Start PinotServiceManager along with controller/broker/server by default.
```
bin/start-service-manager.sh -zkAddress localhost:2181 -clusterName pinot-service-demo -port 8055
```
 * Start PinotServiceManager along with Broker&Server with default configs
```
bin/start-service-manager.sh -zkAddress localhost:2181 -clusterName pinot-service-demo -port 8055 -bootstrapServices BROKER SERVER
```
 * Start PinotServiceManager along with Broker&Server with bootstrap configs.
```
bin/start-service-manager.sh -zkAddress localhost:2181 -clusterName pinot-service-demo -port 8055 -bootstrapConfigPaths /path/to/pinot-broker.conf /path/to/pinot-server.conf
```
* Once PinotServiceManager is up, it exposes APIs using swagger.

| METHOD | API                             | Description                                |
|--------|---------------------------------|--------------------------------------------|
| GET    | /health                         | Checking Pinot Service health              |
| GET    | /health/services                | Checking all services health for a service |
| GET    | /health/services/{instanceName} | Checking service health for an instance    |
| GET    | /instances                      | Get Pinot Instances Status                 |
| GET    | /instances/{instanceName}       | Get Pinot Instance Status                  |
| POST   | /instances/{role}               | Start a Pinot instance                     |
| DELETE | /instances                      | Stop all Pinot Instances                   |
| DELETE | /instances/{instanceName}       | Stop a Pinot Instance                      |
| DELETE | /instances/roles/{role}         | Stop Pinot Instances for a Role            |

## Note: backward incompatible: 
- `HelixBrokerStarter`, method `shutdown()` is replaced as `stop()`
- `HelixServerStarter` requires an explicitly call of `start()` to start it. In
the old behavior, there is no `start()` method and the constructor will also take care of start server.