### PR TITLE
Make Compilation time function evaluation after query parser

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -88,6 +88,8 @@ public class FunctionRegistry {
       FunctionRegistry.registerFunction(DateTimeFunctions.class.getDeclaredMethod("now"));
 
       FunctionRegistry.registerFunction(JsonFunctions.class.getDeclaredMethod("toJsonMapStr", Map.class));
+
+      FunctionRegistry.registerFunction(StringFunctions.class.getDeclaredMethod("reverse", String.class));
     } catch (NoSuchMethodException e) {
       LOGGER.error("Caught exception when registering function", e);
       throw new IllegalStateException(e);

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/StringFunctions.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function;
+
+import org.apache.commons.lang.StringUtils;
+
+
+/**
+ * Inbuilt string related transform functions
+ *
+ */
+public class StringFunctions {
+  /**
+   * Reverse any given string
+   */
+  static String reverse(String input) {
+    return StringUtils.reverse(input);
+  }
+}


### PR DESCRIPTION
- Follow old query parsing logic to generate query expressions first
- Recursively evaluate expressions during queryRewrite phase to see if we can rewrite any compile time function.
- Adding more tests 