### PR TITLE
Prune stop words for text index

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
@@ -20,7 +20,15 @@ package org.apache.pinot.core.segment.creator.impl.inv.text;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharArraySet;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.core.StopFilterFactory;
+import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StoredField;
@@ -49,6 +57,15 @@ public class LuceneTextIndexCreator implements InvertedIndexCreator {
   private final String _textColumn;
   private final Directory _indexDirectory;
   private final IndexWriter _indexWriter;
+
+  public static final CharArraySet ENGLISH_STOP_WORDS_SET =
+      new CharArraySet(Arrays.asList(
+          "a", "an", "and", "are", "as", "at", "be", "but", "by",
+          "for", "if", "in", "into", "is", "it",
+          "no", "not", "of", "on", "or", "such",
+          "that", "the", "their", "then", "than", "there", "these",
+          "they", "this", "to", "was", "will", "with", "those"
+      ), true);
 
   /**
    * Called by {@link org.apache.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator}
@@ -81,7 +98,7 @@ public class LuceneTextIndexCreator implements InvertedIndexCreator {
       // to V3 if segmentVersion is set to V3 in SegmentGeneratorConfig.
       File indexFile = getV1TextIndexFile(segmentIndexDir);
       _indexDirectory = FSDirectory.open(indexFile.toPath());
-      StandardAnalyzer standardAnalyzer = new StandardAnalyzer();
+      StandardAnalyzer standardAnalyzer = new StandardAnalyzer(ENGLISH_STOP_WORDS_SET);
       IndexWriterConfig indexWriterConfig = new IndexWriterConfig(standardAnalyzer);
       indexWriterConfig.setRAMBufferSizeMB(LUCENE_INDEX_MAX_BUFFER_SIZE_MB);
       indexWriterConfig.setCommitOnClose(commit);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneTextIndexReader.java
@@ -85,7 +85,7 @@ public class LuceneTextIndexReader implements InvertedIndexReader<MutableRoaring
       // TODO: consider using a threshold of num docs per segment to decide between building
       // mapping file upfront on segment load v/s on-the-fly during query processing
       _docIdTranslator = new DocIdTranslator(indexDir, _column, numDocs, _indexSearcher);
-      _standardAnalyzer = new StandardAnalyzer();
+      _standardAnalyzer = new StandardAnalyzer(LuceneTextIndexCreator.ENGLISH_STOP_WORDS_SET);
     } catch (Exception e) {
       LOGGER
           .error("Failed to instantiate Lucene text index reader for column {}, exception {}", column, e.getMessage());

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -1163,6 +1163,21 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
     expected.add(new Serializable[]{1020, "Databases, columnar query processing, Apache Arrow, distributed systems, Machine learning, cluster management, docker image building and distribution"});
     expected.add(new Serializable[]{1020, "Databases, columnar query processing, Apache Arrow, distributed systems, Machine learning, cluster management, docker image building and distribution"});
     testInterSegmentSelectionQueryHelper(query, expected);
+
+    // query with only stop-words. they should not be indexed
+    query = "SELECT count(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, 'a and or in the are')";
+    testInterSegmentAggregationQueryHelper(query, 0);
+    // analyzer should prune/ignore the stop words from search expression and consider everything else for a match
+    query = "SELECT count(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"learned a lot\"')";
+    testInterSegmentAggregationQueryHelper(query, 4);
+    query = "SELECT count(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"indexing and transaction processing\"')";
+    testInterSegmentAggregationQueryHelper(query, 12);
+    query = "SELECT count(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"docker image building and distribution\"')";
+    testInterSegmentAggregationQueryHelper(query, 8);
+    query = "SELECT count(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"distributed query engines for analytics and data warehouses\"')";
+    testInterSegmentAggregationQueryHelper(query, 8);
+    query = "SELECT count(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"worked in NGO\"')";
+    testInterSegmentAggregationQueryHelper(query, 4);
   }
 
   private void testInterSegmentAggregationQueryHelper(String query, long expectedCount) {

--- a/pinot-core/src/test/resources/data/text_search_data/skills.txt
+++ b/pinot-core/src/test/resources/data/text_search_data/skills.txt
@@ -21,3 +21,4 @@ C++, Java, Python, realtime streaming systems, Machine learning, spark, Kubernet
 Databases, columnar query processing, Apache Arrow, distributed systems, Machine learning, cluster management, docker image building and distribution
 Database engine, OLAP systems, OLTP transaction processing at large scale, concurrency, multi-threading, GO, building large scale systems
 GET /administrator/ HTTP/1.1 200 4263 - Mozilla/5.0 (Windows NT 6.0; rv:34.0) Gecko/20100101 Firefox/34.0 - NullPointerException
+Foo worked in a lot of places and learned a lot of things


### PR DESCRIPTION
For general english text, indexing the stop words can easily lead to explosion in the size of text index and consequently impact the performance of queries. For now use a predefined list of general stop words that can be passed to the text analyzer both during indexing and querying. The analyzer ensures that stop words in input text are pruned and not indexed. Similarly, on the query path, if stop words are present in search expression, the matching is done without stop words.

This is something that can possibly be specified on a per use case (per text index basis). Currently we have a hardcoded list of common english stop words.