### PR TITLE
Detect segments which are in ERROR state on all replicas

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
@@ -28,14 +28,19 @@ import org.apache.pinot.common.response.BrokerResponse;
  * post-processing at a finer level than metrics.
  */
 public class RequestStatistics {
+  public enum FanoutType {
+    OFFLINE, REALTIME, HYBRID
+  }
 
   private static final String DEFAULT_TABLE_NAME = "NotYetParsed";
 
-  private int _errorCode = 0;
+  private String _brokerId;
+  private long _requestId;
   private String _pql;
+  private FanoutType _fanoutType;
+  private int _errorCode = 0;
   private String _tableName = DEFAULT_TABLE_NAME;
   private long _processingTimeMillis = -1;
-
   private long _totalDocs;
   private long _numDocsScanned;
   private long _numEntriesScannedInFilter;
@@ -47,51 +52,11 @@ public class RequestStatistics {
   private int _numServersResponded;
   private boolean _isNumGroupsLimitReached;
   private int _numExceptions;
-  private String _brokerId;
-  private long _requestId;
-
-  public String getBrokerId() {
-    return _brokerId;
-  }
-
-  public long getRequestId() {
-    return _requestId;
-  }
-
-  public long getRequestArrivalTimeMillis() {
-    return _requestArrivalTimeMillis;
-  }
-
-  public long getReduceTimeMillis() {
-    return _reduceTimeMillis;
-  }
-
+  private boolean _queryNoReplicaSegments;
   private long _requestArrivalTimeMillis;
   private long _reduceTimeMillis;
 
-  public enum FanoutType {
-    OFFLINE, REALTIME, HYBRID
-  }
-
-  private FanoutType _fanoutType;
-
   public RequestStatistics() {
-  }
-
-  public void setErrorCode(int errorCode) {
-    _errorCode = errorCode;
-  }
-
-  public void setPql(String pql) {
-    _pql = pql;
-  }
-
-  public void setTableName(String tableName) {
-    _tableName = tableName;
-  }
-
-  public void setQueryProcessingTime(long processingTimeMillis) {
-    _processingTimeMillis = processingTimeMillis;
   }
 
   public void setStatistics(BrokerResponse brokerResponse) {
@@ -109,16 +74,32 @@ public class RequestStatistics {
     _numExceptions = brokerResponse.getExceptionsSize();
   }
 
+  public String getBrokerId() {
+    return _brokerId;
+  }
+
   public void setBrokerId(String brokerId) {
     _brokerId = brokerId;
+  }
+
+  public long getRequestId() {
+    return _requestId;
   }
 
   public void setRequestId(long requestId) {
     _requestId = requestId;
   }
 
+  public long getRequestArrivalTimeMillis() {
+    return _requestArrivalTimeMillis;
+  }
+
   public void setRequestArrivalTimeMillis(long requestArrivalTimeMillis) {
     _requestArrivalTimeMillis = requestArrivalTimeMillis;
+  }
+
+  public long getReduceTimeMillis() {
+    return _reduceTimeMillis;
   }
 
   public void setReduceTimeNanos(long reduceTimeNanos) {
@@ -137,16 +118,32 @@ public class RequestStatistics {
     return _errorCode;
   }
 
+  public void setErrorCode(int errorCode) {
+    _errorCode = errorCode;
+  }
+
   public String getPql() {
     return _pql;
+  }
+
+  public void setPql(String pql) {
+    _pql = pql;
   }
 
   public String getTableName() {
     return _tableName;
   }
 
+  public void setTableName(String tableName) {
+    _tableName = tableName;
+  }
+
   public long getProcessingTimeMillis() {
     return _processingTimeMillis;
+  }
+
+  public void setQueryProcessingTime(long processingTimeMillis) {
+    _processingTimeMillis = processingTimeMillis;
   }
 
   public long getTotalDocs() {
@@ -194,6 +191,14 @@ public class RequestStatistics {
   }
 
   public boolean hasValidTableName() {
-    return ! DEFAULT_TABLE_NAME.equals(_tableName);
+    return !DEFAULT_TABLE_NAME.equals(_tableName);
+  }
+
+  public boolean isQueryNoReplicaSegments() {
+    return _queryNoReplicaSegments;
+  }
+
+  public void setQueryNoReplicaSegments(boolean queryNoReplicaSegments) {
+    _queryNoReplicaSegments = queryNoReplicaSegments;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
@@ -52,7 +52,7 @@ public class RequestStatistics {
   private int _numServersResponded;
   private boolean _isNumGroupsLimitReached;
   private int _numExceptions;
-  private boolean _queryNoReplicaSegments;
+  private int _unavailableSegmentCount;
   private long _requestArrivalTimeMillis;
   private long _reduceTimeMillis;
 
@@ -194,11 +194,11 @@ public class RequestStatistics {
     return !DEFAULT_TABLE_NAME.equals(_tableName);
   }
 
-  public boolean isQueryNoReplicaSegments() {
-    return _queryNoReplicaSegments;
+  public int getUnavailableSegmentCount() {
+    return _unavailableSegmentCount;
   }
 
-  public void setQueryNoReplicaSegments(boolean queryNoReplicaSegments) {
-    _queryNoReplicaSegments = queryNoReplicaSegments;
+  public void setUnavailableSegmentCount(int unavailableSegmentCount) {
+    _unavailableSegmentCount = unavailableSegmentCount;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -55,7 +55,9 @@ public class PinotBrokerDebug {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/debug/timeBoundary/{tableName}")
   @ApiOperation(value = "Get the time boundary information for a table")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Time boundary information for a table"), @ApiResponse(code = 404, message = "Time boundary not found"), @ApiResponse(code = 500, message = "Internal server error")})
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Time boundary information for a table"),
+      @ApiResponse(code = 404, message = "Time boundary not found"),
+      @ApiResponse(code = 500, message = "Internal server error")})
   public TimeBoundaryInfo getTimeBoundary(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName) {
     String offlineTableName =
@@ -72,7 +74,9 @@ public class PinotBrokerDebug {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/debug/routingTable/{tableName}")
   @ApiOperation(value = "Get the routing table for a table")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Routing table"), @ApiResponse(code = 404, message = "Routing not found"), @ApiResponse(code = 500, message = "Internal server error")})
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Routing table"),
+      @ApiResponse(code = 404, message = "Routing not found"),
+      @ApiResponse(code = 500, message = "Internal server error")})
   public Map<String, Map<ServerInstance, List<String>>> getRoutingTable(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName) {
     Map<String, Map<ServerInstance, List<String>>> result = new TreeMap<>();
@@ -80,7 +84,8 @@ public class PinotBrokerDebug {
     if (tableType != TableType.REALTIME) {
       String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
       Map<ServerInstance, List<String>> routingTable =
-          _routingManager.getRoutingTable(COMPILER.compileToBrokerRequest("SELECT * FROM " + offlineTableName));
+          _routingManager.getRoutingTable(COMPILER.compileToBrokerRequest("SELECT * FROM " + offlineTableName))
+              .getServerInstanceToSegmentsMap();
       if (routingTable != null) {
         result.put(offlineTableName, routingTable);
       }
@@ -88,7 +93,8 @@ public class PinotBrokerDebug {
     if (tableType != TableType.OFFLINE) {
       String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
       Map<ServerInstance, List<String>> routingTable =
-          _routingManager.getRoutingTable(COMPILER.compileToBrokerRequest("SELECT * FROM " + realtimeTableName));
+          _routingManager.getRoutingTable(COMPILER.compileToBrokerRequest("SELECT * FROM " + realtimeTableName))
+              .getServerInstanceToSegmentsMap();
       if (routingTable != null) {
         result.put(realtimeTableName, routingTable);
       }
@@ -104,11 +110,13 @@ public class PinotBrokerDebug {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/debug/routingTable")
   @ApiOperation(value = "Get the routing table for a query")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Routing table"), @ApiResponse(code = 404, message = "Routing not found"), @ApiResponse(code = 500, message = "Internal server error")})
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Routing table"),
+      @ApiResponse(code = 404, message = "Routing not found"),
+      @ApiResponse(code = 500, message = "Internal server error")})
   public Map<ServerInstance, List<String>> getRoutingTableForQuery(
       @ApiParam(value = "Pql query (table name should have type suffix)") @QueryParam("pql") String pql) {
     Map<ServerInstance, List<String>> routingTable =
-        _routingManager.getRoutingTable(COMPILER.compileToBrokerRequest(pql));
+        _routingManager.getRoutingTable(COMPILER.compileToBrokerRequest(pql)).getServerInstanceToSegmentsMap();
     if (routingTable != null) {
       return routingTable;
     } else {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -312,6 +312,11 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     long routingEndTimeNs = System.nanoTime();
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.QUERY_ROUTING, routingEndTimeNs - routingStartTimeNs);
 
+    // Set querying no replica segment to true
+    if (offlineBrokerRequest != null && _routingManager.containsNoReplicaSegments(offlineBrokerRequest)) {
+      requestStatistics.setQueryNoReplicaSegments(true);
+    }
+
     // Set timeout in the requests
     long timeSpentMs = TimeUnit.NANOSECONDS.toMillis(routingEndTimeNs - compilationStartTimeNs);
     // Remaining time in milliseconds for the server query execution

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -312,10 +312,10 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     long routingEndTimeNs = System.nanoTime();
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.QUERY_ROUTING, routingEndTimeNs - routingStartTimeNs);
 
-    // Set querying no replica segment to true
-    if (offlineBrokerRequest != null && _routingManager.containsNoReplicaSegments(offlineBrokerRequest)) {
-      requestStatistics.setQueryNoReplicaSegments(true);
-    }
+    // Set number of segments with no replicas matched with this query
+    int unavailableSegmentCount = _routingManager.getNumSegmentsWithNoReplicas(offlineBrokerRequest)
+        + _routingManager.getNumSegmentsWithNoReplicas(realtimeBrokerRequest);
+    requestStatistics.setUnavailableSegmentCount(unavailableSegmentCount);
 
     // Set timeout in the requests
     long timeSpentMs = TimeUnit.NANOSECONDS.toMillis(routingEndTimeNs - compilationStartTimeNs);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.core.transport.ServerInstance;
+
+
+public class RoutingTable {
+  private Map<ServerInstance, List<String>> _serverInstanceToSegmentsMap;
+  private List<String> _segmentsWithNoReplicas;
+
+  public RoutingTable(@Nullable Map<ServerInstance, List<String>> serverInstanceToSegmentsMap,
+      List<String> segmentsWithNoReplicas) {
+    _serverInstanceToSegmentsMap = serverInstanceToSegmentsMap;
+    _segmentsWithNoReplicas = segmentsWithNoReplicas;
+  }
+
+  public Map<ServerInstance, List<String>> getServerInstanceToSegmentsMap() {
+    return _serverInstanceToSegmentsMap;
+  }
+
+  public List<String> getSegmentsWithNoReplicas() {
+    return _segmentsWithNoReplicas;
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RoutingManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RoutingManagerTest.java
@@ -113,7 +113,9 @@ public class RoutingManagerTest {
 
     // Constructs routing entry map
     routingManager.buildRouting(OFFLINE_TABLE_NAME);
+
+    RoutingTable routingTable = routingManager.getRoutingTable(brokerRequest);
     // There is 1 segment which is in ERROR state on all replicas
-    Assert.assertEquals(routingManager.getNumSegmentsWithNoReplicas(brokerRequest), 1);
+    Assert.assertEquals(routingTable.getSegmentsWithNoReplicas().size(), 1);
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RoutingManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/RoutingManagerTest.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.AccessOption;
+import org.apache.helix.BaseDataAccessor;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.QuerySource;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.config.TableConfigUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class RoutingManagerTest {
+  private static String TABLE_NAME = "testTable";
+  private static String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME);
+  private static String SEGMENT_NAME = "segment1";
+  private static String INSTANCE_NAME = "host1";
+
+  @Test
+  public void testRoutingManager() throws JsonProcessingException {
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    RoutingManager routingManager = new RoutingManager(brokerMetrics);
+    HelixManager helixManager = mock(HelixManager.class);
+    HelixDataAccessor helixDataAccessor = mock(HelixDataAccessor.class);
+    when(helixManager.getHelixDataAccessor()).thenReturn(helixDataAccessor);
+    PropertyKey.Builder builder = new PropertyKey.Builder("testCluster");
+    when(helixDataAccessor.keyBuilder()).thenReturn(builder);
+    @SuppressWarnings("unchecked")
+    BaseDataAccessor<ZNRecord> zkDataAccessor = mock(BaseDataAccessor.class);
+    when(helixDataAccessor.getBaseDataAccessor()).thenReturn(zkDataAccessor);
+    @SuppressWarnings("unchecked")
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    when(propertyStore.get("/CONFIGS/TABLE/testTable_OFFLINE", null, AccessOption.PERSISTENT)).thenReturn(
+        TableConfigUtils.toZNRecord(tableConfig));
+    ZNRecord znRecord = mock(ZNRecord.class);
+    Map<String, Map<String, String>> mapFields = new HashMap<>();
+    Map<String, String> instanceToStateMap = new HashMap<>();
+    instanceToStateMap.put(INSTANCE_NAME, SegmentOnlineOfflineStateModel.ERROR);
+    mapFields.put(SEGMENT_NAME, instanceToStateMap);
+    when(znRecord.getMapFields()).thenReturn(mapFields);
+    znRecord.setMapFields(mapFields);
+    when(zkDataAccessor.get(helixDataAccessor.keyBuilder().idealStates().getPath() + "/" + OFFLINE_TABLE_NAME, null,
+        AccessOption.PERSISTENT)).thenReturn(znRecord);
+
+    ZNRecord externalViewZNRecord = mock(ZNRecord.class);
+    externalViewZNRecord.setMapFields(mapFields);
+    when(externalViewZNRecord.getMapFields()).thenReturn(mapFields);
+    when(zkDataAccessor.get(eq(helixDataAccessor.keyBuilder().externalViews().getPath() + "/" + OFFLINE_TABLE_NAME),
+        any(), eq(AccessOption.PERSISTENT))).thenReturn(externalViewZNRecord);
+
+    routingManager.init(helixManager);
+
+    ExternalView externalView = mock(ExternalView.class);
+    Set<String> partitionSet = new HashSet<>();
+    partitionSet.add(SEGMENT_NAME);
+    when(externalView.getPartitionSet()).thenReturn(partitionSet);
+    Map<String, String> partitionMap = new HashMap<>();
+    partitionMap.put(INSTANCE_NAME, SegmentOnlineOfflineStateModel.ERROR);
+    when(externalView.getStateMap(anyString())).thenReturn(partitionMap);
+
+    Set<String> noReplicasSegments = new HashSet<>();
+    routingManager.fetchSegmentsInErrorState(externalView, noReplicasSegments);
+    Assert.assertFalse(noReplicasSegments.isEmpty());
+
+    BrokerRequest brokerRequest = new BrokerRequest();
+    QuerySource querySource = new QuerySource();
+    querySource.setTableName(OFFLINE_TABLE_NAME);
+    brokerRequest.setQuerySource(querySource);
+
+    // Constructs routing entry map
+    routingManager.buildRouting(OFFLINE_TABLE_NAME);
+    Assert.assertTrue(routingManager.containsNoReplicaSegments(brokerRequest));
+  }
+}


### PR DESCRIPTION
Currently when pinot broker builds the routing table, the segments in routing table are always valid (either online or consuming). While the segments in ERROR state won't be captured during querying; those bad segments could have been queried. In this case, the query should be partial response.
