### PR TITLE
Schema method to fetch field spec of time column

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -84,7 +84,7 @@ public class SchemaTest {
     Assert.assertEquals(dimensionFieldSpec.getFieldType(), FieldSpec.FieldType.DIMENSION);
     Assert.assertEquals(dimensionFieldSpec.getName(), "svDimension");
     Assert.assertEquals(dimensionFieldSpec.getDataType(), FieldSpec.DataType.INT);
-    Assert.assertEquals(dimensionFieldSpec.isSingleValueField(), true);
+    Assert.assertTrue(dimensionFieldSpec.isSingleValueField());
     Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), Integer.MIN_VALUE);
 
     dimensionFieldSpec = schema.getDimensionSpec("svDimensionWithDefault");
@@ -92,7 +92,7 @@ public class SchemaTest {
     Assert.assertEquals(dimensionFieldSpec.getFieldType(), FieldSpec.FieldType.DIMENSION);
     Assert.assertEquals(dimensionFieldSpec.getName(), "svDimensionWithDefault");
     Assert.assertEquals(dimensionFieldSpec.getDataType(), FieldSpec.DataType.INT);
-    Assert.assertEquals(dimensionFieldSpec.isSingleValueField(), true);
+    Assert.assertTrue(dimensionFieldSpec.isSingleValueField());
     Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), 10);
 
     dimensionFieldSpec = schema.getDimensionSpec("mvDimension");
@@ -100,7 +100,7 @@ public class SchemaTest {
     Assert.assertEquals(dimensionFieldSpec.getFieldType(), FieldSpec.FieldType.DIMENSION);
     Assert.assertEquals(dimensionFieldSpec.getName(), "mvDimension");
     Assert.assertEquals(dimensionFieldSpec.getDataType(), FieldSpec.DataType.STRING);
-    Assert.assertEquals(dimensionFieldSpec.isSingleValueField(), false);
+    Assert.assertFalse(dimensionFieldSpec.isSingleValueField());
     Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), "null");
 
     dimensionFieldSpec = schema.getDimensionSpec("mvDimensionWithDefault");
@@ -108,7 +108,7 @@ public class SchemaTest {
     Assert.assertEquals(dimensionFieldSpec.getFieldType(), FieldSpec.FieldType.DIMENSION);
     Assert.assertEquals(dimensionFieldSpec.getName(), "mvDimensionWithDefault");
     Assert.assertEquals(dimensionFieldSpec.getDataType(), FieldSpec.DataType.STRING);
-    Assert.assertEquals(dimensionFieldSpec.isSingleValueField(), false);
+    Assert.assertFalse(dimensionFieldSpec.isSingleValueField());
     Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), defaultString);
 
     MetricFieldSpec metricFieldSpec = schema.getMetricSpec("metric");
@@ -116,7 +116,7 @@ public class SchemaTest {
     Assert.assertEquals(metricFieldSpec.getFieldType(), FieldSpec.FieldType.METRIC);
     Assert.assertEquals(metricFieldSpec.getName(), "metric");
     Assert.assertEquals(metricFieldSpec.getDataType(), FieldSpec.DataType.INT);
-    Assert.assertEquals(metricFieldSpec.isSingleValueField(), true);
+    Assert.assertTrue(metricFieldSpec.isSingleValueField());
     Assert.assertEquals(metricFieldSpec.getDefaultNullValue(), 0);
 
     metricFieldSpec = schema.getMetricSpec("metricWithDefault");
@@ -124,7 +124,7 @@ public class SchemaTest {
     Assert.assertEquals(metricFieldSpec.getFieldType(), FieldSpec.FieldType.METRIC);
     Assert.assertEquals(metricFieldSpec.getName(), "metricWithDefault");
     Assert.assertEquals(metricFieldSpec.getDataType(), FieldSpec.DataType.INT);
-    Assert.assertEquals(metricFieldSpec.isSingleValueField(), true);
+    Assert.assertTrue(metricFieldSpec.isSingleValueField());
     Assert.assertEquals(metricFieldSpec.getDefaultNullValue(), 5);
 
     TimeFieldSpec timeFieldSpec = schema.getTimeFieldSpec();
@@ -132,7 +132,7 @@ public class SchemaTest {
     Assert.assertEquals(timeFieldSpec.getFieldType(), FieldSpec.FieldType.TIME);
     Assert.assertEquals(timeFieldSpec.getName(), "time");
     Assert.assertEquals(timeFieldSpec.getDataType(), FieldSpec.DataType.LONG);
-    Assert.assertEquals(timeFieldSpec.isSingleValueField(), true);
+    Assert.assertTrue(timeFieldSpec.isSingleValueField());
     Assert.assertEquals(timeFieldSpec.getDefaultNullValue(), Long.MIN_VALUE);
 
     DateTimeFieldSpec dateTimeFieldSpec = schema.getDateTimeSpec("dateTime");
@@ -140,7 +140,38 @@ public class SchemaTest {
     Assert.assertEquals(dateTimeFieldSpec.getFieldType(), FieldSpec.FieldType.DATE_TIME);
     Assert.assertEquals(dateTimeFieldSpec.getName(), "dateTime");
     Assert.assertEquals(dateTimeFieldSpec.getDataType(), FieldSpec.DataType.LONG);
-    Assert.assertEquals(dateTimeFieldSpec.isSingleValueField(), true);
+    Assert.assertTrue(dateTimeFieldSpec.isSingleValueField());
+    Assert.assertEquals(dateTimeFieldSpec.getDefaultNullValue(), Long.MIN_VALUE);
+    Assert.assertEquals(dateTimeFieldSpec.getFormat(), "1:HOURS:EPOCH");
+    Assert.assertEquals(dateTimeFieldSpec.getGranularity(), "1:HOURS");
+  }
+
+  @Test
+  public void testFetchFieldSpecForTime() {
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
+        .addMetric("metric", FieldSpec.DataType.INT)
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "time"), null)
+        .addDateTime("dateTime", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS").build();
+
+    // Test method which fetches the DateTimeFieldSpec given the timeColumnName
+    // Test is on TIME
+    DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn("time");
+    Assert.assertNotNull(dateTimeFieldSpec);
+    Assert.assertEquals(dateTimeFieldSpec.getFieldType(), FieldSpec.FieldType.DATE_TIME);
+    Assert.assertEquals(dateTimeFieldSpec.getName(), "time");
+    Assert.assertEquals(dateTimeFieldSpec.getDataType(), FieldSpec.DataType.LONG);
+    Assert.assertTrue(dateTimeFieldSpec.isSingleValueField());
+    Assert.assertEquals(dateTimeFieldSpec.getDefaultNullValue(), Long.MIN_VALUE);
+    Assert.assertEquals(dateTimeFieldSpec.getFormat(), "1:DAYS:EPOCH");
+    Assert.assertEquals(dateTimeFieldSpec.getGranularity(), "1:DAYS");
+
+    // Test it on DATE_TIME
+    dateTimeFieldSpec = schema.getSpecForTimeColumn("dateTime");
+    Assert.assertNotNull(dateTimeFieldSpec);
+    Assert.assertEquals(dateTimeFieldSpec.getFieldType(), FieldSpec.FieldType.DATE_TIME);
+    Assert.assertEquals(dateTimeFieldSpec.getName(), "dateTime");
+    Assert.assertEquals(dateTimeFieldSpec.getDataType(), FieldSpec.DataType.LONG);
+    Assert.assertTrue(dateTimeFieldSpec.isSingleValueField());
     Assert.assertEquals(dateTimeFieldSpec.getDefaultNullValue(), Long.MIN_VALUE);
     Assert.assertEquals(dateTimeFieldSpec.getFormat(), "1:HOURS:EPOCH");
     Assert.assertEquals(dateTimeFieldSpec.getGranularity(), "1:HOURS");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -304,6 +304,8 @@ public final class Schema {
    * If the columnName is a DATE_TIME column, returns the DateTimeFieldSpec
    * If the columnName is a TIME column, converts to DateTimeFieldSpec before returning
    */
+  @JsonIgnore
+  @Nullable
   public DateTimeFieldSpec getSpecForTimeColumn(String timeColumnName) {
     FieldSpec fieldSpec = _fieldSpecMap.get(timeColumnName);
     if (fieldSpec != null) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -299,6 +299,24 @@ public final class Schema {
     return null;
   }
 
+  /**
+   * Fetches the DateTimeFieldSpec for the given time column name.
+   * If the columnName is a DATE_TIME column, returns the DateTimeFieldSpec
+   * If the columnName is a TIME column, converts to DateTimeFieldSpec before returning
+   */
+  public DateTimeFieldSpec getSpecForTimeColumn(String timeColumnName) {
+    FieldSpec fieldSpec = _fieldSpecMap.get(timeColumnName);
+    if (fieldSpec != null) {
+      if (fieldSpec.getFieldType() == FieldType.DATE_TIME) {
+        return (DateTimeFieldSpec) fieldSpec;
+      }
+      if (fieldSpec.getFieldType() == FieldType.TIME) {
+        return convertToDateTimeFieldSpec((TimeFieldSpec) fieldSpec);
+      }
+    }
+    return null;
+  }
+
   @JsonIgnore
   public List<String> getDimensionNames() {
     return _dimensionNames;


### PR DESCRIPTION
https://github.com/apache/incubator-pinot/issues/2756

Introducing  method in `Schema.getFieldSpecForTimeColumn(String timeColumnName)`. If, FieldType for time columnName is
1) DATE_TIME - return the DateTimeFieldSpec
2) TIME - convert to DateTimeFieldSpec before returning
As per recent discussions, we will not be changing the ser/deser of TimeFieldSpec in schema, so as to not mess with external integrations. As a result, we decided that Schema can have TimeFieldSpec/DateTimeFieldSpecs/both/none. The timeColumn is anyway decided by the table config.
This means, the callers of getFieldSpecFor(time) can get either DateTimeFieldSpec or TimeFieldSpec, and the caller should be prepared to read both. This helper method will take that burden off the caller.

NOTE: this will be used as a substitution for getFieldSpecFor() method, wherever it was being called to get TimeFieldSpec