### PR TITLE
Clean slate on every quickstart run

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -115,16 +115,16 @@ public class Quickstart {
 
   public void execute()
       throws Exception {
-    final File quickStartDataDir = new File("quickStartData" + System.currentTimeMillis());
+    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File configDir = new File(quickstartTmpDir, "configs");
+    File dataDir = new File(quickstartTmpDir, "data");
+    Preconditions.checkState(configDir.mkdirs());
+    Preconditions.checkState(dataDir.mkdirs());
 
-    if (!quickStartDataDir.exists()) {
-      Preconditions.checkState(quickStartDataDir.mkdirs());
-    }
-
-    File schemaFile = new File(quickStartDataDir, "baseballStats_schema.json");
-    File dataFile = new File(quickStartDataDir, "baseballStats_data.csv");
-    File tableConfigFile = new File(quickStartDataDir, "baseballStats_offline_table_config.json");
-    File ingestionJobSpecFile = new File(quickStartDataDir, "ingestionJobSpec.yaml");
+    File schemaFile = new File(configDir, "baseballStats_schema.json");
+    File dataFile = new File(configDir, "baseballStats_data.csv");
+    File tableConfigFile = new File(configDir, "baseballStats_offline_table_config.json");
+    File ingestionJobSpecFile = new File(configDir, "ingestionJobSpec.yaml");
 
     ClassLoader classLoader = Quickstart.class.getClassLoader();
     URL resource = classLoader.getResource("examples/batch/baseballStats/baseballStats_schema.json");
@@ -140,11 +140,9 @@ public class Quickstart {
     com.google.common.base.Preconditions.checkNotNull(resource);
     FileUtils.copyURLToFile(resource, tableConfigFile);
 
-    File tempDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
-    Preconditions.checkState(tempDir.mkdirs());
     QuickstartTableRequest request =
-        new QuickstartTableRequest("baseballStats", schemaFile, tableConfigFile, ingestionJobSpecFile, quickStartDataDir, FileFormat.CSV);
-    final QuickstartRunner runner = new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, tempDir);
+        new QuickstartTableRequest("baseballStats", schemaFile, tableConfigFile, ingestionJobSpecFile, FileFormat.CSV);
+    final QuickstartRunner runner = new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, dataDir);
 
     printStatus(Color.CYAN, "***** Starting Zookeeper, controller, broker and server *****");
     runner.startAll();
@@ -161,7 +159,7 @@ public class Quickstart {
         try {
           printStatus(Color.GREEN, "***** Shutting down offline quick start *****");
           runner.stop();
-          FileUtils.deleteDirectory(quickStartDataDir);
+          FileUtils.deleteDirectory(quickstartTmpDir);
         } catch (Exception e) {
           e.printStackTrace();
         }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickstartTableRequest.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickstartTableRequest.java
@@ -28,16 +28,14 @@ public class QuickstartTableRequest {
   File schemaFile;
   File tableRequestFile;
   File ingestionJobFile;
-  File dataDir;
   TableType tableType;
   String tableName;
   FileFormat segmentFileFormat = FileFormat.CSV;
 
-  public QuickstartTableRequest(String tableName, File schemaFile, File tableRequest, File ingestionJobFile, File dataDir,
+  public QuickstartTableRequest(String tableName, File schemaFile, File tableRequest, File ingestionJobFile,
       FileFormat segmentFileFormat) {
     this.tableName = tableName;
     this.schemaFile = schemaFile;
-    this.dataDir = dataDir;
     this.tableRequestFile = tableRequest;
     tableType = TableType.OFFLINE;
     this.segmentFileFormat = segmentFileFormat;
@@ -81,14 +79,6 @@ public class QuickstartTableRequest {
 
   public void setIngestionJobFile(File ingestionJobFile) {
     this.ingestionJobFile = ingestionJobFile;
-  }
-
-  public File getDataDir() {
-    return dataDir;
-  }
-
-  public void setDataDir(File dataDir) {
-    this.dataDir = dataDir;
   }
 
   public TableType getTableType() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -47,14 +47,14 @@ public class RealtimeQuickStart {
 
   public void execute()
       throws Exception {
-    final File quickStartDataDir = new File("quickStartData" + System.currentTimeMillis());
+    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File configDir = new File(quickstartTmpDir, "configs");
+    File dataDir = new File(quickstartTmpDir, "data");
+    Preconditions.checkState(configDir.mkdirs());
+    Preconditions.checkState(dataDir.mkdirs());
 
-    if (!quickStartDataDir.exists()) {
-      Preconditions.checkState(quickStartDataDir.mkdirs());
-    }
-
-    File schemaFile = new File(quickStartDataDir, "meetupRsvp_schema.json");
-    File tableConfigFile = new File(quickStartDataDir, "meetupRsvp_realtime_table_config.json");
+    File schemaFile = new File(configDir, "meetupRsvp_schema.json");
+    File tableConfigFile = new File(configDir, "meetupRsvp_realtime_table_config.json");
 
     ClassLoader classLoader = Quickstart.class.getClassLoader();
     URL resource = classLoader.getResource("examples/stream/meetupRsvp/meetupRsvp_schema.json");
@@ -64,10 +64,8 @@ public class RealtimeQuickStart {
     com.google.common.base.Preconditions.checkNotNull(resource);
     FileUtils.copyURLToFile(resource, tableConfigFile);
 
-    File tempDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
-    Preconditions.checkState(tempDir.mkdirs());
     QuickstartTableRequest request = new QuickstartTableRequest("meetupRsvp", schemaFile, tableConfigFile);
-    final QuickstartRunner runner = new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, tempDir);
+    final QuickstartRunner runner = new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, dataDir);
 
     printStatus(Color.CYAN, "***** Starting Kafka *****");
     final ZkStarter.ZookeeperInstance zookeeperInstance = ZkStarter.startLocalZkServer();
@@ -98,7 +96,7 @@ public class RealtimeQuickStart {
           runner.stop();
           _kafkaStarter.stop();
           ZkStarter.stopLocalZkServer(zookeeperInstance);
-          FileUtils.deleteDirectory(quickStartDataDir);
+          FileUtils.deleteDirectory(quickstartTmpDir);
         } catch (Exception e) {
           e.printStackTrace();
         }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -51,6 +51,11 @@ public class QuickstartRunner {
   private static final int DEFAULT_BROKER_PORT = 8000;
   private static final int DEFAULT_CONTROLLER_PORT = 9000;
 
+  private static final String DEFAULT_ZK_DIR = "PinotZkDir";
+  private static final String DEFAULT_CONTROLLER_DIR = "PinotControllerDir";
+  private static final String DEFAULT_SERVER_DATA_DIR = "PinotServerDataDir";
+  private static final String DEFAULT_SERVER_SEGMENT_DIR = "PinotServerSegmentDir";
+
   private final List<QuickstartTableRequest> _tableRequests;
   private final int _numServers;
   private final int _numBrokers;
@@ -85,6 +90,7 @@ public class QuickstartRunner {
       throws IOException {
     StartZookeeperCommand zkStarter = new StartZookeeperCommand();
     zkStarter.setPort(ZK_PORT);
+    zkStarter.setDataDir(new File(_tempDir, DEFAULT_ZK_DIR).getAbsolutePath());
     zkStarter.execute();
   }
 
@@ -93,7 +99,8 @@ public class QuickstartRunner {
     for (int i = 0; i < _numControllers; i++) {
       StartControllerCommand controllerStarter = new StartControllerCommand();
       controllerStarter.setControllerPort(String.valueOf(DEFAULT_CONTROLLER_PORT + i)).setZkAddress(ZK_ADDRESS)
-          .setClusterName(CLUSTER_NAME).setTenantIsolation(_enableTenantIsolation);
+          .setClusterName(CLUSTER_NAME).setTenantIsolation(_enableTenantIsolation)
+          .setDataDir(new File(_tempDir, DEFAULT_CONTROLLER_DIR + i).getAbsolutePath());
       controllerStarter.execute();
       _controllerPorts.add(DEFAULT_CONTROLLER_PORT + i);
     }
@@ -115,8 +122,8 @@ public class QuickstartRunner {
       StartServerCommand serverStarter = new StartServerCommand();
       serverStarter.setPort(DEFAULT_SERVER_NETTY_PORT + i).setAdminPort(DEFAULT_SERVER_ADMIN_API_PORT + i)
           .setZkAddress(ZK_ADDRESS).setClusterName(CLUSTER_NAME)
-          .setDataDir(new File(_tempDir, "PinotServerData" + i).getAbsolutePath())
-          .setSegmentDir(new File(_tempDir, "PinotServerSegment" + i).getAbsolutePath());
+          .setDataDir(new File(_tempDir, DEFAULT_SERVER_DATA_DIR + i).getAbsolutePath())
+          .setSegmentDir(new File(_tempDir, DEFAULT_SERVER_SEGMENT_DIR + i).getAbsolutePath());
       serverStarter.execute();
     }
   }


### PR DESCRIPTION
Using tmp dir generated within quickstart (which has a timestamp) as the directory for the zk, controller and server, instead of the default. This will ensure we have a clean slate for every quickstart run.