### PR TITLE
One to many records from record reader/decoder

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -363,5 +363,7 @@ public class CommonConstants {
 
     @Deprecated
     public static final String TABLE_NAME = "segment.table.name";
+
+    public static final String MULTIPLE_RECORDS_KEY = "multiple.records.key";
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -363,7 +363,5 @@ public class CommonConstants {
 
     @Deprecated
     public static final String TABLE_NAME = "segment.table.name";
-
-    public static final String MULTIPLE_RECORDS_KEY = "multiple.records.key";
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
@@ -62,8 +62,8 @@ public class RecordReaderSegmentCreationDataSource implements SegmentCreationDat
         reuse.clear();
 
         reuse = _recordReader.next(reuse);
-        if (reuse.getValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY) != null) {
-          for (Object singleRow : (Collection) reuse.getValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY)) {
+        if (reuse.getValue(GenericRow.MULTIPLE_RECORDS_KEY) != null) {
+          for (Object singleRow : (Collection) reuse.getValue(GenericRow.MULTIPLE_RECORDS_KEY)) {
             GenericRow transformedRow = recordTransformer.transform((GenericRow) singleRow);
             if (transformedRow != null) {
               collector.collectRow(transformedRow);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
@@ -18,7 +18,12 @@
  */
 package org.apache.pinot.core.segment.creator;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import org.apache.pinot.common.Utils;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.core.data.recordtransformer.CompositeTransformer;
@@ -55,9 +60,20 @@ public class RecordReaderSegmentCreationDataSource implements SegmentCreationDat
       GenericRow reuse = new GenericRow();
       while (_recordReader.hasNext()) {
         reuse.clear();
-        GenericRow transformedRow = recordTransformer.transform(_recordReader.next(reuse));
-        if (transformedRow != null) {
-          collector.collectRow(transformedRow);
+
+        reuse = _recordReader.next(reuse);
+        if (reuse.getValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY) != null) {
+          for (Object singleRow : (Collection) reuse.getValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY)) {
+            GenericRow transformedRow = recordTransformer.transform((GenericRow) singleRow);
+            if (transformedRow != null) {
+              collector.collectRow(transformedRow);
+            }
+          }
+        } else {
+          GenericRow transformedRow = recordTransformer.transform(reuse);
+          if (transformedRow != null) {
+            collector.collectRow(transformedRow);
+          }
         }
       }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithMultipleRecordsKey.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithMultipleRecordsKey.java
@@ -75,7 +75,6 @@ public class SegmentGenerationWithMultipleRecordsKey {
     Assert.assertTrue(metadata.getAllColumns().containsAll(Sets.newHashSet(SUB_COLUMN_1, SUB_COLUMN_2)));
   }
 
-
   private File buildSegment(final TableConfig tableConfig, final Schema schema)
       throws Exception {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
@@ -85,13 +84,15 @@ public class SegmentGenerationWithMultipleRecordsKey {
     List<GenericRow> rows = new ArrayList<>(3);
 
     GenericRow genericRow1 = new GenericRow();
-    genericRow1.putValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY, Lists.newArrayList(getRandomArrayElement(), getRandomArrayElement(), getRandomArrayElement()));
+    genericRow1.putValue(GenericRow.MULTIPLE_RECORDS_KEY,
+        Lists.newArrayList(getRandomArrayElement(), getRandomArrayElement(), getRandomArrayElement()));
     rows.add(genericRow1);
     GenericRow genericRow2 = new GenericRow();
-    genericRow2.putValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY, Lists.newArrayList(getRandomArrayElement()));
+    genericRow2.putValue(GenericRow.MULTIPLE_RECORDS_KEY, Lists.newArrayList(getRandomArrayElement()));
     rows.add(genericRow2);
     GenericRow genericRow3 = new GenericRow();
-    genericRow3.putValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY, Lists.newArrayList(getRandomArrayElement(), getRandomArrayElement()));
+    genericRow3.putValue(GenericRow.MULTIPLE_RECORDS_KEY,
+        Lists.newArrayList(getRandomArrayElement(), getRandomArrayElement()));
     rows.add(genericRow3);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithMultipleRecordsKey.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithMultipleRecordsKey.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.index.creator;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.math.RandomUtils;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.core.segment.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class SegmentGenerationWithMultipleRecordsKey {
+  private static final String SUB_COLUMN_1 = "sub1";
+  private static final String SUB_COLUMN_2 = "sub2";
+  private static final String SEGMENT_DIR_NAME =
+      System.getProperty("java.io.tmpdir") + File.separator + "segmentMultipleRecordsTest";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  private Schema _schema;
+  private TableConfig _tableConfig;
+
+  @BeforeClass
+  public void setup() {
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build();
+    _schema = new Schema.SchemaBuilder().addSingleValueDimension(SUB_COLUMN_1, FieldSpec.DataType.STRING)
+        .addMetric(SUB_COLUMN_2, FieldSpec.DataType.LONG).build();
+  }
+
+  @BeforeMethod
+  public void reset() {
+    FileUtils.deleteQuietly(new File(SEGMENT_DIR_NAME));
+  }
+
+  @Test
+  public void testNumDocs()
+      throws Exception {
+    File segmentDir = buildSegment(_tableConfig, _schema);
+    SegmentMetadataImpl metadata = SegmentDirectory.loadSegmentMetadata(segmentDir);
+    Assert.assertEquals(metadata.getTotalDocs(), 6);
+    Assert.assertTrue(metadata.getAllColumns().containsAll(Sets.newHashSet(SUB_COLUMN_1, SUB_COLUMN_2)));
+  }
+
+
+  private File buildSegment(final TableConfig tableConfig, final Schema schema)
+      throws Exception {
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(SEGMENT_DIR_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+
+    List<GenericRow> rows = new ArrayList<>(3);
+
+    GenericRow genericRow1 = new GenericRow();
+    genericRow1.putValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY, Lists.newArrayList(getRandomArrayElement(), getRandomArrayElement(), getRandomArrayElement()));
+    rows.add(genericRow1);
+    GenericRow genericRow2 = new GenericRow();
+    genericRow2.putValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY, Lists.newArrayList(getRandomArrayElement()));
+    rows.add(genericRow2);
+    GenericRow genericRow3 = new GenericRow();
+    genericRow3.putValue(CommonConstants.Segment.MULTIPLE_RECORDS_KEY, Lists.newArrayList(getRandomArrayElement(), getRandomArrayElement()));
+    rows.add(genericRow3);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+    driver.getOutputDirectory().deleteOnExit();
+    return driver.getOutputDirectory();
+  }
+
+  private GenericRow getRandomArrayElement() {
+    GenericRow element = new GenericRow();
+    element.putValue(SUB_COLUMN_1, RandomStringUtils.randomAlphabetic(4));
+    element.putValue(SUB_COLUMN_2, RandomUtils.nextLong());
+    return element;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -48,6 +48,9 @@ import org.apache.pinot.spi.utils.JsonUtils;
  *  We should not be using Boolean, Byte, Character and Short to keep it simple
  */
 public class GenericRow {
+
+  public static final String MULTIPLE_RECORDS_KEY = "$MULTIPLE_RECORDS_KEY$";
+
   private final Map<String, Object> _fieldToValueMap = new HashMap<>();
   private final Set<String> _nullValueFields = new HashSet<>();
 


### PR DESCRIPTION
Handles the case where a record reader generates multiple records in an invocation of next(). 
Note: None of our record readers have the ability to generate multiple records yet. This change assumes a custom record reader has been plugged in, which is generating multiple records. The record reader should generate `List<GenericRow> genericRecordsList`, and put it in the the `GenericRecord to`, as,
```
to.putValue("multiple.records.key", genericRecordsList);
```