### PR TITLE
Decouple Schema from RecordReader and StreamMessageDecoder

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -202,7 +202,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final TableConfig _tableConfig;
   private final RealtimeTableDataManager _realtimeTableDataManager;
   private final StreamMessageDecoder _messageDecoder;
-  private final Set<String> _sourceFields;
   private final int _segmentMaxRowCount;
   private final String _resourceDataDir;
   private final IndexLoadingConfig _indexLoadingConfig;
@@ -627,6 +626,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.LLC_PARTITION_CONSUMING, 0);
     }
   }
+
   /**
    * Fetches the completion mode for the segment completion for the given realtime table
    */
@@ -819,9 +819,10 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       // TODO: make segment uploader used in the segment committer configurable.
       SegmentUploader segmentUploader;
       try {
-        segmentUploader = new Server2ControllerSegmentUploader(segmentLogger, _protocolHandler.getFileUploadDownloadClient(),
-            _protocolHandler.getSegmentCommitUploadURL(params, controllerVipUrl), _segmentNameStr,
-            ServerSegmentCompletionProtocolHandler.getSegmentUploadRequestTimeoutMs(),  _serverMetrics);
+        segmentUploader =
+            new Server2ControllerSegmentUploader(segmentLogger, _protocolHandler.getFileUploadDownloadClient(),
+                _protocolHandler.getSegmentCommitUploadURL(params, controllerVipUrl), _segmentNameStr,
+                ServerSegmentCompletionProtocolHandler.getSegmentUploadRequestTimeoutMs(), _serverMetrics);
       } catch (URISyntaxException e) {
         segmentLogger.error("Segment commit upload url error: ", e);
         return SegmentCompletionProtocol.RESP_NOT_SENT;
@@ -1153,8 +1154,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             .setConsumerDir(consumerDir);
 
     // Create message decoder
-    _sourceFields = SchemaUtils.extractSourceFields(_schema);
-    _messageDecoder = StreamDecoderProvider.create(_partitionLevelStreamConfig, _schema, _sourceFields);
+    _messageDecoder =
+        StreamDecoderProvider.create(_partitionLevelStreamConfig, SchemaUtils.extractSourceFields(_schema));
     _clientId = _streamTopic + "-" + _streamPartitionId;
 
     // Create record transformer

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/GenericRowRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/GenericRowRecordReader.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
@@ -34,18 +33,16 @@ import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 public class GenericRowRecordReader implements RecordReader {
   private final List<GenericRow> _rows;
   private final int _numRows;
-  private final Schema _schema;
 
   private int _nextRowId = 0;
 
-  public GenericRowRecordReader(List<GenericRow> rows, Schema schema) {
+  public GenericRowRecordReader(List<GenericRow> rows) {
     _rows = rows;
     _numRows = rows.size();
-    _schema = schema;
   }
 
   @Override
-  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig, Set<String> sourceFields) {
+  public void init(File dataFile, Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override
@@ -67,11 +64,6 @@ public class GenericRowRecordReader implements RecordReader {
   @Override
   public void rewind() {
     _nextRowId = 0;
-  }
-
-  @Override
-  public Schema getSchema() {
-    return _schema;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReader.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -49,7 +48,7 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
    *
    * @param indexDirs a list of input segment directory paths
    */
-  public MultiplePinotSegmentRecordReader(@Nonnull List<File> indexDirs)
+  public MultiplePinotSegmentRecordReader(List<File> indexDirs)
       throws Exception {
     this(indexDirs, null, null);
   }
@@ -64,7 +63,7 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
    * @param schema input schema that is a subset of the segment schema
    * @param sortOrder a list of column names that represent the sorting order
    */
-  public MultiplePinotSegmentRecordReader(@Nonnull List<File> indexDirs, @Nullable Schema schema,
+  public MultiplePinotSegmentRecordReader(List<File> indexDirs, @Nullable Schema schema,
       @Nullable List<String> sortOrder)
       throws Exception {
     // Initialize pinot segment record readers
@@ -77,8 +76,8 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
     if (schema == null) {
       // Validate that segment schemas from all segments are the same if the schema is not passed.
       Set<Schema> schemas = new HashSet<>();
-      for (PinotSegmentRecordReader reader : _pinotSegmentRecordReaders) {
-        schemas.add(reader.getSchema());
+      for (PinotSegmentRecordReader pinotSegmentRecordReader : _pinotSegmentRecordReaders) {
+        schemas.add(pinotSegmentRecordReader.getSchema());
       }
       if (schemas.size() == 1) {
         _schema = schemas.iterator().next();
@@ -102,6 +101,10 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
     }
   }
 
+  public Schema getSchema() {
+    return _schema;
+  }
+
   /**
    * Indicate whether the segment should be sorted or not
    */
@@ -110,7 +113,7 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig, Set<String> sourceFields) {
+  public void init(File dataFile, Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override
@@ -181,11 +184,6 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
     } else {
       _currentReaderId = 0;
     }
-  }
-
-  @Override
-  public Schema getSchema() {
-    return _schema;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/MapperRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/segment/MapperRecordReader.java
@@ -35,7 +35,7 @@ import org.apache.pinot.spi.data.readers.RecordReaderConfig;
  * Record reader for mapper stage of the segment conversion
  */
 public class MapperRecordReader implements RecordReader {
-  private MultiplePinotSegmentRecordReader _recordReader;
+  private MultiplePinotSegmentRecordReader _multiplePinotSegmentRecordReader;
   private RecordTransformer _recordTransformer;
   private RecordPartitioner _recordPartitioner;
   private int _totalNumPartition;
@@ -48,15 +48,19 @@ public class MapperRecordReader implements RecordReader {
   public MapperRecordReader(List<File> indexDirs, RecordTransformer recordTransformer,
       RecordPartitioner recordPartitioner, int totalNumPartition, int currentPartition)
       throws Exception {
-    _recordReader = new MultiplePinotSegmentRecordReader(indexDirs);
+    _multiplePinotSegmentRecordReader = new MultiplePinotSegmentRecordReader(indexDirs);
     _recordPartitioner = recordPartitioner;
     _recordTransformer = recordTransformer;
     _totalNumPartition = totalNumPartition;
     _currentPartition = currentPartition;
   }
 
+  public Schema getSchema() {
+    return _multiplePinotSegmentRecordReader.getSchema();
+  }
+
   @Override
-  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig, Set<String> sourceFields) {
+  public void init(File dataFile, Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override
@@ -69,8 +73,8 @@ public class MapperRecordReader implements RecordReader {
       return true;
     }
 
-    while (_recordReader.hasNext()) {
-      _nextRow = _recordReader.next(_nextRow);
+    while (_multiplePinotSegmentRecordReader.hasNext()) {
+      _nextRow = _multiplePinotSegmentRecordReader.next(_nextRow);
       // Filter out the records that do not belong to the current partition
       if (_recordPartitioner.getPartitionFromRecord(_nextRow, _totalNumPartition) == _currentPartition) {
         // Transform record
@@ -106,19 +110,14 @@ public class MapperRecordReader implements RecordReader {
 
   @Override
   public void rewind() {
-    _recordReader.rewind();
+    _multiplePinotSegmentRecordReader.rewind();
     _nextRowReturned = true;
     _finished = false;
   }
 
   @Override
-  public Schema getSchema() {
-    return _recordReader.getSchema();
-  }
-
-  @Override
   public void close()
       throws IOException {
-    _recordReader.close();
+    _multiplePinotSegmentRecordReader.close();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -93,12 +93,7 @@ public class RealtimeSegmentConverter {
   public void build(@Nullable SegmentVersion segmentVersion, ServerMetrics serverMetrics)
       throws Exception {
     // lets create a record reader
-    RealtimeSegmentRecordReader reader;
-    if (sortedColumn == null) {
-      reader = new RealtimeSegmentRecordReader(realtimeSegmentImpl, dataSchema);
-    } else {
-      reader = new RealtimeSegmentRecordReader(realtimeSegmentImpl, dataSchema, sortedColumn);
-    }
+    RealtimeSegmentRecordReader reader = new RealtimeSegmentRecordReader(realtimeSegmentImpl, sortedColumn);
     SegmentGeneratorConfig genConfig = new SegmentGeneratorConfig(dataSchema);
     // The segment generation code in SegmentColumnarIndexCreator will throw
     // exception if start and end time in time column are not in acceptable

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.indexsegment.mutable.MutableSegmentImpl;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
@@ -34,23 +33,14 @@ import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 public class RealtimeSegmentRecordReader implements RecordReader {
   private final MutableSegmentImpl _realtimeSegment;
   private final int _numDocs;
-  private final Schema _schema;
   private final int[] _sortedDocIdIterationOrder;
 
   private int _nextDocId = 0;
 
-  public RealtimeSegmentRecordReader(MutableSegmentImpl realtimeSegment, Schema schema) {
+  public RealtimeSegmentRecordReader(MutableSegmentImpl realtimeSegment, @Nullable String sortedColumn) {
     _realtimeSegment = realtimeSegment;
     _numDocs = realtimeSegment.getNumDocsIndexed();
-    _schema = schema;
-    _sortedDocIdIterationOrder = null;
-  }
-
-  public RealtimeSegmentRecordReader(MutableSegmentImpl realtimeSegment, Schema schema, String sortedColumn) {
-    _realtimeSegment = realtimeSegment;
-    _numDocs = realtimeSegment.getNumDocsIndexed();
-    _schema = schema;
-    _sortedDocIdIterationOrder = realtimeSegment.getSortedDocIdIterationOrderWithSortedColumn(sortedColumn);
+    _sortedDocIdIterationOrder = sortedColumn != null ? realtimeSegment.getSortedDocIdIterationOrderWithSortedColumn(sortedColumn) : null;
   }
 
   public int[] getSortedDocIdIterationOrder() {
@@ -58,7 +48,7 @@ public class RealtimeSegmentRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig, Set<String> sourceFields) {
+  public void init(File dataFile, Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig) {
   }
 
   @Override
@@ -83,11 +73,6 @@ public class RealtimeSegmentRecordReader implements RecordReader {
   @Override
   public void rewind() {
     _nextDocId = 0;
-  }
-
-  @Override
-  public Schema getSchema() {
-    return _schema;
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/DataFetcherTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/DataFetcherTest.java
@@ -119,7 +119,7 @@ public class DataFetcherTest {
             NO_DICT_DOUBLE_METRIC_NAME));
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
 
     IndexSegment indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR_PATH, SEGMENT_NAME), ReadMode.heap);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReaderTest.java
@@ -68,7 +68,7 @@ public class MultiplePinotSegmentRecordReaderTest {
       String segmentName = "multiplePinotSegmentRecordReaderTest_" + i;
       List<GenericRow> rows = PinotSegmentUtil.createTestData(schema, NUM_ROWS);
       _rowsList.add(rows);
-      RecordReader recordReader = new GenericRowRecordReader(rows, schema);
+      RecordReader recordReader = new GenericRowRecordReader(rows);
       _segmentIndexDirList.add(PinotSegmentUtil.createSegment(schema, segmentName, _segmentOutputDir, recordReader));
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
@@ -64,7 +64,7 @@ public class PinotSegmentRecordReaderTest {
     String segmentName = "pinotSegmentRecordReaderTest";
     _segmentOutputDir = Files.createTempDir().toString();
     _rows = PinotSegmentUtil.createTestData(schema, NUM_ROWS);
-    _recordReader = new GenericRowRecordReader(_rows, schema);
+    _recordReader = new GenericRowRecordReader(_rows);
     _segmentIndexDir = PinotSegmentUtil.createSegment(schema, segmentName, _segmentOutputDir, _recordReader);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/RecordReaderSampleDataTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/RecordReaderSampleDataTest.java
@@ -22,15 +22,14 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.data.recordtransformer.CompositeTransformer;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
-import org.apache.pinot.spi.data.readers.RecordReaderFactory;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -75,11 +74,11 @@ public class RecordReaderSampleDataTest {
       throws Exception {
     CompositeTransformer defaultTransformer = CompositeTransformer.getDefaultTransformer(SCHEMA);
     try (RecordReader avroRecordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.AVRO, AVRO_SAMPLE_DATA_FILE, SCHEMA, null, SCHEMA.getColumnNames());
+        .getRecordReader(FileFormat.AVRO, AVRO_SAMPLE_DATA_FILE, SCHEMA.getColumnNames(), null);
         RecordReader csvRecordReader = RecordReaderFactory
-            .getRecordReader(FileFormat.CSV, CSV_SAMPLE_DATA_FILE, SCHEMA, null, SCHEMA.getColumnNames());
+            .getRecordReader(FileFormat.CSV, CSV_SAMPLE_DATA_FILE, SCHEMA.getColumnNames(), null);
         RecordReader jsonRecordReader = RecordReaderFactory
-            .getRecordReader(FileFormat.JSON, JSON_SAMPLE_DATA_FILE, SCHEMA, null, SCHEMA.getColumnNames())) {
+            .getRecordReader(FileFormat.JSON, JSON_SAMPLE_DATA_FILE, SCHEMA.getColumnNames(), null)) {
       int numRecords = 0;
       while (avroRecordReader.hasNext()) {
         assertTrue(csvRecordReader.hasNext());
@@ -120,14 +119,11 @@ public class RecordReaderSampleDataTest {
   public void testDifferentIncomingOutgoing()
       throws Exception {
     try (RecordReader avroRecordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.AVRO, AVRO_SAMPLE_DATA_FILE, SCHEMA_DIFFERENT_INCOMING_OUTGOING, null,
-            Sets.newHashSet("time_day", "column2"));
+        .getRecordReader(FileFormat.AVRO, AVRO_SAMPLE_DATA_FILE, Sets.newHashSet("time_day", "column2"), null);
         RecordReader csvRecordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.CSV, CSV_SAMPLE_DATA_FILE, SCHEMA_DIFFERENT_INCOMING_OUTGOING, null,
-            Sets.newHashSet("time_day", "column2"));
+            .getRecordReader(FileFormat.CSV, CSV_SAMPLE_DATA_FILE, Sets.newHashSet("time_day", "column2"), null);
         RecordReader jsonRecordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.JSON, JSON_SAMPLE_DATA_FILE, SCHEMA_DIFFERENT_INCOMING_OUTGOING, null,
-            Sets.newHashSet("time_day", "column2"))) {
+            .getRecordReader(FileFormat.JSON, JSON_SAMPLE_DATA_FILE, Sets.newHashSet("time_day", "column2"), null)) {
       int numRecords = 0;
       while (avroRecordReader.hasNext()) {
         assertTrue(csvRecordReader.hasNext());
@@ -157,11 +153,11 @@ public class RecordReaderSampleDataTest {
   public void testNoIncoming()
       throws Exception {
     try (RecordReader avroRecordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.AVRO, AVRO_SAMPLE_DATA_FILE, SCHEMA_NO_INCOMING, null, SCHEMA_NO_INCOMING.getColumnNames());
+        .getRecordReader(FileFormat.AVRO, AVRO_SAMPLE_DATA_FILE, SCHEMA_NO_INCOMING.getColumnNames(), null);
         RecordReader csvRecordReader = RecordReaderFactory
-            .getRecordReader(FileFormat.CSV, CSV_SAMPLE_DATA_FILE, SCHEMA_NO_INCOMING, null, SCHEMA_NO_INCOMING.getColumnNames());
+            .getRecordReader(FileFormat.CSV, CSV_SAMPLE_DATA_FILE, SCHEMA_NO_INCOMING.getColumnNames(), null);
         RecordReader jsonRecordReader = RecordReaderFactory
-            .getRecordReader(FileFormat.JSON, JSON_SAMPLE_DATA_FILE, SCHEMA_NO_INCOMING, null, SCHEMA_NO_INCOMING.getColumnNames())) {
+            .getRecordReader(FileFormat.JSON, JSON_SAMPLE_DATA_FILE, SCHEMA_NO_INCOMING.getColumnNames(), null)) {
       int numRecords = 0;
       while (avroRecordReader.hasNext()) {
         assertTrue(csvRecordReader.hasNext());
@@ -191,12 +187,11 @@ public class RecordReaderSampleDataTest {
   public void testNoOutgoing()
       throws Exception {
     try (RecordReader avroRecordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.AVRO, AVRO_SAMPLE_DATA_FILE, SCHEMA_NO_OUTGOING, null,
-            Sets.newHashSet("time_day", "outgoing")); RecordReader csvRecordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.CSV, CSV_SAMPLE_DATA_FILE, SCHEMA_NO_OUTGOING, null,
-            Sets.newHashSet("time_day", "outgoing")); RecordReader jsonRecordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.JSON, JSON_SAMPLE_DATA_FILE, SCHEMA_NO_OUTGOING, null,
-            Sets.newHashSet("time_day", "outgoing"))) {
+        .getRecordReader(FileFormat.AVRO, AVRO_SAMPLE_DATA_FILE, Sets.newHashSet("time_day", "outgoing"), null);
+        RecordReader csvRecordReader = RecordReaderFactory
+            .getRecordReader(FileFormat.CSV, CSV_SAMPLE_DATA_FILE, Sets.newHashSet("time_day", "outgoing"), null);
+        RecordReader jsonRecordReader = RecordReaderFactory
+            .getRecordReader(FileFormat.JSON, JSON_SAMPLE_DATA_FILE, Sets.newHashSet("time_day", "outgoing"), null)) {
       int numRecords = 0;
       while (avroRecordReader.hasNext()) {
         assertTrue(csvRecordReader.hasNext());

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplNullValueVectorTest.java
@@ -57,7 +57,7 @@ public class MutableSegmentImplNullValueVectorTest {
             false, true);
     GenericRow reuse = new GenericRow();
     try (RecordReader recordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.JSON, jsonFile, _schema, null, _schema.getColumnNames())) {
+        .getRecordReader(FileFormat.JSON, jsonFile, _schema.getColumnNames(), null)) {
       while (recordReader.hasNext()) {
         recordReader.next(reuse);
         GenericRow transformedRow = _recordTransformer.transform(reuse);

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplTest.java
@@ -87,7 +87,7 @@ public class MutableSegmentImplTest {
     _startTimeMs = System.currentTimeMillis();
 
     try (RecordReader recordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.AVRO, avroFile, _schema, null, _schema.getColumnNames())) {
+        .getRecordReader(FileFormat.AVRO, avroFile, _schema.getColumnNames(), null)) {
       GenericRow reuse = new GenericRow();
       while (recordReader.hasNext()) {
         _mutableSegmentImpl.index(recordReader.next(reuse), defaultMetadata);

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/MergeRollupSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/MergeRollupSegmentConverterTest.java
@@ -90,7 +90,7 @@ public class MergeRollupSegmentConverterTest {
 
     for (int i = 0; i < NUM_SEGMENTS; i++) {
       String segmentName = INPUT_SEGMENT_NAME_PREFIX + i;
-      RecordReader recordReader = new GenericRowRecordReader(rows, schema);
+      RecordReader recordReader = new GenericRowRecordReader(rows);
       SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
       config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());
       config.setTableName(TABLE_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
@@ -85,7 +85,7 @@ public class SegmentConverterTest {
 
     for (int i = 0; i < NUM_SEGMENTS; i++) {
       String segmentName = INPUT_SEGMENT_NAME_PREFIX + i;
-      RecordReader recordReader = new GenericRowRecordReader(rows, schema);
+      RecordReader recordReader = new GenericRowRecordReader(rows);
 
       SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
       config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -85,7 +85,7 @@ public class SegmentPurgerTest {
       row.putField(D2, value2);
       rows.add(row);
     }
-    GenericRowRecordReader genericRowRecordReader = new GenericRowRecordReader(rows, schema);
+    GenericRowRecordReader genericRowRecordReader = new GenericRowRecordReader(rows);
 
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
     config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -128,7 +128,7 @@ public abstract class BaseTransformFunctionTest {
     config.setOutDir(INDEX_DIR_PATH);
     config.setSegmentName(SEGMENT_NAME);
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
 
     IndexSegment indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR_PATH, SEGMENT_NAME), ReadMode.heap);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
@@ -91,7 +91,7 @@ public class DateTruncTransformFunctionTest
       config.setOutDir(indexDirPath);
       config.setSegmentName(segmentName);
       SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-      driver.init(config, new GenericRowRecordReader(rows, schema));
+      driver.init(config, new GenericRowRecordReader(rows));
       driver.build();
 
       IndexSegment indexSegment = ImmutableSegmentLoader.load(new File(indexDirPath, segmentName), ReadMode.heap);

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.realtime.impl.fakestream;
 
 import java.util.Set;
+import org.apache.pinot.core.util.SchemaUtils;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.MessageBatch;
@@ -31,7 +32,6 @@ import org.apache.pinot.spi.stream.StreamDecoderProvider;
 import org.apache.pinot.spi.stream.StreamLevelConsumer;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
-import org.apache.pinot.core.util.SchemaUtils;
 
 
 /**
@@ -48,8 +48,8 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
   }
 
   @Override
-  public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema,
-      String groupId, Set<String> sourceFields) {
+  public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Set<String> fieldsToRead,
+      String groupId) {
     return new FakeStreamLevelConsumer();
   }
 
@@ -63,7 +63,8 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
     return new FakeStreamMetadataProvider(_streamConfig);
   }
 
-  public static void main(String[] args) throws Exception {
+  public static void main(String[] args)
+      throws Exception {
     String clientId = "client_id_localhost_tester";
 
     // stream config
@@ -93,8 +94,8 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
 
     // Message decoder
     Schema pinotSchema = FakeStreamConfigUtils.getPinotSchema();
-    StreamMessageDecoder streamMessageDecoder = StreamDecoderProvider.create(streamConfig, pinotSchema,
-        SchemaUtils.extractSourceFields(pinotSchema));
+    StreamMessageDecoder streamMessageDecoder =
+        StreamDecoderProvider.create(streamConfig, SchemaUtils.extractSourceFields(pinotSchema));
     GenericRow decodedRow = new GenericRow();
     streamMessageDecoder.decode(messageBatch.getMessageAtIndex(0), decodedRow);
     System.out.println(decodedRow);

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMessageDecoder.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMessageDecoder.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.realtime.impl.fakestream;
 
 import java.util.Map;
 import java.util.Set;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
 
@@ -29,9 +28,9 @@ import org.apache.pinot.spi.stream.StreamMessageDecoder;
  * StreamMessageDecoder implementation for fake stream
  */
 public class FakeStreamMessageDecoder implements StreamMessageDecoder<byte[]> {
-  @Override
-  public void init(Map<String, String> props, Schema indexingSchema, String topicName, Set<String> sourceFields) throws Exception {
 
+  @Override
+  public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName) {
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RawIndexCreatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RawIndexCreatorTest.java
@@ -226,7 +226,7 @@ public class RawIndexCreatorTest {
       rows.add(genericRow);
     }
 
-    RecordReader recordReader = new GenericRowRecordReader(rows, schema);
+    RecordReader recordReader = new GenericRowRecordReader(rows);
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, recordReader);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
@@ -255,7 +255,7 @@ public class SegmentGenerationWithBytesTypeTest {
       rows.add(genericRow);
     }
 
-    RecordReader recordReader = new GenericRowRecordReader(rows, schema);
+    RecordReader recordReader = new GenericRowRecordReader(rows);
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, recordReader);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
@@ -214,7 +214,7 @@ public class SegmentGenerationWithNullValueVectorTest {
       rows.add(genericRow);
     }
 
-    RecordReader recordReader = new GenericRowRecordReader(rows, schema);
+    RecordReader recordReader = new GenericRowRecordReader(rows);
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, recordReader);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -145,7 +145,7 @@ public class SegmentGenerationWithTimeColumnTest {
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
     driver.getOutputDirectory().deleteOnExit();
     return driver.getOutputDirectory();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentPartitionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentPartitionTest.java
@@ -220,7 +220,7 @@ public class SegmentPartitionTest {
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
     _segment = ImmutableSegmentLoader.load(new File(SEGMENT_PATH), ReadMode.mmap);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -129,7 +129,7 @@ abstract class BaseStarTreeV2Test<R, A> {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
     segmentGeneratorConfig.setOutDir(TEMP_DIR.getPath());
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(segmentRecords, schema));
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(segmentRecords));
     driver.build();
 
     StarTreeV2BuilderConfig starTreeV2BuilderConfig =

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -157,7 +157,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records, SCHEMA));
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
     driver.build();
 
     return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName), ReadMode.mmap);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestMVQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestMVQueriesTest.java
@@ -91,7 +91,7 @@ public class PercentileTDigestMVQueriesTest extends PercentileTDigestQueriesTest
     config.setRawIndexCreationColumns(Collections.singletonList(TDIGEST_COLUMN));
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    try (RecordReader recordReader = new GenericRowRecordReader(rows, schema)) {
+    try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
       driver.init(config, recordReader);
       driver.build();
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
@@ -153,7 +153,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
     config.setRawIndexCreationColumns(Collections.singletonList(TDIGEST_COLUMN));
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    try (RecordReader recordReader = new GenericRowRecordReader(rows, schema)) {
+    try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
       driver.init(config, recordReader);
       driver.build();
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/RangePredicateWithSortedInvertedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/RangePredicateWithSortedInvertedIndexTest.java
@@ -140,7 +140,7 @@ public class RangePredicateWithSortedInvertedIndexTest extends BaseQueriesTest {
   public void testInnerSegmentQuery()
       throws Exception {
     Random random = new Random();
-    try (RecordReader recordReader = new GenericRowRecordReader(_rows, _schema)) {
+    try (RecordReader recordReader = new GenericRowRecordReader(_rows)) {
       createSegment(_schema, recordReader, SEGMENT_NAME_1, TABLE_NAME);
       final ImmutableSegment immutableSegment = loadSegment(SEGMENT_NAME_1);
       _indexSegments.add(immutableSegment);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
@@ -213,7 +213,7 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
     config.setSegmentName(SEGMENT_NAME);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    try (RecordReader recordReader = new GenericRowRecordReader(rows, schema)) {
+    try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
       driver.init(config, recordReader);
       driver.build();
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -103,7 +103,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
       throws Exception {
     createPinotTableSchema();
     createTestData();
-    _recordReader = new GenericRowRecordReader(_rows, _schema);
+    _recordReader = new GenericRowRecordReader(_rows);
     createSegment();
     loadSegment();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
@@ -104,7 +104,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
       throws Exception {
     try {
       final List<GenericRow> rows = createDataSet(10);
-      try (final RecordReader recordReader = new GenericRowRecordReader(rows, _schema)) {
+      try (final RecordReader recordReader = new GenericRowRecordReader(rows)) {
         createSegment(_schema, recordReader, SEGMENT_NAME_1, TABLE_NAME);
         final ImmutableSegment segment = loadSegment(SEGMENT_NAME_1);
         _indexSegments.add(segment);
@@ -167,7 +167,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
       rows.add(row);
     }
 
-    try (final RecordReader recordReader = new GenericRowRecordReader(rows, _schema)) {
+    try (final RecordReader recordReader = new GenericRowRecordReader(rows)) {
       createSegment(_schema, recordReader, SEGMENT_NAME_1, TABLE_NAME);
       final ImmutableSegment segment = loadSegment(SEGMENT_NAME_1);
       _indexSegments.add(segment);
@@ -205,8 +205,8 @@ public class TransformQueriesTest extends BaseQueriesTest {
       final List<GenericRow> segmentOneRows = createDataSet(10);
       final List<GenericRow> segmentTwoRows = createDataSet(10);
 
-      try (final RecordReader recordReaderOne = new GenericRowRecordReader(segmentOneRows, _schema);
-          final RecordReader recordReaderTwo = new GenericRowRecordReader(segmentTwoRows, _schema)) {
+      try (final RecordReader recordReaderOne = new GenericRowRecordReader(segmentOneRows);
+          final RecordReader recordReaderTwo = new GenericRowRecordReader(segmentTwoRows)) {
         createSegment(_schema, recordReaderOne, SEGMENT_NAME_1, TABLE_NAME);
         createSegment(_schema, recordReaderTwo, SEGMENT_NAME_2, TABLE_NAME);
 

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/DefaultAggregationExecutorTest.java
@@ -193,7 +193,7 @@ public class DefaultAggregationExecutorTest {
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
 
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, driver.getSegmentName()), ReadMode.heap);

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -126,7 +126,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     config.setSegmentName(SEGMENT_NAME);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
     IndexSegment indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR_PATH, SEGMENT_NAME), ReadMode.heap);
 

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -256,7 +256,7 @@ public class NoDictionaryGroupKeyGeneratorTest {
       rows.add(genericRow);
     }
 
-    RecordReader recordReader = new GenericRowRecordReader(rows, schema);
+    RecordReader recordReader = new GenericRowRecordReader(rows);
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, recordReader);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/OnHeapDictionariesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/OnHeapDictionariesTest.java
@@ -190,7 +190,7 @@ public class OnHeapDictionariesTest {
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
 
     LOGGER.info("Built segment {} at {}", segmentName, segmentDirName);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -69,7 +69,6 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TenantConfig;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordExtractor;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -352,14 +351,14 @@ public abstract class ClusterTest extends ControllerTest {
     private DatumReader<GenericData.Record> _reader;
 
     @Override
-    public void init(Map<String, String> props, Schema indexingSchema, String topicName, Set<String> sourceFields)
+    public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
         throws Exception {
       // Load Avro schema
-      DataFileStream<GenericRecord> reader = AvroUtils.getAvroReader(avroFile);
-      _avroSchema = reader.getSchema();
-      reader.close();
+      try (DataFileStream<GenericRecord> reader = AvroUtils.getAvroReader(avroFile)) {
+        _avroSchema = reader.getSchema();
+      }
       _recordExtractor = new AvroRecordExtractor();
-      _recordExtractor.init(sourceFields, null);
+      _recordExtractor.init(fieldsToRead, null);
       _reader = new GenericDatumReader<>(_avroSchema);
     }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DefaultCommitterRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DefaultCommitterRealtimeIntegrationTest.java
@@ -144,7 +144,7 @@ public class DefaultCommitterRealtimeIntegrationTest extends RealtimeClusterInte
     Schema schema = _helixResourceManager.getSchema(getTableName());
     String _segmentOutputDir = Files.createTempDir().toString();
     List<GenericRow> _rows = PinotSegmentUtil.createTestData(schema, 1);
-    RecordReader _recordReader = new GenericRowRecordReader(_rows, schema);
+    RecordReader _recordReader = new GenericRowRecordReader(_rows);
 
     _indexDir = PinotSegmentUtil.createSegment(schema, "segmentName", _segmentOutputDir, _recordReader);
   }

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/executor/PurgeTaskExecutorTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/executor/PurgeTaskExecutorTest.java
@@ -71,7 +71,7 @@ public class PurgeTaskExecutorTest {
       row.putField(D1, i);
       rows.add(row);
     }
-    GenericRowRecordReader genericRowRecordReader = new GenericRowRecordReader(rows, schema);
+    GenericRowRecordReader genericRowRecordReader = new GenericRowRecordReader(rows);
 
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
     config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
@@ -159,7 +159,7 @@ public class RawIndexBenchmark {
 
     System.out.println("Generating segment...");
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
 
     return new File(SEGMENT_DIR_NAME, SEGMENT_NAME);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
@@ -113,7 +113,7 @@ public class StringDictionaryPerfTest {
 
     long start = System.currentTimeMillis();
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
     System.out.println("Total time for building segment: " + (System.currentTimeMillis() - start));
   }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
@@ -201,35 +201,6 @@ public class AvroUtils {
   }
 
   /**
-   * Validates Pinot schema against the given Avro schema.
-   */
-  public static void validateSchema(Schema schema, org.apache.avro.Schema avroSchema) {
-    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-      String fieldName = fieldSpec.getName();
-      Field avroField = avroSchema.getField(fieldName);
-      if (avroField == null) {
-        LOGGER.warn("Pinot field: {} does not exist in Avro Schema", fieldName);
-      } else {
-        boolean isPinotFieldSingleValue = fieldSpec.isSingleValueField();
-        boolean isAvroFieldSingleValue = AvroUtils.isSingleValueField(avroField);
-        if (isPinotFieldSingleValue != isAvroFieldSingleValue) {
-          String errorMessage = "Pinot field: " + fieldName + " is " + (isPinotFieldSingleValue ? "Single" : "Multi")
-              + "-valued in Pinot schema but not in Avro schema";
-          LOGGER.error(errorMessage);
-          throw new IllegalStateException(errorMessage);
-        }
-
-        FieldSpec.DataType pinotFieldDataType = fieldSpec.getDataType();
-        FieldSpec.DataType avroFieldDataType = AvroUtils.extractFieldDataType(avroField);
-        if (pinotFieldDataType != avroFieldDataType) {
-          LOGGER.warn("Pinot field: {} of type: {} mismatches with corresponding field in Avro Schema of type: {}",
-              fieldName, pinotFieldDataType, avroFieldDataType);
-        }
-      }
-    }
-  }
-
-  /**
    * Get the Avro file reader for the given file.
    */
   public static DataFileStream<GenericRecord> getAvroReader(File avroFile)

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorMapTypeTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorMapTypeTest.java
@@ -92,7 +92,7 @@ public class AvroRecordExtractorMapTypeTest extends AbstractRecordExtractorTest 
   protected RecordReader createRecordReader()
       throws IOException {
     AvroRecordReader avroRecordReader = new AvroRecordReader();
-    avroRecordReader.init(_dataFile, _pinotSchema, null, _sourceFieldNames);
+    avroRecordReader.init(_dataFile, _sourceFieldNames, null);
     return avroRecordReader;
   }
 
@@ -105,8 +105,8 @@ public class AvroRecordExtractorMapTypeTest extends AbstractRecordExtractorTest 
     org.apache.avro.Schema avroSchema = createRecord("mapRecord", null, null, false);
     org.apache.avro.Schema intStringMapAvroSchema = createMap(create(Type.STRING));
     org.apache.avro.Schema stringIntMapAvroSchema = createMap(create(Type.INT));
-    List<Field> fields = Arrays
-        .asList(new Field("map1", intStringMapAvroSchema, null, null), new Field("map2", stringIntMapAvroSchema, null, null));
+    List<Field> fields = Arrays.asList(new Field("map1", intStringMapAvroSchema, null, null),
+        new Field("map2", stringIntMapAvroSchema, null, null));
     avroSchema.setFields(fields);
 
     try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorTest.java
@@ -48,7 +48,7 @@ public class AvroRecordExtractorTest extends AbstractRecordExtractorTest {
   protected RecordReader createRecordReader()
       throws IOException {
     AvroRecordReader avroRecordReader = new AvroRecordReader();
-    avroRecordReader.init(_dataFile, _pinotSchema, null, _sourceFieldNames);
+    avroRecordReader.init(_dataFile, _sourceFieldNames, null);
     return avroRecordReader;
   }
 
@@ -64,10 +64,9 @@ public class AvroRecordExtractorTest extends AbstractRecordExtractorTest {
         .asList(new Field("user_id", createUnion(Lists.newArrayList(create(Type.INT), create(Type.NULL))), null, null),
             new Field("firstName", createUnion(Lists.newArrayList(create(Type.STRING), create(Type.NULL))), null, null),
             new Field("lastName", createUnion(Lists.newArrayList(create(Type.STRING), create(Type.NULL))), null, null),
-            new Field("bids", createUnion(Lists.newArrayList(createArray(create(Type.INT)), create(Type.NULL))), null, null),
-            new Field("campaignInfo", create(Type.STRING), null, null),
-            new Field("cost", create(Type.DOUBLE), null, null),
-            new Field("timestamp", create(Type.LONG), null, null));
+            new Field("bids", createUnion(Lists.newArrayList(createArray(create(Type.INT)), create(Type.NULL))), null,
+                null), new Field("campaignInfo", create(Type.STRING), null, null),
+            new Field("cost", create(Type.DOUBLE), null, null), new Field("timestamp", create(Type.LONG), null, null));
 
     avroSchema.setFields(fields);
 

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordReaderTest.java
@@ -39,7 +39,7 @@ public class AvroRecordReaderTest extends AbstractRecordReaderTest {
   protected RecordReader createRecordReader()
       throws Exception {
     AvroRecordReader avroRecordReader = new AvroRecordReader();
-    avroRecordReader.init(_dataFile, getPinotSchema(), null, _sourceFields);
+    avroRecordReader.init(_dataFile, _sourceFields, null);
     return avroRecordReader;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/SimpleAvroMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/SimpleAvroMessageDecoder.java
@@ -28,7 +28,6 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordExtractor;
 import org.apache.pinot.spi.plugin.PluginManager;
@@ -54,7 +53,7 @@ public class SimpleAvroMessageDecoder implements StreamMessageDecoder<byte[]> {
   private GenericData.Record _avroRecordToReuse;
 
   @Override
-  public void init(Map<String, String> props, Schema indexingSchema, String topicName, Set<String> sourceFields)
+  public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
       throws Exception {
     Preconditions.checkState(props.containsKey(SCHEMA), "Avro schema must be provided");
     _avroSchema = new org.apache.avro.Schema.Parser().parse(props.get(SCHEMA));
@@ -65,7 +64,7 @@ public class SimpleAvroMessageDecoder implements StreamMessageDecoder<byte[]> {
       recordExtractorClass = AvroRecordExtractor.class.getName();
     }
     _avroRecordExtractor = PluginManager.get().createInstance(recordExtractorClass);
-    _avroRecordExtractor.init(sourceFields, null);
+    _avroRecordExtractor.init(fieldsToRead, null);
   }
 
   /**

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
@@ -49,7 +49,7 @@ public class CSVRecordExtractorTest extends AbstractRecordExtractorTest {
     CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
     csvRecordReaderConfig.setMultiValueDelimiter(CSV_MULTI_VALUE_DELIMITER);
     CSVRecordReader csvRecordReader = new CSVRecordReader();
-    csvRecordReader.init(_dataFile, _pinotSchema, csvRecordReaderConfig, _sourceFieldNames);
+    csvRecordReader.init(_dataFile, _sourceFieldNames, csvRecordReaderConfig);
     return csvRecordReader;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
@@ -43,7 +43,7 @@ public class CSVRecordReaderTest extends AbstractRecordReaderTest {
     CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
     csvRecordReaderConfig.setMultiValueDelimiter(CSV_MULTI_VALUE_DELIMITER);
     CSVRecordReader csvRecordReader = new CSVRecordReader();
-    csvRecordReader.init(_dataFile, getPinotSchema(), csvRecordReaderConfig, _sourceFields);
+    csvRecordReader.init(_dataFile, _sourceFields, csvRecordReaderConfig);
     return csvRecordReader;
   }
 
@@ -75,11 +75,11 @@ public class CSVRecordReaderTest extends AbstractRecordReaderTest {
       throws Exception {
     for (Map<String, Object> expectedRecord : expectedRecordsMap) {
       GenericRow actualRecord = recordReader.next();
-      org.apache.pinot.spi.data.Schema pinotSchema = recordReader.getSchema();
-      for (FieldSpec fieldSpec : pinotSchema.getAllFieldSpecs()) {
+      for (FieldSpec fieldSpec : _pinotSchema.getAllFieldSpecs()) {
         String fieldSpecName = fieldSpec.getName();
         if (fieldSpec.isSingleValueField()) {
-          Assert.assertEquals(actualRecord.getValue(fieldSpecName).toString(), expectedRecord.get(fieldSpecName).toString());
+          Assert.assertEquals(actualRecord.getValue(fieldSpecName).toString(),
+              expectedRecord.get(fieldSpecName).toString());
         } else {
           List expectedRecords = (List) expectedRecord.get(fieldSpecName);
           if (expectedRecords.size() == 1) {

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordReader.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
@@ -37,7 +36,6 @@ import org.apache.pinot.spi.utils.JsonUtils;
  */
 public class JSONRecordReader implements RecordReader {
   private File _dataFile;
-  private Schema _schema;
   private JSONRecordExtractor _recordExtractor;
 
   private MappingIterator<Map<String, Object>> _iterator;
@@ -59,12 +57,11 @@ public class JSONRecordReader implements RecordReader {
   }
 
   @Override
-  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig, Set<String> sourceFields)
+  public void init(File dataFile, Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
     _dataFile = dataFile;
-    _schema = schema;
     _recordExtractor = new JSONRecordExtractor();
-    _recordExtractor.init(sourceFields, null);
+    _recordExtractor.init(fieldsToRead, null);
     init();
   }
 
@@ -78,8 +75,6 @@ public class JSONRecordReader implements RecordReader {
     return next(new GenericRow());
   }
 
-  // NOTE: hard to extract common code further
-  @SuppressWarnings("Duplicates")
   @Override
   public GenericRow next(GenericRow reuse) {
     Map<String, Object> record = _iterator.next();
@@ -92,11 +87,6 @@ public class JSONRecordReader implements RecordReader {
       throws IOException {
     _iterator.close();
     init();
-  }
-
-  @Override
-  public Schema getSchema() {
-    return _schema;
   }
 
   @Override

--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractorTest.java
@@ -42,7 +42,7 @@ public class JSONRecordExtractorTest extends AbstractRecordExtractorTest {
   protected RecordReader createRecordReader()
       throws IOException {
     JSONRecordReader recordReader = new JSONRecordReader();
-    recordReader.init(_dataFile, _pinotSchema, null, _sourceFieldNames);
+    recordReader.init(_dataFile, _sourceFieldNames, null);
     return recordReader;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONRecordReaderTest.java
@@ -38,7 +38,7 @@ public class JSONRecordReaderTest extends AbstractRecordReaderTest {
   protected RecordReader createRecordReader()
       throws Exception {
     JSONRecordReader recordReader = new JSONRecordReader();
-    recordReader.init(_dateFile, getPinotSchema(), null, _sourceFields);
+    recordReader.init(_dateFile, _sourceFields, null);
     return recordReader;
   }
 
@@ -61,11 +61,11 @@ public class JSONRecordReaderTest extends AbstractRecordReaderTest {
       throws Exception {
     for (Map<String, Object> expectedRecord : expectedRecordsMap) {
       GenericRow actualRecord = recordReader.next();
-      org.apache.pinot.spi.data.Schema pinotSchema = recordReader.getSchema();
-      for (FieldSpec fieldSpec : pinotSchema.getAllFieldSpecs()) {
+      for (FieldSpec fieldSpec : _pinotSchema.getAllFieldSpecs()) {
         String fieldSpecName = fieldSpec.getName();
         if (fieldSpec.isSingleValueField()) {
-          Assert.assertEquals(actualRecord.getValue(fieldSpecName).toString(), expectedRecord.get(fieldSpecName).toString());
+          Assert.assertEquals(actualRecord.getValue(fieldSpecName).toString(),
+              expectedRecord.get(fieldSpecName).toString());
         } else {
           Object[] actualRecords = (Object[]) actualRecord.getValue(fieldSpecName);
           List expectedRecords = (List) expectedRecord.get(fieldSpecName);

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractorTest.java
@@ -50,7 +50,7 @@ public class ORCRecordExtractorTest extends AbstractRecordExtractorTest {
   protected RecordReader createRecordReader()
       throws IOException {
     ORCRecordReader orcRecordReader = new ORCRecordReader();
-    orcRecordReader.init(_dataFile, _pinotSchema, null, _sourceFieldNames);
+    orcRecordReader.init(_dataFile, _sourceFieldNames, null);
     return orcRecordReader;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
@@ -44,7 +44,7 @@ public class ORCRecordReaderTest extends AbstractRecordReaderTest {
   protected RecordReader createRecordReader()
       throws Exception {
     ORCRecordReader orcRecordReader = new ORCRecordReader();
-    orcRecordReader.init(_dataFile, _pinotSchema, null, _sourceFields);
+    orcRecordReader.init(_dataFile, _sourceFields, null);
     return orcRecordReader;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
@@ -158,35 +158,6 @@ public class ParquetUtils {
   }
 
   /**
-   * Validates Pinot schema against the given Avro schema.
-   */
-  public static void validateSchema(org.apache.pinot.spi.data.Schema schema, org.apache.avro.Schema avroSchema) {
-    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-      String fieldName = fieldSpec.getName();
-      Schema.Field avroField = avroSchema.getField(fieldName);
-      if (avroField == null) {
-        LOGGER.warn("Pinot field: {} does not exist in Avro Schema", fieldName);
-      } else {
-        boolean isPinotFieldSingleValue = fieldSpec.isSingleValueField();
-        boolean isAvroFieldSingleValue = isSingleValueField(avroField);
-        if (isPinotFieldSingleValue != isAvroFieldSingleValue) {
-          String errorMessage = "Pinot field: " + fieldName + " is " + (isPinotFieldSingleValue ? "Single" : "Multi")
-              + "-valued in Pinot schema but not in Avro schema";
-          LOGGER.error(errorMessage);
-          throw new IllegalStateException(errorMessage);
-        }
-
-        FieldSpec.DataType pinotFieldDataType = fieldSpec.getDataType();
-        FieldSpec.DataType avroFieldDataType = extractFieldDataType(avroField);
-        if (pinotFieldDataType != avroFieldDataType) {
-          LOGGER.warn("Pinot field: {} of type: {} mismatches with corresponding field in Avro Schema of type: {}",
-              fieldName, pinotFieldDataType, avroFieldDataType);
-        }
-      }
-    }
-  }
-
-  /**
    * Get the Avro file reader for the given file.
    */
   public static DataFileStream<GenericRecord> getAvroReader(File avroFile)

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordExtractorTest.java
@@ -21,19 +21,15 @@ package org.apache.pinot.plugin.inputformat.parquet;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
-import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetWriter;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.AbstractRecordExtractorTest;
-import org.apache.pinot.spi.data.readers.AbstractRecordReaderTest;
 import org.apache.pinot.spi.data.readers.RecordReader;
 
 import static org.apache.avro.Schema.create;
@@ -54,7 +50,7 @@ public class ParquetRecordExtractorTest extends AbstractRecordExtractorTest {
   protected RecordReader createRecordReader()
       throws IOException {
     ParquetRecordReader recordReader = new ParquetRecordReader();
-    recordReader.init(_dataFile, _pinotSchema, null, _sourceFieldNames);
+    recordReader.init(_dataFile, _sourceFieldNames, null);
     return recordReader;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
@@ -39,7 +39,7 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
   protected RecordReader createRecordReader()
       throws Exception {
     ParquetRecordReader recordReader = new ParquetRecordReader();
-    recordReader.init(_dataFile, getPinotSchema(), null, _sourceFields);
+    recordReader.init(_dataFile, _sourceFields, null);
     return recordReader;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-thrift/src/test/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/src/test/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordReaderTest.java
@@ -96,7 +96,7 @@ public class ThriftRecordReaderTest {
   public void testReadData()
       throws IOException {
     ThriftRecordReader recordReader = new ThriftRecordReader();
-    recordReader.init(_tempFile, getSchema(), getThriftRecordReaderConfig(), getSourceFields());
+    recordReader.init(_tempFile, getSourceFields(), getThriftRecordReaderConfig());
     List<GenericRow> genericRows = new ArrayList<>();
     while (recordReader.hasNext()) {
       genericRows.add(recordReader.next());
@@ -115,7 +115,7 @@ public class ThriftRecordReaderTest {
   public void testRewind()
       throws IOException {
     ThriftRecordReader recordReader = new ThriftRecordReader();
-    recordReader.init(_tempFile, getSchema(), getThriftRecordReaderConfig(), getSourceFields());
+    recordReader.init(_tempFile, getSourceFields(), getThriftRecordReaderConfig());
     List<GenericRow> genericRows = new ArrayList<>();
     while (recordReader.hasNext()) {
       genericRows.add(recordReader.next());

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaConsumerFactory.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaConsumerFactory.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.plugin.stream.kafka09;
 
 import java.util.Set;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.PartitionLevelConsumer;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamLevelConsumer;
@@ -31,47 +30,22 @@ import org.apache.pinot.spi.stream.StreamMetadataProvider;
  */
 public class KafkaConsumerFactory extends StreamConsumerFactory {
 
-  /**
-   * Creates a partition level consumer for fetching from a partition of a kafka stream
-   * @param clientId
-   * @param partition
-   * @return
-   */
   @Override
   public PartitionLevelConsumer createPartitionLevelConsumer(String clientId, int partition) {
     return new KafkaPartitionLevelConsumer(clientId, _streamConfig, partition);
   }
 
-  /**
-   * Creates a stream level consumer for a kafka stream
-   * @param clientId
-   * @param tableName
-   * @param schema
-   * @param groupId
-   * @return
-   */
   @Override
-  public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema,
-      String groupId, Set<String> sourceFields) {
-    return new KafkaStreamLevelConsumer(clientId, tableName, _streamConfig, schema, groupId, sourceFields);
+  public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Set<String> fieldsToRead,
+      String groupId) {
+    return new KafkaStreamLevelConsumer(clientId, tableName, _streamConfig, fieldsToRead, groupId);
   }
 
-  /**
-   * Creates a partition metadata provider for a kafka stream
-   * @param clientId
-   * @param partition
-   * @return
-   */
   @Override
   public StreamMetadataProvider createPartitionMetadataProvider(String clientId, int partition) {
     return new KafkaStreamMetadataProvider(clientId, _streamConfig, partition);
   }
 
-  /**
-   * Creates a stream metadata provider for a kafka stream
-   * @param clientId
-   * @return
-   */
   @Override
   public StreamMetadataProvider createStreamMetadataProvider(String clientId) {
     return new KafkaStreamMetadataProvider(clientId, _streamConfig);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaStreamLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaStreamLevelConsumer.java
@@ -21,12 +21,11 @@ package org.apache.pinot.plugin.stream.kafka09;
 import java.util.Set;
 import kafka.consumer.ConsumerIterator;
 import kafka.javaapi.consumer.ConsumerConnector;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamDecoderProvider;
 import org.apache.pinot.spi.stream.StreamLevelConsumer;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
-import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.readers.GenericRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,13 +51,13 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
   private long lastCount = 0;
   private long currentCount = 0L;
 
-  public KafkaStreamLevelConsumer(String clientId, String tableName, StreamConfig streamConfig, Schema schema,
-      String groupId, Set<String> sourceFields) {
+  public KafkaStreamLevelConsumer(String clientId, String tableName, StreamConfig streamConfig,
+      Set<String> fieldsToRead, String groupId) {
     _clientId = clientId;
     _streamConfig = streamConfig;
     _kafkaHighLevelStreamConfig = new KafkaHighLevelStreamConfig(streamConfig, tableName, groupId);
 
-    _messageDecoder = StreamDecoderProvider.create(streamConfig, schema, sourceFields);
+    _messageDecoder = StreamDecoderProvider.create(streamConfig, fieldsToRead);
 
     _tableAndStreamName = tableName + "-" + streamConfig.getTopicName();
     INSTANCE_LOGGER = LoggerFactory

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerFactory.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerFactory.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.plugin.stream.kafka20;
 
 import java.util.Set;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.PartitionLevelConsumer;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamLevelConsumer;
@@ -27,15 +26,16 @@ import org.apache.pinot.spi.stream.StreamMetadataProvider;
 
 
 public class KafkaConsumerFactory extends StreamConsumerFactory {
+
   @Override
   public PartitionLevelConsumer createPartitionLevelConsumer(String clientId, int partition) {
     return new KafkaPartitionLevelConsumer(clientId, _streamConfig, partition);
   }
 
   @Override
-  public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema,
-      String groupId, Set<String> sourceFields) {
-    return new KafkaStreamLevelConsumer(clientId, tableName, _streamConfig, schema, groupId, sourceFields);
+  public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Set<String> fieldsToRead,
+      String groupId) {
+    return new KafkaStreamLevelConsumer(clientId, tableName, _streamConfig, fieldsToRead, groupId);
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamLevelConsumer.java
@@ -29,7 +29,6 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamDecoderProvider;
@@ -62,15 +61,13 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
   private long lastCount = 0;
   private long currentCount = 0L;
 
-
-
-  public KafkaStreamLevelConsumer(String clientId, String tableName, StreamConfig streamConfig, Schema schema,
-      String groupId, Set<String> sourceFields) {
+  public KafkaStreamLevelConsumer(String clientId, String tableName, StreamConfig streamConfig,
+      Set<String> sourceFields, String groupId) {
     _clientId = clientId;
     _streamConfig = streamConfig;
     _kafkaStreamLevelStreamConfig = new KafkaStreamLevelStreamConfig(streamConfig, tableName, groupId);
 
-    _messageDecoder = StreamDecoderProvider.create(streamConfig, schema, sourceFields);
+    _messageDecoder = StreamDecoderProvider.create(streamConfig, sourceFields);
 
     _tableAndStreamName = tableName + "-" + streamConfig.getTopicName();
     INSTANCE_LOGGER = LoggerFactory

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoderTest.java
@@ -63,7 +63,7 @@ public class KafkaJSONMessageDecoderTest {
     try (BufferedReader reader = new BufferedReader(
         new FileReader(getClass().getClassLoader().getResource("data/test_sample_data.json").getFile()))) {
       KafkaJSONMessageDecoder decoder = new KafkaJSONMessageDecoder();
-      decoder.init(new HashMap<>(), schema, "testTopic", schema.getColumnNames());
+      decoder.init(new HashMap<>(), schema.getColumnNames(), "testTopic");
       GenericRow r = new GenericRow();
       String line = reader.readLine();
       while (line != null) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReader.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.data.Schema;
 
 
 /**
@@ -37,14 +36,11 @@ public interface RecordReader extends Closeable {
    * Initializes the record reader with data file, schema and (optional) record reader config.
    *
    * @param dataFile Data file
-   * @param schema Pinot Schema associated with the table
+   * @param fieldsToRead The fields to read from the data file
    * @param recordReaderConfig Config for the reader specific to the format. e.g. delimiter for csv format etc
-   * @param sourceFields The fields to extract from the source record
    * @throws IOException If an I/O error occurs
-   *
-   * TODO: decouple Schema and RecordReader. This should be easier, now that we have field names to extract
    */
-  void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig, Set<String> sourceFields)
+  void init(File dataFile, Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException;
 
   /**
@@ -70,9 +66,4 @@ public interface RecordReader extends Closeable {
    */
   void rewind()
       throws IOException;
-
-  /**
-   * Get the Pinot schema.
-   */
-  Schema getSchema();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactory.java
@@ -48,13 +48,12 @@ public abstract class StreamConsumerFactory {
    * Creates a stream level consumer (high level) which can fetch messages from the stream
    * @param clientId a client id to identify the creator of this consumer
    * @param tableName the table name for the topic of this consumer
-   * @param schema the pinot schema of the event being consumed
+   * @param fieldsToRead the fields to read from the source stream
    * @param groupId consumer group Id
-   * @param sourceFields the fields to extract from the source stream
    * @return the stream level consumer
    */
-  public abstract StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName, Schema schema,
-      String groupId, Set<String> sourceFields);
+  public abstract StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName,
+      Set<String> fieldsToRead, String groupId);
 
   /**
    * Creates a metadata provider which provides partition specific metadata

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDecoderProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDecoderProvider.java
@@ -20,33 +20,33 @@ package org.apache.pinot.spi.stream;
 
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.plugin.PluginManager;
 
 
 /**
  * Provider for {@link StreamMessageDecoder}
  */
-public abstract class StreamDecoderProvider {
+public class StreamDecoderProvider {
+  private StreamDecoderProvider() {
+  }
 
   /**
-   * Constructs a {@link StreamMessageDecoder} using properties in {@link StreamConfig} and initializes it
-   * @param streamConfig the stream configs from the table config
-   * @param schema the schema of the Pinot table
-   * @param sourceFields the fields to extract from the source stream
-   * @return the StreamMessageDecoder
+   * Creates a {@link StreamMessageDecoder} using properties in {@link StreamConfig}.
+   *
+   * @param streamConfig The stream config from the table config
+   * @param fieldsToRead The fields to read from the source stream
+   * @return The initialized StreamMessageDecoder
    */
-  public static StreamMessageDecoder create(StreamConfig streamConfig, Schema schema, Set<String> sourceFields) {
-    StreamMessageDecoder decoder = null;
+  public static StreamMessageDecoder create(StreamConfig streamConfig, Set<String> fieldsToRead) {
     String decoderClass = streamConfig.getDecoderClass();
     Map<String, String> decoderProperties = streamConfig.getDecoderProperties();
     try {
-      decoder = PluginManager.get().createInstance(decoderClass);
-      decoder.init(decoderProperties, schema, streamConfig.getTopicName(), sourceFields);
+      StreamMessageDecoder decoder = PluginManager.get().createInstance(decoderClass);
+      decoder.init(decoderProperties, fieldsToRead, streamConfig.getTopicName());
+      return decoder;
     } catch (Exception e) {
-      ExceptionUtils.rethrow(e);
+      throw new RuntimeException(
+          "Caught exception while creating StreamMessageDecoder from stream config: " + streamConfig, e);
     }
-    return decoder;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageDecoder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageDecoder.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -37,20 +36,21 @@ public interface StreamMessageDecoder<T> {
   String RECORD_EXTRACTOR_CONFIG_KEY = "recordExtractorClass";
 
   /**
-   * Initialize the decoder
-   * @param props decoder properties extracted from the {@link StreamConfig}
-   * @param indexingSchema the Pinot schema TODO: Remove Schema from StreamMessageDecoder. Do not use inside the implementation, as this will be removed
-   * @param topicName topic name of the stream
-   * @param sourceFields the fields to be read from the source stream's record
-   * @throws Exception
+   * Initializes the decoder.
+   *
+   * @param props Decoder properties extracted from the {@link StreamConfig}
+   * @param fieldsToRead The fields to read from the source stream
+   * @param topicName Topic name of the stream
+   * @throws Exception If an error occurs
    */
-  void init(Map<String, String> props, Schema indexingSchema, String topicName, Set<String> sourceFields)
+  void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
       throws Exception;
 
   /**
-   * Decodes the payload received into a generic row
-   * @param payload
-   * @return
+   * Decodes a row.
+   *
+   * @param payload The buffer from which to read the row.
+   * @return A new row decoded from the buffer
    */
   GenericRow decode(T payload, GenericRow destination);
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordReaderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordReaderTest.java
@@ -92,8 +92,7 @@ public abstract class AbstractRecordReaderTest {
       throws Exception {
     for (Map<String, Object> expectedRecord : expectedRecordsMap) {
       GenericRow actualRecord = recordReader.next();
-      org.apache.pinot.spi.data.Schema pinotSchema = recordReader.getSchema();
-      for (FieldSpec fieldSpec : pinotSchema.getAllFieldSpecs()) {
+      for (FieldSpec fieldSpec : _pinotSchema.getAllFieldSpecs()) {
         String fieldSpecName = fieldSpec.getName();
         if (fieldSpec.isSingleValueField()) {
           Assert.assertEquals(actualRecord.getValue(fieldSpecName), expectedRecord.get(fieldSpecName));

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
@@ -73,7 +73,7 @@ public class PluginManagerTest {
         PluginManager.get().load("test-record-reader", jarDirFile);
 
         RecordReader testRecordReader = PluginManager.get().createInstance("test-record-reader", "TestRecordReader");
-        testRecordReader.init(null, null, null, null);
+        testRecordReader.init(null, null, null);
         int count = 0;
         while (testRecordReader.hasNext()) {
           GenericRow row = testRecordReader.next();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -32,6 +32,7 @@ import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.core.util.SchemaUtils;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReader;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -40,7 +41,6 @@ import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.utils.JsonUtils;
-import org.apache.pinot.core.util.SchemaUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -365,7 +365,7 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
                   if (_readerConfigFile != null) {
                     readerConfig = JsonUtils.fileToObject(new File(_readerConfigFile), CSVRecordReaderConfig.class);
                   }
-                  csvRecordReader.init(localFile, schema, readerConfig, SchemaUtils.extractSourceFields(schema));
+                  csvRecordReader.init(localFile, SchemaUtils.extractSourceFields(schema), readerConfig);
                   driver.init(config, csvRecordReader);
                   break;
                 default:

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentToAvroConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentToAvroConverter.java
@@ -24,9 +24,9 @@ import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 
 
 /**
@@ -44,15 +44,15 @@ public class PinotSegmentToAvroConverter implements PinotSegmentConverter {
   @Override
   public void convert()
       throws Exception {
-    try (PinotSegmentRecordReader recordReader = new PinotSegmentRecordReader(new File(_segmentDir))) {
-      Schema avroSchema = AvroUtils.getAvroSchemaFromPinotSchema(recordReader.getSchema());
+    try (PinotSegmentRecordReader pinotSegmentRecordReader = new PinotSegmentRecordReader(new File(_segmentDir))) {
+      Schema avroSchema = AvroUtils.getAvroSchemaFromPinotSchema(pinotSegmentRecordReader.getSchema());
 
-      try (DataFileWriter<Record> recordWriter = new DataFileWriter<>(new GenericDatumWriter<Record>(avroSchema))) {
+      try (DataFileWriter<Record> recordWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
         recordWriter.create(avroSchema, new File(_outputFile));
 
         GenericRow row = new GenericRow();
-        while (recordReader.hasNext()) {
-          row = recordReader.next(row);
+        while (pinotSegmentRecordReader.hasNext()) {
+          row = pinotSegmentRecordReader.next(row);
           Record record = new Record(avroSchema);
 
           for (String field : row.getFieldNames()) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpStream.java
@@ -30,13 +30,13 @@ import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 import javax.websocket.MessageHandler;
 import javax.websocket.Session;
+import org.apache.pinot.core.util.SchemaUtils;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.plugin.PluginManager;
-import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.stream.StreamDataProducer;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
-import org.apache.pinot.core.util.SchemaUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
 import org.glassfish.tyrus.client.ClientManager;
 
@@ -66,9 +66,10 @@ public class MeetupRsvpStream {
 
   public void run() {
     try {
-      final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
-      final StreamMessageDecoder decoder = PluginManager.get().createInstance(KafkaStarterUtils.KAFKA_JSON_MESSAGE_DECODER_CLASS_NAME);
-      decoder.init(null, schema, null, SchemaUtils.extractSourceFields(schema));
+      ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
+      StreamMessageDecoder decoder =
+          PluginManager.get().createInstance(KafkaStarterUtils.KAFKA_JSON_MESSAGE_DECODER_CLASS_NAME);
+      decoder.init(null, SchemaUtils.extractSourceFields(schema), null);
       client = ClientManager.createClient();
       client.connectToServer(new Endpoint() {
 


### PR DESCRIPTION
RecordReader and StreamMessageDecoder is the entry point for batch and streaming data ingestion. They are expected to be implemented and plugged to provide customized format support.
To make the abstraction more crispy and easier to understand, remove the Schema and replace it with fields to read so that users do not need to worry about extracting fields from the Pinot schema when adding a new format.