### PR TITLE
Add a new table config field for peer segment download.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
@@ -214,7 +214,7 @@ public class TableConfigUtils {
       String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
       if (peerSegmentDownloadScheme != null) {
         if (!"http".equalsIgnoreCase(peerSegmentDownloadScheme) && !"https".equalsIgnoreCase(peerSegmentDownloadScheme)) {
-          throw new IllegalStateException("peerSegmentDownloadScheme: " + peerSegmentDownloadScheme + " is not http nor https" );
+          throw new IllegalStateException("Invalid value '" + peerSegmentDownloadScheme + "' for peerSegmentDownloadScheme. Must be one of http nor https" );
         }
       }
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
@@ -213,7 +213,7 @@ public class TableConfigUtils {
     if (validationConfig != null) {
       String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
       if (peerSegmentDownloadScheme != null) {
-        if (!"http".equals(peerSegmentDownloadScheme) && !"https".equals(peerSegmentDownloadScheme)) {
+        if (!"http".equalsIgnoreCase(peerSegmentDownloadScheme) && !"https".equalsIgnoreCase(peerSegmentDownloadScheme)) {
           throw new IllegalStateException("peerSegmentDownloadScheme: " + peerSegmentDownloadScheme + " is not http nor https" );
         }
       }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
@@ -181,9 +181,15 @@ public class TableConfigUtils {
    * Validates the table config with the following rules:
    * <ul>
    *   <li>Text index column must be raw</li>
+   *   <li>peerSegmentDownloadScheme in ValidationConfig must be http or https</li>
    * </ul>
    */
   public static void validate(TableConfig tableConfig) {
+    validateFieldConfigList(tableConfig);
+    validateValidationConfig(tableConfig);
+  }
+
+  private static void validateFieldConfigList(TableConfig tableConfig) {
     List<FieldConfig> fieldConfigList = tableConfig.getFieldConfigList();
     if (fieldConfigList != null) {
       List<String> noDictionaryColumns = tableConfig.getIndexingConfig().getNoDictionaryColumns();
@@ -197,6 +203,18 @@ public class TableConfigUtils {
             throw new IllegalStateException(
                 "Text index column: " + column + " must be raw (no-dictionary) in both FieldConfig and IndexingConfig");
           }
+        }
+      }
+    }
+  }
+
+  private static void validateValidationConfig(TableConfig tableConfig) {
+    SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
+    if (validationConfig != null) {
+      String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
+      if (peerSegmentDownloadScheme != null) {
+        if (!"http".equals(peerSegmentDownloadScheme) && !"https".equals(peerSegmentDownloadScheme)) {
+          throw new IllegalStateException("peerSegmentDownloadScheme: " + peerSegmentDownloadScheme + " is not http nor https" );
         }
       }
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -243,6 +243,17 @@ public class TableConfigSerDeTest {
       checkTableConfigWithUpsertConfig(JsonUtils.stringToObject(tableConfig.toJsonString(), TableConfig.class));
       checkTableConfigWithUpsertConfig(TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(tableConfig)));
     }
+    {
+      // with SegmentsValidationAndRetentionConfig
+      TableConfig tableConfig = tableConfigBuilder.setPeerSegmentDownloadScheme("http").build();
+      checkSegmentsValidationAndRetentionConfig(JsonUtils.stringToObject(tableConfig.toJsonString(), TableConfig.class));
+      checkSegmentsValidationAndRetentionConfig(TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(tableConfig)));
+    }
+  }
+
+  private void checkSegmentsValidationAndRetentionConfig(TableConfig tableConfig) {
+    // TODO validate other fields of SegmentsValidationAndRetentionConfig.
+    assertEquals(tableConfig.getValidationConfig().getPeerSegmentDownloadScheme(), "http");
   }
 
   private void checkDefaultTableConfig(TableConfig tableConfig) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -40,7 +40,9 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
   private CompletionConfig _completionConfig;
   // Possible values can be http or https. If this field is set, a Pinot server can download segments from peer servers
-  // using the specified download scheme.
+  // using the specified download scheme. Both realtime tables and offline tables can set this field.
+  // For more usage of this field, please refer to this design doc:
+  // https://cwiki.apache.org/confluence/display/PINOT/By-passing+deep-store+requirement+for+Realtime+segment+completion#By-passingdeep-storerequirementforRealtimesegmentcompletion-EnablebesteffortsegmentuploadinSplitSegmentCommiteranddownloadsegmentfrompeerservers.
   private String _peerSegmentDownloadScheme;
 
   // Number of replicas per partition of low-level consumers. This config is used for realtime tables only.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -39,6 +39,9 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _segmentAssignmentStrategy;
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
   private CompletionConfig _completionConfig;
+  // Possible values can be http or https. If this field is set, a Pinot server can download segments from peer servers
+  // using the specified download scheme.
+  private String _peerSegmentDownloadScheme;
 
   // Number of replicas per partition of low-level consumers. This config is used for realtime tables only.
   private String _replicasPerPartition;
@@ -151,5 +154,11 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   @JsonIgnore
   public int getReplicasPerPartitionNumber() {
     return Integer.parseInt(_replicasPerPartition);
+  }
+
+  public String getPeerSegmentDownloadScheme() { return _peerSegmentDownloadScheme; }
+
+  public void setPeerSegmentDownloadScheme(String peerSegmentDownloadScheme) {
+    _peerSegmentDownloadScheme = peerSegmentDownloadScheme;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -64,6 +64,7 @@ public class TableConfigBuilder {
   private String _segmentPushFrequency;
   private String _segmentPushType = DEFAULT_SEGMENT_PUSH_TYPE;
   private String _segmentAssignmentStrategy = DEFAULT_SEGMENT_ASSIGNMENT_STRATEGY;
+  private String _peerSegmentDownloadScheme;
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
   private CompletionConfig _completionConfig;
 
@@ -287,6 +288,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setPeerSegmentDownloadScheme(String peerSegmentDownloadScheme) {
+    _peerSegmentDownloadScheme = peerSegmentDownloadScheme;
+    return this;
+  }
+
   public TableConfig build() {
     // Validation config
     SegmentsValidationAndRetentionConfig validationConfig = new SegmentsValidationAndRetentionConfig();
@@ -301,6 +307,7 @@ public class TableConfigBuilder {
     validationConfig.setCompletionConfig(_completionConfig);
     validationConfig.setSchemaName(_schemaName);
     validationConfig.setReplication(_numReplicas);
+    validationConfig.setPeerSegmentDownloadScheme(_peerSegmentDownloadScheme);
     if (_isLLC) {
       validationConfig.setReplicasPerPartition(_numReplicas);
     }


### PR DESCRIPTION
## Description
Add a new optional string field peerSegmentDownloadScheme to the SegmentsValidationAndRetentionConfig in the TableConfig. The value can be http or https. 
The field will enable download of segments for both realtime and offline table segments from peer servers. In the beginning, only realtime table segments download will be supported. The design details can be found [in this section ](https://cwiki.apache.org/confluence/display/PINOT/By-passing+deep-store+requirement+for+Realtime+segment+completion#By-passingdeep-storerequirementforRealtimesegmentcompletion-EnablebesteffortsegmentuploadinSplitSegmentCommiteranddownloadsegmentfrompeerservers.)of the cwiki doc. 

@mcvsubbu 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
   Add a new optional string field peerSegmentDownloadScheme to the SegmentsValidationAndRetentionConfig in the TableConfig. The value can be http or https. 
The field will enable download of segments for both realtime and offline table segments from peer servers. Currently, only realtime table segment download during LLC segment completion protocol will be supported. For more details, please refer to the cwiki design doc "By-passing deepstore requirement for realtime segment completion". 

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
