### PR TITLE
Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,3 +22,7 @@ next release.
 If you have a series of commits adding or enabling a feature, then
 add this section only in final commit that marks the feature completed.
 Refer to earlier release notes to see examples of text
+
+## Documentation
+If you have introduced a new feature or configuration, please add it to the documentation as well.
+See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,20 +3,20 @@ Add a description of your PR here.
 A good description should include pointers to an issue or design document, etc.
 ## Upgrade Notes
 Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
-* [ ] Yes (Please label as **<code>backward-incompat</code>**)
+* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)
 
 Does this PR fix a zero-downtime upgrade introduced earlier?
-* [ ] Yes (Please label this as **<code>backward-incompat</code>**)
+* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)
 
 Does this PR otherwise need attention when creating release notes? Things to consider:
 - New configuration options
 - Deprecation of configurations
 - Signature changes to public methods/interfaces
 - New plugins added or old plugins removed
-* [ ] Yes (Please label this PR as **<code>release-notes</code>**)
+* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
 ## Release Notes
 If you have tagged this as either backward-incompat or release-notes,
-add text here that you would like to see appear in release notes of the
+you MUST add text here that you would like to see appear in release notes of the
 next release.
 
 If you have a series of commits adding or enabling a feature, then

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,10 @@ Does this PR otherwise need attention when creating release notes? Things to con
 - New plugins added or old plugins removed
 * [ ] Yes (Please label this PR as **<code>release-notes</code>**)
 ## Release Notes
-Add text here that you would like to see appear in release notes.
+If you have tagged this as either backward-incompat or release-notes,
+add text here that you would like to see appear in release notes of the
+next release.
+
 If you have a series of commits adding or enabling a feature, then
 add this section only in final commit that marks the feature completed.
 Refer to earlier release notes to see examples of text

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,10 @@ Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller
 
 Does this PR fix a zero-downtime upgrade introduced earlier?
 * [ ] Yes (Please label this as **<code>backward-incompat</code>**)
+
 Does this PR otherwise need attention when creating release notes? Things to consider:
 - New configuration options
 - Deprecation of configurations
 - Signature changes to public methods/interfaces
+- New plugins added or old plugins removed
 * [ ] Yes (Please label this PR as **<code>release-notes</code>**)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Upgrade Notes
+Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
+* [ ] Yes (Please label as **<code>backward-incompat</code>**)
+
+Does this PR fix a zero-downtime upgrade introduced earlier?
+* [ ] Yes (Please label this as **<code>backward-incompat</code>**)
+Does this PR otherwise need attention when creating release notes? Things to consider:
+- New configuration options
+- Deprecation of configurations
+- Signature changes to public methods/interfaces
+* [ ] Yes (Please label this PR as **<code>release-notes</code>**)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+## Description
+Add a description of your PR here.
+A good description should include pointers to an issue or design document, etc.
 ## Upgrade Notes
 Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
 * [ ] Yes (Please label as **<code>backward-incompat</code>**)
@@ -11,3 +14,8 @@ Does this PR otherwise need attention when creating release notes? Things to con
 - Signature changes to public methods/interfaces
 - New plugins added or old plugins removed
 * [ ] Yes (Please label this PR as **<code>release-notes</code>**)
+## Release Notes
+Add text here that you would like to see appear in release notes.
+If you have a series of commits adding or enabling a feature, then
+add this section only in final commit that marks the feature completed.
+Refer to earlier release notes to see examples of text

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ yarn.lock
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.github/PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
Added a pull request template so that PRs can be labelled appropriately

While creating release notes, it is hard to find which PRs need special mention because of new features, backward incompatibility, upgrade order, new configurations, etc. This PR creates a template that we can use for this purpose.