### PR TITLE
Use time column from table config instead of schema

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/AutoAddInvertedIndex.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/AutoAddInvertedIndex.java
@@ -230,14 +230,20 @@ public class AutoAddInvertedIndex {
       }
 
       // Skip tables without a proper time column
-      TimeFieldSpec timeFieldSpec = tableSchema.getTimeFieldSpec();
-      if (timeFieldSpec == null || timeFieldSpec.getDataType() == FieldSpec.DataType.STRING) {
+      String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+      if (timeColumnName == null) {
+        LOGGER.info(
+            "Table: {}, skip adding inverted index because it does not have a time column specified in the table config",
+            tableNameWithType);
+        continue;
+      }
+      FieldSpec fieldSpec = tableSchema.getFieldSpecFor(timeColumnName);
+      if (fieldSpec == null || fieldSpec.getDataType() == FieldSpec.DataType.STRING) {
         LOGGER.info("Table: {}, skip adding inverted index because it does not have a numeric time column",
             tableNameWithType);
         continue;
       }
-      String timeColumnName = timeFieldSpec.getName();
-      TimeUnit timeUnit = timeFieldSpec.getOutgoingGranularitySpec().getTimeType();
+      TimeUnit timeUnit = ((TimeFieldSpec) fieldSpec).getOutgoingGranularitySpec().getTimeType();
       if (timeUnit != TimeUnit.DAYS) {
         LOGGER.warn("Table: {}, time column {] has non-DAYS time unit: {}", timeColumnName, timeUnit);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -25,7 +25,6 @@ public class MinionConstants {
   public static final String TASK_TIME_SUFFIX = ".time";
 
   public static final String TABLE_NAME_KEY = "tableName";
-  public static final String TIME_COLUMN_NAME_KEY = "timeColumnName";
   public static final String SEGMENT_NAME_KEY = "segmentName";
   public static final String DOWNLOAD_URL_KEY = "downloadURL";
   public static final String UPLOAD_URL_KEY = "uploadURL";

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -25,6 +25,7 @@ public class MinionConstants {
   public static final String TASK_TIME_SUFFIX = ".time";
 
   public static final String TABLE_NAME_KEY = "tableName";
+  public static final String TIME_COLUMN_NAME_KEY = "timeColumnName";
   public static final String SEGMENT_NAME_KEY = "segmentName";
   public static final String DOWNLOAD_URL_KEY = "downloadURL";
   public static final String UPLOAD_URL_KEY = "uploadURL";

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -47,6 +47,7 @@ import org.apache.pinot.core.util.SchemaUtils;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
@@ -62,42 +63,39 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(HLRealtimeSegmentDataManager.class);
   private final static long ONE_MINUTE_IN_MILLSEC = 1000 * 60;
 
-  private final String tableNameWithType;
-  private final String segmentName;
-  private final Schema schema;
-  private final String timeColumnName;
+  private final String _tableNameWithType;
+  private final String _segmentName;
+  private final String _timeColumnName;
+  private final TimeUnit _timeType;
   private final RecordTransformer _recordTransformer;
-  private final RealtimeSegmentZKMetadata segmentMetatdaZk;
 
-  private final StreamConsumerFactory _streamConsumerFactory;
   private final StreamLevelConsumer _streamLevelConsumer;
-  private final File resourceDir;
-  private final File resourceTmpDir;
-  private final MutableSegmentImpl realtimeSegment;
-  private final String tableStreamName;
+  private final File _resourceTmpDir;
+  private final MutableSegmentImpl _realtimeSegment;
+  private final String _tableStreamName;
   private final StreamConfig _streamConfig;
 
-  private final long start = System.currentTimeMillis();
-  private long segmentEndTimeThreshold;
-  private AtomicLong lastUpdatedRawDocuments = new AtomicLong(0);
+  private final long _start = System.currentTimeMillis();
+  private long _segmentEndTimeThreshold;
+  private AtomicLong _lastUpdatedRawDocuments = new AtomicLong(0);
 
-  private volatile boolean keepIndexing = true;
-  private volatile boolean isShuttingDown = false;
+  private volatile boolean _keepIndexing = true;
+  private volatile boolean _isShuttingDown = false;
 
-  private TimerTask segmentStatusTask;
-  private final ServerMetrics serverMetrics;
-  private final RealtimeTableDataManager notifier;
-  private Thread indexingThread;
+  private final TimerTask _segmentStatusTask;
+  private final ServerMetrics _serverMetrics;
+  private final RealtimeTableDataManager _notifier;
+  private Thread _indexingThread;
 
-  private final String sortedColumn;
-  private final List<String> invertedIndexColumns;
-  private final List<String> noDictionaryColumns;
-  private final List<String> varLengthDictionaryColumns;
-  private Logger segmentLogger = LOGGER;
+  private final String _sortedColumn;
+  private final List<String> _invertedIndexColumns;
+  private final List<String> _noDictionaryColumns;
+  private final List<String> _varLengthDictionaryColumns;
+  private final Logger _segmentLogger;
   private final SegmentVersion _segmentVersion;
 
-  private Meter tableAndStreamRowsConsumed = null;
-  private Meter tableRowsConsumed = null;
+  private Meter _tableAndStreamRowsConsumed = null;
+  private Meter _tableRowsConsumed = null;
 
   // An instance of this class exists only for the duration of the realtime segment that is currently being consumed.
   // Once the segment is committed, the segment is handled by OfflineSegmentDataManager
@@ -108,29 +106,29 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       throws Exception {
     super();
     _segmentVersion = indexLoadingConfig.getSegmentVersion();
-    this.schema = schema;
     _recordTransformer = CompositeTransformer.getDefaultTransformer(schema);
-    this.serverMetrics = serverMetrics;
-    this.segmentName = realtimeSegmentZKMetadata.getSegmentName();
-    this.tableNameWithType = tableConfig.getTableName();
-    this.timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+    _serverMetrics = serverMetrics;
+    _segmentName = realtimeSegmentZKMetadata.getSegmentName();
+    _tableNameWithType = tableConfig.getTableName();
+    _timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+    _timeType = ((TimeFieldSpec) schema.getFieldSpecFor(_timeColumnName)).getOutgoingGranularitySpec().getTimeType();
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {
       LOGGER.info("RealtimeDataResourceZKMetadata contains no information about sorted column for segment {}",
-          segmentName);
-      this.sortedColumn = null;
+          _segmentName);
+      _sortedColumn = null;
     } else {
       String firstSortedColumn = sortedColumns.get(0);
-      if (this.schema.hasColumn(firstSortedColumn)) {
+      if (schema.hasColumn(firstSortedColumn)) {
         LOGGER.info("Setting sorted column name: {} from RealtimeDataResourceZKMetadata for segment {}",
-            firstSortedColumn, segmentName);
-        this.sortedColumn = firstSortedColumn;
+            firstSortedColumn, _segmentName);
+        _sortedColumn = firstSortedColumn;
       } else {
         LOGGER
             .warn("Sorted column name: {} from RealtimeDataResourceZKMetadata is not existed in schema for segment {}.",
-                firstSortedColumn, segmentName);
-        this.sortedColumn = null;
+                firstSortedColumn, _segmentName);
+        _sortedColumn = null;
       }
     }
 
@@ -139,40 +137,36 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // We need to add sorted column into inverted index columns because when we convert realtime in memory segment into
     // offline segment, we use sorted column's inverted index to maintain the order of the records so that the records
     // are sorted on the sorted column.
-    if (sortedColumn != null) {
-      invertedIndexColumns.add(sortedColumn);
+    if (_sortedColumn != null) {
+      invertedIndexColumns.add(_sortedColumn);
     }
-    this.invertedIndexColumns = new ArrayList<>(invertedIndexColumns);
-
-    this.segmentMetatdaZk = realtimeSegmentZKMetadata;
+    _invertedIndexColumns = new ArrayList<>(invertedIndexColumns);
 
     // No DictionaryColumns
-    noDictionaryColumns = new ArrayList<>(indexLoadingConfig.getNoDictionaryColumns());
+    _noDictionaryColumns = new ArrayList<>(indexLoadingConfig.getNoDictionaryColumns());
 
-    varLengthDictionaryColumns = new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns());
+    _varLengthDictionaryColumns = new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns());
 
-    _streamConfig = new StreamConfig(tableNameWithType, tableConfig.getIndexingConfig().getStreamConfigs());
+    _streamConfig = new StreamConfig(_tableNameWithType, tableConfig.getIndexingConfig().getStreamConfigs());
 
-    segmentLogger = LoggerFactory.getLogger(
-        HLRealtimeSegmentDataManager.class.getName() + "_" + segmentName + "_" + _streamConfig.getTopicName());
-    segmentLogger.info("Created segment data manager with Sorted column:{}, invertedIndexColumns:{}", sortedColumn,
-        this.invertedIndexColumns);
+    _segmentLogger = LoggerFactory.getLogger(
+        HLRealtimeSegmentDataManager.class.getName() + "_" + _segmentName + "_" + _streamConfig.getTopicName());
+    _segmentLogger.info("Created segment data manager with Sorted column:{}, invertedIndexColumns:{}", _sortedColumn,
+        _invertedIndexColumns);
 
-    segmentEndTimeThreshold = start + _streamConfig.getFlushThresholdTimeMillis();
-
-    this.resourceDir = new File(resourceDataDir);
-    this.resourceTmpDir = new File(resourceDataDir, "_tmp");
-    if (!resourceTmpDir.exists()) {
-      resourceTmpDir.mkdirs();
+    _segmentEndTimeThreshold = _start + _streamConfig.getFlushThresholdTimeMillis();
+    _resourceTmpDir = new File(resourceDataDir, "_tmp");
+    if (!_resourceTmpDir.exists()) {
+      _resourceTmpDir.mkdirs();
     }
     // create and init stream level consumer
-    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
+    StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
     String clientId = HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getTopicName();
-    _streamLevelConsumer = _streamConsumerFactory
-        .createStreamLevelConsumer(clientId, tableNameWithType, SchemaUtils.extractSourceFields(schema),
-            instanceMetadata.getGroupId(tableNameWithType));
+    _streamLevelConsumer = streamConsumerFactory
+        .createStreamLevelConsumer(clientId, _tableNameWithType, SchemaUtils.extractSourceFields(schema),
+            instanceMetadata.getGroupId(_tableNameWithType));
     _streamLevelConsumer.start();
-    tableStreamName = tableNameWithType + "_" + _streamConfig.getTopicName();
+    _tableStreamName = _tableNameWithType + "_" + _streamConfig.getTopicName();
 
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     if (indexingConfig != null && indexingConfig.isAggregateMetrics()) {
@@ -180,28 +174,28 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
 
     // lets create a new realtime segment
-    segmentLogger.info("Started {} stream provider", _streamConfig.getType());
+    _segmentLogger.info("Started {} stream provider", _streamConfig.getType());
     final int capacity = _streamConfig.getFlushThresholdRows();
     RealtimeSegmentConfig realtimeSegmentConfig =
-        new RealtimeSegmentConfig.Builder().setSegmentName(segmentName).setStreamName(_streamConfig.getTopicName())
+        new RealtimeSegmentConfig.Builder().setSegmentName(_segmentName).setStreamName(_streamConfig.getTopicName())
             .setSchema(schema).setCapacity(capacity)
             .setAvgNumMultiValues(indexLoadingConfig.getRealtimeAvgMultiValueCount())
             .setNoDictionaryColumns(indexLoadingConfig.getNoDictionaryColumns())
             .setVarLengthDictionaryColumns(indexLoadingConfig.getVarLengthDictionaryColumns())
             .setInvertedIndexColumns(invertedIndexColumns).setRealtimeSegmentZKMetadata(realtimeSegmentZKMetadata)
             .setOffHeap(indexLoadingConfig.isRealtimeOffheapAllocation()).setMemoryManager(
-            getMemoryManager(realtimeTableDataManager.getConsumerDir(), segmentName,
+            getMemoryManager(realtimeTableDataManager.getConsumerDir(), _segmentName,
                 indexLoadingConfig.isRealtimeOffheapAllocation(),
                 indexLoadingConfig.isDirectRealtimeOffheapAllocation(), serverMetrics))
             .setStatsHistory(realtimeTableDataManager.getStatsHistory())
             .setNullHandlingEnabled(indexingConfig.isNullHandlingEnabled()).build();
-    realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfig);
+    _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfig);
 
-    notifier = realtimeTableDataManager;
+    _notifier = realtimeTableDataManager;
 
-    LOGGER.info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}", segmentName,
-        capacity, new DateTime(segmentEndTimeThreshold, DateTimeZone.UTC).toString());
-    segmentStatusTask = new TimerTask() {
+    LOGGER.info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}", _segmentName,
+        capacity, new DateTime(_segmentEndTimeThreshold, DateTimeZone.UTC).toString());
+    _segmentStatusTask = new TimerTask() {
       @Override
       public void run() {
         computeKeepIndexing();
@@ -209,13 +203,13 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     };
 
     // start the indexing thread
-    indexingThread = new Thread(new Runnable() {
+    _indexingThread = new Thread(new Runnable() {
       @Override
       public void run() {
         // continue indexing until criteria is met
         boolean notFull = true;
         long exceptionSleepMillis = 50L;
-        segmentLogger.info("Starting to collect rows");
+        _segmentLogger.info("Starting to collect rows");
 
         int numRowsErrored = 0;
         GenericRow reuse = new GenericRow();
@@ -225,15 +219,15 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             GenericRow consumedRow;
             try {
               consumedRow = _streamLevelConsumer.next(reuse);
-              tableAndStreamRowsConsumed = serverMetrics
-                  .addMeteredTableValue(tableStreamName, ServerMeter.REALTIME_ROWS_CONSUMED, 1L,
-                      tableAndStreamRowsConsumed);
-              tableRowsConsumed =
-                  serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_ROWS_CONSUMED, 1L, tableRowsConsumed);
+              _tableAndStreamRowsConsumed = serverMetrics
+                  .addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_ROWS_CONSUMED, 1L,
+                      _tableAndStreamRowsConsumed);
+              _tableRowsConsumed =
+                  serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_ROWS_CONSUMED, 1L, _tableRowsConsumed);
             } catch (Exception e) {
-              segmentLogger.warn("Caught exception while consuming row, sleeping for {} ms", exceptionSleepMillis, e);
+              _segmentLogger.warn("Caught exception while consuming row, sleeping for {} ms", exceptionSleepMillis, e);
               numRowsErrored++;
-              serverMetrics.addMeteredTableValue(tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
+              serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
               serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
 
               // Sleep for a short time as to avoid filling the logs with exceptions too quickly
@@ -246,11 +240,11 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
                 GenericRow transformedRow = _recordTransformer.transform(consumedRow);
                 if (transformedRow != null) {
                   // we currently do not get ingestion data through stream-consumer
-                  notFull = realtimeSegment.index(transformedRow, null);
+                  notFull = _realtimeSegment.index(transformedRow, null);
                   exceptionSleepMillis = 50L;
                 }
               } catch (Exception e) {
-                segmentLogger.warn("Caught exception while indexing row, sleeping for {} ms, row contents {}",
+                _segmentLogger.warn("Caught exception while indexing row, sleeping for {} ms, row contents {}",
                     exceptionSleepMillis, consumedRow, e);
                 numRowsErrored++;
 
@@ -260,57 +254,57 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
               }
             }
           } catch (Error e) {
-            segmentLogger.error("Caught error in indexing thread", e);
+            _segmentLogger.error("Caught error in indexing thread", e);
             throw e;
           }
-        } while (notFull && keepIndexing && (!isShuttingDown));
+        } while (notFull && _keepIndexing && (!_isShuttingDown));
 
-        if (isShuttingDown) {
-          segmentLogger.info("Shutting down indexing thread!");
+        if (_isShuttingDown) {
+          _segmentLogger.info("Shutting down indexing thread!");
           return;
         }
         try {
           if (numRowsErrored > 0) {
-            serverMetrics.addMeteredTableValue(tableStreamName, ServerMeter.ROWS_WITH_ERRORS, numRowsErrored);
+            serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.ROWS_WITH_ERRORS, numRowsErrored);
           }
-          segmentLogger.info("Indexing threshold reached, proceeding with index conversion");
+          _segmentLogger.info("Indexing threshold reached, proceeding with index conversion");
           // kill the timer first
-          segmentStatusTask.cancel();
+          _segmentStatusTask.cancel();
           updateCurrentDocumentCountMetrics();
-          segmentLogger.info("Indexed {} raw events", realtimeSegment.getNumDocsIndexed());
-          File tempSegmentFolder = new File(resourceTmpDir, "tmp-" + System.currentTimeMillis());
+          _segmentLogger.info("Indexed {} raw events", _realtimeSegment.getNumDocsIndexed());
+          File tempSegmentFolder = new File(_resourceTmpDir, "tmp-" + System.currentTimeMillis());
 
           // lets convert the segment now
           RealtimeSegmentConverter converter =
-              new RealtimeSegmentConverter(realtimeSegment, tempSegmentFolder.getAbsolutePath(), schema,
-                  tableNameWithType, timeColumnName, realtimeSegmentZKMetadata.getSegmentName(), sortedColumn,
-                  HLRealtimeSegmentDataManager.this.invertedIndexColumns, noDictionaryColumns,
-                  varLengthDictionaryColumns, null/*StarTreeIndexSpec*/,
+              new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), schema,
+                  _tableNameWithType, tableConfig, realtimeSegmentZKMetadata.getSegmentName(), _sortedColumn,
+                  HLRealtimeSegmentDataManager.this._invertedIndexColumns, _noDictionaryColumns,
+                  _varLengthDictionaryColumns, null/*StarTreeIndexSpec*/,
                   indexingConfig.isNullHandlingEnabled()); // Star tree not supported for HLC.
 
-          segmentLogger.info("Trying to build segment");
+          _segmentLogger.info("Trying to build segment");
           final long buildStartTime = System.nanoTime();
           converter.build(_segmentVersion, serverMetrics);
           final long buildEndTime = System.nanoTime();
-          segmentLogger.info("Built segment in {} ms",
+          _segmentLogger.info("Built segment in {} ms",
               TimeUnit.MILLISECONDS.convert((buildEndTime - buildStartTime), TimeUnit.NANOSECONDS));
           File destDir = new File(resourceDataDir, realtimeSegmentZKMetadata.getSegmentName());
           FileUtils.deleteQuietly(destDir);
           FileUtils.moveDirectory(tempSegmentFolder.listFiles()[0], destDir);
 
           FileUtils.deleteQuietly(tempSegmentFolder);
-          long segStartTime = realtimeSegment.getMinTime();
-          long segEndTime = realtimeSegment.getMaxTime();
+          long segStartTime = _realtimeSegment.getMinTime();
+          long segEndTime = _realtimeSegment.getMaxTime();
 
-          segmentLogger.info("Committing {} offsets", _streamConfig.getType());
+          _segmentLogger.info("Committing {} offsets", _streamConfig.getType());
           boolean commitSuccessful = false;
           try {
             _streamLevelConsumer.commit();
             commitSuccessful = true;
             _streamLevelConsumer.shutdown();
-            segmentLogger
+            _segmentLogger
                 .info("Successfully committed {} offsets, consumer release requested.", _streamConfig.getType());
-            serverMetrics.addMeteredTableValue(tableStreamName, ServerMeter.REALTIME_OFFSET_COMMITS, 1L);
+            serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_OFFSET_COMMITS, 1L);
             serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_OFFSET_COMMITS, 1L);
           } catch (Throwable e) {
             // If we got here, it means that either the commit or the shutdown failed. Considering that the
@@ -360,101 +354,101 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             //   metadata to reflect the new consumer group id, copy the Kafka offsets from the shutdown replica onto
             //   the new consumer group id and then restart both replicas. This should get you the missing rows.
 
-            segmentLogger
+            _segmentLogger
                 .error("FATAL: Exception committing or shutting down consumer commitSuccessful={}", commitSuccessful,
                     e);
-            serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.REALTIME_OFFSET_COMMIT_EXCEPTIONS, 1L);
+            serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.REALTIME_OFFSET_COMMIT_EXCEPTIONS, 1L);
             if (!commitSuccessful) {
               _streamLevelConsumer.shutdown();
             }
           }
 
           try {
-            segmentLogger.info("Marking current segment as completed in Helix");
+            _segmentLogger.info("Marking current segment as completed in Helix");
             RealtimeSegmentZKMetadata metadataToOverwrite = new RealtimeSegmentZKMetadata();
-            metadataToOverwrite.setTableName(tableNameWithType);
+            metadataToOverwrite.setTableName(_tableNameWithType);
             metadataToOverwrite.setSegmentName(realtimeSegmentZKMetadata.getSegmentName());
             metadataToOverwrite.setSegmentType(SegmentType.OFFLINE);
             metadataToOverwrite.setStatus(Status.DONE);
             metadataToOverwrite.setStartTime(segStartTime);
             metadataToOverwrite.setEndTime(segEndTime);
-            metadataToOverwrite.setTimeUnit(schema.getOutgoingTimeUnit());
-            metadataToOverwrite.setTotalDocs(realtimeSegment.getNumDocsIndexed());
-            notifier.replaceHLSegment(metadataToOverwrite, indexLoadingConfig);
-            segmentLogger
+            metadataToOverwrite.setTimeUnit(_timeType);
+            metadataToOverwrite.setTotalDocs(_realtimeSegment.getNumDocsIndexed());
+            _notifier.replaceHLSegment(metadataToOverwrite, indexLoadingConfig);
+            _segmentLogger
                 .info("Completed write of segment completion to Helix, waiting for controller to assign a new segment");
           } catch (Exception e) {
             if (commitSuccessful) {
-              segmentLogger.error(
+              _segmentLogger.error(
                   "Offsets were committed to Kafka but we were unable to mark this segment as completed in Helix. Manually mark the segment as completed in Helix; restarting this instance will result in data loss.",
                   e);
             } else {
-              segmentLogger.warn(
+              _segmentLogger.warn(
                   "Caught exception while marking segment as completed in Helix. Offsets were not written, restarting the instance should be safe.",
                   e);
             }
           }
         } catch (Exception e) {
-          segmentLogger.error("Caught exception in the realtime indexing thread", e);
+          _segmentLogger.error("Caught exception in the realtime indexing thread", e);
         }
       }
     });
 
-    indexingThread.start();
-    serverMetrics.addValueToTableGauge(tableNameWithType, ServerGauge.SEGMENT_COUNT, 1L);
-    segmentLogger.debug("scheduling keepIndexing timer check");
+    _indexingThread.start();
+    serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.SEGMENT_COUNT, 1L);
+    _segmentLogger.debug("scheduling keepIndexing timer check");
     // start a schedule timer to keep track of the segment
-    TimerService.timer.schedule(segmentStatusTask, ONE_MINUTE_IN_MILLSEC, ONE_MINUTE_IN_MILLSEC);
-    segmentLogger.info("finished scheduling keepIndexing timer check");
+    TimerService.timer.schedule(_segmentStatusTask, ONE_MINUTE_IN_MILLSEC, ONE_MINUTE_IN_MILLSEC);
+    _segmentLogger.info("finished scheduling keepIndexing timer check");
   }
 
   @Override
   public MutableSegment getSegment() {
-    return realtimeSegment;
+    return _realtimeSegment;
   }
 
   @Override
   public String getSegmentName() {
-    return segmentName;
+    return _segmentName;
   }
 
   private void computeKeepIndexing() {
-    if (keepIndexing) {
-      segmentLogger.debug("Current indexed {} raw events", realtimeSegment.getNumDocsIndexed());
-      if ((System.currentTimeMillis() >= segmentEndTimeThreshold)
-          || realtimeSegment.getNumDocsIndexed() >= _streamConfig.getFlushThresholdRows()) {
-        if (realtimeSegment.getNumDocsIndexed() == 0) {
-          segmentLogger.info("no new events coming in, extending the end time by another hour");
-          segmentEndTimeThreshold = System.currentTimeMillis() + _streamConfig.getFlushThresholdTimeMillis();
+    if (_keepIndexing) {
+      _segmentLogger.debug("Current indexed {} raw events", _realtimeSegment.getNumDocsIndexed());
+      if ((System.currentTimeMillis() >= _segmentEndTimeThreshold)
+          || _realtimeSegment.getNumDocsIndexed() >= _streamConfig.getFlushThresholdRows()) {
+        if (_realtimeSegment.getNumDocsIndexed() == 0) {
+          _segmentLogger.info("no new events coming in, extending the end time by another hour");
+          _segmentEndTimeThreshold = System.currentTimeMillis() + _streamConfig.getFlushThresholdTimeMillis();
           return;
         }
-        segmentLogger.info(
+        _segmentLogger.info(
             "Stopped indexing due to reaching segment limit: {} raw documents indexed, segment is aged {} minutes",
-            realtimeSegment.getNumDocsIndexed(), ((System.currentTimeMillis() - start) / (ONE_MINUTE_IN_MILLSEC)));
-        keepIndexing = false;
+            _realtimeSegment.getNumDocsIndexed(), ((System.currentTimeMillis() - _start) / (ONE_MINUTE_IN_MILLSEC)));
+        _keepIndexing = false;
       }
     }
     updateCurrentDocumentCountMetrics();
   }
 
   private void updateCurrentDocumentCountMetrics() {
-    int currentRawDocs = realtimeSegment.getNumDocsIndexed();
-    serverMetrics.addValueToTableGauge(tableNameWithType, ServerGauge.DOCUMENT_COUNT,
-        (currentRawDocs - lastUpdatedRawDocuments.get()));
-    lastUpdatedRawDocuments.set(currentRawDocs);
+    int currentRawDocs = _realtimeSegment.getNumDocsIndexed();
+    _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.DOCUMENT_COUNT,
+        (currentRawDocs - _lastUpdatedRawDocuments.get()));
+    _lastUpdatedRawDocuments.set(currentRawDocs);
   }
 
   @Override
   public void destroy() {
-    LOGGER.info("Trying to shutdown RealtimeSegmentDataManager : {}!", this.segmentName);
-    isShuttingDown = true;
+    LOGGER.info("Trying to shutdown RealtimeSegmentDataManager : {}!", _segmentName);
+    _isShuttingDown = true;
     try {
       _streamLevelConsumer.shutdown();
     } catch (Exception e) {
       LOGGER.error("Failed to shutdown stream consumer!", e);
     }
-    keepIndexing = false;
-    segmentStatusTask.cancel();
-    realtimeSegment.destroy();
+    _keepIndexing = false;
+    _segmentStatusTask.cancel();
+    _realtimeSegment.destroy();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -249,7 +249,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private StreamMetadataProvider _streamMetadataProvider = null;
   private final File _resourceTmpDir;
   private final String _tableNameWithType;
-  private final String _timeColumnName;
   private final List<String> _invertedIndexColumns;
   private final List<String> _textIndexColumns;
   private final List<String> _noDictionaryColumns;
@@ -711,7 +710,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       // lets convert the segment now
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), _schema,
-              _tableNameWithType, _timeColumnName, _segmentZKMetadata.getSegmentName(), _sortedColumn,
+              _tableNameWithType, _tableConfig, _segmentZKMetadata.getSegmentName(), _sortedColumn,
               _invertedIndexColumns, _textIndexColumns, _noDictionaryColumns, _varLengthDictionaryColumns,
               _nullHandlingEnabled);
       segmentLogger.info("Trying to build segment");
@@ -1083,7 +1082,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     _streamPartitionId = _llcSegmentName.getPartitionId();
     _partitionConsumerSemaphore = partitionConsumerSemaphore;
     _acquiredConsumerSemaphore = new AtomicBoolean(false);
-    _timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
     _metricKeyName = _tableNameWithType + "-" + _streamTopic + "-" + _streamPartitionId;
     segmentLogger = LoggerFactory.getLogger(LLRealtimeSegmentDataManager.class.getName() + "_" + _segmentNameStr);
     _tableStreamName = _tableNameWithType + "_" + _streamTopic;

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -175,16 +175,15 @@ public class SegmentGeneratorConfig {
     //  Hence, if table config is null, but timeFieldSpec is not null, read time from schema
     //  Once we move to multiple time columns - DateTimeFieldSpec - table config has to be provided with valid time
     //  If more than 1 dateTimeFieldSpec is found along with null table config, throw exception.
+    String timeColumnName = null;
+    if (tableConfig != null && tableConfig.getValidationConfig() != null) {
+      timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+    }
+    setTime(timeColumnName, schema);
+
     if (tableConfig == null) {
-      setTime(schema.getTimeFieldSpec());
       return;
     }
-
-    String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
-    if (timeColumnName != null) {
-      setTime(schema.getFieldSpecFor(timeColumnName));
-    }
-
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     if (indexingConfig != null) {
       List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
@@ -225,7 +224,24 @@ public class SegmentGeneratorConfig {
     }
   }
 
-  public void setTime(FieldSpec timeSpec) {
+  /**
+   * Set time column details using the given time column. If not found, use schema
+   */
+  public void setTime(String timeColumnName, Schema schema) {
+    if (timeColumnName != null) {
+      FieldSpec fieldSpec = schema.getFieldSpecFor(timeColumnName);
+      if (fieldSpec != null) {
+        setTime(fieldSpec);
+        return;
+      }
+    }
+    setTime(schema.getTimeFieldSpec());
+  }
+
+  /**
+   * Set time column details using the given field spec
+   */
+  private void setTime(FieldSpec timeSpec) {
     if (timeSpec == null) {
       return;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -43,6 +43,7 @@ import org.apache.pinot.core.startree.v2.builder.StarTreeV2BuilderConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -157,54 +158,93 @@ public class SegmentGeneratorConfig {
   }
 
   /**
-   * This constructor is used during offline data generation. Note that it has an option that will generate inverted
-   * index.
+   * Construct the SegmentGeneratorConfig using schema and table config.
+   * If table config is passed, it will be used to initialize the time column details and the indexing config
+   * This constructor is used during offline data generation.
+   * @param tableConfig table config of the segment. Used for getting time column information and indexing information
+   * @param schema schema of the segment to be generated. The time column information should be taken from table config.
+   *               However, for maintaining backward compatibility, taking it from schema if table config is null.
+   *               This will not work once we start supporting multiple time columns (DateTimeFieldSpec)
    */
   public SegmentGeneratorConfig(@Nullable TableConfig tableConfig, Schema schema) {
     Preconditions.checkNotNull(schema);
     setSchema(schema);
 
+    // NOTE: SegmentGeneratorConfig#setSchema doesn't set the time column anymore. timeColumnName is expected to be read from table config.
+    //  But table config is not mandatory, and cannot be easily enforced as the instantiation can happen in external code.
+    //  Hence, if table config is null, but timeFieldSpec is not null, read time from schema
+    //  Once we move to multiple time columns - DateTimeFieldSpec - table config has to be provided with valid time
+    //  If more than 1 dateTimeFieldSpec is found along with null table config, throw exception.
     if (tableConfig == null) {
+      setTime(schema.getTimeFieldSpec());
       return;
     }
 
+    String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+    if (timeColumnName != null) {
+      setTime(schema.getFieldSpecFor(timeColumnName));
+    }
+
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
-    List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
-    Map<String, String> noDictionaryColumnMap = indexingConfig.getNoDictionaryConfig();
+    if (indexingConfig != null) {
+      List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+      Map<String, String> noDictionaryColumnMap = indexingConfig.getNoDictionaryConfig();
 
-    if (noDictionaryColumns != null) {
-      this.setRawIndexCreationColumns(noDictionaryColumns);
+      if (noDictionaryColumns != null) {
+        this.setRawIndexCreationColumns(noDictionaryColumns);
 
-      if (noDictionaryColumnMap != null) {
-        Map<String, ChunkCompressorFactory.CompressionType> serializedNoDictionaryColumnMap =
-            noDictionaryColumnMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-                e -> (ChunkCompressorFactory.CompressionType) ChunkCompressorFactory.CompressionType
-                    .valueOf(e.getValue())));
-        this.setRawIndexCompressionType(serializedNoDictionaryColumnMap);
+        if (noDictionaryColumnMap != null) {
+          Map<String, ChunkCompressorFactory.CompressionType> serializedNoDictionaryColumnMap =
+              noDictionaryColumnMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+                  e -> (ChunkCompressorFactory.CompressionType) ChunkCompressorFactory.CompressionType.valueOf(e.getValue())));
+          this.setRawIndexCompressionType(serializedNoDictionaryColumnMap);
+        }
       }
-    }
-    if (indexingConfig.getVarLengthDictionaryColumns() != null) {
-      setVarLengthDictionaryColumns(indexingConfig.getVarLengthDictionaryColumns());
-    }
-    _segmentPartitionConfig = indexingConfig.getSegmentPartitionConfig();
-
-    // Star-tree V2 configs
-    List<StarTreeIndexConfig> starTreeIndexConfigs = indexingConfig.getStarTreeIndexConfigs();
-    if (starTreeIndexConfigs != null && !starTreeIndexConfigs.isEmpty()) {
-      List<StarTreeV2BuilderConfig> starTreeV2BuilderConfigs = new ArrayList<>(starTreeIndexConfigs.size());
-      for (StarTreeIndexConfig starTreeIndexConfig : starTreeIndexConfigs) {
-        starTreeV2BuilderConfigs.add(StarTreeV2BuilderConfig.fromIndexConfig(starTreeIndexConfig));
+      if (indexingConfig.getVarLengthDictionaryColumns() != null) {
+        setVarLengthDictionaryColumns(indexingConfig.getVarLengthDictionaryColumns());
       }
-      setStarTreeV2BuilderConfigs(starTreeV2BuilderConfigs);
+      _segmentPartitionConfig = indexingConfig.getSegmentPartitionConfig();
+
+      // Star-tree V2 configs
+      List<StarTreeIndexConfig> starTreeIndexConfigs = indexingConfig.getStarTreeIndexConfigs();
+      if (starTreeIndexConfigs != null && !starTreeIndexConfigs.isEmpty()) {
+        List<StarTreeV2BuilderConfig> starTreeV2BuilderConfigs = new ArrayList<>(starTreeIndexConfigs.size());
+        for (StarTreeIndexConfig starTreeIndexConfig : starTreeIndexConfigs) {
+          starTreeV2BuilderConfigs.add(StarTreeV2BuilderConfig.fromIndexConfig(starTreeIndexConfig));
+        }
+        setStarTreeV2BuilderConfigs(starTreeV2BuilderConfigs);
+      }
+
+      if (indexingConfig.isCreateInvertedIndexDuringSegmentGeneration()) {
+        _invertedIndexCreationColumns = indexingConfig.getInvertedIndexColumns();
+      }
+
+      extractTextIndexColumnsFromTableConfig(tableConfig);
+
+      _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
     }
+  }
 
-    if (indexingConfig.isCreateInvertedIndexDuringSegmentGeneration()) {
-      _invertedIndexCreationColumns = indexingConfig.getInvertedIndexColumns();
+  public void setTime(FieldSpec timeSpec) {
+    if (timeSpec == null) {
+      return;
     }
+    TimeFieldSpec timeFieldSpec = (TimeFieldSpec) timeSpec;
+    setTimeColumnName(timeFieldSpec.getName());
 
-    extractTextIndexColumnsFromTableConfig(tableConfig);
+    TimeGranularitySpec timeGranularitySpec = timeFieldSpec.getOutgoingGranularitySpec();
 
-    _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
+    String timeFormat = timeGranularitySpec.getTimeFormat();
+    if (timeFormat.equals(TimeGranularitySpec.TimeFormat.EPOCH.toString())) {
+      // Time format: 'EPOCH'
+      setSegmentTimeUnit(timeGranularitySpec.getTimeType());
+    } else {
+      // Time format: 'SIMPLE_DATE_FORMAT:<pattern>'
+      Preconditions.checkArgument(timeFormat.startsWith(TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT.toString()),
+          "Invalid time format: %s, must be one of '%s' or '%s:<pattern>'", timeFormat,
+          TimeGranularitySpec.TimeFormat.EPOCH, TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT);
+      setSimpleDateFormat(timeFormat.substring(timeFormat.indexOf(':') + 1));
+    }
   }
 
   /**
@@ -224,10 +264,6 @@ public class SegmentGeneratorConfig {
         }
       }
     }
-  }
-
-  public SegmentGeneratorConfig(Schema schema) {
-    setSchema(schema);
   }
 
   public Map<String, String> getCustomProperties() {
@@ -506,25 +542,6 @@ public class SegmentGeneratorConfig {
   public void setSchema(Schema schema) {
     Preconditions.checkNotNull(schema);
     _schema = schema;
-
-    // Set time related fields
-    // TODO: support datetime field as time column
-    TimeFieldSpec timeFieldSpec = _schema.getTimeFieldSpec();
-    if (timeFieldSpec != null) {
-      TimeGranularitySpec timeGranularitySpec = timeFieldSpec.getOutgoingGranularitySpec();
-      setTimeColumnName(timeGranularitySpec.getName());
-      String timeFormat = timeGranularitySpec.getTimeFormat();
-      if (timeFormat.equals(TimeGranularitySpec.TimeFormat.EPOCH.toString())) {
-        // Time format: 'EPOCH'
-        setSegmentTimeUnit(timeGranularitySpec.getTimeType());
-      } else {
-        // Time format: 'SIMPLE_DATE_FORMAT:<pattern>'
-        Preconditions.checkArgument(timeFormat.startsWith(TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT.toString()),
-            "Invalid time format: %s, must be one of '%s' or '%s:<pattern>'", timeFormat,
-            TimeGranularitySpec.TimeFormat.EPOCH, TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT);
-        setSimpleDateFormat(timeFormat.substring(timeFormat.indexOf(':') + 1));
-      }
-    }
 
     // Remove inverted index columns not in schema
     // TODO: add a validate() method to perform all validations

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
@@ -34,6 +34,7 @@ import org.apache.pinot.core.minion.segment.RecordTransformer;
 import org.apache.pinot.core.minion.segment.ReducerRecordReader;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
 
@@ -62,32 +63,34 @@ public class SegmentConverter {
   private String _tableName;
   private String _segmentName;
   private RecordTransformer _recordTransformer;
+  private TableConfig _tableConfig;
 
   // Optional
   private int _totalNumPartition;
   private RecordPartitioner _recordPartitioner;
   private RecordAggregator _recordAggregator;
   private List<String> _groupByColumns;
-  private IndexingConfig _indexingConfig;
   private boolean _skipTimeValueCheck;
+  private IndexingConfig _indexingConfig;
 
   public SegmentConverter(List<File> inputIndexDirs, File workingDir, String tableName, String segmentName,
       int totalNumPartition, RecordTransformer recordTransformer, @Nullable RecordPartitioner recordPartitioner,
       @Nullable RecordAggregator recordAggregator, @Nullable List<String> groupByColumns,
-      @Nullable IndexingConfig indexingConfig, boolean skipTimeValueCheck) {
+      TableConfig tableConfig, boolean skipTimeValueCheck) {
     _inputIndexDirs = inputIndexDirs;
     _workingDir = workingDir;
     _recordTransformer = recordTransformer;
     _tableName = tableName;
     _segmentName = segmentName;
+    _tableConfig = tableConfig;
 
     _recordPartitioner = (recordPartitioner == null) ? new DefaultRecordPartitioner() : recordPartitioner;
     _totalNumPartition = (totalNumPartition < 1) ? DEFAULT_NUM_PARTITION : totalNumPartition;
 
     _recordAggregator = recordAggregator;
     _groupByColumns = groupByColumns;
-    _indexingConfig = indexingConfig;
     _skipTimeValueCheck = skipTimeValueCheck;
+    _indexingConfig = tableConfig.getIndexingConfig();
   }
 
   public List<File> convertSegment()
@@ -101,8 +104,8 @@ public class SegmentConverter {
 
       try (MapperRecordReader mapperRecordReader = new MapperRecordReader(_inputIndexDirs, _recordTransformer,
           _recordPartitioner, _totalNumPartition, currentPartition)) {
-        buildSegment(mapperOutputPath, _tableName, outputSegmentName, mapperRecordReader, null,
-            mapperRecordReader.getSchema());
+        buildSegment(mapperOutputPath, _tableName, outputSegmentName, mapperRecordReader,
+            mapperRecordReader.getSchema(), _tableConfig);
       }
       File outputSegment = new File(mapperOutputPath + File.separator + outputSegmentName);
 
@@ -111,8 +114,8 @@ public class SegmentConverter {
         String reducerOutputPath = _workingDir.getPath() + File.separator + REDUCER_PREFIX + currentPartition;
         try (ReducerRecordReader reducerRecordReader = new ReducerRecordReader(outputSegment, _recordAggregator,
             _groupByColumns)) {
-          buildSegment(reducerOutputPath, _tableName, outputSegmentName, reducerRecordReader, null,
-              reducerRecordReader.getSchema());
+          buildSegment(reducerOutputPath, _tableName, outputSegmentName, reducerRecordReader,
+              reducerRecordReader.getSchema(), _tableConfig);
         }
         outputSegment = new File(reducerOutputPath + File.separator + outputSegmentName);
       }
@@ -128,7 +131,7 @@ public class SegmentConverter {
           try (PinotSegmentRecordReader pinotSegmentRecordReader = new PinotSegmentRecordReader(outputSegment, null,
               sortedColumn)) {
             buildSegment(indexGenerationOutputPath, _tableName, outputSegmentName, pinotSegmentRecordReader,
-                _indexingConfig, pinotSegmentRecordReader.getSchema());
+                pinotSegmentRecordReader.getSchema(), _tableConfig);
           }
           outputSegment = new File(indexGenerationOutputPath + File.separator + outputSegmentName);
         }
@@ -145,13 +148,14 @@ public class SegmentConverter {
    * TODO: Support all kinds of indexing (no dictionary)
    */
   private void buildSegment(String outputPath, String tableName, String segmentName, RecordReader recordReader,
-      @Nullable IndexingConfig indexingConfig, Schema schema)
+      Schema schema, TableConfig tableConfig)
       throws Exception {
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setOutDir(outputPath);
     segmentGeneratorConfig.setTableName(tableName);
     segmentGeneratorConfig.setSegmentName(segmentName);
     segmentGeneratorConfig.setSkipTimeValueCheck(_skipTimeValueCheck);
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     if (indexingConfig != null) {
       segmentGeneratorConfig.setInvertedIndexCreationColumns(indexingConfig.getInvertedIndexColumns());
     }
@@ -167,13 +171,13 @@ public class SegmentConverter {
     private String _tableName;
     private String _segmentName;
     private RecordTransformer _recordTransformer;
+    private TableConfig _tableConfig;
 
     // Optional
     private int _totalNumPartition;
     private RecordPartitioner _recordPartitioner;
     private RecordAggregator _recordAggregator;
     private List<String> _groupByColumns;
-    private IndexingConfig _indexingConfig;
     private boolean _skipTimeValueCheck;
 
     public Builder setInputIndexDirs(List<File> inputIndexDirs) {
@@ -221,8 +225,8 @@ public class SegmentConverter {
       return this;
     }
 
-    public Builder setIndexingConfig(IndexingConfig indexingConfig) {
-      _indexingConfig = indexingConfig;
+    public Builder setTableConfig(TableConfig tableConfig) {
+      _tableConfig = tableConfig;
       return this;
     }
 
@@ -242,7 +246,7 @@ public class SegmentConverter {
       }
 
       return new SegmentConverter(_inputIndexDirs, _workingDir, _tableName, _segmentName, _totalNumPartition,
-          _recordTransformer, _recordPartitioner, _recordAggregator, _groupByColumns, _indexingConfig,
+          _recordTransformer, _recordPartitioner, _recordAggregator, _groupByColumns, _tableConfig,
           _skipTimeValueCheck);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
@@ -156,7 +156,7 @@ public class SegmentConverter {
     segmentGeneratorConfig.setSegmentName(segmentName);
     segmentGeneratorConfig.setSkipTimeValueCheck(_skipTimeValueCheck);
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
-    if (indexingConfig != null) {
+    if (indexingConfig != null && indexingConfig.getInvertedIndexColumns() != null) {
       segmentGeneratorConfig.setInvertedIndexCreationColumns(indexingConfig.getInvertedIndexColumns());
     }
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -85,7 +85,10 @@ public class SegmentPurger {
       }
 
       Schema schema = purgeRecordReader.getSchema();
-      SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+      // FIXME: figure out how to get table config here.
+      //  Fine for now, since we will only have timeFieldSpec.
+      //  Will be an issue once we start using DateTimeFieldSpec
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
       config.setOutDir(_workingDir.getPath());
       config.setTableName(_rawTableName);
       config.setSegmentName(segmentName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -48,7 +48,6 @@ public class SegmentPurger {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPurger.class);
 
   private final String _rawTableName;
-  private final String _timeColumnName;
   private final File _originalIndexDir;
   private final File _workingDir;
   private final RecordPurger _recordPurger;
@@ -57,12 +56,11 @@ public class SegmentPurger {
   private int _numRecordsPurged;
   private int _numRecordsModified;
 
-  public SegmentPurger(String rawTableName, String timeColumnName, File originalIndexDir, File workingDir,
-      @Nullable RecordPurger recordPurger, @Nullable RecordModifier recordModifier) {
+  public SegmentPurger(String rawTableName, File originalIndexDir, File workingDir, @Nullable RecordPurger recordPurger,
+      @Nullable RecordModifier recordModifier) {
     Preconditions.checkArgument(recordPurger != null || recordModifier != null,
         "At least one of record purger and modifier should be non-null");
     _rawTableName = rawTableName;
-    _timeColumnName = timeColumnName;
     _originalIndexDir = originalIndexDir;
     _workingDir = workingDir;
     _recordPurger = recordPurger;
@@ -87,11 +85,10 @@ public class SegmentPurger {
       }
 
       Schema schema = purgeRecordReader.getSchema();
-      SegmentGeneratorConfig config = new SegmentGeneratorConfig();
-      config.setSchema(schema);
+      // FIXME: make table config available here, and pass it to the SegmentGeneratorConfig
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
       config.setOutDir(_workingDir.getPath());
       config.setTableName(_rawTableName);
-      config.setTime(_timeColumnName, schema);
       config.setSegmentName(segmentName);
 
       // Keep index creation time the same as original segment because both segments use the same raw data.

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -48,6 +48,7 @@ public class SegmentPurger {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPurger.class);
 
   private final String _rawTableName;
+  private final String _timeColumnName;
   private final File _originalIndexDir;
   private final File _workingDir;
   private final RecordPurger _recordPurger;
@@ -56,11 +57,12 @@ public class SegmentPurger {
   private int _numRecordsPurged;
   private int _numRecordsModified;
 
-  public SegmentPurger(String rawTableName, File originalIndexDir, File workingDir, @Nullable RecordPurger recordPurger,
-      @Nullable RecordModifier recordModifier) {
+  public SegmentPurger(String rawTableName, String timeColumnName, File originalIndexDir, File workingDir,
+      @Nullable RecordPurger recordPurger, @Nullable RecordModifier recordModifier) {
     Preconditions.checkArgument(recordPurger != null || recordModifier != null,
         "At least one of record purger and modifier should be non-null");
     _rawTableName = rawTableName;
+    _timeColumnName = timeColumnName;
     _originalIndexDir = originalIndexDir;
     _workingDir = workingDir;
     _recordPurger = recordPurger;
@@ -85,12 +87,11 @@ public class SegmentPurger {
       }
 
       Schema schema = purgeRecordReader.getSchema();
-      // FIXME: figure out how to get table config here.
-      //  Fine for now, since we will only have timeFieldSpec.
-      //  Will be an issue once we start using DateTimeFieldSpec
-      SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig();
+      config.setSchema(schema);
       config.setOutDir(_workingDir.getPath());
       config.setTableName(_rawTableName);
+      config.setTime(_timeColumnName, schema);
       config.setSegmentName(segmentName);
 
       // Keep index creation time the same as original segment because both segments use the same raw data.

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/rollup/MergeRollupSegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/rollup/MergeRollupSegmentConverter.java
@@ -30,6 +30,8 @@ import org.apache.pinot.core.minion.segment.RecordAggregator;
 import org.apache.pinot.core.minion.segment.RecordTransformer;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 
@@ -42,7 +44,7 @@ import org.apache.pinot.spi.data.Schema;
 public class MergeRollupSegmentConverter {
   private List<File> _inputIndexDirs;
   private File _workingDir;
-  private IndexingConfig _indexingConfig;
+  private TableConfig _tableConfig;
   private String _tableName;
   private String _segmentName;
   private MergeType _mergeType;
@@ -50,14 +52,14 @@ public class MergeRollupSegmentConverter {
 
   private MergeRollupSegmentConverter(@Nonnull List<File> inputIndexDirs, @Nonnull File workingDir,
       @Nonnull String tableName, @Nonnull String segmentName, @Nonnull String mergeType,
-      @Nullable Map<String, String> rollupPreAggregateType, @Nullable IndexingConfig indexingConfig) {
+      @Nullable Map<String, String> rollupPreAggregateType, TableConfig tableConfig) {
     _inputIndexDirs = inputIndexDirs;
     _workingDir = workingDir;
     _tableName = tableName;
     _segmentName = segmentName;
     _mergeType = MergeType.fromString(mergeType);
     _rolllupPreAggregateType = rollupPreAggregateType;
-    _indexingConfig = indexingConfig;
+    _tableConfig = tableConfig;
   }
 
   public List<File> convert()
@@ -89,7 +91,7 @@ public class MergeRollupSegmentConverter {
     SegmentConverter concatenateSegmentConverter =
         new SegmentConverter.Builder().setTableName(_tableName).setSegmentName(_segmentName)
             .setInputIndexDirs(_inputIndexDirs).setWorkingDir(_workingDir).setRecordTransformer((row) -> row)
-            .setIndexingConfig(_indexingConfig).build();
+            .setTableConfig(_tableConfig).build();
 
     return concatenateSegmentConverter.convertSegment();
   }
@@ -101,10 +103,13 @@ public class MergeRollupSegmentConverter {
    */
   private List<File> rollupSegments(Schema schema)
       throws Exception {
-    // Compute group by columns for roll-up preparation (all dimensions + time column)
+    // Compute group by columns for roll-up preparation (all dimensions + date time columns + time column)
     List<String> groupByColumns = new ArrayList<>();
     for (DimensionFieldSpec dimensionFieldSpec : schema.getDimensionFieldSpecs()) {
       groupByColumns.add(dimensionFieldSpec.getName());
+    }
+    for (DateTimeFieldSpec dateTimeFieldSpec : schema.getDateTimeFieldSpecs()) {
+      groupByColumns.add(dateTimeFieldSpec.getName());
     }
     String timeColumn = schema.getTimeColumnName();
     if (timeColumn != null) {
@@ -121,8 +126,8 @@ public class MergeRollupSegmentConverter {
     SegmentConverter rollupSegmentConverter =
         new SegmentConverter.Builder().setTableName(_tableName).setSegmentName(_segmentName)
             .setInputIndexDirs(_inputIndexDirs).setWorkingDir(_workingDir).setRecordTransformer(rollupRecordTransformer)
-            .setRecordAggregator(rollupRecordAggregator).setGroupByColumns(groupByColumns)
-            .setIndexingConfig(_indexingConfig).build();
+            .setRecordAggregator(rollupRecordAggregator).setGroupByColumns(groupByColumns).setTableConfig(_tableConfig)
+            .build();
 
     return rollupSegmentConverter.convertSegment();
   }
@@ -134,10 +139,10 @@ public class MergeRollupSegmentConverter {
     private String _mergeType;
     private String _tableName;
     private String _segmentName;
+    private TableConfig _tableConfig;
 
     // Optional
     private Map<String, String> _rollupPreAggregateType;
-    private IndexingConfig _indexingConfig;
 
     public Builder setInputIndexDirs(List<File> inputIndexDirs) {
       _inputIndexDirs = inputIndexDirs;
@@ -159,8 +164,8 @@ public class MergeRollupSegmentConverter {
       return this;
     }
 
-    public Builder setIndexingConfig(IndexingConfig indexingConfig) {
-      _indexingConfig = indexingConfig;
+    public Builder setTableConfig(TableConfig tableConfig) {
+      _tableConfig = tableConfig;
       return this;
     }
 
@@ -176,7 +181,7 @@ public class MergeRollupSegmentConverter {
 
     public MergeRollupSegmentConverter build() {
       return new MergeRollupSegmentConverter(_inputIndexDirs, _workingDir, _tableName, _segmentName, _mergeType,
-          _rollupPreAggregateType, _indexingConfig);
+          _rollupPreAggregateType, _tableConfig);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -62,6 +62,9 @@ public class ColumnMinMaxValueGenerator {
     if (timeColumnName != null) {
       addColumnMinMaxValueForColumn(timeColumnName);
     }
+    for (String dateTimeColumn : schema.getDateTimeNames()) {
+      addColumnMinMaxValueForColumn(dateTimeColumn);
+    }
     if (_columnMinMaxValueGeneratorMode == ColumnMinMaxValueGeneratorMode.TIME) {
       saveMetadata();
       return;

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/DataFetcherTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/DataFetcherTest.java
@@ -110,8 +110,9 @@ public class DataFetcherTest {
     schema.addField(new MetricFieldSpec(NO_DICT_FLOAT_METRIC_NAME, FieldSpec.DataType.FLOAT));
     schema.addField(new MetricFieldSpec(NO_DICT_DOUBLE_METRIC_NAME, FieldSpec.DataType.DOUBLE));
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig();
     FileUtils.deleteQuietly(new File(INDEX_DIR_PATH));
+    config.setSchema(schema);
     config.setOutDir(INDEX_DIR_PATH);
     config.setSegmentName(SEGMENT_NAME);
     config.setRawIndexCreationColumns(Arrays

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReaderTest.java
@@ -91,7 +91,7 @@ public class MultiplePinotSegmentRecordReaderTest {
   }
 
   private TableConfig createTableConfig() {
-    return new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME).build();
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME).build();
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReaderTest.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
@@ -32,6 +34,7 @@ import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -60,6 +63,7 @@ public class MultiplePinotSegmentRecordReaderTest {
   public void setup()
       throws Exception {
     Schema schema = createPinotSchema();
+    TableConfig tableConfig = createTableConfig();
     _segmentOutputDir = Files.createTempDir().toString();
     _rowsList = new ArrayList<>(NUM_SEGMENTS);
     _segmentIndexDirList = new ArrayList<>(NUM_SEGMENTS);
@@ -69,7 +73,8 @@ public class MultiplePinotSegmentRecordReaderTest {
       List<GenericRow> rows = PinotSegmentUtil.createTestData(schema, NUM_ROWS);
       _rowsList.add(rows);
       RecordReader recordReader = new GenericRowRecordReader(rows);
-      _segmentIndexDirList.add(PinotSegmentUtil.createSegment(schema, segmentName, _segmentOutputDir, recordReader));
+      _segmentIndexDirList
+          .add(PinotSegmentUtil.createSegment(tableConfig, schema, segmentName, _segmentOutputDir, recordReader));
     }
   }
 
@@ -83,6 +88,10 @@ public class MultiplePinotSegmentRecordReaderTest {
     testSchema.addField(new MetricFieldSpec(M2, FieldSpec.DataType.FLOAT));
     testSchema.addField(new TimeFieldSpec(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.HOURS, TIME)));
     return testSchema;
+  }
+
+  private TableConfig createTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME).build();
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -33,6 +35,7 @@ import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -61,11 +64,13 @@ public class PinotSegmentRecordReaderTest {
   public void setup()
       throws Exception {
     Schema schema = createPinotSchema();
+    TableConfig tableConfig = createTableConfig();
     String segmentName = "pinotSegmentRecordReaderTest";
     _segmentOutputDir = Files.createTempDir().toString();
     _rows = PinotSegmentUtil.createTestData(schema, NUM_ROWS);
     _recordReader = new GenericRowRecordReader(_rows);
-    _segmentIndexDir = PinotSegmentUtil.createSegment(schema, segmentName, _segmentOutputDir, _recordReader);
+    _segmentIndexDir =
+        PinotSegmentUtil.createSegment(tableConfig, schema, segmentName, _segmentOutputDir, _recordReader);
   }
 
   private Schema createPinotSchema() {
@@ -77,6 +82,10 @@ public class PinotSegmentRecordReaderTest {
     testSchema.addField(new MetricFieldSpec(M2, FieldSpec.DataType.FLOAT));
     testSchema.addField(new TimeFieldSpec(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.HOURS, TIME)));
     return testSchema;
+  }
+
+  private TableConfig createTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME).build();
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
@@ -85,7 +85,7 @@ public class PinotSegmentRecordReaderTest {
   }
 
   private TableConfig createTableConfig() {
-    return new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME).build();
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME).build();
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentUtil.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentUtil.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
@@ -79,9 +80,10 @@ public class PinotSegmentUtil {
     return value1Set.containsAll(value2Set);
   }
 
-  public static File createSegment(Schema schema, String segmentName, String segmentOutputDir, RecordReader recordReader)
+  public static File createSegment(TableConfig tableConfig, Schema schema, String segmentName, String segmentOutputDir,
+      RecordReader recordReader)
       throws Exception {
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setTableName(segmentName);
     segmentGeneratorConfig.setOutDir(segmentOutputDir);
     segmentGeneratorConfig.setSegmentName(segmentName);

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfigTest.java
@@ -38,7 +38,8 @@ public class SegmentGeneratorConfigTest {
   public void testEpochTime() {
     Schema schema = new Schema.SchemaBuilder()
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch")).build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName("daysSinceEpoch").build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName("daysSinceEpoch").build();
     // table config provided
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "daysSinceEpoch");
@@ -58,7 +59,8 @@ public class SegmentGeneratorConfigTest {
   public void testSimpleDateFormat() {
     Schema schema = new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(FieldSpec.DataType.STRING, TimeUnit.DAYS,
         TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "Date")).build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName("Date").build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName("Date").build();
 
     // Table config provided
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/MergeRollupSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/MergeRollupSegmentConverterTest.java
@@ -78,7 +78,7 @@ public class MergeRollupSegmentConverterTest {
     schema.addField(new MetricFieldSpec(M1, FieldSpec.DataType.LONG));
     schema.addField(new MetricFieldSpec(M2, FieldSpec.DataType.DOUBLE));
     schema.addField(new TimeFieldSpec(T, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
-    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(T).build();
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(T).build();
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
     long timestamp = _referenceTimestamp;

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
@@ -75,7 +75,7 @@ public class SegmentConverterTest {
     schema.addField(new DimensionFieldSpec(D2, FieldSpec.DataType.STRING, true));
     schema.addField(new MetricFieldSpec(M1, FieldSpec.DataType.INT));
     schema.addField(new TimeFieldSpec(T, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
-    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(T).build();
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(T).build();
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
     for (int i = 0; i < NUM_ROWS; i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -116,7 +116,7 @@ public class SegmentPurgerTest {
     };
 
     SegmentPurger segmentPurger =
-        new SegmentPurger(TABLE_NAME, _originalIndexDir, PURGED_SEGMENT_DIR, recordPurger, recordModifier);
+        new SegmentPurger(TABLE_NAME, null, _originalIndexDir, PURGED_SEGMENT_DIR, recordPurger, recordModifier);
     File purgedIndexDir = segmentPurger.purgeSegment();
 
     // Check the purge/modify counter in segment purger

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -87,7 +87,7 @@ public class SegmentPurgerTest {
     }
     GenericRowRecordReader genericRowRecordReader = new GenericRowRecordReader(rows);
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -32,10 +32,13 @@ import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.store.ColumnIndexType;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -70,6 +73,7 @@ public class SegmentPurgerTest {
     Schema schema = new Schema();
     schema.addField(new DimensionFieldSpec(D1, FieldSpec.DataType.INT, true));
     schema.addField(new DimensionFieldSpec(D2, FieldSpec.DataType.INT, true));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -87,7 +91,7 @@ public class SegmentPurgerTest {
     }
     GenericRowRecordReader genericRowRecordReader = new GenericRowRecordReader(rows);
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);
@@ -116,7 +120,7 @@ public class SegmentPurgerTest {
     };
 
     SegmentPurger segmentPurger =
-        new SegmentPurger(TABLE_NAME, null, _originalIndexDir, PURGED_SEGMENT_DIR, recordPurger, recordModifier);
+        new SegmentPurger(TABLE_NAME, _originalIndexDir, PURGED_SEGMENT_DIR, recordPurger, recordModifier);
     File purgedIndexDir = segmentPurger.purgeSegment();
 
     // Check the purge/modify counter in segment purger

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -28,6 +28,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -45,6 +47,7 @@ import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -123,8 +126,9 @@ public abstract class BaseTransformFunctionTest {
     schema.addField(new DimensionFieldSpec(STRING_SV_COLUMN, FieldSpec.DataType.STRING, true));
     schema.addField(new DimensionFieldSpec(INT_MV_COLUMN, FieldSpec.DataType.INT, false));
     schema.addField(new TimeFieldSpec(TIME_COLUMN, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME_COLUMN).build();
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(INDEX_DIR_PATH);
     config.setSegmentName(SEGMENT_NAME);
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -126,7 +126,8 @@ public abstract class BaseTransformFunctionTest {
     schema.addField(new DimensionFieldSpec(STRING_SV_COLUMN, FieldSpec.DataType.STRING, true));
     schema.addField(new DimensionFieldSpec(INT_MV_COLUMN, FieldSpec.DataType.INT, false));
     schema.addField(new TimeFieldSpec(TIME_COLUMN, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME_COLUMN).build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME_COLUMN).build();
 
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(INDEX_DIR_PATH);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.core.operator.transform.function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
@@ -38,6 +40,7 @@ import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
@@ -82,8 +85,9 @@ public class DateTruncTransformFunctionTest
     List<GenericRow> rows = ImmutableList.of(row);
     Schema schema = new Schema();
     schema.addField(new TimeFieldSpec(TIME_COLUMN, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME_COLUMN).build();
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     String segmentName = "testSegment";
     String indexDirPath = Paths.get(Files.createTempDirectory("pinot_date_trunc_test").toAbsolutePath().toString(), segmentName).toAbsolutePath().toString();
     try {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
@@ -85,7 +85,8 @@ public class DateTruncTransformFunctionTest
     List<GenericRow> rows = ImmutableList.of(row);
     Schema schema = new Schema();
     schema.addField(new TimeFieldSpec(TIME_COLUMN, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME_COLUMN).build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME_COLUMN).build();
 
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     String segmentName = "testSegment";

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -39,9 +39,12 @@ import org.apache.pinot.core.plan.SelectionPlanNode;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
@@ -81,9 +84,10 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
         .addSingleValueDimension("column12", FieldSpec.DataType.STRING).addMetric("column17", FieldSpec.DataType.INT)
         .addMetric("column18", FieldSpec.DataType.INT).addTime("daysSinceEpoch", 1, TimeUnit.DAYS, DataType.INT)
         .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName("daysSinceEpoch").build();
 
     // Create the segment generator config.
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setInputFilePath(filePath);
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -84,7 +84,8 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
         .addSingleValueDimension("column12", FieldSpec.DataType.STRING).addMetric("column17", FieldSpec.DataType.INT)
         .addMetric("column18", FieldSpec.DataType.INT).addTime("daysSinceEpoch", 1, TimeUnit.DAYS, DataType.INT)
         .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName("daysSinceEpoch").build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName("daysSinceEpoch").build();
 
     // Create the segment generator config.
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RawIndexCreatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RawIndexCreatorTest.java
@@ -204,7 +204,7 @@ public class RawIndexCreatorTest {
    */
   private RecordReader buildIndex(Schema schema)
       throws Exception {
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setRawIndexCreationColumns(schema.getDimensionNames());
 
     config.setOutDir(SEGMENT_DIR_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
@@ -223,7 +223,7 @@ public class SegmentGenerationWithBytesTypeTest {
 
   private RecordReader buildIndex(Schema schema)
       throws Exception {
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
 
     config.setOutDir(SEGMENT_DIR_NAME);
     config.setSegmentName(SEGMENT_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
@@ -164,7 +164,7 @@ public class SegmentGenerationWithNullValueVectorTest {
 
   private void buildIndex(Schema schema)
       throws Exception {
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
 
     config.setOutDir(SEGMENT_DIR_NAME);
     config.setSegmentName(SEGMENT_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -122,7 +122,7 @@ public class SegmentGenerationWithTimeColumnTest {
   }
 
   private TableConfig createTableConfig() {
-    return new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME_COL_NAME).build();
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME_COL_NAME).build();
   }
 
   private File buildSegment(final TableConfig tableConfig, final Schema schema, final boolean isSimpleDate,

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentPartitionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentPartitionTest.java
@@ -197,7 +197,7 @@ public class SegmentPartitionTest {
         .put(PARTITIONED_COLUMN_NAME, new ColumnPartitionConfig(PARTITION_FUNCTION_NAME, NUM_PARTITIONS));
 
     SegmentPartitionConfig segmentPartitionConfig = new SegmentPartitionConfig(partitionFunctionMap);
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
 
     config.setOutDir(SEGMENT_DIR_NAME);
     config.setSegmentName(SEGMENT_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -126,7 +126,7 @@ abstract class BaseStarTreeV2Test<R, A> {
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(null, schema);
     segmentGeneratorConfig.setOutDir(TEMP_DIR.getPath());
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
     driver.init(segmentGeneratorConfig, new GenericRowRecordReader(segmentRecords));

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
@@ -96,7 +96,8 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
         .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
         .addMetric("column10", FieldSpec.DataType.INT).addTime("daysSinceEpoch", TimeUnit.DAYS, FieldSpec.DataType.INT)
         .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName("daysSinceEpoch").build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName("daysSinceEpoch").build();
 
     // Create the segment generator config.
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.segment.ReadMode;
@@ -35,6 +37,7 @@ import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
@@ -93,9 +96,10 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
         .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
         .addMetric("column10", FieldSpec.DataType.INT).addTime("daysSinceEpoch", TimeUnit.DAYS, FieldSpec.DataType.INT)
         .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName("daysSinceEpoch").build();
 
     // Create the segment generator config.
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setInputFilePath(filePath);
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -100,7 +100,8 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
         .addSingleValueDimension("column12", FieldSpec.DataType.STRING).addMetric("column17", FieldSpec.DataType.INT)
         .addMetric("column18", FieldSpec.DataType.INT).addTime("daysSinceEpoch", TimeUnit.DAYS, FieldSpec.DataType.INT)
         .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName("daysSinceEpoch").build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName("daysSinceEpoch").build();
 
     // Create the segment generator config.
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -34,8 +34,11 @@ import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
@@ -97,9 +100,10 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
         .addSingleValueDimension("column12", FieldSpec.DataType.STRING).addMetric("column17", FieldSpec.DataType.INT)
         .addMetric("column18", FieldSpec.DataType.INT).addTime("daysSinceEpoch", TimeUnit.DAYS, FieldSpec.DataType.INT)
         .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName("daysSinceEpoch").build();
 
     // Create the segment generator config.
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setInputFilePath(filePath);
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -151,7 +151,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
       throws Exception {
     String segmentName = SEGMENT_NAME_PREFIX + index;
 
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(SCHEMA);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(null, SCHEMA);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(segmentName);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -169,7 +169,7 @@ public class FastHllQueriesTest extends BaseQueriesTest {
         .addSingleValueDimension("column18_HLL", FieldSpec.DataType.STRING).build();
 
     // Create the segment generator config
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(null, schema);
     segmentGeneratorConfig.setInputFilePath(filePath);
     segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestMVQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestMVQueriesTest.java
@@ -84,7 +84,7 @@ public class PercentileTDigestMVQueriesTest extends PercentileTDigestQueriesTest
     schema.addField(new MetricFieldSpec(TDIGEST_COLUMN, FieldSpec.DataType.BYTES));
     schema.addField(new DimensionFieldSpec(GROUP_BY_COLUMN, FieldSpec.DataType.STRING, true));
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setOutDir(INDEX_DIR.getPath());
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
@@ -146,7 +146,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
     schema.addField(new MetricFieldSpec(TDIGEST_COLUMN, FieldSpec.DataType.BYTES));
     schema.addField(new DimensionFieldSpec(GROUP_BY_COLUMN, FieldSpec.DataType.STRING, true));
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setOutDir(INDEX_DIR.getPath());
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/RangePredicateWithSortedInvertedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/RangePredicateWithSortedInvertedIndexTest.java
@@ -116,7 +116,7 @@ public class RangePredicateWithSortedInvertedIndexTest extends BaseQueriesTest {
 
   private void createSegment(Schema schema, RecordReader recordReader, String segmentName, String tableName)
       throws Exception {
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(null, schema);
     segmentGeneratorConfig.setTableName(tableName);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
     segmentGeneratorConfig.setSegmentName(segmentName);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
@@ -207,7 +207,7 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
         .addMetric(DISTINCT_COUNT_HLL_COLUMN, DataType.BYTES).addMetric(MIN_MAX_RANGE_COLUMN, DataType.BYTES)
         .addMetric(PERCENTILE_EST_COLUMN, DataType.BYTES).addMetric(PERCENTILE_TDIGEST_COLUMN, DataType.BYTES).build();
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setOutDir(INDEX_DIR.getPath());
     config.setTableName(RAW_TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -145,7 +145,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
       throws Exception {
     textIndexColumns.add(QUERY_LOG_TEXT_COL_NAME);
     textIndexColumns.add(SKILLS_TEXT_COL_NAME);
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(_schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(null, _schema);
     segmentGeneratorConfig.setTableName(TABLE_NAME);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
@@ -87,7 +87,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
             .addSingleValueDimension(M1, FieldSpec.DataType.INT).addSingleValueDimension(M2, FieldSpec.DataType.INT)
             .addSingleValueDimension(M3, FieldSpec.DataType.LONG).addSingleValueDimension(M4, FieldSpec.DataType.LONG)
             .addTime(TIME, TimeUnit.MILLISECONDS, FieldSpec.DataType.LONG).build();
-    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME).build();
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME).build();
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.response.broker.AggregationResult;
@@ -50,6 +52,7 @@ import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.testng.Assert;
@@ -73,6 +76,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "TransformQueriesTest");
 
   private Schema _schema;
+  private TableConfig _tableConfig;
   private List<IndexSegment> _indexSegments = new ArrayList<>();
   private List<SegmentDataManager> _segmentDataManagers;
 
@@ -83,6 +87,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
             .addSingleValueDimension(M1, FieldSpec.DataType.INT).addSingleValueDimension(M2, FieldSpec.DataType.INT)
             .addSingleValueDimension(M3, FieldSpec.DataType.LONG).addSingleValueDimension(M4, FieldSpec.DataType.LONG)
             .addTime(TIME, TimeUnit.MILLISECONDS, FieldSpec.DataType.LONG).build();
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(TIME).build();
   }
 
   @AfterClass
@@ -105,7 +110,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
     try {
       final List<GenericRow> rows = createDataSet(10);
       try (final RecordReader recordReader = new GenericRowRecordReader(rows)) {
-        createSegment(_schema, recordReader, SEGMENT_NAME_1, TABLE_NAME);
+        createSegment(_tableConfig, _schema, recordReader, SEGMENT_NAME_1, TABLE_NAME);
         final ImmutableSegment segment = loadSegment(SEGMENT_NAME_1);
         _indexSegments.add(segment);
 
@@ -168,7 +173,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
     }
 
     try (final RecordReader recordReader = new GenericRowRecordReader(rows)) {
-      createSegment(_schema, recordReader, SEGMENT_NAME_1, TABLE_NAME);
+      createSegment(_tableConfig, _schema, recordReader, SEGMENT_NAME_1, TABLE_NAME);
       final ImmutableSegment segment = loadSegment(SEGMENT_NAME_1);
       _indexSegments.add(segment);
 
@@ -207,8 +212,8 @@ public class TransformQueriesTest extends BaseQueriesTest {
 
       try (final RecordReader recordReaderOne = new GenericRowRecordReader(segmentOneRows);
           final RecordReader recordReaderTwo = new GenericRowRecordReader(segmentTwoRows)) {
-        createSegment(_schema, recordReaderOne, SEGMENT_NAME_1, TABLE_NAME);
-        createSegment(_schema, recordReaderTwo, SEGMENT_NAME_2, TABLE_NAME);
+        createSegment(_tableConfig, _schema, recordReaderOne, SEGMENT_NAME_1, TABLE_NAME);
+        createSegment(_tableConfig, _schema, recordReaderTwo, SEGMENT_NAME_2, TABLE_NAME);
 
         final ImmutableSegment segmentOne = loadSegment(SEGMENT_NAME_1);
         final ImmutableSegment segmentTwo = loadSegment(SEGMENT_NAME_2);
@@ -298,9 +303,10 @@ public class TransformQueriesTest extends BaseQueriesTest {
     return _segmentDataManagers;
   }
 
-  private void createSegment(Schema schema, RecordReader recordReader, String segmentName, String tableName)
+  private void createSegment(TableConfig tableConfig, Schema schema, RecordReader recordReader, String segmentName,
+      String tableName)
       throws Exception {
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setTableName(tableName);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
     segmentGeneratorConfig.setSegmentName(segmentName);

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -121,7 +121,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
       schema.addField(new DimensionFieldSpec(multiValueColumn, FieldSpec.DataType.INT, false));
     }
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setOutDir(INDEX_DIR_PATH);
     config.setSegmentName(SEGMENT_NAME);
 

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -210,7 +210,7 @@ public class NoDictionaryGroupKeyGeneratorTest {
       schema.addField(dimensionFieldSpec);
     }
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setRawIndexCreationColumns(Arrays.asList(NO_DICT_COLUMN_NAMES));
 
     config.setOutDir(INDEX_DIR_PATH);

--- a/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
@@ -44,7 +44,8 @@ public class RealtimeSegmentConverterTest {
         new TimeFieldSpec("col1", FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "col2", FieldSpec.DataType.LONG,
             TimeUnit.DAYS);
     schema.addField(tfs);
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTimeColumnName("col2").build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName("test").setTimeColumnName("col2").build();
     String segmentName = "segment1";
     VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSegmentSchema(schema, segmentName);
     Assert.assertEquals(schema.getColumnNames().size(), 5);

--- a/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
@@ -21,11 +21,14 @@ package org.apache.pinot.realtime.converter;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -41,13 +44,14 @@ public class RealtimeSegmentConverterTest {
         new TimeFieldSpec("col1", FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "col2", FieldSpec.DataType.LONG,
             TimeUnit.DAYS);
     schema.addField(tfs);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTimeColumnName("col2").build();
     String segmentName = "segment1";
     VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSegmentSchema(schema, segmentName);
     Assert.assertEquals(schema.getColumnNames().size(), 5);
     Assert.assertEquals(schema.getTimeFieldSpec().getIncomingGranularitySpec().getTimeType(), TimeUnit.MILLISECONDS);
 
     RealtimeSegmentConverter converter =
-        new RealtimeSegmentConverter(null, "", schema, "testTable", "col1", segmentName, "col1");
+        new RealtimeSegmentConverter(null, "", schema, "testTable", tableConfig, segmentName, "col1");
 
     Schema newSchema = converter.getUpdatedSchema(schema);
     Assert.assertEquals(newSchema.getColumnNames().size(), 2);
@@ -64,7 +68,7 @@ public class RealtimeSegmentConverterTest {
     schema.addField(new MetricFieldSpec("met2", FieldSpec.DataType.LONG, 0));
     Assert.assertEquals(schema.getColumnNames().size(), 5);
     RealtimeSegmentConverter converter =
-        new RealtimeSegmentConverter(null, "", schema, "testTable", "col1", "segment1", "col1");
+        new RealtimeSegmentConverter(null, "", schema, "testTable", null, "segment1", "col1");
     Schema newSchema = converter.getUpdatedSchema(schema);
     Assert.assertEquals(newSchema.getColumnNames().size(), 5);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/OnHeapDictionariesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/OnHeapDictionariesTest.java
@@ -166,7 +166,7 @@ public class OnHeapDictionariesTest {
   private Schema buildSegment(String segmentDirName, String segmentName, Schema schema)
       throws Exception {
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setOutDir(segmentDirName);
     config.setFormat(FileFormat.AVRO);
     config.setSegmentName(segmentName);

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/SegmentTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/SegmentTestUtils.java
@@ -18,14 +18,10 @@
  */
 package org.apache.pinot.segments.v1.creator;
 
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.apache.avro.Schema.Field;
@@ -38,18 +34,15 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
+import org.apache.pinot.plugin.inputformat.avro.AvroSchemaUtil;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeFieldSpec;
-import org.apache.pinot.spi.data.TimeGranularitySpec;
-import org.apache.pinot.plugin.inputformat.avro.AvroSchemaUtil;
 import org.apache.pinot.spi.data.readers.FileFormat;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
-import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +55,7 @@ public class SegmentTestUtils {
       @Nonnull File outputDir, @Nonnull String tableName)
       throws IOException {
     SegmentGeneratorConfig segmentGeneratorConfig =
-        new SegmentGeneratorConfig(extractSchemaFromAvroWithoutTime(avroFile));
+        new SegmentGeneratorConfig(null, extractSchemaFromAvroWithoutTime(avroFile));
     segmentGeneratorConfig.setInputFilePath(avroFile.getAbsolutePath());
     segmentGeneratorConfig.setOutDir(outputDir.getAbsolutePath());
     segmentGeneratorConfig.setTableName(tableName);
@@ -73,7 +66,7 @@ public class SegmentTestUtils {
       String timeColumn, TimeUnit timeUnit, String tableName)
       throws IOException {
     final SegmentGeneratorConfig segmentGenSpec =
-        new SegmentGeneratorConfig(extractSchemaFromAvroWithoutTime(inputAvro));
+        new SegmentGeneratorConfig(null, extractSchemaFromAvroWithoutTime(inputAvro));
     segmentGenSpec.setInputFilePath(inputAvro.getAbsolutePath());
     segmentGenSpec.setTimeColumnName(timeColumn);
     segmentGenSpec.setSegmentTimeUnit(timeUnit);
@@ -87,61 +80,14 @@ public class SegmentTestUtils {
 
   public static SegmentGeneratorConfig getSegmentGeneratorConfigWithSchema(File inputAvro, File outputDir,
       String tableName, Schema schema) {
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(null, schema);
     segmentGeneratorConfig.setInputFilePath(inputAvro.getAbsolutePath());
     segmentGeneratorConfig.setOutDir(outputDir.getAbsolutePath());
     segmentGeneratorConfig.setFormat(FileFormat.AVRO);
     segmentGeneratorConfig.setSegmentVersion(SegmentVersion.v1);
     segmentGeneratorConfig.setTableName(tableName);
-    segmentGeneratorConfig.setTimeColumnName(schema.getTimeColumnName());
-    segmentGeneratorConfig.setSegmentTimeUnit(schema.getOutgoingTimeUnit());
+    segmentGeneratorConfig.setTime(schema.getTimeFieldSpec());
     return segmentGeneratorConfig;
-  }
-
-  public static List<String> getColumnNamesFromAvro(File avro)
-      throws IOException {
-    List<String> ret = new ArrayList<String>();
-    DataFileStream<GenericRecord> dataStream =
-        new DataFileStream<GenericRecord>(new FileInputStream(avro), new GenericDatumReader<GenericRecord>());
-    for (final Field field : dataStream.getSchema().getFields()) {
-      ret.add(field.name());
-    }
-    return ret;
-  }
-
-  public static Schema extractSchemaFromAvro(File avroFile, Map<String, FieldType> fieldTypeMap, TimeUnit granularity)
-      throws IOException {
-    DataFileStream<GenericRecord> dataStream =
-        new DataFileStream<>(new FileInputStream(avroFile), new GenericDatumReader<GenericRecord>());
-    Schema schema = new Schema();
-
-    for (final Field field : dataStream.getSchema().getFields()) {
-      final String columnName = field.name();
-      FieldType fieldType = fieldTypeMap.get(columnName);
-      Preconditions.checkNotNull(fieldType);
-
-      switch (fieldType) {
-        case TIME:
-          final TimeGranularitySpec gSpec = new TimeGranularitySpec(getColumnType(field), granularity, columnName);
-          final TimeFieldSpec fSpec = new TimeFieldSpec(gSpec);
-          schema.addField(fSpec);
-          continue;
-        case DIMENSION:
-          final FieldSpec dimensionFieldSpec =
-              new DimensionFieldSpec(columnName, getColumnType(field), isSingleValueField(field));
-          schema.addField(dimensionFieldSpec);
-          continue;
-        case METRIC:
-          final FieldSpec metricFieldSpec = new MetricFieldSpec(columnName, getColumnType(field));
-          schema.addField(metricFieldSpec);
-          continue;
-        default:
-          throw new UnsupportedOperationException("Unsupported field type: " + fieldType);
-      }
-    }
-
-    dataStream.close();
-    return schema;
   }
 
   public static Schema extractSchemaFromAvroWithoutTime(File avroFile)

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/SegmentTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/SegmentTestUtils.java
@@ -86,7 +86,7 @@ public class SegmentTestUtils {
     segmentGeneratorConfig.setFormat(FileFormat.AVRO);
     segmentGeneratorConfig.setSegmentVersion(SegmentVersion.v1);
     segmentGeneratorConfig.setTableName(tableName);
-    segmentGeneratorConfig.setTime(schema.getTimeFieldSpec());
+    segmentGeneratorConfig.setTime(null, schema);
     return segmentGeneratorConfig;
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -38,7 +38,9 @@ import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
 import org.apache.pinot.util.TestUtils;
@@ -53,6 +55,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   // Default settings
   private static final String DEFAULT_TABLE_NAME = "mytable";
   private static final String DEFAULT_SCHEMA_FILE_NAME = "On_Time_On_Time_Performance_2014_100k_subset_nonulls.schema";
+  private static final String DEFAULT_TIME_COLUMN_NAME = "DaysSinceEpoch";
   private static final String DEFAULT_AVRO_TAR_FILE_NAME =
       "On_Time_On_Time_Performance_2014_100k_subset_nonulls.tar.gz";
   private static final long DEFAULT_COUNT_STAR_RESULT = 115545L;
@@ -89,6 +92,10 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
 
   protected String getSchemaFileName() {
     return DEFAULT_SCHEMA_FILE_NAME;
+  }
+
+  protected String getTimeColumnName() {
+    return DEFAULT_TIME_COLUMN_NAME;
   }
 
   protected String getAvroTarFileName() {
@@ -402,9 +409,11 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
     String schemaName = schema.getSchemaName();
     addSchema(schemaFile, schemaName);
 
-    String timeColumnName = schema.getTimeColumnName();
-    Assert.assertNotNull(timeColumnName);
-    TimeUnit outgoingTimeUnit = schema.getOutgoingTimeUnit();
+    String timeColumnName = getTimeColumnName();
+    FieldSpec fieldSpec = schema.getFieldSpecFor(timeColumnName);
+    Assert.assertNotNull(fieldSpec);
+    TimeFieldSpec timeFieldSpec = (TimeFieldSpec) fieldSpec;
+    TimeUnit outgoingTimeUnit = timeFieldSpec.getOutgoingGranularitySpec().getTimeType();
     Assert.assertNotNull(outgoingTimeUnit);
     String timeType = outgoingTimeUnit.toString();
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTests.java
@@ -48,7 +48,9 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TagOverrideConfig;
 import org.apache.pinot.spi.config.table.TenantConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
@@ -183,9 +185,11 @@ public class ControllerPeriodicTasksIntegrationTests extends BaseClusterIntegrat
     String schemaName = schema.getSchemaName();
     addSchema(schemaFile, schemaName);
 
-    String timeColumnName = schema.getTimeColumnName();
-    Assert.assertNotNull(timeColumnName);
-    TimeUnit outgoingTimeUnit = schema.getOutgoingTimeUnit();
+    String timeColumnName = getTimeColumnName();
+    FieldSpec fieldSpec = schema.getFieldSpecFor(timeColumnName);
+    Assert.assertNotNull(fieldSpec);
+    TimeFieldSpec timeFieldSpec = (TimeFieldSpec) fieldSpec;
+    TimeUnit outgoingTimeUnit = timeFieldSpec.getOutgoingGranularitySpec().getTimeType();
     Assert.assertNotNull(outgoingTimeUnit);
     String timeType = outgoingTimeUnit.toString();
 
@@ -211,9 +215,11 @@ public class ControllerPeriodicTasksIntegrationTests extends BaseClusterIntegrat
     String schemaName = schema.getSchemaName();
     addSchema(schemaFile, schemaName);
 
-    String timeColumnName = schema.getTimeColumnName();
-    Assert.assertNotNull(timeColumnName);
-    TimeUnit outgoingTimeUnit = schema.getOutgoingTimeUnit();
+    String timeColumnName = getTimeColumnName();
+    FieldSpec fieldSpec = schema.getFieldSpecFor(timeColumnName);
+    Assert.assertNotNull(fieldSpec);
+    TimeFieldSpec timeFieldSpec = (TimeFieldSpec) fieldSpec;
+    TimeUnit outgoingTimeUnit = timeFieldSpec.getOutgoingGranularitySpec().getTimeType();
     Assert.assertNotNull(outgoingTimeUnit);
     String timeType = outgoingTimeUnit.toString();
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DefaultCommitterRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DefaultCommitterRealtimeIntegrationTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.core.data.readers.PinotSegmentUtil;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.server.realtime.ControllerLeaderLocator;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -142,11 +143,12 @@ public class DefaultCommitterRealtimeIntegrationTest extends RealtimeClusterInte
   public void buildSegment()
       throws Exception {
     Schema schema = _helixResourceManager.getSchema(getTableName());
+    TableConfig tableConfig = _helixResourceManager.getTableConfig(getTableName());
     String _segmentOutputDir = Files.createTempDir().toString();
     List<GenericRow> _rows = PinotSegmentUtil.createTestData(schema, 1);
     RecordReader _recordReader = new GenericRowRecordReader(_rows);
 
-    _indexDir = PinotSegmentUtil.createSegment(schema, "segmentName", _segmentOutputDir, _recordReader);
+    _indexDir = PinotSegmentUtil.createSegment(tableConfig, schema, "segmentName", _segmentOutputDir, _recordReader);
   }
 
   private JsonNode getSegmentsFromJsonSegmentAPI(String json, String type)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -31,7 +31,9 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
@@ -127,9 +129,11 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
     String schemaName = _schema.getSchemaName();
     addSchema(getSchemaFile(), schemaName);
 
-    String timeColumnName = _schema.getTimeColumnName();
-    Assert.assertNotNull(timeColumnName);
-    TimeUnit outgoingTimeUnit = _schema.getOutgoingTimeUnit();
+    String timeColumnName = getTimeColumnName();
+    FieldSpec fieldSpec = _schema.getFieldSpecFor(timeColumnName);
+    Assert.assertNotNull(fieldSpec);
+    TimeFieldSpec timeFieldSpec = (TimeFieldSpec) fieldSpec;
+    TimeUnit outgoingTimeUnit = timeFieldSpec.getOutgoingGranularitySpec().getTimeType();
     Assert.assertNotNull(outgoingTimeUnit);
     String timeType = outgoingTimeUnit.toString();
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTestCommandLineRunner.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTestCommandLineRunner.java
@@ -37,7 +37,9 @@ import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.broker.requesthandler.PinotQueryRequest;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.tools.query.comparison.QueryComparison;
@@ -289,9 +291,11 @@ public class HybridClusterIntegrationTestCommandLineRunner {
       // Create Pinot table
       String schemaName = schema.getSchemaName();
       addSchema(_schemaFile, schemaName);
-      String timeColumnName = schema.getTimeColumnName();
-      Assert.assertNotNull(timeColumnName);
-      TimeUnit outgoingTimeUnit = schema.getOutgoingTimeUnit();
+      String timeColumnName = getTimeColumnName();
+      FieldSpec fieldSpec = schema.getFieldSpecFor(timeColumnName);
+      Assert.assertNotNull(fieldSpec);
+      TimeFieldSpec timeFieldSpec = (TimeFieldSpec) fieldSpec;
+      TimeUnit outgoingTimeUnit = timeFieldSpec.getOutgoingGranularitySpec().getTimeType();
       Assert.assertNotNull(outgoingTimeUnit);
       String timeType = outgoingTimeUnit.toString();
       addHybridTable(_tableName, _useLlc, KAFKA_BROKER, KAFKA_ZK_STR, getKafkaTopic(), getRealtimeSegmentFlushSize(),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/server/util/SegmentTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/server/util/SegmentTestUtils.java
@@ -40,9 +40,9 @@ public class SegmentTestUtils {
       throws IOException {
     SegmentGeneratorConfig segmentGeneratorConfig;
     if (pinotSchema == null) {
-      segmentGeneratorConfig = new SegmentGeneratorConfig(AvroUtils.getPinotSchemaFromAvroDataFile(inputAvro));
+      segmentGeneratorConfig = new SegmentGeneratorConfig(null, AvroUtils.getPinotSchemaFromAvroDataFile(inputAvro));
     } else {
-      segmentGeneratorConfig = new SegmentGeneratorConfig(pinotSchema);
+      segmentGeneratorConfig = new SegmentGeneratorConfig(null, pinotSchema);
     }
 
     segmentGeneratorConfig.setInputFilePath(inputAvro.getAbsolutePath());

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PurgeTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PurgeTaskExecutor.java
@@ -43,13 +43,15 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
 
+    String timeColumnName = configs.get(MinionConstants.TIME_COLUMN_NAME_KEY);
     SegmentPurger.RecordPurgerFactory recordPurgerFactory = MINION_CONTEXT.getRecordPurgerFactory();
     SegmentPurger.RecordPurger recordPurger =
         recordPurgerFactory != null ? recordPurgerFactory.getRecordPurger(rawTableName) : null;
     SegmentPurger.RecordModifierFactory recordModifierFactory = MINION_CONTEXT.getRecordModifierFactory();
     SegmentPurger.RecordModifier recordModifier =
         recordModifierFactory != null ? recordModifierFactory.getRecordModifier(rawTableName) : null;
-    SegmentPurger segmentPurger = new SegmentPurger(rawTableName, originalIndexDir, workingDir, recordPurger, recordModifier);
+    SegmentPurger segmentPurger =
+        new SegmentPurger(rawTableName, timeColumnName, originalIndexDir, workingDir, recordPurger, recordModifier);
 
     File purgedSegmentFile = segmentPurger.purgeSegment();
     if (purgedSegmentFile == null) {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PurgeTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PurgeTaskExecutor.java
@@ -43,7 +43,6 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
 
-    String timeColumnName = configs.get(MinionConstants.TIME_COLUMN_NAME_KEY);
     SegmentPurger.RecordPurgerFactory recordPurgerFactory = MINION_CONTEXT.getRecordPurgerFactory();
     SegmentPurger.RecordPurger recordPurger =
         recordPurgerFactory != null ? recordPurgerFactory.getRecordPurger(rawTableName) : null;
@@ -51,7 +50,7 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     SegmentPurger.RecordModifier recordModifier =
         recordModifierFactory != null ? recordModifierFactory.getRecordModifier(rawTableName) : null;
     SegmentPurger segmentPurger =
-        new SegmentPurger(rawTableName, timeColumnName, originalIndexDir, workingDir, recordPurger, recordModifier);
+        new SegmentPurger(rawTableName, originalIndexDir, workingDir, recordPurger, recordModifier);
 
     File purgedSegmentFile = segmentPurger.purgeSegment();
     if (purgedSegmentFile == null) {

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/executor/PurgeTaskExecutorTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/executor/PurgeTaskExecutorTest.java
@@ -73,7 +73,7 @@ public class PurgeTaskExecutorTest {
     }
     GenericRowRecordReader genericRowRecordReader = new GenericRowRecordReader(rows);
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
@@ -128,7 +128,7 @@ public class RawIndexBenchmark {
       schema.addField(dimensionFieldSpec);
     }
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setRawIndexCreationColumns(Collections.singletonList(_rawIndexColumn));
 
     config.setOutDir(SEGMENT_DIR_NAME);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
@@ -81,7 +81,7 @@ public class StringDictionaryPerfTest {
     _dictLength = dictLength;
     _inputStrings = new String[dictLength];
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(null, schema);
     config.setOutDir(_indexDir.getParent());
     config.setFormat(FileFormat.AVRO);
     config.setSegmentName(segmentName);

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
@@ -49,6 +49,9 @@ public class PinotOutputFormat<K, V> extends FileOutputFormat<K, V> {
   // Name of the segment.
   public static final String SEGMENT_NAME = "pinot.segment_name";
 
+  // Name of the time column.
+  public static final String TIME_COLUMN_NAME = "pinot.time_column_name";
+
   // file containing schema for the data
   public static final String SCHEMA = "pinot.schema.file";
 
@@ -91,6 +94,14 @@ public class PinotOutputFormat<K, V> extends FileOutputFormat<K, V> {
       throw new RuntimeException("pinot segment name not set.");
     }
     return segment;
+  }
+
+  public static void setTimeColumnName(Job job, String timeColumnName) {
+    job.getConfiguration().set(PinotOutputFormat.TIME_COLUMN_NAME, timeColumnName);
+  }
+
+  public static String getTimeColumnName(JobContext context) {
+    return context.getConfiguration().get(PinotOutputFormat.TIME_COLUMN_NAME);
   }
 
   public static void setSchema(Job job, Schema schema) {
@@ -165,7 +176,7 @@ public class PinotOutputFormat<K, V> extends FileOutputFormat<K, V> {
     _segmentConfig.setSegmentName(PinotOutputFormat.getSegmentName(context));
     Schema schema = Schema.fromString(PinotOutputFormat.getSchema(context));
     _segmentConfig.setSchema(schema);
-    _segmentConfig.setTime(schema.getTimeFieldSpec());
+    _segmentConfig.setTime(PinotOutputFormat.getTimeColumnName(context), schema);
     _segmentConfig.setReaderConfigFile(PinotOutputFormat.getReaderConfig(context));
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
@@ -163,7 +163,9 @@ public class PinotOutputFormat<K, V> extends FileOutputFormat<K, V> {
     _segmentConfig.setOverwrite(true);
     _segmentConfig.setTableName(PinotOutputFormat.getTableName(context));
     _segmentConfig.setSegmentName(PinotOutputFormat.getSegmentName(context));
-    _segmentConfig.setSchema(Schema.fromString(PinotOutputFormat.getSchema(context)));
+    Schema schema = Schema.fromString(PinotOutputFormat.getSchema(context));
+    _segmentConfig.setSchema(schema);
+    _segmentConfig.setTime(schema.getTimeFieldSpec());
     _segmentConfig.setReaderConfigFile(PinotOutputFormat.getReaderConfig(context));
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
@@ -68,6 +68,7 @@ public class PinotOutputFormatTest {
     PinotOutputFormat.setOutputPath(job, outDir);
     PinotOutputFormat.setTableName(job, "emp");
     PinotOutputFormat.setSegmentName(job, indexType + "segment_one");
+    PinotOutputFormat.setTimeColumnName(job, "epochDays");
     PinotOutputFormat.setTempSegmentDir(job, workingTempDir.getAbsolutePath());
 
     Schema schema = Schema.fromString(getSchema());

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoderTest.java
@@ -55,7 +55,7 @@ public class KafkaJSONMessageDecoderTest {
   public void testJsonDecoderWithOutgoingTimeSpec()
       throws Exception {
     Schema schema = Schema.fromFile(new File(
-        getClass().getClassLoader().getResource("data/test_sample_data_schema_with_outgoing_time_field.json")
+        getClass().getClassLoader().getResource("data/test_sample_data_schema_with_outgoing_time_spec.json")
             .getFile()));
     Map<String, FieldSpec.DataType> sourceFields = new HashMap<>();
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoderTest.java
@@ -24,6 +24,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
@@ -39,43 +41,58 @@ public class KafkaJSONMessageDecoderTest {
   @Test
   public void testJsonDecoderWithoutOutgoingTimeSpec()
       throws Exception {
-    testJsonDecoderWithSchema(Schema.fromFile(new File(
+    Schema schema = Schema.fromFile(new File(
         getClass().getClassLoader().getResource("data/test_sample_data_schema_without_outgoing_time_spec.json")
-            .getFile())));
+            .getFile()));
+    Map<String, FieldSpec.DataType> sourceFields = new HashMap<>();
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      sourceFields.put(fieldSpec.getName(), fieldSpec.getDataType());
+    }
+    testJsonDecoder(sourceFields);
   }
 
   @Test
   public void testJsonDecoderWithOutgoingTimeSpec()
       throws Exception {
-    testJsonDecoderWithSchema(Schema.fromFile(new File(
-        getClass().getClassLoader().getResource("data/test_sample_data_schema_no_time_field.json").getFile())));
+    Schema schema = Schema.fromFile(new File(
+        getClass().getClassLoader().getResource("data/test_sample_data_schema_with_outgoing_time_field.json")
+            .getFile()));
+    Map<String, FieldSpec.DataType> sourceFields = new HashMap<>();
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      sourceFields.put(fieldSpec.getName(), fieldSpec.getDataType());
+    }
+    sourceFields.remove("secondsSinceEpoch");
+    sourceFields.put("time_day", FieldSpec.DataType.INT);
+    testJsonDecoder(sourceFields);
   }
 
   @Test
   public void testJsonDecoderNoTimeSpec()
       throws Exception {
-    testJsonDecoderWithSchema(Schema.fromFile(new File(
-        getClass().getClassLoader().getResource("data/test_sample_data_schema_no_time_field.json").getFile())));
+    Schema schema = Schema.fromFile(
+        new File(getClass().getClassLoader().getResource("data/test_sample_data_schema_no_time_field.json").getFile()));
+    Map<String, FieldSpec.DataType> sourceFields = new HashMap<>();
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      sourceFields.put(fieldSpec.getName(), fieldSpec.getDataType());
+    }
+    testJsonDecoder(sourceFields);
   }
 
-  private void testJsonDecoderWithSchema(Schema schema)
+  private void testJsonDecoder(Map<String, FieldSpec.DataType> sourceFields)
       throws Exception {
     try (BufferedReader reader = new BufferedReader(
         new FileReader(getClass().getClassLoader().getResource("data/test_sample_data.json").getFile()))) {
       KafkaJSONMessageDecoder decoder = new KafkaJSONMessageDecoder();
-      decoder.init(new HashMap<>(), schema.getColumnNames(), "testTopic");
+      decoder.init(new HashMap<>(), sourceFields.keySet(), "testTopic");
       GenericRow r = new GenericRow();
       String line = reader.readLine();
       while (line != null) {
         JsonNode jsonNode = objectMapper.reader().readTree(line);
         decoder.decode(line.getBytes(), r);
-        for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-          FieldSpec incomingFieldSpec = fieldSpec.getFieldType() == FieldSpec.FieldType.TIME ? new TimeFieldSpec(
-              schema.getTimeFieldSpec().getIncomingGranularitySpec()) : fieldSpec;
-          String fieldSpecName = incomingFieldSpec.getName();
-          Object actualValue = r.getValue(fieldSpecName);
-          JsonNode expectedValue = jsonNode.get(fieldSpecName);
-          switch (incomingFieldSpec.getDataType()) {
+        for (String field : sourceFields.keySet()) {
+          Object actualValue = r.getValue(field);
+          JsonNode expectedValue = jsonNode.get(field);
+          switch (sourceFields.get(field)) {
             case STRING:
               Assert.assertEquals(actualValue, expectedValue.asText());
               break;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -51,8 +51,6 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     _segmentAssignmentStrategy = segmentAssignmentStrategy;
   }
 
-  // TODO: Use TimeFieldSpec in Schema
-  @Deprecated
   public String getTimeColumnName() {
     return _timeColumnName;
   }
@@ -61,7 +59,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     _timeColumnName = timeColumnName;
   }
 
-  // TODO: Use TimeFieldSpec in Schema
+  // TODO: Get field spec of _timeColumnName from Schema for the timeType
   @Deprecated
   public TimeUnit getTimeType() {
     return _timeType;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -348,6 +348,7 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
               config.setSegmentName(_segmentName + "_" + segCnt);
               Schema schema = Schema.fromFile(new File(_schemaFile));
               config.setSchema(schema);
+              config.setTime(schema.getTimeFieldSpec());
 
               final SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
               switch (config.getFormat()) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -348,7 +348,7 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
               config.setSegmentName(_segmentName + "_" + segCnt);
               Schema schema = Schema.fromFile(new File(_schemaFile));
               config.setSchema(schema);
-              config.setTime(schema.getTimeFieldSpec());
+              config.setTime(_timeColumnName, schema);
 
               final SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
               switch (config.getFormat()) {


### PR DESCRIPTION
This is an item for this project: https://github.com/apache/incubator-pinot/issues/2756
One of the initial steps is - in all places where primary time column is needed, refer to timeColumnName in tableConfig, instead of from schema. Then use the timeColumnName to fetch the fieldSpec from schema. 
Major changes:
1) Removing SegmentGeneratorConfig(Schema schema) constructor. Enforcing the usage of SegmentGeneratorConfig(TableConfig tableConfig, Schema schema) instead. This allows us to read time from table config.
2) If table config is not available, reading timeSpec. This will change to reading 1st dateTimeFieldSpec soon. This will fail if we have multiple dateTimeFieldSpecs and no table config defined.

Pending:
~1) Haven't figured out how to bring table config to SegmentPurger~