### PR TITLE
Move bintray target to mvn deploy command

### DIFF
--- a/.travis/.travis_nightly_build.sh
+++ b/.travis/.travis_nightly_build.sh
@@ -27,5 +27,5 @@ if [ -n "${DEPLOY_BUILD_OPTS}" ]; then
   mvn versions:commit -q -B
 
   # Deploy to bintray
-  mvn deploy -s .travis/.ci.settings.xml -DskipTests -q -DretryFailedDeploymentCount=5
+  mvn deploy -s .travis/.ci.settings.xml -DskipTests -q -DretryFailedDeploymentCount=5 -DaltDeploymentRepository=bintray-linkedin-maven::default::'https://api.bintray.com/maven/linkedin/maven/pinot/;publish=1;override=1'
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -97,14 +97,6 @@
   <!-- Apache project inception year for generating correct NOTICE file for jar bundle. -->
   <inceptionYear>2018</inceptionYear>
 
-  <distributionManagement>
-    <repository>
-      <id>bintray-linkedin-maven</id>
-      <name>linkedin-maven</name>
-      <url>https://api.bintray.com/maven/linkedin/maven/pinot/;publish=1;override=1</url>
-    </repository>
-  </distributionManagement>
-
   <properties>
     <pinot.root>${basedir}</pinot.root>
     <revision>0.4.0</revision>


### PR DESCRIPTION
This PR moves LinkedIn bintray target as a parameter in `mvn deploy` command.

Reference:
https://stackoverflow.com/questions/12435283/adding-a-maven-distribution-repository-on-the-command-line