### PR TITLE
Removing the explicit reference to index types in segmentDirectory/co…

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/ColumnIndexDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/ColumnIndexDirectory.java
@@ -71,99 +71,23 @@ abstract class ColumnIndexDirectory implements Closeable {
   }
 
   /**
-   * Get dictionary data buffer for a column
+   * Get data buffer of a specified indexType for a column
    * @param column column name
-   * @return in-memory ByteBuffer like buffer for data
+   * @param type index type
+   * @return ByteBuffer like buffer for data
    * @throws IOException
    */
-  public abstract PinotDataBuffer getDictionaryBufferFor(String column)
-      throws IOException;
-
-  /**
-   * Get forward index data buffer for a column
-   * @param column column name
-   * @return in-memory ByteBuffer like buffer for data
-   * @throws IOException
-   */
-  public abstract PinotDataBuffer getForwardIndexBufferFor(String column)
-      throws IOException;
-
-  /**
-   * Get inverted index data buffer for a column
-   * @param column column name
-   * @return in-memory ByteBuffer like buffer for data
-   * @throws IOException
-   */
-  public abstract PinotDataBuffer getInvertedIndexBufferFor(String column)
-      throws IOException;
-
-  /**
-   * Get inverted bloom filter buffer for a column
-   * @param column column name
-   * @return in-memory ByteBuffer like buffer for data
-   * @throws IOException
-   */
-  public abstract PinotDataBuffer getBloomFilterBufferFor(String column)
-      throws IOException;
-
-  /**
-   * Get null value vector buffer for a column
-   * @param column column name
-   * @return in-memory ByteBuffer like buffer for data
-   * @throws IOException
-   */
-  public abstract PinotDataBuffer getNullValueVectorBufferFor(String column)
-      throws IOException;
+  public abstract PinotDataBuffer getBuffer(String column, ColumnIndexType type) throws IOException;
 
   /**
    * Allocate a new data buffer of specified sizeBytes in the columnar index directory
    * @param column column name
+   * @param type index type
    * @param sizeBytes sizeBytes for the buffer allocation
-   * @return in-memory ByteBuffer like buffer for data
+   * @return ByteBuffer like buffer for data
    * @throws IOException
    */
-  public abstract PinotDataBuffer newDictionaryBuffer(String column, long sizeBytes)
-      throws IOException;
-
-  /**
-   * Allocate a new data buffer of specified sizeBytes in the columnar index directory
-   * @param column column name
-   * @param sizeBytes sizeBytes for the buffer allocation
-   * @return in-memory ByteBuffer like buffer for data
-   * @throws IOException
-   */
-  public abstract PinotDataBuffer newForwardIndexBuffer(String column, long sizeBytes)
-      throws IOException;
-
-  /**
-   * Allocate a new data buffer of specified sizeBytes in the columnar index directory
-   * @param column column name
-   * @param sizeBytes sizeBytes for the buffer allocation
-   * @return in-memory ByteBuffer like buffer for data
-   * @throws IOException
-   */
-  public abstract PinotDataBuffer newInvertedIndexBuffer(String column, long sizeBytes)
-      throws IOException;
-
-  /**
-   * Allocate a new data buffer of specified sizeBytes in the columnar index directory
-   * @param column column name
-   * @param sizeBytes sizeBytes for the buffer allocation
-   * @return in-memory ByteBuffer like buffer for data
-   * @throws IOException
-   */
-  public abstract PinotDataBuffer newBloomFilterBuffer(String column, long sizeBytes)
-      throws IOException;
-
-  /**
-   * Allocate a new data buffer of specified sizeBytes in the columnar index directory
-   * @param column column name
-   * @param sizeBytes sizeBytes for the buffer allocation
-   * @return in-memory ByteBuffer like buffer for data
-   * @throws IOException
-   */
-  public abstract PinotDataBuffer newNullValueVectorBuffer(String column, long sizeBytes)
-      throws IOException;
+  public abstract PinotDataBuffer newBuffer(String column, ColumnIndexType type, long sizeBytes) throws IOException;
 
   /**
    * Check if an index exists for a column

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/ColumnIndexDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/ColumnIndexDirectory.java
@@ -77,7 +77,8 @@ abstract class ColumnIndexDirectory implements Closeable {
    * @return ByteBuffer like buffer for data
    * @throws IOException
    */
-  public abstract PinotDataBuffer getBuffer(String column, ColumnIndexType type) throws IOException;
+  public abstract PinotDataBuffer getBuffer(String column, ColumnIndexType type)
+      throws IOException;
 
   /**
    * Allocate a new data buffer of specified sizeBytes in the columnar index directory
@@ -87,7 +88,8 @@ abstract class ColumnIndexDirectory implements Closeable {
    * @return ByteBuffer like buffer for data
    * @throws IOException
    */
-  public abstract PinotDataBuffer newBuffer(String column, ColumnIndexType type, long sizeBytes) throws IOException;
+  public abstract PinotDataBuffer newBuffer(String column, ColumnIndexType type, long sizeBytes)
+      throws IOException;
 
   /**
    * Check if an index exists for a column

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/FilePerIndexDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/FilePerIndexDirectory.java
@@ -43,72 +43,14 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
   }
 
   @Override
-  public PinotDataBuffer getDictionaryBufferFor(String column)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.DICTIONARY);
+  public PinotDataBuffer getBuffer(String column, ColumnIndexType type) throws IOException{
+    IndexKey key = new IndexKey(column, type);
     return getReadBufferFor(key);
   }
 
   @Override
-  public PinotDataBuffer newDictionaryBuffer(String column, long sizeBytes)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.DICTIONARY);
-    return getWriteBufferFor(key, sizeBytes);
-  }
-
-  @Override
-  public PinotDataBuffer getForwardIndexBufferFor(String column)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.FORWARD_INDEX);
-    return getReadBufferFor(key);
-  }
-
-  @Override
-  public PinotDataBuffer newForwardIndexBuffer(String column, long sizeBytes)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.FORWARD_INDEX);
-    return getWriteBufferFor(key, sizeBytes);
-  }
-
-  @Override
-  public PinotDataBuffer getInvertedIndexBufferFor(String column)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.INVERTED_INDEX);
-    return getReadBufferFor(key);
-  }
-
-  @Override
-  public PinotDataBuffer newInvertedIndexBuffer(String column, long sizeBytes)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.INVERTED_INDEX);
-    return getWriteBufferFor(key, sizeBytes);
-  }
-
-  @Override
-  public PinotDataBuffer getBloomFilterBufferFor(String column)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.BLOOM_FILTER);
-    return getReadBufferFor(key);
-  }
-
-  @Override
-  public PinotDataBuffer newBloomFilterBuffer(String column, long sizeBytes)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.BLOOM_FILTER);
-    return getWriteBufferFor(key, sizeBytes);
-  }
-
-  @Override
-  public PinotDataBuffer getNullValueVectorBufferFor(String column)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.NULLVALUE_VECTOR);
-    return getReadBufferFor(key);
-  }
-
-  @Override
-  public PinotDataBuffer newNullValueVectorBuffer(String column, long sizeBytes)
-      throws IOException {
-    IndexKey key = new IndexKey(column, ColumnIndexType.NULLVALUE_VECTOR);
+  public PinotDataBuffer newBuffer(String column, ColumnIndexType type, long sizeBytes) throws IOException{
+    IndexKey key = new IndexKey(column, type);
     return getWriteBufferFor(key, sizeBytes);
   }
 
@@ -143,8 +85,13 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
       return indexBuffers.get(key);
     }
 
-    File filename = getFileFor(key.name, key.type);
-    PinotDataBuffer buffer = mapForReads(filename, key.type.toString() + ".reader");
+    File file = getFileFor(key.name, key.type);
+    if (!file.exists()) {
+      throw new RuntimeException(
+          "Could not find index for column: " + key.name + ", type: " + key.type + ", segment: " + segmentDirectory
+              .toString());
+    }
+    PinotDataBuffer buffer = mapForReads(file, key.type.toString() + ".reader");
     indexBuffers.put(key, buffer);
     return buffer;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/FilePerIndexDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/FilePerIndexDirectory.java
@@ -43,13 +43,15 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
   }
 
   @Override
-  public PinotDataBuffer getBuffer(String column, ColumnIndexType type) throws IOException{
+  public PinotDataBuffer getBuffer(String column, ColumnIndexType type)
+      throws IOException {
     IndexKey key = new IndexKey(column, type);
     return getReadBufferFor(key);
   }
 
   @Override
-  public PinotDataBuffer newBuffer(String column, ColumnIndexType type, long sizeBytes) throws IOException{
+  public PinotDataBuffer newBuffer(String column, ColumnIndexType type, long sizeBytes)
+      throws IOException {
     IndexKey key = new IndexKey(column, type);
     return getWriteBufferFor(key, sizeBytes);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentLocalFSDirectory.java
@@ -79,7 +79,8 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
   }
 
   @Override
-  public void reloadMetadata() throws Exception {
+  public void reloadMetadata()
+      throws Exception {
     this.segmentMetadata = loadSegmentMetadata(segmentDirectory);
     columnIndexDirectory.metadata = this.segmentMetadata;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SegmentLocalFSDirectory.java
@@ -224,25 +224,9 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
   private PinotDataBuffer getIndexForColumn(String column, ColumnIndexType type)
       throws IOException {
     PinotDataBuffer buffer;
-    switch (type) {
-      case DICTIONARY:
-        buffer = columnIndexDirectory.getDictionaryBufferFor(column);
-        break;
-      case FORWARD_INDEX:
-        buffer = columnIndexDirectory.getForwardIndexBufferFor(column);
-        break;
-      case INVERTED_INDEX:
-        buffer = columnIndexDirectory.getInvertedIndexBufferFor(column);
-        break;
-      case BLOOM_FILTER:
-        buffer = columnIndexDirectory.getBloomFilterBufferFor(column);
-        break;
-      case NULLVALUE_VECTOR:
-        buffer = columnIndexDirectory.getNullValueVectorBufferFor(column);
-        break;
-      default:
-        throw new RuntimeException("Unknown index type: " + type.name());
-    }
+
+    buffer = columnIndexDirectory.getBuffer(column, type);
+
     if (readMode == ReadMode.mmap) {
       prefetchMmapData(buffer);
     }
@@ -347,21 +331,7 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
 
     private PinotDataBuffer getNewIndexBuffer(IndexKey key, long sizeBytes)
         throws IOException {
-      ColumnIndexType indexType = key.type;
-      switch (indexType) {
-        case DICTIONARY:
-          return columnIndexDirectory.newDictionaryBuffer(key.name, sizeBytes);
-        case FORWARD_INDEX:
-          return columnIndexDirectory.newForwardIndexBuffer(key.name, sizeBytes);
-        case INVERTED_INDEX:
-          return columnIndexDirectory.newInvertedIndexBuffer(key.name, sizeBytes);
-        case BLOOM_FILTER:
-          return columnIndexDirectory.newBloomFilterBuffer(key.name, sizeBytes);
-        case NULLVALUE_VECTOR:
-          return columnIndexDirectory.newNullValueVectorBuffer(key.name, sizeBytes);
-        default:
-          throw new RuntimeException("Unknown index type: " + indexType.name() + " for directory: " + segmentDirectory);
-      }
+      return columnIndexDirectory.newBuffer(key.name, key.type, sizeBytes);
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SingleFileIndexDirectory.java
@@ -93,34 +93,17 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   }
 
   @Override
-  public PinotDataBuffer getDictionaryBufferFor(String column)
+  public PinotDataBuffer getBuffer(String column, ColumnIndexType type)
       throws IOException {
-    return checkAndGetIndexBuffer(column, ColumnIndexType.DICTIONARY);
+    return checkAndGetIndexBuffer(column, type);
   }
 
   @Override
-  public PinotDataBuffer getForwardIndexBufferFor(String column)
+  public PinotDataBuffer newBuffer(String column, ColumnIndexType type, long sizeBytes)
       throws IOException {
-    return checkAndGetIndexBuffer(column, ColumnIndexType.FORWARD_INDEX);
+    return allocNewBufferInternal(column, type, sizeBytes, type.name().toLowerCase() + ".create");
   }
 
-  @Override
-  public PinotDataBuffer getInvertedIndexBufferFor(String column)
-      throws IOException {
-    return checkAndGetIndexBuffer(column, ColumnIndexType.INVERTED_INDEX);
-  }
-
-  @Override
-  public PinotDataBuffer getBloomFilterBufferFor(String column)
-      throws IOException {
-    return checkAndGetIndexBuffer(column, ColumnIndexType.BLOOM_FILTER);
-  }
-
-  @Override
-  public PinotDataBuffer getNullValueVectorBufferFor(String column)
-      throws IOException {
-    return checkAndGetIndexBuffer(column, ColumnIndexType.NULLVALUE_VECTOR);
-  }
 
   @Override
   public boolean hasIndexFor(String column, ColumnIndexType type) {
@@ -145,36 +128,6 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
       return true;
     }
     return false;
-  }
-
-  @Override
-  public PinotDataBuffer newDictionaryBuffer(String column, long sizeBytes)
-      throws IOException {
-    return allocNewBufferInternal(column, ColumnIndexType.DICTIONARY, sizeBytes, "dictionary.create");
-  }
-
-  @Override
-  public PinotDataBuffer newForwardIndexBuffer(String column, long sizeBytes)
-      throws IOException {
-    return allocNewBufferInternal(column, ColumnIndexType.FORWARD_INDEX, sizeBytes, "forward_index.create");
-  }
-
-  @Override
-  public PinotDataBuffer newInvertedIndexBuffer(String column, long sizeBytes)
-      throws IOException {
-    return allocNewBufferInternal(column, ColumnIndexType.INVERTED_INDEX, sizeBytes, "inverted_index.create");
-  }
-
-  @Override
-  public PinotDataBuffer newBloomFilterBuffer(String column, long sizeBytes)
-      throws IOException {
-    return allocNewBufferInternal(column, ColumnIndexType.BLOOM_FILTER, sizeBytes, "bloom_filter.create");
-  }
-
-  @Override
-  public PinotDataBuffer newNullValueVectorBuffer(String column, long sizeBytes)
-      throws IOException {
-    return allocNewBufferInternal(column, ColumnIndexType.NULLVALUE_VECTOR, sizeBytes, "nullvalue_vector.create");
   }
 
   private PinotDataBuffer checkAndGetIndexBuffer(String column, ColumnIndexType type) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SingleFileIndexDirectory.java
@@ -104,7 +104,6 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
     return allocNewBufferInternal(column, type, sizeBytes, type.name().toLowerCase() + ".create");
   }
 
-
   @Override
   public boolean hasIndexFor(String column, ColumnIndexType type) {
     if (type == ColumnIndexType.TEXT_INDEX) {
@@ -124,7 +123,8 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
     });
     if (textIndexFiles.length > 0) {
       Preconditions.checkState(textIndexFiles.length == 1,
-          "Illegal number of text index directories for columns " + column  + " segment directory " + segmentDirectory.getAbsolutePath());
+          "Illegal number of text index directories for columns " + column + " segment directory " + segmentDirectory
+              .getAbsolutePath());
       return true;
     }
     return false;

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/store/ColumnIndexDirectoryTestHelper.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/store/ColumnIndexDirectoryTestHelper.java
@@ -36,32 +36,15 @@ import static org.mockito.Mockito.when;
 public class ColumnIndexDirectoryTestHelper {
   private static Logger LOGGER = LoggerFactory.getLogger(ColumnIndexDirectoryTestHelper.class);
 
-  static ColumnIndexType[] indexTypes = {ColumnIndexType.DICTIONARY, ColumnIndexType.FORWARD_INDEX, ColumnIndexType.INVERTED_INDEX,
-  ColumnIndexType.BLOOM_FILTER, ColumnIndexType.NULLVALUE_VECTOR};
+  static ColumnIndexType[] indexTypes =
+      {ColumnIndexType.DICTIONARY, ColumnIndexType.FORWARD_INDEX, ColumnIndexType.INVERTED_INDEX, ColumnIndexType.BLOOM_FILTER, ColumnIndexType.NULLVALUE_VECTOR};
 
   static PinotDataBuffer newIndexBuffer(ColumnIndexDirectory columnDirectory, String column, int size, int index)
       throws IOException {
     String columnName = column + "." + Integer.toString(index);
     // skip star tree. It's managed differently
     ColumnIndexType indexType = indexTypes[index % indexTypes.length];
-    PinotDataBuffer buf = null;
-    switch (indexType) {
-      case DICTIONARY:
-        buf = columnDirectory.newDictionaryBuffer(columnName, size);
-        break;
-      case FORWARD_INDEX:
-        buf = columnDirectory.newForwardIndexBuffer(columnName, size);
-        break;
-      case INVERTED_INDEX:
-        buf = columnDirectory.newInvertedIndexBuffer(columnName, size);
-        break;
-      case BLOOM_FILTER:
-        buf = columnDirectory.newBloomFilterBuffer(columnName, size);
-        break;
-      case NULLVALUE_VECTOR:
-        buf = columnDirectory.newNullValueVectorBuffer(columnName, size);
-        break;
-    }
+    PinotDataBuffer buf = columnDirectory.newBuffer(columnName, indexType, size);
     return buf;
   }
 
@@ -70,24 +53,7 @@ public class ColumnIndexDirectoryTestHelper {
     String columnName = column + "." + Integer.toString(index);
     // skip star tree
     ColumnIndexType indexType = indexTypes[index % indexTypes.length];
-    PinotDataBuffer buf = null;
-    switch (indexType) {
-      case DICTIONARY:
-        buf = columnDirectory.getDictionaryBufferFor(columnName);
-        break;
-      case FORWARD_INDEX:
-        buf = columnDirectory.getForwardIndexBufferFor(columnName);
-        break;
-      case INVERTED_INDEX:
-        buf = columnDirectory.getInvertedIndexBufferFor(columnName);
-        break;
-      case BLOOM_FILTER:
-        buf = columnDirectory.getBloomFilterBufferFor(columnName);
-        break;
-      case NULLVALUE_VECTOR:
-        buf = columnDirectory.getNullValueVectorBufferFor(columnName);
-        break;
-    }
+    PinotDataBuffer buf = columnDirectory.getBuffer(columnName, indexType);
     return buf;
   }
 
@@ -153,7 +119,7 @@ public class ColumnIndexDirectoryTestHelper {
     when(meta.getNullValueVectorFileName(anyString())).thenAnswer(new Answer<String>() {
       @Override
       public String answer(InvocationOnMock invocationOnMock)
-              throws Throwable {
+          throws Throwable {
         return invocationOnMock.getArguments()[0] + ".nullvalue";
       }
     });

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/store/FilePerIndexDirectoryTest.java
@@ -141,7 +141,7 @@ public class FilePerIndexDirectoryTest {
     }
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
+  @Test(expectedExceptions = RuntimeException.class)
   public void testMissingIndex()
       throws IOException {
     try (FilePerIndexDirectory fpiDirectory = new FilePerIndexDirectory(segmentDir, segmentMetadata, ReadMode.mmap);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/store/FilePerIndexDirectoryTest.java
@@ -78,7 +78,7 @@ public class FilePerIndexDirectoryTest {
       throws Exception {
     Assert.assertEquals(0, segmentDir.list().length, segmentDir.list().toString());
     try (FilePerIndexDirectory fpiDir = new FilePerIndexDirectory(segmentDir, segmentMetadata, ReadMode.heap);
-        PinotDataBuffer buffer = fpiDir.newDictionaryBuffer("col1", 1024)) {
+        PinotDataBuffer buffer = fpiDir.newBuffer("col1", ColumnIndexType.DICTIONARY, 1024)) {
       Assert.assertEquals(1, segmentDir.list().length, segmentDir.list().toString());
 
       buffer.putLong(0, 0xbadfadL);
@@ -90,7 +90,7 @@ public class FilePerIndexDirectoryTest {
     Assert.assertEquals(1, segmentDir.list().length);
 
     try (FilePerIndexDirectory colDir = new FilePerIndexDirectory(segmentDir, segmentMetadata, ReadMode.mmap);
-        PinotDataBuffer readBuffer = colDir.getDictionaryBufferFor("col1")) {
+        PinotDataBuffer readBuffer = colDir.getBuffer("col1", ColumnIndexType.DICTIONARY)) {
       Assert.assertEquals(readBuffer.getLong(0), 0xbadfadL);
       Assert.assertEquals(readBuffer.getInt(8), 51);
       Assert.assertEquals(readBuffer.getInt(101), 55);
@@ -134,10 +134,10 @@ public class FilePerIndexDirectoryTest {
   public void testWriteExisting()
       throws Exception {
     try (FilePerIndexDirectory columnDirectory = new FilePerIndexDirectory(segmentDir, segmentMetadata, ReadMode.mmap);
-        PinotDataBuffer buffer = columnDirectory.newDictionaryBuffer("column1", 1024)) {
+        PinotDataBuffer buffer = columnDirectory.newBuffer("column1", ColumnIndexType.DICTIONARY, 1024)) {
     }
     try (FilePerIndexDirectory columnDirectory = new FilePerIndexDirectory(segmentDir, segmentMetadata, ReadMode.mmap);
-        PinotDataBuffer repeatBuffer = columnDirectory.newDictionaryBuffer("column1", 1024)) {
+        PinotDataBuffer repeatBuffer = columnDirectory.newBuffer("column1", ColumnIndexType.DICTIONARY, 1024)) {
     }
   }
 
@@ -145,7 +145,7 @@ public class FilePerIndexDirectoryTest {
   public void testMissingIndex()
       throws IOException {
     try (FilePerIndexDirectory fpiDirectory = new FilePerIndexDirectory(segmentDir, segmentMetadata, ReadMode.mmap);
-        PinotDataBuffer buffer = fpiDirectory.getDictionaryBufferFor("noSuchColumn")) {
+        PinotDataBuffer buffer = fpiDirectory.getBuffer("noSuchColumn", ColumnIndexType.DICTIONARY)) {
 
     }
   }
@@ -154,7 +154,7 @@ public class FilePerIndexDirectoryTest {
   public void testHasIndex()
       throws IOException {
     try (FilePerIndexDirectory fpiDirectory = new FilePerIndexDirectory(segmentDir, segmentMetadata, ReadMode.mmap)) {
-      PinotDataBuffer buffer = fpiDirectory.newDictionaryBuffer("foo", 1024);
+      PinotDataBuffer buffer = fpiDirectory.newBuffer("foo", ColumnIndexType.DICTIONARY, 1024);
       buffer.putInt(0, 100);
       Assert.assertTrue(fpiDirectory.hasIndexFor("foo", ColumnIndexType.DICTIONARY));
     }
@@ -164,9 +164,9 @@ public class FilePerIndexDirectoryTest {
   public void testRemoveIndex()
       throws IOException {
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(segmentDir, segmentMetadata, ReadMode.mmap)) {
-      try (PinotDataBuffer buffer = fpi.newForwardIndexBuffer("col1", 1024)) {
+      try (PinotDataBuffer buffer = fpi.newBuffer("col1", ColumnIndexType.FORWARD_INDEX, 1024)) {
       }
-      try (PinotDataBuffer buffer = fpi.newDictionaryBuffer("col2", 100)) {
+      try (PinotDataBuffer buffer = fpi.newBuffer("col2", ColumnIndexType.DICTIONARY,100)) {
       }
       Assert.assertTrue(fpi.getFileFor("col1", ColumnIndexType.FORWARD_INDEX).exists());
       Assert.assertTrue(fpi.getFileFor("col2", ColumnIndexType.DICTIONARY).exists());

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/store/SingleFileIndexDirectoryTest.java
@@ -91,7 +91,7 @@ public class SingleFileIndexDirectoryTest {
     // segmentDir does not have anything to begin with
     Assert.assertEquals(segmentDir.list().length, 0);
     SingleFileIndexDirectory columnDirectory = new SingleFileIndexDirectory(segmentDir, segmentMetadata, ReadMode.mmap);
-    PinotDataBuffer writtenBuffer = columnDirectory.newDictionaryBuffer("foo", 1024);
+    PinotDataBuffer writtenBuffer = columnDirectory.newBuffer("foo", ColumnIndexType.DICTIONARY, 1024);
     String data = new String("This is a test string");
     final byte[] dataBytes = data.getBytes();
     int pos = 0;
@@ -102,7 +102,7 @@ public class SingleFileIndexDirectoryTest {
 
     when(segmentMetadata.getAllColumns()).thenReturn(new HashSet<String>(Arrays.asList("foo")));
     try (SingleFileIndexDirectory directoryReader = new SingleFileIndexDirectory(segmentDir, segmentMetadata,
-        ReadMode.mmap); PinotDataBuffer readBuffer = directoryReader.getDictionaryBufferFor("foo")) {
+        ReadMode.mmap); PinotDataBuffer readBuffer = directoryReader.getBuffer("foo", ColumnIndexType.DICTIONARY)) {
       Assert.assertEquals(1024, readBuffer.size());
       int length = dataBytes.length;
       for (int i = 0; i < length; i++) {
@@ -162,12 +162,14 @@ public class SingleFileIndexDirectoryTest {
       throws Exception {
     {
       try (SingleFileIndexDirectory columnDirectory = new SingleFileIndexDirectory(segmentDir, segmentMetadata,
-          ReadMode.mmap); PinotDataBuffer buffer = columnDirectory.newDictionaryBuffer("column1", 1024)) {
+          ReadMode.mmap);
+          PinotDataBuffer buffer = columnDirectory.newBuffer("column1", ColumnIndexType.DICTIONARY, 1024)) {
       }
     }
     {
       try (SingleFileIndexDirectory columnDirectory = new SingleFileIndexDirectory(segmentDir, segmentMetadata,
-          ReadMode.mmap); PinotDataBuffer repeatBuffer = columnDirectory.newDictionaryBuffer("column1", 1024)) {
+          ReadMode.mmap);
+          PinotDataBuffer repeatBuffer = columnDirectory.newBuffer("column1", ColumnIndexType.DICTIONARY, 1024)) {
 
       }
     }
@@ -178,7 +180,7 @@ public class SingleFileIndexDirectoryTest {
       throws IOException, ConfigurationException {
     try (SingleFileIndexDirectory columnDirectory = new SingleFileIndexDirectory(segmentDir, segmentMetadata,
         ReadMode.mmap)) {
-      try (PinotDataBuffer buffer = columnDirectory.getDictionaryBufferFor("column1")) {
+      try (PinotDataBuffer buffer = columnDirectory.getBuffer("column1", ColumnIndexType.DICTIONARY)) {
 
       }
     }
@@ -188,7 +190,7 @@ public class SingleFileIndexDirectoryTest {
   public void testRemoveIndex()
       throws IOException, ConfigurationException {
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(segmentDir, segmentMetadata, ReadMode.mmap)) {
-      try (PinotDataBuffer buffer = sfd.newDictionaryBuffer("col1", 1024)) {
+      try (PinotDataBuffer buffer = sfd.newBuffer("col1", ColumnIndexType.DICTIONARY, 1024)) {
       }
       Assert.assertFalse(sfd.isIndexRemovalSupported());
       sfd.removeIndex("col1", ColumnIndexType.DICTIONARY);


### PR DESCRIPTION
…lumnindexdirectory

Cleaning up ColumnIndexDirectory and SegmentDirectory (FilePerIndexDirectory and SingleFileIndexDirectory) by removing explicit references to dictionary, forward index, inverted index etc.

This was not adding any value, in fact, it was making it hard to add new index types.

