### PR TITLE
Remove some timeFieldSpec constructors

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
@@ -128,8 +128,6 @@ public class FieldSpecTest {
 
   /**
    * Test {@link TimeFieldSpec} constructors.
-   *
-   * NOTE:
    */
   @Test
   public void testTimeFieldSpecConstructor() {

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
@@ -128,76 +128,34 @@ public class FieldSpecTest {
 
   /**
    * Test {@link TimeFieldSpec} constructors.
+   *
+   * NOTE:
    */
   @Test
   public void testTimeFieldSpecConstructor() {
     String incomingName = "incoming";
-    FieldSpec.DataType incomingDataType = LONG;
     TimeUnit incomingTimeUnit = TimeUnit.HOURS;
     int incomingTimeUnitSize = 1;
     TimeGranularitySpec incomingTimeGranularitySpec =
-        new TimeGranularitySpec(incomingDataType, incomingTimeUnitSize, incomingTimeUnit, incomingName);
+        new TimeGranularitySpec(LONG, incomingTimeUnitSize, incomingTimeUnit, incomingName);
     String outgoingName = "outgoing";
-    FieldSpec.DataType outgoingDataType = INT;
     TimeUnit outgoingTimeUnit = TimeUnit.DAYS;
     int outgoingTimeUnitSize = 1;
     TimeGranularitySpec outgoingTimeGranularitySpec =
-        new TimeGranularitySpec(outgoingDataType, outgoingTimeUnitSize, outgoingTimeUnit, outgoingName);
+        new TimeGranularitySpec(INT, outgoingTimeUnitSize, outgoingTimeUnit, outgoingName);
     int defaultNullValue = 17050;
-
-    TimeFieldSpec timeFieldSpec1 = new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit);
-    TimeFieldSpec timeFieldSpec2 =
-        new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit, defaultNullValue);
-    TimeFieldSpec timeFieldSpec3 =
-        new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit, outgoingName, outgoingDataType,
-            outgoingTimeUnit);
-    TimeFieldSpec timeFieldSpec4 =
-        new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit, outgoingName, outgoingDataType,
-            outgoingTimeUnit, defaultNullValue);
-    TimeFieldSpec timeFieldSpec5 =
-        new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit);
-    TimeFieldSpec timeFieldSpec6 =
-        new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit, defaultNullValue);
-    TimeFieldSpec timeFieldSpec7 =
-        new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit, outgoingName,
-            outgoingDataType, outgoingTimeUnitSize, outgoingTimeUnit);
-    TimeFieldSpec timeFieldSpec8 =
-        new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit, outgoingName,
-            outgoingDataType, outgoingTimeUnitSize, outgoingTimeUnit, defaultNullValue);
     TimeFieldSpec timeFieldSpec9 = new TimeFieldSpec(incomingTimeGranularitySpec);
     TimeFieldSpec timeFieldSpec10 = new TimeFieldSpec(incomingTimeGranularitySpec, defaultNullValue);
     TimeFieldSpec timeFieldSpec11 = new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec);
     TimeFieldSpec timeFieldSpec12 =
         new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec, defaultNullValue);
 
-    Assert.assertEquals(timeFieldSpec1, timeFieldSpec5);
-    Assert.assertEquals(timeFieldSpec1, timeFieldSpec9);
-    Assert.assertEquals(timeFieldSpec2, timeFieldSpec6);
-    Assert.assertEquals(timeFieldSpec2, timeFieldSpec10);
-    Assert.assertEquals(timeFieldSpec3, timeFieldSpec7);
-    Assert.assertEquals(timeFieldSpec3, timeFieldSpec11);
-    Assert.assertEquals(timeFieldSpec4, timeFieldSpec8);
-    Assert.assertEquals(timeFieldSpec4, timeFieldSpec12);
-
-    // Before adding default null value.
-    Assert.assertFalse(timeFieldSpec1.equals(timeFieldSpec2));
-    Assert.assertFalse(timeFieldSpec3.equals(timeFieldSpec4));
-    Assert.assertFalse(timeFieldSpec5.equals(timeFieldSpec6));
-    Assert.assertFalse(timeFieldSpec7.equals(timeFieldSpec8));
-    Assert.assertFalse(timeFieldSpec9.equals(timeFieldSpec10));
-    Assert.assertFalse(timeFieldSpec11.equals(timeFieldSpec12));
+    Assert.assertNotEquals(timeFieldSpec10, timeFieldSpec9);
+    Assert.assertNotEquals(timeFieldSpec12, timeFieldSpec11);
 
     // After adding default null value.
-    timeFieldSpec1.setDefaultNullValue(defaultNullValue);
-    timeFieldSpec3.setDefaultNullValue(defaultNullValue);
-    timeFieldSpec5.setDefaultNullValue(defaultNullValue);
-    timeFieldSpec7.setDefaultNullValue(defaultNullValue);
     timeFieldSpec9.setDefaultNullValue(defaultNullValue);
     timeFieldSpec11.setDefaultNullValue(defaultNullValue);
-    Assert.assertEquals(timeFieldSpec1, timeFieldSpec2);
-    Assert.assertEquals(timeFieldSpec3, timeFieldSpec4);
-    Assert.assertEquals(timeFieldSpec5, timeFieldSpec6);
-    Assert.assertEquals(timeFieldSpec7, timeFieldSpec8);
     Assert.assertEquals(timeFieldSpec9, timeFieldSpec10);
     Assert.assertEquals(timeFieldSpec11, timeFieldSpec12);
   }
@@ -301,7 +259,8 @@ public class FieldSpecTest {
         {"\"incomingGranularitySpec\":{\"timeType\":\"MILLISECONDS\",\"dataType\":\"LONG\",\"name\":\"incomingTime\"}", "\"outgoingGranularitySpec\":{\"timeType\":\"SECONDS\",\"dataType\":\"INT\",\"name\":\"outgoingTime\"}", "\"defaultNullValue\":-1"};
     TimeFieldSpec timeFieldSpec1 = JsonUtils.stringToObject(getRandomOrderJsonString(timeFields), TimeFieldSpec.class);
     TimeFieldSpec timeFieldSpec2 =
-        new TimeFieldSpec("incomingTime", LONG, TimeUnit.MILLISECONDS, "outgoingTime", INT, TimeUnit.SECONDS, -1);
+        new TimeFieldSpec(new TimeGranularitySpec(LONG, TimeUnit.MILLISECONDS, "incomingTime"),
+            new TimeGranularitySpec(INT, TimeUnit.SECONDS, "outgoingTime"), -1);
     Assert.assertEquals(timeFieldSpec1, timeFieldSpec2, ERROR_MESSAGE);
     Assert.assertEquals(timeFieldSpec1.getDefaultNullValue(), -1, ERROR_MESSAGE);
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
@@ -243,16 +243,6 @@ public class FieldSpecTest {
     Assert.assertEquals(dimensionFieldSpec1, dimensionFieldSpec2, ERROR_MESSAGE);
     Assert.assertEquals(dimensionFieldSpec1.getDefaultNullValue(), "default", ERROR_MESSAGE);
 
-    // Time field with default null value.
-    String[] timeFields =
-        {"\"incomingGranularitySpec\":{\"timeType\":\"MILLISECONDS\",\"dataType\":\"LONG\",\"name\":\"incomingTime\"}", "\"outgoingGranularitySpec\":{\"timeType\":\"SECONDS\",\"dataType\":\"INT\",\"name\":\"outgoingTime\"}", "\"defaultNullValue\":-1"};
-    TimeFieldSpec timeFieldSpec1 = JsonUtils.stringToObject(getRandomOrderJsonString(timeFields), TimeFieldSpec.class);
-    TimeFieldSpec timeFieldSpec2 =
-        new TimeFieldSpec(new TimeGranularitySpec(LONG, TimeUnit.MILLISECONDS, "incomingTime"),
-            new TimeGranularitySpec(INT, TimeUnit.SECONDS, "outgoingTime"), -1);
-    Assert.assertEquals(timeFieldSpec1, timeFieldSpec2, ERROR_MESSAGE);
-    Assert.assertEquals(timeFieldSpec1.getDefaultNullValue(), -1, ERROR_MESSAGE);
-
     // Date time field with default null value.
     String[] dateTimeFields =
         {"\"name\":\"Date\"", "\"dataType\":\"LONG\"", "\"format\":\"1:MILLISECONDS:EPOCH\"", "\"granularity\":\"5:MINUTES\"", "\"dateTimeType\":\"PRIMARY\""};

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
@@ -141,21 +141,12 @@ public class FieldSpecTest {
     int outgoingTimeUnitSize = 1;
     TimeGranularitySpec outgoingTimeGranularitySpec =
         new TimeGranularitySpec(INT, outgoingTimeUnitSize, outgoingTimeUnit, outgoingName);
-    int defaultNullValue = 17050;
-    TimeFieldSpec timeFieldSpec9 = new TimeFieldSpec(incomingTimeGranularitySpec);
-    TimeFieldSpec timeFieldSpec10 = new TimeFieldSpec(incomingTimeGranularitySpec, defaultNullValue);
-    TimeFieldSpec timeFieldSpec11 = new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec);
-    TimeFieldSpec timeFieldSpec12 =
-        new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec, defaultNullValue);
+    TimeFieldSpec timeFieldSpec1 = new TimeFieldSpec(incomingTimeGranularitySpec);
+    TimeFieldSpec timeFieldSpec2 = new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec);
+    Assert.assertNotEquals(timeFieldSpec1, timeFieldSpec2);
 
-    Assert.assertNotEquals(timeFieldSpec10, timeFieldSpec9);
-    Assert.assertNotEquals(timeFieldSpec12, timeFieldSpec11);
-
-    // After adding default null value.
-    timeFieldSpec9.setDefaultNullValue(defaultNullValue);
-    timeFieldSpec11.setDefaultNullValue(defaultNullValue);
-    Assert.assertEquals(timeFieldSpec9, timeFieldSpec10);
-    Assert.assertEquals(timeFieldSpec11, timeFieldSpec12);
+    timeFieldSpec1.setOutgoingGranularitySpec(outgoingTimeGranularitySpec);
+    Assert.assertEquals(timeFieldSpec1, timeFieldSpec2);
   }
 
   /**

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -160,20 +160,18 @@ public class SchemaTest {
     int outgoingTimeUnitSize = 1;
     TimeGranularitySpec outgoingTimeGranularitySpec =
         new TimeGranularitySpec(outgoingDataType, outgoingTimeUnitSize, outgoingTimeUnit, outgoingName);
-    int defaultNullValue = 17050;
 
     Schema schema11 = new Schema.SchemaBuilder().setSchemaName("testSchema")
-        .addTime(incomingTimeGranularitySpec, outgoingTimeGranularitySpec).build();
+        .addTime(incomingTimeGranularitySpec, null).build();
     Schema schema12 = new Schema.SchemaBuilder().setSchemaName("testSchema").build();
-    schema12.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec, defaultNullValue));
+    schema12.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec));
     Assert.assertNotNull(schema11.getTimeFieldSpec());
     Assert.assertNotNull(schema12.getTimeFieldSpec());
 
-    // Before adding default null value.
     Assert.assertNotEquals(schema12, schema11);
 
-    // After adding default null value.
-    schema11.getTimeFieldSpec().setDefaultNullValue(defaultNullValue);
+    schema11 = new Schema.SchemaBuilder().setSchemaName("testSchema")
+        .addTime(incomingTimeGranularitySpec, outgoingTimeGranularitySpec).build();
     Assert.assertEquals(schema11, schema12);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/ColumnMetadata.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/ColumnMetadata.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.TimeFieldSpec;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -392,7 +393,7 @@ public class ColumnMetadata {
         this.fieldSpec = new MetricFieldSpec(columnName, dataType);
         break;
       case TIME:
-        this.fieldSpec = new TimeFieldSpec(columnName, dataType, timeUnit);
+        this.fieldSpec = new TimeFieldSpec(new TimeGranularitySpec(dataType, timeUnit, columnName));
         break;
       case DATE_TIME:
         this.fieldSpec = new DateTimeFieldSpec(columnName, dataType, dateTimeFormat, dateTimeGranularity);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/MultiplePinotSegmentRecordReaderTest.java
@@ -79,15 +79,15 @@ public class MultiplePinotSegmentRecordReaderTest {
   }
 
   private Schema createPinotSchema() {
-    Schema testSchema = new Schema();
-    testSchema.setSchemaName("schema");
-    testSchema.addField(new DimensionFieldSpec(D_SV_1, FieldSpec.DataType.STRING, true));
-    testSchema.addField(new DimensionFieldSpec(D_SV_2, FieldSpec.DataType.INT, true));
-    testSchema.addField(new DimensionFieldSpec(D_MV_1, FieldSpec.DataType.STRING, false));
-    testSchema.addField(new MetricFieldSpec(M1, FieldSpec.DataType.INT));
-    testSchema.addField(new MetricFieldSpec(M2, FieldSpec.DataType.FLOAT));
-    testSchema.addField(new TimeFieldSpec(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.HOURS, TIME)));
-    return testSchema;
+    return new Schema.SchemaBuilder()
+        .setSchemaName("schema")
+        .addSingleValueDimension(D_SV_1, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(D_SV_2, FieldSpec.DataType.INT)
+        .addMultiValueDimension(D_MV_1, FieldSpec.DataType.STRING)
+        .addMetric(M1, FieldSpec.DataType.INT)
+        .addMetric(M2, FieldSpec.DataType.FLOAT)
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.HOURS, TIME), null)
+        .build();
   }
 
   private TableConfig createTableConfig() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
@@ -74,14 +74,14 @@ public class PinotSegmentRecordReaderTest {
   }
 
   private Schema createPinotSchema() {
-    Schema testSchema = new Schema();
-    testSchema.setSchemaName("schema");
-    testSchema.addField(new DimensionFieldSpec(D_SV_1, DataType.STRING, true));
-    testSchema.addField(new DimensionFieldSpec(D_MV_1, FieldSpec.DataType.STRING, false));
-    testSchema.addField(new MetricFieldSpec(M1, FieldSpec.DataType.INT));
-    testSchema.addField(new MetricFieldSpec(M2, FieldSpec.DataType.FLOAT));
-    testSchema.addField(new TimeFieldSpec(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.HOURS, TIME)));
-    return testSchema;
+    return new Schema.SchemaBuilder()
+        .setSchemaName("schema")
+        .addSingleValueDimension(D_SV_1, DataType.STRING)
+        .addSingleValueDimension(D_MV_1, DataType.STRING)
+        .addMetric(M1, DataType.INT)
+        .addMetric(M2, DataType.FLOAT)
+        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.HOURS, TIME), null)
+        .build();
   }
 
   private TableConfig createTableConfig() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReaderTest.java
@@ -77,7 +77,7 @@ public class PinotSegmentRecordReaderTest {
     return new Schema.SchemaBuilder()
         .setSchemaName("schema")
         .addSingleValueDimension(D_SV_1, DataType.STRING)
-        .addSingleValueDimension(D_MV_1, DataType.STRING)
+        .addMultiValueDimension(D_MV_1, DataType.STRING)
         .addMetric(M1, DataType.INT)
         .addMetric(M2, DataType.FLOAT)
         .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.HOURS, TIME), null)

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
@@ -145,10 +145,9 @@ public class ExpressionTransformerTest {
     expressionTransformer.transform(genericRow);
     Assert.assertEquals(genericRow.getValue("fullName"), "John N Denver");
 
-    pinotSchema = new Schema();
-    TimeFieldSpec timeFieldSpec = new TimeFieldSpec(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "incoming"), new TimeGranularitySpec(
-        FieldSpec.DataType.INT, TimeUnit.DAYS, "outgoing"));
-    pinotSchema.addField(timeFieldSpec);
+    pinotSchema = new Schema.SchemaBuilder()
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
+            new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "outgoing")).build();
     expressionTransformer = new ExpressionTransformer(pinotSchema);
 
     genericRow = new GenericRow();

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/MergeRollupSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/MergeRollupSegmentConverterTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
@@ -72,12 +73,11 @@ public class MergeRollupSegmentConverterTest {
     FileUtils.deleteDirectory(WORKING_DIR);
     _segmentIndexDirList = new ArrayList<>(NUM_SEGMENTS);
 
-    Schema schema = new Schema();
-    schema.addField(new DimensionFieldSpec(D1, FieldSpec.DataType.INT, true));
-    schema.addField(new DimensionFieldSpec(D2, FieldSpec.DataType.STRING, true));
-    schema.addField(new MetricFieldSpec(M1, FieldSpec.DataType.LONG));
-    schema.addField(new MetricFieldSpec(M2, FieldSpec.DataType.DOUBLE));
-    schema.addField(new TimeFieldSpec(T, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(D1, FieldSpec.DataType.INT)
+        .addSingleValueDimension(D2, FieldSpec.DataType.STRING).addMetric(M1, FieldSpec.DataType.LONG)
+        .addMetric(M2, FieldSpec.DataType.DOUBLE)
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, T), null).build();
+
     _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(T).build();
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
@@ -70,11 +71,9 @@ public class SegmentConverterTest {
     FileUtils.deleteDirectory(WORKING_DIR);
     _segmentIndexDirList = new ArrayList<>(NUM_SEGMENTS);
 
-    Schema schema = new Schema();
-    schema.addField(new DimensionFieldSpec(D1, FieldSpec.DataType.INT, true));
-    schema.addField(new DimensionFieldSpec(D2, FieldSpec.DataType.STRING, true));
-    schema.addField(new MetricFieldSpec(M1, FieldSpec.DataType.INT));
-    schema.addField(new TimeFieldSpec(T, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(D1, FieldSpec.DataType.INT)
+        .addSingleValueDimension(D1, FieldSpec.DataType.INT).addMetric(M1, FieldSpec.DataType.INT)
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, T), null).build();
     _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(T).build();
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentConverterTest.java
@@ -72,7 +72,7 @@ public class SegmentConverterTest {
     _segmentIndexDirList = new ArrayList<>(NUM_SEGMENTS);
 
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(D1, FieldSpec.DataType.INT)
-        .addSingleValueDimension(D1, FieldSpec.DataType.INT).addMetric(M1, FieldSpec.DataType.INT)
+        .addSingleValueDimension(D2, FieldSpec.DataType.STRING).addMetric(M1, FieldSpec.DataType.INT)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, T), null).build();
     _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(T).build();
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.indexsegment.IndexSegment;
@@ -118,14 +119,15 @@ public abstract class BaseTransformFunctionTest {
       rows.add(row);
     }
 
-    Schema schema = new Schema();
-    schema.addField(new DimensionFieldSpec(INT_SV_COLUMN, FieldSpec.DataType.INT, true));
-    schema.addField(new DimensionFieldSpec(LONG_SV_COLUMN, FieldSpec.DataType.LONG, true));
-    schema.addField(new DimensionFieldSpec(FLOAT_SV_COLUMN, FieldSpec.DataType.FLOAT, true));
-    schema.addField(new DimensionFieldSpec(DOUBLE_SV_COLUMN, FieldSpec.DataType.DOUBLE, true));
-    schema.addField(new DimensionFieldSpec(STRING_SV_COLUMN, FieldSpec.DataType.STRING, true));
-    schema.addField(new DimensionFieldSpec(INT_MV_COLUMN, FieldSpec.DataType.INT, false));
-    schema.addField(new TimeFieldSpec(TIME_COLUMN, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension(INT_SV_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(LONG_SV_COLUMN, FieldSpec.DataType.LONG)
+        .addSingleValueDimension(FLOAT_SV_COLUMN, FieldSpec.DataType.FLOAT)
+        .addSingleValueDimension(DOUBLE_SV_COLUMN, FieldSpec.DataType.DOUBLE)
+        .addSingleValueDimension(STRING_SV_COLUMN, FieldSpec.DataType.STRING)
+        .addMultiValueDimension(INT_MV_COLUMN, FieldSpec.DataType.INT)
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, TIME_COLUMN), null)
+        .build();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME_COLUMN).build();
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.indexsegment.IndexSegment;
@@ -83,8 +84,8 @@ public class DateTruncTransformFunctionTest
     GenericRow row = new GenericRow();
     row.init(ImmutableMap.of(TIME_COLUMN, zmillisInput));
     List<GenericRow> rows = ImmutableList.of(row);
-    Schema schema = new Schema();
-    schema.addField(new TimeFieldSpec(TIME_COLUMN, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
+    Schema schema = new Schema.SchemaBuilder()
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, TIME_COLUMN), null).build();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME_COLUMN).build();
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -116,7 +116,7 @@ public class SegmentGenerationWithTimeColumnTest {
         new Schema.SchemaBuilder().addSingleValueDimension(STRING_COL_NAME, FieldSpec.DataType.STRING);
     if (isSimpleDate) {
       builder.addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS,
-          TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT.toString(), TIME_COL_NAME), null);
+          TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT.toString() + ":" + TIME_COL_FORMAT, TIME_COL_NAME), null);
     } else {
       builder.addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, TIME_COL_NAME), null);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -37,13 +38,9 @@ public class RealtimeSegmentConverterTest {
 
   @Test
   public void testNoVirtualColumnsInSchema() {
-    Schema schema = new Schema();
-    FieldSpec spec = new DimensionFieldSpec("col1", FieldSpec.DataType.STRING, true);
-    schema.addField(spec);
-    TimeFieldSpec tfs =
-        new TimeFieldSpec("col1", FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "col2", FieldSpec.DataType.LONG,
-            TimeUnit.DAYS);
-    schema.addField(tfs);
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("col1", FieldSpec.DataType.STRING)
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "col1"),
+            new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "col2")).build();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName("test").setTimeColumnName("col2").build();
     String segmentName = "segment1";

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/SegmentTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/SegmentTestUtils.java
@@ -91,7 +91,6 @@ public class SegmentTestUtils {
     segmentGeneratorConfig.setFormat(FileFormat.AVRO);
     segmentGeneratorConfig.setSegmentVersion(SegmentVersion.v1);
     segmentGeneratorConfig.setTableName(tableName);
-    segmentGeneratorConfig.setTime(null, schema);
     return segmentGeneratorConfig;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
@@ -41,6 +41,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +85,7 @@ public class AvroUtils {
           case TIME:
             Preconditions.checkState(isSingleValueField, "Time field: %s cannot be multi-valued", fieldName);
             Preconditions.checkNotNull(timeUnit, "Time unit cannot be null");
-            pinotSchema.addField(new TimeFieldSpec(field.name(), dataType, timeUnit));
+            pinotSchema.addField(new TimeFieldSpec(new TimeGranularitySpec(dataType, timeUnit, field.name())));
             break;
           default:
             throw new UnsupportedOperationException(

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -715,4 +715,11 @@ public final class Schema {
     }
     return outerFunction;
   }
+
+  public static void main(String[] args)
+      throws IOException {
+    Schema schema =
+        Schema.fromFile(new File("/Users/npawar/quick_start_configs/pinot-quick-start/transcript-schema.json"));
+    System.out.println(schema);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -715,11 +715,4 @@ public final class Schema {
     }
     return outerFunction;
   }
-
-  public static void main(String[] args)
-      throws IOException {
-    Schema schema =
-        Schema.fromFile(new File("/Users/npawar/quick_start_configs/pinot-quick-start/transcript-schema.json"));
-    System.out.println(schema);
-  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeFieldSpec.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.utils.EqualityUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 
@@ -43,20 +42,8 @@ public final class TimeFieldSpec extends FieldSpec {
     _incomingGranularitySpec = incomingGranularitySpec;
   }
 
-  public TimeFieldSpec(TimeGranularitySpec incomingGranularitySpec, Object defaultNullValue) {
-    super(incomingGranularitySpec.getName(), incomingGranularitySpec.getDataType(), true, defaultNullValue);
-    _incomingGranularitySpec = incomingGranularitySpec;
-  }
-
   public TimeFieldSpec(TimeGranularitySpec incomingGranularitySpec, TimeGranularitySpec outgoingGranularitySpec) {
     super(outgoingGranularitySpec.getName(), outgoingGranularitySpec.getDataType(), true);
-    _incomingGranularitySpec = incomingGranularitySpec;
-    _outgoingGranularitySpec = outgoingGranularitySpec;
-  }
-
-  public TimeFieldSpec(TimeGranularitySpec incomingGranularitySpec, TimeGranularitySpec outgoingGranularitySpec,
-      Object defaultNullValue) {
-    super(outgoingGranularitySpec.getName(), outgoingGranularitySpec.getDataType(), true, defaultNullValue);
     _incomingGranularitySpec = incomingGranularitySpec;
     _outgoingGranularitySpec = outgoingGranularitySpec;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeFieldSpec.java
@@ -38,65 +38,6 @@ public final class TimeFieldSpec extends FieldSpec {
     super();
   }
 
-  public TimeFieldSpec(String incomingName, DataType incomingDataType, TimeUnit incomingTimeUnit) {
-    super(incomingName, incomingDataType, true);
-    _incomingGranularitySpec = new TimeGranularitySpec(incomingDataType, incomingTimeUnit, incomingName);
-  }
-
-  public TimeFieldSpec(String incomingName, DataType incomingDataType, TimeUnit incomingTimeUnit,
-      Object defaultNullValue) {
-    super(incomingName, incomingDataType, true, defaultNullValue);
-    _incomingGranularitySpec = new TimeGranularitySpec(incomingDataType, incomingTimeUnit, incomingName);
-  }
-
-  public TimeFieldSpec(String incomingName, DataType incomingDataType, TimeUnit incomingTimeUnit, String outgoingName,
-      DataType outgoingDataType, TimeUnit outgoingTimeUnit) {
-    super(outgoingName, outgoingDataType, true);
-    _incomingGranularitySpec = new TimeGranularitySpec(incomingDataType, incomingTimeUnit, incomingName);
-    _outgoingGranularitySpec = new TimeGranularitySpec(outgoingDataType, outgoingTimeUnit, outgoingName);
-  }
-
-  public TimeFieldSpec(String incomingName, DataType incomingDataType, TimeUnit incomingTimeUnit, String outgoingName,
-      DataType outgoingDataType, TimeUnit outgoingTimeUnit, Object defaultNullValue) {
-    super(outgoingName, outgoingDataType, true, defaultNullValue);
-    _incomingGranularitySpec = new TimeGranularitySpec(incomingDataType, incomingTimeUnit, incomingName);
-    _outgoingGranularitySpec = new TimeGranularitySpec(outgoingDataType, outgoingTimeUnit, outgoingName);
-  }
-
-  public TimeFieldSpec(String incomingName, DataType incomingDataType, int incomingTimeUnitSize,
-      TimeUnit incomingTimeUnit) {
-    super(incomingName, incomingDataType, true);
-    _incomingGranularitySpec =
-        new TimeGranularitySpec(incomingDataType, incomingTimeUnitSize, incomingTimeUnit, incomingName);
-  }
-
-  public TimeFieldSpec(String incomingName, DataType incomingDataType, int incomingTimeUnitSize,
-      TimeUnit incomingTimeUnit, Object defaultNullValue) {
-    super(incomingName, incomingDataType, true, defaultNullValue);
-    _incomingGranularitySpec =
-        new TimeGranularitySpec(incomingDataType, incomingTimeUnitSize, incomingTimeUnit, incomingName);
-  }
-
-  public TimeFieldSpec(String incomingName, DataType incomingDataType, int incomingTimeUnitSize,
-      TimeUnit incomingTimeUnit, String outgoingName, DataType outgoingDataType, int outgoingTimeUnitSize,
-      TimeUnit outgoingTimeUnit) {
-    super(outgoingName, outgoingDataType, true);
-    _incomingGranularitySpec =
-        new TimeGranularitySpec(incomingDataType, incomingTimeUnitSize, incomingTimeUnit, incomingName);
-    _outgoingGranularitySpec =
-        new TimeGranularitySpec(outgoingDataType, outgoingTimeUnitSize, outgoingTimeUnit, outgoingName);
-  }
-
-  public TimeFieldSpec(String incomingName, DataType incomingDataType, int incomingTimeUnitSize,
-      TimeUnit incomingTimeUnit, String outgoingName, DataType outgoingDataType, int outgoingTimeUnitSize,
-      TimeUnit outgoingTimeUnit, Object defaultNullValue) {
-    super(outgoingName, outgoingDataType, true, defaultNullValue);
-    _incomingGranularitySpec =
-        new TimeGranularitySpec(incomingDataType, incomingTimeUnitSize, incomingTimeUnit, incomingName);
-    _outgoingGranularitySpec =
-        new TimeGranularitySpec(outgoingDataType, outgoingTimeUnitSize, outgoingTimeUnit, outgoingName);
-  }
-
   public TimeFieldSpec(TimeGranularitySpec incomingGranularitySpec) {
     super(incomingGranularitySpec.getName(), incomingGranularitySpec.getDataType(), true);
     _incomingGranularitySpec = incomingGranularitySpec;
@@ -142,23 +83,6 @@ public final class TimeFieldSpec extends FieldSpec {
   @Override
   public void setSingleValueField(boolean isSingleValueField) {
     Preconditions.checkArgument(isSingleValueField, "Unsupported multi-value for time field.");
-  }
-
-  @JsonIgnore
-  public String getIncomingTimeColumnName() {
-    return _incomingGranularitySpec.getName();
-  }
-
-  @JsonIgnore
-  public String getOutgoingTimeColumnName() {
-    return getName();
-  }
-
-  // For third-eye backward compatible.
-  @Deprecated
-  @JsonIgnore
-  public String getOutGoingTimeColumnName() {
-    return getName();
   }
 
   public TimeGranularitySpec getIncomingGranularitySpec() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
@@ -147,7 +147,7 @@ public class DataGenerator {
         break;
 
       case TIME:
-        spec = new TimeFieldSpec(column, dataType, genSpec.getTimeUnitMap().get(column));
+        spec = new TimeFieldSpec(new TimeGranularitySpec(dataType, genSpec.getTimeUnitMap().get(column), column));
         break;
 
       default:

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AirlineDataStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AirlineDataStream.java
@@ -125,7 +125,7 @@ public class AirlineDataStream {
             }
 
             TimeFieldSpec spec = pinotSchema.getTimeFieldSpec();
-            String timeColumn = spec.getIncomingTimeColumnName();
+            String timeColumn = spec.getName();
             message.put(timeColumn, currentTimeValue);
 
             try {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AirlineDataStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AirlineDataStream.java
@@ -125,7 +125,7 @@ public class AirlineDataStream {
             }
 
             TimeFieldSpec spec = pinotSchema.getTimeFieldSpec();
-            String timeColumn = spec.getName();
+            String timeColumn = spec.getIncomingGranularitySpec().getName();
             message.put(timeColumn, currentTimeValue);
 
             try {


### PR DESCRIPTION
As part of https://github.com/apache/incubator-pinot/issues/2756 we are going to move away from TimeFieldSpec and instead use DateTimeFieldSpec.

We have a lot of constructors for TimeFieldSpec. Most of those constructor calls will be replaced by equivalent DateTimeFieldSpec constructor calls. After the final change to DateTimeFieldSpec, other than tests, no one should be calling these constructors. We will keep some basic constructor around, for the backward compatibility tests.

In this PR, 
1) attempting to clean up 9 constructors, keeping only 4 basic ones. 
2) Wherever possible, using SchemaBuilder in tests.
This will make it one more step easier to switch over to the new stuff.
