### PR TITLE
Fix issue with PerfBenchmarkRunner where server can no longer pre-load segments from dataDir.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.controller.api.upload;
 
 import java.io.File;
 import java.net.URI;
-import javax.annotation.Nullable;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.helix.ZNRecord;
@@ -60,7 +59,7 @@ public class ZKOperator {
 
   public void completeSegmentOperations(String rawTableName, SegmentMetadata segmentMetadata,
       URI finalSegmentLocationURI, File currentSegmentLocation, boolean enableParallelPushProtection,
-      @Nullable HttpHeaders headers, String zkDownloadURI, boolean moveSegmentToFinalLocation)
+      HttpHeaders headers, String zkDownloadURI, boolean moveSegmentToFinalLocation)
       throws Exception {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
     String segmentName = segmentMetadata.getName();
@@ -70,7 +69,7 @@ public class ZKOperator {
         _pinotHelixResourceManager.getSegmentMetadataZnRecord(offlineTableName, segmentName);
     if (segmentMetadataZnRecord == null) {
       LOGGER.info("Adding new segment {} from table {}", segmentName, rawTableName);
-      String crypter = headers != null ? headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER) : null;
+      String crypter = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER);
       processNewSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation, zkDownloadURI, crypter,
           rawTableName, segmentName, moveSegmentToFinalLocation);
       return;
@@ -203,7 +202,7 @@ public class ZKOperator {
   }
 
   private void processNewSegment(SegmentMetadata segmentMetadata, URI finalSegmentLocationURI,
-      File currentSegmentLocation, String zkDownloadURI, @Nullable String crypter, String rawTableName, String segmentName,
+      File currentSegmentLocation, String zkDownloadURI, String crypter, String rawTableName, String segmentName,
       boolean moveSegmentToFinalLocation) {
     // For v1 segment uploads, we will not move the segment
     if (moveSegmentToFinalLocation) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueryEngine.java
@@ -27,7 +27,6 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.pinot.broker.requesthandler.OptimizationFlags;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.controller.api.resources.ControllerFilePathProvider;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.tools.perf.PerfBenchmarkDriver;
 import org.apache.pinot.tools.perf.PerfBenchmarkDriverConf;
@@ -99,14 +98,13 @@ public class BenchmarkQueryEngine {
     conf.setConfigureResources(false);
     _perfBenchmarkDriver = new PerfBenchmarkDriver(conf);
     _perfBenchmarkDriver.run();
-    ControllerFilePathProvider.init(_perfBenchmarkDriver.getControllerConf());
 
     File[] segments = new File(DATA_DIRECTORY, TABLE_NAME).listFiles();
     for (File segmentDir : segments) {
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segmentDir);
       _perfBenchmarkDriver.configureTable(TABLE_NAME);
       System.out.println("Adding segment " + segmentDir.getAbsolutePath());
-      _perfBenchmarkDriver.addSegment(TABLE_NAME, segmentDir, segmentMetadata);
+      _perfBenchmarkDriver.addSegment(TABLE_NAME, segmentMetadata);
     }
 
     ZkClient client = new ZkClient("localhost:2191", 10000, 10000, new ZNRecordSerializer());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.apache.pinot.controller.api.resources.ControllerFilePathProvider;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.Command;
@@ -42,7 +41,7 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
   @Option(name = "-mode", required = true, metaVar = "<String>", usage = "Mode of the PerfBenchmarkRunner (startAll|startAllButServer|startServerWithPreLoadedSegments).")
   private String _mode;
 
-  @Option(name = "-dataDir", required = false, metaVar = "<String>", usage = "Path to data directory.")
+  @Option(name = "-dataDir", required = false, metaVar = "<String>", usage = "Path to directory containing un-tarred segments.")
   private String _dataDir;
 
   @Option(name = "-tempDir", required = false, metaVar = "<String>", usage = "Path to temporary directory to start the cluster")
@@ -161,14 +160,13 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
     boolean tableConfigured = false;
     File[] segments = new File(dataDir, tableName).listFiles();
     Preconditions.checkNotNull(segments);
-    ControllerFilePathProvider.init(driver.getControllerConf());
     for (File segment : segments) {
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segment);
       if (!tableConfigured) {
         driver.configureTable(tableName, invertedIndexColumns, bloomFilterColumns);
         tableConfigured = true;
       }
-      driver.addSegment(tableName, segment, segmentMetadata);
+      driver.addSegment(tableName, segmentMetadata);
     }
   }
 


### PR DESCRIPTION
Due to recent PRs (#5383, #5381), PerfBenchmarkRunner now makes additional copy
of segments on controller, and makes server download data from controller.
The original behavior was to bypass this and for servers to directly preload
from disk. This PR is undoing the changes from above PR to get back to old
behavior that is more optimal.