### PR TITLE
Fix in PluginManagerTest to fail if TestRecordReader cannot be compiled.

### DIFF
--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
@@ -36,6 +36,8 @@ import org.testng.annotations.Test;
 
 public class PluginManagerTest {
 
+  private final String TEST_RECORD_READER_FILE = "TestRecordReader.java";
+
   private File tempDir;
   private String jarFile;
   private File jarDirFile;
@@ -57,9 +59,10 @@ public class PluginManagerTest {
   public void testSimple()
       throws Exception {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-    URL javaFile = Thread.currentThread().getContextClassLoader().getResource("TestRecordReader.java");
+    URL javaFile = Thread.currentThread().getContextClassLoader().getResource(TEST_RECORD_READER_FILE);
     if (javaFile != null) {
-      compiler.run(null, null, null, javaFile.getFile(), "-d", tempDir.getAbsolutePath());
+      int compileStatus = compiler.run(null, null, null, javaFile.getFile(), "-d", tempDir.getAbsolutePath());
+      Assert.assertTrue(compileStatus == 0, "Error when compiling resource: " + TEST_RECORD_READER_FILE);
 
       URL classFile = Thread.currentThread().getContextClassLoader().getResource("TestRecordReader.class");
 

--- a/pinot-spi/src/test/resources/TestRecordReader.java
+++ b/pinot-spi/src/test/resources/TestRecordReader.java
@@ -20,11 +20,9 @@ public class TestRecordReader implements RecordReader {
 
   List<GenericRow> _rows = new ArrayList<>();
   Iterator<GenericRow> _iterator;
-  Schema _schema;
 
-  public void init(File dataFile, Schema schema, @Nullable RecordReaderConfig recordReaderConfig, Set<String> fields)
+  public void init(File dataFile, Set<String> fields, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
-    _schema = schema;
     int numRows = 10;
     for (int i = 0; i < numRows; i++) {
       GenericRow row = new GenericRow();
@@ -53,10 +51,7 @@ public class TestRecordReader implements RecordReader {
     _iterator = _rows.iterator();
   }
 
-  public Schema getSchema() {
-    return _schema;
-  }
-  public void close () {
+  public void close() {
 
   }
 }


### PR DESCRIPTION
With a recent change in RecordReader interface, two issues where exposed:

1. TestRecordReader.java that implements the interface was not updated as it is under
   the resources directory, so it is not compiled (and hence does not lead to build failures).

2. It is read in as a resource inside of PluginManagerTest that compiles the file, which should
   have caught the compile issue, however, the test simply ignores the compile error and ends
   up passing (incorrectly).

This PR fixes the issue in PluginManagerTest to ensure that compile errors in TestRecordReader.java
are caught when the test is run, thus solving both problems.