### PR TITLE
Set `pinot.server.netty.host` from PerfBenchmarkDriver to avoid using NetUtils.getHostAddress().

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -237,6 +237,7 @@ public class PerfBenchmarkDriver {
     serverConfiguration.addProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_DATA_DIR, _serverInstanceDataDir);
     serverConfiguration
         .addProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, _serverInstanceSegmentTarDir);
+    serverConfiguration.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, "localhost");
     if (_segmentFormatVersion != null) {
       serverConfiguration.setProperty(CommonConstants.Server.CONFIG_OF_SEGMENT_FORMAT_VERSION, _segmentFormatVersion);
     }


### PR DESCRIPTION
If `pinot.server.netty.host` is not explictly set, the HELIX_HOST in instance config gets
overwritten by a value returned by `NetUtils.getHostAddress()`, which depending on internet/firewall
may return an addresses that cannot be connected to. Explicitly setting this to `localhost` solves
the issue.