### PR TITLE
Do not release the PinotDataBuffer when closing the index

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/FixedBitMultiValueReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/FixedBitMultiValueReader.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.io.reader.impl.v1;
 
-import java.io.IOException;
 import org.apache.pinot.core.io.reader.BaseSingleColumnMultiValueReader;
 import org.apache.pinot.core.io.reader.ReaderContext;
 import org.apache.pinot.core.io.util.FixedBitIntReaderWriter;
@@ -49,7 +48,6 @@ import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 public final class FixedBitMultiValueReader extends BaseSingleColumnMultiValueReader<FixedBitMultiValueReader.Context> {
   private static final int PREFERRED_NUM_VALUES_PER_CHUNK = 2048;
 
-  private final PinotDataBuffer _dataBuffer;
   private final FixedByteValueReaderWriter _chunkOffsetReader;
   private final PinotDataBitSet _bitmapReader;
   private final FixedBitIntReaderWriter _rawDataReader;
@@ -58,7 +56,6 @@ public final class FixedBitMultiValueReader extends BaseSingleColumnMultiValueRe
   private final int _numRowsPerChunk;
 
   public FixedBitMultiValueReader(PinotDataBuffer dataBuffer, int numRows, int numValues, int numBitsPerValue) {
-    _dataBuffer = dataBuffer;
     _numRows = numRows;
     _numValues = numValues;
     _numRowsPerChunk = (int) (Math.ceil((float) PREFERRED_NUM_VALUES_PER_CHUNK / (numValues / numRows)));
@@ -140,12 +137,12 @@ public final class FixedBitMultiValueReader extends BaseSingleColumnMultiValueRe
   }
 
   @Override
-  public void close()
-      throws IOException {
+  public void close() {
+    // NOTE: DO NOT close the PinotDataBuffer here because it is tracked by the caller and might be reused later. The
+    // caller is responsible of closing the PinotDataBuffer.
     _chunkOffsetReader.close();
     _bitmapReader.close();
     _rawDataReader.close();
-    _dataBuffer.close();
   }
 
   public static class Context implements ReaderContext {

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/FixedBitSingleValueReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/FixedBitSingleValueReader.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.io.reader.impl.v1;
 
-import java.io.IOException;
 import org.apache.pinot.core.io.reader.BaseSingleColumnSingleValueReader;
 import org.apache.pinot.core.io.reader.ReaderContext;
 import org.apache.pinot.core.io.util.FixedBitIntReaderWriter;
@@ -56,8 +55,7 @@ public final class FixedBitSingleValueReader extends BaseSingleColumnSingleValue
   }
 
   @Override
-  public void close()
-      throws IOException {
+  public void close() {
     _reader.close();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/util/FixedBitIntReaderWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/util/FixedBitIntReaderWriter.java
@@ -20,21 +20,11 @@ package org.apache.pinot.core.io.util;
 
 import com.google.common.base.Preconditions;
 import java.io.Closeable;
-import java.io.IOException;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 
 
 public final class FixedBitIntReaderWriter implements Closeable {
-  // To deal with a multi-threading scenario in query processing threads
-  // (which are currently non-interruptible), a segment could be dropped by
-  // the parent thread and the child query thread could still be using
-  // segment memory which may have been unmapped depending on when the
-  // drop was completed. To protect against this scenario, the data buffer
-  // is made volatile and set to null in close() operation after releasing
-  // the buffer. This ensures that concurrent thread(s) trying to invoke
-  // set**() operations on this class will hit NPE as opposed accessing
-  // illegal/invalid memory (which will crash the JVM).
-  private volatile PinotDataBitSet _dataBitSet;
+  private final PinotDataBitSet _dataBitSet;
   private final int _numBitsPerValue;
 
   public FixedBitIntReaderWriter(PinotDataBuffer dataBuffer, int numValues, int numBitsPerValue) {
@@ -61,11 +51,7 @@ public final class FixedBitIntReaderWriter implements Closeable {
   }
 
   @Override
-  public void close()
-      throws IOException {
-    if (_dataBitSet != null) {
-      _dataBitSet.close();
-      _dataBitSet = null;
-    }
+  public void close() {
+    _dataBitSet.close();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/util/PinotDataBitSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/util/PinotDataBitSet.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.io.util;
 
 import java.io.Closeable;
-import java.io.IOException;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 
 
@@ -242,8 +241,8 @@ public final class PinotDataBitSet implements Closeable {
   }
 
   @Override
-  public void close()
-      throws IOException {
-    _dataBuffer.close();
+  public void close() {
+    // NOTE: DO NOT close the PinotDataBuffer here because it is tracked by the caller and might be reused later. The
+    // caller is responsible of closing the PinotDataBuffer.
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/util/ValueReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/util/ValueReader.java
@@ -18,13 +18,13 @@
  */
 package org.apache.pinot.core.io.util;
 
-import java.io.IOException;
+import java.io.Closeable;
 
 
 /**
  * Interface for value readers, which read a value at a given index.
  */
-public interface ValueReader {
+public interface ValueReader extends Closeable {
 
   int getInt(int index);
 
@@ -48,7 +48,4 @@ public interface ValueReader {
    * NOTE: Do not reuse buffer for BYTES because the return value can have variable length.
    */
   byte[] getBytes(int index, int numBytesPerValue);
-
-  void close()
-      throws IOException;
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/util/VarLengthBytesValueReaderWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/util/VarLengthBytesValueReaderWriter.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.core.io.util;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.Arrays;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
@@ -60,7 +58,7 @@ import org.apache.pinot.core.segment.memory.PinotDataBuffer;
  *
  * @see FixedByteValueReaderWriter
  */
-public class VarLengthBytesValueReaderWriter implements Closeable, ValueReader {
+public class VarLengthBytesValueReaderWriter implements ValueReader {
 
   /**
    * Magic bytes used to identify the dictionary files written in variable length bytes format.
@@ -236,8 +234,8 @@ public class VarLengthBytesValueReaderWriter implements Closeable, ValueReader {
   }
 
   @Override
-  public void close()
-      throws IOException {
-    _dataBuffer.close();
+  public void close() {
+    // NOTE: DO NOT close the PinotDataBuffer here because it is tracked by the caller and might be reused later. The
+    // caller is responsible of closing the PinotDataBuffer.
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -144,18 +144,18 @@ public class MutableOffHeapByteArrayStore implements Closeable {
       return value;
     }
 
-    @Override
-    public void close()
-        throws IOException {
-      _pinotDataBuffer.close();
-    }
-
     private int getSize() {
       return _size;
     }
 
     private int getStartIndex() {
       return _startIndex;
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+      // NOTE: DO NOT close the PinotDataBuffer here because it is tracked in the PinotDataBufferMemoryManager.
     }
   }
 
@@ -245,11 +245,9 @@ public class MutableOffHeapByteArrayStore implements Closeable {
   @Override
   public void close()
       throws IOException {
-    _numElements = 0;
     for (Buffer buffer : _buffers) {
       buffer.close();
     }
-    _buffers.clear();
   }
 
   public long getTotalOffHeapMemUsed() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.io.writer.impl.v1;
 
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/ColumnIndexContainer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/ColumnIndexContainer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.index.column;
 
+import java.io.Closeable;
 import org.apache.pinot.core.io.reader.DataFileReader;
 import org.apache.pinot.core.segment.index.readers.BloomFilterReader;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
@@ -28,7 +29,7 @@ import org.apache.pinot.core.segment.index.readers.NullValueVectorReaderImpl;
 /**
  * A container for all the indexes for a column.
  */
-public interface ColumnIndexContainer {
+public interface ColumnIndexContainer extends Closeable {
 
   /**
    * Returns the forward index for the column.

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
@@ -240,4 +240,19 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
         throw new IllegalStateException("Illegal data type for raw forward index: " + dataType);
     }
   }
+
+  @Override
+  public void close()
+      throws IOException {
+    _forwardIndex.close();
+    if (_invertedIndex != null) {
+      _invertedIndex.close();
+    }
+    if (_rangeIndex != null) {
+      _rangeIndex.close();
+    }
+    if (_dictionary != null) {
+      _dictionary.close();
+    }
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/LoaderUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/LoaderUtils.java
@@ -53,10 +53,10 @@ public class LoaderUtils {
       ColumnIndexType indexType)
       throws IOException {
     long fileLength = indexFile.length();
-    try (PinotDataBuffer buffer = segmentWriter.newIndexFor(column, indexType, fileLength)) {
-      buffer.readFrom(0, indexFile, 0, fileLength);
-      FileUtils.forceDelete(indexFile);
-    }
+    // NOTE: DO NOT close buffer here as it is managed in the SegmentDirectory.
+    PinotDataBuffer buffer = segmentWriter.newIndexFor(column, indexType, fileLength);
+    buffer.readFrom(0, indexFile, 0, fileLength);
+    FileUtils.forceDelete(indexFile);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/NullValueVectorReaderImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/NullValueVectorReaderImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
-import java.io.IOException;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
@@ -27,9 +26,8 @@ public class NullValueVectorReaderImpl implements NullValueVectorReader {
 
   private final ImmutableRoaringBitmap _nullBitmap;
 
-  public NullValueVectorReaderImpl(PinotDataBuffer nullValueVectorBuffer) throws IOException {
-    _nullBitmap = new ImmutableRoaringBitmap(nullValueVectorBuffer.toDirectByteBuffer(0,
-        (int) nullValueVectorBuffer.size()));
+  public NullValueVectorReaderImpl(PinotDataBuffer dataBuffer) {
+    _nullBitmap = new ImmutableRoaringBitmap(dataBuffer.toDirectByteBuffer(0, (int) dataBuffer.size()));
   }
 
   public boolean isNull(int docId) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
@@ -27,13 +27,10 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.core.util.CleanerUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 @ThreadSafe
 public class PinotByteBuffer extends PinotDataBuffer {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PinotByteBuffer.class);
   private final ByteBuffer _buffer;
   private final boolean _flushable;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/virtualcolumn/VirtualColumnIndexContainer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/virtualcolumn/VirtualColumnIndexContainer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.virtualcolumn;
 
+import java.io.IOException;
 import org.apache.pinot.core.io.reader.DataFileReader;
 import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
 import org.apache.pinot.core.segment.index.readers.BloomFilterReader;
@@ -69,5 +70,17 @@ public class VirtualColumnIndexContainer implements ColumnIndexContainer {
   @Override
   public NullValueVectorReaderImpl getNullValueVector() {
     return null;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _forwardIndex.close();
+    if (_invertedIndex != null) {
+      _invertedIndex.close();
+    }
+    if (_dictionary != null) {
+      _dictionary.close();
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/StarTreeV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/StarTreeV2.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.startree.v2;
 
+import java.io.Closeable;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.startree.StarTree;
 
@@ -26,7 +27,7 @@ import org.apache.pinot.core.startree.StarTree;
  * The {@code StarTreeV2} class is a wrapper on top of star-tree, its metadata, and the data sources associated
  * with it.
  */
-public interface StarTreeV2 {
+public interface StarTreeV2 extends Closeable {
 
   /**
    * Returns the {@link StarTree} data structure.

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/store/StarTreeDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/store/StarTreeDataSource.java
@@ -25,7 +25,6 @@ import org.apache.pinot.core.data.partition.PartitionFunction;
 import org.apache.pinot.core.io.reader.SingleColumnSingleValueReader;
 import org.apache.pinot.core.segment.index.datasource.BaseDataSource;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
-import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
@@ -34,7 +33,7 @@ public class StarTreeDataSource extends BaseDataSource {
 
   public StarTreeDataSource(FieldSpec fieldSpec, int numDocs, SingleColumnSingleValueReader forwardIndex,
       @Nullable Dictionary dictionary) {
-    super(new StarTreeDataSourceMetadata(fieldSpec, numDocs), forwardIndex, dictionary, null, null,null, null,
+    super(new StarTreeDataSourceMetadata(fieldSpec, numDocs), forwardIndex, dictionary, null, null, null, null,
         OPERATOR_NAME_PREFIX + fieldSpec.getName());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/store/StarTreeLoaderUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/store/StarTreeLoaderUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.startree.v2.store;
 
+import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -120,6 +121,15 @@ public class StarTreeLoaderUtils {
         @Override
         public DataSource getDataSource(String columnName) {
           return dataSourceMap.get(columnName);
+        }
+
+        @Override
+        public void close()
+            throws IOException {
+          // NOTE: Close the indexes managed by the star-tree (dictionary is managed inside the ColumnIndexContainer).
+          for (DataSource dataSource : dataSourceMap.values()) {
+            dataSource.getForwardIndex().close();
+          }
         }
       });
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/FixedIntArrayOffHeapIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/FixedIntArrayOffHeapIdMap.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.util;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.io.IOException;
 import java.util.Arrays;
-import org.apache.pinot.common.Utils;
 import org.apache.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import org.apache.pinot.core.io.readerwriter.impl.FixedByteSingleValueMultiColumnReaderWriter;
 import org.apache.pinot.core.realtime.impl.dictionary.BaseOffHeapMutableDictionary;
@@ -72,16 +71,6 @@ public class FixedIntArrayOffHeapIdMap extends BaseOffHeapMutableDictionary impl
   @Override
   public int size() {
     return length();
-  }
-
-  @Override
-  public void clear() {
-    try {
-      close();
-      init();
-    } catch (IOException e) {
-      Utils.rethrowException(e);
-    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/IdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/IdMap.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pinot.core.util;
 
+import java.io.Closeable;
+
+
 /**
  * Interface for a map from Key to auto-generated contiguous integer Id's.
  *
  * @param <Key>
  */
-public interface IdMap<Key> {
+public interface IdMap<Key> extends Closeable {
   int INVALID_ID = -1;
 
   /**
@@ -68,9 +71,4 @@ public interface IdMap<Key> {
    * @return Size of the map.
    */
   int size();
-
-  /**
-   * Clears all contents of the map.
-   */
-  void clear();
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/io/util/PinotDataBitSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/io/util/PinotDataBitSetTest.java
@@ -57,7 +57,8 @@ public class PinotDataBitSetTest {
     int[] values = new int[numValues];
     int dataBufferSize = (numValues * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
 
-    try (PinotDataBitSet dataBitSet = getEmptyBitSet(dataBufferSize)) {
+    try (PinotDataBuffer dataBuffer = getEmptyDataBuffer(dataBufferSize);
+        PinotDataBitSet dataBitSet = new PinotDataBitSet(dataBuffer)) {
       for (int i = 0; i < numValues; i++) {
         int value = RANDOM.nextInt(maxAllowedValue);
         values[i] = value;
@@ -100,8 +101,9 @@ public class PinotDataBitSetTest {
   public void testSetUnsetBit()
       throws IOException {
     int dataBufferSize = RANDOM.nextInt(100) + 1;
-    boolean bits[] = new boolean[dataBufferSize * Byte.SIZE];
-    try (PinotDataBitSet dataBitSet = getEmptyBitSet(dataBufferSize)) {
+    boolean[] bits = new boolean[dataBufferSize * Byte.SIZE];
+    try (PinotDataBuffer dataBuffer = getEmptyDataBuffer(dataBufferSize);
+        PinotDataBitSet dataBitSet = new PinotDataBitSet(dataBuffer)) {
       for (int i = 0; i < NUM_ITERATIONS; i++) {
         int bitOffset = RANDOM.nextInt(dataBufferSize * Byte.SIZE);
         if (bits[bitOffset]) {
@@ -132,7 +134,8 @@ public class PinotDataBitSetTest {
       bitOffset += RANDOM.nextInt(10) + 1;
     }
     int dataBufferSize = setBitOffsets[NUM_ITERATIONS - 1] / Byte.SIZE + 1;
-    try (PinotDataBitSet dataBitSet = getEmptyBitSet(dataBufferSize)) {
+    try (PinotDataBuffer dataBuffer = getEmptyDataBuffer(dataBufferSize);
+        PinotDataBitSet dataBitSet = new PinotDataBitSet(dataBuffer)) {
       for (int i = 0; i < NUM_ITERATIONS; i++) {
         dataBitSet.setBit(setBitOffsets[i]);
       }
@@ -154,11 +157,11 @@ public class PinotDataBitSetTest {
     }
   }
 
-  private PinotDataBitSet getEmptyBitSet(int size) {
-    PinotDataBuffer pinotDataBuffer = PinotDataBuffer.allocateDirect(size, ByteOrder.BIG_ENDIAN, null);
+  private PinotDataBuffer getEmptyDataBuffer(int size) {
+    PinotDataBuffer dataBuffer = PinotDataBuffer.allocateDirect(size, ByteOrder.BIG_ENDIAN, null);
     for (int i = 0; i < size; i++) {
-      pinotDataBuffer.readFrom(0, new byte[size]);
+      dataBuffer.readFrom(0, new byte[size]);
     }
-    return new PinotDataBitSet(pinotDataBuffer);
+    return dataBuffer;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
@@ -37,7 +37,6 @@ import org.apache.pinot.core.segment.index.converter.SegmentV1V2ToV3FormatConver
 import org.apache.pinot.core.segment.index.loader.columnminmaxvalue.ColumnMinMaxValueGeneratorMode;
 import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
-import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 import org.apache.pinot.core.segment.store.ColumnIndexType;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
 import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
@@ -379,12 +378,8 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(segmentDirectoryPath, ReadMode.mmap);
         SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
       // 8 bytes overhead is for checking integrity of the segment.
-      try (PinotDataBuffer col1Buffer = reader.getIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX)) {
-        addedLength += col1Buffer.size() + 8;
-      }
-      try (PinotDataBuffer col13Buffer = reader.getIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX)) {
-        addedLength += col13Buffer.size() + 8;
-      }
+      addedLength += reader.getIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX).size() + 8;
+      addedLength += reader.getIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX).size() + 8;
     }
     FileTime newLastModifiedTime = Files.getLastModifiedTime(singleFileIndex.toPath());
     Assert.assertTrue(newLastModifiedTime.compareTo(lastModifiedTime) > 0);

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/FixedIntArrayIdMapTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/FixedIntArrayIdMapTest.java
@@ -40,15 +40,14 @@ public class FixedIntArrayIdMapTest {
   private static final int NUM_COLUMNS = 3;
   private static final int INITIAL_CARDINALITY = 23;
   private static final int ON_HEAP_CACHE_SIZE = 10;
+  private static final Random RANDOM = new Random();
+
   private DirectMemoryManager _memoryManager;
-  private Random _random;
   private IdMap<FixedIntArray> _idMap;
 
   @BeforeClass
   public void setup() {
-    _random = new Random(System.nanoTime());
     _memoryManager = new DirectMemoryManager(FixedIntArrayIdMapTest.class.getName());
-
     _idMap = new FixedIntArrayOffHeapIdMap(INITIAL_CARDINALITY, ON_HEAP_CACHE_SIZE, NUM_COLUMNS, _memoryManager,
         FixedIntArrayIdMapTest.class.getName());
   }
@@ -56,7 +55,7 @@ public class FixedIntArrayIdMapTest {
   @AfterClass
   public void tearDown()
       throws IOException {
-    _idMap.clear();
+    _idMap.close();
     _memoryManager.close();
   }
 
@@ -71,24 +70,11 @@ public class FixedIntArrayIdMapTest {
    */
   @Test
   public void test() {
-
     BiMap<FixedIntArray, Integer> expectedMap = addValues(_idMap);
     int numValues = expectedMap.size();
 
     // Test invalid Value
     Assert.assertEquals(_idMap.getId(new FixedIntArray(new int[]{})), IdMap.INVALID_ID);
-
-    Assert.assertEquals(_idMap.size(), numValues);
-    testValues(expectedMap);
-
-    // Test the clear() api.
-    _idMap.clear();
-    Assert.assertEquals(_idMap.size(), 0);
-
-    // Test adding after clearing.
-    expectedMap.clear();
-    expectedMap = addValues(_idMap);
-    numValues = expectedMap.size();
 
     Assert.assertEquals(_idMap.size(), numValues);
     testValues(expectedMap);
@@ -111,7 +97,7 @@ public class FixedIntArrayIdMapTest {
     for (int row = 0; row < NUM_ROWS; row++) {
       int[] values = new int[NUM_COLUMNS];
       for (int col = 0; col < NUM_COLUMNS; col++) {
-        values[col] = _random.nextInt(10); // Max of 1000 unique values possible, so there will be duplicates.
+        values[col] = RANDOM.nextInt(10); // Max of 1000 unique values possible, so there will be duplicates.
       }
       FixedIntArray value = new FixedIntArray(values);
       idMap.put(value);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -193,7 +193,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   @Nullable
   protected List<String> getRangeIndexColumns() {
     return null;
-    // TODO: Fix the JVM crash then uncomment this line
+    // TODO: Fix the range index then uncomment this line
 //    return DEFAULT_RANGE_INDEX_COLUMNS;
   }
 


### PR DESCRIPTION
The PinotDataBuffers are tracked and maintained inside SegmentDirectory
for ImmutableSegment and PinotDataBufferMemoryManager for MutableSegment.
They are created when loading the indexes and released when closing the
segment. If the PinotDataBuffer gets released when closing the indexes,
and if the buffer manager decides to reuse the buffer, the following read
on the buffer will cause JVM to crash. This can be triggered in
SegmentPreProcessor when the same indexes need to be opened twice in two
different preprocessors.

This PR standardize the behavior of indexes to not release (close) the
PinotDataBuffer when closing the index.
We don't need to worry about accessing the index after it is already
closed because that is already addressed in #4764