### PR TITLE
ReturnType in ConstantExecutionNode

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/function/DefaultFunctionEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/function/DefaultFunctionEvaluator.java
@@ -131,12 +131,15 @@ public class DefaultFunctionEvaluator implements FunctionEvaluator {
 
   private static class ConstantExecutionNode implements ExecutableNode {
     private Object _value;
+    private Class<?> _returnType;
 
     public ConstantExecutionNode(String value) {
       if (NumberUtils.isCreatable(value)) {
         _value = NumberUtils.createNumber(value);
+        _returnType = Number.class;
       } else {
         _value = value;
+        _returnType = String.class;
       }
     }
 
@@ -147,7 +150,7 @@ public class DefaultFunctionEvaluator implements FunctionEvaluator {
 
     @Override
     public Class<?> getReturnType() {
-      return String.class;
+      return _returnType;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/function/DefaultFunctionEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/function/DefaultFunctionEvaluator.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.data.function;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
@@ -129,10 +130,14 @@ public class DefaultFunctionEvaluator implements FunctionEvaluator {
   }
 
   private static class ConstantExecutionNode implements ExecutableNode {
-    private String _value;
+    private Object _value;
 
     public ConstantExecutionNode(String value) {
-      _value = value;
+      if (NumberUtils.isCreatable(value)) {
+        _value = NumberUtils.createNumber(value);
+      } else {
+        _value = value;
+      }
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/function/FunctionRegistry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/function/FunctionRegistry.java
@@ -45,31 +45,31 @@ public class FunctionRegistry {
       registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("toEpochHours", Long.class));
       registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("toEpochDays", Long.class));
       registerStaticFunction(
-          DateTimeFunctions.class.getDeclaredMethod("toEpochSecondsRounded", Long.class, String.class));
+          DateTimeFunctions.class.getDeclaredMethod("toEpochSecondsRounded", Long.class, Number.class));
       registerStaticFunction(
-          DateTimeFunctions.class.getDeclaredMethod("toEpochMinutesRounded", Long.class, String.class));
+          DateTimeFunctions.class.getDeclaredMethod("toEpochMinutesRounded", Long.class, Number.class));
       registerStaticFunction(
-          DateTimeFunctions.class.getDeclaredMethod("toEpochHoursRounded", Long.class, String.class));
-      registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("toEpochDaysRounded", Long.class, String.class));
+          DateTimeFunctions.class.getDeclaredMethod("toEpochHoursRounded", Long.class, Number.class));
+      registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("toEpochDaysRounded", Long.class, Number.class));
       registerStaticFunction(
-          DateTimeFunctions.class.getDeclaredMethod("toEpochSecondsBucket", Long.class, String.class));
+          DateTimeFunctions.class.getDeclaredMethod("toEpochSecondsBucket", Long.class, Number.class));
       registerStaticFunction(
-          DateTimeFunctions.class.getDeclaredMethod("toEpochMinutesBucket", Long.class, String.class));
-      registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("toEpochHoursBucket", Long.class, String.class));
-      registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("toEpochDaysBucket", Long.class, String.class));
+          DateTimeFunctions.class.getDeclaredMethod("toEpochMinutesBucket", Long.class, Number.class));
+      registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("toEpochHoursBucket", Long.class, Number.class));
+      registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("toEpochDaysBucket", Long.class, Number.class));
 
       registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("fromEpochSeconds", Long.class));
       registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("fromEpochMinutes", Number.class));
       registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("fromEpochHours", Number.class));
       registerStaticFunction(DateTimeFunctions.class.getDeclaredMethod("fromEpochDays", Number.class));
       registerStaticFunction(
-          DateTimeFunctions.class.getDeclaredMethod("fromEpochSecondsBucket", Long.class, String.class));
+          DateTimeFunctions.class.getDeclaredMethod("fromEpochSecondsBucket", Long.class, Number.class));
       registerStaticFunction(
-          DateTimeFunctions.class.getDeclaredMethod("fromEpochMinutesBucket", Number.class, String.class));
+          DateTimeFunctions.class.getDeclaredMethod("fromEpochMinutesBucket", Number.class, Number.class));
       registerStaticFunction(
-          DateTimeFunctions.class.getDeclaredMethod("fromEpochHoursBucket", Number.class, String.class));
+          DateTimeFunctions.class.getDeclaredMethod("fromEpochHoursBucket", Number.class, Number.class));
       registerStaticFunction(
-          DateTimeFunctions.class.getDeclaredMethod("fromEpochDaysBucket", Number.class, String.class));
+          DateTimeFunctions.class.getDeclaredMethod("fromEpochDaysBucket", Number.class, Number.class));
     } catch (NoSuchMethodException e) {
       LOGGER.error("Caught exception when registering function", e);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionEvaluatorTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class DateTimeFunctionEvaluatorTest {
 
   @Test(dataProvider = "dateTimeFunctionsTestDataProvider")
-  public void testExpressionWithColumn(String transformFunction, List<String> arguments, GenericRow row, Object result)
+  public void testDateTimeTransformFunctions(String transformFunction, List<String> arguments, GenericRow row, Object result)
       throws Exception {
     DefaultFunctionEvaluator evaluator = new DefaultFunctionEvaluator(transformFunction);
     Assert.assertEquals(evaluator.getArguments(), arguments);


### PR DESCRIPTION
Setting the returnType in ConstantExecutionNode based on the value, instead of always returning String. This prevents parsing the string to number on every record.
#2756