### PR TITLE
Initial implementation for support Theta Sketches (WIP).

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/AggregationFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/AggregationFunctionType.java
@@ -30,9 +30,11 @@ public enum AggregationFunctionType {
   DISTINCTCOUNTHLL("distinctCountHLL"),
   DISTINCTCOUNTRAWHLL("distinctCountRawHLL"),
   FASTHLL("fastHLL"),
+  DISTINCTCOUNTTHETASKETCH("distinctCountThetaSketch"),
   PERCENTILE("percentile"),
   PERCENTILEEST("percentileEst"),
   PERCENTILETDIGEST("percentileTDigest"),
+
   // Aggregation functions for multi-valued columns
   COUNTMV("countMV"),
   MINMV("minMV"),

--- a/pinot-common/src/main/java/org/apache/pinot/parsers/utils/ParserUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/parsers/utils/ParserUtils.java
@@ -1,0 +1,214 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.parsers.utils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.FilterOperator;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
+
+
+/**
+ * Class for holding Parser specific utility functions.
+ */
+public class ParserUtils {
+  // Private constructor to disable instantiation.
+  private ParserUtils() {
+
+  }
+
+  private static final Map<FilterKind, FilterOperator> FILTER_OPERATOR_MAP;
+
+  static {
+    FILTER_OPERATOR_MAP = new HashMap<>();
+    FILTER_OPERATOR_MAP.put(FilterKind.AND, FilterOperator.AND);
+    FILTER_OPERATOR_MAP.put(FilterKind.OR, FilterOperator.OR);
+    FILTER_OPERATOR_MAP.put(FilterKind.EQUALS, FilterOperator.EQUALITY);
+    FILTER_OPERATOR_MAP.put(FilterKind.NOT_EQUALS, FilterOperator.NOT);
+    FILTER_OPERATOR_MAP.put(FilterKind.GREATER_THAN, FilterOperator.RANGE);
+    FILTER_OPERATOR_MAP.put(FilterKind.LESS_THAN, FilterOperator.RANGE);
+    FILTER_OPERATOR_MAP.put(FilterKind.GREATER_THAN_OR_EQUAL, FilterOperator.RANGE);
+    FILTER_OPERATOR_MAP.put(FilterKind.LESS_THAN_OR_EQUAL, FilterOperator.RANGE);
+    FILTER_OPERATOR_MAP.put(FilterKind.BETWEEN, FilterOperator.RANGE);
+    FILTER_OPERATOR_MAP.put(FilterKind.IN, FilterOperator.IN);
+    FILTER_OPERATOR_MAP.put(FilterKind.NOT_IN, FilterOperator.NOT_IN);
+    FILTER_OPERATOR_MAP.put(FilterKind.REGEXP_LIKE, FilterOperator.REGEXP_LIKE);
+    FILTER_OPERATOR_MAP.put(FilterKind.TEXT_MATCH, FilterOperator.TEXT_MATCH);
+  }
+
+  /**
+   * Utility method that returns the {@link FilterOperator} for a given expression.
+   * Assumes that the passed in expression is a filter expression.
+   *
+   * @param expression Expression for which to get the filter type
+   * @return Filter Operator for the given Expression.
+   */
+  public static FilterOperator getFilterType(Expression expression) {
+    String operator = expression.getFunctionCall().getOperator();
+    return filterKindToOperator(FilterKind.valueOf(operator));
+  }
+
+  /**
+   * Utility method to map {@link FilterKind} to {@link FilterOperator}.
+   *
+   * @param filterKind Filter kind for which to get the Filter Operator
+   * @return Filter Operator for the given Filter kind
+   */
+  public static FilterOperator filterKindToOperator(FilterKind filterKind) {
+    return FILTER_OPERATOR_MAP.get(filterKind);
+  }
+
+  /**
+   * Returns the filter column from a given expression.
+   * Assumes that the passed expression is a filter expression of form LHS Operator RHS.
+   * LHS is expected to be a single column name.
+   *
+   * @param expression Filter expression
+   * @return
+   */
+  public static String getFilterColumn(Expression expression) {
+    Function functionCall = expression.getFunctionCall();
+    Expression operand = functionCall.getOperands().get(0);
+    return standardizeExpression(operand, false);
+  }
+
+  /**
+   * Utility method that returns the RHS of a filter expression as a list of String's.
+   *
+   * @param filterExpression Filter expression
+   * @return RHS of the filter expression
+   */
+  public static List<String> getFilterValues(Expression filterExpression) {
+    Function function = filterExpression.getFunctionCall();
+    FilterKind filterKind = FilterKind.valueOf(function.getOperator());
+
+    return getFilterValues(filterKind, function.getOperands());
+  }
+
+  /**
+   * Given a expression filter, returns the values (RHS) on which the filter predicate applies.
+   *
+   * @param filterKind Kind of filter
+   * @param operands Filter operands
+   * @return Values to filter on, as a list of strings.
+   */
+  public static List<String> getFilterValues(FilterKind filterKind, List<Expression> operands) {
+    List<String> valueList = new ArrayList<>();
+
+    // For non-range expressions, RHS is just the list of values from first index.
+    if (!filterKind.isRange()) {
+      for (int i = 1; i < operands.size(); i++) {
+        valueList.add(standardizeExpression(operands.get(i), true));
+      }
+      return valueList;
+    }
+
+    String rangeExpression;
+    //PQL does not quote the string literals when we create expression
+    boolean treatLiteralAsIdentifier = true;
+
+    if (FilterKind.LESS_THAN == filterKind) {
+
+      String value = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
+      rangeExpression = "(*\t\t" + value + ")";
+    } else if (FilterKind.LESS_THAN_OR_EQUAL == filterKind) {
+
+      String value = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
+      rangeExpression = "(*\t\t" + value + "]";
+    } else if (FilterKind.GREATER_THAN == filterKind) {
+
+      String value = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
+      rangeExpression = "(" + value + "\t\t*)";
+    } else if (FilterKind.GREATER_THAN_OR_EQUAL == filterKind) {
+
+      String value = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
+      rangeExpression = "[" + value + "\t\t*)";
+    } else if (FilterKind.BETWEEN == filterKind) {
+
+      String left = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
+      String right = standardizeExpression(operands.get(2), treatLiteralAsIdentifier);
+      rangeExpression = "[" + left + "\t\t" + right + "]";
+    } else {
+      throw new UnsupportedOperationException("Unknown Filter Kind:" + filterKind);
+    }
+
+    valueList.add(rangeExpression);
+    return valueList;
+  }
+
+  /**
+   * Standardizes a given expression, by quoting String literals.
+   *
+   * @param expression Expression to standardize
+   * @param treatLiteralAsIdentifier If true, literals are not quoted
+   * @return Standardized expression
+   */
+  public static String standardizeExpression(Expression expression, boolean treatLiteralAsIdentifier) {
+    return standardizeExpression(expression, treatLiteralAsIdentifier, false);
+  }
+
+  public static String standardizeExpression(Expression expression, boolean treatLiteralAsIdentifier,
+      boolean forceSingleQuoteOnNonStringLiteral) {
+    switch (expression.getType()) {
+      case LITERAL:
+        Literal literal = expression.getLiteral();
+        // Force single quote on non-string literal inside a function.
+        if (forceSingleQuoteOnNonStringLiteral && !literal.isSetStringValue()) {
+          return "'" + literal.getFieldValue() + "'";
+        }
+        if (treatLiteralAsIdentifier || !literal.isSetStringValue()) {
+          return literal.getFieldValue().toString();
+        } else {
+          return "'" + literal.getFieldValue() + "'";
+        }
+      case IDENTIFIER:
+        return expression.getIdentifier().getName();
+      case FUNCTION:
+        Function functionCall = expression.getFunctionCall();
+        return standardizeFunction(functionCall);
+      default:
+        throw new UnsupportedOperationException("Unknown Expression type: " + expression.getType());
+    }
+  }
+
+  /**
+   * Standardizes a function call by quoting literal operands.
+   *
+   * @param functionCall Function call to standardize
+   * @return Standardized String equivalent of the Function.
+   */
+  public static String standardizeFunction(Function functionCall) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(functionCall.getOperator().toLowerCase());
+    sb.append("(");
+    String delim = "";
+    for (Expression operand : functionCall.getOperands()) {
+      sb.append(delim);
+      sb.append(standardizeExpression(operand, false, true));
+      delim = ",";
+    }
+    sb.append(")");
+    return sb.toString();
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
@@ -33,5 +33,15 @@ public enum FilterKind {
   REGEXP_LIKE,
   IS_NULL,
   IS_NOT_NULL,
-  TEXT_MATCH
+  TEXT_MATCH;
+
+  /**
+   * Helper method that returns true if the enum maps to a Range.
+   *
+   * @return True if the enum is of Range type, false otherwise.
+   */
+  public boolean isRange() {
+    return (this == GREATER_THAN || this == GREATER_THAN_OR_EQUAL || this == LESS_THAN || this == LESS_THAN_OR_EQUAL
+        || this == BETWEEN);
+  }
 }

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -134,6 +134,10 @@
       <artifactId>stream</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.datasketches</groupId>
+      <artifactId>datasketches-java</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.tdunning</groupId>
       <artifactId>t-digest</artifactId>
     </dependency>

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/Predicate.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/Predicate.java
@@ -75,6 +75,11 @@ public abstract class Predicate {
     final String column = filterQueryTree.getColumn();
     final List<String> value = filterQueryTree.getValue();
 
+    Predicate predicate = newPredicate(filterType, column, value);
+    return predicate;
+  }
+
+  public static Predicate newPredicate(FilterOperator filterType, String column, List<String> value) {
     Predicate predicate = null;
     switch (filterType) {
       case EQUALITY:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/ThetaSketchParams.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/ThetaSketchParams.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/**
+ * Class to hold Theta Sketch Params, and is Json serializable.
+ */
+@SuppressWarnings("unused")
+public class ThetaSketchParams {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String PARAMS_DELIMITER = ";";
+  private static final String PARAM_KEY_VALUE_SEPARATOR = "=";
+
+  @JsonProperty("nominalEntries")
+  private int _nominalEntries;
+
+  public int getNominalEntries() {
+    return _nominalEntries;
+  }
+
+  public void setNominalEntries(int nominalEntries) {
+    _nominalEntries = nominalEntries;
+  }
+
+  /**
+   * Creates a ThetaSketchParams object from the specified string. The specified string is
+   * expected to be of form: "key1 = value1; key2 = value2.."
+   * @param paramsString Param in string form
+   * @return Param object, null if string is null or empty
+   */
+  public static ThetaSketchParams fromString(String paramsString) {
+    if (paramsString == null || paramsString.isEmpty()) {
+      return null;
+    }
+
+    ObjectNode objectNode = JsonUtils.newObjectNode();
+    for (String pair : paramsString.split(PARAMS_DELIMITER)) {
+      String[] keyValue = pair.split(PARAM_KEY_VALUE_SEPARATOR);
+      objectNode.put(keyValue[0].replaceAll("\\s", ""), keyValue[1].replaceAll("\\s", ""));
+    }
+
+    return OBJECT_MAPPER.convertValue(objectNode, ThetaSketchParams.class);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -45,13 +45,13 @@ public class AggregationFunctionFactory {
   public static AggregationFunction getAggregationFunction(AggregationInfo aggregationInfo,
       @Nullable BrokerRequest brokerRequest) {
     String functionName = aggregationInfo.getAggregationType();
-    List<String> arguments = AggregationFunctionUtils.getAggregationExpressions(aggregationInfo);
+    List<String> expressions = AggregationFunctionUtils.getAggregationExpressions(aggregationInfo);
 
     try {
       String upperCaseFunctionName = functionName.toUpperCase();
       if (upperCaseFunctionName.startsWith("PERCENTILE")) {
         String remainingFunctionName = upperCaseFunctionName.substring(10);
-        List<String> args = new ArrayList<>(arguments);
+        List<String> args = new ArrayList<>(expressions);
         if (remainingFunctionName.matches("\\d+")) {
           // Percentile
           args.add(remainingFunctionName);
@@ -80,7 +80,7 @@ public class AggregationFunctionFactory {
           throw new IllegalArgumentException();
         }
       } else {
-        String column = arguments.get(0);
+        String column = expressions.get(0);
         switch (AggregationFunctionType.valueOf(upperCaseFunctionName)) {
           case COUNT:
             return new CountAggregationFunction(column);
@@ -102,6 +102,8 @@ public class AggregationFunctionFactory {
             return new DistinctCountRawHLLAggregationFunction(column);
           case FASTHLL:
             return new FastHLLAggregationFunction(column);
+          case DISTINCTCOUNTTHETASKETCH:
+            return new DistinctCountThetaSketchAggregationFunction(expressions);
           case COUNTMV:
             return new CountMVAggregationFunction(column);
           case MINMV:
@@ -123,7 +125,7 @@ public class AggregationFunctionFactory {
           case DISTINCT:
             Preconditions.checkState(brokerRequest != null,
                 "Broker request must be provided for 'DISTINCT' aggregation function");
-            return new DistinctAggregationFunction(arguments, brokerRequest.getOrderBy(),
+            return new DistinctAggregationFunction(expressions, brokerRequest.getOrderBy(),
                 brokerRequest.getLimit());
           default:
             throw new IllegalArgumentException();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionVisitorBase.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionVisitorBase.java
@@ -95,5 +95,8 @@ public class AggregationFunctionVisitorBase {
 
   public void visit(SumMVAggregationFunction function) {
   }
+
+  public void visit(DistinctCountThetaSketchAggregationFunction function) {
+  }
 }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -1,0 +1,637 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.datasketches.memory.Memory;
+import org.apache.datasketches.theta.Intersection;
+import org.apache.datasketches.theta.SetOperation;
+import org.apache.datasketches.theta.SetOperationBuilder;
+import org.apache.datasketches.theta.Sketch;
+import org.apache.datasketches.theta.Union;
+import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.Predicate;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ThetaSketchParams;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.parsers.utils.ParserUtils;
+import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
+import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+
+
+/**
+ * Implementation of {@link AggregationFunction} to perform the distinct count aggregation using
+ * Theta Sketches.
+ */
+@SuppressWarnings("Duplicates")
+public class DistinctCountThetaSketchAggregationFunction implements AggregationFunction<Map<String, Sketch>, Integer> {
+
+  private String _thetaSketchColumn;
+  private Set<String> _predicateStrings;
+  private Expression _postAggregationExpression;
+  private Set<PredicateInfo> _predicateInfoSet;
+  private Map<Expression, String> _expressionMap;
+  private ThetaSketchParams _thetaSketchParams;
+  private List<TransformExpressionTree> _inputExpressions;
+
+  /**
+   * Constructor for the class.
+   * @param arguments List of parameters as arguments strings. At least three arguments are expected:
+   *                    <ul>
+   *                    <li> Required: First expression is interpreted as theta sketch column to aggregate on. </li>
+   *                    <li> Required: Second argument is the thetaSketchParams. </li>
+   *                    <li> Optional: Third to penultimate are predicates with LHS and RHS. </li>
+   *                    <li> Required: Last expression is the one that will be evaluated to compute final result. </li>
+   *                    </ul>
+   */
+  public DistinctCountThetaSketchAggregationFunction(List<String> arguments)
+      throws SqlParseException {
+    int numExpressions = arguments.size();
+
+    // This function expects at least 3 arguments: Theta Sketch Column, Predicates & final aggregation expression.
+    Preconditions.checkArgument(numExpressions >= 3, "DistinctCountThetaSketch expects at least three arguments, got: ",
+        numExpressions);
+
+    // Initialize all the internal state.
+    init(arguments);
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.DISTINCTCOUNTTHETASKETCH;
+  }
+
+  @Override
+  public String getColumnName() {
+    return AggregationFunctionType.DISTINCTCOUNTTHETASKETCH.getName() + "_" + _thetaSketchColumn;
+  }
+
+  @Override
+  public String getResultColumnName() {
+    return AggregationFunctionType.DISTINCTCOUNTTHETASKETCH.getName().toLowerCase() + "(" + _thetaSketchColumn + ")";
+  }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
+  }
+
+  @Override
+  public void accept(AggregationFunctionVisitorBase visitor) {
+    visitor.visit(this);
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    return new ObjectAggregationResultHolder();
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<String, BlockValSet> blockValSetMap) {
+
+    Map<String, Union> result = getDefaultResult(aggregationResultHolder, _predicateStrings);
+    Sketch[] sketches = deserializeSketches(blockValSetMap.get(_thetaSketchColumn).getBytesValuesSV(), length);
+
+    for (PredicateInfo predicateInfo : _predicateInfoSet) {
+      String predicate = predicateInfo.getStringVal();
+
+      BlockValSet blockValSet = blockValSetMap.get(predicateInfo.getColumn());
+      FieldSpec.DataType valueType = blockValSet.getValueType();
+      PredicateEvaluator predicateEvaluator = predicateInfo.getPredicateEvaluator(valueType);
+
+      Union union = result.get(predicate);
+      switch (valueType) {
+        case INT:
+        case LONG:
+          long[] longValues = blockValSet.getLongValuesSV();
+          for (int i = 0; i < length; i++) {
+            if (predicateEvaluator.applySV(longValues[i])) {
+              union.update(sketches[i]);
+            }
+          }
+          break;
+
+        case FLOAT:
+        case DOUBLE:
+          double[] doubleValues = blockValSet.getDoubleValuesSV();
+          for (int i = 0; i < length; i++) {
+            if (predicateEvaluator.applySV(doubleValues[i])) {
+              union.update(sketches[i]);
+            }
+          }
+          break;
+
+        case STRING:
+          String[] stringValues = blockValSet.getStringValuesSV();
+          for (int i = 0; i < length; i++) {
+            if (predicateEvaluator.applySV(stringValues[i])) {
+              union.update(sketches[i]);
+            }
+          }
+          break;
+
+        default: // Predicates on BYTES is not allowed.
+          throw new IllegalStateException("Illegal data type for " + getType() + " aggregation function: " + valueType);
+      }
+    }
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<String, BlockValSet> blockValSetMap) {
+    Sketch[] sketches = deserializeSketches(blockValSetMap.get(_thetaSketchColumn).getBytesValuesSV(), length);
+
+    for (PredicateInfo predicateInfo : _predicateInfoSet) {
+      String predicate = predicateInfo.getStringVal();
+
+      BlockValSet blockValSet = blockValSetMap.get(predicateInfo.getColumn());
+      FieldSpec.DataType valueType = blockValSet.getValueType();
+      PredicateEvaluator predicateEvaluator = predicateInfo.getPredicateEvaluator(valueType);
+
+      Map<String, Union> result;
+      switch (valueType) {
+        case INT:
+        case LONG:
+          long[] longValues = blockValSet.getLongValuesSV();
+          for (int i = 0; i < length; i++) {
+            if (predicateEvaluator.applySV(longValues[i])) {
+              result = getDefaultResult(groupByResultHolder, groupKeyArray[i], _predicateStrings);
+              Union union = result.get(predicate);
+              union.update(sketches[i]);
+            }
+          }
+          break;
+
+        case FLOAT:
+        case DOUBLE:
+          double[] doubleValues = blockValSet.getDoubleValuesSV();
+          for (int i = 0; i < length; i++) {
+            if (predicateEvaluator.applySV(doubleValues[i])) {
+              result = getDefaultResult(groupByResultHolder, groupKeyArray[i], _predicateStrings);
+              Union union = result.get(predicate);
+              union.update(sketches[i]);
+            }
+          }
+          break;
+
+        case STRING:
+          String[] stringValues = blockValSet.getStringValuesSV();
+
+          for (int i = 0; i < length; i++) {
+            if (predicateEvaluator.applySV(stringValues[i])) {
+              result = getDefaultResult(groupByResultHolder, groupKeyArray[i], _predicateStrings);
+              Union union = result.get(predicate);
+              union.update(sketches[i]);
+            }
+          }
+          break;
+
+        default: // Predicates on BYTES is not allowed.
+          throw new IllegalStateException("Illegal data type for " + getType() + " aggregation function: " + valueType);
+      }
+    }
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<String, BlockValSet> blockValSetMap) {
+    Sketch[] sketches = deserializeSketches(blockValSetMap.get(_thetaSketchColumn).getBytesValuesSV(), length);
+
+    for (PredicateInfo predicateInfo : _predicateInfoSet) {
+      String predicate = predicateInfo.getStringVal();
+
+      BlockValSet blockValSet = blockValSetMap.get(predicateInfo.getColumn());
+      FieldSpec.DataType valueType = blockValSet.getValueType();
+      PredicateEvaluator predicateEvaluator = predicateInfo.getPredicateEvaluator(valueType);
+
+      Map<String, Union> result;
+      switch (valueType) {
+        case INT:
+        case LONG:
+          long[] longValues = blockValSet.getLongValuesSV();
+
+          for (int i = 0; i < length; i++) {
+            if (predicateEvaluator.applySV(longValues[i])) {
+
+              for (int groupKey : groupKeysArray[i]) {
+                result = getDefaultResult(groupByResultHolder, groupKey, _predicateStrings);
+                Union union = result.get(predicate);
+                union.update(sketches[i]);
+              }
+            }
+          }
+          break;
+
+        case FLOAT:
+        case DOUBLE:
+          double[] doubleValues = blockValSet.getDoubleValuesSV();
+
+          for (int i = 0; i < length; i++) {
+            if (predicateEvaluator.applySV(doubleValues[i])) {
+
+              for (int groupKey : groupKeysArray[i]) {
+                result = getDefaultResult(groupByResultHolder, groupKey, _predicateStrings);
+                Union union = result.get(predicate);
+                union.update(sketches[i]);
+              }
+            }
+          }
+          break;
+
+        case STRING:
+          String[] stringValues = blockValSet.getStringValuesSV();
+
+          for (int i = 0; i < length; i++) {
+            if (predicateEvaluator.applySV(stringValues[i])) {
+
+              for (int groupKey : groupKeysArray[i]) {
+                result = getDefaultResult(groupByResultHolder, groupKey, _predicateStrings);
+                Union union = result.get(predicate);
+                union.update(sketches[i]);
+              }
+            }
+          }
+          break;
+
+        default: // Predicates on BYTES is not allowed.
+          throw new IllegalStateException("Illegal data type for " + getType() + " aggregation function: " + valueType);
+      }
+    }
+  }
+
+  @Override
+  public Map<String, Sketch> extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    Map<String, Union> result = aggregationResultHolder.getResult();
+    if (result == null) {
+      result = getDefaultResult(aggregationResultHolder, _predicateStrings);
+    }
+
+    return result.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getResult()));
+  }
+
+  @Override
+  public Map<String, Sketch> extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+    Map<String, Union> result = groupByResultHolder.getResult(groupKey);
+    if (result == null) {
+      result = getDefaultResult(groupByResultHolder, groupKey, _predicateStrings);
+    }
+
+    return result.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getResult()));
+  }
+
+  @Override
+  public Map<String, Sketch> merge(Map<String, Sketch> intermediateResult1, Map<String, Sketch> intermediateResult2) {
+    if (intermediateResult1 == null) {
+      return intermediateResult2;
+    } else if (intermediateResult2 == null) {
+      return intermediateResult1;
+    }
+
+    for (Map.Entry<String, Sketch> entry : intermediateResult1.entrySet()) {
+      String predicate = entry.getKey();
+      Union union = getSetOperationBuilder().buildUnion();
+      union.update(entry.getValue());
+      union.update(intermediateResult2.get(predicate));
+      intermediateResult1.put(predicate, union.getResult());
+    }
+    return intermediateResult1;
+  }
+
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return false;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getFinalResultColumnType() {
+    return DataSchema.ColumnDataType.INT;
+  }
+
+  @Override
+  public Integer extractFinalResult(Map<String, Sketch> intermediateResult) {
+    // Compute the post aggregation expression and return the result.
+    Sketch finalSketch = evalPostAggregationExpression(_postAggregationExpression, intermediateResult);
+    return (int) Math.round(finalSketch.getEstimate());
+  }
+
+  /**
+   * Returns the Default result for the given expression.
+   *
+   * @param aggregationResultHolder Aggregation result holder
+   * @param expressions Set of expressions that are expected in the result holder
+   * @return Default result
+   */
+  private Map<String, Union> getDefaultResult(AggregationResultHolder aggregationResultHolder,
+      Set<String> expressions) {
+    Map<String, Union> result = aggregationResultHolder.getResult();
+
+    if (result == null) {
+      result = new HashMap<>();
+      aggregationResultHolder.setValue(result);
+    }
+
+    for (String expression : expressions) {
+      result.putIfAbsent(expression, getSetOperationBuilder().buildUnion());
+    }
+    return result;
+  }
+
+  /**
+   * Returns the Default result for the given group key if exists, or creates a new one.
+   *
+   * @param groupByResultHolder Result holder
+   * @param groupKey Group key for which to return the default result
+   * @param expressions Set of expressions that are expected in the result holder
+   *
+   * @return Default result for the group-key
+   */
+  private Map<String, Union> getDefaultResult(GroupByResultHolder groupByResultHolder, int groupKey,
+      Set<String> expressions) {
+    Map<String, Union> result = groupByResultHolder.getResult(groupKey);
+
+    if (result == null) {
+      result = new HashMap<>();
+      groupByResultHolder.setValueForKey(groupKey, result);
+    }
+
+    for (String expression : expressions) {
+      result.putIfAbsent(expression, getSetOperationBuilder().buildUnion());
+    }
+    return result;
+  }
+
+  private Sketch[] deserializeSketches(byte[][] serializedSketches, int length) {
+    Sketch[] sketches = new Sketch[length];
+    for (int i = 0; i < length; i++) {
+      sketches[i] = Sketch.wrap(Memory.wrap(serializedSketches[i]));
+    }
+    return sketches;
+  }
+
+  private void init(List<String> arguments)
+      throws SqlParseException {
+    int numArgs = arguments.size();
+
+    // Predicate Strings are optional. When not specified, they are derived from postAggregationExpression
+    boolean predicatesSpecified = numArgs > 3;
+
+    // Initialize the Theta-Sketch Column.
+    _thetaSketchColumn = arguments.get(0);
+
+    // Initialize input expressions. It is expected they are covered between the theta-sketch column and the predicates.
+    _inputExpressions = new ArrayList<>();
+    _inputExpressions.add(TransformExpressionTree.compileToExpressionTree(_thetaSketchColumn));
+
+    // Initialize thetaSketchParams
+    String paramsString = arguments.get(1);
+    _thetaSketchParams = ThetaSketchParams.fromString(paramsString);
+
+    String postAggrExpressionString = arguments.get(numArgs - 1);
+    _postAggregationExpression = CalciteSqlParser.compileToExpression(postAggrExpressionString);
+
+    _predicateInfoSet = new LinkedHashSet<>();
+    _predicateStrings = new LinkedHashSet<>(arguments.subList(2, numArgs - 1));
+    _expressionMap = new HashMap<>();
+
+    if (predicatesSpecified) {
+      for (String predicateString : _predicateStrings) {
+        Expression expression = CalciteSqlParser.compileToExpression(predicateString);
+
+        // TODO: Add support for complex predicates with AND/OR.
+        String filterColumn = ParserUtils.getFilterColumn(expression);
+        Predicate predicate = Predicate
+            .newPredicate(ParserUtils.getFilterType(expression), filterColumn, ParserUtils.getFilterValues(expression));
+
+        _predicateInfoSet.add(new PredicateInfo(predicateString, filterColumn, predicate));
+        _expressionMap.put(expression, predicateString);
+        _inputExpressions.add(new TransformExpressionTree(new IdentifierAstNode(filterColumn)));
+      }
+    } else {
+      // Auto-derive predicates from postAggregationExpression.
+      Set<Expression> predicateExpressions = extractPredicatesFromString(postAggrExpressionString);
+      for (Expression predicateExpression : predicateExpressions) {
+        String filterColumn = ParserUtils.getFilterColumn(predicateExpression);
+        Predicate predicate = Predicate.newPredicate(ParserUtils.getFilterType(predicateExpression), filterColumn,
+            ParserUtils.getFilterValues(predicateExpression));
+
+        String predicateString = ParserUtils.standardizeExpression(predicateExpression, false);
+        _predicateStrings.add(predicateString);
+        _predicateInfoSet.add(new PredicateInfo(predicateString, filterColumn, predicate));
+        _expressionMap.put(predicateExpression, predicateString);
+        _inputExpressions.add(new TransformExpressionTree(new IdentifierAstNode(filterColumn)));
+      }
+    }
+  }
+
+  /**
+   * Given a post aggregation String of form like ((p1 and p2) or (p3 and p4)), returns the individual
+   * predicates p1, p2, p3, p4.
+   *
+   * @param postAggrExpressionString Post aggregation expression String input
+   * @return Set of predicates that compose the input expression
+   * @throws SqlParseException If invalid expression String specified
+   */
+  private Set<Expression> extractPredicatesFromString(String postAggrExpressionString)
+      throws SqlParseException {
+    Set<Expression> predicates = new LinkedHashSet<>();
+    _postAggregationExpression = CalciteSqlParser.compileToExpression(postAggrExpressionString);
+    extractPredicatesFromExpression(_postAggregationExpression, predicates);
+    return predicates;
+  }
+
+  private void extractPredicatesFromExpression(Expression expression, Set<Expression> predicates) {
+    ExpressionType type = expression.getType();
+
+    if (type.equals(ExpressionType.FUNCTION)) {
+      Function function = expression.getFunctionCall();
+      FilterKind filterKind = FilterKind.valueOf(function.getOperator());
+
+      List<Expression> operands = function.getOperands();
+      if (filterKind.equals(FilterKind.AND) || filterKind.equals(FilterKind.OR)) {
+        for (Expression operand : operands) {
+          extractPredicatesFromExpression(operand, predicates);
+        }
+      } else {
+        predicates.add(expression);
+      }
+    } // else do nothing
+  }
+
+  /**
+   * Evaluates the theta-sketch post-aggregation expression, which is composed by performing AND/OR on top of
+   * pre-defined predicates. These predicates are evaluated during the aggregation phase, and the cached
+   * result is passed to this method to be used when evaluating the expression.
+   *
+   * @param expression Expression to evaluate, this is built by applying AND/OR on precomputed sketches
+   * @param intermediateResult Precomputed sketches for predicates that are part of the expression.
+   * @return Overall evaluated sketch for the expression.
+   */
+  private Sketch evalPostAggregationExpression(Expression expression, Map<String, Sketch> intermediateResult) {
+    Function functionCall = expression.getFunctionCall();
+    FilterKind kind = FilterKind.valueOf(functionCall.getOperator());
+    Sketch result;
+
+    switch (kind) {
+      case AND:
+        Intersection intersection = getSetOperationBuilder().buildIntersection();
+        for (Expression operand : functionCall.getOperands()) {
+          intersection.update(evalPostAggregationExpression(operand, intermediateResult));
+        }
+        result = intersection.getResult();
+        break;
+
+      case OR:
+        Union union = getSetOperationBuilder().buildUnion();
+        for (Expression operand : functionCall.getOperands()) {
+          union.update(evalPostAggregationExpression(operand, intermediateResult));
+        }
+        result = union.getResult();
+        break;
+
+      default:
+        String predicate = _expressionMap.get(expression);
+        result = intermediateResult.get(predicate);
+        Preconditions.checkState(result != null, "Precomputed sketch for predicate not provided: " + predicate);
+        break;
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns the theta-sketch SetOperation builder properly configured.
+   * Currently, only setting of nominalEntries is supported.
+   * @return SetOperationBuilder
+   */
+  private SetOperationBuilder getSetOperationBuilder() {
+    return (_thetaSketchParams == null) ? SetOperation.builder()
+        : SetOperation.builder().setNominalEntries(_thetaSketchParams.getNominalEntries());
+  }
+
+  /**
+   * Helper class to store predicate related information:
+   * <ul>
+   *   <li> String representation of the predicate. </li>
+   *   <li> LHS column of the predicate. </li>
+   *   <li> Complied {@link Predicate}. </li>
+   *   <li> Predicate Evaluator. </li>
+   * </ul>
+   *
+   */
+  private static class PredicateInfo {
+
+    private final String _stringVal;
+    private final String _column; // LHS
+    private final Predicate _predicate;
+    private PredicateEvaluator _predicateEvaluator;
+
+    private PredicateInfo(String stringVal, String column, Predicate predicate) {
+      _stringVal = stringVal;
+      _column = column;
+      _predicate = predicate;
+      _predicateEvaluator = null; // Initialized lazily
+    }
+
+    public String getStringVal() {
+      return _stringVal;
+    }
+
+    public String getColumn() {
+      return _column;
+    }
+
+    public Predicate getPredicate() {
+      return _predicate;
+    }
+
+    /**
+     * Since PredicateEvaluator requires data-type, it is initialized lazily.
+     *
+     * @param dataType Data type for RHS of the predicate
+     * @return Predicate Evaluator
+     */
+    public PredicateEvaluator getPredicateEvaluator(FieldSpec.DataType dataType) {
+      if (_predicateEvaluator != null) {
+        return _predicateEvaluator;
+      }
+
+      // Theta-sketch does not work on INT and FLOAT.
+      if (dataType == FieldSpec.DataType.INT) {
+        dataType = FieldSpec.DataType.LONG;
+      } else if (dataType == FieldSpec.DataType.FLOAT) {
+        dataType = FieldSpec.DataType.DOUBLE;
+      }
+
+      _predicateEvaluator = PredicateEvaluatorProvider.getPredicateEvaluator(_predicate, null, dataType);
+      return _predicateEvaluator;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+
+      if (!(o instanceof PredicateInfo)) {
+        return false;
+      }
+
+      PredicateInfo that = (PredicateInfo) o;
+      return Objects.equals(_stringVal, that._stringVal) && Objects.equals(_column, that._column) && Objects
+          .equals(_predicate, that._predicate);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_stringVal, _column, _predicate);
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/executor/StarTreeAggregationExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/executor/StarTreeAggregationExecutor.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.core.startree.executor;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
@@ -40,14 +43,19 @@ import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
  */
 public class StarTreeAggregationExecutor extends DefaultAggregationExecutor {
   // StarTree converts column names from min(col) to min__col, this is to store the original mapping.
-  private final String[] _functionArgs;
+  private final String[][] _functionArgs;
 
   public StarTreeAggregationExecutor(AggregationFunctionContext[] functionContexts) {
     super(StarTreeUtils.createStarTreeFunctionContexts(functionContexts));
 
-    _functionArgs = new String[functionContexts.length];
+    _functionArgs = new String[functionContexts.length][];
     for (int i = 0; i < functionContexts.length; i++) {
-      _functionArgs[i] = functionContexts[i].getColumnName();
+      List<String> expressions = functionContexts[i].getExpressions();
+      _functionArgs[i] = new String[expressions.size()];
+
+      for (int j = 0; j < expressions.size(); j++) {
+        _functionArgs[i][j] = expressions.get(j);
+      }
     }
   }
 
@@ -58,11 +66,21 @@ public class StarTreeAggregationExecutor extends DefaultAggregationExecutor {
       AggregationFunction function = _functions[i];
       AggregationResultHolder resultHolder = _resultHolders[i];
 
-      BlockValSet blockValueSet = (function.getType() == AggregationFunctionType.COUNT) ? transformBlock
-          .getBlockValueSet(AggregationFunctionColumnPair.COUNT_STAR_COLUMN_NAME) :
+      AggregationFunctionType functionType = function.getType();
+      if ((functionType == AggregationFunctionType.COUNT)) {
+        BlockValSet blockValueSet =
+            transformBlock.getBlockValueSet(AggregationFunctionColumnPair.COUNT_STAR_COLUMN_NAME);
+        function.aggregate(length, resultHolder, Collections.singletonMap(_functionArgs[i][0], blockValueSet));
+      } else {
 
-          transformBlock.getBlockValueSet(_expressions[i].getValue());
-      function.aggregate(length, resultHolder, Collections.singletonMap(_functionArgs[i], blockValueSet));
+        Map<String, BlockValSet> blockValSetMap = new HashMap<>();
+        for (int j = 0; j < _functionArgs[i].length; j++) {
+          blockValSetMap.put(_functionArgs[i][j], transformBlock.getBlockValueSet(
+              AggregationFunctionColumnPair.toColumnName(functionType, _expressions[i][j].getValue())));
+        }
+
+        function.aggregate(length, resultHolder, blockValSetMap);
+      }
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/AggregationFunctionColumnPair.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/AggregationFunctionColumnPair.java
@@ -53,7 +53,12 @@ public class AggregationFunctionColumnPair {
 
   @Nonnull
   public String toColumnName() {
-    return _functionType.getName() + DELIMITER + _column;
+    return toColumnName(_functionType, _column);
+  }
+
+  @Nonnull
+  public static String toColumnName(AggregationFunctionType functionType, String column) {
+    return functionType.getName() + DELIMITER + column;
   }
 
   @Nonnull

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountThetaSketchTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountThetaSketchTest.java
@@ -1,0 +1,353 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import joptsimple.internal.Strings;
+import org.apache.commons.io.FileUtils;
+import org.apache.datasketches.theta.UpdateSketch;
+import org.apache.datasketches.theta.UpdateSketchBuilder;
+import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.response.broker.AggregationResult;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.GroupByResult;
+import org.apache.pinot.common.segment.ReadMode;
+import org.apache.pinot.core.data.manager.SegmentDataManager;
+import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.MetricFieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link org.apache.pinot.core.query.aggregation.function.DistinctCountThetaSketchAggregationFunction}.
+ * <ul>
+ *   <li> Generates a segment with 3 dimension columns with low cardinality (to increase distinct count). </li>
+ *   <li> Runs various queries and compares result of distinctCountThetaSketch against distinctCount function. </li>
+ * </ul>
+ */
+public class DistinctCountThetaSketchTest extends BaseQueriesTest {
+  protected static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "DistinctCountThetaSketchTest");
+  protected static final String TABLE_NAME = "testTable";
+  protected static final String SEGMENT_NAME = "testSegment";
+
+  protected static final int NUM_ROWS = 1001;
+  protected static final long RANDOM_SEED = System.nanoTime();
+
+  private static final String THETA_SKETCH_COLUMN = "colTS";
+  private static final String DISTINCT_COLUMN = "distinctColumn";
+  private static final List<String> ALL_COLUMNS;
+
+  static {
+    ALL_COLUMNS = Arrays.asList("colA", "colB", "colC", DISTINCT_COLUMN, THETA_SKETCH_COLUMN);
+  }
+
+  private static final List<String> DIMENSIONS = ALL_COLUMNS.subList(0, 3);
+
+  private static Random RANDOM = new Random(RANDOM_SEED);
+  protected static final int MAX_CARDINALITY = 5; // 3 columns will lead to at most 125 groups
+
+  private ImmutableSegment _indexSegment;
+  private List<SegmentDataManager> _segmentDataManagers;
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+
+    File segmentFile = buildSegment(buildSchema());
+    _indexSegment = ImmutableSegmentLoader.load(segmentFile, ReadMode.mmap);
+    _segmentDataManagers =
+        Arrays.asList(new ImmutableSegmentDataManager(_indexSegment), new ImmutableSegmentDataManager(_indexSegment));
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _indexSegment.destroy();
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  @Test
+  public void testAggregationPql() {
+    testThetaSketches(false, false);
+  }
+
+  @Test
+  public void testAggregationSql() {
+    testThetaSketches(false, true);
+  }
+
+  @Test
+  public void testGroupByPql() {
+    testThetaSketches(true, false);
+  }
+
+  @Test
+  public void testGroupBySql() {
+    testThetaSketches(true, true);
+  }
+
+  private void testThetaSketches(boolean groupBy, boolean sql) {
+    List<String> predicates = Collections.singletonList("colA = 'colA_1'");
+    String whereClause = Strings.join(predicates, " or ");
+    testQuery(whereClause, null, predicates, whereClause, groupBy, sql);
+
+    // Test Intersection (AND)
+    predicates = Arrays.asList("colA = 'colA_1'", "colB >= 'colB_1'", "colC <> 'colC_1'");
+    whereClause = Strings.join(predicates, " and ");
+    testQuery(whereClause, "nominalEntries=1001", predicates, whereClause, groupBy, sql);
+
+    // Test Union (OR)
+    predicates = Arrays.asList("colA = 'colA_1'", "colB = 'colB_2'");
+    whereClause = Strings.join(predicates, " or ");
+    testQuery(whereClause, " nominalEntries =1001 ", predicates, whereClause, groupBy, sql);
+
+    // Test complex predicates
+    predicates =
+        Arrays.asList("colA in ('colA_1', 'colA_2')", "colB not in ('colB_1')", "colC between 'colC_1' and 'colC_5'");
+    whereClause =
+        predicates.get(0) + " and " + predicates.get(1) + " or " + predicates.get(0) + " and " + predicates.get(2);
+    testQuery(whereClause, "nominalEntries =  1001", predicates, whereClause, groupBy, sql);
+
+    // Test without predicate arguments
+    whereClause =
+        predicates.get(0) + " and " + predicates.get(1) + " or " + predicates.get(0) + " and " + predicates.get(2);
+    testQuery(whereClause, "nominalEntries =  1001", Collections.emptyList(), whereClause, groupBy, sql);
+  }
+
+  private void testQuery(String whereClause, String thetaSketchParams, List<String> predicateStrings,
+      String postAggregationExpression, boolean groupBy, boolean sql) {
+    String tsQuery = buildQuery(whereClause, thetaSketchParams, predicateStrings, postAggregationExpression, groupBy);
+    String distinctQuery = buildQuery(whereClause, null, null, null, groupBy);
+
+    Map<String, String> queryOptions = Collections.emptyMap();
+    BrokerResponseNative actualResponse =
+        (sql) ? getBrokerResponseForSqlQuery(tsQuery) : getBrokerResponseForPqlQuery(tsQuery, queryOptions);
+
+    BrokerResponseNative expectedResponse =
+        (sql) ? getBrokerResponseForSqlQuery(distinctQuery) : getBrokerResponseForPqlQuery(distinctQuery, queryOptions);
+
+    if (groupBy) {
+      compareGroupBy(actualResponse, expectedResponse, sql);
+    } else {
+      compareAggregation(actualResponse, expectedResponse, sql);
+    }
+  }
+
+  private void compareAggregation(BrokerResponseNative actualResponse, BrokerResponseNative expectedResponse,
+      boolean sql) {
+    if (sql) {
+      compareSql(actualResponse, expectedResponse);
+    } else {
+      compareAggregationPql(actualResponse, expectedResponse);
+    }
+  }
+
+  private void compareGroupBy(BrokerResponseNative actualResponse, BrokerResponseNative expectedResponse, boolean sql) {
+    if (sql) {
+      compareSql(actualResponse, expectedResponse);
+    } else {
+      compareGroupByPql(actualResponse, expectedResponse);
+    }
+  }
+
+  private void compareAggregationPql(BrokerResponseNative actualResponse, BrokerResponseNative expectedResponse) {
+    List<AggregationResult> actualResults = actualResponse.getAggregationResults();
+    Assert.assertEquals(actualResults.size(), 1);
+    double actual = Double.parseDouble((String) actualResults.get(0).getValue());
+
+    List<AggregationResult> expectedResults = expectedResponse.getAggregationResults();
+    double expected = Double.parseDouble((String) expectedResults.get(0).getValue());
+
+    Assert.assertEquals(actual, expected, (expected * 0.1), // Allow for 10 % error.
+        "Distinct count mismatch: actual: " + actual + "expected: " + expected + "seed:" + RANDOM_SEED);
+  }
+
+  private void compareSql(BrokerResponseNative actualResponse, BrokerResponseNative expectedResponse) {
+    List<Object[]> actualRows = actualResponse.getResultTable().getRows();
+    List<Object[]> expectedRows = expectedResponse.getResultTable().getRows();
+
+    Assert.assertEquals(actualRows.size(), expectedRows.size());
+
+    for (int i = 0; i < actualRows.size(); i++) {
+      Assert.assertEquals(actualRows.get(i), expectedRows.get(i));
+    }
+  }
+
+  private void compareGroupByPql(BrokerResponseNative actualResponse, BrokerResponseNative expectedResponse) {
+    AggregationResult actualResult = actualResponse.getAggregationResults().get(0);
+    List<GroupByResult> actualGroupBy = actualResult.getGroupByResult();
+
+    AggregationResult expectedResult = expectedResponse.getAggregationResults().get(0);
+    List<GroupByResult> expectedGroupBy = expectedResult.getGroupByResult();
+
+    Assert.assertEquals(actualGroupBy.size(), expectedGroupBy.size());
+    for (int i = 0; i < actualGroupBy.size(); i++) {
+      double actual = Double.parseDouble((String) actualGroupBy.get(i).getValue());
+      double expected = Double.parseDouble((String) expectedGroupBy.get(i).getValue());
+
+      Assert.assertEquals(actual, expected, (expected * 0.1), // Allow for 10 % error.
+          "Distinct count mismatch: actual: " + actual + "expected: " + expected + "seed:" + RANDOM_SEED);
+    }
+  }
+
+  private String buildQuery(String whereClause, String thetaSketchParams, List<String> thetaSketchPredicates,
+      String postAggregationExpression, boolean groupBy) {
+    String column;
+    String aggrFunction;
+    boolean thetaSketch = (postAggregationExpression != null);
+
+    if (thetaSketch) {
+      aggrFunction = AggregationFunctionType.DISTINCTCOUNTTHETASKETCH.getName();
+      column = THETA_SKETCH_COLUMN;
+    } else {
+      aggrFunction = AggregationFunctionType.DISTINCTCOUNT.getName();
+      column = DISTINCT_COLUMN;
+    }
+
+    StringBuilder sb = new StringBuilder("select ");
+    sb.append(aggrFunction);
+    sb.append("(");
+    sb.append(column);
+
+    if (thetaSketch) {
+      sb.append(", ");
+
+      sb.append("'");
+      if (thetaSketchParams != null) {
+        sb.append(thetaSketchParams);
+      }
+      sb.append("', ");
+
+      for (String predicate : thetaSketchPredicates) {
+        sb.append("\"");
+        sb.append(predicate);
+        sb.append("\"");
+        sb.append(", ");
+      }
+      sb.append("\"");
+      sb.append(postAggregationExpression);
+      sb.append("\"");
+    }
+
+    sb.append(") from ");
+
+    sb.append(TABLE_NAME);
+    sb.append(" where ");
+    sb.append(whereClause);
+
+    if (groupBy) {
+      sb.append(" group by colA, colB");
+    }
+
+    return sb.toString();
+  }
+
+  @Override
+  protected String getFilter() {
+    return ""; // No filters required for this test.
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<SegmentDataManager> getSegmentDataManagers() {
+    return _segmentDataManagers;
+  }
+
+  protected File buildSegment(Schema schema)
+      throws Exception {
+
+    StringBuilder stringBuilder = new StringBuilder();
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      stringBuilder.setLength(0);
+      HashMap<String, Object> valueMap = new HashMap<>();
+
+      for (String dimension : DIMENSIONS) {
+        String value = dimension + "_" + (i % (1 + RANDOM.nextInt(MAX_CARDINALITY)));
+        valueMap.put(dimension, value);
+
+        stringBuilder.append(value);
+      }
+
+      String distinctValue = stringBuilder.toString();
+      valueMap.put(DISTINCT_COLUMN, distinctValue);
+
+      UpdateSketch sketch = new UpdateSketchBuilder().build();
+      sketch.update(distinctValue);
+      valueMap.put(THETA_SKETCH_COLUMN, sketch.compact().toByteArray());
+
+      GenericRow genericRow = new GenericRow();
+      genericRow.init(valueMap);
+      rows.add(genericRow);
+    }
+
+    SegmentGeneratorConfig config =
+        new SegmentGeneratorConfig(new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build(), schema);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+
+    config.setRawIndexCreationColumns(Collections.singletonList(THETA_SKETCH_COLUMN));
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+
+    try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
+      driver.init(config, recordReader);
+      driver.build();
+    }
+
+    return driver.getOutputDirectory();
+  }
+
+  private Schema buildSchema() {
+    Schema schema = new Schema();
+    DIMENSIONS.forEach(column -> schema.addField(new DimensionFieldSpec(column, FieldSpec.DataType.STRING, true)));
+
+    schema.addField(new DimensionFieldSpec(DISTINCT_COLUMN, FieldSpec.DataType.STRING, true));
+    schema.addField(new MetricFieldSpec(THETA_SKETCH_COLUMN, FieldSpec.DataType.BYTES));
+    return schema;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -874,6 +874,11 @@
         <version>2.7.0</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.datasketches</groupId>
+        <artifactId>datasketches-java</artifactId>
+        <version>1.2.0-incubating</version>
+      </dependency>
+      <dependency>
         <groupId>com.tdunning</groupId>
         <artifactId>t-digest</artifactId>
         <version>3.2</version>


### PR DESCRIPTION
1. Added an initial implementation for theta-sketch based distinct count
       aggregation function, which can be invoked as follows:
       `select distinctCountThetaSketch(thetaSketchColumn, thetaSketchParams, p1, p2..pn, postAggrExpression)`
        - Required: thetaSketchColumn is the column of type BYTES that stores serialized theta sketches.
        - Required: thetaSketchParams in the form "param1=v1;param2=v2..", pass empty literal '' if no params.
        - Optional: p1, p2 etc are filter predicates that make up the postAggregationExpression
        - Required: postAggrExpression is the expression built with AND/OR on predicates p1..pn.
        Example:
        `select distinctCountThetaSketch(tsCol, "nominalEntries=1024", "dim1='foo', dim2='bar', "dim1 = 'foo and dim2='bar') from table where dim1 = 'foo' or dim2 = 'bar'`
    

2. The aggregation function works as follows:
   - The postAggrExpression is basically an expression that AND/OR's some predicates,
     these predicates are expected to be specified as part of aggregation function.
   - The aggregation goes over all values in the blockValSet and applies each predicate
     on the values. If the predicate is satisfied, the theta-sketch is aggregated and stored
     as value in a map, where the key is the predicate.
   - Once all theta-sketches corresponding to all predicates are evaluated, across all segments
     and servers, the final result is computed by evaluating the postAggrFunction, by performing
     set operations on predicate theta-sketches (AND = intersection, OR = union).

3. The Theta-Sketch library being used is from org.apache.datasketches.

4. Now that more than one aggregation functions take multiple arguments, generalized handling of
   multiple args, and removed special casing of Distinct.

5. Refactored methods from PinotQuery2BrokerRequestConverter to reusable utility class ParserUtils.

6. Added unit tests for new code.

TODO:
1. Performance tuning to ensure the aggregation function works at par.
2. Support complex predicates p1, p2, p3, current PR only supports predicates of form like `LHS = RHS`, `LHS IN (...)`, etc.
3. Evaluate theta-sketch creation params, and pick default or come up with ways
   to configure (by user).
4. MultiValue aggregation support.
5. Auto derive predicates that make up postAggrExpression, so they don't need to be specified
   in the aggregation function.
6. Auto sharding of Sketches with high cardinality into smaller ones to improve accuracy.
7. Pql2Compiler.compileToExpressionTree does not seem to handle parenthesized expressions,
   e.g., ((col1 = 1 and col2 = 2) or col3 = 3).