### PR TITLE
In SegmentPurger, use table config to generate the segment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/RawIndexConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/RawIndexConverter.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.minion;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -84,8 +83,8 @@ public class RawIndexConverter {
    * NOTE: original segment should be in V1 format.
    * TODO: support V3 format
    */
-  public RawIndexConverter(@Nonnull String rawTableName, @Nonnull File originalIndexDir,
-      @Nonnull File convertedIndexDir, @Nullable String columnsToConvert)
+  public RawIndexConverter(String rawTableName, File originalIndexDir, File convertedIndexDir,
+      @Nullable String columnsToConvert)
       throws Exception {
     FileUtils.copyDirectory(originalIndexDir, convertedIndexDir);
     IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
@@ -119,15 +118,15 @@ public class RawIndexConverter {
       for (String columnToConvert : StringUtils.split(_columnsToConvert, ',')) {
         FieldSpec fieldSpec = schema.getFieldSpecFor(columnToConvert);
         if (fieldSpec == null) {
-          LOGGER.warn("Skip converting column: {} because is does not exist in the schema");
+          LOGGER.warn("Skip converting column: {} because is does not exist in the schema", columnsToConvert);
           continue;
         }
         if (!fieldSpec.isSingleValueField()) {
-          LOGGER.warn("Skip converting column: {} because it's a multi-value column");
+          LOGGER.warn("Skip converting column: {} because it's a multi-value column", columnsToConvert);
           continue;
         }
         if (!_originalSegmentMetadata.hasDictionary(columnToConvert)) {
-          LOGGER.warn("Skip converting column: {} because its index is not dictionary-based");
+          LOGGER.warn("Skip converting column: {} because its index is not dictionary-based", columnsToConvert);
           continue;
         }
         columnsToConvert.add(fieldSpec);

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
@@ -75,8 +75,8 @@ public class SegmentConverter {
 
   public SegmentConverter(List<File> inputIndexDirs, File workingDir, String tableName, String segmentName,
       int totalNumPartition, RecordTransformer recordTransformer, @Nullable RecordPartitioner recordPartitioner,
-      @Nullable RecordAggregator recordAggregator, @Nullable List<String> groupByColumns,
-      TableConfig tableConfig, boolean skipTimeValueCheck) {
+      @Nullable RecordAggregator recordAggregator, @Nullable List<String> groupByColumns, TableConfig tableConfig,
+      boolean skipTimeValueCheck) {
     _inputIndexDirs = inputIndexDirs;
     _workingDir = workingDir;
     _recordTransformer = recordTransformer;
@@ -152,13 +152,8 @@ public class SegmentConverter {
       throws Exception {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setOutDir(outputPath);
-    segmentGeneratorConfig.setTableName(tableName);
     segmentGeneratorConfig.setSegmentName(segmentName);
     segmentGeneratorConfig.setSkipTimeValueCheck(_skipTimeValueCheck);
-    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
-    if (indexingConfig != null && indexingConfig.getInvertedIndexColumns() != null) {
-      segmentGeneratorConfig.setInvertedIndexCreationColumns(indexingConfig.getInvertedIndexColumns());
-    }
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(segmentGeneratorConfig, recordReader);
     driver.build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -34,7 +34,6 @@ import org.apache.pinot.core.segment.store.ColumnIndexType;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -61,6 +60,7 @@ public class SegmentPurgerTest {
   private static final String D1 = "d1";
   private static final String D2 = "d2";
 
+  private TableConfig _tableConfig;
   private File _originalIndexDir;
   private int _expectedNumRecordsPurged;
   private int _expectedNumRecordsModified;
@@ -70,10 +70,11 @@ public class SegmentPurgerTest {
       throws Exception {
     FileUtils.deleteDirectory(TEMP_DIR);
 
-    Schema schema = new Schema();
-    schema.addField(new DimensionFieldSpec(D1, FieldSpec.DataType.INT, true));
-    schema.addField(new DimensionFieldSpec(D2, FieldSpec.DataType.INT, true));
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setInvertedIndexColumns(Collections.singletonList(D1)).setCreateInvertedIndexDuringSegmentGeneration(true)
+        .build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(D1, FieldSpec.DataType.INT)
+        .addSingleValueDimension(D2, FieldSpec.DataType.INT).build();
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -85,17 +86,15 @@ public class SegmentPurgerTest {
       } else if (value2 == 0) {
         _expectedNumRecordsModified++;
       }
-      row.putField(D1, value1);
-      row.putField(D2, value2);
+      row.putValue(D1, value1);
+      row.putValue(D2, value2);
       rows.add(row);
     }
     GenericRowRecordReader genericRowRecordReader = new GenericRowRecordReader(rows);
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(_tableConfig, schema);
     config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());
-    config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);
-    config.setInvertedIndexCreationColumns(Collections.singletonList(D1));
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, genericRowRecordReader);
@@ -112,7 +111,7 @@ public class SegmentPurgerTest {
     // Modify records with d2 = 0 to d2 = Integer.MAX_VALUE
     SegmentPurger.RecordModifier recordModifier = row -> {
       if (row.getValue(D2).equals(0)) {
-        row.putField(D2, Integer.MAX_VALUE);
+        row.putValue(D2, Integer.MAX_VALUE);
         return true;
       } else {
         return false;
@@ -120,7 +119,7 @@ public class SegmentPurgerTest {
     };
 
     SegmentPurger segmentPurger =
-        new SegmentPurger(TABLE_NAME, _originalIndexDir, PURGED_SEGMENT_DIR, recordPurger, recordModifier);
+        new SegmentPurger(_originalIndexDir, PURGED_SEGMENT_DIR, _tableConfig, recordPurger, recordModifier);
     File purgedIndexDir = segmentPurger.purgeSegment();
 
     // Check the purge/modify counter in segment purger

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
@@ -49,7 +49,6 @@ import org.testng.annotations.Test;
  * columns' index into raw index for OFFLINE segments.
  */
 public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridClusterIntegrationTest {
-  private static final int NUM_MINIONS = 3;
   private static final String COLUMNS_TO_CONVERT = "ActualElapsedTime,ArrDelay,DepDelay,CRSDepTime";
 
   private PinotHelixTaskResourceManager _helixTaskResourceManager;
@@ -75,8 +74,7 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
     // The parent setUp() sets up Zookeeper, Kafka, controller, broker and servers
     super.setUp();
 
-    startMinions(NUM_MINIONS, null, null);
-
+    startMinion(null, null);
     _helixTaskResourceManager = _controllerStarter.getHelixTaskResourceManager();
     _taskManager = _controllerStarter.getTaskManager();
   }
@@ -84,14 +82,14 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
   @Test
   public void testConvertToRawIndexTask()
       throws Exception {
-    final String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(getTableName());
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(getTableName());
 
     File testDataDir = new File(CommonConstants.Server.DEFAULT_INSTANCE_DATA_DIR + "-0", offlineTableName);
     if (!testDataDir.isDirectory()) {
       testDataDir = new File(CommonConstants.Server.DEFAULT_INSTANCE_DATA_DIR + "-1", offlineTableName);
     }
     Assert.assertTrue(testDataDir.isDirectory());
-    final File tableDataDir = testDataDir;
+    File tableDataDir = testDataDir;
 
     // Check that all columns have dictionary
     File[] indexDirs = tableDataDir.listFiles();
@@ -168,8 +166,8 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
   @Test
   public void testPinotHelixResourceManagerAPIs() {
     // Instance APIs
-    Assert.assertEquals(_helixResourceManager.getAllInstances().size(), 7);
-    Assert.assertEquals(_helixResourceManager.getOnlineInstanceList().size(), 7);
+    Assert.assertEquals(_helixResourceManager.getAllInstances().size(), 5);
+    Assert.assertEquals(_helixResourceManager.getOnlineInstanceList().size(), 5);
     Assert.assertEquals(_helixResourceManager.getOnlineUnTaggedBrokerInstanceList().size(), 0);
     Assert.assertEquals(_helixResourceManager.getOnlineUnTaggedServerInstanceList().size(), 0);
 

--- a/pinot-minion/pom.xml
+++ b/pinot-minion/pom.xml
@@ -99,5 +99,10 @@
       <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionContext.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionContext.java
@@ -20,6 +20,8 @@ package org.apache.pinot.minion;
 
 import java.io.File;
 import javax.net.ssl.SSLContext;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.core.minion.SegmentPurger;
 import org.apache.pinot.minion.metrics.MinionMetrics;
 
@@ -39,7 +41,7 @@ public class MinionContext {
 
   private File _dataDir;
   private MinionMetrics _minionMetrics;
-  private String _minionVersion;
+  private ZkHelixPropertyStore<ZNRecord> _helixPropertyStore;
 
   // For segment upload
   private SSLContext _sslContext;
@@ -64,12 +66,12 @@ public class MinionContext {
     _minionMetrics = minionMetrics;
   }
 
-  public String getMinionVersion() {
-    return _minionVersion;
+  public ZkHelixPropertyStore<ZNRecord> getHelixPropertyStore() {
+    return _helixPropertyStore;
   }
 
-  public void setMinionVersion(String minionVersion) {
-    _minionVersion = minionVersion;
+  public void setHelixPropertyStore(ZkHelixPropertyStore<ZNRecord> helixPropertyStore) {
+    _helixPropertyStore = helixPropertyStore;
   }
 
   public SSLContext getSSLContext() {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -18,13 +18,12 @@
  */
 package org.apache.pinot.minion;
 
-import com.google.common.base.Preconditions;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
 import java.io.IOException;
-import javax.annotation.Nonnull;
 import javax.net.ssl.SSLContext;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
@@ -62,24 +61,20 @@ public class MinionStarter {
   private static final String HTTPS_PROTOCOL = "https";
   private static final String HTTPS_ENABLED = "enabled";
 
-  private final String _helixClusterName;
   private final Configuration _config;
   private final String _instanceId;
   private final HelixManager _helixManager;
   private final TaskExecutorFactoryRegistry _taskExecutorFactoryRegistry;
   private final EventObserverFactoryRegistry _eventObserverFactoryRegistry;
 
-  private HelixAdmin _helixAdmin;
-
   public MinionStarter(String zkAddress, String helixClusterName, Configuration config)
       throws Exception {
-    _helixClusterName = helixClusterName;
     _config = config;
     _instanceId = config.getString(CommonConstants.Helix.Instance.INSTANCE_ID_KEY,
         CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE + NetUtil.getHostAddress() + "_"
             + CommonConstants.Minion.DEFAULT_HELIX_PORT);
     setupHelixSystemProperties();
-    _helixManager = new ZKHelixManager(_helixClusterName, _instanceId, InstanceType.PARTICIPANT, zkAddress);
+    _helixManager = new ZKHelixManager(helixClusterName, _instanceId, InstanceType.PARTICIPANT, zkAddress);
     _taskExecutorFactoryRegistry = new TaskExecutorFactoryRegistry();
     _eventObserverFactoryRegistry = new EventObserverFactoryRegistry();
   }
@@ -96,29 +91,21 @@ public class MinionStarter {
   /**
    * Registers a task executor factory.
    * <p>This is for pluggable task executor factories.
-   *
-   * @param taskType Task type
-   * @param taskExecutorFactory Task executor factory associated with the task type
    */
-  public void registerTaskExecutorFactory(@Nonnull String taskType,
-      @Nonnull PinotTaskExecutorFactory taskExecutorFactory) {
+  public void registerTaskExecutorFactory(String taskType, PinotTaskExecutorFactory taskExecutorFactory) {
     _taskExecutorFactoryRegistry.registerTaskExecutorFactory(taskType, taskExecutorFactory);
   }
 
   /**
    * Registers an event observer factory.
    * <p>This is for pluggable event observer factories.
-   *
-   * @param taskType Task type
-   * @param eventObserverFactory Event observer factory associated with the task type
    */
-  public void registerEventObserverFactory(@Nonnull String taskType,
-      @Nonnull MinionEventObserverFactory eventObserverFactory) {
+  public void registerEventObserverFactory(String taskType, MinionEventObserverFactory eventObserverFactory) {
     _eventObserverFactoryRegistry.registerEventObserverFactory(taskType, eventObserverFactory);
   }
 
   /**
-   * Start the Pinot Minion instance.
+   * Starts the Pinot Minion instance.
    * <p>Should be called after all classes of task executor get registered.
    */
   public void start()
@@ -131,9 +118,10 @@ public class MinionStarter {
     LOGGER.info("Initializing data directory");
     File dataDir = new File(_config
         .getString(CommonConstants.Helix.Instance.DATA_DIR_KEY, CommonConstants.Minion.DEFAULT_INSTANCE_DATA_DIR));
-    if (!dataDir.exists()) {
-      Preconditions.checkState(dataDir.mkdirs());
+    if (dataDir.exists()) {
+      FileUtils.forceDelete(dataDir);
     }
+    FileUtils.forceMkdir(dataDir);
     minionContext.setDataDir(dataDir);
 
     // Initialize metrics
@@ -141,14 +129,11 @@ public class MinionStarter {
     MetricsHelper.initializeMetrics(_config);
     MetricsRegistry metricsRegistry = new MetricsRegistry();
     MetricsHelper.registerMetricsRegistry(metricsRegistry);
-    final MinionMetrics minionMetrics = new MinionMetrics(_config
+    MinionMetrics minionMetrics = new MinionMetrics(_config
         .getString(CommonConstants.Minion.CONFIG_OF_METRICS_PREFIX_KEY,
             CommonConstants.Minion.CONFIG_OF_METRICS_PREFIX), metricsRegistry);
     minionMetrics.initializeGlobalMeters();
     minionContext.setMinionMetrics(minionMetrics);
-
-    // TODO: set the correct minion version
-    minionContext.setMinionVersion("1.0");
 
     // Start all components
     LOGGER.info("Initializing PinotFSFactory");
@@ -179,8 +164,8 @@ public class MinionStarter {
     _helixManager.getStateMachineEngine().registerStateModelFactory("Task", new TaskStateModelFactory(_helixManager,
         new TaskFactoryRegistry(_taskExecutorFactoryRegistry, _eventObserverFactoryRegistry).getTaskFactoryRegistry()));
     _helixManager.connect();
-    _helixAdmin = _helixManager.getClusterManagmentTool();
     addInstanceTagIfNeeded();
+    minionContext.setHelixPropertyStore(_helixManager.getHelixPropertyStore());
 
     // Initialize health check callback
     LOGGER.info("Initializing health check callback");
@@ -202,7 +187,7 @@ public class MinionStarter {
   }
 
   /**
-   * Stop the Pinot Minion instance.
+   * Stops the Pinot Minion instance.
    */
   public void stop() {
     try {
@@ -217,13 +202,15 @@ public class MinionStarter {
   }
 
   /**
-   * Tag Pinot Minion instance if needed.
+   * Tags Pinot Minion instance if needed.
    */
   private void addInstanceTagIfNeeded() {
-    InstanceConfig instanceConfig = _helixAdmin.getInstanceConfig(_helixClusterName, _instanceId);
+    HelixAdmin helixAdmin = _helixManager.getClusterManagmentTool();
+    String clusterName = _helixManager.getClusterName();
+    InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, _instanceId);
     if (instanceConfig.getTags().isEmpty()) {
       LOGGER.info("Adding default Helix tag: {} to Pinot minion", CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
-      _helixAdmin.addInstanceTag(_helixClusterName, _instanceId, CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
+      helixAdmin.addInstanceTag(clusterName, _instanceId, CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
     }
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/events/DefaultMinionEventObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/events/DefaultMinionEventObserver.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.minion.events;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 
@@ -29,18 +28,18 @@ import org.apache.pinot.core.minion.PinotTaskConfig;
 public class DefaultMinionEventObserver implements MinionEventObserver {
 
   @Override
-  public void notifyTaskStart(@Nonnull PinotTaskConfig pinotTaskConfig) {
+  public void notifyTaskStart(PinotTaskConfig pinotTaskConfig) {
   }
 
   @Override
-  public void notifyTaskSuccess(@Nonnull PinotTaskConfig pinotTaskConfig, @Nullable Object executionResult) {
+  public void notifyTaskSuccess(PinotTaskConfig pinotTaskConfig, @Nullable Object executionResult) {
   }
 
   @Override
-  public void notifyTaskCancelled(@Nonnull PinotTaskConfig pinotTaskConfig) {
+  public void notifyTaskCancelled(PinotTaskConfig pinotTaskConfig) {
   }
 
   @Override
-  public void notifyTaskError(@Nonnull PinotTaskConfig pinotTaskConfig, @Nonnull Exception exception) {
+  public void notifyTaskError(PinotTaskConfig pinotTaskConfig, Exception exception) {
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/events/EventObserverFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/events/EventObserverFactoryRegistry.java
@@ -20,7 +20,6 @@ package org.apache.pinot.minion.events;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nonnull;
 
 
 /**
@@ -35,8 +34,7 @@ public class EventObserverFactoryRegistry {
    * @param taskType Task type
    * @param eventObserverFactory Event observer factory associated with the task type
    */
-  public void registerEventObserverFactory(@Nonnull String taskType,
-      @Nonnull MinionEventObserverFactory eventObserverFactory) {
+  public void registerEventObserverFactory(String taskType, MinionEventObserverFactory eventObserverFactory) {
     _eventObserverFactoryRegistry.put(taskType, eventObserverFactory);
   }
 
@@ -46,7 +44,7 @@ public class EventObserverFactoryRegistry {
    * @param taskType Task type
    * @return Event observer factory associated with the given task type, or default event observer if no one registered
    */
-  public MinionEventObserverFactory getEventObserverFactory(@Nonnull String taskType) {
+  public MinionEventObserverFactory getEventObserverFactory(String taskType) {
     return _eventObserverFactoryRegistry.getOrDefault(taskType, DefaultMinionEventObserverFactory.getInstance());
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/events/MinionEventObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/events/MinionEventObserver.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.minion.events;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 
@@ -33,7 +32,7 @@ public interface MinionEventObserver {
    *
    * @param pinotTaskConfig Pinot task config
    */
-  void notifyTaskStart(@Nonnull PinotTaskConfig pinotTaskConfig);
+  void notifyTaskStart(PinotTaskConfig pinotTaskConfig);
 
   /**
    * Invoked when a minion task succeeds.
@@ -41,14 +40,14 @@ public interface MinionEventObserver {
    * @param pinotTaskConfig Pinot task config
    * @param executionResult Execution result
    */
-  void notifyTaskSuccess(@Nonnull PinotTaskConfig pinotTaskConfig, @Nullable Object executionResult);
+  void notifyTaskSuccess(PinotTaskConfig pinotTaskConfig, @Nullable Object executionResult);
 
   /**
    * Invoked when a minion task gets cancelled.
    *
    * @param pinotTaskConfig Pinot task config
    */
-  void notifyTaskCancelled(@Nonnull PinotTaskConfig pinotTaskConfig);
+  void notifyTaskCancelled(PinotTaskConfig pinotTaskConfig);
 
   /**
    * Invoked when a minion task encounters exception.
@@ -56,5 +55,5 @@ public interface MinionEventObserver {
    * @param pinotTaskConfig Pinot task config
    * @param exception Exception encountered during execution
    */
-  void notifyTaskError(@Nonnull PinotTaskConfig pinotTaskConfig, @Nonnull Exception exception);
+  void notifyTaskError(PinotTaskConfig pinotTaskConfig, Exception exception);
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
@@ -52,27 +51,18 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseSingleSegmentConversionExecutor.class);
 
   /**
-   * Converts the segment based on the given {@link PinotTaskConfig}.
-   *
-   * @param pinotTaskConfig Task config
-   * @param originalIndexDir Index directory for the original segment
-   * @param workingDir Working directory for the converted segment
-   * @return Segment conversion result
-   * @throws Exception
+   * Converts the segment based on the given task config and returns the conversion result.
    */
-  protected abstract SegmentConversionResult convert(@Nonnull PinotTaskConfig pinotTaskConfig,
-      @Nonnull File originalIndexDir, @Nonnull File workingDir)
+  protected abstract SegmentConversionResult convert(PinotTaskConfig pinotTaskConfig, File indexDir, File workingDir)
       throws Exception;
 
   /**
    * Returns the segment ZK metadata custom map modifier.
-   *
-   * @return Segment ZK metadata custom map modifier
    */
   protected abstract SegmentZKMetadataCustomMapModifier getSegmentZKMetadataCustomMapModifier();
 
   @Override
-  public SegmentConversionResult executeTask(@Nonnull PinotTaskConfig pinotTaskConfig)
+  public SegmentConversionResult executeTask(PinotTaskConfig pinotTaskConfig)
       throws Exception {
     String taskType = pinotTaskConfig.getTaskType();
     Map<String, String> configs = pinotTaskConfig.getConfigs();
@@ -86,10 +76,10 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
         tableNameWithType, segmentName, downloadURL, uploadURL);
 
     File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + System.nanoTime());
-    Preconditions.checkState(tempDataDir.mkdirs());
+    Preconditions.checkState(tempDataDir.mkdirs(), "Failed to create temporary directory: %s", tempDataDir);
     try {
       // Download the tarred segment file
-      File tarredSegmentFile = new File(tempDataDir, "tarredSegmentFile");
+      File tarredSegmentFile = new File(tempDataDir, "tarredSegment");
       LOGGER.info("Downloading segment from {} to {}", downloadURL, tarredSegmentFile.getAbsolutePath());
       SegmentFetcherFactory.fetchSegmentToLocal(downloadURL, tarredSegmentFile);
 
@@ -104,16 +94,14 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
       File workingDir = new File(tempDataDir, "workingDir");
       Preconditions.checkState(workingDir.mkdir());
       SegmentConversionResult segmentConversionResult = convert(pinotTaskConfig, indexDir, workingDir);
-      File convertedIndexDir = segmentConversionResult.getFile();
-      String convertedSegmentName = segmentConversionResult.getSegmentName();
-      Preconditions.checkState(convertedSegmentName.equals(segmentName));
+      Preconditions.checkState(segmentConversionResult.getSegmentName().equals(segmentName),
+          "Converted segment name: %s does not match original segment name: %s",
+          segmentConversionResult.getSegmentName(), segmentName);
 
       // Tar the converted segment
-      File convertedTarredSegmentDir = new File(tempDataDir, "convertedTarredSegmentDir");
-      Preconditions.checkState(convertedTarredSegmentDir.mkdir());
-      File convertedTarredSegmentFile = new File(TarGzCompressionUtils
-          .createTarGzOfDirectory(convertedIndexDir.getPath(),
-              new File(convertedTarredSegmentDir, convertedSegmentName).getPath()));
+      File convertedTarredSegment = new File(TarGzCompressionUtils
+          .createTarGzOfDirectory(segmentConversionResult.getFile().getPath(),
+              new File(tempDataDir, "convertedTarredSegment").getPath()));
 
       // Check whether the task get cancelled before uploading the segment
       if (_cancelled) {
@@ -144,12 +132,10 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
       List<NameValuePair> parameters = Arrays.asList(enableParallelPushProtectionParameter, tableNameParameter);
 
       // Upload the tarred segment
-      SegmentConversionUtils
-          .uploadSegment(configs, httpHeaders, parameters, tableNameWithType, convertedSegmentName, uploadURL,
-              convertedTarredSegmentFile);
+      SegmentConversionUtils.uploadSegment(configs, httpHeaders, parameters, tableNameWithType, segmentName, uploadURL,
+          convertedTarredSegment);
 
-      LOGGER.info("Done executing {} on table: {}, input segment: {}, output segment: {}", taskType, tableNameWithType,
-          segmentName, convertedSegmentName);
+      LOGGER.info("Done executing {} on table: {}, segment: {}", taskType, tableNameWithType, segmentName);
       return segmentConversionResult;
     } finally {
       FileUtils.deleteQuietly(tempDataDir);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
@@ -21,7 +21,6 @@ package org.apache.pinot.minion.executor;
 import java.io.File;
 import java.util.Collections;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
@@ -32,13 +31,12 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 public class ConvertToRawIndexTaskExecutor extends BaseSingleSegmentConversionExecutor {
 
   @Override
-  protected SegmentConversionResult convert(@Nonnull PinotTaskConfig pinotTaskConfig, @Nonnull File originalIndexDir,
-      @Nonnull File workingDir)
+  protected SegmentConversionResult convert(PinotTaskConfig pinotTaskConfig, File indexDir, File workingDir)
       throws Exception {
     Map<String, String> configs = pinotTaskConfig.getConfigs();
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-    new RawIndexConverter(rawTableName, originalIndexDir, workingDir,
+    new RawIndexConverter(rawTableName, indexDir, workingDir,
         configs.get(MinionConstants.ConvertToRawIndexTask.COLUMNS_TO_CONVERT_KEY)).convert();
     return new SegmentConversionResult.Builder().setFile(workingDir)
         .setTableNameWithType(configs.get(MinionConstants.TABLE_NAME_KEY))

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PinotTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PinotTaskExecutor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.minion.executor;
 
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 
 
@@ -28,17 +27,13 @@ import org.apache.pinot.core.minion.PinotTaskConfig;
 public interface PinotTaskExecutor {
 
   /**
-   * Execute the task based on the given {@link PinotTaskConfig}.
-   *
-   * @param pinotTaskConfig Pinot task config
-   * @return Execution result
-   * @throws Exception
+   * Executes the task based on the given task config and returns the execution result.
    */
-  Object executeTask(@Nonnull PinotTaskConfig pinotTaskConfig)
+  Object executeTask(PinotTaskConfig pinotTaskConfig)
       throws Exception;
 
   /**
-   * Try to cancel the task.
+   * Tries to cancel the task.
    */
   void cancel();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -77,6 +77,7 @@ public class TableConfigBuilder {
   private String _segmentVersion;
   private String _sortedColumn;
   private List<String> _invertedIndexColumns;
+  private boolean _createInvertedIndexDuringSegmentGeneration;
   private List<String> _noDictionaryColumns;
   private List<String> _onHeapDictionaryColumns;
   private List<String> _bloomFilterColumns;
@@ -207,6 +208,12 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setCreateInvertedIndexDuringSegmentGeneration(
+      boolean createInvertedIndexDuringSegmentGeneration) {
+    _createInvertedIndexDuringSegmentGeneration = createInvertedIndexDuringSegmentGeneration;
+    return this;
+  }
+
   public TableConfigBuilder setNoDictionaryColumns(List<String> noDictionaryColumns) {
     _noDictionaryColumns = noDictionaryColumns;
     return this;
@@ -303,6 +310,7 @@ public class TableConfigBuilder {
       indexingConfig.setSortedColumn(Collections.singletonList(_sortedColumn));
     }
     indexingConfig.setInvertedIndexColumns(_invertedIndexColumns);
+    indexingConfig.setCreateInvertedIndexDuringSegmentGeneration(_createInvertedIndexDuringSegmentGeneration);
     indexingConfig.setNoDictionaryColumns(_noDictionaryColumns);
     indexingConfig.setOnHeapDictionaryColumns(_onHeapDictionaryColumns);
     indexingConfig.setBloomFilterColumns(_bloomFilterColumns);


### PR DESCRIPTION
All the indexing and partition info are stored in the table config.
Without the table config, purged segment will lose the indexing and partition info, which could cause performance issue.

In the following pr, we will enforce all segment creation to provide table config and schema to guarantee the consistent behavior.