### PR TITLE
Templatizing pinot configs name in HelmCharts

### DIFF
--- a/kubernetes/helm/pinot/templates/_helpers.tpl
+++ b/kubernetes/helm/pinot/templates/_helpers.tpl
@@ -141,3 +141,24 @@ The name of the pinot broker external service.
 {{- define "pinot.broker.external" -}}
 {{- printf "%s-external" (include "pinot.broker.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+The name of the pinot controller config.
+*/}}
+{{- define "pinot.controller.config" -}}
+{{- printf "%s-config" (include "pinot.controller.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the pinot broker config.
+*/}}
+{{- define "pinot.broker.config" -}}
+{{- printf "%s-config" (include "pinot.broker.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the pinot server config.
+*/}}
+{{- define "pinot.server.config" -}}
+{{- printf "%s-config" (include "pinot.server.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/kubernetes/helm/pinot/templates/broker/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/broker/configmap.yaml
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: broker-config
+  name: {{ include "pinot.broker.config" . }}
 data:
   pinot-broker.conf: |-
     pinot.broker.client.queryPort={{ .Values.broker.port }}

--- a/kubernetes/helm/pinot/templates/broker/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/broker/statefulset.yml
@@ -88,4 +88,4 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: broker-config
+            name: {{ include "pinot.broker.config" . }}

--- a/kubernetes/helm/pinot/templates/controller/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/controller/configmap.yaml
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: controller-config
+  name: {{ include "pinot.controller.config" . }}
 data:
   pinot-controller.conf: |-
     controller.helix.cluster.name={{ .Values.cluster.name }}

--- a/kubernetes/helm/pinot/templates/controller/statefulset.yaml
+++ b/kubernetes/helm/pinot/templates/controller/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: controller-config
+          name: {{ include "pinot.controller.config" . }}
 {{- if not .Values.controller.persistence.enabled }}
       - name: data
         emptyDir: {}

--- a/kubernetes/helm/pinot/templates/server/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/server/configmap.yaml
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: server-config
+  name: {{ include "pinot.server.config" . }}
 data:
   pinot-server.conf: |-
     pinot.server.netty.port={{ .Values.server.ports.netty }}

--- a/kubernetes/helm/pinot/templates/server/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/server/statefulset.yml
@@ -82,7 +82,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: server-config
+            name: {{ include "pinot.server.config" . }}
       {{- if not .Values.server.persistence.enabled }}
         - name: data
           emptyDir: {}


### PR DESCRIPTION
Now it's possible to have multiple Pinot Deployments in same namespace.

Sample Usage:
```
helm install pinot-deploy-1  -n pinot --set cluster.name=pinot .
```

The deployment looks like:
```
➜ kubectl get all -n pinot|grep pinot-deploy-1
pod/pinot-deploy-1-broker-0       1/1     Running   1          45m
pod/pinot-deploy-1-controller-0   1/1     Running   0          45m
pod/pinot-deploy-1-server-0       1/1     Running   1          45m
pod/pinot-deploy-1-zookeeper-0    1/1     Running   0          45m
service/pinot-deploy-1-broker                ClusterIP      10.100.168.96    <none>        8099/TCP                     45m
service/pinot-deploy-1-broker-external       LoadBalancer   10.109.196.137   <pending>     8099:31583/TCP               45m
service/pinot-deploy-1-broker-headless       ClusterIP      None             <none>        8099/TCP                     45m
service/pinot-deploy-1-controller            ClusterIP      10.101.65.170    <none>        9000/TCP                     45m
service/pinot-deploy-1-controller-external   LoadBalancer   10.111.35.43     <pending>     9000:30911/TCP               45m
service/pinot-deploy-1-controller-headless   ClusterIP      None             <none>        9000/TCP                     45m
service/pinot-deploy-1-server                ClusterIP      10.110.6.198     <none>        8098/TCP                     45m
service/pinot-deploy-1-server-headless       ClusterIP      None             <none>        8098/TCP                     45m
service/pinot-deploy-1-zookeeper             ClusterIP      10.107.166.134   <none>        2181/TCP                     45m
service/pinot-deploy-1-zookeeper-headless    ClusterIP      None             <none>        2181/TCP,3888/TCP,2888/TCP   45m
statefulset.apps/pinot-deploy-1-broker       1/1     45m
statefulset.apps/pinot-deploy-1-controller   1/1     45m
statefulset.apps/pinot-deploy-1-server       1/1     45m
statefulset.apps/pinot-deploy-1-zookeeper    1/1     45m
```
