### PR TITLE
Superset Docker Image: upgrade pinotdb version to 0.3.2 to use new pinot sql endpoint

### DIFF
--- a/docker/images/pinot-superset/requirements-db.txt
+++ b/docker/images/pinot-superset/requirements-db.txt
@@ -20,4 +20,4 @@ gevent==1.4.0
 psycopg2-binary==2.7.5
 pyhive==0.6.1
 redis==3.2.1
-pinotdb==0.2.5
+pinotdb==0.3.2


### PR DESCRIPTION
## Description
Upgrade pypi pinotdb(https://pypi.org/project/pinotdb/) version to 0.3.2 to use new pinot sql api for superset docker image.

## Release Notes
No