### PR TITLE
Remove master branch restriction to trigger Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,14 @@ addons:
 install:
   - ./.travis/.travis_install.sh
 
-branches:
-  only:
-    - master
+#branches:
+#  only:
+#    - master
 
 stages:
   - test
   - name: deploy
-    if: branch = master
+#    if: branch = master
 
 jobs:
   include:


### PR DESCRIPTION
This PR removes the restriction on running the build only on master branch. This is helpful especially when we want to make a hotfix branch and publish jars to remote repositories like bintray.