### PR TITLE
Change a NPE to have a better error message

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -60,7 +60,11 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
 
   @Override
   public Dictionary getDictionary(String column) {
-    return _indexContainerMap.get(column).getDictionary();
+    ColumnIndexContainer container = _indexContainerMap.get(column);
+    if (container == null) {
+      throw new NullPointerException("Invalid column: " + column);
+    }
+    return container.getDictionary();
   }
 
   @Override


### PR DESCRIPTION
## Description
Improve an error message when a table spec is missing a dimension that is specified in a star tree schema.

https://github.com/apache/incubator-pinot/issues/5479