### PR TITLE
Single Quote String Literal for function invoker results

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -676,6 +676,9 @@ public class CalciteSqlParser {
       try {
         FunctionInvoker invoker = new FunctionInvoker(functionInfo);
         Object result = invoker.process(arguments);
+        if (result instanceof String) {
+          result = String.format("'%s'", result);
+        }
         return RequestUtils.getLiteralExpression(result);
       } catch (Exception e) {
         throw new SqlCompilationException(new IllegalArgumentException("Unsupported function - " + funcName, e));

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1534,7 +1534,7 @@ public class CalciteSqlCompilerTest {
     Function greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
     String today = greaterThan.getOperands().get(1).getLiteral().getStringValue();
     String expectedTodayStr =
-        Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z"));
+        "'" + Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z")) + "'";
     Assert.assertEquals(today, expectedTodayStr);
   }
 
@@ -1557,7 +1557,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(expression.getLiteral() != null);
     String today = expression.getLiteral().getStringValue();
     String expectedTodayStr =
-        Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z"));
+        "'" + Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z")) + "'";
     Assert.assertEquals(today, expectedTodayStr);
     expression = CalciteSqlParser.compileToExpression("toDateTime(playerName)");
     Assert.assertTrue(expression.getFunctionCall() != null);
@@ -1575,7 +1575,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(expression.getFunctionCall() != null);
     expression = CalciteSqlParser.invokeCompileTimeFunctionExpression(expression);
     Assert.assertTrue(expression.getLiteral() != null);
-    Assert.assertEquals(expression.getLiteral().getFieldValue(), "emaNreyalp");
+    Assert.assertEquals(expression.getLiteral().getFieldValue(), "'emaNreyalp'");
     expression = CalciteSqlParser.compileToExpression("count(*)");
     Assert.assertTrue(expression.getFunctionCall() != null);
     expression = CalciteSqlParser.invokeCompileTimeFunctionExpression(expression);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -306,6 +309,17 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         throw new RuntimeException(e);
       }
     }, 600_000L, "Failed to generate inverted index");
+  }
+
+  @Test
+  public void testTimeFunc()
+      throws Exception {
+    String sqlQuery = "SELECT toDateTime(now(), 'yyyy-MM-dd z') FROM mytable";
+    JsonNode response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
+    String todayStr = response.get("resultTable").get("rows").get(0).get(0).asText();
+    String expectedTodayStr =
+        Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z"));
+    Assert.assertEquals(todayStr, expectedTodayStr);
   }
 
   @Test


### PR DESCRIPTION
This fix the issue that of function invoker string output breaks query syntax.
E.g. 
query: `SELECT toDateTime(now(), 'yyyy-MM-dd z') FROM mytable` becomes:
`SELECT 2020-05-27 UTC FROM mytable`. And not recognized in Transformation function.

After the fix, it will use `'2020-05-27 UTC'` to replace the literal.

