### PR TITLE
[TE] endpoints for alerts page filters

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -75,7 +75,7 @@ import org.apache.pinot.thirdeye.datasource.loader.DefaultTimeSeriesLoader;
 import org.apache.pinot.thirdeye.datasource.loader.TimeSeriesLoader;
 import org.apache.pinot.thirdeye.datasource.sql.resources.SqlDataSourceResource;
 import org.apache.pinot.thirdeye.detection.DetectionResource;
-import org.apache.pinot.thirdeye.detection.annotation.DetectionConfigurationResource;
+import org.apache.pinot.thirdeye.detection.DetectionConfigurationResource;
 import org.apache.pinot.thirdeye.detection.yaml.YamlResource;
 import org.apache.pinot.thirdeye.detector.email.filter.AlertFilterFactory;
 import org.apache.pinot.thirdeye.detector.function.AnomalyFunctionFactory;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertResource.java
@@ -58,6 +58,7 @@ public class AlertResource {
    * @param subscriptionGroups the subscription groups for the alerts
    * @param names the names for the alerts
    * @param createdBy the owners for the alerts
+   * @param subscribedBy the subscriber for the alerts
    * @param ruleTypes the rule types for the alerts
    * @param metrics the metrics for the alerts
    * @param datasets the datasets for the alerts
@@ -70,10 +71,11 @@ public class AlertResource {
   public Response findAlerts(@QueryParam("limit") @DefaultValue("10") long limit,
       @QueryParam("offset") @DefaultValue("0") long offset, @QueryParam("application") List<String> applications,
       @QueryParam("subscriptionGroup") List<String> subscriptionGroups, @QueryParam("names") List<String> names,
-      @QueryParam("createdBy") List<String> createdBy, @QueryParam("ruleType") List<String> ruleTypes,
+      @QueryParam("createdBy") List<String> createdBy, @QueryParam("subscribedBy") List<String> subscribedBy, @QueryParam("ruleType") List<String> ruleTypes,
       @QueryParam("metric") List<String> metrics, @QueryParam("dataset") List<String> datasets,
       @QueryParam("active") Boolean active) {
-    AlertSearchFilter searchFilter = new AlertSearchFilter(applications, subscriptionGroups, names, createdBy, ruleTypes, metrics, datasets, active);
+    AlertSearchFilter searchFilter =
+        new AlertSearchFilter(applications, subscriptionGroups, names, createdBy, subscribedBy, ruleTypes, metrics, datasets, active);
     return Response.ok().entity(this.alertSearcher.search(searchFilter, limit, offset)).build();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertSearchFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertSearchFilter.java
@@ -31,6 +31,7 @@ public class AlertSearchFilter {
   private final List<String> applications;
   private final List<String> subscriptionGroups;
   private final List<String> createdBy;
+  private final List<String> subscribedBy;
   private final List<String> ruleTypes;
   private final List<String> metrics;
   private final List<String> datasets;
@@ -41,6 +42,7 @@ public class AlertSearchFilter {
     this.applications = Collections.emptyList();
     this.subscriptionGroups = Collections.emptyList();
     this.createdBy = Collections.emptyList();
+    this.subscribedBy = Collections.emptyList();
     this.ruleTypes = Collections.emptyList();
     this.datasets = Collections.emptyList();
     this.metrics = Collections.emptyList();
@@ -55,17 +57,19 @@ public class AlertSearchFilter {
    * @param subscriptionGroups the subscription groups
    * @param names the names
    * @param createdBy the createdBy
+   * @param subscribedBy the subscribed by
    * @param ruleTypes the rule types
    * @param metrics the metrics
    * @param datasets the datasets
    * @param active the active
    */
   public AlertSearchFilter(List<String> applications, List<String> subscriptionGroups, List<String> names,
-      List<String> createdBy, List<String> ruleTypes, List<String> metrics, List<String> datasets, Boolean active) {
+      List<String> createdBy, List<String> subscribedBy, List<String> ruleTypes, List<String> metrics, List<String> datasets, Boolean active) {
     this.applications = applications;
     this.subscriptionGroups = subscriptionGroups;
     this.names = names;
     this.createdBy = createdBy;
+    this.subscribedBy = subscribedBy;
     this.ruleTypes = ruleTypes;
     this.metrics = metrics;
     this.datasets = datasets;
@@ -97,6 +101,15 @@ public class AlertSearchFilter {
    */
   public List<String> getCreatedBy() {
     return createdBy;
+  }
+
+  /**
+   * Gets subscribedBy.
+   *
+   * @return the subscribedBy
+   */
+  public List<String> getSubscribedBy() {
+    return subscribedBy;
   }
 
   /**
@@ -151,7 +164,7 @@ public class AlertSearchFilter {
    */
   public boolean isEmpty() {
     return this.applications.isEmpty() && this.subscriptionGroups.isEmpty() && this.names.isEmpty()
-        && this.createdBy.isEmpty() && this.ruleTypes.isEmpty() && this.metrics.isEmpty() && this.datasets.isEmpty()
+        && this.createdBy.isEmpty() && this.subscribedBy.isEmpty() && this.ruleTypes.isEmpty() && this.metrics.isEmpty() && this.datasets.isEmpty()
         && active == null;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionConfigurationResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/DetectionConfigurationResource.java
@@ -15,27 +15,41 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
  */
 
-package org.apache.pinot.thirdeye.detection.annotation;
+package org.apache.pinot.thirdeye.detection;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionRegistry;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.thirdeye.api.Constants;
+import org.apache.pinot.thirdeye.detection.annotation.Components;
+import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionRegistry;
 
 
-@Path("/detection/annotation")
+@Path("/detection/rule")
+@Api(tags = {Constants.DETECTION_TAG})
 public class DetectionConfigurationResource {
   private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static DetectionRegistry detectionRegistry = DetectionRegistry.getInstance();
 
+  private static String TUNABLE_TYPE = "TUNABLE";
+  private static String BASELINE_TYPE = "BASELINE";
+
   @GET
-  public Response getConfigurations(@ApiParam("tag") String tag) throws Exception {
-    return Response.ok(
-        OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(detectionRegistry.getAllAnnotation()))
-        .build();
+  public Response getRules() throws Exception {
+    List<Components> componentsList = detectionRegistry.getAllAnnotation();
+    componentsList = componentsList.stream().filter(component -> {
+      String type = component.type().toUpperCase();
+      return !type.contains(TUNABLE_TYPE) && !type.contains(BASELINE_TYPE);
+    }).collect(Collectors.toList());
+    return Response.ok(OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(componentsList)).build();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertSearcherTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertSearcherTest.java
@@ -67,7 +67,7 @@ public class AlertSearcherTest {
   @Test
   public void testSearchActive() {
     AlertSearcher searcher = new AlertSearcher();
-    Map<String, Object> result = searcher.search(new AlertSearchFilter(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), true), 10 ,0);
+    Map<String, Object> result = searcher.search(new AlertSearchFilter(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), true), 10 ,0);
     Assert.assertEquals(result.get("count"), 1L);
     Assert.assertEquals(result.get("limit"), 10L);
     Assert.assertEquals(result.get("offset"), 0L);


### PR DESCRIPTION
This PR adds the endpoints for the filters in the new alert list page.

- Auto-complete for detections, subscription groups, applications, and alert owners.
- Search for the alerts that are subscribed by a user.
- The endpoints to return a list of all rules in the detection pipeline.