### PR TITLE
[SegmentGeneratorConfig Cleanup] Refactor CreateSegmentCommand and remove the clone constructor in SegmentGeneratorConfig

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.core.indexsegment.generator;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.ArrayList;
@@ -60,8 +58,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Configuration properties used in the creation of index segments.
  */
-@SuppressWarnings("unused")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class SegmentGeneratorConfig {
   public enum TimeColumnType {
     EPOCH, SIMPLE_DATE
@@ -76,12 +72,10 @@ public class SegmentGeneratorConfig {
   private List<String> _textIndexCreationColumns = new ArrayList<>();
   private List<String> _columnSortOrder = new ArrayList<>();
   private List<String> _varLengthDictionaryColumns = new ArrayList<>();
-  private String _dataDir = null;
   private String _inputFilePath = null;
   private FileFormat _format = FileFormat.AVRO;
   private String _recordReaderPath = null; //TODO: this should be renamed to recordReaderClass or even better removed
   private String _outDir = null;
-  private boolean _overwrite = false;
   private String _tableName = null;
   private String _segmentName = null;
   private String _segmentNamePostfix = null;
@@ -91,9 +85,7 @@ public class SegmentGeneratorConfig {
   private String _segmentStartTime = null;
   private String _segmentEndTime = null;
   private SegmentVersion _segmentVersion = SegmentVersion.v3;
-  private String _schemaFile = null;
   private Schema _schema = null;
-  private String _readerConfigFile = null;
   private RecordReaderConfig _readerConfig = null;
   private List<StarTreeV2BuilderConfig> _starTreeV2BuilderConfigs = null;
   private String _creatorVersion = null;
@@ -107,53 +99,8 @@ public class SegmentGeneratorConfig {
   private boolean _skipTimeValueCheck = false;
   private boolean _nullHandlingEnabled = false;
 
-  public SegmentGeneratorConfig() {
-  }
-
-  /**
-   * @deprecated To be replaced by a builder pattern. Use set methods in the meantime.
-   * For now, this works only if no setters are called after this copy constructor.
-   * @param config to copy from
-   */
   @Deprecated
-  public SegmentGeneratorConfig(SegmentGeneratorConfig config) {
-    Preconditions.checkNotNull(config);
-    _customProperties.putAll(config._customProperties);
-    _rawIndexCreationColumns.addAll(config._rawIndexCreationColumns);
-    _rawIndexCompressionType.putAll(config._rawIndexCompressionType);
-    _invertedIndexCreationColumns.addAll(config._invertedIndexCreationColumns);
-    _textIndexCreationColumns.addAll(config._textIndexCreationColumns);
-    _columnSortOrder.addAll(config._columnSortOrder);
-    _varLengthDictionaryColumns.addAll(config._varLengthDictionaryColumns);
-    _dataDir = config._dataDir;
-    _inputFilePath = config._inputFilePath;
-    _format = config._format;
-    _outDir = config._outDir;
-    _overwrite = config._overwrite;
-    _tableName = config._tableName;
-    _segmentName = config._segmentName;
-    _segmentNamePostfix = config._segmentNamePostfix;
-    _segmentTimeColumnName = config._segmentTimeColumnName;
-    _segmentTimeUnit = config._segmentTimeUnit;
-    _segmentCreationTime = config._segmentCreationTime;
-    _segmentStartTime = config._segmentStartTime;
-    _segmentEndTime = config._segmentEndTime;
-    _segmentVersion = config._segmentVersion;
-    _schemaFile = config._schemaFile;
-    _schema = config._schema;
-    _readerConfigFile = config._readerConfigFile;
-    _readerConfig = config._readerConfig;
-    _starTreeV2BuilderConfigs = config._starTreeV2BuilderConfigs;
-    _creatorVersion = config._creatorVersion;
-    _segmentNameGenerator = config._segmentNameGenerator;
-    _segmentPartitionConfig = config._segmentPartitionConfig;
-    _sequenceId = config._sequenceId;
-    _timeColumnType = config._timeColumnType;
-    _simpleDateFormat = config._simpleDateFormat;
-    _onHeap = config._onHeap;
-    _recordReaderPath = config._recordReaderPath;
-    _skipTimeValueCheck = config._skipTimeValueCheck;
-    _nullHandlingEnabled = config._nullHandlingEnabled;
+  public SegmentGeneratorConfig() {
   }
 
   /**
@@ -399,14 +346,6 @@ public class SegmentGeneratorConfig {
     }
   }
 
-  public String getDataDir() {
-    return _dataDir;
-  }
-
-  public void setDataDir(String dataDir) {
-    _dataDir = dataDir;
-  }
-
   public String getInputFilePath() {
     return _inputFilePath;
   }
@@ -447,14 +386,6 @@ public class SegmentGeneratorConfig {
       Preconditions.checkState(outputDir.mkdirs(), "Cannot create output dir: {}", dir);
     }
     _outDir = outputDir.getAbsolutePath();
-  }
-
-  public boolean isOverwrite() {
-    return _overwrite;
-  }
-
-  public void setOverwrite(boolean overwrite) {
-    _overwrite = overwrite;
   }
 
   public String getTableName() {
@@ -551,14 +482,6 @@ public class SegmentGeneratorConfig {
     _segmentVersion = segmentVersion;
   }
 
-  public String getSchemaFile() {
-    return _schemaFile;
-  }
-
-  public void setSchemaFile(String schemaFile) {
-    _schemaFile = schemaFile;
-  }
-
   public Schema getSchema() {
     return _schema;
   }
@@ -579,14 +502,6 @@ public class SegmentGeneratorConfig {
         }
       }
     }
-  }
-
-  public String getReaderConfigFile() {
-    return _readerConfigFile;
-  }
-
-  public void setReaderConfigFile(String readerConfigFile) {
-    _readerConfigFile = readerConfigFile;
   }
 
   public RecordReaderConfig getReaderConfig() {
@@ -644,17 +559,14 @@ public class SegmentGeneratorConfig {
     _rawIndexCompressionType.putAll(rawIndexCompressionType);
   }
 
-  @JsonIgnore
   public String getMetrics() {
     return getQualifyingFields(FieldType.METRIC, true);
   }
 
-  @JsonIgnore
   public String getDimensions() {
     return getQualifyingFields(FieldType.DIMENSION, true);
   }
 
-  @JsonIgnore
   public String getDateTimeColumnNames() {
     return getQualifyingFields(FieldType.DATE_TIME, true);
   }
@@ -672,7 +584,6 @@ public class SegmentGeneratorConfig {
    * @param type FieldType to filter on
    * @return Comma separate qualifying fields names.
    */
-  @JsonIgnore
   private String getQualifyingFields(FieldType type, boolean excludeVirtualColumns) {
     List<String> fields = new ArrayList<>();
 

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
@@ -55,9 +55,6 @@ public class PinotOutputFormat<K, V> extends FileOutputFormat<K, V> {
   // file containing schema for the data
   public static final String SCHEMA = "pinot.schema.file";
 
-  // config file for the record reader
-  public static final String READER_CONFIG = "pinot.reader.config.file";
-
   public static final String PINOT_RECORD_SERIALIZATION_CLASS = "pinot.record.serialization.class";
 
   public PinotOutputFormat() {
@@ -116,14 +113,6 @@ public class PinotOutputFormat<K, V> extends FileOutputFormat<K, V> {
     return schemaFile;
   }
 
-  public static void setReaderConfig(Job job, String readConfig) {
-    job.getConfiguration().set(PinotOutputFormat.READER_CONFIG, readConfig);
-  }
-
-  public static String getReaderConfig(JobContext context) {
-    return context.getConfiguration().get(PinotOutputFormat.READER_CONFIG);
-  }
-
   public static void setDataWriteSupportClass(Job job, Class<? extends PinotRecordSerialization> pinotSerialization) {
     job.getConfiguration().set(PinotOutputFormat.PINOT_RECORD_SERIALIZATION_CLASS, pinotSerialization.getName());
   }
@@ -171,12 +160,10 @@ public class PinotOutputFormat<K, V> extends FileOutputFormat<K, V> {
       throws IOException {
     _segmentConfig.setFormat(FileFormat.JSON);
     _segmentConfig.setOutDir(PinotOutputFormat.getTempSegmentDir(context) + "/segmentDir");
-    _segmentConfig.setOverwrite(true);
     _segmentConfig.setTableName(PinotOutputFormat.getTableName(context));
     _segmentConfig.setSegmentName(PinotOutputFormat.getSegmentName(context));
     Schema schema = Schema.fromString(PinotOutputFormat.getSchema(context));
     _segmentConfig.setSchema(schema);
     _segmentConfig.setTime(PinotOutputFormat.getTimeColumnName(context), schema);
-    _segmentConfig.setReaderConfigFile(PinotOutputFormat.getReaderConfig(context));
   }
 }

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -72,6 +72,21 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-orc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-parquet</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-thrift</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-kafka-${kafka.version}</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -18,29 +18,27 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.UUID;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Future;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
-import org.apache.pinot.core.util.SchemaUtils;
-import org.apache.pinot.plugin.inputformat.csv.CSVRecordReader;
-import org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
-import org.apache.pinot.spi.data.readers.RecordReader;
-import org.apache.pinot.spi.filesystem.PinotFS;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.data.readers.RecordReaderFactory;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -49,14 +47,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Class to implement CreateSegment command.
- *
- * TODO: Support star-tree creation
  */
+@SuppressWarnings("unused")
 public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(CreateSegmentCommand.class);
-
-  @Option(name = "-generatorConfigFile", metaVar = "<string>", usage = "Config file for segment generator.")
-  private String _generatorConfigFile;
 
   @Option(name = "-dataDir", metaVar = "<string>", usage = "Directory containing the data.")
   private String _dataDir;
@@ -70,14 +64,8 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   @Option(name = "-overwrite", usage = "Overwrite existing output directory.")
   private boolean _overwrite = false;
 
-  @Option(name = "-tableName", metaVar = "<string>", usage = "Name of the table.")
-  private String _tableName;
-
-  @Option(name = "-segmentName", metaVar = "<string>", usage = "Name of the segment.")
-  private String _segmentName;
-
-  @Option(name = "-timeColumnName", metaVar = "<string>", usage = "Primary time column.")
-  private String _timeColumnName;
+  @Option(name = "-tableConfigFile", metaVar = "<string>", usage = "File containing table config for data.")
+  private String _tableConfigFile;
 
   @Option(name = "-schemaFile", metaVar = "<string>", usage = "File containing schema for data.")
   private String _schemaFile;
@@ -85,23 +73,18 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   @Option(name = "-readerConfigFile", metaVar = "<string>", usage = "Config file for record reader.")
   private String _readerConfigFile;
 
-  @Option(name = "-numThreads", metaVar = "<int>", usage = "Parallelism while generating segments, default is 1.")
-  private int _numThreads = 1;
+  @Option(name = "-retry", metaVar = "<int>", usage = "Number of retries if encountered any segment creation failure, default is 0.")
+  private int _retry = 0;
 
   @Option(name = "-postCreationVerification", usage = "Verify segment data file after segment creation. Please ensure you have enough local disk to hold data for verification")
   private boolean _postCreationVerification = false;
 
-  @Option(name = "-retry", metaVar = "<int>", usage = "Number of retries if encountered any segment creation failure, default is 0.")
-  private int _retry = 0;
+  @Option(name = "-numThreads", metaVar = "<int>", usage = "Parallelism while generating segments, default is 1.")
+  private int _numThreads = 1;
 
   @SuppressWarnings("FieldCanBeLocal")
   @Option(name = "-help", help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
-
-  public CreateSegmentCommand setGeneratorConfigFile(String generatorConfigFile) {
-    _generatorConfigFile = generatorConfigFile;
-    return this;
-  }
 
   public CreateSegmentCommand setDataDir(String dataDir) {
     _dataDir = dataDir;
@@ -123,18 +106,8 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
     return this;
   }
 
-  public CreateSegmentCommand setTableName(String tableName) {
-    _tableName = tableName;
-    return this;
-  }
-
-  public CreateSegmentCommand setSegmentName(String segmentName) {
-    _segmentName = segmentName;
-    return this;
-  }
-
-  public CreateSegmentCommand setTimeColumnName(String timeColumnName) {
-    _timeColumnName = timeColumnName;
+  public CreateSegmentCommand setTableConfigFile(String tableConfigFile) {
+    _tableConfigFile = tableConfigFile;
     return this;
   }
 
@@ -165,10 +138,10 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
 
   @Override
   public String toString() {
-    return ("CreateSegment  -generatorConfigFile " + _generatorConfigFile + " -dataDir " + _dataDir + " -format "
-        + _format + " -outDir " + _outDir + " -overwrite " + _overwrite + " -tableName " + _tableName + " -segmentName "
-        + _segmentName + " -timeColumnName " + _timeColumnName + " -schemaFile " + _schemaFile + " -readerConfigFile "
-        + _readerConfigFile + " -numThreads " + _numThreads);
+    return String.format(
+        "CreateSegment -dataDir %s -format %s -outDir %s -overwrite %s -tableConfigFile %s -schemaFile %s -readerConfigFile %s -retry %d -postCreationVerification %s -numThreads %d",
+        _dataDir, _format, _outDir, _overwrite, _tableConfigFile, _schemaFile, _readerConfigFile, _retry,
+        _postCreationVerification, _numThreads);
   }
 
   @Override
@@ -178,7 +151,7 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
 
   @Override
   public String description() {
-    return "Create pinot segments from provided avro/csv/json input data.";
+    return "Create pinot segments from the provided data files.";
   }
 
   @Override
@@ -191,249 +164,135 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
       throws Exception {
     LOGGER.info("Executing command: {}", toString());
 
-    // Load generator config if exist.
-    final SegmentGeneratorConfig segmentGeneratorConfig;
-    if (_generatorConfigFile != null) {
-      segmentGeneratorConfig = JsonUtils.fileToObject(new File(_generatorConfigFile), SegmentGeneratorConfig.class);
-    } else {
-      segmentGeneratorConfig = new SegmentGeneratorConfig();
-    }
+    Preconditions.checkArgument(_dataDir != null, "'dataDir' must be specified");
+    File dataDir = new File(_dataDir);
+    Preconditions.checkArgument(dataDir.isDirectory(), "'dataDir': '%s' is not a directory", dataDir);
 
-    // Load config from segment generator config.
-    String configDataDir = segmentGeneratorConfig.getDataDir();
-    if (_dataDir == null) {
-      if (configDataDir == null) {
-        throw new RuntimeException("Must specify dataDir.");
-      }
-      _dataDir = configDataDir;
-    } else {
-      if (configDataDir != null && !configDataDir.equals(_dataDir)) {
-        LOGGER.warn("Find dataDir conflict in command line and config file, use config in command line: {}", _dataDir);
-      }
-    }
+    // Filter out all input data files
+    Preconditions.checkArgument(_format != null, "'format' must be specified");
+    List<String> dataFiles = getDataFiles(dataDir);
+    Preconditions
+        .checkState(!dataFiles.isEmpty(), "Failed to find any data file of format: %s under directory: %s", _format,
+            dataDir);
+    LOGGER.info("Found data files: {} of format: {} under directory: {}", dataFiles, _format, dataDir);
 
-    FileFormat configFormat = segmentGeneratorConfig.getFormat();
-    if (_format == null) {
-      if (configFormat == null) {
-        throw new RuntimeException("Format cannot be null in config file.");
-      }
-      _format = configFormat;
-    } else {
-      if (configFormat != _format && configFormat != FileFormat.AVRO) {
-        LOGGER.warn("Find format conflict in command line and config file, use config in command line: {}", _format);
-      }
-    }
-
-    String configOutDir = segmentGeneratorConfig.getOutDir();
-    if (_outDir == null) {
-      if (configOutDir == null) {
-        throw new RuntimeException("Must specify outDir.");
-      }
-      _outDir = configOutDir;
-    } else {
-      if (configOutDir != null && !configOutDir.equals(_outDir)) {
-        LOGGER.warn("Find outDir conflict in command line and config file, use config in command line: {}", _outDir);
-      }
-    }
-
-    if (segmentGeneratorConfig.isOverwrite()) {
-      _overwrite = true;
-    }
-
-    String configTableName = segmentGeneratorConfig.getTableName();
-    if (_tableName == null) {
-      if (configTableName == null) {
-        throw new RuntimeException("Must specify tableName.");
-      }
-      _tableName = configTableName;
-    } else {
-      if (configTableName != null && !configTableName.equals(_tableName)) {
-        LOGGER.warn("Find tableName conflict in command line and config file, use config in command line: {}",
-            _tableName);
-      }
-    }
-
-    String configSegmentName = segmentGeneratorConfig.getSegmentName();
-    if (_segmentName == null) {
-      if (configSegmentName == null) {
-        throw new RuntimeException("Must specify segmentName.");
-      }
-      _segmentName = configSegmentName;
-    } else {
-      if (configSegmentName != null && !configSegmentName.equals(_segmentName)) {
-        LOGGER.warn("Find segmentName conflict in command line and config file, use config in command line: {}",
-            _segmentName);
-      }
-    }
-
-    // Filter out all input files.
-    URI dataDirURI = URI.create(_dataDir);
-    if (dataDirURI.getScheme() == null) {
-      dataDirURI = new File(_dataDir).toURI();
-    }
-    PinotFS pinotFS = PinotFSFactory.create(dataDirURI.getScheme());
-
-    if (!pinotFS.exists(dataDirURI) || !pinotFS.isDirectory(dataDirURI)) {
-      throw new RuntimeException("Data directory " + _dataDir + " not found.");
-    }
-
-    // Gather all data files
-    String[] dataFilePaths = pinotFS.listFiles(dataDirURI, true);
-
-    if ((dataFilePaths == null) || (dataFilePaths.length == 0)) {
-      throw new RuntimeException(
-          "Data directory " + _dataDir + " does not contain " + _format.toString().toUpperCase() + " files.");
-    }
-
-    LOGGER.info("Accepted files: {}", Arrays.toString(dataFilePaths));
-
-    // Make sure output directory does not already exist, or can be overwritten.
+    Preconditions.checkArgument(_outDir != null, "'outDir' must be specified");
     File outDir = new File(_outDir);
-    if (outDir.exists()) {
-      if (!_overwrite) {
-        throw new IOException("Output directory " + _outDir + " already exists.");
-      } else {
-        FileUtils.deleteDirectory(outDir);
+    if (_overwrite) {
+      if (outDir.exists()) {
+        LOGGER.info("Deleting the existing 'outDir': {}", outDir);
+        FileUtils.forceDelete(outDir);
       }
     }
+    FileUtils.forceMkdir(outDir);
 
-    // Set other generator configs from command line.
-    segmentGeneratorConfig.setDataDir(_dataDir);
-    segmentGeneratorConfig.setFormat(_format);
-    segmentGeneratorConfig.setOutDir(_outDir);
-    segmentGeneratorConfig.setOverwrite(_overwrite);
-    segmentGeneratorConfig.setTableName(_tableName);
-    segmentGeneratorConfig.setSegmentName(_segmentName);
-    if (_timeColumnName != null) {
-      segmentGeneratorConfig.setTimeColumnName(_timeColumnName);
+    Preconditions.checkArgument(_tableConfigFile != null, "'tableConfigFile' must be specified");
+    TableConfig tableConfig;
+    try {
+      tableConfig = JsonUtils.fileToObject(new File(_tableConfigFile), TableConfig.class);
+    } catch (Exception e) {
+      throw new IllegalStateException("Caught exception while reading table config from file: " + _tableConfigFile, e);
     }
-    if (_schemaFile != null) {
-      if (segmentGeneratorConfig.getSchemaFile() != null && !segmentGeneratorConfig.getSchemaFile()
-          .equals(_schemaFile)) {
-        LOGGER.warn("Find schemaFile conflict in command line and config file, use config in command line: {}",
-            _schemaFile);
-      }
-      segmentGeneratorConfig.setSchemaFile(_schemaFile);
+    LOGGER.info("Using table config: {}", tableConfig.toJsonString());
+    String rawTableName = TableNameBuilder.extractRawTableName(tableConfig.getTableName());
+
+    Preconditions.checkArgument(_schemaFile != null, "'schemaFile' must be specified");
+    Schema schema;
+    try {
+      schema = JsonUtils.fileToObject(new File(_schemaFile), Schema.class);
+    } catch (Exception e) {
+      throw new IllegalStateException("Caught exception while reading schema from file: " + _schemaFile, e);
     }
+    LOGGER.info("Using schema: {}", schema.toSingleLineJsonString());
+
+    RecordReaderConfig recordReaderConfig;
     if (_readerConfigFile != null) {
-      if (segmentGeneratorConfig.getReaderConfigFile() != null && !segmentGeneratorConfig.getReaderConfigFile()
-          .equals(_readerConfigFile)) {
-        LOGGER.warn("Find readerConfigFile conflict in command line and config file, use config in command line: {}",
-            _readerConfigFile);
+      try {
+        recordReaderConfig = RecordReaderFactory.getRecordReaderConfig(_format, _readerConfigFile);
+      } catch (Exception e) {
+        throw new IllegalStateException(String
+            .format("Caught exception while reading %s record reader config from file: %s", _format, _readerConfigFile),
+            e);
       }
-      segmentGeneratorConfig.setReaderConfigFile(_readerConfigFile);
+      LOGGER.info("Using {} record reader config: {}", _format, recordReaderConfig);
+    } else {
+      recordReaderConfig = null;
     }
 
-    ExecutorService executor = Executors.newFixedThreadPool(_numThreads);
-    int cnt = 0;
-    for (final String dataFilePath : dataFilePaths) {
-      final int segCnt = cnt;
-
-      executor.execute(new Runnable() {
-        @Override
-        public void run() {
-          for (int curr = 0; curr <= _retry; curr++) {
-            File localDir = new File(UUID.randomUUID().toString());
-            try {
-              SegmentGeneratorConfig config = new SegmentGeneratorConfig(segmentGeneratorConfig);
-              URI dataFileUri = URI.create(dataFilePath);
-              String[] splits = dataFilePath.split("/");
-              String fileName = splits[splits.length - 1];
-              if (!isDataFile(fileName)) {
-                return;
-              }
-              File localFile = new File(localDir, fileName);
-              pinotFS.copyToLocalFile(dataFileUri, localFile);
-              config.setInputFilePath(localFile.getAbsolutePath());
-              config.setSegmentName(_segmentName + "_" + segCnt);
-              Schema schema = Schema.fromFile(new File(_schemaFile));
-              config.setSchema(schema);
-              config.setTime(_timeColumnName, schema);
-
-              final SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-              switch (config.getFormat()) {
-                case PARQUET:
-                  config.setRecordReaderPath("org.apache.pinot.plugin.inputformat.ParquetRecordReader");
-                  driver.init(config);
-                  break;
-                case ORC:
-                  config.setRecordReaderPath("org.apache.pinot.plugin.inputformat.orc.ORCRecordReader");
-                  driver.init(config);
-                  break;
-                case CSV:
-                  RecordReader csvRecordReader = new CSVRecordReader();
-                  CSVRecordReaderConfig readerConfig = null;
-                  if (_readerConfigFile != null) {
-                    readerConfig = JsonUtils.fileToObject(new File(_readerConfigFile), CSVRecordReaderConfig.class);
-                  }
-                  csvRecordReader.init(localFile, SchemaUtils.extractSourceFields(schema), readerConfig);
-                  driver.init(config, csvRecordReader);
-                  break;
-                default:
-                  driver.init(config);
-              }
-              driver.build();
-              if (_postCreationVerification) {
-                if (!verifySegment(new File(config.getOutDir(), driver.getSegmentName()))) {
-                  throw new RuntimeException("Pinot segment is corrupted, please try to recreate it.");
-                } else {
-                  LOGGER.info("Post segment creation verification is succeed for segment {}.", driver.getSegmentName());
-                }
-              }
+    ExecutorService executorService = Executors.newFixedThreadPool(_numThreads);
+    int numDataFiles = dataFiles.size();
+    Future[] futures = new Future[numDataFiles];
+    for (int i = 0; i < numDataFiles; i++) {
+      int sequenceId = i;
+      futures[sequenceId] = executorService.submit(() -> {
+        SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+        segmentGeneratorConfig.setInputFilePath(dataFiles.get(sequenceId));
+        segmentGeneratorConfig.setFormat(_format);
+        segmentGeneratorConfig.setOutDir(outDir.getPath());
+        segmentGeneratorConfig.setReaderConfig(recordReaderConfig);
+        segmentGeneratorConfig.setTableName(rawTableName);
+        segmentGeneratorConfig.setSequenceId(sequenceId);
+        for (int j = 0; j <= _retry; j++) {
+          try {
+            SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
+            driver.init(segmentGeneratorConfig);
+            driver.build();
+            String segmentName = driver.getSegmentName();
+            File indexDir = new File(outDir, segmentName);
+            LOGGER.info("Successfully created segment: {} at directory: {}", segmentName, indexDir);
+            if (_postCreationVerification) {
+              LOGGER.info("Verifying the segment by loading it");
+              ImmutableSegment segment = ImmutableSegmentLoader.load(indexDir, ReadMode.mmap);
+              LOGGER.info("Successfully loaded segment: {} of size: {} bytes", segmentName,
+                  segment.getSegmentSizeBytes());
+              segment.destroy();
               break;
-            } catch (Exception e) {
-              LOGGER.error("Got exception during segment creation.", e);
-              if (curr == _retry) {
-                throw new RuntimeException(e);
-              } else {
-                LOGGER.error("Failed to create Pinot segment, retry: {}/{}", curr + 1, _retry);
-              }
-            } finally {
-              FileUtils.deleteQuietly(localDir);
+            }
+          } catch (Exception e) {
+            if (j < _retry) {
+              LOGGER.warn("Caught exception while creating/verifying segment, will retry", e);
+            } else {
+              throw e;
             }
           }
         }
+        return null;
       });
-      cnt += 1;
     }
-
-    executor.shutdown();
-    return executor.awaitTermination(1, TimeUnit.HOURS);
+    executorService.shutdown();
+    for (Future future : futures) {
+      future.get();
+    }
+    LOGGER.info("Successfully created {} segments from data files: {}", numDataFiles, dataFiles);
+    return true;
   }
 
-  private boolean verifySegment(File indexDir) {
-    File localTempDir =
-        new File(FileUtils.getTempDirectory(), org.apache.pinot.common.utils.FileUtils.getRandomFileName());
-    try {
-      try {
-        localTempDir.getParentFile().mkdirs();
-        URI indexDirUri = URI.create(indexDir.toString());
-        PinotFS pinotFs = PinotFSFactory.create(indexDirUri.getScheme());
-        pinotFs.copyToLocalFile(indexDirUri, localTempDir);
-      } catch (Exception e) {
-        LOGGER.error("Failed to copy segment {} to local directory {} for verification.", indexDir, localTempDir, e);
-        return false;
+  private List<String> getDataFiles(File dataDir) {
+    List<String> dataFiles = new ArrayList<>();
+    //noinspection ConstantConditions
+    getDataFilesHelper(dataDir.listFiles(), dataFiles);
+    return dataFiles;
+  }
+
+  private void getDataFilesHelper(File[] files, List<String> dataFiles) {
+    for (File file : files) {
+      if (file.isDirectory()) {
+        //noinspection ConstantConditions
+        getDataFilesHelper(file.listFiles(), dataFiles);
+      } else {
+        if (isDataFile(file.getName())) {
+          dataFiles.add(file.getPath());
+        }
       }
-      try {
-        ImmutableSegment segment = ImmutableSegmentLoader.load(localTempDir, ReadMode.mmap);
-        LOGGER.info("Successfully loaded Pinot segment {} (size: {} Bytes) from {}.", segment.getSegmentName(),
-            segment.getSegmentSizeBytes(), localTempDir);
-        segment.destroy();
-      } catch (Exception e) {
-        LOGGER.error("Failed to load segment from {}.", localTempDir, e);
-        return false;
-      }
-      return true;
-    } finally {
-      FileUtils.deleteQuietly(localTempDir);
     }
   }
 
-  protected boolean isDataFile(String fileName) {
+  private boolean isDataFile(String fileName) {
     switch (_format) {
       case AVRO:
-      case GZIPPED_AVRO:
         return fileName.endsWith(".avro");
+      case GZIPPED_AVRO:
+        return fileName.endsWith(".gz");
       case CSV:
         return fileName.endsWith(".csv");
       case JSON:

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/ClusterStarter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/ClusterStarter.java
@@ -218,8 +218,8 @@ public class ClusterStarter {
       throws Exception {
     if (_inputDataDir != null) {
       CreateSegmentCommand segmentCreator =
-          new CreateSegmentCommand().setDataDir(_inputDataDir).setSchemaFile(_schemaFileName).setTableName(_tableName)
-              .setSegmentName(_segmentName).setOutDir(_segmentDirName).setOverwrite(true);
+          new CreateSegmentCommand().setDataDir(_inputDataDir).setOutDir(_segmentDirName).setOverwrite(true)
+              .setTableConfigFile(_tableConfigFile).setSchemaFile(_schemaFileName);
 
       segmentCreator.execute();
     }


### PR DESCRIPTION
This is one step of cleaning up the SegmentGeneratorConfig. The end state we should always construct SegmentGeneratorConfig with table config and schema