### PR TITLE
fixing template argument if not specify values

### DIFF
--- a/docker/images/pinot/ingestion-job-specs/airlineStats.yaml
+++ b/docker/images/pinot/ingestion-job-specs/airlineStats.yaml
@@ -47,13 +47,13 @@ inputDirURI: 'examples/batch/airlineStats/rawdata'
 # includeFileNamePattern: include file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will include all the avro files under inputDirURI recursively.
 includeFileNamePattern: 'glob:**/*.avro'
 
 # excludeFileNamePattern: exclude file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will exclude all the avro files under inputDirURI recursively.
 # _excludeFileNamePattern: ''
 
 # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.

--- a/docker/images/pinot/ingestion-job-specs/baseballStats.yaml
+++ b/docker/images/pinot/ingestion-job-specs/baseballStats.yaml
@@ -47,13 +47,13 @@ inputDirURI: 'examples/batch/baseballStats/rawdata'
 # includeFileNamePattern: include file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will include all the avro files under inputDirURI recursively.
 includeFileNamePattern: 'glob:**/*.csv'
 
 # excludeFileNamePattern: exclude file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will exclude all the avro files under inputDirURI recursively.
 # _excludeFileNamePattern: ''
 
 # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.

--- a/docs/batch_data_ingestion.rst
+++ b/docs/batch_data_ingestion.rst
@@ -78,13 +78,13 @@ Below is an example (also located at `examples/batch/airlineStats/ingestionJobSp
   # includeFileNamePattern: include file name pattern, supported glob pattern.
   # Sample usage:
   #   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-  #   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+  #   'glob:**/*.avro' will include all the avro files under inputDirURI recursively.
   includeFileNamePattern: 'glob:**/*.avro'
 
   # excludeFileNamePattern: exclude file name pattern, supported glob pattern.
   # Sample usage:
   #   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-  #   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
+  #   'glob:**/*.avro' will exclude all the avro files under inputDirURI recursively.
   # _excludeFileNamePattern: ''
 
   # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.
@@ -171,7 +171,7 @@ Below command will kick off the ingestion job to generate Pinot segments and pus
 
 .. code-block:: bash
 
-   bin/pinot-ingestion-job.sh examples/batch/airlineStats/ingestionJobSpec.yaml
+   bin/pinot-ingestion-job.sh -jobSpec examples/batch/airlineStats/ingestionJobSpec.yaml
 
 After job finished, segments are stored in ` examples/batch/airlineStats/segments` following same layout of input directory layout.
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/GroovyTemplateUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/GroovyTemplateUtils.java
@@ -57,6 +57,9 @@ public class GroovyTemplateUtils {
   }
 
   public static Map<String, Object> getTemplateContext(List<String> values) {
+    if (values == null) {
+      return Collections.emptyMap();
+    }
     Map<String, Object> context = new HashMap<>();
     for (String value : values) {
       String[] splits = value.split("=", 2);

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -281,7 +281,7 @@
               </jvmSettings>
             </program>
             <program>
-              <mainClass>org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher</mainClass>
+              <mainClass>org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand</mainClass>
               <name>pinot-ingestion-job</name>
               <jvmSettings>
                 <initialMemorySize>1G</initialMemorySize>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -22,8 +22,11 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.GroovyTemplateUtils;
 import org.apache.pinot.tools.Command;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 import org.slf4j.Logger;
@@ -44,6 +47,31 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
   private List<String> _values;
   @Option(name = "-propertyFile", required = false, metaVar = "<template context file>", usage = "A property file contains context values to set the job spec template")
   private String _propertyFile;
+
+  public static void main(String[] args) {
+    PluginManager.get().init();
+    LaunchDataIngestionJobCommand cmd = new LaunchDataIngestionJobCommand();
+    CmdLineParser parser = new CmdLineParser(cmd);
+    if (args.length == 0) {
+      cmd.printUsage();
+      return;
+    }
+    try {
+      parser.parseArgument(args);
+      if (cmd.getHelp()) {
+        cmd.printUsage();
+        return;
+      }
+      boolean status = cmd.execute();
+      if (System.getProperties().getProperty("pinot.admin.system.exit", "false").equalsIgnoreCase("true")) {
+        System.exit(status ? 0 : 1);
+      }
+    } catch (CmdLineException e) {
+      LOGGER.error("Error: {}", e.getMessage());
+    } catch (Exception e) {
+      LOGGER.error("Exception caught: ", e);
+    }
+  }
 
   public String getJobSpecFile() {
     return _jobSpecFile;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -107,8 +107,14 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
 
   @Override
   public String toString() {
-    return ("LaunchDataIngestionJob -jobSpecFile " + _jobSpecFile + " -propertyFile " + _propertyFile + " -values "
-        + Arrays.toString(_values.toArray()));
+    String results = "LaunchDataIngestionJob -jobSpecFile " + _jobSpecFile;
+    if (_propertyFile != null) {
+      results += " -propertyFile " + _propertyFile;
+    }
+    if (_values != null) {
+      results += " -values " + Arrays.toString(_values.toArray());
+    }
+    return results;
   }
 
   @Override

--- a/pinot-tools/src/main/resources/conf/pinot-ingestion-job-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-ingestion-job-log4j2.xml
@@ -34,13 +34,19 @@
 
   </Appenders>
   <Loggers>
-    <Root level="error" additivity="false">
+    <Root level="info" additivity="false">
       <AppenderRef ref="console"/>
     </Root>
+    <Logger name="org.apache.pinot.tools.admin" level="info" additivity="false">
+      <AppenderRef ref="console"/>
+    </Logger>
     <Logger name="org.apache.pinot" level="info" additivity="false">
       <AppenderRef ref="console"/>
       <AppenderRef ref="ingestionJobLog"/>
     </Logger>
     <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+    <AsyncLogger name="org.apache.pinot.spi.plugin" level="error" additivity="false">
+      <AppenderRef ref="console"/>
+    </AsyncLogger>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/hadoopIngestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/hadoopIngestionJobSpec.yaml
@@ -53,13 +53,13 @@ inputDirURI: 'examples/batch/airlineStats/rawdata'
 # includeFileNamePattern: include file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will include all the avro files under inputDirURI recursively.
 includeFileNamePattern: 'glob:**/*.avro'
 
 # excludeFileNamePattern: exclude file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will exclude all the avro files under inputDirURI recursively.
 # _excludeFileNamePattern: ''
 
 # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/ingestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/ingestionJobSpec.yaml
@@ -47,13 +47,13 @@ inputDirURI: 'examples/batch/airlineStats/rawdata'
 # includeFileNamePattern: include file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will include all the avro files under inputDirURI recursively.
 includeFileNamePattern: 'glob:**/*.avro'
 
 # excludeFileNamePattern: exclude file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will exclude all the avro files under inputDirURI recursively.
 # _excludeFileNamePattern: ''
 
 # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/sparkIngestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/sparkIngestionJobSpec.yaml
@@ -53,13 +53,13 @@ inputDirURI: 'examples/batch/airlineStats/rawdata'
 # includeFileNamePattern: include file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will include all the avro files under inputDirURI recursively.
 includeFileNamePattern: 'glob:**/*.avro'
 
 # excludeFileNamePattern: exclude file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will exclude all the avro files under inputDirURI recursively.
 # _excludeFileNamePattern: ''
 
 # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/baseballStats/ingestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/baseballStats/ingestionJobSpec.yaml
@@ -47,13 +47,13 @@ inputDirURI: 'examples/batch/baseballStats/rawdata'
 # includeFileNamePattern: include file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will include all the avro files under inputDirURI recursively.
 includeFileNamePattern: 'glob:**/*.csv'
 
 # excludeFileNamePattern: exclude file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will exclude all the avro files under inputDirURI recursively.
 # _excludeFileNamePattern: ''
 
 # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/baseballStats/sparkIngestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/baseballStats/sparkIngestionJobSpec.yaml
@@ -49,13 +49,13 @@ inputDirURI: 'examples/batch/baseballStats/rawdata'
 # includeFileNamePattern: include file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will include all the avro files under inputDirURI recursively.
 includeFileNamePattern: 'glob:**/*.csv'
 
 # excludeFileNamePattern: exclude file name pattern, supported glob pattern.
 # Sample usage:
 #   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' will exclude all the avro files under inputDirURI recursively.
 # _excludeFileNamePattern: ''
 
 # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.


### PR DESCRIPTION
1. Fixing the NPE issue that if `-values` is not specified, then a null array is parsed instead of empty array. So need to check null for `values` array.
Thanks to Manoj Singh for reporting this.
2. Fixing `pinot-ingesiton-job.sh` script.