### PR TITLE
Initialize ControllerFilePathProvider in PerfBenchmarkDriver

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
@@ -27,6 +27,7 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.pinot.broker.requesthandler.OptimizationFlags;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.controller.api.resources.ControllerFilePathProvider;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.tools.perf.PerfBenchmarkDriver;
 import org.apache.pinot.tools.perf.PerfBenchmarkDriverConf;
@@ -98,6 +99,7 @@ public class BenchmarkQueryEngine {
     conf.setConfigureResources(false);
     _perfBenchmarkDriver = new PerfBenchmarkDriver(conf);
     _perfBenchmarkDriver.run();
+    ControllerFilePathProvider.init(_perfBenchmarkDriver.getControllerConf());
 
     File[] segments = new File(DATA_DIRECTORY, TABLE_NAME).listFiles();
     for (File segmentDir : segments) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -204,7 +204,7 @@ public class PerfBenchmarkDriver {
     _controllerStarter.start();
   }
 
-  private ControllerConf getControllerConf() {
+  public ControllerConf getControllerConf() {
     ControllerConf conf = new ControllerConf();
     conf.setHelixClusterName(_clusterName);
     conf.setZkStr(_zkAddress);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.controller.api.resources.ControllerFilePathProvider;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.Command;
@@ -160,6 +161,7 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
     boolean tableConfigured = false;
     File[] segments = new File(dataDir, tableName).listFiles();
     Preconditions.checkNotNull(segments);
+    ControllerFilePathProvider.init(driver.getControllerConf());
     for (File segment : segments) {
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segment);
       if (!tableConfigured) {


### PR DESCRIPTION
This PR initializes ControllerFilePathProvider:
```
Exception in thread "main" java.lang.IllegalStateException: ControllerFilePathProvider has not been initialized
	at com.google.common.base.Preconditions.checkState(Preconditions.java:444)
	at org.apache.pinot.controller.api.resources.ControllerFilePathProvider.getInstance(ControllerFilePathProvider.java:53)
	at org.apache.pinot.tools.perf.PerfBenchmarkDriver.addSegment(PerfBenchmarkDriver.java:332)
	at org.apache.pinot.tools.perf.PerfBenchmarkRunner.loadTable(PerfBenchmarkRunner.java:169)
	at org.apache.pinot.tools.perf.PerfBenchmarkRunner.startServerWithPreLoadedSegments(PerfBenchmarkRunner.java:152)
	at org.apache.pinot.tools.perf.PerfBenchmarkRunner.execute(PerfBenchmarkRunner.java:99)
```