### PR TITLE
Fix flaky test for InterSegmentResultTableMultiValueQueriesTest

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
@@ -38,8 +38,8 @@ import org.testng.annotations.Test;
  * Tests Response Format = sql for selection, distinct, aggregations and aggregation group bys
  */
 public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValueQueriesTest {
-  private static String SV_GROUP_BY = " GROUP BY column8 TOP 1";
-  private static String MV_GROUP_BY = " GROUP BY column7 TOP 1";
+  private static String SV_GROUP_BY = " WHERE column6 != 2147483647 GROUP BY column8 TOP 1";
+  private static String MV_GROUP_BY = " WHERE column6 != 2147483647 GROUP BY column7 TOP 1";
 
   @Test
   public void testCountMV() {
@@ -71,19 +71,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "countmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"674022574", 231056L});
+    rows.add(new Object[]{"674022574", 43600L});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "countmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"2147483647", 199896L});
+    rows.add(new Object[]{"469", 29256L});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -117,19 +117,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "maxmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"872818679", 2147483647.0});
+    rows.add(new Object[]{"674022574", 5400497.0});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "maxmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"350", 2147483647.0});
+    rows.add(new Object[]{"225", 5400497.0});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -166,7 +166,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     rows.add(new Object[]{"674022574", 1001.0});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
@@ -175,7 +175,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     rows = new ArrayList<>();
     rows.add(new Object[]{"469", 1001.0});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -209,19 +209,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "summv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"674022574", 402591409613620.0});
+    rows.add(new Object[]{"716819109", 39334429344.0});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "summv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"2147483647", 393483780531788.0});
+    rows.add(new Object[]{"363", 58236246660.0});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -255,19 +255,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "avgmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"872818679", 2147483647.0});
+    rows.add(new Object[]{"118380643", 5392989.0});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "avgmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"243", 2147483647.0});
+    rows.add(new Object[]{"380", 3694440.5});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -301,19 +301,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "minmaxrangemv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"674022574", 2147482646.0});
+    rows.add(new Object[]{"674022574", 5399496.0});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "minmaxrangemv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"469", 2147482646.0});
+    rows.add(new Object[]{"225", 5399488.0});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -347,19 +347,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "distinctcountmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"674022574", 4784});
+    rows.add(new Object[]{"674022574", 4783});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "distinctcountmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"363", 3434});
+    rows.add(new Object[]{"363", 3433});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -396,7 +396,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     rows.add(new Object[]{"674022574", 4715L});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
@@ -405,7 +405,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     rows = new ArrayList<>();
     rows.add(new Object[]{"363", 3490L});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -448,7 +448,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     expectedRow0 = new Object[]{"674022574", 4715L};
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
     row0 = brokerResponse.getResultTable().getRows().get(0);
     Assert.assertEquals(row0[0], expectedRow0[0]);
@@ -461,7 +461,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
     expectedRow0 = new Object[]{"363", 3490L};
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
     row0 = brokerResponse.getResultTable().getRows().get(0);
     Assert.assertEquals(row0[0], expectedRow0[0]);
@@ -503,19 +503,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
       dataSchema = new DataSchema(new String[]{"column8", "percentile50mv(column6)"},
           new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
       rows = new ArrayList<>();
-      rows.add(new Object[]{"872818679", 2147483647.0});
+      rows.add(new Object[]{"118380643", 5392989.0});
       expectedResultsSize = 1;
       QueriesTestUtils
-          .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+          .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
               dataSchema);
 
       brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
       dataSchema = new DataSchema(new String[]{"column7", "percentile50mv(column6)"},
           new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
       rows = new ArrayList<>();
-      rows.add(new Object[]{"243", 2147483647.0});
+      rows.add(new Object[]{"341", 5084850.0});
       QueriesTestUtils
-          .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+          .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
               dataSchema);
     }
   }
@@ -550,19 +550,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentile90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"872818679", 2147483647.0});
+    rows.add(new Object[]{"118380643", 5392989.0});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentile90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"350", 2147483647.0});
+    rows.add(new Object[]{"371", 5380174.0});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -596,19 +596,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentile95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"872818679", 2147483647.0});
+    rows.add(new Object[]{"118380643", 5392989.0});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentile95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"350", 2147483647.0});
+    rows.add(new Object[]{"371", 5380174.0});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -642,19 +642,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentile99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"872818679", 2147483647.0});
+    rows.add(new Object[]{"2057094396", 5393010.0});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentile99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"350", 2147483647.0});
+    rows.add(new Object[]{"476", 5394180.0});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -688,19 +688,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentileest50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"872818679", 2147483647L});
+    rows.add(new Object[]{"118380643", 5392989L});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentileest50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"243", 2147483647L});
+    rows.add(new Object[]{"341", 5084850L});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -734,19 +734,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentileest90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"872818679", 2147483647L});
+    rows.add(new Object[]{"118380643", 5392989L});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentileest90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"350", 2147483647L});
+    rows.add(new Object[]{"371", 5380174L});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -780,19 +780,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentileest95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"872818679", 2147483647L});
+    rows.add(new Object[]{"118380643", 5392989L});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentileest95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"350", 2147483647L});
+    rows.add(new Object[]{"371", 5380174L});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 
@@ -826,19 +826,19 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentileest99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"872818679", 2147483647L});
+    rows.add(new Object[]{"2057094396", 5393010L});
     expectedResultsSize = 1;
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + MV_GROUP_BY, queryOptions);
     dataSchema = new DataSchema(new String[]{"column7", "percentileest99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"350", 2147483647L});
+    rows.add(new Object[]{"476", 5394180L});
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows, expectedResultsSize,
             dataSchema);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
@@ -38,8 +38,8 @@ import org.testng.annotations.Test;
  * Tests Response Format = sql for selection, distinct, aggregations and aggregation group bys
  */
 public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValueQueriesTest {
-  private static String SV_GROUP_BY = " group by column8";
-  private static String MV_GROUP_BY = " group by column7";
+  private static String SV_GROUP_BY = " GROUP BY column8 TOP 1";
+  private static String MV_GROUP_BY = " GROUP BY column7 TOP 1";
 
   @Test
   public void testCountMV() {
@@ -72,7 +72,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
     rows.add(new Object[]{"674022574", 231056L});
-    expectedResultsSize = 10;
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -117,8 +117,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "maxmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"711508739", 2147483647.0});
-    expectedResultsSize = 10;
+    rows.add(new Object[]{"872818679", 2147483647.0});
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -127,7 +127,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column7", "maxmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"353", 2147483647.0});
+    rows.add(new Object[]{"350", 2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -164,7 +164,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
     rows.add(new Object[]{"674022574", 1001.0});
-    expectedResultsSize = 10;
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -210,7 +210,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
     rows.add(new Object[]{"674022574", 402591409613620.0});
-    expectedResultsSize = 10;
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -255,8 +255,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "avgmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"1040894941", 2147483647.0});
-    expectedResultsSize = 10;
+    rows.add(new Object[]{"872818679", 2147483647.0});
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -265,7 +265,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column7", "avgmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"208", 2147483647.0});
+    rows.add(new Object[]{"243", 2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -302,7 +302,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
     rows.add(new Object[]{"674022574", 2147482646.0});
-    expectedResultsSize = 10;
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -348,7 +348,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     rows = new ArrayList<>();
     rows.add(new Object[]{"674022574", 4784});
-    expectedResultsSize = 10;
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -394,7 +394,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
     rows.add(new Object[]{"674022574", 4715L});
-    expectedResultsSize = 10;
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -446,7 +446,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "distinctcountrawhllmv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
     expectedRow0 = new Object[]{"674022574", 4715L};
-    expectedResultsSize = 10;
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -503,8 +503,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
       dataSchema = new DataSchema(new String[]{"column8", "percentile50mv(column6)"},
           new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
       rows = new ArrayList<>();
-      rows.add(new Object[]{"169878844", 2147483647.0});
-      expectedResultsSize = 10;
+      rows.add(new Object[]{"872818679", 2147483647.0});
+      expectedResultsSize = 1;
       QueriesTestUtils
           .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
               dataSchema);
@@ -513,7 +513,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
       dataSchema = new DataSchema(new String[]{"column7", "percentile50mv(column6)"},
           new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
       rows = new ArrayList<>();
-      rows.add(new Object[]{"372", 2147483647.0});
+      rows.add(new Object[]{"243", 2147483647.0});
       QueriesTestUtils
           .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
               dataSchema);
@@ -550,8 +550,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentile90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"600729221", 2147483647.0});
-    expectedResultsSize = 10;
+    rows.add(new Object[]{"872818679", 2147483647.0});
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -560,7 +560,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column7", "percentile90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"475", 2147483647.0});
+    rows.add(new Object[]{"350", 2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -596,8 +596,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentile95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"711508739", 2147483647.0});
-    expectedResultsSize = 10;
+    rows.add(new Object[]{"872818679", 2147483647.0});
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -606,7 +606,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column7", "percentile95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"354", 2147483647.0});
+    rows.add(new Object[]{"350", 2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -642,8 +642,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentile99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"711508739", 2147483647.0});
-    expectedResultsSize = 10;
+    rows.add(new Object[]{"872818679", 2147483647.0});
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -652,7 +652,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column7", "percentile99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"353", 2147483647.0});
+    rows.add(new Object[]{"350", 2147483647.0});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -688,8 +688,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentileest50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"169878844", 2147483647L});
-    expectedResultsSize = 10;
+    rows.add(new Object[]{"872818679", 2147483647L});
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -698,7 +698,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column7", "percentileest50mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"372", 2147483647L});
+    rows.add(new Object[]{"243", 2147483647L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -734,8 +734,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentileest90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"600729221", 2147483647L});
-    expectedResultsSize = 10;
+    rows.add(new Object[]{"872818679", 2147483647L});
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -744,7 +744,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column7", "percentileest90mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"475", 2147483647L});
+    rows.add(new Object[]{"350", 2147483647L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -780,8 +780,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentileest95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"711508739", 2147483647L});
-    expectedResultsSize = 10;
+    rows.add(new Object[]{"872818679", 2147483647L});
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -790,7 +790,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column7", "percentileest95mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"354", 2147483647L});
+    rows.add(new Object[]{"350", 2147483647L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -826,8 +826,8 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column8", "percentileest99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"711508739", 2147483647L});
-    expectedResultsSize = 10;
+    rows.add(new Object[]{"872818679", 2147483647L});
+    expectedResultsSize = 1;
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);
@@ -836,7 +836,7 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
     dataSchema = new DataSchema(new String[]{"column7", "percentileest99mv(column6)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
     rows = new ArrayList<>();
-    rows.add(new Object[]{"353", 2147483647L});
+    rows.add(new Object[]{"350", 2147483647L});
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0L, 800000L, 400000L, rows, expectedResultsSize,
             dataSchema);


### PR DESCRIPTION
The test was checking 1st row of the group by result, where all
10 aggregated group by values are the same. So, sometimes the test
fails because the order of 10 resulting rows is somtimes different.
Fixing this issue by adding "TOP 1" to have deterministic result.