### PR TITLE
Update Quickstart to take tmp dir as a parameter

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
@@ -23,15 +23,18 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.AirlineDataStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
@@ -40,7 +43,7 @@ import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
-public class HybridQuickstart {
+public class HybridQuickstart extends QuickStartBase {
   private StreamDataServerStartable _kafkaStarter;
   private ZkStarter.ZookeeperInstance _zookeeperInstance;
   private File _schemaFile;
@@ -50,10 +53,10 @@ public class HybridQuickstart {
 
   public static void main(String[] args)
       throws Exception {
-    // TODO: Explicitly call below method to load dependencies from pinot-plugins libs which are excluded from pinot-tools packaging.
-    // E.g. Kafka related libs are coming from pinot-kafka-* lib, avro libs are coming from pinot-avro lib.
-    PluginManager.get().init();
-    new HybridQuickstart().execute();
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "HYBRID"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
   }
 
   private QuickstartTableRequest prepareTableRequest(File baseDir)
@@ -101,7 +104,7 @@ public class HybridQuickstart {
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
     File baseDir = new File(quickstartTmpDir, "airlineStats");
     File dataDir = new File(baseDir, "data");
     Preconditions.checkState(dataDir.mkdirs());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/JoinQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/JoinQuickStart.java
@@ -22,19 +22,22 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
-public class JoinQuickStart {
+public class JoinQuickStart extends QuickStartBase {
 
-  private void execute()
+  public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
 
     // Baseball stat table
     File baseBallStatsBaseDir = new File(quickstartTmpDir, "baseballStats");
@@ -120,7 +123,9 @@ public class JoinQuickStart {
 
   public static void main(String[] args)
       throws Exception {
-    PluginManager.get().init();
-    new JoinQuickStart().execute();
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "JOIN"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/JsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/JsonIndexQuickStart.java
@@ -21,21 +21,24 @@ package org.apache.pinot.tools;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
-public class JsonIndexQuickStart {
+public class JsonIndexQuickStart extends QuickStartBase {
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
     File baseDir = new File(quickstartTmpDir, "githubEvents");
     File dataDir = new File(quickstartTmpDir, "rawdata");
     Preconditions.checkState(dataDir.mkdirs());
@@ -89,7 +92,9 @@ public class JsonIndexQuickStart {
 
   public static void main(String[] args)
       throws Exception {
-    PluginManager.get().init();
-    new JsonIndexQuickStart().execute();
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "BATCH-JSON-INDEX"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/OfflineComplexTypeHandlingQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/OfflineComplexTypeHandlingQuickStart.java
@@ -21,21 +21,24 @@ package org.apache.pinot.tools;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
-public class OfflineComplexTypeHandlingQuickStart {
+public class OfflineComplexTypeHandlingQuickStart extends QuickStartBase {
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
     File baseDir = new File(quickstartTmpDir, "githubEvents");
     File dataDir = new File(quickstartTmpDir, "rawdata");
     Preconditions.checkState(dataDir.mkdirs());
@@ -89,7 +92,9 @@ public class OfflineComplexTypeHandlingQuickStart {
 
   public static void main(String[] args)
       throws Exception {
-    PluginManager.get().init();
-    new OfflineComplexTypeHandlingQuickStart().execute();
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "BATCH-COMPLEX-TYPE"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -18,28 +18,18 @@
  */
 package org.apache.pinot.tools;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import org.apache.pinot.tools.admin.PinotAdministrator;
+import java.io.File;
+import org.apache.commons.io.FileUtils;
 
 
-public class BatchQuickstartWithMinion extends Quickstart {
+public abstract class QuickStartBase {
+  protected File _tmpDir = FileUtils.getTempDirectory();
 
-  public String getBootstrapDataDir() {
-    return "examples/minions/batch/baseballStats";
+  public QuickStartBase setTmpDir(String tmpDir) {
+    this._tmpDir = new File(tmpDir);
+    return this;
   }
 
-  @Override
-  public int getNumMinions() {
-    return 1;
-  }
-
-  public static void main(String[] args)
-      throws Exception {
-    List<String> arguments = new ArrayList<>();
-    arguments.addAll(Arrays.asList("QuickStart", "-type", "BATCH-MINION"));
-    arguments.addAll(Arrays.asList(args));
-    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
-  }
+  public abstract void execute()
+      throws Exception;
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -23,15 +23,19 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 
-public class Quickstart {
+public class Quickstart extends QuickStartBase {
   private static final String TAB = "\t\t";
   private static final String NEW_LINE = "\n";
+
 
   public enum Color {
     RESET("\u001B[0m"), GREEN("\u001B[32m"), YELLOW("\u001B[33m"), CYAN("\u001B[36m");
@@ -149,7 +153,7 @@ public class Quickstart {
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
     File baseDir = new File(quickstartTmpDir, "baseballStats");
     File dataDir = new File(baseDir, "rawdata");
     Preconditions.checkState(dataDir.mkdirs());
@@ -235,7 +239,9 @@ public class Quickstart {
 
   public static void main(String[] args)
       throws Exception {
-    PluginManager.get().init();
-    new Quickstart().execute();
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "BATCH"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeComplexTypeHandlingQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeComplexTypeHandlingQuickStart.java
@@ -22,12 +22,15 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
 import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpJsonStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
@@ -36,18 +39,20 @@ import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
-public class RealtimeComplexTypeHandlingQuickStart {
+public class RealtimeComplexTypeHandlingQuickStart extends QuickStartBase {
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)
       throws Exception {
-    PluginManager.get().init();
-    new RealtimeComplexTypeHandlingQuickStart().execute();
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "REALTIME-COMPLEX-TYPE"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
   }
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
     File baseDir = new File(quickstartTmpDir, "meetupRsvp");
     File dataDir = new File(baseDir, "data");
     Preconditions.checkState(dataDir.mkdirs());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
@@ -22,12 +22,15 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
 import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpJsonStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
@@ -36,18 +39,20 @@ import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
-public class RealtimeJsonIndexQuickStart {
+public class RealtimeJsonIndexQuickStart extends QuickStartBase {
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)
       throws Exception {
-    PluginManager.get().init();
-    new RealtimeJsonIndexQuickStart().execute();
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "REALTIME-JSON-INDEX"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
   }
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
     File baseDir = new File(quickstartTmpDir, "meetupRsvp");
     File dataDir = new File(baseDir, "data");
     Preconditions.checkState(dataDir.mkdirs());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -22,12 +22,15 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
 import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
@@ -36,19 +39,20 @@ import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
-public class RealtimeQuickStart {
+public class RealtimeQuickStart extends QuickStartBase {
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)
       throws Exception {
-    PluginManager.get().init();
-    new RealtimeQuickStart().execute();
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "REALTIME"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
   }
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
-
+    File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
     File baseDir = new File(quickstartTmpDir, "meetupRsvp");
     File dataDir = new File(baseDir, "rawdata");
     Preconditions.checkState(dataDir.mkdirs());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
@@ -22,12 +22,15 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
 import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
@@ -36,18 +39,20 @@ import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
-public class UpsertQuickStart {
+public class UpsertQuickStart extends QuickStartBase {
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)
       throws Exception {
-    PluginManager.get().init();
-    new UpsertQuickStart().execute();
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "UPSERT"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
   }
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
     File bootstrapTableDir = new File(quickstartTmpDir, "meetupRsvp");
     File dataDir = new File(bootstrapTableDir, "data");
     Preconditions.checkState(dataDir.mkdirs());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -22,8 +22,15 @@ import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.BatchQuickstartWithMinion;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.HybridQuickstart;
+import org.apache.pinot.tools.JoinQuickStart;
+import org.apache.pinot.tools.JsonIndexQuickStart;
+import org.apache.pinot.tools.OfflineComplexTypeHandlingQuickStart;
+import org.apache.pinot.tools.QuickStartBase;
 import org.apache.pinot.tools.Quickstart;
+import org.apache.pinot.tools.RealtimeComplexTypeHandlingQuickStart;
+import org.apache.pinot.tools.RealtimeJsonIndexQuickStart;
 import org.apache.pinot.tools.RealtimeQuickStart;
+import org.apache.pinot.tools.UpsertQuickStart;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +41,9 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
 
   @Option(name = "-type", required = false, metaVar = "<String>", usage = "Type of quickstart, supported: STREAM/BATCH/HYBRID")
   private String _type;
+
+  @Option(name = "-tmpDir", required = false, aliases = {"-quickstartDir", "-dataDir"}, metaVar = "<String>", usage = "Temp Directory to host quickstart data")
+  private String _tmpDir;
 
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
@@ -53,6 +63,14 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
     return this;
   }
 
+  public String getTmpDir() {
+    return _tmpDir;
+  }
+
+  public void setTmpDir(String tmpDir) {
+    _tmpDir = tmpDir;
+  }
+
   @Override
   public String toString() {
     return ("QuickStart -type " + _type);
@@ -60,7 +78,6 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
 
   @Override
   public void cleanup() {
-
   }
 
   @Override
@@ -72,27 +89,62 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
   public boolean execute()
       throws Exception {
     PluginManager.get().init();
+    QuickStartBase quickstart;
     switch (_type.toUpperCase()) {
       case "OFFLINE":
       case "BATCH":
-        new Quickstart().execute();
+        quickstart = new Quickstart();
         break;
       case "OFFLINE_MINION":
       case "BATCH_MINION":
       case "OFFLINE-MINION":
       case "BATCH-MINION":
-        new BatchQuickstartWithMinion().execute();
+        quickstart = new BatchQuickstartWithMinion();
         break;
       case "REALTIME":
       case "STREAM":
-        new RealtimeQuickStart().execute();
+        quickstart = new RealtimeQuickStart();
         break;
       case "HYBRID":
-        new HybridQuickstart().execute();
+        quickstart = new HybridQuickstart();
+        break;
+      case "JOIN":
+        quickstart = new JoinQuickStart();
+        break;
+      case "UPSERT":
+        quickstart = new UpsertQuickStart();
+        break;
+      case "OFFLINE_JSON_INDEX":
+      case "OFFLINE-JSON-INDEX":
+      case "BATCH_JSON_INDEX":
+      case "BATCH-JSON-INDEX":
+        quickstart = new JsonIndexQuickStart();
+        break;
+      case "REALTIME_JSON_INDEX":
+      case "REALTIME-JSON-INDEX":
+      case "STREAM_JSON_INDEX":
+      case "STREAM-JSON-INDEX":
+        quickstart = new RealtimeJsonIndexQuickStart();
+        break;
+      case "OFFLINE_COMPLEX_TYPE":
+      case "OFFLINE-COMPLEX-TYPE":
+      case "BATCH_COMPLEX_TYPE":
+      case "BATCH-COMPLEX-TYPE":
+        quickstart = new OfflineComplexTypeHandlingQuickStart();
+        break;
+      case "REALTIME_COMPLEX_TYPE":
+      case "REALTIME-COMPLEX-TYPE":
+      case "STREAM_COMPLEX_TYPE":
+      case "STREAM-COMPLEX-TYPE":
+        quickstart = new RealtimeComplexTypeHandlingQuickStart();
         break;
       default:
         throw new UnsupportedOperationException("Unsupported QuickStart type: " + _type);
     }
+    if (_tmpDir != null) {
+      quickstart.setTmpDir(_tmpDir);
+    }
+    quickstart.execute();
     return true;
   }
 }


### PR DESCRIPTION
- Move all quickstart main functions to use pinot-admin
- Update Quickstart to take `-tmpDir`( alias: `-quickstartDir`, `-dataDir`) as a parameter to host pinot data