### PR TITLE
Add transformFunction field in equals, hashCode and toJsonObject of FieldSpec

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -263,6 +263,9 @@ public abstract class FieldSpec implements Comparable<FieldSpec> {
       jsonObject.put("maxLength", _maxLength);
     }
     appendDefaultNullValue(jsonObject);
+    if (_transformFunction != null) {
+      jsonObject.put("transformFunction", _transformFunction);
+    }
     return jsonObject;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -292,7 +292,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec> {
     return EqualityUtils.isEqual(_name, that._name) && EqualityUtils.isEqual(_dataType, that._dataType) && EqualityUtils
         .isEqual(_isSingleValueField, that._isSingleValueField) && EqualityUtils
         .isEqual(getStringValue(_defaultNullValue), getStringValue(that._defaultNullValue)) && EqualityUtils
-        .isEqual(_maxLength, that._maxLength);
+        .isEqual(_maxLength, that._maxLength) && EqualityUtils.isEqual(_transformFunction, that._transformFunction);
   }
 
   @Override
@@ -302,6 +302,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec> {
     result = EqualityUtils.hashCodeOf(result, _isSingleValueField);
     result = EqualityUtils.hashCodeOf(result, getStringValue(_defaultNullValue));
     result = EqualityUtils.hashCodeOf(result, _maxLength);
+    result = EqualityUtils.hashCodeOf(result, _transformFunction);
     return result;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -722,7 +722,7 @@ public final class Schema {
         break;
     }
 
-    String outerFunction = null;
+    String outerFunction = innerFunction;
     switch (outgoingTimeUnit) {
 
       case MILLISECONDS:


### PR DESCRIPTION
TransformFunction was not added to equals, hashCode, toJsonObject. Probably unintentionally left out?
Now that we've started using transformFunctions actively, we should have this in the fieldSpec equality check. 