### PR TITLE
Support escaping single quote for SQL literal

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -121,7 +121,7 @@ public class RequestUtils {
         literal.setDoubleValue(node.bigDecimalValue().doubleValue());
       }
     } else {
-      literal.setStringValue(node.toString().replaceAll("^\'|\'$", ""));
+      literal.setStringValue(node.toString().replaceAll("^'|'$", "").replace("''", "'"));
     }
     expression.setLiteral(literal);
     return expression;
@@ -176,10 +176,11 @@ public class RequestUtils {
     if (object instanceof String) {
       return RequestUtils.getLiteralExpression((String) object);
     }
-    if(object instanceof SqlLiteral) {
+    if (object instanceof SqlLiteral) {
       return RequestUtils.getLiteralExpression((SqlLiteral) object);
     }
-    throw new SqlCompilationException(new IllegalArgumentException("Unsupported Literal value type - " + object.getClass()));
+    throw new SqlCompilationException(
+        new IllegalArgumentException("Unsupported Literal value type - " + object.getClass()));
   }
 
   public static Expression getFunctionExpression(String operator) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -55,7 +55,7 @@ public class CalciteSqlCompilerTest {
         CalciteSqlParser.compileToPinotQuery("select * from vegetables where origin = 'Martha''s Vineyard'");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
-        "Martha''s Vineyard");
+        "Martha's Vineyard");
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where origin = 'Martha\"\"s Vineyard'");
     Assert.assertEquals(


### PR DESCRIPTION
Currently there is no way to escape single quote for SQL literal
Support escaping single quote by using the SQL convention of double single quote "''"
This is especially useful for DistinctCountThetaSketch because it stores expression as literal
E.g. DistinctCountThetaSketch(..., 'foo=''bar''', ...)