### PR TITLE
Fix new broker to old server backward compatibility issue.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.QuerySource;
 import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.SelectionSort;
+import org.apache.pinot.parsers.CompilerConstants;
 import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 import org.apache.pinot.pql.parsers.pql2.ast.OrderByAstNode;
 
@@ -259,6 +260,12 @@ public class PinotQuery2BrokerRequestConverter {
     aggregationInfo.setAggregationType(functionName);
     aggregationInfo.setExpressions(args);
     aggregationInfo.setIsInSelectList(true);
+
+    // For backward compatibility (new broker - old server), also set the old way.
+    // TODO: remove with a major version change.
+    aggregationInfo.putToAggregationParams(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO,
+        String.join(CompilerConstants.AGGREGATION_FUNCTION_ARG_SEPARATOR, args));
+
     return aggregationInfo;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FunctionCallAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FunctionCallAstNode.java
@@ -25,6 +25,7 @@ import java.util.TreeSet;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.parsers.CompilerConstants;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
 import org.apache.pinot.spi.utils.EqualityUtils;
 
@@ -119,6 +120,11 @@ public class FunctionCallAstNode extends BaseAstNode {
     aggregationInfo.setAggregationType(_name);
     aggregationInfo.setExpressions(functionArgs);
     aggregationInfo.setIsInSelectList(_isInSelectList);
+
+    // For backward compatibility (new broker - old server), also set the old way.
+    // TODO: remove with a major version change.
+    aggregationInfo.putToAggregationParams(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO,
+        String.join(CompilerConstants.AGGREGATION_FUNCTION_ARG_SEPARATOR, functionArgs));
 
     return aggregationInfo;
   }


### PR DESCRIPTION
With PR #5259 and #5275, the broker starts to send aggregation function arguments
in a new field in the thrift class. While new server prefers new field and falls back
to old field, in case of new broker and old server the server is unable to find
values in the field.

This PR fixes this issue by adding both old and new field in the broker. We will need to
change back broker to stop setting the old field with a future release.