### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -141,9 +141,8 @@ module.exports = {
       trackingID: 'UA-157446650-1',
     },
     algolia: {
-      apiKey: 'f3cde09979e469ad62eaea4e115c21ea',
+      apiKey: 'ef0051ce1fd0a5d07af57bffdbb46f87',
       indexName: 'apache_pinot',
-      algoliaOptions: {}, // Optional, if provided by Algolia
     },
   },
   plugins: [


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.