### PR TITLE
Add additional datetime functionality

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimePatternHandler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimePatternHandler.java
@@ -29,7 +29,7 @@ public class DateTimePatternHandler {
   /**
    * Converts the dateTimeString of passed pattern into a long of the millis since epoch
    */
-  public static Long parseDateTimeStringToEpochMillis(String dateTimeString, String pattern) {
+  public static long parseDateTimeStringToEpochMillis(String dateTimeString, String pattern) {
     DateTimeFormatter dateTimeFormatter = getDateTimeFormatter(pattern);
     return dateTimeFormatter.parseMillis(dateTimeString);
   }
@@ -37,7 +37,7 @@ public class DateTimePatternHandler {
   /**
    * Converts the millis representing seconds since epoch into a string of passed pattern
    */
-  public static String parseEpochMillisToDateTimeString(Long millis, String pattern) {
+  public static String parseEpochMillisToDateTimeString(long millis, String pattern) {
     DateTimeFormatter dateTimeFormatter = getDateTimeFormatter(pattern);
     return dateTimeFormatter.print(millis);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -94,7 +94,7 @@ public enum TransformFunctionType {
     try {
       return TransformFunctionType.valueOf(upperCaseFunctionName);
     } catch (Exception e) {
-      if (FunctionRegistry.getFunctionByName(functionName) != null) {
+      if (FunctionRegistry.containsFunction(functionName)) {
         return SCALAR;
       }
       // Support function name of both jsonExtractScalar and json_extract_scalar

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -21,15 +21,12 @@ package org.apache.pinot.common.function.scalar;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.function.DateTimePatternHandler;
 import org.apache.pinot.common.function.annotations.ScalarFunction;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 
 /**
  * Inbuilt date time related transform functions
- * TODO: Exhaustively add all time conversion functions
- *  eg:
- *   1) round(time, roundingValue) - round(minutes, 10), round(millis, 15:MINUTES)
- *   2) simple date time transformations
- *   3) convert(from_format, to_format, bucketing)
  *
  *   NOTE:
  *   <code>toEpochXXXBucket</code> methods are only needed to convert from TimeFieldSpec to DateTimeFieldSpec, to maintain the backward compatibility.
@@ -259,5 +256,300 @@ public class DateTimeFunctions {
   @ScalarFunction
   public static long now() {
     return System.currentTimeMillis();
+  }
+
+  /**
+   * The {@code timezoneId} for the following methods must be of a Joda-Time format:
+   * https://www.joda.org/joda-time/timezones.html
+   */
+
+  /**
+   * Returns the hour of the time zone offset.
+   */
+  @ScalarFunction
+  public static int timezoneHour(String timezoneId) {
+    return new DateTime(DateTimeZone.forID(timezoneId).getOffset(null), DateTimeZone.UTC).getHourOfDay();
+  }
+
+  /**
+   * Returns the minute of the time zone offset.
+   */
+  @ScalarFunction
+  public static int timezoneMinute(String timezoneId) {
+    return new DateTime(DateTimeZone.forID(timezoneId).getOffset(null), DateTimeZone.UTC).getMinuteOfHour();
+  }
+
+  /**
+   * Returns the year from the given epoch millis in UTC timezone.
+   */
+  @ScalarFunction
+  public static int year(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getYear();
+  }
+
+  /**
+   * Returns the year from the given epoch millis and timezone id.
+   */
+  @ScalarFunction
+  public static int year(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getYear();
+  }
+
+  /**
+   * Returns the year of the ISO week from the given epoch millis in UTC timezone.
+   */
+  @ScalarFunction
+  public static int yearOfWeek(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getWeekyear();
+  }
+
+  /**
+   * Returns the year of the ISO week from the given epoch millis and timezone id.
+   */
+  @ScalarFunction
+  public static int yearOfWeek(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getWeekyear();
+  }
+
+  /**
+   * An alias for yearOfWeek().
+   */
+  @ScalarFunction
+  public static int yow(long millis) {
+    return yearOfWeek(millis);
+  }
+
+  /**
+   * An alias for yearOfWeek().
+   */
+  @ScalarFunction
+  public static int yow(long millis, String timezoneId) {
+    return yearOfWeek(millis, timezoneId);
+  }
+
+  /**
+   * Returns the quarter of the year from the given epoch millis in UTC timezone. The value ranges from 1 to 4.
+   */
+  @ScalarFunction
+  public static int quarter(long millis) {
+    return (month(millis) - 1) / 3 + 1;
+  }
+
+  /**
+   * Returns the quarter of the year from the given epoch millis and timezone id. The value ranges from 1 to 4.
+   */
+  @ScalarFunction
+  public static int quarter(long millis, String timezoneId) {
+    return (month(millis, timezoneId) - 1) / 3 + 1;
+  }
+
+  /**
+   * Returns the month of the year from the given epoch millis in UTC timezone. The value ranges from 1 to 12.
+   */
+  @ScalarFunction
+  public static int month(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getMonthOfYear();
+  }
+
+  /**
+   * Returns the month of the year from the given epoch millis and timezone id. The value ranges from 1 to 12.
+   */
+  @ScalarFunction
+  public static int month(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getMonthOfYear();
+  }
+
+  /**
+   * Returns the ISO week of the year from the given epoch millis in UTC timezone.The value ranges from 1 to 53.
+   */
+  @ScalarFunction
+  public static int week(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getWeekOfWeekyear();
+  }
+
+  /**
+   * Returns the ISO week of the year from the given epoch millis and timezone id. The value ranges from 1 to 53.
+   */
+  @ScalarFunction
+  public static int week(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getWeekOfWeekyear();
+  }
+
+  /**
+   * An alias for week().
+   */
+  @ScalarFunction
+  public static int weekOfYear(long millis) {
+    return week(millis);
+  }
+
+  /**
+   * An alias for week().
+   */
+  @ScalarFunction
+  public static int weekOfYear(long millis, String timezoneId) {
+    return week(millis, timezoneId);
+  }
+
+  /**
+   * Returns the day of the year from the given epoch millis in UTC timezone. The value ranges from 1 to 366.
+   */
+  @ScalarFunction
+  public static int dayOfYear(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getDayOfYear();
+  }
+
+  /**
+   * Returns the day of the year from the given epoch millis and timezone id. The value ranges from 1 to 366.
+   */
+  @ScalarFunction
+  public static int dayOfYear(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getDayOfYear();
+  }
+
+  /**
+   * An alias for dayOfYear().
+   */
+  @ScalarFunction
+  public static int doy(long millis) {
+    return dayOfYear(millis);
+  }
+
+  /**
+   * An alias for dayOfYear().
+   */
+  @ScalarFunction
+  public static int doy(long millis, String timezoneId) {
+    return dayOfYear(millis, timezoneId);
+  }
+
+  /**
+   * Returns the day of the month from the given epoch millis in UTC timezone. The value ranges from 1 to 31.
+   */
+  @ScalarFunction
+  public static int day(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getDayOfMonth();
+  }
+
+  /**
+   * Returns the day of the month from the given epoch millis and timezone id. The value ranges from 1 to 31.
+   */
+  @ScalarFunction
+  public static int day(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getDayOfMonth();
+  }
+
+  /**
+   * An alias for day().
+   */
+  @ScalarFunction
+  public static int dayOfMonth(long millis) {
+    return day(millis);
+  }
+
+  /**
+   * An alias for day().
+   */
+  @ScalarFunction
+  public static int dayOfMonth(long millis, String timezoneId) {
+    return day(millis, timezoneId);
+  }
+
+  /**
+   * Returns the day of the week from the given epoch millis in UTC timezone. The value ranges from 1 (Monday) to 7
+   * (Sunday).
+   */
+  @ScalarFunction
+  public static int dayOfWeek(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getDayOfWeek();
+  }
+
+  /**
+   * Returns the day of the week from the given epoch millis and timezone id. The value ranges from 1 (Monday) to 7
+   * (Sunday).
+   */
+  @ScalarFunction
+  public static int dayOfWeek(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getDayOfWeek();
+  }
+
+  /**
+   * An alias for dayOfWeek().
+   */
+  @ScalarFunction
+  public static int dow(long millis) {
+    return dayOfWeek(millis);
+  }
+
+  /**
+   * An alias for dayOfWeek().
+   */
+  @ScalarFunction
+  public static int dow(long millis, String timezoneId) {
+    return dayOfWeek(millis, timezoneId);
+  }
+
+  /**
+   * Returns the hour of the day from the given epoch millis in UTC timezone. The value ranges from 0 to 23.
+   */
+  @ScalarFunction
+  public static int hour(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getHourOfDay();
+  }
+
+  /**
+   * Returns the hour of the day from the given epoch millis and timezone id. The value ranges from 0 to 23.
+   */
+  @ScalarFunction
+  public static int hour(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getHourOfDay();
+  }
+
+  /**
+   * Returns the minute of the hour from the given epoch millis in UTC timezone. The value ranges from 0 to 59.
+   */
+  @ScalarFunction
+  public static int minute(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getMinuteOfHour();
+  }
+
+  /**
+   * Returns the minute of the hour from the given epoch millis and timezone id. The value ranges from 0 to 59.
+   */
+  @ScalarFunction
+  public static int minute(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getMinuteOfHour();
+  }
+
+  /**
+   * Returns the second of the minute from the given epoch millis in UTC timezone. The value ranges from 0 to 59.
+   */
+  @ScalarFunction
+  public static int second(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getSecondOfMinute();
+  }
+
+  /**
+   * Returns the second of the minute from the given epoch millis and timezone id. The value ranges from 0 to 59.
+   */
+  @ScalarFunction
+  public static int second(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getSecondOfMinute();
+  }
+
+  /**
+   * Returns the millisecond of the second from the given epoch millis in UTC timezone. The value ranges from 0 to 999.
+   */
+  @ScalarFunction
+  public static int millisecond(long millis) {
+    return new DateTime(millis, DateTimeZone.UTC).getMillisOfSecond();
+  }
+
+  /**
+   * Returns the millisecond of the second from the given epoch millis and timezone id. The value ranges from 0 to 999.
+   */
+  @ScalarFunction
+  public static int millisecond(long millis, String timezoneId) {
+    return new DateTime(millis, DateTimeZone.forID(timezoneId)).getMillisOfSecond();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluator.java
@@ -87,7 +87,10 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
       childNodes[i] = childNode;
     }
 
-    FunctionInfo functionInfo = FunctionRegistry.getFunctionByName(function.getFunctionName());
+    FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(function.getFunctionName(), numArguments);
+    Preconditions
+        .checkState(functionInfo != null, "Unsupported function: %s with %s parameters", function.getFunctionName(),
+            numArguments);
     return new FunctionExecutionNode(functionInfo, childNodes);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -161,6 +161,9 @@ public class TransformFunctionFactory {
       case FUNCTION:
         FunctionContext function = expression.getFunction();
         String functionName = function.getFunctionName();
+        List<ExpressionContext> arguments = function.getArguments();
+        int numArguments = arguments.size();
+
         TransformFunction transformFunction;
         Class<? extends TransformFunction> transformFunctionClass = TRANSFORM_FUNCTION_MAP.get(functionName);
         if (transformFunctionClass != null) {
@@ -172,14 +175,15 @@ public class TransformFunctionFactory {
           }
         } else {
           // Scalar function
-          FunctionInfo functionInfo = FunctionRegistry.getFunctionByName(functionName);
+          FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
           if (functionInfo == null) {
-            throw new BadQueryRequestException("Unsupported transform function: " + functionName);
+            throw new BadQueryRequestException(
+                String.format("Unsupported function: %s with %d parameters", functionName, numArguments));
           }
           transformFunction = new ScalarTransformFunctionWrapper(functionInfo);
         }
-        List<ExpressionContext> arguments = function.getArguments();
-        List<TransformFunction> transformFunctionArguments = new ArrayList<>(arguments.size());
+
+        List<TransformFunction> transformFunctionArguments = new ArrayList<>(numArguments);
         for (ExpressionContext argument : arguments) {
           transformFunctionArguments.add(TransformFunctionFactory.get(argument, dataSourceMap));
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
@@ -36,11 +36,12 @@ public class PostAggregationFunction {
   private final ColumnDataType _resultType;
 
   public PostAggregationFunction(String functionName, ColumnDataType[] argumentTypes) {
-    FunctionInfo functionInfo = FunctionRegistry.getFunctionByName(functionName);
-    Preconditions.checkArgument(functionInfo != null, "Unsupported function: %s", functionName);
+    int numArguments = argumentTypes.length;
+    FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+    Preconditions
+        .checkArgument(functionInfo != null, "Unsupported function: %s with %s parameters", functionName, numArguments);
     _functionInvoker = new FunctionInvoker(functionInfo);
     PinotDataType[] parameterTypes = _functionInvoker.getParameterTypes();
-    int numArguments = argumentTypes.length;
     Preconditions.checkArgument(numArguments == parameterTypes.length,
         "Wrong number of arguments for method: %s, expected: %s, actual: %s", functionInfo.getMethod(),
         parameterTypes.length, numArguments);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -18,68 +18,50 @@
  */
 package org.apache.pinot.core.data.function;
 
-import com.google.common.collect.Lists;
+import java.util.Collections;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.joda.time.DateTime;
-import org.joda.time.Days;
-import org.joda.time.MutableDateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class InbuiltFunctionEvaluatorTest {
 
   @Test
-  public void testExpressionWithColumn()
-      throws Exception {
-    MyFunc myFunc = new MyFunc();
-    FunctionRegistry.registerFunction(myFunc.getClass().getDeclaredMethod("reverseString", String.class));
-    String expression = "reverseString(testColumn)";
+  public void testExpressionWithColumn() {
+    String expression = "reverse(testColumn)";
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
-    Assert.assertEquals(evaluator.getArguments(), Lists.newArrayList("testColumn"));
+    assertEquals(evaluator.getArguments(), Collections.singletonList("testColumn"));
     GenericRow row = new GenericRow();
     for (int i = 0; i < 5; i++) {
       String value = "testValue" + i;
-      row.putField("testColumn", value);
-      Object result = evaluator.evaluate(row);
-      Assert.assertEquals(result, new StringBuilder(value).reverse().toString());
+      row.putValue("testColumn", value);
+      assertEquals(evaluator.evaluate(row), new StringBuilder(value).reverse().toString());
     }
   }
 
   @Test
-  public void testExpressionWithConstant()
-      throws Exception {
-    MyFunc myFunc = new MyFunc();
-    FunctionRegistry
-        .registerFunction(myFunc.getClass().getDeclaredMethod("daysSinceEpoch", String.class, String.class));
-    String input = "1980-01-01";
-    String format = "yyyy-MM-dd";
-    String expression = String.format("daysSinceEpoch('%s', '%s')", input, format);
+  public void testExpressionWithConstant() {
+    String expression = "reverse(12345)";
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
-    Assert.assertTrue(evaluator.getArguments().isEmpty());
+    assertTrue(evaluator.getArguments().isEmpty());
     GenericRow row = new GenericRow();
-    Object result = evaluator.evaluate(row);
-    Assert.assertEquals(result, myFunc.daysSinceEpoch(input, format));
+    assertEquals(evaluator.evaluate(row), "54321");
   }
 
   @Test
-  public void testMultiFunctionExpression()
-      throws Exception {
-    MyFunc myFunc = new MyFunc();
-    FunctionRegistry.registerFunction(myFunc.getClass().getDeclaredMethod("reverseString", String.class));
-    FunctionRegistry
-        .registerFunction(myFunc.getClass().getDeclaredMethod("daysSinceEpoch", String.class, String.class));
-    String input = "1980-01-01";
-    String reversedInput = myFunc.reverseString(input);
-    String format = "yyyy-MM-dd";
-    String expression = String.format("daysSinceEpoch(reverseString('%s'), '%s')", reversedInput, format);
+  public void testMultiFunctionExpression() {
+    String expression = "reverse(reverse(testColumn))";
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
-    Assert.assertTrue(evaluator.getArguments().isEmpty());
+    assertEquals(evaluator.getArguments(), Collections.singletonList("testColumn"));
     GenericRow row = new GenericRow();
-    Object result = evaluator.evaluate(row);
-    Assert.assertEquals(result, myFunc.daysSinceEpoch(input, format));
+    for (int i = 0; i < 5; i++) {
+      String value = "testValue" + i;
+      row.putValue("testColumn", value);
+      assertEquals(evaluator.evaluate(row), value);
+    }
   }
 
   @Test
@@ -87,36 +69,21 @@ public class InbuiltFunctionEvaluatorTest {
       throws Exception {
     MyFunc myFunc = new MyFunc();
     FunctionRegistry.registerFunction(myFunc.getClass().getDeclaredMethod("appendToStringAndReturn", String.class));
-    String expression = String.format("appendToStringAndReturn('%s')", "test ");
+    String expression = "appendToStringAndReturn('test ')";
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
-    Assert.assertTrue(evaluator.getArguments().isEmpty());
+    assertTrue(evaluator.getArguments().isEmpty());
     GenericRow row = new GenericRow();
-    Assert.assertEquals(evaluator.evaluate(row), "test ");
-    Assert.assertEquals(evaluator.evaluate(row), "test test ");
-    Assert.assertEquals(evaluator.evaluate(row), "test test test ");
+    assertEquals(evaluator.evaluate(row), "test ");
+    assertEquals(evaluator.evaluate(row), "test test ");
+    assertEquals(evaluator.evaluate(row), "test test test ");
   }
 
   private static class MyFunc {
-    String reverseString(String input) {
-      return new StringBuilder(input).reverse().toString();
-    }
-
-    MutableDateTime EPOCH_START = new MutableDateTime();
-
-    public MyFunc() {
-      EPOCH_START.setDate(0L);
-    }
-
-    int daysSinceEpoch(String input, String format) {
-      DateTime dateTime = DateTimeFormat.forPattern(format).parseDateTime(input);
-      return Days.daysBetween(EPOCH_START, dateTime).getDays();
-    }
-
-    private String baseString = "";
+    String _baseString = "";
 
     String appendToStringAndReturn(String addedString) {
-      baseString += addedString;
-      return baseString;
+      _baseString += addedString;
+      return _baseString;
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.core.data.function;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -215,6 +217,81 @@ public class InbuiltFunctionsTest {
     row11_2.putValue("dateTime", "Mon Aug 24 12:36:46 America/Los_Angeles 2009");
     inputs.add(new Object[]{"fromDateTime(dateTime, \"EEE MMM dd HH:mm:ss ZZZ yyyy\")", Lists.newArrayList(
         "dateTime"), row11_2, 1251142606000L});
+
+    // timezone_hour and timezone_minute
+    List<String> expectedArguments = Collections.singletonList("tz");
+    GenericRow row12_0 = new GenericRow();
+    row12_0.putValue("tz", "UTC");
+    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row12_0, 0});
+    inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row12_0, 0});
+
+    GenericRow row12_1 = new GenericRow();
+    row12_1.putValue("tz", "America/Los_Angeles");
+    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row12_1, 17});
+    inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row12_1, 0});
+
+    GenericRow row12_2 = new GenericRow();
+    row12_2.putValue("tz", "Pacific/Marquesas");
+    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row12_2, 14});
+    inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row12_2, 30});
+
+    GenericRow row12_3 = new GenericRow();
+    row12_3.putValue("tz", "Etc/GMT+12");
+    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row12_3, 12});
+    inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row12_3, 0});
+
+    GenericRow row12_4 = new GenericRow();
+    row12_4.putValue("tz", "Etc/GMT+1");
+    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row12_4, 23});
+    inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row12_4, 0});
+
+    // Convenience extraction functions
+    expectedArguments = Collections.singletonList("millis");
+    GenericRow row13_0 = new GenericRow();
+    // Sat May 23 2020 22:23:13.123 UTC
+    row13_0.putValue("millis", 1590272593123L);
+
+    inputs.add(new Object[]{"year(millis)", expectedArguments, row13_0, 2020});
+    inputs.add(new Object[]{"year_of_week(millis)", expectedArguments, row13_0, 2020});
+    inputs.add(new Object[]{"yow(millis)", expectedArguments, row13_0, 2020});
+    inputs.add(new Object[]{"quarter(millis)", expectedArguments, row13_0, 2});
+    inputs.add(new Object[]{"month(millis)", expectedArguments, row13_0, 5});
+    inputs.add(new Object[]{"week(millis)", expectedArguments, row13_0, 21});
+    inputs.add(new Object[]{"week_of_year(millis)", expectedArguments, row13_0, 21});
+    inputs.add(new Object[]{"day_of_year(millis)", expectedArguments, row13_0, 144});
+    inputs.add(new Object[]{"doy(millis)", expectedArguments, row13_0, 144});
+    inputs.add(new Object[]{"day(millis)", expectedArguments, row13_0, 23});
+    inputs.add(new Object[]{"day_of_month(millis)", expectedArguments, row13_0, 23});
+    inputs.add(new Object[]{"day_of_week(millis)", expectedArguments, row13_0, 6});
+    inputs.add(new Object[]{"dow(millis)", expectedArguments, row13_0, 6});
+    inputs.add(new Object[]{"hour(millis)", expectedArguments, row13_0, 22});
+    inputs.add(new Object[]{"minute(millis)", expectedArguments, row13_0, 23});
+    inputs.add(new Object[]{"second(millis)", expectedArguments, row13_0, 13});
+    inputs.add(new Object[]{"millisecond(millis)", expectedArguments, row13_0, 123});
+
+    expectedArguments = Arrays.asList("millis", "tz");
+    GenericRow row13_1 = new GenericRow();
+    // Sat May 23 2020 15:23:13.123 America/Los_Angeles
+    row13_1.putValue("millis", 1590272593123L);
+    row13_1.putValue("tz", "America/Los_Angeles");
+
+    inputs.add(new Object[]{"year(millis, tz)", expectedArguments, row13_1, 2020});
+    inputs.add(new Object[]{"year_of_week(millis, tz)", expectedArguments, row13_1, 2020});
+    inputs.add(new Object[]{"yow(millis, tz)", expectedArguments, row13_1, 2020});
+    inputs.add(new Object[]{"quarter(millis, tz)", expectedArguments, row13_1, 2});
+    inputs.add(new Object[]{"month(millis, tz)", expectedArguments, row13_1, 5});
+    inputs.add(new Object[]{"week(millis, tz)", expectedArguments, row13_1, 21});
+    inputs.add(new Object[]{"week_of_year(millis, tz)", expectedArguments, row13_1, 21});
+    inputs.add(new Object[]{"day_of_year(millis, tz)", expectedArguments, row13_1, 144});
+    inputs.add(new Object[]{"doy(millis, tz)", expectedArguments, row13_1, 144});
+    inputs.add(new Object[]{"day(millis, tz)", expectedArguments, row13_1, 23});
+    inputs.add(new Object[]{"day_of_month(millis, tz)", expectedArguments, row13_1, 23});
+    inputs.add(new Object[]{"day_of_week(millis, tz)", expectedArguments, row13_1, 6});
+    inputs.add(new Object[]{"dow(millis, tz)", expectedArguments, row13_1, 6});
+    inputs.add(new Object[]{"hour(millis, tz)", expectedArguments, row13_1, 15});
+    inputs.add(new Object[]{"minute(millis, tz)", expectedArguments, row13_1, 23});
+    inputs.add(new Object[]{"second(millis, tz)", expectedArguments, row13_1, 13});
+    inputs.add(new Object[]{"millisecond(millis, tz)", expectedArguments, row13_1, 123});
 
     return inputs.toArray(new Object[0][]);
   }


### PR DESCRIPTION
This PR continues to add more datetime functionality during both ingestion and query time. It is inspired by PrestoDB's datetime functionality, detailed here: https://prestodb.io/docs/current/functions/datetime.html

Also does some refactoring of FunctionRegistry to allow for function overloading.

New functions include: (all functions can take optional time zone)
- `timezone_hour`: Returns the hour of the time zone offset (time zone is mandatory)
- `timezone_minute`: Returns the minute of the time zone offset (time zone is mandatory)
- `year`: Returns the year from the given epoch millis
- `year_of_week`: Returns the year of the ISO week from the given epoch millis
- `yow`: Alias for `year_of_week`
- `quarter`: Returns the quarter of the year from the given epoch millis
- `month`: Returns the month of the year from the given epoch millis
- `week`: Returns the ISO week of the year from the given epoch millis
- `week_of_year`: Alias for `week`
- `day_of_year`: Returns the day of the year from the given epoch millis
- `doy`: Alias for `day_of_year`
- `day`: Returns the day of the month from the given epoch millis
- `day_of_month`: Alias for `day`
- `day_of_week`: Returns the day of the week from the given epoch millis
- `dow`: Alias for `day_of_week`
- `hour`: Returns the hour of the day from the given epoch millis
- `minute`: Returns the minute of the hour from the given epoch millis
- `second`: Returns the second of the minute from the given epoch millis
- `millisecond`: Returns the millisecond of the second from the given epoch millis