### PR TITLE
Add broker request info to the error msg in combine operator.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
@@ -174,8 +174,8 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
           } catch (EarlyTerminationException e) {
             // Early-terminated because query times out or is already satisfied
           } catch (Exception e) {
-            LOGGER.error("Exception processing CombineGroupBy for index {}, operator {}", index,
-                _operators.get(index).getClass().getName(), e);
+            LOGGER.error("Exception processing CombineGroupBy for index {}, operator {}, brokerRequest {}", index,
+                _operators.get(index).getClass().getName(), _brokerRequest, e);
             mergedProcessingExceptions.add(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
           } finally {
             operatorLatch.countDown();
@@ -189,7 +189,9 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       boolean opCompleted = operatorLatch.await(_timeOutMs, TimeUnit.MILLISECONDS);
       if (!opCompleted) {
         // If this happens, the broker side should already timed out, just log the error and return
-        String errorMessage = "Timed out while combining group-by results after " + _timeOutMs + "ms";
+        String errorMessage =
+            String.format("Timed out while combining group-by results after %dms, brokerRequest = %s", _timeOutMs,
+                _brokerRequest);
         LOGGER.error(errorMessage);
         return new IntermediateResultsBlock(new TimeoutException(errorMessage));
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
@@ -189,8 +189,8 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
           } catch (EarlyTerminationException e) {
             // Early-terminated because query times out or is already satisfied
           } catch (Exception e) {
-            LOGGER.error("Exception processing CombineGroupByOrderBy for index {}, operator {}", index,
-                _operators.get(index).getClass().getName(), e);
+            LOGGER.error("Exception processing CombineGroupByOrderBy for index {}, operator {}, brokerRequest {}", index,
+                _operators.get(index).getClass().getName(), _brokerRequest, e);
             mergedProcessingExceptions.add(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
           } finally {
             operatorLatch.countDown();
@@ -204,7 +204,9 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
       boolean opCompleted = operatorLatch.await(_timeOutMs, TimeUnit.MILLISECONDS);
       if (!opCompleted) {
         // If this happens, the broker side should already timed out, just log the error and return
-        String errorMessage = "Timed out while combining group-by results after " + _timeOutMs + "ms";
+        String errorMessage =
+            String.format("Timed out while combining group-by results after %dms, brokerRequest = %s", _timeOutMs,
+                _brokerRequest);
         LOGGER.error(errorMessage);
         return new IntermediateResultsBlock(new TimeoutException(errorMessage));
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineOperator.java
@@ -168,13 +168,13 @@ public class CombineOperator extends BaseOperator<IntermediateResultsBlock> {
     try {
       mergedBlock = mergedBlockFuture.get(endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      LOGGER.error("Caught InterruptedException.", e);
+      LOGGER.error("Caught InterruptedException. (brokerRequest = {})", _brokerRequest, e);
       mergedBlock = new IntermediateResultsBlock(QueryException.getException(QueryException.FUTURE_CALL_ERROR, e));
     } catch (ExecutionException e) {
-      LOGGER.error("Caught ExecutionException.", e);
+      LOGGER.error("Caught ExecutionException. (brokerRequest = {})", _brokerRequest, e);
       mergedBlock = new IntermediateResultsBlock(QueryException.getException(QueryException.MERGE_RESPONSE_ERROR, e));
     } catch (TimeoutException e) {
-      LOGGER.error("Caught TimeoutException", e);
+      LOGGER.error("Caught TimeoutException. (brokerRequest = {})", _brokerRequest, e);
       mergedBlockFuture.cancel(true);
       mergedBlock =
           new IntermediateResultsBlock(QueryException.getException(QueryException.EXECUTION_TIMEOUT_ERROR, e));


### PR DESCRIPTION
Current log indicates exception/timeout in combine operator but
this does not give much information for debugging. Adding broker
request to the log will help for debugging.

```
select * from testTable where time > 12345 group by a, b order by a limit 100

BrokerRequest(querySource:QuerySource(tableName:testTable), filterQuery:FilterQuery(id:0, column:time, value:[(12345		*)], operator:RANGE, nestedFilterQueryIds:[]), groupBy:GroupBy(topN:100, expressions:[a, b]), selections:Selection(selectionColumns:[*], selectionSortSequence:[SelectionSort(column:a, isAsc:true)], offset:0, size:100), filterSubQueryMap:FilterQueryMap(filterQueryMap:{0=FilterQuery(id:0, column:time, value:[(12345		*)], operator:RANGE, nestedFilterQueryIds:[])}), orderBy:[SelectionSort(column:a, isAsc:true)], limit:100)
```