### PR TITLE
Introduced StreamPartitionMsgOffset class

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/DefaultSegmentCommitter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/DefaultSegmentCommitter.java
@@ -41,7 +41,7 @@ public class DefaultSegmentCommitter implements SegmentCommitter {
   }
 
   @Override
-  public SegmentCompletionProtocol.Response commit(long currentOffset, int numRows, LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor) {
+  public SegmentCompletionProtocol.Response commit(LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor) {
     final File segmentTarFile = new File(segmentBuildDescriptor.getSegmentTarFilePath());
 
     SegmentCompletionProtocol.Response response = _protocolHandler.segmentCommit(_params, segmentTarFile);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,10 +91,10 @@ public class SegmentBuildTimeLeaseExtender {
    * @param initialBuildTimeMs is the initial time budget that SegmentCompletionManager has allocated.
    * @param offset The offset at which this segment is being built.
    */
-  public void addSegment(String segmentId, long initialBuildTimeMs, long offset) {
+  public void addSegment(String segmentId, long initialBuildTimeMs, StreamPartitionMsgOffset offset) {
     final long initialDelayMs = initialBuildTimeMs * 9 / 10;
     final SegmentCompletionProtocol.Request.Params reqParams = new SegmentCompletionProtocol.Request.Params();
-    reqParams.withOffset(offset).withSegmentName(segmentId).withExtraTimeSec(EXTRA_TIME_SECONDS)
+    reqParams.withOffset(offset.getOffset()).withSegmentName(segmentId).withExtraTimeSec(EXTRA_TIME_SECONDS)
         .withInstanceId(_instanceId);
     Future future = _executor
         .scheduleWithFixedDelay(new LeaseExtender(reqParams), initialDelayMs, REPEAT_REQUEST_PERIOD_SEC * 1000L,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitter.java
@@ -27,10 +27,8 @@ import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 public interface SegmentCommitter {
   /**
    * Commits a realtime segment to persistent store
-   * @param currentOffset current offset in the stream
-   * @param numRows num rows consumed in the segment being committed
    * @param segmentBuildDescriptor object that describes segment to be committed
    * @return
    */
-  SegmentCompletionProtocol.Response commit(long currentOffset, int numRows, LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor);
+  SegmentCompletionProtocol.Response commit(LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SplitSegmentCommitter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SplitSegmentCommitter.java
@@ -45,7 +45,7 @@ public class SplitSegmentCommitter implements SegmentCommitter {
   }
 
   @Override
-  public SegmentCompletionProtocol.Response commit(long currentOffset, int numRowsConsumed, LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor) {
+  public SegmentCompletionProtocol.Response commit(LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor) {
     final File segmentTarFile = new File(segmentBuildDescriptor.getSegmentTarFilePath());
 
     SegmentCompletionProtocol.Response segmentCommitStartResponse = _protocolHandler.segmentCommitStart(_params);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DefaultCommitterRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DefaultCommitterRealtimeIntegrationTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -116,9 +117,10 @@ public class DefaultCommitterRealtimeIntegrationTest extends RealtimeClusterInte
     TarGzCompressionUtils.createTarGzOfDirectory(_realtimeSegmentUntarred.getAbsolutePath());
 
     // SegmentBuildDescriptor is currently not a static class, so we will mock this object.
+    StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(END_OFFSET);
     when(segmentBuildDescriptor.getSegmentTarFilePath()).thenReturn(_realtimeSegmentUntarred + TARGZ_SUFFIX);
     when(segmentBuildDescriptor.getBuildTimeMillis()).thenReturn(0L);
-    when(segmentBuildDescriptor.getOffset()).thenReturn(END_OFFSET);
+    when(segmentBuildDescriptor.getOffset()).thenReturn(endOffset);
     when(segmentBuildDescriptor.getSegmentSizeBytes()).thenReturn(0L);
     when(segmentBuildDescriptor.getWaitTimeMillis()).thenReturn(0L);
 
@@ -134,7 +136,7 @@ public class DefaultCommitterRealtimeIntegrationTest extends RealtimeClusterInte
 
     SegmentCommitterFactory segmentCommitterFactory = new SegmentCommitterFactory(LOGGER, protocolHandler);
     SegmentCommitter segmentCommitter = segmentCommitterFactory.createDefaultSegmentCommitter(params);
-    segmentCommitter.commit(END_OFFSET, 3, segmentBuildDescriptor);
+    segmentCommitter.commit(segmentBuildDescriptor);
   }
 
   public void buildSegment()

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffset.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffset.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.stream;
+
+import org.apache.pinot.spi.annotations.InterfaceStability;
+
+/**
+ * This is a class for now (so we can make one round of changes to the code)
+ * It will evolve to an interface later with different implementations for the
+ * streams. Each stream needs to provide its own serde of an offset.
+ *
+ * For now, we will take toString as a serializer.
+ * Must be thread-safe for multiple readers and one writer. Readers could get the offset
+ * and the writer can update it.
+ */
+@InterfaceStability.Evolving
+public class StreamPartitionMsgOffset implements Comparable {
+  private volatile long _offset;
+
+  /**
+   * This constructor will go away when this becomes an interface.
+   * @param offset
+   */
+  @Deprecated
+  public StreamPartitionMsgOffset(long offset) {
+    _offset = offset;
+  }
+
+  @Deprecated
+  public void setOffset(long offset) {
+    _offset = offset;
+  }
+
+  @Override
+  public int compareTo(Object other) {
+    return Long.compare(_offset, ((StreamPartitionMsgOffset)other)._offset);
+  }
+
+  @Override
+  public String toString() {
+    return Long.toString(_offset);
+  }
+
+  /**
+   * Once we fix the protocol to use serialzied offsets, this should go away.
+   * @return
+   */
+  @Deprecated
+  public long getOffset() {
+    return _offset;
+  }
+}


### PR DESCRIPTION
This change is mostly mechanical to use the new offset class (instead of a long offset)
on the server side. Segment completion protocol and segment zk metadata still hold the
offset in long format.

The StreamPartitionMsgOffset should eventually become an interface. For now, we just
hold a long value there.

Issue #5359 