### PR TITLE
[TE] fix an issue that in some cases the evaluations are not generated

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/algorithm/DimensionWrapper.java
@@ -227,6 +227,7 @@ public class DimensionWrapper extends DetectionPipeline {
 
       for (String nestedMetricUrn : this.nestedMetricUrns) {
         nestedMetrics.add(MetricEntity.fromURN(nestedMetricUrn));
+        evaluationMetricUrns.add(nestedMetricUrn);
       }
     }
 


### PR DESCRIPTION
Previously, for the detections w/o dimension exploration, the detection evaluations won't be generated. This PR fixes the issue.