### PR TITLE
Re-work on adding template support for Pinot Ingestion Job Spec

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
@@ -19,13 +19,14 @@
 package org.apache.pinot.spi.ingestion.batch;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
 import org.apache.pinot.spi.ingestion.batch.spec.ExecutionFrameworkSpec;
@@ -41,38 +42,39 @@ public class IngestionJobLauncher {
 
   public static final Logger LOGGER = LoggerFactory.getLogger(IngestionJobLauncher.class);
 
-  private static final String USAGE = "usage: [jobSpec.yaml] [template_key=template_value]...";
-
-  private static void usage() {
-    System.err.println(USAGE);
-  }
-
-  public static void main(String[] args)
-      throws Exception {
-    if (args.length < 1) {
-      usage();
-      System.exit(1);
+  public static SegmentGenerationJobSpec getSegmentGenerationJobSpec(String jobSpecFilePath, String propertyFilePath,
+      Map<String, Object> context) {
+    Properties properties = new Properties();
+    if (propertyFilePath != null) {
+      try {
+        properties.load(FileUtils.openInputStream(new File(propertyFilePath)));
+      } catch (IOException e) {
+        throw new RuntimeException(
+            String.format("Unable to read property file [%s] into properties.", propertyFilePath), e);
+      }
     }
-    String jobSpecFilePath = args[0];
-    List<String> valueList = new ArrayList<>();
-    for (int i = 1; i < args.length; i++) {
-      valueList.add(args[i]);
+    Map<String, Object> propertiesMap = (Map) properties;
+    if (context != null) {
+      propertiesMap.putAll(context);
     }
-    SegmentGenerationJobSpec spec =
-        getSegmentGenerationJobSpec(jobSpecFilePath, GroovyTemplateUtils.getTemplateContext(valueList));
-    runIngestionJob(spec);
-  }
-
-  public static SegmentGenerationJobSpec getSegmentGenerationJobSpec(String jobSpecFilePath,
-      Map<String, Object> context)
-      throws IOException, ClassNotFoundException {
-    String yamlTemplate = IOUtils.toString(new BufferedReader(new FileReader(jobSpecFilePath)));
-    String yamlStr = GroovyTemplateUtils.renderTemplate(yamlTemplate, context);
+    String yamlTemplate;
+    try {
+      yamlTemplate = IOUtils.toString(new BufferedReader(new FileReader(jobSpecFilePath)));
+    } catch (IOException e) {
+      throw new RuntimeException(String.format("Unable to read ingestion job spec file [%s].", jobSpecFilePath), e);
+    }
+    String yamlStr;
+    try {
+      yamlStr = GroovyTemplateUtils.renderTemplate(yamlTemplate, propertiesMap);
+    } catch (Exception e) {
+      throw new RuntimeException(String
+          .format("Unable to render templates on ingestion job spec template file - [%s] with propertiesMap - [%s].",
+              jobSpecFilePath, Arrays.toString(propertiesMap.entrySet().toArray())), e);
+    }
     return new Yaml().loadAs(yamlStr, SegmentGenerationJobSpec.class);
   }
 
-  public static void runIngestionJob(SegmentGenerationJobSpec spec)
-      throws Exception {
+  public static void runIngestionJob(SegmentGenerationJobSpec spec) {
     StringWriter sw = new StringWriter();
     new Yaml().dump(spec, sw);
     LOGGER.info("SegmentGenerationJobSpec: \n{}", sw.toString());
@@ -103,12 +105,21 @@ public class IngestionJobLauncher {
     }
   }
 
-  private static void kickoffIngestionJob(SegmentGenerationJobSpec spec, String ingestionJobRunnerClassName)
-      throws Exception {
+  private static void kickoffIngestionJob(SegmentGenerationJobSpec spec, String ingestionJobRunnerClassName) {
     LOGGER.info("Trying to create instance for class {}", ingestionJobRunnerClassName);
-    IngestionJobRunner ingestionJobRunner = PluginManager.get().createInstance(ingestionJobRunnerClassName);
+    IngestionJobRunner ingestionJobRunner;
+    try {
+      ingestionJobRunner = PluginManager.get().createInstance(ingestionJobRunnerClassName);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to create IngestionJobRunner instance for class - " + ingestionJobRunnerClassName, e);
+    }
     ingestionJobRunner.init(spec);
-    ingestionJobRunner.run();
+    try {
+      ingestionJobRunner.run();
+    } catch (Exception e) {
+      throw new RuntimeException("Caught exception during running - " + ingestionJobRunnerClassName, e);
+    }
   }
 
   enum PinotIngestionJobType {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
@@ -20,13 +20,18 @@ package org.apache.pinot.spi.ingestion.batch;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.io.Reader;
+import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
 import org.apache.pinot.spi.ingestion.batch.spec.ExecutionFrameworkSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.utils.GroovyTemplateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -36,7 +41,7 @@ public class IngestionJobLauncher {
 
   public static final Logger LOGGER = LoggerFactory.getLogger(IngestionJobLauncher.class);
 
-  private static final String USAGE = "usage: [jobSpec.yaml]";
+  private static final String USAGE = "usage: [jobSpec.yaml] [template_key=template_value]...";
 
   private static void usage() {
     System.err.println(USAGE);
@@ -44,16 +49,26 @@ public class IngestionJobLauncher {
 
   public static void main(String[] args)
       throws Exception {
-    if (args.length != 1) {
+    if (args.length < 1) {
       usage();
       System.exit(1);
     }
     String jobSpecFilePath = args[0];
-
-    try (Reader reader = new BufferedReader(new FileReader(jobSpecFilePath))) {
-      SegmentGenerationJobSpec spec = new Yaml().loadAs(reader, SegmentGenerationJobSpec.class);
-      runIngestionJob(spec);
+    List<String> valueList = new ArrayList<>();
+    for (int i = 1; i < args.length; i++) {
+      valueList.add(args[i]);
     }
+    SegmentGenerationJobSpec spec =
+        getSegmentGenerationJobSpec(jobSpecFilePath, GroovyTemplateUtils.getTemplateContext(valueList));
+    runIngestionJob(spec);
+  }
+
+  public static SegmentGenerationJobSpec getSegmentGenerationJobSpec(String jobSpecFilePath,
+      Map<String, Object> context)
+      throws IOException, ClassNotFoundException {
+    String yamlTemplate = IOUtils.toString(new BufferedReader(new FileReader(jobSpecFilePath)));
+    String yamlStr = GroovyTemplateUtils.renderTemplate(yamlTemplate, context);
+    return new Yaml().loadAs(yamlStr, SegmentGenerationJobSpec.class);
   }
 
   public static void runIngestionJob(SegmentGenerationJobSpec spec)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/GroovyTemplateUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/GroovyTemplateUtils.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import groovy.text.SimpleTemplateEngine;
+import groovy.text.TemplateEngine;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+
+public class GroovyTemplateUtils {
+  private static final TemplateEngine GROOVY_TEMPLATE_ENGINE = new SimpleTemplateEngine();
+  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+  public static String renderTemplate(String template, Map<String, Object> newContext)
+      throws IOException, ClassNotFoundException {
+    Map<String, Object> contextMap = getDefaultContextMap();
+    contextMap.putAll(newContext);
+    return GROOVY_TEMPLATE_ENGINE.createTemplate(template).make(contextMap).toString();
+  }
+
+  /**
+   Construct default template context:
+   today : today's date in format `yyyy-MM-dd`, example value: '2020-05-06'
+   yesterday : yesterday's date in format `yyyy-MM-dd`, example value: '2020-05-06'
+   */
+  public static Map<String, Object> getDefaultContextMap() {
+    Map<String, Object> defaultContextMap = new HashMap<>();
+    Instant now = Instant.now();
+    defaultContextMap.put("today", DATE_FORMAT.format(new Date(now.toEpochMilli())));
+    defaultContextMap.put("yesterday", DATE_FORMAT.format(new Date(now.minus(1, ChronoUnit.DAYS).toEpochMilli())));
+    return defaultContextMap;
+  }
+
+  public static Map<String, Object> getTemplateContext(List<String> values) {
+    Map<String, Object> context = new HashMap<>();
+    for (String value : values) {
+      String[] splits = value.split("=", 2);
+      if (splits.length > 1) {
+        context.put(splits[0], splits[1]);
+      }
+    }
+    return context;
+  }
+
+  public static String renderTemplate(String template)
+      throws IOException, ClassNotFoundException {
+    return renderTemplate(template, Collections.emptyMap());
+  }
+
+  static {
+    DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncherTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncherTest.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.ingestion.batch;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.apache.pinot.spi.utils.GroovyTemplateUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class IngestionJobLauncherTest {
+
+  @Test
+  public void testIngestionJobLauncherWithTemplate()
+      throws IOException, ClassNotFoundException {
+    Map<String, Object> context =
+        GroovyTemplateUtils.getTemplateContext(Arrays.asList("year=2020", "month=05", "day=06"));
+    SegmentGenerationJobSpec spec = IngestionJobLauncher.getSegmentGenerationJobSpec(
+        GroovyTemplateUtils.class.getClassLoader().getResource("ingestionJobSpecTemplate.yaml").getFile(), context);
+    Assert.assertEquals(spec.getInputDirURI(), "file:///path/to/input/2020/05/06");
+    Assert.assertEquals(spec.getOutputDirURI(), "file:///path/to/output/2020/05/06");
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncherTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncherTest.java
@@ -35,8 +35,30 @@ public class IngestionJobLauncherTest {
     Map<String, Object> context =
         GroovyTemplateUtils.getTemplateContext(Arrays.asList("year=2020", "month=05", "day=06"));
     SegmentGenerationJobSpec spec = IngestionJobLauncher.getSegmentGenerationJobSpec(
-        GroovyTemplateUtils.class.getClassLoader().getResource("ingestionJobSpecTemplate.yaml").getFile(), context);
+        GroovyTemplateUtils.class.getClassLoader().getResource("ingestionJobSpecTemplate.yaml").getFile(), null,
+        context);
     Assert.assertEquals(spec.getInputDirURI(), "file:///path/to/input/2020/05/06");
     Assert.assertEquals(spec.getOutputDirURI(), "file:///path/to/output/2020/05/06");
+  }
+
+  @Test
+  public void testIngestionJobLauncherWithTemplateAndPropertyFile()
+      throws IOException, ClassNotFoundException {
+    SegmentGenerationJobSpec spec = IngestionJobLauncher.getSegmentGenerationJobSpec(
+        GroovyTemplateUtils.class.getClassLoader().getResource("ingestionJobSpecTemplate.yaml").getFile(),
+        GroovyTemplateUtils.class.getClassLoader().getResource("job.config").getFile(), null);
+    Assert.assertEquals(spec.getInputDirURI(), "file:///path/to/input/2019/06/07");
+    Assert.assertEquals(spec.getOutputDirURI(), "file:///path/to/output/2019/06/07");
+  }
+
+  @Test
+  public void testIngestionJobLauncherWithTemplateAndPropertyFileAndValueOverride()
+      throws IOException, ClassNotFoundException {
+    Map<String, Object> context = GroovyTemplateUtils.getTemplateContext(Arrays.asList("year=2020"));
+    SegmentGenerationJobSpec spec = IngestionJobLauncher.getSegmentGenerationJobSpec(
+        GroovyTemplateUtils.class.getClassLoader().getResource("ingestionJobSpecTemplate.yaml").getFile(),
+        GroovyTemplateUtils.class.getClassLoader().getResource("job.config").getFile(), context);
+    Assert.assertEquals(spec.getInputDirURI(), "file:///path/to/input/2020/06/07");
+    Assert.assertEquals(spec.getOutputDirURI(), "file:///path/to/output/2020/06/07");
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/GroovyTemplateUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/GroovyTemplateUtilsTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+import org.apache.commons.io.IOUtils;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.yaml.snakeyaml.Yaml;
+
+
+public class GroovyTemplateUtilsTest {
+
+  @Test
+  public void testDefaultRenderTemplate()
+      throws IOException, ClassNotFoundException {
+    Date today = new Date(Instant.now().toEpochMilli());
+    Date yesterday = new Date(Instant.now().minus(1, ChronoUnit.DAYS).toEpochMilli());
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    Assert.assertEquals(GroovyTemplateUtils.renderTemplate("${ today }"), dateFormat.format(today));
+    Assert.assertEquals(GroovyTemplateUtils.renderTemplate("${ yesterday }"), dateFormat.format(yesterday));
+  }
+
+  @Test
+  public void testRenderTemplateWithGivenContextMap()
+      throws IOException, ClassNotFoundException {
+    Map<String, Object> contextMap = new HashMap<>();
+    contextMap.put("first_date_2020", "2020-01-01");
+    contextMap.put("name", "xiang");
+    contextMap.put("ts", 1577836800);
+    contextMap.put("yyyy", "2020");
+    contextMap.put("YYYY", "1919");
+    contextMap.put("MM", "05");
+    contextMap.put("dd", "06");
+    Assert.assertEquals(GroovyTemplateUtils.renderTemplate("$first_date_2020", contextMap), "2020-01-01");
+    Assert.assertEquals(GroovyTemplateUtils.renderTemplate("${first_date_2020}", contextMap), "2020-01-01");
+    Assert.assertEquals(GroovyTemplateUtils.renderTemplate("${ name }", contextMap), "xiang");
+    Assert.assertEquals(GroovyTemplateUtils.renderTemplate("${ ts }", contextMap), "1577836800");
+    Assert.assertEquals(GroovyTemplateUtils.renderTemplate("/var/rawdata/${ yyyy }/${ MM }/${ dd }", contextMap),
+        "/var/rawdata/2020/05/06");
+    Assert.assertEquals(GroovyTemplateUtils.renderTemplate("/var/rawdata/${yyyy}/${MM}/${dd}", contextMap),
+        "/var/rawdata/2020/05/06");
+    Assert.assertEquals(GroovyTemplateUtils.renderTemplate("/var/rawdata/${YYYY}/${MM}/${dd}", contextMap),
+        "/var/rawdata/1919/05/06");
+  }
+
+  @Test
+  public void testIngestionJobTemplate()
+      throws IOException, ClassNotFoundException {
+    InputStream resourceAsStream =
+        GroovyTemplateUtils.class.getClassLoader().getResourceAsStream("ingestionJobSpecTemplate.yaml");
+    String yamlTemplate = IOUtils.toString(resourceAsStream);
+    Map<String, Object> context =
+        GroovyTemplateUtils.getTemplateContext(Arrays.asList("year=2020", "month=05", "day=06"));
+    String yamlStr = GroovyTemplateUtils.renderTemplate(yamlTemplate, context);
+    SegmentGenerationJobSpec spec = new Yaml().loadAs(yamlStr, SegmentGenerationJobSpec.class);
+    Assert.assertEquals(spec.getInputDirURI(), "file:///path/to/input/2020/05/06");
+    Assert.assertEquals(spec.getOutputDirURI(), "file:///path/to/output/2020/05/06");
+  }
+}

--- a/pinot-spi/src/test/resources/ingestionJobSpecTemplate.yaml
+++ b/pinot-spi/src/test/resources/ingestionJobSpecTemplate.yaml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+executionFrameworkSpec:
+  name: 'standalone'
+  segmentGenerationJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentGenerationJobRunner'
+  segmentTarPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentTarPushJobRunner'
+  segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
+jobType: SegmentCreationAndTarPush
+inputDirURI: 'file:///path/to/input/${ year }/${ month }/${ day }'
+includeFileNamePattern: 'glob:**/*.parquet'
+excludeFileNamePattern: 'glob:**/*.avro'
+outputDirURI: 'file:///path/to/output/${year}/${month}/${day}'
+overwriteOutput: true
+pinotFSSpecs:
+  - scheme: file
+    className: org.apache.pinot.spi.filesystem.LocalPinotFS
+recordReaderSpec:
+  dataFormat: 'parquet'
+  className: 'org.apache.pinot.parquet.data.readers.ParquetRecordReader'
+tableSpec:
+  tableName: 'myTable'
+  schemaURI: 'http://localhost:9000/tables/myTable/schema'
+  tableConfigURI: 'http://localhost:9000/tables/myTable'
+pinotClusterSpecs:
+  - controllerURI: 'localhost:9000'
+pushJobSpec:
+  pushAttempts: 2
+  pushRetryIntervalMillis: 1000

--- a/pinot-spi/src/test/resources/job.config
+++ b/pinot-spi/src/test/resources/job.config
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+year=2019
+month=06
+day=07

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -18,10 +18,11 @@
  */
 package org.apache.pinot.tools.admin.command;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.apache.pinot.spi.utils.GroovyTemplateUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.spi.StringArrayOptionHandler;
@@ -35,29 +36,63 @@ import org.slf4j.LoggerFactory;
  */
 public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(LaunchDataIngestionJobCommand.class);
-
-  @Option(name = "-jobSpecFile", required = true, metaVar = "<string>", usage = "Ingestion job spec file")
-  private String _jobSpecFile;
-
-  @Option(name = "-values", required = false, metaVar = "<template context>", handler = StringArrayOptionHandler.class, usage = "Context values set to the job spec template")
-  private List<String> _values;
-
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
+  @Option(name = "-jobSpecFile", required = true, metaVar = "<string>", usage = "Ingestion job spec file")
+  private String _jobSpecFile;
+  @Option(name = "-values", required = false, metaVar = "<template context>", handler = StringArrayOptionHandler.class, usage = "Context values set to the job spec template")
+  private List<String> _values;
+  @Option(name = "-propertyFile", required = false, metaVar = "<template context file>", usage = "A property file contains context values to set the job spec template")
+  private String _propertyFile;
+
+  public String getJobSpecFile() {
+    return _jobSpecFile;
+  }
+
+  public void setJobSpecFile(String jobSpecFile) {
+    _jobSpecFile = jobSpecFile;
+  }
+
+  public List<String> getValues() {
+    return _values;
+  }
+
+  public void setValues(List<String> values) {
+    _values = values;
+  }
+
+  public String getPropertyFile() {
+    return _propertyFile;
+  }
+
+  public void setPropertyFile(String propertyFile) {
+    _propertyFile = propertyFile;
+  }
 
   @Override
   public boolean getHelp() {
     return _help;
   }
 
+  public void setHelp(boolean help) {
+    _help = help;
+  }
+
   @Override
   public boolean execute()
       throws Exception {
+    String jobSpecFilePath = _jobSpecFile;
+    String propertyFilePath = _propertyFile;
+    SegmentGenerationJobSpec spec;
     try {
-      List<String> arguments = new ArrayList();
-      arguments.add(_jobSpecFile);
-      arguments.addAll(_values);
-      IngestionJobLauncher.main(arguments.toArray(new String[0]));
+      spec = IngestionJobLauncher.getSegmentGenerationJobSpec(jobSpecFilePath, propertyFilePath,
+          GroovyTemplateUtils.getTemplateContext(_values));
+    } catch (Exception e) {
+      LOGGER.error("Got exception to generate IngestionJobSpec for data ingestion job - ", e);
+      throw e;
+    }
+    try {
+      IngestionJobLauncher.runIngestionJob(spec);
     } catch (Exception e) {
       LOGGER.error("Got exception to kick off standalone data ingestion job - ", e);
       throw e;
@@ -72,7 +107,8 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
 
   @Override
   public String toString() {
-    return ("LaunchDataIngestionJob -jobSpecFile " + _jobSpecFile + " -values " + Arrays.toString(_values.toArray()));
+    return ("LaunchDataIngestionJob -jobSpecFile " + _jobSpecFile + " -propertyFile " + _propertyFile + " -values "
+        + Arrays.toString(_values.toArray()));
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -18,9 +18,13 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +39,9 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
   @Option(name = "-jobSpecFile", required = true, metaVar = "<string>", usage = "Ingestion job spec file")
   private String _jobSpecFile;
 
+  @Option(name = "-values", required = false, metaVar = "<template context>", handler = StringArrayOptionHandler.class, usage = "Context values set to the job spec template")
+  private List<String> _values;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -47,9 +54,12 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
   public boolean execute()
       throws Exception {
     try {
-      IngestionJobLauncher.main(new String[]{_jobSpecFile});
+      List<String> arguments = new ArrayList();
+      arguments.add(_jobSpecFile);
+      arguments.addAll(_values);
+      IngestionJobLauncher.main(arguments.toArray(new String[0]));
     } catch (Exception e) {
-      LOGGER.error("Got exception to kick off standalone data ingestion job -", e);
+      LOGGER.error("Got exception to kick off standalone data ingestion job - ", e);
       throw e;
     }
     return true;
@@ -62,7 +72,7 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
 
   @Override
   public String toString() {
-    return ("LaunchDataIngestionJob -jobSpecFile " + _jobSpecFile);
+    return ("LaunchDataIngestionJob -jobSpecFile " + _jobSpecFile + " -values " + Arrays.toString(_values.toArray()));
   }
 
   @Override


### PR DESCRIPTION
This is the re-work of https://github.com/apache/incubator-pinot/issues/5330, as the previous PR #5341 is reverted in #5366.

Templating is based on [Groovy SimpleTemplateEngine](https://docs.groovy-lang.org/docs/next/html/documentation/template-engines.html).

we need to support Pinot Ingestion job take an ingestion job spec template file and passing thru values.

This will make user to schedule daily job simpler, without generating new yaml file everyday.

- Adding groovy template render support for Pinot.
- Adding `-propertyFile` parameter in `LaunchDataIngestionJobCommand` (in format of 'k1=v1' 'k2=v2'...) which will be the context to set in the template.
- Adding `-values` parameter in `LaunchDataIngestionJobCommand` which takes a list of parameters(in format of 'k1=v1' 'k2=v2'...) that will override the context read from the `propertyFile` and set to the template.
- The template ingestion spec file will be rendered to final ingestion spec with the given context values.
- Adding support for default values `today`, `yesterday` into context for dev simplicity.

Usage example:
User can define `inputDirURI` as `'file:///path/to/input/${year}/${month}/${day}/${hour}'`
in job spec and a config file `job.config` contains:
```
year=2020
month=05
day=01
hour=00
```
Then the new command line is :
```
bin/pinot-admin.sh LaunchDataIngestionJob  \
-jobSpecFile ingestionJobSpec.yaml \
-propertyFile job.confg \
-values day=06 hour=07
```
After that the real ingestion spec passed to ingestion job will have `inputDirURI` as `'file:///path/to/input/2020/05/06/07'`
