### PR TITLE
Fix NoSuchMethodError on ServerConfiguration.addHttpHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1082,12 +1082,6 @@
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-standalone-client</artifactId>
         <version>1.5</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-http-server</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <!-- hadoop-common & jmh-core use common-math3 -->
       <dependency>


### PR DESCRIPTION
We encounter the following exception when running any command for `PerfBenchmarkRunner`:
```
Exception in thread "main" java.lang.NoSuchMethodError: org.glassfish.grizzly.http.server.ServerConfiguration.addHttpHandler(Lorg/glassfish/grizzly/http/server/HttpHandler;[Lorg/glassfish/grizzly/http/server/HttpHandlerRegistration;)V
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory.createHttpServer(GrizzlyHttpServerFactory.java:258)
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory.createHttpServer(GrizzlyHttpServerFactory.java:93)
	at org.apache.pinot.controller.api.ControllerAdminApiApplication.start(ControllerAdminApiApplication.java:85)
	at org.apache.pinot.controller.ControllerStarter.setUpPinotController(ControllerStarter.java:359)
	at org.apache.pinot.controller.ControllerStarter.start(ControllerStarter.java:231)
	at org.apache.pinot.tools.perf.PerfBenchmarkDriver.startController(PerfBenchmarkDriver.java:200)
	at org.apache.pinot.tools.perf.PerfBenchmarkDriver.run(PerfBenchmarkDriver.java:172)
	at org.apache.pinot.tools.perf.PerfBenchmarkRunner.startAllButServer(PerfBenchmarkRunner.java:110)
	at org.apache.pinot.tools.perf.PerfBenchmarkRunner.execute(PerfBenchmarkRunner.java:96)
	at org.apache.pinot.tools.PinotToolLauncher.execute(PinotToolLauncher.java:67)
	at org.apache.pinot.tools.PinotToolLauncher.main(PinotToolLauncher.java:79)
```
This PR removes the exclusion that caused the exception.

Tested by running `mvn clean install -DskipTests -Pbin-dist` and tests passed.