### PR TITLE
Fix the bug introduced in #5132 where ScanBasedDocIdIterator.isMatch() is still required

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIterator.java
@@ -102,6 +102,17 @@ public final class AndDocIdIterator implements BlockDocIdIterator {
           i = -1;
         }
       }
+      if (hasScanBasedIterators && i == docIdIterators.length - 1) {
+        // this means we found the docId common to all nonScanBased iterators, now we need to ensure
+        // that its also found in scanBasedIterator, if not matched, we restart the intersection
+        for (ScanBasedDocIdIterator iterator : scanBasedDocIdIterators) {
+          if (!iterator.isMatch(currentMax)) {
+            i = -1;
+            currentMax = currentMax + 1;
+            break;
+          }
+        }
+      }
     }
     currentDocId = currentMax;
     return currentDocId;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -75,6 +75,17 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
   }
 
   @Override
+  public boolean isMatch(int docId) {
+    if (currentDocId == Constants.EOF) {
+      return false;
+    }
+    valueIterator.skipTo(docId);
+    int length = valueIterator.nextIntVal(intArray);
+    _numEntriesScanned += length;
+    return evaluator.applyMV(intArray, length);
+  }
+
+  @Override
   public int advance(int targetDocId) {
     if (currentDocId == Constants.EOF) {
       return currentDocId;
@@ -89,8 +100,7 @@ public class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     } else {
       currentDocId = targetDocId - 1;
       valueIterator.skipTo(targetDocId);
-      int next = next();
-      return next;
+      return next();
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -18,12 +18,12 @@
  */
 package org.apache.pinot.core.operator.dociditerators;
 
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.core.common.BlockMetadata;
 import org.apache.pinot.core.common.BlockSingleValIterator;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.Constants;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.IntIterator;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
@@ -80,6 +80,16 @@ public class SVScanDocIdIterator implements ScanBasedDocIdIterator {
    */
   public void setEndDocId(int endDocId) {
     _endDocId = endDocId;
+  }
+
+  @Override
+  public boolean isMatch(int docId) {
+    if (_currentDocId == Constants.EOF) {
+      return false;
+    }
+    _valueIterator.skipTo(docId);
+    _numEntriesScanned++;
+    return _valueMatcher.doesCurrentEntryMatch(_valueIterator);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -31,6 +31,8 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  */
 public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
 
+  boolean isMatch(int docId);
+
   MutableRoaringBitmap applyAnd(MutableRoaringBitmap answer);
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -138,6 +138,9 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     testQuery(query, Arrays.asList("SELECT MAX(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 15312",
         "SELECT MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 15312"));
     query =
+        "SELECT SUM(TotalAddGTime) FROM mytable WHERE DivArrDelay NOT IN (67, 260) AND Carrier IN ('F9', 'B6') OR DepTime BETWEEN 2144 AND 1926";
+    testQuery(query, Collections.singletonList(query));
+    query =
         "SELECT ActualElapsedTime, OriginStateFips, MIN(DivReachedDest), SUM(ArrDelay), AVG(CRSDepTime) FROM mytable "
             + "WHERE OriginCityName > 'Beaumont/Port Arthur, TX' OR FlightDate IN ('2014-12-09', '2014-10-05')"
             + " GROUP BY ActualElapsedTime, OriginStateFips "
@@ -320,7 +323,6 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
 
   /**
    * Test random SQL queries from the query file.
-   * TODO: fix this test by adding the SQL query file
    */
   public void testSqlQueriesFromQueryFile()
       throws Exception {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -244,9 +244,30 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
 
   @Test
   @Override
+  public void testHardcodedQueries()
+      throws Exception {
+    super.testHardcodedQueries();
+  }
+
+  @Test
+  @Override
+  public void testHardcodedSqlQueries()
+      throws Exception {
+    super.testHardcodedSqlQueries();
+  }
+
+  @Test
+  @Override
   public void testQueriesFromQueryFile()
       throws Exception {
     super.testQueriesFromQueryFile();
+  }
+
+  @Test
+  @Override
+  public void testSqlQueriesFromQueryFile()
+      throws Exception {
+    super.testSqlQueriesFromQueryFile();
   }
 
   @Test


### PR DESCRIPTION
ScanBasedDocIdIterator.isMatch() is still required when the query is in the following format:
SELECT ... WHERE (filterA OR filterB) AND filterC
And filterC is working on a scan-based column (column without inverted index)

Enhance the HybridClusterIntegrationTest to catch this issue