### PR TITLE
[Issue# 5359] Changes to use StreamPartitionMsgOffset

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -18,11 +18,13 @@
  */
 package org.apache.pinot.common.protocols;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
@@ -283,6 +285,11 @@ public class SegmentCompletionProtocol {
         return this;
       }
 
+      public Params withStreamPartitionMsgOffset(StreamPartitionMsgOffset offset) {
+        _offset = offset.getOffset();
+        return this;
+      }
+
       public String getSegmentName() {
         return _segmentName;
       }
@@ -325,6 +332,10 @@ public class SegmentCompletionProtocol {
 
       public long getSegmentSizeBytes() {
         return _segmentSizeBytes;
+      }
+
+      public StreamPartitionMsgOffset getStreamPartitionMsgOffset() {
+        return new StreamPartitionMsgOffset(_offset);
       }
 
       public String toString() {
@@ -417,6 +428,12 @@ public class SegmentCompletionProtocol {
     @JsonProperty(OFFSET_KEY)
     public long getOffset() {
       return _offset;
+    }
+
+    // TODO Make it a JsonProperty when we are ready to move the protocol
+    @JsonIgnore
+    public StreamPartitionMsgOffset getStreamPartitionMsgOffset() {
+      return new StreamPartitionMsgOffset(_offset);
     }
 
     @JsonProperty(OFFSET_KEY)
@@ -529,6 +546,11 @@ public class SegmentCompletionProtocol {
         return this;
       }
 
+      public Params withStreamPartitionMsgOffset(StreamPartitionMsgOffset offset) {
+        _offset = offset.getOffset();
+        return this;
+      }
+
       public ControllerResponseStatus getStatus() {
         return _status;
       }
@@ -551,6 +573,10 @@ public class SegmentCompletionProtocol {
 
       public String getControllerVipUrl() {
         return _controllerVipUrl;
+      }
+
+      public StreamPartitionMsgOffset getStreamPartitionMsgOffset() {
+        return new StreamPartitionMsgOffset(_offset);
       }
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -325,7 +325,8 @@ public class LLCSegmentCompletionHandlers {
               URIUtils.encode(SegmentCompletionUtils.generateSegmentFileName(segmentName)));
       PinotFSFactory.create(segmentFileURI.getScheme()).copyFromLocalFile(localTempFile, segmentFileURI);
       SegmentCompletionProtocol.Response.Params responseParams =
-          new SegmentCompletionProtocol.Response.Params().withOffset(requestParams.getOffset())
+          new SegmentCompletionProtocol.Response.Params()
+              .withStreamPartitionMsgOffset(requestParams.getStreamPartitionMsgOffset())
               .withSegmentLocation(segmentFileURI.toString())
               .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.UPLOAD_SUCCESS);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.helix.core.realtime.segment;
 
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
 /**
@@ -29,13 +30,13 @@ public class CommittingSegmentDescriptor {
   private String _segmentName;
   private long _segmentSizeBytes;
   private String _segmentLocation;
-  private long _nextOffset;
+  private StreamPartitionMsgOffset _nextOffset;
   private SegmentMetadataImpl _segmentMetadata;
 
   public static CommittingSegmentDescriptor fromSegmentCompletionReqParams(
       SegmentCompletionProtocol.Request.Params reqParams) {
     CommittingSegmentDescriptor committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(reqParams.getSegmentName(), reqParams.getOffset(),
+        new CommittingSegmentDescriptor(reqParams.getSegmentName(), reqParams.getStreamPartitionMsgOffset(),
             reqParams.getSegmentSizeBytes());
     committingSegmentDescriptor.setSegmentLocation(reqParams.getSegmentLocation());
     return committingSegmentDescriptor;
@@ -49,13 +50,13 @@ public class CommittingSegmentDescriptor {
     return committingSegmentDescriptor;
   }
 
-  public CommittingSegmentDescriptor(String segmentName, long nextOffset, long segmentSizeBytes) {
+  public CommittingSegmentDescriptor(String segmentName, StreamPartitionMsgOffset nextOffset, long segmentSizeBytes) {
     _segmentName = segmentName;
     _nextOffset = nextOffset;
     _segmentSizeBytes = segmentSizeBytes;
   }
 
-  public CommittingSegmentDescriptor(String segmentName, long nextOffset, long segmentSizeBytes,
+  public CommittingSegmentDescriptor(String segmentName, StreamPartitionMsgOffset nextOffset, long segmentSizeBytes,
       String segmentLocation) {
     this(segmentName, nextOffset, segmentSizeBytes);
     _segmentLocation = segmentLocation;
@@ -85,12 +86,8 @@ public class CommittingSegmentDescriptor {
     _segmentLocation = segmentLocation;
   }
 
-  public long getNextOffset() {
+  public StreamPartitionMsgOffset getNextOffset() {
     return _nextOffset;
-  }
-
-  public void setNextOffset(long nextOffset) {
-    _nextOffset = nextOffset;
   }
 
   public SegmentMetadataImpl getSegmentMetadata() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/SegmentCompletionProtocolDeserTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/SegmentCompletionProtocolDeserTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
@@ -30,7 +31,7 @@ import static org.testng.Assert.assertTrue;
 
 
 public class SegmentCompletionProtocolDeserTest {
-  private final int OFFSET = 1;
+  private final StreamPartitionMsgOffset OFFSET = new StreamPartitionMsgOffset(1);
   private final long BUILD_TIME_MILLIS = 123;
   private final String SEGMENT_LOCATION = "file.tmp";
   private final String CONTROLLER_VIP_URL = "http://localhost:8998";
@@ -39,13 +40,14 @@ public class SegmentCompletionProtocolDeserTest {
   public void testCompleteResponseParams() {
     // Test with all params
     SegmentCompletionProtocol.Response.Params params =
-        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS).withOffset(OFFSET)
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withStreamPartitionMsgOffset(OFFSET)
             .withSegmentLocation(SEGMENT_LOCATION).withSplitCommit(true)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
-    assertEquals(response.getOffset(), OFFSET);
+    assertEquals(response.getStreamPartitionMsgOffset().compareTo(OFFSET), 0);
     assertEquals(response.getSegmentLocation(), SEGMENT_LOCATION);
     assertTrue(response.isSplitCommit());
     assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
@@ -55,12 +57,13 @@ public class SegmentCompletionProtocolDeserTest {
   public void testIncompleteResponseParams() {
     // Test with reduced params
     SegmentCompletionProtocol.Response.Params params =
-        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS).withOffset(OFFSET)
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withStreamPartitionMsgOffset(OFFSET)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
-    assertEquals(response.getOffset(), OFFSET);
+    assertEquals(response.getStreamPartitionMsgOffset().compareTo(OFFSET), 0);
     assertNull(response.getSegmentLocation());
     assertFalse(response.isSplitCommit());
     assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
@@ -70,14 +73,15 @@ public class SegmentCompletionProtocolDeserTest {
   public void testJsonResponseWithAllParams() {
     // Test with all params
     SegmentCompletionProtocol.Response.Params params =
-        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS).withOffset(OFFSET)
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withStreamPartitionMsgOffset(OFFSET)
             .withSegmentLocation(SEGMENT_LOCATION).withSplitCommit(true).withControllerVipUrl(CONTROLLER_VIP_URL)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertEquals(jsonNode.get("offset").asText(), OFFSET.toString());
     assertEquals(jsonNode.get("segmentLocation").asText(), SEGMENT_LOCATION);
     assertTrue(jsonNode.get("isSplitCommitType").asBoolean());
     assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
@@ -87,13 +91,14 @@ public class SegmentCompletionProtocolDeserTest {
   @Test
   public void testJsonNullSegmentLocationAndVip() {
     SegmentCompletionProtocol.Response.Params params =
-        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS).withOffset(OFFSET)
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withStreamPartitionMsgOffset(OFFSET)
             .withSplitCommit(false).withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertEquals(jsonNode.get("offset").asText(), OFFSET.toString());
     assertNull(jsonNode.get("segmentLocation"));
     assertFalse(jsonNode.get("isSplitCommitType").asBoolean());
     assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
@@ -103,13 +108,14 @@ public class SegmentCompletionProtocolDeserTest {
   @Test
   public void testJsonResponseWithoutSplitCommit() {
     SegmentCompletionProtocol.Response.Params params =
-        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS).withOffset(OFFSET)
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withStreamPartitionMsgOffset(OFFSET)
             .withSplitCommit(false).withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertEquals(jsonNode.get("offset").asText(), OFFSET.toString());
     assertNull(jsonNode.get("segmentLocation"));
     assertFalse(jsonNode.get("isSplitCommitType").asBoolean());
     assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
@@ -120,14 +126,15 @@ public class SegmentCompletionProtocolDeserTest {
   public void testJsonResponseWithSegmentLocationNullVip() {
     // Should never happen because if split commit, should have both location and VIP, but testing deserialization regardless
     SegmentCompletionProtocol.Response.Params params =
-        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS).withOffset(OFFSET)
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withStreamPartitionMsgOffset(OFFSET)
             .withSegmentLocation(SEGMENT_LOCATION).withSplitCommit(false)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertEquals(jsonNode.get("offset").asText(), OFFSET.toString());
     assertEquals(jsonNode.get("segmentLocation").asText(), SEGMENT_LOCATION);
     assertFalse(jsonNode.get("isSplitCommitType").asBoolean());
     assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());
@@ -138,14 +145,15 @@ public class SegmentCompletionProtocolDeserTest {
   public void testJsonResponseWithVipAndNullSegmentLocation() {
     // Should never happen because if split commit, should have both location and VIP, but testing deserialization regardless
     SegmentCompletionProtocol.Response.Params params =
-        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS).withOffset(OFFSET)
+        new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
+            .withStreamPartitionMsgOffset(OFFSET)
             .withControllerVipUrl(CONTROLLER_VIP_URL).withSplitCommit(false)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     JsonNode jsonNode = JsonUtils.objectToJsonNode(response);
 
-    assertEquals(jsonNode.get("offset").asInt(), OFFSET);
+    assertEquals(jsonNode.get("offset").asText(), OFFSET.toString());
     assertNull(jsonNode.get("segmentLocation"));
     assertFalse(jsonNode.get("isSplitCommitType").asBoolean());
     assertEquals(jsonNode.get("status").asText(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT.toString());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -56,6 +56,7 @@ import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
@@ -187,7 +188,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // Commit a segment for partition 0
     String committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
     CommittingSegmentDescriptor committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(committingSegment, PARTITION_OFFSET + NUM_DOCS, 0L);
+        new CommittingSegmentDescriptor(committingSegment, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS), 0L);
     committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
     segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
 
@@ -226,7 +227,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
         .setValue(RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
     committingSegment = consumingSegment;
     committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(committingSegment, PARTITION_OFFSET + NUM_DOCS + NUM_DOCS, 0L);
+        new CommittingSegmentDescriptor(committingSegment, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS + NUM_DOCS), 0L);
     committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
     segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
 
@@ -277,7 +278,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     for (int partitionId = 0; partitionId < 2; partitionId++) {
       String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, CURRENT_TIME_MS).getSegmentName();
       CommittingSegmentDescriptor committingSegmentDescriptor =
-          new CommittingSegmentDescriptor(segmentName, PARTITION_OFFSET + NUM_DOCS, 0L);
+          new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS), 0L);
       committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
       segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     }
@@ -433,7 +434,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     for (int partitionId = 0; partitionId < 2; partitionId++) {
       String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, CURRENT_TIME_MS).getSegmentName();
       CommittingSegmentDescriptor committingSegmentDescriptor =
-          new CommittingSegmentDescriptor(segmentName, PARTITION_OFFSET + NUM_DOCS, 0L);
+          new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS), 0L);
       committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
       segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     }
@@ -475,7 +476,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       String segmentName =
           new LLCSegmentName(RAW_TABLE_NAME, partitionId, sequenceNumber, CURRENT_TIME_MS).getSegmentName();
       CommittingSegmentDescriptor committingSegmentDescriptor =
-          new CommittingSegmentDescriptor(segmentName, PARTITION_OFFSET + NUM_DOCS, 0L);
+          new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS), 0L);
       committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
       segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     }
@@ -653,7 +654,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // Commit a segment for partition 0
     String committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
     CommittingSegmentDescriptor committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(committingSegment, PARTITION_OFFSET + NUM_DOCS, 0L);
+        new CommittingSegmentDescriptor(committingSegment, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS), 0L);
     committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
 
     try {
@@ -683,7 +684,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
     String segmentLocation = SCHEME + tableDir + "/" + segmentFileName;
     CommittingSegmentDescriptor committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(segmentName, PARTITION_OFFSET, 0, segmentLocation);
+        new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET), 0, segmentLocation);
     segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     assertFalse(segmentFile.exists());
   }
@@ -708,7 +709,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
     String segmentLocation = SCHEME + tableDir + "/" + segmentFileName;
     CommittingSegmentDescriptor committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(segmentName, PARTITION_OFFSET, 0, segmentLocation);
+        new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET), 0, segmentLocation);
     segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     assertFalse(segmentFile.exists());
     assertFalse(extraSegmentFile.exists());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1162,7 +1162,7 @@ public class SegmentCompletionTest {
     @Override
     public void commitSegmentMetadata(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
       _segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
-      _segmentMetadata.setEndOffset(committingSegmentDescriptor.getNextOffset());
+      _segmentMetadata.setEndOffset(committingSegmentDescriptor.getNextOffset().getOffset());
       _segmentMetadata.setDownloadUrl(URIUtils.constructDownloadUrl(CONTROLLER_CONF.generateVipUrl(), rawTableName,
           committingSegmentDescriptor.getSegmentName()));
       _segmentMetadata.setEndTime(_segmentCompletionMgr.getCurrentTimeMs());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.annotations.Test;
 
@@ -161,7 +162,7 @@ public class FlushThresholdUpdaterTest {
   }
 
   private CommittingSegmentDescriptor getCommittingSegmentDescriptor(long segmentSizeBytes) {
-    return new CommittingSegmentDescriptor(null, 0L, segmentSizeBytes);
+    return new CommittingSegmentDescriptor(null, new StreamPartitionMsgOffset(0), segmentSizeBytes);
   }
 
   private LLCRealtimeSegmentZKMetadata getCommittingSegmentZKMetadata(long creationTime,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -806,7 +806,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   protected SegmentCompletionProtocol.Response commit(String controllerVipUrl, boolean isSplitCommit) {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
 
-    params.withSegmentName(_segmentNameStr).withOffset(_currentOffset.getOffset()).withNumRows(_numRowsConsumed)
+    params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset).withNumRows(_numRowsConsumed)
         .withInstanceId(_instanceId).withBuildTimeMillis(_segmentBuildDescriptor.getBuildTimeMillis())
         .withSegmentSizeBytes(_segmentBuildDescriptor.getSegmentSizeBytes())
         .withWaitTimeMillis(_segmentBuildDescriptor.getWaitTimeMillis());
@@ -882,7 +882,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   protected void postStopConsumedMsg(String reason) {
     do {
       SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
-      params.withOffset(_currentOffset.getOffset()).withReason(reason).withSegmentName(_segmentNameStr).withInstanceId(_instanceId);
+      params.withStreamPartitionMsgOffset(_currentOffset).withReason(reason).withSegmentName(_segmentNameStr).withInstanceId(_instanceId);
 
       SegmentCompletionProtocol.Response response = _protocolHandler.segmentStoppedConsuming(params);
       if (response.getStatus() == SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED) {
@@ -898,7 +898,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // Post segmentConsumed to current leader.
     // Retry maybe once if leader is not found.
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
-    params.withOffset(_currentOffset.getOffset()).withSegmentName(_segmentNameStr).withReason(_stopReason)
+    params.withStreamPartitionMsgOffset(_currentOffset).withSegmentName(_segmentNameStr).withReason(_stopReason)
         .withNumRows(_numRowsConsumed).withInstanceId(_instanceId);
     if (_isOffHeap) {
       params.withMemoryUsedBytes(_memoryManager.getTotalAllocatedBytes());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
@@ -94,7 +94,7 @@ public class SegmentBuildTimeLeaseExtender {
   public void addSegment(String segmentId, long initialBuildTimeMs, StreamPartitionMsgOffset offset) {
     final long initialDelayMs = initialBuildTimeMs * 9 / 10;
     final SegmentCompletionProtocol.Request.Params reqParams = new SegmentCompletionProtocol.Request.Params();
-    reqParams.withOffset(offset.getOffset()).withSegmentName(segmentId).withExtraTimeSec(EXTRA_TIME_SECONDS)
+    reqParams.withStreamPartitionMsgOffset(offset).withSegmentName(segmentId).withExtraTimeSec(EXTRA_TIME_SECONDS)
         .withInstanceId(_instanceId);
     Future future = _executor
         .scheduleWithFixedDelay(new LeaseExtender(reqParams), initialDelayMs, REPEAT_REQUEST_PERIOD_SEC * 1000L,


### PR DESCRIPTION
These changes are mostly on the controller side inner code.
A good bit of tests still use long offset and need to be modified.
Protocol and persistent data are still unaffected.