### PR TITLE
Changed the segment commit protocol to send/receive streamPartitionMs…

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/SegmentCompletionProtocolDeserTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/SegmentCompletionProtocolDeserTest.java
@@ -47,7 +47,7 @@ public class SegmentCompletionProtocolDeserTest {
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
-    assertEquals(response.getStreamPartitionMsgOffset().compareTo(OFFSET), 0);
+    assertEquals(new StreamPartitionMsgOffset(response.getStreamPartitionMsgOffset()).compareTo(OFFSET), 0);
     assertEquals(response.getSegmentLocation(), SEGMENT_LOCATION);
     assertTrue(response.isSplitCommit());
     assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
@@ -63,7 +63,7 @@ public class SegmentCompletionProtocolDeserTest {
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
-    assertEquals(response.getStreamPartitionMsgOffset().compareTo(OFFSET), 0);
+    assertEquals(new StreamPartitionMsgOffset(response.getStreamPartitionMsgOffset()).compareTo(OFFSET), 0);
     assertNull(response.getSegmentLocation());
     assertFalse(response.isSplitCommit());
     assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -536,7 +536,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           _state = State.HOLDING;
           SegmentCompletionProtocol.Response response = postSegmentConsumedMsg();
           SegmentCompletionProtocol.ControllerResponseStatus status = response.getStatus();
-          StreamPartitionMsgOffset rspOffset = new StreamPartitionMsgOffset(response.getOffset());
+          StreamPartitionMsgOffset rspOffset = response.extractOffset();
           boolean success;
           switch (status) {
             case NOT_LEADER:

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -486,11 +486,6 @@ public class LLRealtimeSegmentDataManagerTest {
   }
 
   @Test
-  public void testName() {
-
-  }
-
-  @Test
   public void testEndCriteriaChecking()
       throws Exception {
     // test reaching max row limit

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConsumerFactory;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamMessageDecoder;
+import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -69,7 +70,8 @@ public class LLRealtimeSegmentDataManagerTest {
   private static final LLCSegmentName _segmentName =
       new LLCSegmentName(_tableName, _partitionId, _sequenceId, _segTimeMs);
   private static final String _segmentNameStr = _segmentName.getSegmentName();
-  private static final long _startOffset = 19885L;
+  private static final long _startOffsetValue = 19885L;
+  private static final StreamPartitionMsgOffset _startOffset = new StreamPartitionMsgOffset(_startOffsetValue);
   private static final String _topicName = "someTopic";
   private static final int maxRowsInSegment = 250000;
   private static final long maxTimeForSegmentCloseMs = 64368000L;
@@ -134,7 +136,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     LLCRealtimeSegmentZKMetadata segmentZKMetadata = new LLCRealtimeSegmentZKMetadata();
     segmentZKMetadata.setSegmentName(_segmentNameStr);
-    segmentZKMetadata.setStartOffset(_startOffset);
+    segmentZKMetadata.setStartOffset(_startOffset.getOffset());
     segmentZKMetadata.setCreationTime(System.currentTimeMillis());
     return segmentZKMetadata;
   }
@@ -173,12 +175,12 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final long endOffset = _startOffset + 500;
+    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(
         new SegmentCompletionProtocol.Response.Params()
-            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD).withOffset(endOffset));
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD).withStreamPartitionMsgOffset(endOffset));
     // And then never consume as long as we get a hold response, 100 times.
     for (int i = 0; i < 100; i++) {
       segmentDataManager._responses.add(response);
@@ -202,14 +204,14 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final long endOffset = _startOffset + 500;
+    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response holdResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     // And then never consume as long as we get a hold response, 100 times.
     segmentDataManager._responses.add(holdResponse);
@@ -233,11 +235,11 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final long endOffset = _startOffset + 500;
+    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     segmentDataManager._responses.add(commitResponse);
     segmentDataManager._failSegmentBuild = true;
@@ -254,23 +256,24 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final long firstOffset = _startOffset + 500;
-    final long catchupOffset = firstOffset + 10;
+    final StreamPartitionMsgOffset firstOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
+    final StreamPartitionMsgOffset catchupOffset = new StreamPartitionMsgOffset(firstOffset.getOffset() + 10);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(firstOffset);
     segmentDataManager._consumeOffsets.add(catchupOffset); // Offset after catchup
     final SegmentCompletionProtocol.Response holdResponse1 = new SegmentCompletionProtocol.Response(
         new SegmentCompletionProtocol.Response.Params()
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD).
-            withOffset(firstOffset));
+            withStreamPartitionMsgOffset(firstOffset));
     final SegmentCompletionProtocol.Response catchupResponse = new SegmentCompletionProtocol.Response(
         new SegmentCompletionProtocol.Response.Params()
-            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP).withOffset(catchupOffset));
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP)
+            .withStreamPartitionMsgOffset(catchupOffset));
     final SegmentCompletionProtocol.Response holdResponse2 = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withOffset(catchupOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(catchupOffset)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withOffset(catchupOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(catchupOffset)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     // And then never consume as long as we get a hold response, 100 times.
     segmentDataManager._responses.add(holdResponse1);
@@ -296,10 +299,10 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final long endOffset = _startOffset + 500;
+    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response discardResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.DISCARD));
     segmentDataManager._responses.add(discardResponse);
 
@@ -321,10 +324,10 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final long endOffset = _startOffset + 500;
+    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
     segmentDataManager._consumeOffsets.add(endOffset);
     SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params();
-    params.withOffset(endOffset).withStatus(SegmentCompletionProtocol.ControllerResponseStatus.KEEP);
+    params.withStreamPartitionMsgOffset(endOffset).withStatus(SegmentCompletionProtocol.ControllerResponseStatus.KEEP);
     final SegmentCompletionProtocol.Response keepResponse = new SegmentCompletionProtocol.Response(params);
     segmentDataManager._responses.add(keepResponse);
 
@@ -345,11 +348,11 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final long endOffset = _startOffset + 500;
+    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER));
     // And then never consume as long as we get a Not leader response, 100 times.
     for (int i = 0; i < 100; i++) {
@@ -389,8 +392,9 @@ public class LLRealtimeSegmentDataManagerTest {
   public void testOnlineTransitionAfterStop()
       throws Exception {
     LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
-    final long finalOffset = _startOffset + 600;
-    metadata.setEndOffset(finalOffset);
+    final long finalOffsetValue = _startOffsetValue + 600;
+    final StreamPartitionMsgOffset finalOffset = new StreamPartitionMsgOffset(finalOffsetValue);
+    metadata.setEndOffset(finalOffset.getOffset());
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
@@ -437,7 +441,7 @@ public class LLRealtimeSegmentDataManagerTest {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.HOLDING);
-      segmentDataManager.setCurrentOffset(finalOffset + 1);
+      segmentDataManager.setCurrentOffset(finalOffsetValue + 1);
       segmentDataManager.goOnlineFromConsuming(metadata);
       Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
       Assert.assertFalse(segmentDataManager._buildAndReplaceCalled);
@@ -449,7 +453,7 @@ public class LLRealtimeSegmentDataManagerTest {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
-      segmentDataManager.setCurrentOffset(finalOffset + 1);
+      segmentDataManager.setCurrentOffset(finalOffsetValue + 1);
       segmentDataManager.goOnlineFromConsuming(metadata);
       Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
       Assert.assertFalse(segmentDataManager._buildAndReplaceCalled);
@@ -461,7 +465,7 @@ public class LLRealtimeSegmentDataManagerTest {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
-      segmentDataManager._consumeOffsets.add(finalOffset - 1);
+      segmentDataManager._consumeOffsets.add(new StreamPartitionMsgOffset(finalOffsetValue - 1));
       segmentDataManager.goOnlineFromConsuming(metadata);
       Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
       Assert.assertFalse(segmentDataManager._buildAndReplaceCalled);
@@ -479,6 +483,11 @@ public class LLRealtimeSegmentDataManagerTest {
       Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
       segmentDataManager.destroy();
     }
+  }
+
+  @Test
+  public void testName() {
+
   }
 
   @Test
@@ -515,7 +524,7 @@ public class LLRealtimeSegmentDataManagerTest {
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
-      final long finalOffset = _startOffset + 100;
+      final long finalOffset = _startOffsetValue + 100;
       segmentDataManager.setFinalOffset(finalOffset);
       segmentDataManager.setCurrentOffset(finalOffset - 1);
       Assert.assertFalse(segmentDataManager.invokeEndCriteriaReached());
@@ -528,7 +537,7 @@ public class LLRealtimeSegmentDataManagerTest {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
       _timeNow += maxTimeForSegmentCloseMs;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
-      final long finalOffset = _startOffset + 100;
+      final long finalOffset = _startOffsetValue + 100;
       segmentDataManager.setFinalOffset(finalOffset);
       segmentDataManager.setCurrentOffset(finalOffset - 1);
       Assert.assertFalse(segmentDataManager.invokeEndCriteriaReached());
@@ -543,7 +552,7 @@ public class LLRealtimeSegmentDataManagerTest {
       _timeNow += 1;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CONSUMING_TO_ONLINE);
       segmentDataManager.setConsumeEndTime(_timeNow + 10);
-      final long finalOffset = _startOffset + 100;
+      final long finalOffset = _startOffsetValue + 100;
       segmentDataManager.setFinalOffset(finalOffset);
       segmentDataManager.setCurrentOffset(finalOffset - 1);
       Assert.assertFalse(segmentDataManager.invokeEndCriteriaReached());
@@ -557,7 +566,7 @@ public class LLRealtimeSegmentDataManagerTest {
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CONSUMING_TO_ONLINE);
       final long endTime = _timeNow + 10;
       segmentDataManager.setConsumeEndTime(endTime);
-      final long finalOffset = _startOffset + 100;
+      final long finalOffset = _startOffsetValue + 100;
       segmentDataManager.setFinalOffset(finalOffset);
       segmentDataManager.setCurrentOffset(finalOffset - 1);
       _timeNow = endTime - 1;
@@ -627,7 +636,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // Set up the responses so that we get a failed response first and then a success response.
     segmentDataManager._responses.add(commitFailed);
     final long leaseTime = 50000L;
-    final long finalOffset = _startOffset + 600;
+    final long finalOffset = _startOffsetValue + 600;
     segmentDataManager.setCurrentOffset(finalOffset);
 
     // We have set up commit to fail, so we should carry over the segment file.
@@ -703,7 +712,7 @@ public class LLRealtimeSegmentDataManagerTest {
     public Field _state;
     public Field _shouldStop;
     public Field _stopReason;
-    public LinkedList<Long> _consumeOffsets = new LinkedList<>();
+    public LinkedList<StreamPartitionMsgOffset> _consumeOffsets = new LinkedList<>();
     public LinkedList<SegmentCompletionProtocol.Response> _responses = new LinkedList<>();
     public boolean _commitSegmentCalled = false;
     public boolean _buildSegmentCalled = false;
@@ -787,7 +796,7 @@ public class LLRealtimeSegmentDataManagerTest {
       if (_throwExceptionFromConsume) {
         throw new PermanentConsumerException(new Throwable("Offset out of range"));
       }
-      setCurrentOffset(_consumeOffsets.remove());
+      setCurrentOffset(_consumeOffsets.remove().getOffset());
       terminateLoopIfNecessary();
       return true;
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTest.java
@@ -44,6 +44,7 @@ import org.apache.pinot.controller.validation.RealtimeSegmentValidationManager;
 import org.apache.pinot.server.realtime.ControllerLeaderLocator;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
@@ -142,8 +143,8 @@ public class SegmentCompletionIntegrationTest extends BaseClusterIntegrationTest
     ServerSegmentCompletionProtocolHandler protocolHandler =
         new ServerSegmentCompletionProtocolHandler(new ServerMetrics(new MetricsRegistry()), realtimeTableName);
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
-    params.withOffset(45688L).withSegmentName(_currentSegment).withReason("RandomReason")
-        .withInstanceId(_serverInstance);
+    params.withStreamPartitionMsgOffset(new StreamPartitionMsgOffset(45688L)).withSegmentName(_currentSegment)
+        .withReason("RandomReason") .withInstanceId(_serverInstance);
     SegmentCompletionProtocol.Response response = protocolHandler.segmentStoppedConsuming(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED);
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffset.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffset.java
@@ -42,6 +42,15 @@ public class StreamPartitionMsgOffset implements Comparable {
     _offset = offset;
   }
 
+  /**
+   * This constructor will go away when this class becomes an interface
+   * @param offsetStr
+   */
+  @Deprecated
+  public StreamPartitionMsgOffset(String offsetStr) {
+    _offset = Long.parseLong(offsetStr);
+  }
+
   @Deprecated
   public void setOffset(long offset) {
     _offset = offset;


### PR DESCRIPTION
…gOffset

Updated the segment commit protocol so that new element streamPartitionMsgOffset
is populated in requests (as request parameters) and in response (as JSON string element)

The server side has been modified to send the 'streamPartitionMsgOffset' as well as we the
'offset' parameters to the controller. The controller looks for and prefers streamPartitionMsgOffset
but falls back to offset if the streamPartitionMsgOffset is not there.

The controller side, in the repsonse message, populates both of the elements, and the server on
the receiver side does likewise -- preferring streamPartitionMsgOffset.

All callers into the protocol module have been modified to NOT set the offset field. Instead,
only set the streamPartitionMsgOffset field. The 'offset' value will be derived from
streamPartitionMsgOffset.

Added a test to make sure that the controller always generates both elements. Such a test was not
possible in the server side at this time, so verified manually.

Manually ran LLCClusterIntergrationTest by disabling populating `streamPartitionMsgOffset` on the
server side (old server/new controller) and on the controller respons side (new server/old controller)

Issue #5359

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
