### PR TITLE
Handling a no-arg function in query parsing and expression tree

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/transform/TransformExpressionTree.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/transform/TransformExpressionTree.java
@@ -89,8 +89,10 @@ public class TransformExpressionTree {
       _expressionType = ExpressionType.FUNCTION;
       _value = ((FunctionCallAstNode) root).getName().toLowerCase();
       _children = new ArrayList<>();
-      for (AstNode child : root.getChildren()) {
-        _children.add(new TransformExpressionTree(child));
+      if(root.hasChildren()) {
+        for (AstNode child : root.getChildren()) {
+          _children.add(new TransformExpressionTree(child));
+        }
       }
     } else if (root instanceof IdentifierAstNode) {
       _expressionType = ExpressionType.IDENTIFIER;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -55,6 +55,7 @@ import org.apache.pinot.common.utils.request.RequestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 public class CalciteSqlParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CalciteSqlParser.class);
@@ -291,7 +292,7 @@ public class CalciteSqlParser {
         throw new RuntimeException(
             "Unable to convert SqlNode: " + sqlNode + " to PinotQuery. Unknown node type: " + sqlNode.getKind());
     }
-    queryReWrite(pinotQuery);
+    queryRewrite(pinotQuery);
     return pinotQuery;
   }
 
@@ -307,7 +308,7 @@ public class CalciteSqlParser {
     return SqlParser.create(sql, parserBuilder.build());
   }
 
-  private static void queryReWrite(PinotQuery pinotQuery) {
+  private static void queryRewrite(PinotQuery pinotQuery) {
     // Update Predicate Comparison
     if (pinotQuery.isSetFilterExpression()) {
       Expression filterExpression = pinotQuery.getFilterExpression();
@@ -361,8 +362,10 @@ public class CalciteSqlParser {
         default:
           List<Expression> operands = functionCall.getOperands();
           List<Expression> newOperands = new ArrayList<>();
-          for (int i = 0; i < operands.size(); i++) {
-            newOperands.add(updateComparisonPredicate(operands.get(i)));
+          if (operands != null) {
+            for (int i = 0; i < operands.size(); i++) {
+              newOperands.add(updateComparisonPredicate(operands.get(i)));
+            }
           }
           functionCall.setOperands(newOperands);
       }
@@ -590,8 +593,9 @@ public class CalciteSqlParser {
         if (funcSqlNode.getOperator().getKind() == SqlKind.OTHER_FUNCTION) {
           funcName = funcSqlNode.getOperator().getName();
         }
-        if (funcName.equalsIgnoreCase(SqlKind.COUNT.toString()) && (funcSqlNode.getFunctionQuantifier() != null) && funcSqlNode
-            .getFunctionQuantifier().toValue().equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
+        if (funcName.equalsIgnoreCase(SqlKind.COUNT.toString()) && (funcSqlNode.getFunctionQuantifier() != null)
+            && funcSqlNode.getFunctionQuantifier().toValue()
+            .equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
           funcName = AggregationFunctionType.DISTINCTCOUNT.getName();
         }
         final Expression funcExpr = RequestUtils.getFunctionExpression(funcName);

--- a/pinot-common/src/test/java/org/apache/pinot/common/request/transform/TransformExpressionTreeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/request/transform/TransformExpressionTreeTest.java
@@ -99,6 +99,15 @@ public class TransformExpressionTreeTest {
     Assert.assertTrue(equalsWithStandardExpressionTree(TransformExpressionTree.compileToExpressionTree(expression)));
   }
 
+  @Test
+  public void testNoArgFunction() {
+    String expression = "now()";
+    TransformExpressionTree expressionTree = TransformExpressionTree.compileToExpressionTree(expression);
+    Assert.assertEquals(expressionTree.isFunction(), true);
+    Assert.assertEquals(expressionTree.getValue(), "now");
+    Assert.assertEquals(expressionTree.getChildren().size(), 0);
+  }
+
   private static boolean equalsWithStandardExpressionTree(TransformExpressionTree expressionTree) {
     return expressionTree.hashCode() == STANDARD_EXPRESSION_TREE.hashCode() && expressionTree
         .equals(STANDARD_EXPRESSION_TREE) && expressionTree.toString().equals(STANDARD_EXPRESSION);

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1467,4 +1467,21 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "distinct_bar");
   }
+
+  @Test
+  public void testNoArgFunction() {
+    String query = "SELECT now() FROM foo ";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "now");
+
+    query = "SELECT a FROM foo where time_col > now()";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    Function greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
+    Function minus = greaterThan.getOperands().get(0).getFunctionCall();
+    Assert.assertEquals(minus.getOperands().get(1).getFunctionCall().getOperator(), "now");
+
+    query = "SELECT sum(a), now() FROM foo group by now()";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "now");
+  }
 }


### PR DESCRIPTION
```select * from T where t > now()``` fails since we expect arguments. This PR fixes the parsing in calcite SQL and transform expression tree.