### PR TITLE
Fix pinot-s3 pom file

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -64,7 +64,6 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-spi</artifactId>
-      <version>0.4.0-SNAPSHOT</version>
     </dependency>
     <!-- amazon s3 -->
     <dependency>


### PR DESCRIPTION
This PR fixes the pom file of pinot-s3, which caused the build failed.
https://travis-ci.org/github/apache/incubator-pinot/jobs/678424895
