### PR TITLE
Fix PerfBenchmarkDriver on uploading/downloading segments

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.api.upload;
 
 import java.io.File;
 import java.net.URI;
+import javax.annotation.Nullable;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.helix.ZNRecord;
@@ -59,7 +60,7 @@ public class ZKOperator {
 
   public void completeSegmentOperations(String rawTableName, SegmentMetadata segmentMetadata,
       URI finalSegmentLocationURI, File currentSegmentLocation, boolean enableParallelPushProtection,
-      HttpHeaders headers, String zkDownloadURI, boolean moveSegmentToFinalLocation)
+      @Nullable HttpHeaders headers, String zkDownloadURI, boolean moveSegmentToFinalLocation)
       throws Exception {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
     String segmentName = segmentMetadata.getName();
@@ -69,7 +70,7 @@ public class ZKOperator {
         _pinotHelixResourceManager.getSegmentMetadataZnRecord(offlineTableName, segmentName);
     if (segmentMetadataZnRecord == null) {
       LOGGER.info("Adding new segment {} from table {}", segmentName, rawTableName);
-      String crypter = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER);
+      String crypter = headers != null ? headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER) : null;
       processNewSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation, zkDownloadURI, crypter,
           rawTableName, segmentName, moveSegmentToFinalLocation);
       return;
@@ -202,7 +203,7 @@ public class ZKOperator {
   }
 
   private void processNewSegment(SegmentMetadata segmentMetadata, URI finalSegmentLocationURI,
-      File currentSegmentLocation, String zkDownloadURI, String crypter, String rawTableName, String segmentName,
+      File currentSegmentLocation, String zkDownloadURI, @Nullable String crypter, String rawTableName, String segmentName,
       boolean moveSegmentToFinalLocation) {
     // For v1 segment uploads, we will not move the segment
     if (moveSegmentToFinalLocation) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
@@ -104,7 +104,7 @@ public class BenchmarkQueryEngine {
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segmentDir);
       _perfBenchmarkDriver.configureTable(TABLE_NAME);
       System.out.println("Adding segment " + segmentDir.getAbsolutePath());
-      _perfBenchmarkDriver.addSegment(TABLE_NAME, segmentMetadata);
+      _perfBenchmarkDriver.addSegment(TABLE_NAME, segmentDir, segmentMetadata);
     }
 
     ZkClient client = new ZkClient("localhost:2191", 10000, 10000, new ZNRecordSerializer());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -166,7 +166,7 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
         driver.configureTable(tableName, invertedIndexColumns, bloomFilterColumns);
         tableConfigured = true;
       }
-      driver.addSegment(tableName, segmentMetadata);
+      driver.addSegment(tableName, segment, segmentMetadata);
     }
   }
 


### PR DESCRIPTION
This PR fixes PerfBenchmarkDriver on uploading/downloading segments.

The current PerfBenchmarkDriver didn't upload segments to deep storage. And the zk download url is wrong.