### PR TITLE
Remove some unused TimeFieldSpec related methods from Schema

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/rollup/MergeRollupSegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/rollup/MergeRollupSegmentConverter.java
@@ -106,10 +106,16 @@ public class MergeRollupSegmentConverter {
       throws Exception {
     // Compute group by columns for roll-up preparation (all dimensions + date time columns + time column)
     List<String> groupByColumns = new ArrayList<>();
-    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-      if (!fieldSpec.isVirtualColumn() && !fieldSpec.getFieldType().equals(FieldSpec.FieldType.METRIC)) {
-        groupByColumns.add(fieldSpec.getName());
-      }
+    for (DimensionFieldSpec dimensionFieldSpec : schema.getDimensionFieldSpecs()) {
+      groupByColumns.add(dimensionFieldSpec.getName());
+    }
+    for (DateTimeFieldSpec dateTimeFieldSpec : schema.getDateTimeFieldSpecs()) {
+      groupByColumns.add(dateTimeFieldSpec.getName());
+    }
+    // TODO: once time column starts showing up as dateTimeFieldSpec (https://github.com/apache/incubator-pinot/issues/2756) below lines becomes redundant
+    String timeColumnName = _tableConfig.getValidationConfig().getTimeColumnName();
+    if (timeColumnName != null && !groupByColumns.contains(timeColumnName)) {
+      groupByColumns.add(timeColumnName);
     }
 
     // Initialize roll-up record transformer

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/rollup/MergeRollupSegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/rollup/MergeRollupSegmentConverter.java
@@ -33,6 +33,7 @@ import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -105,15 +106,10 @@ public class MergeRollupSegmentConverter {
       throws Exception {
     // Compute group by columns for roll-up preparation (all dimensions + date time columns + time column)
     List<String> groupByColumns = new ArrayList<>();
-    for (DimensionFieldSpec dimensionFieldSpec : schema.getDimensionFieldSpecs()) {
-      groupByColumns.add(dimensionFieldSpec.getName());
-    }
-    for (DateTimeFieldSpec dateTimeFieldSpec : schema.getDateTimeFieldSpecs()) {
-      groupByColumns.add(dateTimeFieldSpec.getName());
-    }
-    String timeColumn = schema.getTimeColumnName();
-    if (timeColumn != null) {
-      groupByColumns.add(timeColumn);
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isVirtualColumn() && !fieldSpec.getFieldType().equals(FieldSpec.FieldType.METRIC)) {
+        groupByColumns.add(fieldSpec.getName());
+      }
     }
 
     // Initialize roll-up record transformer

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -60,9 +60,13 @@ public class ColumnMinMaxValueGenerator {
     Schema schema = _segmentMetadata.getSchema();
     Set<String> columnsToAddMinMaxValue = new HashSet<>(schema.getPhysicalColumnNames());
 
+    // mode ALL - use all columns
+    // mode NON_METRIC - use all dimensions and time columns 
+    // mode TIME - use only time columns
     switch (_columnMinMaxValueGeneratorMode) {
       case TIME:
         columnsToAddMinMaxValue.removeAll(schema.getDimensionNames());
+        // Intentionally falling through to next case
       case NON_METRIC:
         columnsToAddMinMaxValue.removeAll(schema.getMetricNames());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.core.segment.index.loader.columnminmaxvalue;
 
 import com.clearspring.analytics.util.Preconditions;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator;
 import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
@@ -56,32 +58,16 @@ public class ColumnMinMaxValueGenerator {
     Preconditions.checkState(_columnMinMaxValueGeneratorMode != ColumnMinMaxValueGeneratorMode.NONE);
 
     Schema schema = _segmentMetadata.getSchema();
+    Set<String> columnsToAddMinMaxValue = new HashSet<>(schema.getPhysicalColumnNames());
 
-    // Process time column
-    String timeColumnName = schema.getTimeColumnName();
-    if (timeColumnName != null) {
-      addColumnMinMaxValueForColumn(timeColumnName);
+    switch (_columnMinMaxValueGeneratorMode) {
+      case TIME:
+        columnsToAddMinMaxValue.removeAll(schema.getDimensionNames());
+      case NON_METRIC:
+        columnsToAddMinMaxValue.removeAll(schema.getMetricNames());
     }
-    for (String dateTimeColumn : schema.getDateTimeNames()) {
-      addColumnMinMaxValueForColumn(dateTimeColumn);
-    }
-    if (_columnMinMaxValueGeneratorMode == ColumnMinMaxValueGeneratorMode.TIME) {
-      saveMetadata();
-      return;
-    }
-
-    // Process dimension columns
-    for (String dimensionColumnName : schema.getDimensionNames()) {
-      addColumnMinMaxValueForColumn(dimensionColumnName);
-    }
-    if (_columnMinMaxValueGeneratorMode == ColumnMinMaxValueGeneratorMode.NON_METRIC) {
-      saveMetadata();
-      return;
-    }
-
-    // Process metric columns
-    for (String metricColumnName : schema.getMetricNames()) {
-      addColumnMinMaxValueForColumn(metricColumnName);
+    for (String column : columnsToAddMinMaxValue) {
+      addColumnMinMaxValueForColumn(column);
     }
     saveMetadata();
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -313,21 +313,6 @@ public final class Schema {
     return _dateTimeNames;
   }
 
-  @JsonIgnore
-  public String getTimeColumnName() {
-    return (_timeFieldSpec != null) ? _timeFieldSpec.getName() : null;
-  }
-
-  @JsonIgnore
-  public TimeUnit getIncomingTimeUnit() {
-    return (_timeFieldSpec != null) ? _timeFieldSpec.getIncomingGranularitySpec().getTimeType() : null;
-  }
-
-  @JsonIgnore
-  public TimeUnit getOutgoingTimeUnit() {
-    return (_timeFieldSpec != null) ? _timeFieldSpec.getOutgoingGranularitySpec().getTimeType() : null;
-  }
-
   /**
    * Returns a json representation of the schema.
    */
@@ -673,7 +658,7 @@ public final class Schema {
               .equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString()),
           "Conversion from incoming to outgoing is not supported for SIMPLE_DATE_FORMAT");
       String transformFunction =
-          getTransformFunction(incomingName, incomingTimeSize, incomingTimeUnit, outgoingTimeSize, outgoingTimeUnit);
+          constructTransformFunctionString(incomingName, incomingTimeSize, incomingTimeUnit, outgoingTimeSize, outgoingTimeUnit);
       dateTimeFieldSpec.setTransformFunction(transformFunction);
     }
 
@@ -683,7 +668,10 @@ public final class Schema {
     return dateTimeFieldSpec;
   }
 
-  private static String getTransformFunction(String incomingName, int incomingTimeSize, TimeUnit incomingTimeUnit,
+  /**
+   * Constructs a transformFunction string for the time column, based on incoming and outgoing timeGranularitySpec
+   */
+  private static String constructTransformFunctionString(String incomingName, int incomingTimeSize, TimeUnit incomingTimeUnit,
       int outgoingTimeSize, TimeUnit outgoingTimeUnit) {
 
     String innerFunction = incomingName;


### PR DESCRIPTION
Another step towards: https://github.com/apache/incubator-pinot/issues/2756

As I was making changes to Schema to treat TIME as DATE_TIME, found a subset of changes that can go prior to the bigger change.
Removing 3 methods from the Schema which are related to TimeFieldSpec
1. getIncomingTimeUnit - was unused
2. getOutgoingTimeUnit - was unused
3. getTimeColumnName - was able to remove the 4 usages