### PR TITLE
Track unavailable segments in InstanceSelector

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
@@ -74,6 +74,7 @@ public class RequestStatistics {
   }
 
   private FanoutType _fanoutType;
+  private int _numUnavailableSegments;
 
   public RequestStatistics() {
   }
@@ -131,6 +132,14 @@ public class RequestStatistics {
 
   public FanoutType getFanoutType() {
     return _fanoutType;
+  }
+
+  public void setNumUnavailableSegments(int numUnavailableSegments) {
+    _numUnavailableSegments = numUnavailableSegments;
+  }
+
+  public int getNumUnavailableSegments() {
+    return _numUnavailableSegments;
   }
 
   public int getErrorCode() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.transport.ServerInstance;
+
+
+public class RoutingTable {
+  private final Map<ServerInstance, List<String>> _serverInstanceToSegmentsMap;
+  private final List<String> _unavailableSegments;
+
+  public RoutingTable(Map<ServerInstance, List<String>> serverInstanceToSegmentsMap, List<String> unavailableSegments) {
+    _serverInstanceToSegmentsMap = serverInstanceToSegmentsMap;
+    _unavailableSegments = unavailableSegments;
+  }
+
+  public Map<ServerInstance, List<String>> getServerInstanceToSegmentsMap() {
+    return _serverInstanceToSegmentsMap;
+  }
+
+  public List<String> getUnavailableSegments() {
+    return _unavailableSegments;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.routing.instanceselector;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -37,8 +38,9 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Base implementation of instance selector which maintains a map from segment to enabled server instances that serves
- * the segment.
+ * Base implementation of instance selector which maintains a map from segment to enabled ONLINE/CONSUMING server
+ * instances that serves the segment and a set of unavailable segments (no enabled instance or all enabled instances are
+ * in ERROR state).
  */
 abstract class BaseInstanceSelector implements InstanceSelector {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseInstanceSelector.class);
@@ -50,10 +52,15 @@ abstract class BaseInstanceSelector implements InstanceSelector {
   private final String _tableNameWithType;
   private final BrokerMetrics _brokerMetrics;
 
-  private volatile Set<String> _enabledInstances;
-  private volatile Map<String, List<String>> _segmentToInstancesMap;
-  private volatile Map<String, List<String>> _instanceToSegmentsMap;
+  // These 4 variables are the cached states to help accelerate the change processing
+  private Set<String> _enabledInstances;
+  private Map<String, List<String>> _segmentToOnlineInstancesMap;
+  private Map<String, List<String>> _segmentToOfflineInstancesMap;
+  private Map<String, List<String>> _instanceToSegmentsMap;
+
+  // These 2 variables are needed for instance selection (multi-threaded), so make them volatile
   private volatile Map<String, List<String>> _segmentToEnabledInstancesMap;
+  private volatile Set<String> _unavailableSegments;
 
   BaseInstanceSelector(String tableNameWithType, BrokerMetrics brokerMetrics) {
     _tableNameWithType = tableNameWithType;
@@ -66,15 +73,20 @@ abstract class BaseInstanceSelector implements InstanceSelector {
     onExternalViewChange(externalView, onlineSegments);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Updates the cached enabled instances and re-calculates {@code segmentToEnabledInstancesMap} and
+   * {@code unavailableSegments} based on the cached states.
+   */
   @Override
   public void onInstancesChange(Set<String> enabledInstances, List<String> changedInstances) {
     _enabledInstances = enabledInstances;
 
     // Update all segments served by the changed instances
     Set<String> segmentsToUpdate = new HashSet<>();
-    Map<String, List<String>> instanceToSegmentsMap = _instanceToSegmentsMap;
     for (String instance : changedInstances) {
-      List<String> segments = instanceToSegmentsMap.get(instance);
+      List<String> segments = _instanceToSegmentsMap.get(instance);
       if (segments != null) {
         segmentsToUpdate.addAll(segments);
       }
@@ -85,94 +97,150 @@ abstract class BaseInstanceSelector implements InstanceSelector {
       return;
     }
 
-    // Update the map from segment to enabled instances
+    // Update the map from segment to enabled ONLINE/CONSUMING instances and set of unavailable segments (no enabled
+    // instance or all enabled instances are in ERROR state)
     // NOTE: We can directly modify the map because we will only update the values without changing the map entries.
     // Because the map is marked as volatile, the running queries (already accessed the map) might use the enabled
     // instances either before or after the change, which is okay; the following queries (not yet accessed the map) will
     // get the updated value.
-    Map<String, List<String>> segmentToInstancesMap = _segmentToInstancesMap;
     Map<String, List<String>> segmentToEnabledInstancesMap = _segmentToEnabledInstancesMap;
+    Set<String> currentUnavailableSegments = _unavailableSegments;
+    Set<String> newUnavailableSegments = new HashSet<>();
     for (Map.Entry<String, List<String>> entry : segmentToEnabledInstancesMap.entrySet()) {
       String segment = entry.getKey();
       if (segmentsToUpdate.contains(segment)) {
-        entry.setValue(
-            calculateEnabledInstancesForSegment(segment, segmentToInstancesMap.get(segment), enabledInstances));
+        List<String> enabledInstancesForSegment =
+            calculateEnabledInstancesForSegment(segment, _segmentToOnlineInstancesMap.get(segment),
+                newUnavailableSegments);
+        entry.setValue(enabledInstancesForSegment);
+      } else {
+        if (currentUnavailableSegments.contains(segment)) {
+          newUnavailableSegments.add(segment);
+        }
       }
     }
+    _unavailableSegments = newUnavailableSegments;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Updates the cached maps ({@code segmentToOnlineInstancesMap}, {@code segmentToOfflineInstancesMap} and
+   * {@code instanceToSegmentsMap}) based on the given ExternalView and re-calculates
+   * {@code segmentToEnabledInstancesMap} and {@code unavailableSegments} based on the cached states.
+   */
   @Override
   public void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
     Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
-    Map<String, List<String>> segmentToInstancesMap =
-        new HashMap<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
-    Map<String, List<String>> instanceToSegmentsMap = new HashMap<>();
+    int numSegments = segmentAssignment.size();
+    _segmentToOnlineInstancesMap = new HashMap<>(HashUtil.getHashMapCapacity(numSegments));
+    _segmentToOfflineInstancesMap = new HashMap<>(HashUtil.getHashMapCapacity(numSegments));
+    if (_instanceToSegmentsMap != null) {
+      _instanceToSegmentsMap = new HashMap<>(HashUtil.getHashMapCapacity(_instanceToSegmentsMap.size()));
+    } else {
+      _instanceToSegmentsMap = new HashMap<>();
+    }
 
     for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
       String segment = entry.getKey();
       Map<String, String> instanceStateMap = entry.getValue();
-      // NOTE: 'instances' will be sorted here because 'instanceStateMap' is a TreeMap
-      List<String> instances = new ArrayList<>(instanceStateMap.size());
-      segmentToInstancesMap.put(segment, instances);
+      // NOTE: Instances will be sorted here because 'instanceStateMap' is a TreeMap
+      List<String> onlineInstances = new ArrayList<>(instanceStateMap.size());
+      List<String> offlineInstances = new ArrayList<>(instanceStateMap.size());
+      _segmentToOnlineInstancesMap.put(segment, onlineInstances);
+      _segmentToOfflineInstancesMap.put(segment, offlineInstances);
       for (Map.Entry<String, String> instanceStateEntry : instanceStateMap.entrySet()) {
         String instance = instanceStateEntry.getKey();
         String state = instanceStateEntry.getValue();
-        if (state.equals(RealtimeSegmentOnlineOfflineStateModel.ONLINE) || state
-            .equals(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
-          instances.add(instance);
-          instanceToSegmentsMap.computeIfAbsent(instance, k -> new ArrayList<>()).add(segment);
+        // Do not track instances in ERROR state
+        if (!state.equals(RealtimeSegmentOnlineOfflineStateModel.ERROR)) {
+          _instanceToSegmentsMap.computeIfAbsent(instance, k -> new ArrayList<>()).add(segment);
+          if (state.equals(RealtimeSegmentOnlineOfflineStateModel.OFFLINE)) {
+            offlineInstances.add(instance);
+          } else {
+            onlineInstances.add(instance);
+          }
         }
       }
     }
 
-    // Generate a new map from segment to enabled instances
-    Set<String> enabledInstances = _enabledInstances;
-    Map<String, List<String>> segmentToEnabledInstancesMap =
-        new HashMap<>(HashUtil.getHashMapCapacity(segmentToInstancesMap.size()));
+    // Generate a new map from segment to enabled ONLINE/CONSUMING instances and a new set of unavailable segments (no
+    // enabled instance or all enabled instances are in ERROR state)
+    Map<String, List<String>> segmentToEnabledInstancesMap = new HashMap<>(HashUtil.getHashMapCapacity(numSegments));
+    Set<String> unavailableSegments = new HashSet<>();
     // NOTE: Put null as the value when there is no enabled instances for a segment so that segmentToEnabledInstancesMap
     // always contains all segments. With this, in onInstancesChange() we can directly iterate over
     // segmentToEnabledInstancesMap.entrySet() and modify the value without changing the map entries.
-    for (Map.Entry<String, List<String>> entry : segmentToInstancesMap.entrySet()) {
+    for (Map.Entry<String, List<String>> entry : _segmentToOnlineInstancesMap.entrySet()) {
       String segment = entry.getKey();
-      segmentToEnabledInstancesMap
-          .put(segment, calculateEnabledInstancesForSegment(segment, entry.getValue(), enabledInstances));
+      List<String> enabledInstancesForSegment =
+          calculateEnabledInstancesForSegment(segment, entry.getValue(), unavailableSegments);
+      segmentToEnabledInstancesMap.put(segment, enabledInstancesForSegment);
     }
 
-    _segmentToInstancesMap = segmentToInstancesMap;
-    _instanceToSegmentsMap = instanceToSegmentsMap;
     _segmentToEnabledInstancesMap = segmentToEnabledInstancesMap;
+    _unavailableSegments = unavailableSegments;
   }
 
+  /**
+   * Calculates the enabled ONLINE/CONSUMING instances for the given segment, and updates the unavailable segments (no
+   * enabled instance or all enabled instances are in ERROR state).
+   */
   @Nullable
-  private List<String> calculateEnabledInstancesForSegment(String segment, List<String> instancesForSegment,
-      Set<String> enabledInstances) {
-    List<String> enabledInstancesForSegment = new ArrayList<>(instancesForSegment.size());
-    for (String instance : instancesForSegment) {
-      if (enabledInstances.contains(instance)) {
-        enabledInstancesForSegment.add(instance);
+  private List<String> calculateEnabledInstancesForSegment(String segment, List<String> onlineInstancesForSegment,
+      Set<String> unavailableSegments) {
+    List<String> enabledInstancesForSegment = new ArrayList<>(onlineInstancesForSegment.size());
+    for (String onlineInstance : onlineInstancesForSegment) {
+      if (_enabledInstances.contains(onlineInstance)) {
+        enabledInstancesForSegment.add(onlineInstance);
       }
     }
     if (!enabledInstancesForSegment.isEmpty()) {
       return enabledInstancesForSegment;
     } else {
-      LOGGER.warn("Failed to find servers hosting segment: {} for table: {} (all online instances: {} are disabled)",
-          segment, _tableNameWithType, instancesForSegment);
+      // NOTE: When there are enabled instances in OFFLINE state, we don't count the segment as unavailable because it
+      //       is a valid state when the segment is new added.
+      List<String> offlineInstancesForSegment = _segmentToOfflineInstancesMap.get(segment);
+      for (String offlineInstance : offlineInstancesForSegment) {
+        if (_enabledInstances.contains(offlineInstance)) {
+          LOGGER.info(
+              "Failed to find servers hosting segment: {} for table: {} (all ONLINE/CONSUMING instances: {} are disabled, but find enabled OFFLINE instance: {} from OFFLINE instances: {}, not counting the segment as unavailable)",
+              segment, _tableNameWithType, onlineInstancesForSegment, offlineInstance, offlineInstancesForSegment);
+          return null;
+        }
+      }
+      LOGGER.warn(
+          "Failed to find servers hosting segment: {} for table: {} (all ONLINE/CONSUMING instances: {} and OFFLINE instances: {} are disabled, counting segment as unavailable)",
+          segment, _tableNameWithType, onlineInstancesForSegment, offlineInstancesForSegment);
+      unavailableSegments.add(segment);
       _brokerMetrics.addMeteredTableValue(_tableNameWithType, BrokerMeter.NO_SERVING_HOST_FOR_SEGMENT, 1);
       return null;
     }
   }
 
   @Override
-  public Map<String, String> select(BrokerRequest brokerRequest, List<String> segments) {
+  public SelectionResult select(BrokerRequest brokerRequest, List<String> segments) {
     int requestId = (int) (_requestId.getAndIncrement() % MAX_REQUEST_ID);
-    return select(segments, requestId, _segmentToEnabledInstancesMap);
+    Map<String, String> segmentToInstanceMap = select(segments, requestId, _segmentToEnabledInstancesMap);
+    Set<String> unavailableSegments = _unavailableSegments;
+    if (unavailableSegments.isEmpty()) {
+      return new SelectionResult(segmentToInstanceMap, Collections.emptyList());
+    } else {
+      List<String> unavailableSegmentsForRequest = new ArrayList<>();
+      for (String segment : segments) {
+        if (unavailableSegments.contains(segment)) {
+          unavailableSegmentsForRequest.add(segment);
+        }
+      }
+      return new SelectionResult(segmentToInstanceMap, unavailableSegmentsForRequest);
+    }
   }
 
   /**
-   * Selects the server instances for the given segments based on the request id and segment to enabled instances map,
-   * returns a map from segment to selected server instance hosting the segment.
-   * <p>NOTE: {@code segmentToEnabledInstancesMap} might contain {@code null} values (segment with {@code null} enabled
-   * instances). If enabled instances are not {@code null}, they are sorted (in alphabetical order).
+   * Selects the server instances for the given segments based on the request id and segment to enabled ONLINE/CONSUMING
+   * instances map, returns a map from segment to selected server instance hosting the segment.
+   * <p>NOTE: {@code segmentToEnabledInstancesMap} might contain {@code null} values (segment with no enabled
+   * ONLINE/CONSUMING instances). If enabled instances are not {@code null}, they are sorted in alphabetical order.
    */
   abstract Map<String, String> select(List<String> segments, int requestId,
       Map<String, List<String>> segmentToEnabledInstancesMap);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -54,7 +54,32 @@ public interface InstanceSelector {
 
   /**
    * Selects the server instances for the given segments queried by the given broker request, returns a map from segment
-   * to selected server instance hosting the segment.
+   * to selected server instance hosting the segment and a set of unavailable segments (no enabled instance or all
+   * enabled instances are in ERROR state).
    */
-  Map<String, String> select(BrokerRequest brokerRequest, List<String> segments);
+  SelectionResult select(BrokerRequest brokerRequest, List<String> segments);
+
+  class SelectionResult {
+    private final Map<String, String> _segmentToInstanceMap;
+    private final List<String> _unavailableSegments;
+
+    public SelectionResult(Map<String, String> segmentToInstanceMap, List<String> unavailableSegments) {
+      _segmentToInstanceMap = segmentToInstanceMap;
+      _unavailableSegments = unavailableSegments;
+    }
+
+    /**
+     * Returns the map from segment to selected server instance hosting the segment.
+     */
+    public Map<String, String> getSegmentToInstanceMap() {
+      return _segmentToInstanceMap;
+    }
+
+    /**
+     * Returns the unavailable segments (no enabled instance or all enabled instances are in ERROR state).
+     */
+    public List<String> getUnavailableSegments() {
+      return _unavailableSegments;
+    }
+  }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -34,7 +34,9 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING;
 import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ERROR;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.OFFLINE;
 import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -151,14 +153,17 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment1, instance2);
     expectedBalancedInstanceSelectorResult.put(segment2, instance1);
     expectedBalancedInstanceSelectorResult.put(segment3, instance3);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    InstanceSelector.SelectionResult selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment0, instance0);
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance0);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // For the second request:
     //   BalancedInstanceSelector:
@@ -176,14 +181,17 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment1, instance0);
     expectedBalancedInstanceSelectorResult.put(segment2, instance3);
     expectedBalancedInstanceSelectorResult.put(segment3, instance1);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment0, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // Disable instance0
     enabledInstances.remove(instance0);
@@ -206,14 +214,17 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment1, instance2);
     expectedBalancedInstanceSelectorResult.put(segment2, instance1);
     expectedBalancedInstanceSelectorResult.put(segment3, instance3);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment0, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // For the fourth request:
     //   BalancedInstanceSelector:
@@ -231,14 +242,17 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment1, instance2);
     expectedBalancedInstanceSelectorResult.put(segment2, instance3);
     expectedBalancedInstanceSelectorResult.put(segment3, instance1);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment0, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // Remove segment0 and add segment4
     segmentAssignment.remove(segment0);
@@ -263,13 +277,16 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment1, instance2);
     expectedBalancedInstanceSelectorResult.put(segment2, instance3);
     expectedBalancedInstanceSelectorResult.put(segment3, instance1);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // For the sixth request:
     //   BalancedInstanceSelector:
@@ -286,13 +303,16 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment1, instance2);
     expectedBalancedInstanceSelectorResult.put(segment2, instance1);
     expectedBalancedInstanceSelectorResult.put(segment3, instance3);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // Process the changes
     balancedInstanceSelector.onExternalViewChange(externalView, onlineSegments);
@@ -314,14 +334,17 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment2, instance3);
     expectedBalancedInstanceSelectorResult.put(segment3, instance1);
     expectedBalancedInstanceSelectorResult.put(segment4, instance2);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
     expectedReplicaGroupInstanceSelectorResult.put(segment4, instance2);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // For the eighth request:
     //   BalancedInstanceSelector:
@@ -339,14 +362,17 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment2, instance1);
     expectedBalancedInstanceSelectorResult.put(segment3, instance3);
     expectedBalancedInstanceSelectorResult.put(segment4, instance2);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
     expectedReplicaGroupInstanceSelectorResult.put(segment4, instance2);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // Re-enable instance0
     enabledInstances.add(instance0);
@@ -369,14 +395,17 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment2, instance3);
     expectedBalancedInstanceSelectorResult.put(segment3, instance1);
     expectedBalancedInstanceSelectorResult.put(segment4, instance2);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance0);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance1);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
     expectedReplicaGroupInstanceSelectorResult.put(segment4, instance0);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // For the tenth request:
     //   BalancedInstanceSelector:
@@ -394,13 +423,142 @@ public class InstanceSelectorTest {
     expectedBalancedInstanceSelectorResult.put(segment2, instance1);
     expectedBalancedInstanceSelectorResult.put(segment3, instance3);
     expectedBalancedInstanceSelectorResult.put(segment4, instance0);
-    assertEquals(balancedInstanceSelector.select(brokerRequest, segments), expectedBalancedInstanceSelectorResult);
+    selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
     expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
     expectedReplicaGroupInstanceSelectorResult.put(segment1, instance2);
     expectedReplicaGroupInstanceSelectorResult.put(segment2, instance3);
     expectedReplicaGroupInstanceSelectorResult.put(segment3, instance3);
     expectedReplicaGroupInstanceSelectorResult.put(segment4, instance2);
-    assertEquals(replicaGroupInstanceSelector.select(brokerRequest, segments),
-        expectedReplicaGroupInstanceSelectorResult);
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+  }
+
+  @Test
+  public void testUnavailableSegments() {
+    String offlineTableName = "testTable_OFFLINE";
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    BalancedInstanceSelector balancedInstanceSelector = new BalancedInstanceSelector(offlineTableName, brokerMetrics);
+
+    Set<String> enabledInstances = new HashSet<>();
+    ExternalView externalView = new ExternalView(offlineTableName);
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    // NOTE: Online segments is not used in the current implementation
+    Set<String> onlineSegments = Collections.emptySet();
+
+    String instance = "instance";
+    String errorInstance = "errorInstance";
+    Map<String, String> instanceStateMap = new TreeMap<>();
+    instanceStateMap.put(instance, CONSUMING);
+    instanceStateMap.put(errorInstance, ERROR);
+    String segment = "segment";
+    segmentAssignment.put(segment, instanceStateMap);
+    List<String> segments = Collections.singletonList(segment);
+
+    // Initialize with no enabled instance, segment should be unavailable
+    // {
+    //   (disabled) instance: CONSUMING
+    //   (disabled) errorInstance: ERROR
+    // }
+    balancedInstanceSelector.init(enabledInstances, externalView, onlineSegments);
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    InstanceSelector.SelectionResult selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+    assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
+    assertEquals(selectionResult.getUnavailableSegments(), Collections.singletonList(segment));
+
+    // Iterate 5 times
+    for (int i = 0; i < 5; i++) {
+
+      // Enable the ERROR instance, segment should be unavailable
+      // {
+      //   (disabled) instance: CONSUMING
+      //   (enabled)  errorInstance: ERROR
+      // }
+      enabledInstances.add(errorInstance);
+      balancedInstanceSelector.onInstancesChange(enabledInstances, Collections.singletonList(errorInstance));
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
+      assertEquals(selectionResult.getUnavailableSegments(), Collections.singletonList(segment));
+
+      // Enable the CONSUMING instance, segment should be available
+      // {
+      //   (enabled)  instance: CONSUMING
+      //   (enabled)  errorInstance: ERROR
+      // }
+      enabledInstances.add(instance);
+      balancedInstanceSelector.onInstancesChange(enabledInstances, Collections.singletonList(instance));
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertEquals(selectionResult.getSegmentToInstanceMap(), Collections.singletonMap(segment, instance));
+      assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+
+      // Change the CONSUMING instance to ONLINE, segment should be available
+      // {
+      //   (enabled)  instance: ONLINE
+      //   (enabled)  errorInstance: ERROR
+      // }
+      instanceStateMap.put(instance, ONLINE);
+      balancedInstanceSelector.onExternalViewChange(externalView, onlineSegments);
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertEquals(selectionResult.getSegmentToInstanceMap(), Collections.singletonMap(segment, instance));
+      assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+
+      // Change the ONLINE instance to OFFLINE, both segment to instance map and unavailable segment should be empty
+      // {
+      //   (enabled)  instance: OFFLINE
+      //   (enabled)  errorInstance: ERROR
+      // }
+      instanceStateMap.put(instance, OFFLINE);
+      balancedInstanceSelector.onExternalViewChange(externalView, onlineSegments);
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
+      assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+
+      // Disable the OFFLINE instance, segment should be unavailable
+      // {
+      //   (disabled) instance: OFFLINE
+      //   (enabled)  errorInstance: ERROR
+      // }
+      enabledInstances.remove(instance);
+      balancedInstanceSelector.onInstancesChange(enabledInstances, Collections.singletonList(instance));
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
+      assertEquals(selectionResult.getUnavailableSegments(), Collections.singletonList(segment));
+
+      // Change the ERROR instance to ONLINE, segment should be available
+      // {
+      //   (disabled) instance: OFFLINE
+      //   (enabled)  errorInstance: ONLINE
+      // }
+      instanceStateMap.put(errorInstance, ONLINE);
+      balancedInstanceSelector.onExternalViewChange(externalView, onlineSegments);
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertEquals(selectionResult.getSegmentToInstanceMap(), Collections.singletonMap(segment, errorInstance));
+      assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+
+      // Disable the ONLINE instance, segment should be unavailable
+      // {
+      //   (disabled) instance: OFFLINE
+      //   (disabled) errorInstance: ONLINE
+      // }
+      enabledInstances.remove(errorInstance);
+      balancedInstanceSelector.onInstancesChange(enabledInstances, Collections.singletonList(errorInstance));
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
+      assertEquals(selectionResult.getUnavailableSegments(), Collections.singletonList(segment));
+
+      // Change back to initial state, segment should be unavailable
+      // {
+      //   (disabled) instance: CONSUMING
+      //   (disabled) errorInstance: ERROR
+      // }
+      instanceStateMap.put(instance, CONSUMING);
+      instanceStateMap.put(errorInstance, ERROR);
+      balancedInstanceSelector.onExternalViewChange(externalView, onlineSegments);
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
+      assertEquals(selectionResult.getUnavailableSegments(), Collections.singletonList(segment));
+    }
   }
 }


### PR DESCRIPTION
Unavailable segments are the segments that has no enabled instance or all enabled instances are in ERROR state.
We don't count segment with enabled instance in OFFLINE state as unavailable because it is a valid state when segment is new added and has not become ONLINE/CONSUMING.

Introduced RoutingTable class to wrap the a map from ServerInstance to segments and a list of unavailable segments.
Added a new property 'numUnavailableSegments' into the RequestStatistics.