### PR TITLE
TimeColumnName  and schema to all Integration test tables

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -246,7 +246,7 @@ public class ClusterIntegrationTestUtils {
    * @param executor Executor
    */
   public static void buildSegmentsFromAvro(List<File> avroFiles, int baseSegmentIndex, File segmentDir, File tarDir,
-      String tableName, @Nullable List<StarTreeV2BuilderConfig> starTreeV2BuilderConfigs,
+      String tableName, String timeColumnName, @Nullable List<StarTreeV2BuilderConfig> starTreeV2BuilderConfigs,
       @Nullable List<String> rawIndexColumns, @Nullable org.apache.pinot.spi.data.Schema pinotSchema,
       Executor executor) {
     int numSegments = avroFiles.size();
@@ -256,8 +256,8 @@ public class ClusterIntegrationTestUtils {
       executor.execute(() -> {
         try {
           File outputDir = new File(segmentDir, "segment-" + segmentIndex);
-          SegmentGeneratorConfig segmentGeneratorConfig =
-              SegmentTestUtils.getSegmentGeneratorConfig(avroFile, outputDir, TimeUnit.DAYS, tableName, pinotSchema);
+          SegmentGeneratorConfig segmentGeneratorConfig = SegmentTestUtils
+              .getSegmentGeneratorConfig(avroFile, outputDir, timeColumnName, TimeUnit.DAYS, tableName, pinotSchema);
 
           // Test segment with space and special character in the file name
           segmentGeneratorConfig.setSegmentNamePostfix(segmentIndex + " %");
@@ -300,8 +300,9 @@ public class ClusterIntegrationTestUtils {
    * @param executor Executor
    */
   public static void buildSegmentsFromAvro(List<File> avroFiles, int baseSegmentIndex, File segmentDir, File tarDir,
-      String tableName, Executor executor) {
-    buildSegmentsFromAvro(avroFiles, baseSegmentIndex, segmentDir, tarDir, tableName, null, null, null, executor);
+      String tableName, String timeColumnName, Executor executor) {
+    buildSegmentsFromAvro(avroFiles, baseSegmentIndex, segmentDir, tarDir, tableName, timeColumnName, null, null, null,
+        executor);
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -257,7 +257,7 @@ public class ClusterIntegrationTestUtils {
         try {
           File outputDir = new File(segmentDir, "segment-" + segmentIndex);
           SegmentGeneratorConfig segmentGeneratorConfig = SegmentTestUtils
-              .getSegmentGeneratorConfig(avroFile, outputDir, timeColumnName, TimeUnit.DAYS, tableName, pinotSchema);
+              .getSegmentGeneratorConfig(avroFile, outputDir, timeColumnName, tableName, pinotSchema);
 
           // Test segment with space and special character in the file name
           segmentGeneratorConfig.setSegmentNamePostfix(segmentIndex + " %");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTests.java
@@ -198,7 +198,8 @@ public class ControllerPeriodicTasksIntegrationTests extends BaseClusterIntegrat
 
     ExecutorService executor = Executors.newCachedThreadPool();
     ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName, null, null, null, executor);
+        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName, timeColumnName, null, null, null,
+            executor);
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);
     uploadSegments(getTableName(), _tarDir);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTests.java
@@ -169,7 +169,7 @@ public class ControllerPeriodicTasksIntegrationTests extends BaseClusterIntegrat
    */
   private void setupOfflineTable(String table)
       throws Exception {
-    addOfflineTable(table, null, null, TENANT_NAME, TENANT_NAME, null, SegmentVersion.v1, null, null, null, null, null);
+    addOfflineTable(table, getTimeColumnName(), null, TENANT_NAME, TENANT_NAME, null, SegmentVersion.v1, null, null, null, null, null);
   }
 
   /**
@@ -198,7 +198,7 @@ public class ControllerPeriodicTasksIntegrationTests extends BaseClusterIntegrat
 
     ExecutorService executor = Executors.newCachedThreadPool();
     ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName, timeColumnName, null, null, null,
+        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName, timeColumnName, null, null, schema,
             executor);
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -81,8 +81,8 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
     File schemaFile = getSchemaFile();
     _schema = Schema.fromFile(schemaFile);
     ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(offlineAvroFiles, 0, _segmentDir, _tarDir, getTableName(), null, getRawIndexColumns(),
-            _schema, executor);
+        .buildSegmentsFromAvro(offlineAvroFiles, 0, _segmentDir, _tarDir, getTableName(), getTimeColumnName(), null,
+            getRawIndexColumns(), _schema, executor);
 
     // Push data into the Kafka topic
     pushAvroIntoKafka(realtimeAvroFiles, getKafkaTopic(), executor);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTestCommandLineRunner.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTestCommandLineRunner.java
@@ -283,8 +283,8 @@ public class HybridClusterIntegrationTestCommandLineRunner {
       ExecutorService executor = Executors.newCachedThreadPool();
       Schema schema = Schema.fromFile(_schemaFile);
       ClusterIntegrationTestUtils
-          .buildSegmentsFromAvro(_offlineAvroFiles, 0, _segmentDir, _tarDir, _tableName, null, getRawIndexColumns(),
-              schema, executor);
+          .buildSegmentsFromAvro(_offlineAvroFiles, 0, _segmentDir, _tarDir, _tableName, getTimeColumnName(), null,
+              getRawIndexColumns(), schema, executor);
       executor.shutdown();
       executor.awaitTermination(10, TimeUnit.MINUTES);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
@@ -100,7 +100,7 @@ public class LuceneRealtimeClusterIntegrationTest extends BaseClusterIntegration
     textIndexColumns.add(fieldConfig);
 
     addRealtimeTable(TABLE_NAME, true, KafkaStarterUtils.DEFAULT_KAFKA_BROKER, KafkaStarterUtils.DEFAULT_ZK_STR,
-        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, null, null, TABLE_NAME,
+        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, TIME_COL_NAME, null, TABLE_NAME,
         getBrokerTenant(), getServerTenant(), getLoadMode(), null, null,
         null, null, getTaskConfig(), getStreamConsumerFactoryClassName(),
         1, textIndexColumns);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MapTypeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MapTypeClusterIntegrationTest.java
@@ -80,7 +80,7 @@ public class MapTypeClusterIntegrationTest extends BaseClusterIntegrationTest {
     ExecutorService executor = Executors.newCachedThreadPool();
     ClusterIntegrationTestUtils
         .buildSegmentsFromAvro(Collections.singletonList(avroFile), 0, _segmentDir, _tarDir, getTableName(), null, null,
-            schema, executor);
+            null, schema, executor);
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);
     uploadSegments(getTableName(), _tarDir);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MetadataAndDictionaryAggregationPlanClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MetadataAndDictionaryAggregationPlanClusterIntegrationTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
@@ -93,18 +94,24 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
     startBrokers(getNumBrokers());
     startServers(getNumServers());
 
+    File schemaFile = getSchemaFile();
+    Schema schema = Schema.fromFile(schemaFile);
+    String timeColumnName = getTimeColumnName();
+
     // Create the tables
-    addOfflineTable(DEFAULT_TABLE_NAME);
-    addOfflineTable(STAR_TREE_TABLE_NAME);
+    addOfflineTable(DEFAULT_TABLE_NAME, timeColumnName, null, null, null, null, SegmentVersion.v1, null, null, null,
+        null, null);
+    addOfflineTable(STAR_TREE_TABLE_NAME, timeColumnName, null, null, null, null, SegmentVersion.v1, null, null, null,
+        null, null);
 
     // Unpack the Avro files
     List<File> avroFiles = unpackAvroData(_tempDir);
 
     // Create and upload segments without star tree indexes from Avro data
-    createAndUploadSegments(avroFiles, DEFAULT_TABLE_NAME, false, getRawIndexColumns(), null);
+    createAndUploadSegments(avroFiles, DEFAULT_TABLE_NAME, false, getRawIndexColumns(), schema);
 
     // Create and upload segments with star tree indexes from Avro data
-    createAndUploadSegments(avroFiles, STAR_TREE_TABLE_NAME, true, null, Schema.fromFile(getSchemaFile()));
+    createAndUploadSegments(avroFiles, STAR_TREE_TABLE_NAME, true, null, schema);
 
     // Load data into H2
     _currentTable = DEFAULT_TABLE_NAME;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MetadataAndDictionaryAggregationPlanClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MetadataAndDictionaryAggregationPlanClusterIntegrationTest.java
@@ -131,7 +131,7 @@ public class MetadataAndDictionaryAggregationPlanClusterIntegrationTest extends 
 
     ExecutorService executor = Executors.newCachedThreadPool();
     ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName, null, rawIndexColumns, pinotSchema,
+        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName, null, null, rawIndexColumns, pinotSchema,
             executor);
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -113,8 +113,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     // Create segments from Avro data
     ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, getTableName(), null, getRawIndexColumns(), null,
-            executor);
+        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, getTableName(), getTimeColumnName(), null,
+            getRawIndexColumns(), null, executor);
 
     // Load data into H2
     setUpH2Connection(avroFiles, executor);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PinotURIUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PinotURIUploadIntegrationTest.java
@@ -136,7 +136,7 @@ public class PinotURIUploadIntegrationTest extends BaseClusterIntegrationTestSet
     ExecutorService executor = MoreExecutors.newDirectExecutorService();
     ClusterIntegrationTestUtils
         .buildSegmentsFromAvro(Collections.singletonList(avroFile), segmentIndex, new File(_segmentDir, segmentName),
-            segmentTarDir, this._tableName, executor);
+            segmentTarDir, this._tableName, null, executor);
     executor.shutdown();
     executor.awaitTermination(1L, TimeUnit.MINUTES);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -170,8 +170,8 @@ public class StarTreeClusterIntegrationTest extends BaseClusterIntegrationTest {
 
     ExecutorService executor = Executors.newCachedThreadPool();
     ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName, starTreeV2BuilderConfigs, null, _schema,
-            executor);
+        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName, getTimeColumnName(),
+            starTreeV2BuilderConfigs, null, _schema, executor);
     executor.shutdown();
     executor.awaitTermination(10, TimeUnit.MINUTES);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -117,7 +117,7 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
     ExecutorService executor = MoreExecutors.newDirectExecutorService();
     ClusterIntegrationTestUtils
         .buildSegmentsFromAvro(Collections.singletonList(avroFile), segmentIndex, new File(_segmentDir, segmentName),
-            segmentTarDir, this._tableName, executor);
+            segmentTarDir, this._tableName, null, executor);
     executor.shutdown();
     executor.awaitTermination(1L, TimeUnit.MINUTES);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/server/util/SegmentTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/server/util/SegmentTestUtils.java
@@ -39,17 +39,13 @@ public class SegmentTestUtils {
 
   @Nonnull
   public static SegmentGeneratorConfig getSegmentGeneratorConfig(@Nonnull File inputAvro, @Nonnull File outputDir,
-      @Nonnull TimeUnit timeUnit, @Nonnull String tableName, @Nullable Schema pinotSchema)
+      @Nonnull String timeColumnName, @Nonnull TimeUnit timeUnit, @Nonnull String tableName, @Nullable Schema pinotSchema)
       throws IOException {
     if (pinotSchema == null) {
       pinotSchema = AvroUtils.getPinotSchemaFromAvroDataFile(inputAvro);
     }
-    TableConfigBuilder tableConfigBuilder = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName);
-    // TODO: change to getDateTimeFieldSpecs().get(0)
-    if (pinotSchema.getTimeFieldSpec() != null) {
-      tableConfigBuilder.setTimeColumnName(pinotSchema.getTimeFieldSpec().getName());
-    }
-    TableConfig tableConfig = tableConfigBuilder.build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(timeColumnName).setTableName(tableName).build();
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, pinotSchema);
 
     segmentGeneratorConfig.setInputFilePath(inputAvro.getAbsolutePath());

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/server/util/SegmentTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/server/util/SegmentTestUtils.java
@@ -39,7 +39,7 @@ public class SegmentTestUtils {
 
   @Nonnull
   public static SegmentGeneratorConfig getSegmentGeneratorConfig(@Nonnull File inputAvro, @Nonnull File outputDir,
-      @Nonnull String timeColumnName, @Nonnull TimeUnit timeUnit, @Nonnull String tableName, @Nullable Schema pinotSchema)
+      @Nonnull String timeColumnName, @Nonnull String tableName, @Nullable Schema pinotSchema)
       throws IOException {
     if (pinotSchema == null) {
       pinotSchema = AvroUtils.getPinotSchemaFromAvroDataFile(inputAvro);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/server/util/SegmentTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/server/util/SegmentTestUtils.java
@@ -49,7 +49,6 @@ public class SegmentTestUtils {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, pinotSchema);
 
     segmentGeneratorConfig.setInputFilePath(inputAvro.getAbsolutePath());
-    segmentGeneratorConfig.setSegmentTimeUnit(timeUnit);
     if (inputAvro.getName().endsWith("gz")) {
       segmentGeneratorConfig.setFormat(FileFormat.GZIPPED_AVRO);
     } else {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/SegmentInfoProvider.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/SegmentInfoProvider.java
@@ -120,6 +120,7 @@ public class SegmentInfoProvider {
           // Treat TIME column as single-value dimension column
           case DIMENSION:
           case TIME:
+          case DATE_TIME:
             uniqueSingleValueDimensions.add(columnName);
             loadValuesForSingleValueDimension(indexSegment, singleValueDimensionValuesMap, columnName);
             break;


### PR DESCRIPTION
https://github.com/apache/incubator-pinot/issues/2756
Providing timecolumnName to SegmentTestUtils.getSegmentGeneratorConfig, so that we dont have to call getTimeFieldSpec.