### PR TITLE
Adding more information into jar manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1241,6 +1241,8 @@
           <configuration>
             <archive>
               <manifestEntries>
+                <Build-Time>${maven.build.timestamp}</Build-Time>
+                <Implementation-Branch>${scmBranch}</Implementation-Branch>
                 <Implementation-Title>${project.artifactId}</Implementation-Title>
                 <Implementation-Version>${project.version}-${buildNumber}</Implementation-Version>
                 <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>


### PR DESCRIPTION
## Description
Adding build time and branch into jar manifest

Sample output from: `pinot-distribution/target/pinot-distribution-0.4.0-SNAPSHOT-shaded.jar:META-INF/MANIFEST.MF`
```
Manifest-Version: 1.0
Archiver-Version: Plexus Archiver
Created-By: Apache Maven
Built-By: xiangfu
Build-Jdk: 1.8.0_232
Specification-Title: Pinot Distribution
Specification-Version: 0.4.0-SNAPSHOT
Specification-Vendor: Apache Software Foundation
Build-Time: 2020-06-02T005003Z
Implementation-Branch: git_plugin
Implementation-Title: pinot-distribution
Implementation-Vendor: Apache Software Foundation
Implementation-Vendor-Id: org.apache.pinot
Implementation-Version: 0.4.0-SNAPSHOT-ed26e8589fe5f91d2876d417aebf235
 75010cc76
```