### PR TITLE
Adding Support for SQL CASE Statement

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -38,7 +38,15 @@ public enum TransformFunctionType {
   LN("ln"),
   SQRT("sqrt"),
 
+  EQUALS("equals"),
+  NOT_EQUALS("not_equals"),
+  GREATER_THAN("greater_than"),
+  GREATER_THAN_OR_EQUAL("greater_than_or_equal"),
+  LESS_THAN("less_than"),
+  LESS_THAN_OR_EQUAL("less_than_or_equal"),
+
   CAST("cast"),
+  CASE("case"),
   JSONEXTRACTSCALAR("jsonExtractScalar"),
   JSONEXTRACTKEY("jsonExtractKey"),
   TIMECONVERT("timeConvert"),

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -103,6 +103,21 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(caseFunc.getOperands().get(6).getLiteral().getFieldValue(), 0L);
   }
 
+  @Test(expectedExceptions = SqlCompilationException.class)
+  public void testInvalidCaseWhenStatements() {
+    // Not support Aggregation functions in case statements.
+    try {
+      CalciteSqlParser.compileToPinotQuery("SELECT OrderID, Quantity,\n" + "CASE\n"
+          + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
+          + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n" + "    ELSE 'The quantity is under 30'\n"
+          + "END AS QuantityText\n" + "FROM OrderDetails");
+    } catch (SqlCompilationException e) {
+      Assert.assertEquals(e.getMessage(),
+          "Aggregation functions inside WHEN Clause is not supported - SUM(`Quantity`) > 30");
+      throw e;
+    }
+  }
+
   @Test
   public void testQuotedStrings() {
     PinotQuery pinotQuery =

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -52,13 +52,9 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testCaseWhenStatements() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT OrderID, Quantity,\n"
-            + "CASE\n"
-            + "    WHEN Quantity > 30 THEN 'The quantity is greater than 30'\n"
-            + "    WHEN Quantity = 30 THEN 'The quantity is 30'\n"
-            + "    ELSE 'The quantity is under 30'\n"
-            + "END AS QuantityText\n"
-            + "FROM OrderDetails");
+        "SELECT OrderID, Quantity,\n" + "CASE\n" + "    WHEN Quantity > 30 THEN 'The quantity is greater than 30'\n"
+            + "    WHEN Quantity = 30 THEN 'The quantity is 30'\n" + "    ELSE 'The quantity is under 30'\n"
+            + "END AS QuantityText\n" + "FROM OrderDetails");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "OrderID");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "Quantity");
     Function asFunc = pinotQuery.getSelectList().get(2).getFunctionCall();
@@ -79,14 +75,8 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(caseFunc.getOperands().get(4).getLiteral().getFieldValue(), "The quantity is under 30");
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT Quantity,\n"
-            + "SUM(CASE\n"
-            + "    WHEN Quantity > 30 THEN 3\n"
-            + "    WHEN Quantity > 20 THEN 2\n"
-            + "    WHEN Quantity > 10 THEN 1\n"
-            + "    ELSE 0\n"
-            + "END) AS new_sum_quant\n"
-            + "FROM OrderDetails");
+        "SELECT Quantity,\n" + "SUM(CASE\n" + "    WHEN Quantity > 30 THEN 3\n" + "    WHEN Quantity > 20 THEN 2\n"
+            + "    WHEN Quantity > 10 THEN 1\n" + "    ELSE 0\n" + "END) AS new_sum_quant\n" + "FROM OrderDetails");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "Quantity");
     asFunc = pinotQuery.getSelectList().get(1).getFunctionCall();
     Assert.assertEquals(asFunc.getOperator(), SqlKind.AS.name());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -95,7 +95,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
           case FLOAT:
             float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
             for (int i = 0; i < length; i++) {
-              _results[i] = getBinaryFuncResult(Double.compare(leftIntValues[i], rightFloatValues[i]));
+              _results[i] = getBinaryFuncResult(Float.compare(leftIntValues[i], rightFloatValues[i]));
             }
             break;
           case DOUBLE:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -65,6 +65,12 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     return INT_SV_NO_DICTIONARY_METADATA;
   }
 
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    fillResultArray(projectionBlock);
+    return _results;
+  }
+
   protected void fillResultArray(ProjectionBlock projectionBlock) {
     if (_results == null) {
       _results = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -1,0 +1,320 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.ByteArray;
+
+
+/**
+ * <code>BinaryOperatorTransformFunction</code> abstracts common functions for binary operators (=, !=, >=, >, <=, <)
+ * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
+ */
+public abstract class BinaryOperatorTransformFunction extends BaseTransformFunction {
+
+  protected TransformFunction _leftTransformFunction;
+  protected TransformFunction _rightTransformFunction;
+  protected FieldSpec.DataType _leftDataType;
+  protected FieldSpec.DataType _rightDataType;
+  protected int[] _results;
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    // Check that there are exact 2 arguments
+    if (arguments.size() != 2) {
+      throw new IllegalArgumentException("Exact 2 arguments are required for binary operator transform function");
+    }
+    _leftTransformFunction = arguments.get(0);
+    _rightTransformFunction = arguments.get(1);
+    _leftDataType = _leftTransformFunction.getResultMetadata().getDataType();
+    _rightDataType = _rightTransformFunction.getResultMetadata().getDataType();
+    switch (_leftDataType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case STRING:
+        switch (_rightDataType) {
+          case INT:
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+          case STRING:
+            break;
+          default:
+            throw new IllegalStateException(String.format(
+                "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform Function [%s] result type is [%s]]",
+                _leftTransformFunction.getName(), _leftDataType, _rightTransformFunction.getName(), _rightDataType));
+        }
+        break;
+      case BYTES:
+        if (_rightDataType != FieldSpec.DataType.BYTES) {
+          throw new IllegalStateException(String.format(
+              "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform Function [%s] result type is [%s]]",
+              _leftTransformFunction.getName(), _leftDataType, _rightTransformFunction.getName(), _rightDataType));
+        }
+        break;
+      default:
+        throw new IllegalStateException(String.format(
+            "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform Function [%s] result type is [%s]]",
+            _leftTransformFunction.getName(), _leftDataType, _rightTransformFunction.getName(), _rightDataType));
+    }
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return INT_SV_NO_DICTIONARY_METADATA;
+  }
+
+  protected void fillResultArray(ProjectionBlock projectionBlock) {
+    if (_results == null) {
+      _results = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+    int length = projectionBlock.getNumDocs();
+    switch (_leftDataType) {
+      case INT:
+        int[] leftIntValues = _leftTransformFunction.transformToIntValuesSV(projectionBlock);
+        switch (_rightDataType) {
+          case INT:
+            int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Integer.compare(leftIntValues[i], rightIntValues[i]));
+            }
+            break;
+          case LONG:
+            long[] rightLongValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Long.compare(leftIntValues[i], rightLongValues[i]));
+            }
+            break;
+          case FLOAT:
+            float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Double.compare(leftIntValues[i], rightFloatValues[i]));
+            }
+            break;
+          case DOUBLE:
+            double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Double.compare(leftIntValues[i], rightDoubleValues[i]));
+            }
+            break;
+          case STRING:
+            String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  BigDecimal.valueOf(leftIntValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+            }
+            break;
+          default:
+            throw new IllegalStateException(String.format(
+                "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform Function [%s] result type is [%s]]",
+                _leftTransformFunction.getName(), _leftDataType, _rightTransformFunction.getName(), _rightDataType));
+        }
+        break;
+      case LONG:
+        long[] leftLongValues = _leftTransformFunction.transformToLongValuesSV(projectionBlock);
+        switch (_rightDataType) {
+          case INT:
+            int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Long.compare(leftLongValues[i], rightIntValues[i]));
+            }
+            break;
+          case LONG:
+            long[] rightLongValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Long.compare(leftLongValues[i], rightLongValues[i]));
+            }
+            break;
+          case FLOAT:
+            float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  BigDecimal.valueOf(leftLongValues[i]).compareTo(BigDecimal.valueOf(rightFloatValues[i])));
+            }
+            break;
+          case DOUBLE:
+            double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  BigDecimal.valueOf(leftLongValues[i]).compareTo(BigDecimal.valueOf(rightDoubleValues[i])));
+            }
+            break;
+          case STRING:
+            String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  BigDecimal.valueOf(leftLongValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+            }
+            break;
+          default:
+            throw new IllegalStateException(String.format(
+                "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform Function [%s] result type is [%s]]",
+                _leftTransformFunction.getName(), _leftDataType, _rightTransformFunction.getName(), _rightDataType));
+        }
+        break;
+      case FLOAT:
+        float[] leftFloatValues = _leftTransformFunction.transformToFloatValuesSV(projectionBlock);
+        switch (_rightDataType) {
+          case INT:
+            int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Double.compare(leftFloatValues[i], rightIntValues[i]));
+            }
+            break;
+          case LONG:
+            long[] rightLongValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  BigDecimal.valueOf(leftFloatValues[i]).compareTo(BigDecimal.valueOf(rightLongValues[i])));
+            }
+            break;
+          case FLOAT:
+            float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Float.compare(leftFloatValues[i], rightFloatValues[i]));
+            }
+            break;
+          case DOUBLE:
+            double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Double.compare(leftFloatValues[i], rightDoubleValues[i]));
+            }
+            break;
+          case STRING:
+            String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  BigDecimal.valueOf(leftFloatValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+            }
+            break;
+          default:
+            throw new IllegalStateException(String.format(
+                "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform Function [%s] result type is [%s]]",
+                _leftTransformFunction.getName(), _leftDataType, _rightTransformFunction.getName(), _rightDataType));
+        }
+        break;
+      case DOUBLE:
+        double[] leftDoubleValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
+        switch (_rightDataType) {
+          case INT:
+            int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Double.compare(leftDoubleValues[i], rightIntValues[i]));
+            }
+            break;
+          case LONG:
+            long[] rightLongValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  BigDecimal.valueOf(leftDoubleValues[i]).compareTo(BigDecimal.valueOf(rightLongValues[i])));
+            }
+            break;
+          case FLOAT:
+            float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Double.compare(leftDoubleValues[i], rightFloatValues[i]));
+            }
+            break;
+          case DOUBLE:
+            double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(Double.compare(leftDoubleValues[i], rightDoubleValues[i]));
+            }
+            break;
+          case STRING:
+            String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  BigDecimal.valueOf(leftDoubleValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+            }
+            break;
+          default:
+            throw new IllegalStateException(String.format(
+                "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform Function [%s] result type is [%s]]",
+                _leftTransformFunction.getName(), _leftDataType, _rightTransformFunction.getName(), _rightDataType));
+        }
+        break;
+      case STRING:
+        String[] leftStringValues = _leftTransformFunction.transformToStringValuesSV(projectionBlock);
+        switch (_rightDataType) {
+          case INT:
+            int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  new BigDecimal(leftStringValues[i]).compareTo(BigDecimal.valueOf(rightIntValues[i])));
+            }
+            break;
+          case LONG:
+            long[] rightLongValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  new BigDecimal(leftStringValues[i]).compareTo(BigDecimal.valueOf(rightLongValues[i])));
+            }
+            break;
+          case FLOAT:
+            float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  new BigDecimal(leftStringValues[i]).compareTo(BigDecimal.valueOf(rightFloatValues[i])));
+            }
+            break;
+          case DOUBLE:
+            double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(
+                  new BigDecimal(leftStringValues[i]).compareTo(BigDecimal.valueOf(rightDoubleValues[i])));
+            }
+            break;
+          case STRING:
+            String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+            for (int i = 0; i < length; i++) {
+              _results[i] = getBinaryFuncResult(leftStringValues[i].compareTo(rightStringValues[i]));
+            }
+            break;
+          default:
+            throw new IllegalStateException(String.format(
+                "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform Function [%s] result type is [%s]]",
+                _leftTransformFunction.getName(), _leftDataType, _rightTransformFunction.getName(), _rightDataType));
+        }
+        break;
+      case BYTES:
+        byte[][] leftBytesValues = _leftTransformFunction.transformToBytesValuesSV(projectionBlock);
+        byte[][] rightBytesValues = _rightTransformFunction.transformToBytesValuesSV(projectionBlock);
+        for (int i = 0; i < length; i++) {
+          _results[i] =
+              getBinaryFuncResult((new ByteArray(leftBytesValues[i])).compareTo(new ByteArray(rightBytesValues[i])));
+        }
+        break;
+      // NOTE: Multi-value columns are not comparable, so we should not reach here
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  abstract int getBinaryFuncResult(int result);
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -18,15 +18,15 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import com.google.common.base.Preconditions;
-import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.util.ArrayCopyUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
@@ -58,6 +58,12 @@ public class CaseTransformFunction extends BaseTransformFunction {
   private final List<TransformFunction> _elseThenStatements = new ArrayList<>();
   private int _numberWhenStatements;
   private TransformResultMetadata _resultMetadata;
+  private int[] _selectedResults;
+  private int[] _intResults;
+  private long[] _longResults;
+  private float[] _floatResults;
+  private double[] _doubleResults;
+  private String[] _stringResults;
 
   @Override
   public String getName() {
@@ -79,17 +85,21 @@ public class CaseTransformFunction extends BaseTransformFunction {
     for (int i = _numberWhenStatements; i < _numberWhenStatements * 2; i++) {
       _elseThenStatements.add(arguments.get(i));
     }
-    Preconditions.checkState(_elseThenStatements.size() == _numberWhenStatements + 1, "Missing THEN/ELSE clause in CASE statement");
-    _resultMetadata = getResultMetadata(_elseThenStatements);
+    getResultMetadata();
   }
 
-  private TransformResultMetadata getResultMetadata(List<TransformFunction> elseThenStatements) {
-    FieldSpec.DataType dataType = elseThenStatements.get(0).getResultMetadata().getDataType();
-    for (int i = 1; i < elseThenStatements.size(); i++) {
-      TransformResultMetadata resultMetadata = elseThenStatements.get(i).getResultMetadata();
-      if (!resultMetadata.isSingleValue()) {
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    if (_resultMetadata != null) {
+      return _resultMetadata;
+    }
+    FieldSpec.DataType dataType = _elseThenStatements.get(0).getResultMetadata().getDataType();
+    boolean isSingleValueField = _elseThenStatements.get(0).getResultMetadata().isSingleValue();
+    for (int i = 1; i < _elseThenStatements.size(); i++) {
+      TransformResultMetadata resultMetadata = _elseThenStatements.get(i).getResultMetadata();
+      if (resultMetadata.isSingleValue() != isSingleValueField) {
         throw new IllegalStateException(
-            String.format("Incompatible expression types in THEN Clause [%s].", resultMetadata));
+            String.format("Mixed Single/Multi Value results in expression types in THEN Clause [%s].", resultMetadata));
       }
       switch (dataType) {
         case INT:
@@ -133,7 +143,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
               dataType = FieldSpec.DataType.DOUBLE;
               break;
             case STRING:
-              dataType = resultMetadata.getDataType();
+              dataType = FieldSpec.DataType.STRING;
               break;
             default:
               throw new IllegalStateException(
@@ -175,310 +185,267 @@ public class CaseTransformFunction extends BaseTransformFunction {
           }
       }
     }
-    return new TransformResultMetadata(dataType, true, false);
-  }
-
-  @Override
-  public TransformResultMetadata getResultMetadata() {
+    _resultMetadata = new TransformResultMetadata(dataType, true, false);
     return _resultMetadata;
   }
 
+  /**
+   * Evaluate the ProjectionBlock for the WHEN statements, returns an array with the
+   * index(1 to N) of matched WHEN clause, 0 means nothing matched, so go to ELSE.
+   *
+   * @param projectionBlock
+   * @return
+   */
   private int[] getSelectedArray(ProjectionBlock projectionBlock) {
-    int[] selected = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_selectedResults == null) {
+      _selectedResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    } else {
+      Arrays.fill(_selectedResults, 0);
+    }
     for (int i = 0; i < _numberWhenStatements; i++) {
       TransformFunction transformFunction = _whenStatements.get(i);
       int[] conditions = transformFunction.transformToIntValuesSV(projectionBlock);
       for (int j = 0; j < conditions.length; j++) {
-        if (selected[j] == 0 && conditions[j] == 1) {
-          selected[j] = i + 1;
+        if (_selectedResults[j] == 0 && conditions[j] == 1) {
+          _selectedResults[j] = i + 1;
         }
       }
     }
-    return selected;
+    return _selectedResults;
   }
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    if (_resultMetadata.getDataType() != FieldSpec.DataType.INT) {
+      return super.transformToIntValuesSV(projectionBlock);
+    }
     int[] selected = getSelectedArray(projectionBlock);
-    int[] results = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_intResults == null) {
+      _intResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
     for (int i = 0; i < _elseThenStatements.size(); i++) {
       TransformFunction transformFunction = _elseThenStatements.get(i);
       FieldSpec.DataType dataType = transformFunction.getResultMetadata().getDataType();
-      switch (dataType) {
-        case INT:
-          int[] evalInts = transformFunction.transformToIntValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalInts[j];
-            }
-          }
-          break;
-        case LONG:
-          long[] evalLongs = transformFunction.transformToLongValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = (int) evalLongs[j];
-            }
-          }
-          break;
-        case FLOAT:
-          float[] evalFloats = transformFunction.transformToFloatValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = (int) evalFloats[j];
-            }
-          }
-          break;
-        case DOUBLE:
-          double[] evalDoubles = transformFunction.transformToDoubleValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = (int) evalDoubles[j];
-            }
-          }
-          break;
-        case STRING:
-          String[] evalStrings = transformFunction.transformToStringValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = new BigDecimal(evalStrings[i]).intValue();
-            }
-          }
-          break;
-        default:
-          throw new IllegalStateException(String
-              .format("Cannot convert result type [%s] to [INT] for transform function [%s]", dataType,
-                  transformFunction));
+      int blockNumDocs = projectionBlock.getNumDocs();
+      int[] evalInts;
+      if (dataType == FieldSpec.DataType.INT) {
+        evalInts = transformFunction.transformToIntValuesSV(projectionBlock);
+      } else {
+        evalInts = new int[blockNumDocs];
+        switch (dataType) {
+          case LONG:
+            ArrayCopyUtils.copy(transformFunction.transformToLongValuesSV(projectionBlock), evalInts, blockNumDocs);
+            break;
+          case FLOAT:
+            ArrayCopyUtils.copy(transformFunction.transformToFloatValuesSV(projectionBlock), evalInts, blockNumDocs);
+            break;
+          case DOUBLE:
+            ArrayCopyUtils.copy(transformFunction.transformToDoubleValuesSV(projectionBlock), evalInts, blockNumDocs);
+            break;
+          case STRING:
+            ArrayCopyUtils.copy(transformFunction.transformToStringValuesSV(projectionBlock), evalInts, blockNumDocs);
+            break;
+          default:
+            throw new IllegalStateException(String
+                .format("Cannot convert result type [%s] to [INT] for transform function [%s]", dataType,
+                    transformFunction));
+        }
+      }
+      for (int j = 0; j < blockNumDocs; j++) {
+        if (selected[j] == i) {
+          _intResults[j] = evalInts[j];
+        }
       }
     }
-    return results;
+    return _intResults;
   }
 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
+    if (_resultMetadata.getDataType() != FieldSpec.DataType.LONG) {
+      return super.transformToLongValuesSV(projectionBlock);
+    }
     int[] selected = getSelectedArray(projectionBlock);
-    long[] results = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_longResults == null) {
+      _longResults = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
     for (int i = 0; i < _elseThenStatements.size(); i++) {
       TransformFunction transformFunction = _elseThenStatements.get(i);
       FieldSpec.DataType dataType = transformFunction.getResultMetadata().getDataType();
-      switch (dataType) {
-        case INT:
-          int[] evalInts = transformFunction.transformToIntValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalInts[j];
-            }
-          }
-          break;
-        case LONG:
-          long[] evalLongs = transformFunction.transformToLongValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalLongs[j];
-            }
-          }
-          break;
-        case FLOAT:
-          float[] evalFloats = transformFunction.transformToFloatValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = (long) evalFloats[j];
-            }
-          }
-          break;
-        case DOUBLE:
-          double[] evalDoubles = transformFunction.transformToDoubleValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = (long) evalDoubles[j];
-            }
-          }
-          break;
-        case STRING:
-          String[] evalStrings = transformFunction.transformToStringValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = new BigDecimal(evalStrings[i]).longValue();
-            }
-          }
-          break;
-        default:
-          throw new IllegalStateException(String
-              .format("Cannot convert result type [%s] to [LONG] for transform function [%s]", dataType,
-                  transformFunction));
+      int blockNumDocs = projectionBlock.getNumDocs();
+      long[] evalLongs;
+      if (dataType == FieldSpec.DataType.LONG) {
+        evalLongs = transformFunction.transformToLongValuesSV(projectionBlock);
+      } else {
+        evalLongs = new long[blockNumDocs];
+        switch (dataType) {
+          case INT:
+            ArrayCopyUtils.copy(transformFunction.transformToIntValuesSV(projectionBlock), evalLongs, blockNumDocs);
+            break;
+          case FLOAT:
+            ArrayCopyUtils.copy(transformFunction.transformToFloatValuesSV(projectionBlock), evalLongs, blockNumDocs);
+            break;
+          case DOUBLE:
+            ArrayCopyUtils.copy(transformFunction.transformToDoubleValuesSV(projectionBlock), evalLongs, blockNumDocs);
+            break;
+          case STRING:
+            ArrayCopyUtils.copy(transformFunction.transformToStringValuesSV(projectionBlock), evalLongs, blockNumDocs);
+            break;
+          default:
+            throw new IllegalStateException(String
+                .format("Cannot convert result type [%s] to [LONG] for transform function [%s]", dataType,
+                    transformFunction));
+        }
+      }
+      for (int j = 0; j < blockNumDocs; j++) {
+        if (selected[j] == i) {
+          _longResults[j] = evalLongs[j];
+        }
       }
     }
-    return results;
+    return _longResults;
   }
 
   @Override
   public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
+    if (_resultMetadata.getDataType() != FieldSpec.DataType.FLOAT) {
+      return super.transformToFloatValuesSV(projectionBlock);
+    }
     int[] selected = getSelectedArray(projectionBlock);
-    float[] results = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_floatResults == null) {
+      _floatResults = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
     for (int i = 0; i < _elseThenStatements.size(); i++) {
       TransformFunction transformFunction = _elseThenStatements.get(i);
       FieldSpec.DataType dataType = transformFunction.getResultMetadata().getDataType();
-      switch (dataType) {
-        case INT:
-          int[] evalInts = transformFunction.transformToIntValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalInts[j];
-            }
-          }
-          break;
-        case LONG:
-          long[] evalLongs = transformFunction.transformToLongValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalLongs[j];
-            }
-          }
-          break;
-        case FLOAT:
-          float[] evalFloats = transformFunction.transformToFloatValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalFloats[j];
-            }
-          }
-          break;
-        case DOUBLE:
-          double[] evalDoubles = transformFunction.transformToDoubleValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = (float) evalDoubles[j];
-            }
-          }
-          break;
-        case STRING:
-          String[] evalStrings = transformFunction.transformToStringValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = new BigDecimal(evalStrings[i]).floatValue();
-            }
-          }
-          break;
-        default:
-          throw new IllegalStateException(String
-              .format("Cannot convert result type [%s] to [FLOAT] for transform function [%s]", dataType,
-                  transformFunction));
+      int blockNumDocs = projectionBlock.getNumDocs();
+      float[] evalFloats;
+      if (dataType == FieldSpec.DataType.FLOAT) {
+        evalFloats = transformFunction.transformToFloatValuesSV(projectionBlock);
+      } else {
+        evalFloats = new float[blockNumDocs];
+        switch (dataType) {
+          case INT:
+            ArrayCopyUtils.copy(transformFunction.transformToIntValuesSV(projectionBlock), evalFloats, blockNumDocs);
+            break;
+          case LONG:
+            ArrayCopyUtils.copy(transformFunction.transformToLongValuesSV(projectionBlock), evalFloats, blockNumDocs);
+            break;
+          case DOUBLE:
+            ArrayCopyUtils.copy(transformFunction.transformToDoubleValuesSV(projectionBlock), evalFloats, blockNumDocs);
+            break;
+          case STRING:
+            ArrayCopyUtils.copy(transformFunction.transformToStringValuesSV(projectionBlock), evalFloats, blockNumDocs);
+            break;
+          default:
+            throw new IllegalStateException(String
+                .format("Cannot convert result type [%s] to [FLOAT] for transform function [%s]", dataType,
+                    transformFunction));
+        }
+      }
+      for (int j = 0; j < blockNumDocs; j++) {
+        if (selected[j] == i) {
+          _floatResults[j] = evalFloats[j];
+        }
       }
     }
-    return results;
+    return _floatResults;
   }
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    if (_resultMetadata.getDataType() != FieldSpec.DataType.DOUBLE) {
+      return super.transformToDoubleValuesSV(projectionBlock);
+    }
     int[] selected = getSelectedArray(projectionBlock);
-    double[] results = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_doubleResults == null) {
+      _doubleResults = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
     for (int i = 0; i < _elseThenStatements.size(); i++) {
       TransformFunction transformFunction = _elseThenStatements.get(i);
       FieldSpec.DataType dataType = transformFunction.getResultMetadata().getDataType();
-      switch (dataType) {
-        case INT:
-          int[] evalInts = transformFunction.transformToIntValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalInts[j];
-            }
-          }
-          break;
-        case LONG:
-          long[] evalLongs = transformFunction.transformToLongValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalLongs[j];
-            }
-          }
-          break;
-        case FLOAT:
-          float[] evalFloats = transformFunction.transformToFloatValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalFloats[j];
-            }
-          }
-          break;
-        case DOUBLE:
-          double[] evalDoubles = transformFunction.transformToDoubleValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalDoubles[j];
-            }
-          }
-          break;
-        case STRING:
-          String[] evalStrings = transformFunction.transformToStringValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = new BigDecimal(evalStrings[i]).doubleValue();
-            }
-          }
-          break;
-        default:
-          throw new IllegalStateException(String
-              .format("Cannot convert result type [%s] to [DOUBLE] for transform function [%s]", dataType,
-                  transformFunction));
+      int blockNumDocs = projectionBlock.getNumDocs();
+      double[] evalDoubles;
+      if (dataType == FieldSpec.DataType.DOUBLE) {
+        evalDoubles = transformFunction.transformToDoubleValuesSV(projectionBlock);
+      } else {
+        evalDoubles = new double[blockNumDocs];
+        switch (dataType) {
+          case INT:
+            ArrayCopyUtils.copy(transformFunction.transformToIntValuesSV(projectionBlock), evalDoubles, blockNumDocs);
+            break;
+          case LONG:
+            ArrayCopyUtils.copy(transformFunction.transformToLongValuesSV(projectionBlock), evalDoubles, blockNumDocs);
+            break;
+          case FLOAT:
+            ArrayCopyUtils.copy(transformFunction.transformToFloatValuesSV(projectionBlock), evalDoubles, blockNumDocs);
+            break;
+          case STRING:
+            ArrayCopyUtils
+                .copy(transformFunction.transformToStringValuesSV(projectionBlock), evalDoubles, blockNumDocs);
+            break;
+          default:
+            throw new IllegalStateException(String
+                .format("Cannot convert result type [%s] to [DOUBLE] for transform function [%s]", dataType,
+                    transformFunction));
+        }
+      }
+      for (int j = 0; j < blockNumDocs; j++) {
+        if (selected[j] == i) {
+          _doubleResults[j] = evalDoubles[j];
+        }
       }
     }
-    return results;
+    return _doubleResults;
   }
 
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
+    if (_resultMetadata.getDataType() != FieldSpec.DataType.STRING) {
+      return super.transformToStringValuesSV(projectionBlock);
+    }
     int[] selected = getSelectedArray(projectionBlock);
-    String[] results = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_stringResults == null) {
+      _stringResults = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
     for (int i = 0; i < _elseThenStatements.size(); i++) {
       TransformFunction transformFunction = _elseThenStatements.get(i);
       FieldSpec.DataType dataType = transformFunction.getResultMetadata().getDataType();
-      switch (dataType) {
-        case INT:
-          int[] evalInts = transformFunction.transformToIntValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = Integer.toString(evalInts[j]);
-            }
-          }
-          break;
-        case LONG:
-          long[] evalLongs = transformFunction.transformToLongValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = Long.toString(evalLongs[j]);
-            }
-          }
-          break;
-        case FLOAT:
-          float[] evalFloats = transformFunction.transformToFloatValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = Float.toString(evalFloats[j]);
-            }
-          }
-          break;
-        case DOUBLE:
-          double[] evalDoubles = transformFunction.transformToDoubleValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = Double.toString(evalDoubles[j]);
-            }
-          }
-          break;
-        case STRING:
-          String[] evalStrings = transformFunction.transformToStringValuesSV(projectionBlock);
-          for (int j = 0; j < selected.length; j++) {
-            if (selected[j] == i) {
-              results[j] = evalStrings[i];
-            }
-          }
-          break;
-        default:
-          throw new IllegalStateException(String
-              .format("Cannot convert result type [%s] to [LONG] for transform function [%s]", dataType,
-                  transformFunction));
+      int blockNumDocs = projectionBlock.getNumDocs();
+      String[] evalStrings;
+      if (dataType == FieldSpec.DataType.STRING) {
+        evalStrings = transformFunction.transformToStringValuesSV(projectionBlock);
+      } else {
+        evalStrings = new String[blockNumDocs];
+        switch (dataType) {
+          case INT:
+            ArrayCopyUtils.copy(transformFunction.transformToIntValuesSV(projectionBlock), evalStrings, blockNumDocs);
+            break;
+          case LONG:
+            ArrayCopyUtils.copy(transformFunction.transformToLongValuesSV(projectionBlock), evalStrings, blockNumDocs);
+            break;
+          case FLOAT:
+            ArrayCopyUtils.copy(transformFunction.transformToFloatValuesSV(projectionBlock), evalStrings, blockNumDocs);
+            break;
+          case DOUBLE:
+            ArrayCopyUtils
+                .copy(transformFunction.transformToDoubleValuesSV(projectionBlock), evalStrings, blockNumDocs);
+            break;
+          case BYTES:
+            ArrayCopyUtils.copy(transformFunction.transformToBytesValuesSV(projectionBlock), evalStrings, blockNumDocs);
+            break;
+          default:
+            throw new IllegalStateException(String
+                .format("Cannot convert result type [%s] to [STRING] for transform function [%s]", dataType,
+                    transformFunction));
+        }
+      }
+      for (int j = 0; j < blockNumDocs; j++) {
+        if (selected[j] == i) {
+          _stringResults[j] = evalStrings[j];
+        }
       }
     }
-    return results;
+    return _stringResults;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -225,32 +225,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     for (int i = 0; i < _elseThenStatements.size(); i++) {
       TransformFunction transformFunction = _elseThenStatements.get(i);
-      FieldSpec.DataType dataType = transformFunction.getResultMetadata().getDataType();
       int blockNumDocs = projectionBlock.getNumDocs();
-      int[] evalInts;
-      if (dataType == FieldSpec.DataType.INT) {
-        evalInts = transformFunction.transformToIntValuesSV(projectionBlock);
-      } else {
-        evalInts = new int[blockNumDocs];
-        switch (dataType) {
-          case LONG:
-            ArrayCopyUtils.copy(transformFunction.transformToLongValuesSV(projectionBlock), evalInts, blockNumDocs);
-            break;
-          case FLOAT:
-            ArrayCopyUtils.copy(transformFunction.transformToFloatValuesSV(projectionBlock), evalInts, blockNumDocs);
-            break;
-          case DOUBLE:
-            ArrayCopyUtils.copy(transformFunction.transformToDoubleValuesSV(projectionBlock), evalInts, blockNumDocs);
-            break;
-          case STRING:
-            ArrayCopyUtils.copy(transformFunction.transformToStringValuesSV(projectionBlock), evalInts, blockNumDocs);
-            break;
-          default:
-            throw new IllegalStateException(String
-                .format("Cannot convert result type [%s] to [INT] for transform function [%s]", dataType,
-                    transformFunction));
-        }
-      }
+      int[] evalInts = transformFunction.transformToIntValuesSV(projectionBlock);
       for (int j = 0; j < blockNumDocs; j++) {
         if (selected[j] == i) {
           _intResults[j] = evalInts[j];
@@ -278,24 +254,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
         evalLongs = transformFunction.transformToLongValuesSV(projectionBlock);
       } else {
         evalLongs = new long[blockNumDocs];
-        switch (dataType) {
-          case INT:
-            ArrayCopyUtils.copy(transformFunction.transformToIntValuesSV(projectionBlock), evalLongs, blockNumDocs);
-            break;
-          case FLOAT:
-            ArrayCopyUtils.copy(transformFunction.transformToFloatValuesSV(projectionBlock), evalLongs, blockNumDocs);
-            break;
-          case DOUBLE:
-            ArrayCopyUtils.copy(transformFunction.transformToDoubleValuesSV(projectionBlock), evalLongs, blockNumDocs);
-            break;
-          case STRING:
-            ArrayCopyUtils.copy(transformFunction.transformToStringValuesSV(projectionBlock), evalLongs, blockNumDocs);
-            break;
-          default:
-            throw new IllegalStateException(String
-                .format("Cannot convert result type [%s] to [LONG] for transform function [%s]", dataType,
-                    transformFunction));
-        }
+        // dataType can only be INT
+        ArrayCopyUtils.copy(transformFunction.transformToIntValuesSV(projectionBlock), evalLongs, blockNumDocs);
       }
       for (int j = 0; j < blockNumDocs; j++) {
         if (selected[j] == i) {
@@ -324,24 +284,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
         evalFloats = transformFunction.transformToFloatValuesSV(projectionBlock);
       } else {
         evalFloats = new float[blockNumDocs];
-        switch (dataType) {
-          case INT:
-            ArrayCopyUtils.copy(transformFunction.transformToIntValuesSV(projectionBlock), evalFloats, blockNumDocs);
-            break;
-          case LONG:
-            ArrayCopyUtils.copy(transformFunction.transformToLongValuesSV(projectionBlock), evalFloats, blockNumDocs);
-            break;
-          case DOUBLE:
-            ArrayCopyUtils.copy(transformFunction.transformToDoubleValuesSV(projectionBlock), evalFloats, blockNumDocs);
-            break;
-          case STRING:
-            ArrayCopyUtils.copy(transformFunction.transformToStringValuesSV(projectionBlock), evalFloats, blockNumDocs);
-            break;
-          default:
-            throw new IllegalStateException(String
-                .format("Cannot convert result type [%s] to [FLOAT] for transform function [%s]", dataType,
-                    transformFunction));
-        }
+        // dataType can only be INT
+        ArrayCopyUtils.copy(transformFunction.transformToIntValuesSV(projectionBlock), evalFloats, blockNumDocs);
       }
       for (int j = 0; j < blockNumDocs; j++) {
         if (selected[j] == i) {
@@ -379,10 +323,6 @@ public class CaseTransformFunction extends BaseTransformFunction {
             break;
           case FLOAT:
             ArrayCopyUtils.copy(transformFunction.transformToFloatValuesSV(projectionBlock), evalDoubles, blockNumDocs);
-            break;
-          case STRING:
-            ArrayCopyUtils
-                .copy(transformFunction.transformToStringValuesSV(projectionBlock), evalDoubles, blockNumDocs);
             break;
           default:
             throw new IllegalStateException(String

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -1,0 +1,175 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+
+
+/**
+ * The <code>CaseTransformFunction</code> class implements the CASE-WHEN-THEN-ELSE transformation.
+ *
+ * The SQL Syntax is:
+ *    CASE
+ *        WHEN condition1 THEN result1
+ *        WHEN condition2 THEN result2
+ *        WHEN conditionN THEN resultN
+ *        ELSE result
+ *    END;
+ *
+ * Usage:
+ *    case(${WHEN_STATEMENT_1}, ..., ${WHEN_STATEMENT_N},
+ *         ${THEN_EXPRESSION_1}, ..., ${THEN_EXPRESSION_N},
+ *         ${ELSE_EXPRESSION})
+ *
+ * There are 2 * N + 1 arguments:
+ *    <code>WHEN_STATEMENT_$i</code> is a <code>BinaryOperatorTransformFunction</code> represents <code>condition$i</code>
+ *    <code>THEN_EXPRESSION_$i</code> is a <code>TransformFunction</code> represents <code>result$i</code>
+ *    <code>ELSE_EXPRESSION</code> is a <code>TransformFunction</code> represents <code>result</code>
+ *
+ */
+public class CaseTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "case";
+  private final List<TransformFunction> _whenStatements = new ArrayList<>();
+  private final List<TransformFunction> _elseThenStatements = new ArrayList<>();
+  private int _numberWhenStatements;
+  private TransformResultMetadata _resultMetadata;
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    // Check that there are more than 1 arguments
+    if (arguments.size() % 2 != 1 || arguments.size() < 3) {
+      throw new IllegalArgumentException("At least 3 odd number of arguments are required for CASE-WHEN-ELSE function");
+    }
+    _numberWhenStatements = arguments.size() / 2;
+    for (int i = 0; i < _numberWhenStatements; i++) {
+      _whenStatements.add(arguments.get(i));
+    }
+    // Add ELSE Statement first
+    _elseThenStatements.add(arguments.get(_numberWhenStatements * 2));
+    for (int i = _numberWhenStatements; i < _numberWhenStatements * 2; i++) {
+      _elseThenStatements.add(arguments.get(i));
+    }
+    _resultMetadata = _elseThenStatements.get(0).getResultMetadata();
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return _resultMetadata;
+  }
+
+  private int[] getSelectedArray(ProjectionBlock projectionBlock) {
+    int[] selected = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    for (int i = 0; i < _numberWhenStatements; i++) {
+      TransformFunction transformFunction = _whenStatements.get(i);
+      int[] conditions = transformFunction.transformToIntValuesSV(projectionBlock);
+      for (int j = 0; j < conditions.length; j++) {
+        if (selected[j] == 0 && conditions[j] == 1) {
+          selected[j] = i + 1;
+        }
+      }
+    }
+    return selected;
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    int[] selected = getSelectedArray(projectionBlock);
+    int[] results = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    for (int i = 0; i < _elseThenStatements.size(); i++) {
+      int[] eval = _elseThenStatements.get(i).transformToIntValuesSV(projectionBlock);
+      for (int j = 0; j < selected.length; j++) {
+        if (selected[j] == i) {
+          results[j] = eval[j];
+        }
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
+    int[] selected = getSelectedArray(projectionBlock);
+    long[] results = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    for (int i = 0; i < _elseThenStatements.size(); i++) {
+      long[] eval = _elseThenStatements.get(i).transformToLongValuesSV(projectionBlock);
+      for (int j = 0; j < selected.length; j++) {
+        if (selected[j] == i) {
+          results[j] = eval[j];
+        }
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
+    int[] selected = getSelectedArray(projectionBlock);
+    float[] results = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    for (int i = 0; i < _elseThenStatements.size(); i++) {
+      float[] eval = _elseThenStatements.get(i).transformToFloatValuesSV(projectionBlock);
+      for (int j = 0; j < selected.length; j++) {
+        if (selected[j] == i) {
+          results[j] = eval[j];
+        }
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    int[] selected = getSelectedArray(projectionBlock);
+    double[] results = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    for (int i = 0; i < _elseThenStatements.size(); i++) {
+      double[] eval = _elseThenStatements.get(i).transformToDoubleValuesSV(projectionBlock);
+      for (int j = 0; j < selected.length; j++) {
+        if (selected[j] == i) {
+          results[j] = eval[j];
+        }
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
+    int[] selected = getSelectedArray(projectionBlock);
+    String[] results = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    for (int i = 0; i < _elseThenStatements.size(); i++) {
+      String[] eval = _elseThenStatements.get(i).transformToStringValuesSV(projectionBlock);
+      for (int j = 0; j < selected.length; j++) {
+        if (selected[j] == i) {
+          results[j] = eval[j];
+        }
+      }
+    }
+    return results;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -78,6 +79,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
     for (int i = _numberWhenStatements; i < _numberWhenStatements * 2; i++) {
       _elseThenStatements.add(arguments.get(i));
     }
+    Preconditions.checkState(_elseThenStatements.size() == _numberWhenStatements + 1, "Missing THEN/ELSE clause in CASE statement");
     _resultMetadata = getResultMetadata(_elseThenStatements);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/EqualsTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/EqualsTransformFunction.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+
+
+/**
+ * The <code>EqualsTransformFunction</code> extends <code>BinaryOperatorTransformFunction</code> to implement the
+ * binary operator(=).
+ *
+ * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
+ *
+ * SQL Syntax:
+ *    columnA = 12
+ *    columnA = 12.0
+ *    columnA = 'fooBar'
+ *
+ * Sample Usage:
+ *    EQUALS(columnA, 12)
+ *    EQUALS(columnA, 12.0)
+ *    EQUALS(columnA, 'fooBar')
+ *
+ */
+public class EqualsTransformFunction extends BinaryOperatorTransformFunction {
+
+  @Override
+  public String getName() {
+    return TransformFunctionType.EQUALS.getName();
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    fillResultArray(projectionBlock);
+    return _results;
+  }
+
+  @Override
+  int getBinaryFuncResult(int result) {
+    return (result == 0) ? 1 : 0;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/EqualsTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/EqualsTransformFunction.java
@@ -47,12 +47,6 @@ public class EqualsTransformFunction extends BinaryOperatorTransformFunction {
   }
 
   @Override
-  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    fillResultArray(projectionBlock);
-    return _results;
-  }
-
-  @Override
   int getBinaryFuncResult(int result) {
     return (result == 0) ? 1 : 0;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanOrEqualTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanOrEqualTransformFunction.java
@@ -58,10 +58,4 @@ public class GreaterThanOrEqualTransformFunction extends BinaryOperatorTransform
   public String getName() {
     return TransformFunctionType.GREATER_THAN_OR_EQUAL.getName();
   }
-
-  @Override
-  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    fillResultArray(projectionBlock);
-    return _results;
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanOrEqualTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanOrEqualTransformFunction.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+
+
+/**
+ * The <code>GreaterThanOrEqualTransformFunction</code> extends <code>BinaryOperatorTransformFunction</code> to
+ * implement the binary operator(>=).
+ *
+ * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
+ *
+ * SQL Syntax:
+ *    columnA >= 12
+ *    columnA >= 12.0
+ *    columnA >= 'fooBar'
+ *
+ * Sample Usage:
+ *    GREATER_THAN_OR_EQUAL(columnA, 12)
+ *    GREATER_THAN_OR_EQUAL(columnA, 12.0)
+ *    GREATER_THAN_OR_EQUAL(columnA, 'fooBar')
+ *
+ */
+public class GreaterThanOrEqualTransformFunction extends BinaryOperatorTransformFunction {
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    super.init(arguments, dataSourceMap);
+  }
+
+  @Override
+  int getBinaryFuncResult(int result) {
+    return (result >= 0) ? 1 : 0;
+  }
+
+  @Override
+  public String getName() {
+    return TransformFunctionType.GREATER_THAN_OR_EQUAL.getName();
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    fillResultArray(projectionBlock);
+    return _results;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanTransformFunction.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+
+
+/**
+ * The <code>GREATER_THAN</code> extends <code>BinaryOperatorTransformFunction</code> to implement the binary
+ * operator(>).
+ *
+ * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
+ *
+ * SQL Syntax:
+ *    columnA > 12
+ *    columnA > 12.0
+ *    columnA > 'fooBar'
+ *
+ * Sample Usage:
+ *    GREATER_THAN(columnA, 12)
+ *    GREATER_THAN(columnA, 12.0)
+ *    GREATER_THAN(columnA, 'fooBar')
+ *
+ */
+public class GreaterThanTransformFunction extends BinaryOperatorTransformFunction {
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    super.init(arguments, dataSourceMap);
+  }
+
+  @Override
+  int getBinaryFuncResult(int result) {
+    return (result > 0) ? 1 : 0;
+  }
+
+  @Override
+  public String getName() {
+    return TransformFunctionType.GREATER_THAN.getName();
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    fillResultArray(projectionBlock);
+    return _results;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanTransformFunction.java
@@ -58,10 +58,4 @@ public class GreaterThanTransformFunction extends BinaryOperatorTransformFunctio
   public String getName() {
     return TransformFunctionType.GREATER_THAN.getName();
   }
-
-  @Override
-  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    fillResultArray(projectionBlock);
-    return _results;
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanOrEqualTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanOrEqualTransformFunction.java
@@ -58,10 +58,4 @@ public class LessThanOrEqualTransformFunction extends BinaryOperatorTransformFun
   public String getName() {
     return TransformFunctionType.LESS_THAN_OR_EQUAL.getName();
   }
-
-  @Override
-  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    fillResultArray(projectionBlock);
-    return _results;
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanOrEqualTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanOrEqualTransformFunction.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+
+
+/**
+ * The <code>GreaterThanOrEqualTransformFunction</code> extends <code>BinaryOperatorTransformFunction</code> to
+ * implement the binary operator(<=).
+ *
+ * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
+ *
+ * SQL Syntax:
+ *    columnA <= 12
+ *    columnA <= 12.0
+ *    columnA <= 'fooBar'
+ *
+ * Sample Usage:
+ *    LESS_THAN_OR_EQUAL(columnA, 12)
+ *    LESS_THAN_OR_EQUAL(columnA, 12.0)
+ *    LESS_THAN_OR_EQUAL(columnA, 'fooBar')
+ *
+ */
+public class LessThanOrEqualTransformFunction extends BinaryOperatorTransformFunction {
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    super.init(arguments, dataSourceMap);
+  }
+
+  @Override
+  int getBinaryFuncResult(int result) {
+    return (result <= 0) ? 1 : 0;
+  }
+
+  @Override
+  public String getName() {
+    return TransformFunctionType.LESS_THAN_OR_EQUAL.getName();
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    fillResultArray(projectionBlock);
+    return _results;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanTransformFunction.java
@@ -58,10 +58,4 @@ public class LessThanTransformFunction extends BinaryOperatorTransformFunction {
   public String getName() {
     return TransformFunctionType.LESS_THAN.getName();
   }
-
-  @Override
-  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    fillResultArray(projectionBlock);
-    return _results;
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanTransformFunction.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+
+
+/**
+ * The <code>LESS_THAN</code> extends <code>BinaryOperatorTransformFunction</code> to implement the binary
+ * operator(<).
+ *
+ * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
+ *
+ * SQL Syntax:
+ *    columnA < 12
+ *    columnA < 12.0
+ *    columnA < 'fooBar'
+ *
+ * Sample Usage:
+ *    LESS_THAN(columnA, 12)
+ *    LESS_THAN(columnA, 12.0)
+ *    LESS_THAN(columnA, 'fooBar')
+ *
+ */
+public class LessThanTransformFunction extends BinaryOperatorTransformFunction {
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    super.init(arguments, dataSourceMap);
+  }
+
+  @Override
+  int getBinaryFuncResult(int result) {
+    return (result < 0) ? 1 : 0;
+  }
+
+  @Override
+  public String getName() {
+    return TransformFunctionType.LESS_THAN.getName();
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    fillResultArray(projectionBlock);
+    return _results;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +26,6 @@ import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
-import org.apache.pinot.spi.utils.BytesUtils;
 
 
 /**
@@ -37,11 +35,6 @@ import org.apache.pinot.spi.utils.BytesUtils;
 public class LiteralTransformFunction implements TransformFunction {
   private final String _literal;
   private String[] _result;
-  private int[] _intResult;
-  private long[] _longResult;
-  private float[] _floatResult;
-  private double[] _doubleResult;
-  private byte[][] _bytesResult;
 
   public LiteralTransformFunction(String literal) {
     _literal = literal;
@@ -82,40 +75,22 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    if (_intResult == null) {
-      _intResult = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-      Arrays.fill(_intResult, Double.valueOf(_literal).intValue());
-    }
-    return _intResult;
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
-    if (_longResult == null) {
-      _longResult = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-      // Use BigDecimal here as: Long.parseLong(String) doesn't parse floats,
-      // Double.valueOf(String) loses precision for large Long value.
-      Arrays.fill(_longResult, new BigDecimal(_literal).longValue());
-    }
-    return _longResult;
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
-    if (_floatResult == null) {
-      _floatResult = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-      Arrays.fill(_floatResult, Double.valueOf(_literal).floatValue());
-    }
-    return _floatResult;
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_doubleResult == null) {
-      _doubleResult = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-      Arrays.fill(_doubleResult, Double.valueOf(_literal));
-    }
-    return _doubleResult;
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -129,11 +104,7 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
-    if (_bytesResult == null) {
-      _bytesResult = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
-      Arrays.fill(_bytesResult, BytesUtils.toBytes(_literal));
-    }
-    return _bytesResult;
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
+import org.apache.pinot.spi.utils.BytesUtils;
 
 
 /**
@@ -35,6 +37,11 @@ import org.apache.pinot.core.segment.index.readers.Dictionary;
 public class LiteralTransformFunction implements TransformFunction {
   private final String _literal;
   private String[] _result;
+  private int[] _intResult;
+  private long[] _longResult;
+  private float[] _floatResult;
+  private double[] _doubleResult;
+  private byte[][] _bytesResult;
 
   public LiteralTransformFunction(String literal) {
     _literal = literal;
@@ -75,22 +82,40 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    throw new UnsupportedOperationException();
+    if (_intResult == null) {
+      _intResult = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      Arrays.fill(_intResult, Double.valueOf(_literal).intValue());
+    }
+    return _intResult;
   }
 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
-    throw new UnsupportedOperationException();
+    if (_longResult == null) {
+      _longResult = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      // Use BigDecimal here as: Long.parseLong(String) doesn't parse floats,
+      // Double.valueOf(String) loses precision for large Long value.
+      Arrays.fill(_longResult, new BigDecimal(_literal).longValue());
+    }
+    return _longResult;
   }
 
   @Override
   public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
-    throw new UnsupportedOperationException();
+    if (_floatResult == null) {
+      _floatResult = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      Arrays.fill(_floatResult, Double.valueOf(_literal).floatValue());
+    }
+    return _floatResult;
   }
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    throw new UnsupportedOperationException();
+    if (_doubleResult == null) {
+      _doubleResult = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      Arrays.fill(_doubleResult, Double.valueOf(_literal));
+    }
+    return _doubleResult;
   }
 
   @Override
@@ -104,7 +129,11 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
-    throw new UnsupportedOperationException();
+    if (_bytesResult == null) {
+      _bytesResult = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      Arrays.fill(_bytesResult, BytesUtils.toBytes(_literal));
+    }
+    return _bytesResult;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotEqualsTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotEqualsTransformFunction.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+
+
+/**
+ * The <code>NotEqualsTransformFunction</code> extends <code>BinaryOperatorTransformFunction</code> to implement the
+ * binary operator(<>).
+ *
+ * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
+ *
+ * SQL Syntax:
+ *    columnA <> 12
+ *    columnA <> 12.0
+ *    columnA <> 'fooBar'
+ *
+ * Sample Usage:
+ *    NOT_EQUALS(columnA, 12)
+ *    NOT_EQUALS(columnA, 12.0)
+ *    NOT_EQUALS(columnA, 'fooBar')
+ *
+ */
+public class NotEqualsTransformFunction extends BinaryOperatorTransformFunction {
+
+  @Override
+  public String getName() {
+    return TransformFunctionType.NOT_EQUALS.getName();
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    fillResultArray(projectionBlock);
+    return _results;
+  }
+
+  @Override
+  int getBinaryFuncResult(int result) {
+    return (result != 0) ? 1 : 0;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotEqualsTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotEqualsTransformFunction.java
@@ -47,12 +47,6 @@ public class NotEqualsTransformFunction extends BinaryOperatorTransformFunction 
   }
 
   @Override
-  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    fillResultArray(projectionBlock);
-    return _results;
-  }
-
-  @Override
   int getBinaryFuncResult(int result) {
     return (result != 0) ? 1 : 0;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -76,6 +76,15 @@ public class TransformFunctionFactory {
           put(TransformFunctionType.ARRAYLENGTH.getName().toLowerCase(), ArrayLengthTransformFunction.class);
           put(TransformFunctionType.VALUEIN.getName().toLowerCase(), ValueInTransformFunction.class);
           put(TransformFunctionType.MAPVALUE.getName().toLowerCase(), MapValueTransformFunction.class);
+
+          put(TransformFunctionType.CASE.getName().toLowerCase(), CaseTransformFunction.class);
+
+          put(TransformFunctionType.EQUALS.getName().toLowerCase(), EqualsTransformFunction.class);
+          put(TransformFunctionType.NOT_EQUALS.getName().toLowerCase(), NotEqualsTransformFunction.class);
+          put(TransformFunctionType.GREATER_THAN.getName().toLowerCase(), GreaterThanTransformFunction.class);
+          put(TransformFunctionType.GREATER_THAN_OR_EQUAL.getName().toLowerCase(), GreaterThanOrEqualTransformFunction.class);
+          put(TransformFunctionType.LESS_THAN.getName().toLowerCase(), LessThanTransformFunction.class);
+          put(TransformFunctionType.LESS_THAN_OR_EQUAL.getName().toLowerCase(), LessThanOrEqualTransformFunction.class);
         }
       };
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ArrayCopyUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ArrayCopyUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.util;
 
+import java.math.BigDecimal;
 import org.apache.pinot.spi.utils.BytesUtils;
 
 
@@ -126,13 +127,13 @@ public class ArrayCopyUtils {
 
   public static void copy(String[] src, int[] dest, int length) {
     for (int i = 0; i < length; i++) {
-      dest[i] = Integer.parseInt(src[i]);
+      dest[i] = Double.valueOf(src[i]).intValue();
     }
   }
 
   public static void copy(String[] src, long[] dest, int length) {
     for (int i = 0; i < length; i++) {
-      dest[i] = Long.parseLong(src[i]);
+      dest[i] = new BigDecimal(src[i]).longValue();
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -160,6 +160,21 @@ public abstract class BaseTransformFunctionTest {
         new DocIdSetOperator(new MatchAllFilterOperator(NUM_ROWS), DocIdSetPlanNode.MAX_DOC_PER_CALL)).nextBlock();
   }
 
+  protected void testTransformFunction(TransformFunction transformFunction, int[] expectedValues) {
+    int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
+    long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);
+    float[] floatValues = transformFunction.transformToFloatValuesSV(_projectionBlock);
+    double[] doubleValues = transformFunction.transformToDoubleValuesSV(_projectionBlock);
+    String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(intValues[i], expectedValues[i]);
+      Assert.assertEquals(longValues[i], expectedValues[i]);
+      Assert.assertEquals(floatValues[i], (float) expectedValues[i]);
+      Assert.assertEquals(doubleValues[i], (double) expectedValues[i]);
+      Assert.assertEquals(stringValues[i], Integer.toString(expectedValues[i]));
+    }
+  }
+
   protected void testTransformFunction(TransformFunction transformFunction, double[] expectedValues) {
     int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
     long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * BinaryOperatorTransformFunctionTest abstracts common test methods for EqualsTransformFunctionTest,
+ * NotEqualsTransformFunctionTest, GreaterThanOrEqualTransformFunctionTest, GreaterThanTransformFunctionTest,
+ * LessThanOrEqualTransformFunctionTest, LessThanTransformFunctionTest
+ *
+ */
+public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformFunctionTest {
+
+  abstract int getExpectedValue(int value, int toCompare);
+
+  abstract int getExpectedValue(long value, long toCompare);
+
+  abstract int getExpectedValue(float value, float toCompare);
+
+  abstract int getExpectedValue(double value, double toCompare);
+
+  abstract int getExpectedValue(String value, String toCompare);
+
+  abstract String getFuncName();
+
+  @Test
+  public void testBinaryOperatorTransformFunction() {
+    TransformExpressionTree expression = TransformExpressionTree
+        .compileToExpressionTree(String.format("%s(%s, %d)", getFuncName(), INT_SV_COLUMN, _intSVValues[0]));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertEquals(transformFunction.getName(), getFuncName().toLowerCase());
+    int[] expectedIntValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedIntValues[i] = getExpectedValue(_intSVValues[i], _intSVValues[0]);
+    }
+    testTransformFunction(transformFunction, expectedIntValues);
+
+    expression = TransformExpressionTree
+        .compileToExpressionTree(String.format("%s(%s, %d)", getFuncName(), LONG_SV_COLUMN, _longSVValues[0]));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    int[] expectedLongValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedLongValues[i] = getExpectedValue(_longSVValues[i], _longSVValues[0]);
+    }
+    testTransformFunction(transformFunction, expectedLongValues);
+
+    expression = TransformExpressionTree
+        .compileToExpressionTree(String.format("%s(%s, %f)", getFuncName(), FLOAT_SV_COLUMN, _floatSVValues[0]));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    int[] expectedFloatValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedFloatValues[i] = getExpectedValue(_floatSVValues[i], _floatSVValues[0]);
+    }
+    testTransformFunction(transformFunction, expectedFloatValues);
+
+    expression = TransformExpressionTree
+        .compileToExpressionTree(String.format("%s(%s, %.20f)", getFuncName(), DOUBLE_SV_COLUMN, _doubleSVValues[0]));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    int[] expectedDoubleValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedDoubleValues[i] = getExpectedValue(_doubleSVValues[i], _doubleSVValues[0]);
+    }
+    testTransformFunction(transformFunction, expectedDoubleValues);
+
+    expression = TransformExpressionTree
+        .compileToExpressionTree(String.format("%s(%s, '%s')", getFuncName(), STRING_SV_COLUMN, _stringSVValues[0]));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    int[] expectedStringValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedStringValues[i] = getExpectedValue(_stringSVValues[i], _stringSVValues[0]);
+    }
+    testTransformFunction(transformFunction, expectedStringValues);
+  }
+
+  @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
+  public void testIllegalArguments(String expressionStr) {
+    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    TransformFunctionFactory.get(expression, _dataSourceMap);
+  }
+
+  @DataProvider(name = "testIllegalArguments")
+  public Object[][] testIllegalArguments() {
+    return new Object[][]{new Object[]{String.format("%s(%s)", getFuncName(),
+        INT_SV_COLUMN)}, new Object[]{String.format("%s(%s, %s, %s)", getFuncName(), LONG_SV_COLUMN, INT_SV_COLUMN,
+        STRING_SV_COLUMN)}};
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
@@ -1,0 +1,522 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.Random;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
+
+  private final int INDEX_TO_COMPARE = new Random(System.currentTimeMillis()).nextInt(NUM_ROWS);
+  private final TransformFunctionType[] BINARY_OPERATOR_TRANSFORM_FUNCTIONS =
+      new TransformFunctionType[]{TransformFunctionType.EQUALS, TransformFunctionType.NOT_EQUALS, TransformFunctionType.GREATER_THAN, TransformFunctionType.GREATER_THAN_OR_EQUAL, TransformFunctionType.LESS_THAN, TransformFunctionType.LESS_THAN_OR_EQUAL};
+
+  @Test
+  public void testCaseTransformFunctionWithIntResults() {
+    for (TransformFunctionType functionType : BINARY_OPERATOR_TRANSFORM_FUNCTIONS) {
+      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), INT_SV_COLUMN,
+          String.format("%d", _intSVValues[INDEX_TO_COMPARE])), getExpectedIntResults(INT_SV_COLUMN, functionType));
+      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), LONG_SV_COLUMN,
+          String.format("%d", _longSVValues[INDEX_TO_COMPARE])), getExpectedIntResults(LONG_SV_COLUMN, functionType));
+      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), FLOAT_SV_COLUMN,
+          String.format("%f", _floatSVValues[INDEX_TO_COMPARE])), getExpectedIntResults(FLOAT_SV_COLUMN, functionType));
+      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), DOUBLE_SV_COLUMN,
+          String.format("%.20f", _doubleSVValues[INDEX_TO_COMPARE])),
+          getExpectedIntResults(DOUBLE_SV_COLUMN, functionType));
+      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), STRING_SV_COLUMN,
+          String.format("'%s'", _stringSVValues[INDEX_TO_COMPARE])),
+          getExpectedIntResults(STRING_SV_COLUMN, functionType));
+    }
+  }
+
+  @Test
+  public void testCaseTransformFunctionWithDoubleResults() {
+    for (TransformFunctionType functionType : BINARY_OPERATOR_TRANSFORM_FUNCTIONS) {
+      testCaseQueryWithDoubleResults(String.format("%s(%s, %s)", functionType.getName(), INT_SV_COLUMN,
+          String.format("%d", _intSVValues[INDEX_TO_COMPARE])), getExpectedDoubleResults(INT_SV_COLUMN, functionType));
+      testCaseQueryWithDoubleResults(String.format("%s(%s, %s)", functionType.getName(), LONG_SV_COLUMN,
+          String.format("%d", _longSVValues[INDEX_TO_COMPARE])),
+          getExpectedDoubleResults(LONG_SV_COLUMN, functionType));
+      testCaseQueryWithDoubleResults(String.format("%s(%s, %s)", functionType.getName(), FLOAT_SV_COLUMN,
+          String.format("%f", _floatSVValues[INDEX_TO_COMPARE])),
+          getExpectedDoubleResults(FLOAT_SV_COLUMN, functionType));
+      testCaseQueryWithDoubleResults(String.format("%s(%s, %s)", functionType.getName(), DOUBLE_SV_COLUMN,
+          String.format("%.20f", _doubleSVValues[INDEX_TO_COMPARE])),
+          getExpectedDoubleResults(DOUBLE_SV_COLUMN, functionType));
+      testCaseQueryWithDoubleResults(String.format("%s(%s, %s)", functionType.getName(), STRING_SV_COLUMN,
+          String.format("'%s'", _stringSVValues[INDEX_TO_COMPARE])),
+          getExpectedDoubleResults(STRING_SV_COLUMN, functionType));
+    }
+  }
+
+  @Test
+  public void testCaseTransformFunctionWithStringResults() {
+    for (TransformFunctionType functionType : BINARY_OPERATOR_TRANSFORM_FUNCTIONS) {
+      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), INT_SV_COLUMN,
+          String.format("%d", _intSVValues[INDEX_TO_COMPARE])), getExpectedStringResults(INT_SV_COLUMN, functionType));
+      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), LONG_SV_COLUMN,
+          String.format("%d", _longSVValues[INDEX_TO_COMPARE])),
+          getExpectedStringResults(LONG_SV_COLUMN, functionType));
+      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), FLOAT_SV_COLUMN,
+          String.format("%f", _floatSVValues[INDEX_TO_COMPARE])),
+          getExpectedStringResults(FLOAT_SV_COLUMN, functionType));
+      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), DOUBLE_SV_COLUMN,
+          String.format("%.20f", _doubleSVValues[INDEX_TO_COMPARE])),
+          getExpectedStringResults(DOUBLE_SV_COLUMN, functionType));
+      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), STRING_SV_COLUMN,
+          String.format("'%s'", _stringSVValues[INDEX_TO_COMPARE])),
+          getExpectedStringResults(STRING_SV_COLUMN, functionType));
+    }
+  }
+
+  private void testCaseQueryWithIntResults(String predicate, int[] expectedValues) {
+    TransformExpressionTree expression =
+        TransformExpressionTree.compileToExpressionTree(String.format("CASE(%s, 100, 10)", predicate));
+    expression.getChildren().set(0, TransformExpressionTree.compileToExpressionTree(predicate));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  private void testCaseQueryWithDoubleResults(String predicate, double[] expectedValues) {
+    TransformExpressionTree expression =
+        TransformExpressionTree.compileToExpressionTree(String.format("CASE(%s, 100.0, 10.0)", predicate));
+    expression.getChildren().set(0, TransformExpressionTree.compileToExpressionTree(predicate));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  private void testCaseQueryWithStringResults(String predicate, String[] expectedValues) {
+    TransformExpressionTree expression =
+        TransformExpressionTree.compileToExpressionTree(String.format("CASE(%s, 'aaa', 'bbb')", predicate));
+    expression.getChildren().set(0, TransformExpressionTree.compileToExpressionTree(predicate));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
+  public void testIllegalArguments(String expressionStr) {
+    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    TransformFunctionFactory.get(expression, _dataSourceMap);
+  }
+
+  @DataProvider(name = "testIllegalArguments")
+  public Object[][] testIllegalArguments() {
+    return new Object[][]{new Object[]{String.format("case(%s)", INT_SV_COLUMN)}, new Object[]{String.format(
+        "case(%s, %s)", LONG_SV_COLUMN, 10)}};
+  }
+
+  private int[] getExpectedIntResults(String column, TransformFunctionType type) {
+    int[] result = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      switch (column) {
+        case INT_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_intSVValues[i] == _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_intSVValues[i] != _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_intSVValues[i] > _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_intSVValues[i] >= _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_intSVValues[i] < _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_intSVValues[i] <= _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case LONG_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_longSVValues[i] == _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_longSVValues[i] != _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_longSVValues[i] > _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_longSVValues[i] >= _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_longSVValues[i] < _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_longSVValues[i] <= _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case FLOAT_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_floatSVValues[i] == _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_floatSVValues[i] != _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_floatSVValues[i] > _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_floatSVValues[i] >= _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_floatSVValues[i] < _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_floatSVValues[i] <= _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case DOUBLE_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_doubleSVValues[i] == _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_doubleSVValues[i] != _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_doubleSVValues[i] > _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_doubleSVValues[i] >= _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_doubleSVValues[i] < _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_doubleSVValues[i] <= _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case STRING_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) == 0) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) != 0) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) > 0) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) >= 0) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) < 0) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) <= 0) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+      }
+    }
+    return result;
+  }
+
+  private double[] getExpectedDoubleResults(String column, TransformFunctionType type) {
+    double[] result = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      switch (column) {
+        case INT_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_intSVValues[i] == _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_intSVValues[i] != _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_intSVValues[i] > _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_intSVValues[i] >= _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_intSVValues[i] < _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_intSVValues[i] <= _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case LONG_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_longSVValues[i] == _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_longSVValues[i] != _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_longSVValues[i] > _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_longSVValues[i] >= _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_longSVValues[i] < _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_longSVValues[i] <= _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case FLOAT_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_floatSVValues[i] == _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_floatSVValues[i] != _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_floatSVValues[i] > _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_floatSVValues[i] >= _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_floatSVValues[i] < _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_floatSVValues[i] <= _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case DOUBLE_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_doubleSVValues[i] == _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_doubleSVValues[i] != _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_doubleSVValues[i] > _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_doubleSVValues[i] >= _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_doubleSVValues[i] < _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_doubleSVValues[i] <= _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case STRING_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) == 0) ? 100 : 10;
+              break;
+            case NOT_EQUALS:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) != 0) ? 100 : 10;
+              break;
+            case GREATER_THAN:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) > 0) ? 100 : 10;
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) >= 0) ? 100 : 10;
+              break;
+            case LESS_THAN:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) < 0) ? 100 : 10;
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) <= 0) ? 100 : 10;
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+      }
+    }
+    return result;
+  }
+
+  private String[] getExpectedStringResults(String column, TransformFunctionType type) {
+    String[] result = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      switch (column) {
+        case INT_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_intSVValues[i] == _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case NOT_EQUALS:
+              result[i] = (_intSVValues[i] != _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN:
+              result[i] = (_intSVValues[i] > _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_intSVValues[i] >= _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN:
+              result[i] = (_intSVValues[i] < _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_intSVValues[i] <= _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case LONG_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_longSVValues[i] == _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case NOT_EQUALS:
+              result[i] = (_longSVValues[i] != _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN:
+              result[i] = (_longSVValues[i] > _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_longSVValues[i] >= _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN:
+              result[i] = (_longSVValues[i] < _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_longSVValues[i] <= _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case FLOAT_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_floatSVValues[i] == _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case NOT_EQUALS:
+              result[i] = (_floatSVValues[i] != _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN:
+              result[i] = (_floatSVValues[i] > _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_floatSVValues[i] >= _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN:
+              result[i] = (_floatSVValues[i] < _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_floatSVValues[i] <= _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case DOUBLE_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_doubleSVValues[i] == _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case NOT_EQUALS:
+              result[i] = (_doubleSVValues[i] != _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN:
+              result[i] = (_doubleSVValues[i] > _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_doubleSVValues[i] >= _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN:
+              result[i] = (_doubleSVValues[i] < _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_doubleSVValues[i] <= _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+        case STRING_SV_COLUMN:
+          switch (type) {
+            case EQUALS:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) == 0) ? "aaa" : "bbb";
+              break;
+            case NOT_EQUALS:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) != 0) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) > 0) ? "aaa" : "bbb";
+              break;
+            case GREATER_THAN_OR_EQUAL:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) >= 0) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) < 0) ? "aaa" : "bbb";
+              break;
+            case LESS_THAN_OR_EQUAL:
+              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) <= 0) ? "aaa" : "bbb";
+              break;
+            default:
+              throw new IllegalStateException("Not supported type - " + type);
+          }
+          break;
+      }
+    }
+    return result;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/EqualsTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/EqualsTransformFunctionTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+public class EqualsTransformFunctionTest extends BinaryOperatorTransformFunctionTest {
+
+  @Override
+  int getExpectedValue(int value, int toCompare) {
+    return (value == toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(long value, long toCompare) {
+    return (value == toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(float value, float toCompare) {
+    return (value == toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(double value, double toCompare) {
+    return (value == toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(String value, String toCompare) {
+    return (value.compareTo(toCompare) == 0) ? 1 : 0;
+  }
+
+  @Override
+  String getFuncName() {
+    return new EqualsTransformFunction().getName();
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GreaterThanOrEqualTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GreaterThanOrEqualTransformFunctionTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+public class GreaterThanOrEqualTransformFunctionTest extends BinaryOperatorTransformFunctionTest {
+
+  @Override
+  int getExpectedValue(int value, int toCompare) {
+    return (value >= toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(long value, long toCompare) {
+    return (value >= toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(float value, float toCompare) {
+    return (value >= toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(double value, double toCompare) {
+    return (value >= toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(String value, String toCompare) {
+    return (value.compareTo(toCompare) >= 0) ? 1 : 0;
+  }
+
+  @Override
+  String getFuncName() {
+    return new GreaterThanOrEqualTransformFunction().getName();
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GreaterThanTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GreaterThanTransformFunctionTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+public class GreaterThanTransformFunctionTest extends BinaryOperatorTransformFunctionTest {
+
+  @Override
+  int getExpectedValue(int value, int toCompare) {
+    return (value > toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(long value, long toCompare) {
+    return (value > toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(float value, float toCompare) {
+    return (value > toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(double value, double toCompare) {
+    return (value > toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(String value, String toCompare) {
+    return (value.compareTo(toCompare) > 0) ? 1 : 0;
+  }
+
+  @Override
+  String getFuncName() {
+    return new GreaterThanTransformFunction().getName();
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LessThanOrEqualTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LessThanOrEqualTransformFunctionTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+public class LessThanOrEqualTransformFunctionTest extends BinaryOperatorTransformFunctionTest {
+
+  @Override
+  int getExpectedValue(int value, int toCompare) {
+    return (value <= toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(long value, long toCompare) {
+    return (value <= toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(float value, float toCompare) {
+    return (value <= toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(double value, double toCompare) {
+    return (value <= toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(String value, String toCompare) {
+    return (value.compareTo(toCompare) <= 0) ? 1 : 0;
+  }
+
+  @Override
+  String getFuncName() {
+    return new LessThanOrEqualTransformFunction().getName();
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LessThanTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LessThanTransformFunctionTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+public class LessThanTransformFunctionTest extends BinaryOperatorTransformFunctionTest {
+
+  @Override
+  int getExpectedValue(int value, int toCompare) {
+    return (value < toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(long value, long toCompare) {
+    return (value < toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(float value, float toCompare) {
+    return (value < toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(double value, double toCompare) {
+    return (value < toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(String value, String toCompare) {
+    return (value.compareTo(toCompare) < 0) ? 1 : 0;
+  }
+
+  @Override
+  String getFuncName() {
+    return new LessThanTransformFunction().getName();
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunctionTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class LiteralTransformFunctionTest {
+
+  @Test
+  public void testLiteralTransformFunction() {
+    Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType(new LiteralTransformFunction("abc")),
+        FieldSpec.DataType.STRING);
+    Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType(new LiteralTransformFunction("123")),
+        FieldSpec.DataType.INT);
+    Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType(new LiteralTransformFunction("2147483649")),
+        FieldSpec.DataType.LONG);
+    Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType(new LiteralTransformFunction("1.2")),
+        FieldSpec.DataType.FLOAT);
+    Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType(new LiteralTransformFunction("41241241.2412")),
+        FieldSpec.DataType.DOUBLE);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NotEqualsTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NotEqualsTransformFunctionTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+public class NotEqualsTransformFunctionTest extends BinaryOperatorTransformFunctionTest {
+
+  @Override
+  int getExpectedValue(int value, int toCompare) {
+    return (value != toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(long value, long toCompare) {
+    return (value != toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(float value, float toCompare) {
+    return (value != toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(double value, double toCompare) {
+    return (value != toCompare) ? 1 : 0;
+  }
+
+  @Override
+  int getExpectedValue(String value, String toCompare) {
+    return (value.compareTo(toCompare) != 0) ? 1 : 0;
+  }
+
+  @Override
+  String getFuncName() {
+    return new NotEqualsTransformFunction().getName();
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -91,6 +91,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
   private final List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbacks =
       new ArrayList<>(getNumBrokers() + getNumServers());
+  private String _schemaFileName = DEFAULT_SCHEMA_FILE_NAME;
 
   protected int getNumBrokers() {
     return NUM_BROKERS;
@@ -99,8 +100,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   protected int getNumServers() {
     return NUM_SERVERS;
   }
-
-  private String _schemaFileName = DEFAULT_SCHEMA_FILE_NAME;
 
   @Override
   protected String getSchemaFileName() {
@@ -747,6 +746,65 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         .format("SELECT count(*) FROM mytable WHERE timeConvert(DaysSinceEpoch,'DAYS','SECONDS') BETWEEN %d AND %d",
             secondsSinceEpoch - 100, secondsSinceEpoch);
     assertEquals(postQuery(pqlQuery).get("aggregationResults").get(0).get("value").asLong(), expectedResult);
+  }
+
+  @Test
+  public void testCaseStatementInSelection()
+      throws Exception {
+    List<String> origins = Arrays
+        .asList("ATL", "ORD", "DFW", "DEN", "LAX", "IAH", "SFO", "PHX", "LAS", "EWR", "MCO", "BOS", "SLC", "SEA", "MSP",
+            "CLT", "LGA", "DTW", "JFK", "BWI");
+    String whenThenStatement = "";
+    for (int i = 0; i < origins.size(); i++) {
+      // WHEN origin = 'ATL' THEN 1
+      // WHEN origin = 'ORD' THEN 2
+      // WHEN origin = 'DFW' THEN 3
+      // ....
+      whenThenStatement += String.format("WHEN origin = '%s' THEN %d ", origins.get(i), i + 1);
+    }
+    String sqlQuery = String.format(
+        "SELECT origin, " + "CASE " + whenThenStatement + "ELSE 0 END " + "AS origin_code " + "FROM mytable "
+            + "LIMIT 1000");
+    JsonNode response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode rows = response.get("resultTable").get("rows");
+    Assert.assertEquals(response.get("exceptions").size(), 0);
+    for (int i = 0; i < rows.size(); i++) {
+      String origin = rows.get(i).get(0).asText();
+      int originCode = rows.get(i).get(1).asInt();
+      if (originCode > 0) {
+        Assert.assertEquals(origin, origins.get(originCode - 1));
+      } else {
+        Assert.assertTrue(!origins.contains(origin));
+      }
+    }
+  }
+
+  @Test
+  public void testCaseStatementWithInAggregation()
+      throws Exception {
+    testCountVsCaseQuery("origin = 'ATL'");
+    testCountVsCaseQuery("origin <> 'ATL'");
+
+    testCountVsCaseQuery("DaysSinceEpoch > 16312");
+    testCountVsCaseQuery("DaysSinceEpoch >= 16312");
+    testCountVsCaseQuery("DaysSinceEpoch < 16312");
+    testCountVsCaseQuery("DaysSinceEpoch <= 16312");
+    testCountVsCaseQuery("DaysSinceEpoch = 16312");
+    testCountVsCaseQuery("DaysSinceEpoch <> 16312");
+  }
+
+  private void testCountVsCaseQuery(String predicate)
+      throws Exception {
+    // System.out.println("predicate = " + predicate);
+    String sqlQuery = String.format("SELECT COUNT(*) FROM mytable WHERE %s", predicate);
+    JsonNode response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
+    // System.out.println(String.format("query = %s, response = %s",sqlQuery, response));
+    long countValue = response.get("resultTable").get("rows").get(0).get(0).asLong();
+    sqlQuery = String.format("SELECT SUM(CASE WHEN %s THEN 1 ELSE 0 END) as sum1 FROM mytable", predicate);
+    response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
+    // System.out.println(String.format("query = %s, response = %s",sqlQuery, response));
+    long caseSum = response.get("resultTable").get("rows").get(0).get(0).asLong();
+    Assert.assertEquals(caseSum, countValue);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -767,14 +767,14 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
             + "LIMIT 1000");
     JsonNode response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
     JsonNode rows = response.get("resultTable").get("rows");
-    Assert.assertEquals(response.get("exceptions").size(), 0);
+    assertEquals(response.get("exceptions").size(), 0);
     for (int i = 0; i < rows.size(); i++) {
       String origin = rows.get(i).get(0).asText();
       int originCode = rows.get(i).get(1).asInt();
       if (originCode > 0) {
-        Assert.assertEquals(origin, origins.get(originCode - 1));
+        assertEquals(origin, origins.get(originCode - 1));
       } else {
-        Assert.assertTrue(!origins.contains(origin));
+        assertTrue(!origins.contains(origin));
       }
     }
   }
@@ -787,14 +787,14 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     JsonNode response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
     System.out.println("response = " + response);
     JsonNode rows = response.get("resultTable").get("rows");
-    Assert.assertEquals(response.get("exceptions").size(), 0);
+    assertEquals(response.get("exceptions").size(), 0);
     for (int i = 0; i < rows.size(); i++) {
       int arrDelay = rows.get(i).get(0).asInt();
       int arrDelayDiff = rows.get(i).get(1).asInt();
       if (arrDelay > 0) {
-        Assert.assertEquals(arrDelay, arrDelayDiff);
+        assertEquals(arrDelay, arrDelayDiff);
       } else {
-        Assert.assertEquals(arrDelay, arrDelayDiff * -1);
+        assertEquals(arrDelay, arrDelayDiff * -1);
       }
     }
   }
@@ -824,7 +824,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
     // System.out.println(String.format("query = %s, response = %s",sqlQuery, response));
     long caseSum = response.get("resultTable").get("rows").get(0).get(0).asLong();
-    Assert.assertEquals(caseSum, countValue);
+    assertEquals(caseSum, countValue);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -780,6 +780,26 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   }
 
   @Test
+  public void testCaseStatementInSelectionWithTransformFunctionInThen()
+      throws Exception {
+    String sqlQuery = String.format(
+        "SELECT ArrDelay, CASE WHEN ArrDelay > 0 THEN ArrDelay WHEN ArrDelay < 0 THEN ArrDelay * -1 ELSE 0 END AS ArrTimeDiff FROM mytable LIMIT 1000");
+    JsonNode response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
+    System.out.println("response = " + response);
+    JsonNode rows = response.get("resultTable").get("rows");
+    Assert.assertEquals(response.get("exceptions").size(), 0);
+    for (int i = 0; i < rows.size(); i++) {
+      int arrDelay = rows.get(i).get(0).asInt();
+      int arrDelayDiff = rows.get(i).get(1).asInt();
+      if (arrDelay > 0) {
+        Assert.assertEquals(arrDelay, arrDelayDiff);
+      } else {
+        Assert.assertEquals(arrDelay, arrDelayDiff * -1);
+      }
+    }
+  }
+
+  @Test
   public void testCaseStatementWithInAggregation()
       throws Exception {
     testCountVsCaseQuery("origin = 'ATL'");


### PR DESCRIPTION
## Description
Adding Support for SQL CASE Statement
```
CASE
    WHEN condition1 THEN result1
    WHEN condition2 THEN result2
    WHEN conditionN THEN resultN
    ELSE result
END;
```

## Major Changes
- Adding SQL Parsing logic for CASE Statement in CalciteSQLParser. Note that the query syntax is not further supported in PQL.
- Adding BinaryOperatorTransformFunctions for (=, <>, >, >=, <, <=)
- Modeled CASE as a TransformFunction takes N conditions, N+1 results as arguments.
  - condition is a BinaryOperatorTransformFunction,
  - result is a TransformFunction.


## Sample queries:
```
SELECT
    CASE
      WHEN price > 30 THEN 3
      WHEN price > 20 THEN 2
      WHEN price > 10 THEN 1
      ELSE 0
    END AS price_category 
FROM
    myTable
```

```
SELECT
  SUM(
    CASE
      WHEN price > 30 THEN 30
      WHEN price > 20 THEN 20
      WHEN price > 10 THEN 10
      ELSE 0
    END) AS weighted_price
FROM
    myTable
```

## Release Notes
Adding Support for SQL CASE Statement
