### PR TITLE
Allow configuring minion task timeout in the PinotTaskGenerator

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -144,7 +144,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         LOGGER
             .info("Submitting {} tasks for task type: {} with task configs: {}", numTasks, taskType, pinotTaskConfigs);
         tasksScheduled.put(taskType, _helixTaskResourceManager
-            .submitTask(pinotTaskConfigs, pinotTaskGenerator.getNumConcurrentTasksPerInstance()));
+            .submitTask(pinotTaskConfigs, pinotTaskGenerator.getTaskTimeoutMs(),
+                pinotTaskGenerator.getNumConcurrentTasksPerInstance()));
         _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_TASKS_SUBMITTED, numTasks);
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.data.Segment;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoProvider;
@@ -46,15 +45,13 @@ public class ConvertToRawIndexTaskGenerator implements PinotTaskGenerator {
     _clusterInfoProvider = clusterInfoProvider;
   }
 
-  @Nonnull
   @Override
   public String getTaskType() {
     return MinionConstants.ConvertToRawIndexTask.TASK_TYPE;
   }
 
-  @Nonnull
   @Override
-  public List<PinotTaskConfig> generateTasks(@Nonnull List<TableConfig> tableConfigs) {
+  public List<PinotTaskConfig> generateTasks(List<TableConfig> tableConfigs) {
     List<PinotTaskConfig> pinotTaskConfigs = new ArrayList<>();
 
     // Get the segments that are being converted so that we don't submit them again
@@ -80,7 +77,7 @@ public class ConvertToRawIndexTaskGenerator implements PinotTaskGenerator {
       String tableMaxNumTasksConfig = taskConfigs.get(MinionConstants.TABLE_MAX_NUM_TASKS_KEY);
       if (tableMaxNumTasksConfig != null) {
         try {
-          tableMaxNumTasks = Integer.valueOf(tableMaxNumTasksConfig);
+          tableMaxNumTasks = Integer.parseInt(tableMaxNumTasksConfig);
         } catch (Exception e) {
           tableMaxNumTasks = Integer.MAX_VALUE;
         }
@@ -126,14 +123,5 @@ public class ConvertToRawIndexTaskGenerator implements PinotTaskGenerator {
     }
 
     return pinotTaskConfigs;
-  }
-
-  @Override
-  public int getNumConcurrentTasksPerInstance() {
-    return DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
-  }
-
-  @Override
-  public void nonLeaderCleanUp() {
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.controller.helix.core.minion.generator;
 
 import java.util.List;
-import javax.annotation.Nonnull;
 import org.apache.helix.task.JobConfig;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -29,14 +28,12 @@ import org.apache.pinot.spi.config.table.TableConfig;
  * The interface <code>PinotTaskGenerator</code> defines the APIs for task generators.
  */
 public interface PinotTaskGenerator {
-  int DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE = JobConfig.DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
 
   /**
    * Returns the task type of the generator.
    *
    * @return Task type of the generator
    */
-  @Nonnull
   String getTaskType();
 
   /**
@@ -44,18 +41,29 @@ public interface PinotTaskGenerator {
    *
    * @return List of tasks to schedule
    */
-  @Nonnull
-  List<PinotTaskConfig> generateTasks(@Nonnull List<TableConfig> tableConfigs);
+  List<PinotTaskConfig> generateTasks(List<TableConfig> tableConfigs);
 
   /**
-   * Returns the maximum number of concurrent tasks allowed per instance.
+   * Returns the timeout in milliseconds for each task, 3600000 (1 hour) by default.
+   *
+   * @return Timeout in milliseconds for each task.
+   */
+  default long getTaskTimeoutMs() {
+    return JobConfig.DEFAULT_TIMEOUT_PER_TASK;
+  }
+
+  /**
+   * Returns the maximum number of concurrent tasks allowed per instance, 1 by default.
    *
    * @return Maximum number of concurrent tasks allowed per instance
    */
-  int getNumConcurrentTasksPerInstance();
+  default int getNumConcurrentTasksPerInstance() {
+    return JobConfig.DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
+  }
 
   /**
    * Performs necessary cleanups (e.g. remove metrics) when the controller leadership changes.
    */
-  void nonLeaderCleanUp();
+  default void nonLeaderCleanUp() {
+  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -205,15 +205,13 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
       _clusterInfoProvider = clusterInfoProvider;
     }
 
-    @Nonnull
     @Override
     public String getTaskType() {
       return TASK_TYPE;
     }
 
-    @Nonnull
     @Override
-    public List<PinotTaskConfig> generateTasks(@Nonnull List<TableConfig> tableConfigs) {
+    public List<PinotTaskConfig> generateTasks(List<TableConfig> tableConfigs) {
       assertEquals(tableConfigs.size(), 2);
 
       // Generate at most 2 tasks
@@ -229,15 +227,6 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
         taskConfigs.add(new PinotTaskConfig(TASK_TYPE, configs));
       }
       return taskConfigs;
-    }
-
-    @Override
-    public int getNumConcurrentTasksPerInstance() {
-      return DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
-    }
-
-    @Override
-    public void nonLeaderCleanUp() {
     }
   }
 


### PR DESCRIPTION
The default task timeout is set to 1 hour. For certain expensive tasks, this might not be enough.
Making it configurable for each task type