### PR TITLE
Adding files generated by running quickstart to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ yarn-debug.log*
 yarn-error.log*
 
 .github/PULL_REQUEST_TEMPLATE.md
+
+#quickstart files
+examples/
+quickstart*


### PR DESCRIPTION
Quickstart generates additional files in the directory and its annoying to see them as part of git status.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        examples/
        quickStartData1589785258792/
        quickStartData1589786369065/
        quickStartData1589786485590/
        quickStartData1589786542192/

```