### PR TITLE
[TE] add back frontend as submodule

### DIFF
--- a/.travis/.travis_te_nightly_build.sh
+++ b/.travis/.travis_te_nightly_build.sh
@@ -26,8 +26,8 @@ if [ -n "${DEPLOY_BUILD_OPTS}" ]; then
   echo "Current build version: $BUILD_VERSION${DEV_VERSION}"
   mvn versions:set -DnewVersion="$BUILD_VERSION${DEV_VERSION}" -q -B
   mvn versions:commit -q -B
-  # Deploy ThirdEye to bintray
-  mvn deploy -s ../.travis/.ci.settings.xml -DskipTests -q
+  # Deploy ThirdEye backend to bintray
+  mvn -pl '!thirdeye-frontend' deploy -s ../.travis/.ci.settings.xml -DskipTests -q
   # Deploy ThirdEye frontend to NPM
   cd thirdeye-frontend/
   npm version ${BUILD_VERSION}${DEV_VERSION}

--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -27,6 +27,7 @@
   <name>thirdeye</name>
 
   <modules>
+    <module>thirdeye-frontend</module>
     <module>thirdeye-pinot</module>
   </modules>
 

--- a/thirdeye/thirdeye-frontend/package.json
+++ b/thirdeye/thirdeye-frontend/package.json
@@ -8,7 +8,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "http://registry.npmjs.org/",
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js app config lib server tests",

--- a/thirdeye/thirdeye-frontend/pom.xml
+++ b/thirdeye/thirdeye-frontend/pom.xml
@@ -21,7 +21,6 @@
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
         <version>1.9.1</version>
-
         <executions>
           <execution>
             <id>install node and npm</id>
@@ -31,7 +30,26 @@
             </goals>
             <configuration>
               <nodeVersion>v10.16.3</nodeVersion>
-              <yarnVersion>v1.12.0</yarnVersion>
+              <yarnVersion>v1.22.4</yarnVersion>
+            </configuration>
+          </execution>
+          <execution>
+            <id>yarn config</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <!-- ensure that it uses packages from open source NPM -->
+              <arguments>config set registry http://registry.npmjs.org/</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>yarn list config</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>config list</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
This PR is to achieve the following items.
- Fix open source build by adding back frontend as submodule.
- Ensure that frontend is built based on packages from open source NPM.