### PR TITLE
Add multi-value support to SegmentDumpTool

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotToolLauncher.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotToolLauncher.java
@@ -45,7 +45,8 @@ public class PinotToolLauncher {
       @SubCommand(name = "ValidateTableRetention", impl = ValidateTableRetention.class),
       @SubCommand(name = "PerfBenchmarkRunner", impl = PerfBenchmarkRunner.class),
       @SubCommand(name = "QueryRunner", impl = QueryRunner.class),
-      @SubCommand(name = "PinotFSBenchmarkRunner", impl = PinotFSBenchmarkRunner.class)
+      @SubCommand(name = "PinotFSBenchmarkRunner", impl = PinotFSBenchmarkRunner.class),
+      @SubCommand(name = "SegmentDump", impl = SegmentDumpTool.class)
   })
   Command _subCommand;
   // @formatter:on

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
@@ -121,7 +121,7 @@ public class SegmentDumpTool extends AbstractBaseCommand implements Command {
               System.out.print(",");
             }
           }
-          System.out.print("]");
+          System.out.print("]\t");
         }
       }
       System.out.println();


### PR DESCRIPTION
Also, add the segment dump tool as part of the pinot-tool.sh script

Currently segment dump tool supports single-value only. This change adds the multi-value support. It also makes segment dump tool a subcommand in `pinot-tool.sh` script.


