### PR TITLE
Temporary work-around to bypass function arguments being treated as expressions with columns.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
@@ -94,7 +94,15 @@ public class ServerQueryRequest {
     if (aggregationsInfo != null) {
       _aggregationExpressions = new HashSet<>();
       for (AggregationInfo aggregationInfo : aggregationsInfo) {
-        if (!aggregationInfo.getAggregationType().equalsIgnoreCase(AggregationFunctionType.COUNT.getName())) {
+        String aggregationType = aggregationInfo.getAggregationType();
+
+        // TODO: Remove special casing of theta-sketch.
+        // This is needed as a work-around because only aggregation functions know how to interpret the expressions.
+        // The code below assumes that all expressions have columns in them, which may not be true. But only Aggregation
+        // functions have that knowledge, and have not been instantiated yet. A clean fix would be to instantiate
+        // aggregation functions upfront to interpret the expressions.
+        if (!aggregationType.equalsIgnoreCase(AggregationFunctionType.COUNT.getName()) && !aggregationType
+            .equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNTTHETASKETCH.getName())) {
           for (String expressions : AggregationFunctionUtils.getArguments(aggregationInfo)) {
             _aggregationExpressions.add(TransformExpressionTree.compileToExpressionTree(expressions));
           }
@@ -131,7 +139,6 @@ public class ServerQueryRequest {
       }
       _selectionColumns = RequestUtils.extractColumnsFromExpressions(_selectionExpressions);
       _allColumns.addAll(_selectionColumns);
-
     } else {
       _selectionColumns = null;
       _selectionExpressions = null;


### PR DESCRIPTION
Only aggregation functions have the knowledge on how to interpret their arguments.
However, the assumption within ServerQueryRequest is that all expression arguments will contain
columns to be collected. A clean fix would be to create aggregation functions upfront and let
them interpret the arguments. However, until that happens, working-around by assuming that first
argument contains all the columns (to be used by DataSchemaPruner), which is true for all functions.

A side effect would be that DataSchemaPruner won't work for DistinctCountThetaSketchAggregatinoFunction.
But since this pruner is only for schema mis-matches, and not for performance, there should not be
an impact.