### PR TITLE
Make Literal transformer return string literals

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -128,7 +128,7 @@ public class PinotQuery2BrokerRequestConverter {
           if (selection == null) {
             selection = new Selection();
           }
-          selection.addToSelectionColumns(expression.getLiteral().getStringValue());
+          selection.addToSelectionColumns(expression.getLiteral().getFieldValue().toString());
           break;
         case IDENTIFIER:
           if (selection == null) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.pql.parsers.PinotQuery2BrokerRequestConverter;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
@@ -290,6 +291,18 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(tempBrokerRequest.getFilterQuery().getValue().get(1), "13");
     Assert.assertEquals(tempBrokerRequest.getFilterQuery().getValue().get(2), "15.2");
     Assert.assertEquals(tempBrokerRequest.getFilterQuery().getValue().get(3), "17");
+  }
+
+  @Test
+  public void testBrokerConverterWithLiteral() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select now() from mytable");
+    Literal literal = pinotQuery.getSelectList().get(0).getLiteral();
+    Assert.assertNotNull(literal);
+    PinotQuery2BrokerRequestConverter converter = new PinotQuery2BrokerRequestConverter();
+    BrokerRequest tempBrokerRequest = converter.convert(pinotQuery);
+    Assert.assertEquals(tempBrokerRequest.getQuerySource().getTableName(), "mytable");
+    Assert.assertEquals(tempBrokerRequest.getSelections().getSelectionColumns().get(0),
+        literal.getFieldValue().toString());
   }
 
   @Test

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -18,11 +18,13 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 
 
@@ -32,6 +34,7 @@ import org.apache.pinot.core.segment.index.readers.Dictionary;
  */
 public class LiteralTransformFunction implements TransformFunction {
   private final String _literal;
+  private String[] _result;
 
   public LiteralTransformFunction(String literal) {
     _literal = literal;
@@ -48,12 +51,11 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-    throw new UnsupportedOperationException();
   }
 
   @Override
   public TransformResultMetadata getResultMetadata() {
-    throw new UnsupportedOperationException();
+    return BaseTransformFunction.STRING_SV_NO_DICTIONARY_METADATA;
   }
 
   @Override
@@ -93,7 +95,11 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
-    throw new UnsupportedOperationException();
+    if (_result == null) {
+      _result = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      Arrays.fill(_result, _literal);
+    }
+    return _result;
   }
 
   @Override


### PR DESCRIPTION
- Let LiteralTransformFunction return strings.
- Convert Literal object to string for Selection List