### PR TITLE
[Cleanup] Merge RealtimeSegmentOnlineOfflineStateModel and SegmentOnlineOfflineStateModel in CommonConstants

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
@@ -168,7 +168,7 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
     if (stateMap != null) {
       for (Map.Entry<String, String> state : stateMap.entrySet()) {
         if (!_helixManager.getInstanceName().equals(state.getKey()) && state.getValue()
-            .equals(CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.ONLINE)) {
+            .equals(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE)) {
           otherOnlineBrokerCount++;
         }
       }
@@ -304,7 +304,7 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
       int otherOnlineBrokerCount = 0;
       for (Map.Entry<String, String> state : stateMap.entrySet()) {
         if (!_helixManager.getInstanceName().equals(state.getKey()) && state.getValue()
-            .equals(CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.ONLINE)) {
+            .equals(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE)) {
           otherOnlineBrokerCount++;
         }
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
@@ -51,7 +51,7 @@ import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.CommonConstants;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.spi.config.table.QueryConfig;
@@ -195,8 +195,8 @@ public class RoutingManager implements ClusterChangeHandler {
       Set<String> onlineSegments = new HashSet<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
       for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
         Map<String, String> instanceStateMap = entry.getValue();
-        if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.ONLINE) || instanceStateMap
-            .containsValue(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+        if (instanceStateMap.containsValue(SegmentStateModel.ONLINE) || instanceStateMap
+            .containsValue(SegmentStateModel.CONSUMING)) {
           onlineSegments.add(entry.getKey());
         }
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -31,7 +31,7 @@ import org.apache.helix.model.ExternalView;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.HashUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -153,9 +153,9 @@ abstract class BaseInstanceSelector implements InstanceSelector {
         String instance = instanceStateEntry.getKey();
         String state = instanceStateEntry.getValue();
         // Do not track instances in ERROR state
-        if (!state.equals(RealtimeSegmentOnlineOfflineStateModel.ERROR)) {
+        if (!state.equals(SegmentStateModel.ERROR)) {
           _instanceToSegmentsMap.computeIfAbsent(instance, k -> new ArrayList<>()).add(segment);
-          if (state.equals(RealtimeSegmentOnlineOfflineStateModel.OFFLINE)) {
+          if (state.equals(SegmentStateModel.OFFLINE)) {
             offlineInstances.add(instance);
           } else {
             onlineInstances.add(instance);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
@@ -28,7 +28,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.helix.model.ExternalView;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.HLCSegmentName;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentName;
@@ -90,7 +90,7 @@ public class RealtimeSegmentSelector implements SegmentSelector {
         HLCSegmentName hlcSegmentName = new HLCSegmentName(segment);
         groupIdToHLCSegmentsMap.computeIfAbsent(hlcSegmentName.getGroupId(), k -> new ArrayList<>()).add(segment);
       } else {
-        if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+        if (instanceStateMap.containsValue(SegmentStateModel.CONSUMING)) {
           // Keep the first CONSUMING segment for each partition
           LLCSegmentName llcSegmentName = new LLCSegmentName(segment);
           partitionIdToFirstConsumingLLCSegmentMap.compute(llcSegmentName.getPartitionId(), (k, consumingSegment) -> {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -34,10 +34,10 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ERROR;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.OFFLINE;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ERROR;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
@@ -32,8 +32,8 @@ import org.testng.annotations.Test;
 
 import static org.apache.pinot.broker.routing.segmentselector.RealtimeSegmentSelector.FORCE_HLC;
 import static org.apache.pinot.broker.routing.segmentselector.RealtimeSegmentSelector.ROUTING_OPTIONS_KEY;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEqualsNoOrder;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -56,20 +56,14 @@ public class CommonConstants {
     public static final String UNTAGGED_MINION_INSTANCE = "minion_untagged";
 
     public static class StateModel {
-      public static class SegmentOnlineOfflineStateModel {
-        public static final String ONLINE = "ONLINE";
-        public static final String OFFLINE = "OFFLINE";
-        public static final String ERROR = "ERROR";
-      }
-
-      public static class RealtimeSegmentOnlineOfflineStateModel {
+      public static class SegmentStateModel {
         public static final String ONLINE = "ONLINE";
         public static final String OFFLINE = "OFFLINE";
         public static final String ERROR = "ERROR";
         public static final String CONSUMING = "CONSUMING";
       }
 
-      public static class BrokerOnlineOfflineStateModel {
+      public static class BrokerResourceStateModel {
         public static final String ONLINE = "ONLINE";
         public static final String OFFLINE = "OFFLINE";
         public static final String ERROR = "ERROR";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
@@ -33,7 +33,7 @@ import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -179,8 +179,8 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
       newAssignment = new TreeMap<>();
       for (String segment : currentAssignment.keySet()) {
         List<String> assignedInstances = assignSegment(segment, newAssignment, instancePartitions);
-        newAssignment.put(segment,
-            SegmentAssignmentUtils.getInstanceStateMap(assignedInstances, SegmentOnlineOfflineStateModel.ONLINE));
+        newAssignment
+            .put(segment, SegmentAssignmentUtils.getInstanceStateMap(assignedInstances, SegmentStateModel.ONLINE));
       }
     } else {
       int numReplicaGroups = instancePartitions.getNumReplicaGroups();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -29,7 +29,7 @@ import java.util.TreeMap;
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.assignment.InstancePartitions;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -208,8 +208,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
         newAssignment = new TreeMap<>();
         for (String segment : completedSegmentAssignment.keySet()) {
           List<String> assignedInstances = assignCompletedSegment(segment, newAssignment, completedInstancePartitions);
-          newAssignment.put(segment, SegmentAssignmentUtils
-              .getInstanceStateMap(assignedInstances, RealtimeSegmentOnlineOfflineStateModel.ONLINE));
+          newAssignment
+              .put(segment, SegmentAssignmentUtils.getInstanceStateMap(assignedInstances, SegmentStateModel.ONLINE));
         }
       } else {
         if (completedInstancePartitions.getNumReplicaGroups() == 1) {
@@ -252,8 +252,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
       newAssignment = new TreeMap<>();
       for (String segmentName : completedSegmentAssignment.keySet()) {
         List<String> instancesAssigned = assignConsumingSegment(segmentName, consumingInstancePartitions);
-        Map<String, String> instanceStateMap = SegmentAssignmentUtils
-            .getInstanceStateMap(instancesAssigned, RealtimeSegmentOnlineOfflineStateModel.ONLINE);
+        Map<String, String> instanceStateMap =
+            SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE);
         newAssignment.put(segmentName, instanceStateMap);
       }
     }
@@ -267,8 +267,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
 
       for (String segmentName : consumingSegmentAssignment.keySet()) {
         List<String> instancesAssigned = assignConsumingSegment(segmentName, consumingInstancePartitions);
-        Map<String, String> instanceStateMap = SegmentAssignmentUtils
-            .getInstanceStateMap(instancesAssigned, RealtimeSegmentOnlineOfflineStateModel.CONSUMING);
+        Map<String, String> instanceStateMap =
+            SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.CONSUMING);
         newAssignment.put(segmentName, instanceStateMap);
       }
     } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -30,8 +30,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.pinot.common.assignment.InstancePartitions;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.Pairs;
 
 
@@ -142,7 +141,7 @@ public class SegmentAssignmentUtils {
       Map<String, Map<String, String>> currentAssignment, List<String> instances, int replication) {
     // Use Helix AutoRebalanceStrategy to rebalance the table
     LinkedHashMap<String, Integer> states = new LinkedHashMap<>();
-    states.put(SegmentOnlineOfflineStateModel.ONLINE, replication);
+    states.put(SegmentStateModel.ONLINE, replication);
     AutoRebalanceStrategy autoRebalanceStrategy =
         new AutoRebalanceStrategy(null, new ArrayList<>(currentAssignment.keySet()), states);
     // Make a copy of the current assignment because this step might change the passed in assignment
@@ -252,8 +251,8 @@ public class SegmentAssignmentUtils {
     Map<String, String> instanceStateMap = new TreeMap<>();
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
     for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
-      instanceStateMap.put(instancePartitions.getInstances(partitionId, replicaGroupId).get(instanceId),
-          SegmentOnlineOfflineStateModel.ONLINE);
+      instanceStateMap
+          .put(instancePartitions.getInstances(partitionId, replicaGroupId).get(instanceId), SegmentStateModel.ONLINE);
     }
     return instanceStateMap;
   }
@@ -305,9 +304,9 @@ public class SegmentAssignmentUtils {
       for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
         String segmentName = entry.getKey();
         Map<String, String> instanceStateMap = entry.getValue();
-        if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+        if (instanceStateMap.containsValue(SegmentStateModel.ONLINE)) {
           _completedSegmentAssignment.put(segmentName, instanceStateMap);
-        } else if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+        } else if (instanceStateMap.containsValue(SegmentStateModel.CONSUMING)) {
           _consumingSegmentAssignment.put(segmentName, instanceStateMap);
         } else {
           _offlineSegmentAssignment.put(segmentName, instanceStateMap);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -35,7 +35,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.assignment.InstanceAssignmentConfigUtils;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.controller.helix.core.assignment.instance.InstanceAssignmentDriver;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignment;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentFactory;
@@ -473,7 +473,7 @@ public class TableRebalancer {
       for (Map.Entry<String, String> instanceStateEntry : idealStateInstanceStateMap.entrySet()) {
         // Ignore OFFLINE state in IdealState
         String idealStateInstanceState = instanceStateEntry.getValue();
-        if (idealStateInstanceState.equals(RealtimeSegmentOnlineOfflineStateModel.OFFLINE)) {
+        if (idealStateInstanceState.equals(SegmentStateModel.OFFLINE)) {
           continue;
         }
 
@@ -486,7 +486,7 @@ public class TableRebalancer {
         String instanceName = instanceStateEntry.getKey();
         String externalViewInstanceState = externalViewInstanceStateMap.get(instanceName);
         if (!idealStateInstanceState.equals(externalViewInstanceState)) {
-          if (RealtimeSegmentOnlineOfflineStateModel.ERROR.equals(externalViewInstanceState)) {
+          if (SegmentStateModel.ERROR.equals(externalViewInstanceState)) {
             if (bestEfforts) {
               LOGGER
                   .warn("Found ERROR instance: {} for segment: {}, table: {}, counting it as good state (best-efforts)",

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -174,8 +174,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
     } else {
       // Delete segment if all of its replicas are OFFLINE
       Set<String> states = new HashSet<>(stateMap.values());
-      return states.size() == 1 && states
-          .contains(CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.OFFLINE);
+      return states.size() == 1 && states.contains(CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE);
     }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupSegmentAssignmentTest.java
@@ -27,7 +27,7 @@ import java.util.TreeMap;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.common.assignment.InstancePartitions;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -95,8 +95,8 @@ public class OfflineNonReplicaGroupSegmentAssignmentTest {
         assertEquals(instancesAssigned.get(replicaId), INSTANCES.get(expectedAssignedInstanceId));
         expectedAssignedInstanceId = (expectedAssignedInstanceId + 1) % NUM_INSTANCES;
       }
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
   }
 
@@ -106,8 +106,8 @@ public class OfflineNonReplicaGroupSegmentAssignmentTest {
     for (String segmentName : SEGMENTS) {
       List<String> instancesAssigned =
           _segmentAssignment.assignSegment(segmentName, currentAssignment, _instancePartitionsMap);
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // There should be 100 segments assigned
@@ -134,8 +134,8 @@ public class OfflineNonReplicaGroupSegmentAssignmentTest {
     for (String segmentName : SEGMENTS) {
       List<String> instancesAssigned =
           _segmentAssignment.assignSegment(segmentName, currentAssignment, _instancePartitionsMap);
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // Bootstrap table should reassign all segments based on their alphabetical order

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
@@ -34,7 +34,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
@@ -201,8 +201,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
         assertEquals(instancesAssigned.get(replicaGroupId), INSTANCES.get(expectedAssignedInstanceId));
       }
 
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
   }
 
@@ -234,8 +234,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
         assertEquals(instancesAssigned.get(replicaGroupId), INSTANCES.get(expectedAssignedInstanceId));
       }
 
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
   }
 
@@ -245,8 +245,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     for (String segmentName : SEGMENTS) {
       List<String> instancesAssigned = _segmentAssignmentWithoutPartition
           .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithoutPartition);
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // There should be 90 segments assigned
@@ -274,8 +274,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     for (String segmentName : SEGMENTS) {
       List<String> instancesAssigned = _segmentAssignmentWithPartition
           .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithPartition);
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // There should be 90 segments assigned
@@ -303,8 +303,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     for (String segmentName : SEGMENTS) {
       List<String> instancesAssigned = _segmentAssignmentWithoutPartition
           .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithoutPartition);
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // Bootstrap table should reassign all segments based on their alphabetical order
@@ -326,8 +326,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     for (String segmentName : SEGMENTS) {
       List<String> instancesAssigned = _segmentAssignmentWithPartition
           .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithPartition);
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // Bootstrap table should reassign all segments based on their alphabetical order within the partition

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.pinot.common.assignment.InstancePartitions;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -145,7 +145,7 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
     String offlineSegmentName = "offlineSegment";
     Map<String, String> offlineSegmentInstanceStateMap = SegmentAssignmentUtils
         .getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
-            RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
+            SegmentStateModel.OFFLINE);
     currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
 
     // Rebalance without COMPLETED instance partitions should not change the segment assignment
@@ -167,14 +167,14 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
         Map<String, String> instanceStateMap = newAssignment.get(_segments.get(segmentId));
         for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
           assertTrue(entry.getKey().startsWith(COMPLETED_INSTANCE_NAME_PREFIX));
-          assertEquals(entry.getValue(), RealtimeSegmentOnlineOfflineStateModel.ONLINE);
+          assertEquals(entry.getValue(), SegmentStateModel.ONLINE);
         }
       } else {
         // CONSUMING segments
         Map<String, String> instanceStateMap = newAssignment.get(_segments.get(segmentId));
         for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
           assertTrue(entry.getKey().startsWith(CONSUMING_INSTANCE_NAME_PREFIX));
-          assertEquals(entry.getValue(), RealtimeSegmentOnlineOfflineStateModel.CONSUMING);
+          assertEquals(entry.getValue(), SegmentStateModel.CONSUMING);
         }
       }
     }
@@ -215,10 +215,10 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
     for (Map.Entry<String, Map<String, String>> entry : newAssignment.entrySet()) {
       String segmentName = entry.getKey();
       Map<String, String> instanceStateMap = entry.getValue();
-      if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+      if (instanceStateMap.containsValue(SegmentStateModel.ONLINE)) {
         for (int i = 0; i < NUM_REPLICAS; i++) {
           String expectedInstance = COMPLETED_INSTANCES.get(index++ % NUM_COMPLETED_INSTANCES);
-          assertEquals(instanceStateMap.get(expectedInstance), RealtimeSegmentOnlineOfflineStateModel.ONLINE);
+          assertEquals(instanceStateMap.get(expectedInstance), SegmentStateModel.ONLINE);
         }
       } else {
         // CONSUMING and OFFLINE segments should not be reassigned
@@ -234,12 +234,11 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
       String lastSegmentInPartition = _segments.get(segmentId - NUM_PARTITIONS);
       Map<String, String> instanceStateMap = currentAssignment.get(lastSegmentInPartition);
       currentAssignment.put(lastSegmentInPartition, SegmentAssignmentUtils
-          .getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()),
-              RealtimeSegmentOnlineOfflineStateModel.ONLINE));
+          .getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()), SegmentStateModel.ONLINE));
     }
 
     // Add the new segment into the assignment as CONSUMING
-    currentAssignment.put(_segments.get(segmentId), SegmentAssignmentUtils
-        .getInstanceStateMap(instancesAssigned, RealtimeSegmentOnlineOfflineStateModel.CONSUMING));
+    currentAssignment.put(_segments.get(segmentId),
+        SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.CONSUMING));
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.pinot.common.assignment.InstancePartitions;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
@@ -170,7 +170,7 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
     String offlineSegmentName = "offlineSegment";
     Map<String, String> offlineSegmentInstanceStateMap = SegmentAssignmentUtils
         .getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
-            RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
+            SegmentStateModel.OFFLINE);
     currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
 
     // Rebalance without COMPLETED instance partitions should not change the segment assignment
@@ -192,14 +192,14 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
         Map<String, String> instanceStateMap = newAssignment.get(_segments.get(segmentId));
         for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
           assertTrue(entry.getKey().startsWith(COMPLETED_INSTANCE_NAME_PREFIX));
-          assertEquals(entry.getValue(), RealtimeSegmentOnlineOfflineStateModel.ONLINE);
+          assertEquals(entry.getValue(), SegmentStateModel.ONLINE);
         }
       } else {
         // CONSUMING segments
         Map<String, String> instanceStateMap = newAssignment.get(_segments.get(segmentId));
         for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
           assertTrue(entry.getKey().startsWith(CONSUMING_INSTANCE_NAME_PREFIX));
-          assertEquals(entry.getValue(), RealtimeSegmentOnlineOfflineStateModel.CONSUMING);
+          assertEquals(entry.getValue(), SegmentStateModel.CONSUMING);
         }
       }
     }
@@ -239,12 +239,12 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
     for (Map.Entry<String, Map<String, String>> entry : newAssignment.entrySet()) {
       String segmentName = entry.getKey();
       Map<String, String> instanceStateMap = entry.getValue();
-      if (instanceStateMap.containsValue(RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+      if (instanceStateMap.containsValue(SegmentStateModel.ONLINE)) {
         int expectedInstanceId = index++ % numCompletedInstancesPerReplicaGroup;
         for (int i = 0; i < NUM_REPLICAS; i++) {
           String expectedInstance =
               COMPLETED_INSTANCES.get(expectedInstanceId + i * numCompletedInstancesPerReplicaGroup);
-          assertEquals(instanceStateMap.get(expectedInstance), RealtimeSegmentOnlineOfflineStateModel.ONLINE);
+          assertEquals(instanceStateMap.get(expectedInstance), SegmentStateModel.ONLINE);
         }
       } else {
         // CONSUMING and OFFLINE segments should not be reassigned
@@ -260,12 +260,11 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
       String lastSegmentInPartition = _segments.get(segmentId - NUM_PARTITIONS);
       Map<String, String> instanceStateMap = currentAssignment.get(lastSegmentInPartition);
       currentAssignment.put(lastSegmentInPartition, SegmentAssignmentUtils
-          .getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()),
-              RealtimeSegmentOnlineOfflineStateModel.ONLINE));
+          .getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()), SegmentStateModel.ONLINE));
     }
 
     // Add the new segment into the assignment as CONSUMING
-    currentAssignment.put(_segments.get(segmentId), SegmentAssignmentUtils
-        .getInstanceStateMap(instancesAssigned, RealtimeSegmentOnlineOfflineStateModel.CONSUMING));
+    currentAssignment.put(_segments.get(segmentId),
+        SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.CONSUMING));
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtilsTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.apache.pinot.common.assignment.InstancePartitions;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -57,8 +57,8 @@ public class SegmentAssignmentUtilsTest {
         instancesAssigned.add(instances.get(assignedInstanceId));
         assignedInstanceId = (assignedInstanceId + 1) % numInstances;
       }
-      currentAssignment.put(segmentName,
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+      currentAssignment
+          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // There should be 100 segments assigned
@@ -240,7 +240,7 @@ public class SegmentAssignmentUtilsTest {
         instancesAssigned.add(instances.get(assignedInstanceId));
       }
       currentAssignment.put(segments.get(segmentId),
-          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentOnlineOfflineStateModel.ONLINE));
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // There should be 90 segments assigned

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.ONLINE;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -24,10 +24,10 @@ import java.util.TreeMap;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ERROR;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.OFFLINE;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ERROR;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTest.java
@@ -31,7 +31,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ValidationMetrics;
-import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.ControllerConf;
@@ -229,7 +229,7 @@ public class ControllerPeriodicTasksIntegrationTest extends BaseClusterIntegrati
         idealState -> {
           assertNotNull(idealState);
           Map<String, String> instanceStateMap = idealState.getRecord().getMapFields().values().iterator().next();
-          instanceStateMap.entrySet().iterator().next().setValue(RealtimeSegmentOnlineOfflineStateModel.OFFLINE);
+          instanceStateMap.entrySet().iterator().next().setValue(SegmentStateModel.OFFLINE);
           return idealState;
         }, RetryPolicies.fixedDelayRetryPolicy(2, 10));
 
@@ -324,9 +324,9 @@ public class ControllerPeriodicTasksIntegrationTest extends BaseClusterIntegrati
       for (Map<String, String> instanceStateMap : idealState.getRecord().getMapFields().values()) {
         for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
           String state = entry.getValue();
-          if (state.equals(RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+          if (state.equals(SegmentStateModel.CONSUMING)) {
             consumingServers.add(entry.getKey());
-          } else if (state.equals(RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+          } else if (state.equals(SegmentStateModel.ONLINE)) {
             completedServers.add(entry.getKey());
           }
         }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -161,7 +161,7 @@ public class HelixServerStarter implements ServiceStartable {
         }
         if (checkRealtime && !foundConsuming && TableNameBuilder.isRealtimeTableResource(resourceName)) {
           for (String partitionName : idealState.getPartitionSet()) {
-            if (StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING
+            if (StateModel.SegmentStateModel.CONSUMING
                 .equals(idealState.getInstanceStateMap(partitionName).get(_instanceId))) {
               foundConsuming = true;
               break;
@@ -570,8 +570,7 @@ public class HelixServerStarter implements ServiceStartable {
     for (String partition : externalView.getPartitionSet()) {
       Map<String, String> instanceStateMap = externalView.getStateMap(partition);
       String state = instanceStateMap.get(_instanceId);
-      if (StateModel.SegmentOnlineOfflineStateModel.ONLINE.equals(state)
-          || StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING.equals(state)) {
+      if (StateModel.SegmentStateModel.ONLINE.equals(state) || StateModel.SegmentStateModel.CONSUMING.equals(state)) {
         return false;
       }
     }


### PR DESCRIPTION
We only have one SegmentOnlineOfflineStateModel, so there is no value keeping both of them