### PR TITLE
Add api in AggregationFunction to get its compiled input expressions.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
@@ -64,6 +64,9 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
     _functionContexts = AggregationFunctionUtils.getAggregationFunctionContexts(brokerRequest);
     _groupBy = brokerRequest.getGroupBy();
 
+    Set<TransformExpressionTree> expressionsToTransform =
+        AggregationFunctionUtils.collectExpressionsToTransform(brokerRequest, _functionContexts);
+
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
     if (starTrees != null) {
       if (!StarTreeUtils.isStarTreeDisabled(brokerRequest)) {
@@ -90,7 +93,7 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
       }
     }
 
-    _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest);
+    _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest, expressionsToTransform);
     _starTreeTransformPlanNode = null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.plan;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.GroupBy;
@@ -91,7 +90,9 @@ public class AggregationGroupByPlanNode implements PlanNode {
       }
     }
 
-    _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest);
+    Set<TransformExpressionTree> expressionsToTransform =
+        AggregationFunctionUtils.collectExpressionsToTransform(brokerRequest, _functionContexts);
+    _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest, expressionsToTransform);
     _starTreeTransformPlanNode = null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -21,9 +21,9 @@ package org.apache.pinot.core.plan;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.indexsegment.IndexSegment;
@@ -77,7 +77,9 @@ public class AggregationPlanNode implements PlanNode {
       }
     }
 
-    _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest);
+    Set<TransformExpressionTree> expressionsToTransform =
+        AggregationFunctionUtils.collectExpressionsToTransform(brokerRequest, _functionContexts);
+    _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest, expressionsToTransform);
     _starTreeTransformPlanNode = null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -48,6 +50,12 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
    * Returns the column name to be used in the data schema of results. e.g. 'MINMAXRANGEMV( foo)' -> 'minmaxrangemv(foo)', 'PERCENTILE75(bar)' -> 'percentile75(bar)'
    */
   String getResultColumnName();
+
+  /**
+   * Returns a list of input expressions needed for performing aggregation.
+   *
+   */
+  List<TransformExpressionTree> getInputExpressions();
 
   /**
    * Accepts an aggregation function visitor to visit.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -28,6 +31,7 @@ import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -35,6 +39,7 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
   protected final String _column;
+  protected final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -42,6 +47,7 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
    */
   public AvgAggregationFunction(String column) {
     _column = column;
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -60,6 +66,11 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
   }
 
   @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }
@@ -75,7 +86,8 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<String, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_column);
 
     if (blockValSet.getValueType() != DataType.BYTES) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -58,6 +61,11 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
   }
 
   @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return Collections.emptyList();
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }
@@ -73,7 +81,8 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<String, BlockValSet> blockValSetMap) {
     if (blockValSetMap.size() == 0) {
       aggregationResultHolder.setValue(aggregationResultHolder.getDoubleResult() + length);
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -27,12 +30,15 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 public class CountMVAggregationFunction extends CountAggregationFunction {
 
+  private final List<TransformExpressionTree> _inputExpressions;
+
   /**
    * Constructor for the class.
    * @param column Column name to aggregate on.
    */
   public CountMVAggregationFunction(String column) {
     super(column);
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(column));
   }
 
   @Override
@@ -51,12 +57,18 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
   }
 
   @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<String, BlockValSet> blockValSetMap) {
     int[] valueArray = blockValSetMap.get(_column).getNumMVEntries();
     long count = 0L;
     for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -19,8 +19,11 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -33,6 +36,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 public class DistinctCountAggregationFunction implements AggregationFunction<IntOpenHashSet, Integer> {
 
   protected final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -40,6 +44,7 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
    */
   public DistinctCountAggregationFunction(String column) {
     _column = column;
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -55,6 +60,11 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _column + ")";
+  }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -20,8 +20,11 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -36,6 +39,7 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
   protected final String _column;
 
   public static final int DEFAULT_LOG2M = 8;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -43,6 +47,7 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
    */
   public DistinctCountHLLAggregationFunction(String column) {
     _column = column;
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -58,6 +63,11 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _column + ")";
+  }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -19,8 +19,11 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -32,6 +35,7 @@ public class DistinctCountRawHLLAggregationFunction implements AggregationFuncti
   private final DistinctCountHLLAggregationFunction _distinctCountHLLAggregationFunction;
 
   protected final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -45,6 +49,7 @@ public class DistinctCountRawHLLAggregationFunction implements AggregationFuncti
       String column) {
     _distinctCountHLLAggregationFunction = distinctCountHLLAggregationFunction;
     _column = column;
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -60,6 +65,11 @@ public class DistinctCountRawHLLAggregationFunction implements AggregationFuncti
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _column + ")";
+  }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -20,8 +20,11 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -40,6 +43,7 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
   private static final int BYTE_TO_CHAR_OFFSET = 129;
 
   private final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -47,6 +51,7 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
    */
   public FastHLLAggregationFunction(String column) {
     _column = column;
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -62,6 +67,11 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _column + ")";
+  }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -32,6 +35,7 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
   private static final double DEFAULT_INITIAL_VALUE = Double.NEGATIVE_INFINITY;
 
   protected final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -39,6 +43,7 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
    */
   public MaxAggregationFunction(String column) {
     _column = column;
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -54,6 +59,11 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _column + ")";
+  }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -32,6 +35,7 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
   private static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
 
   protected final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -39,6 +43,7 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
    */
   public MinAggregationFunction(String column) {
     _column = column;
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -55,6 +60,12 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _column + ")";
   }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
+  }
+
   @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -34,6 +37,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMaxRangePair, Double> {
 
   protected final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -41,6 +45,7 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
    */
   public MinMaxRangeAggregationFunction(String column) {
     _column = column;
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -59,6 +64,11 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
   }
 
   @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }
@@ -74,7 +84,8 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<String, BlockValSet> blockValSetMap) {
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -21,9 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -37,6 +39,7 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
 
   protected final int _percentile;
   protected final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -53,6 +56,7 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
 
     _column = arguments.get(0);
     _percentile = AggregationFunctionUtils.parsePercentile(arguments.get(1));
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -68,6 +72,11 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + _percentile + "(" + _column + ")";
+  }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -19,9 +19,11 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import com.google.common.base.Preconditions;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -38,6 +40,7 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
 
   protected final int _percentile;
   protected final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -54,6 +57,7 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
 
     _column = arguments.get(0);
     _percentile = AggregationFunctionUtils.parsePercentile(arguments.get(1));
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -72,6 +76,11 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
   }
 
   @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
+  }
+
+  @Override
   public void accept(AggregationFunctionVisitorBase visitor) {
     visitor.visit(this);
   }
@@ -87,7 +96,8 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
   }
 
   @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<String, BlockValSet> blockValSetMap) {
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<String, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_column);
     if (blockValSet.getValueType() != DataType.BYTES) {
       long[] longValues = blockValSet.getLongValuesSV();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -20,9 +20,11 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.google.common.base.Preconditions;
 import com.tdunning.math.stats.TDigest;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -41,6 +43,7 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
 
   protected final int _percentile;
   protected final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -56,6 +59,7 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
     Preconditions.checkArgument(numArgs == 2, getType() + " expects two argument, got: " + numArgs);
     _column = arguments.get(0);
     _percentile = AggregationFunctionUtils.parsePercentile(arguments.get(1));
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -71,6 +75,11 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
   @Override
   public String getResultColumnName() {
     return AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + _percentile + "(" + _column + ")";
+  }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -31,6 +34,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 public class SumAggregationFunction implements AggregationFunction<Double, Double> {
   private static final double DEFAULT_VALUE = 0.0;
   protected final String _column;
+  private final List<TransformExpressionTree> _inputExpressions;
 
   /**
    * Constructor for the class.
@@ -38,6 +42,7 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
    */
   public SumAggregationFunction(String column) {
     _column = column;
+    _inputExpressions = Collections.singletonList(TransformExpressionTree.compileToExpressionTree(_column));
   }
 
   @Override
@@ -53,6 +58,11 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _column + ")";
+  }
+
+  @Override
+  public List<TransformExpressionTree> getInputExpressions() {
+    return _inputExpressions;
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -24,20 +24,16 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.segment.ReadMode;
-import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
-import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
@@ -50,6 +46,11 @@ import org.apache.pinot.core.query.aggregation.groupby.NoDictionaryMultiColumnGr
 import org.apache.pinot.core.query.aggregation.groupby.NoDictionarySingleColumnGroupKeyGenerator;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -89,8 +90,14 @@ public class NoDictionaryGroupKeyGeneratorTest {
     // Create transform operator and block
     // NOTE: put all columns into group-by so that transform operator has expressions for all columns
     String query = String.format("SELECT COUNT(*) FROM table GROUP BY %s", StringUtils.join(COLUMN_NAMES, ", "));
+
+    // Compute the transform expressions
+    Set<TransformExpressionTree> expressionTrees = new LinkedHashSet<>();
+    for (String columnName : COLUMN_NAMES) {
+      expressionTrees.add(TransformExpressionTree.compileToExpressionTree(columnName));
+    }
     TransformPlanNode transformPlanNode =
-        new TransformPlanNode(indexSegment, new Pql2Compiler().compileToBrokerRequest(query));
+        new TransformPlanNode(indexSegment, new Pql2Compiler().compileToBrokerRequest(query), expressionTrees);
     _transformOperator = transformPlanNode.run();
     _transformBlock = _transformOperator.nextBlock();
   }


### PR DESCRIPTION
With aggregation functions now taking multiple agruments, only the functions themselves
have the knowledge on how to interpret these arguments. This poses a problem for the planning
phase on what columns need to be projected and what expressions need to be computed.
With this change, AggregationFunction's are now responsible for providing what inputs they need.

1. Added a new api in AggregationFunction interface `getInputExpressions()`, that returns a list
   of compiled TransformExpressionTrees that the aggregation function needs as input to compute.

2. Cleaned up the chaining data dependency during planning phase. Before this PR, all planning nodes
   receive the BrokerRequest (and pass to their child plan node) to extract out all information needed.
   With this change:
   - Aggregation plan nodes only specify the expression trees they need from Transform plan nodes, and
     Transform plan nodes use that to specify what columns they need from projection plan nodes.

TODO: Ideally we should completely eliminate passing of BrokerRequest throughout the chain plan nodes,
and only pass minimal information instead. This change only does so for projection columns. A TODO here
is to extend it to FilterPlanNode and deeper.