### PR TITLE
Config for raw index writer version

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.io.writer.impl.v1;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -36,6 +37,9 @@ import org.slf4j.LoggerFactory;
  * Base class for fixed and variable byte writer implementations.
  */
 public abstract class BaseChunkSingleValueWriter implements SingleColumnSingleValueWriter {
+  public static final int DEFAULT_VERSION = 2;
+  public static final int CURRENT_VERSION = 3;
+
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseChunkSingleValueWriter.class);
   private static final int FILE_HEADER_ENTRY_CHUNK_OFFSET_SIZE_V1V2 = Integer.BYTES;
   private static final int FILE_HEADER_ENTRY_CHUNK_OFFSET_SIZE_V3 = Long.BYTES;
@@ -60,12 +64,13 @@ public abstract class BaseChunkSingleValueWriter implements SingleColumnSingleVa
    * @param numDocsPerChunk Number of docs per data chunk
    * @param chunkSize Size of chunk
    * @param sizeOfEntry Size of entry (in bytes), max size for variable byte implementation.
-   * @param version Version of file
+   * @param version format version used to determine whether to use 8 or 4 byte chunk offsets
    * @throws FileNotFoundException
    */
   protected BaseChunkSingleValueWriter(File file, ChunkCompressorFactory.CompressionType compressionType, int totalDocs,
       int numDocsPerChunk, int chunkSize, int sizeOfEntry, int version)
       throws FileNotFoundException {
+    Preconditions.checkArgument(version == DEFAULT_VERSION || version == CURRENT_VERSION);
     _chunkSize = chunkSize;
     _chunkCompressor = ChunkCompressorFactory.getCompressor(compressionType);
     _headerEntryChunkOffsetSize = getHeaderEntryChunkOffsetSize(version);

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
  * Base class for fixed and variable byte writer implementations.
  */
 public abstract class BaseChunkSingleValueWriter implements SingleColumnSingleValueWriter {
+  // TODO: Remove this before release 0.5.0
   public static final int DEFAULT_VERSION = 2;
   public static final int CURRENT_VERSION = 3;
 
@@ -64,7 +65,7 @@ public abstract class BaseChunkSingleValueWriter implements SingleColumnSingleVa
    * @param numDocsPerChunk Number of docs per data chunk
    * @param chunkSize Size of chunk
    * @param sizeOfEntry Size of entry (in bytes), max size for variable byte implementation.
-   * @param version format version used to determine whether to use 8 or 4 byte chunk offsets
+   * @param version version of File
    * @throws FileNotFoundException
    */
   protected BaseChunkSingleValueWriter(File file, ChunkCompressorFactory.CompressionType compressionType, int totalDocs,

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
@@ -53,8 +53,6 @@ import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
  */
 @NotThreadSafe
 public class FixedByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
-
-  private static final int CURRENT_VERSION = 3;
   private int _chunkDataOffset;
 
   /**
@@ -64,15 +62,15 @@ public class FixedByteChunkSingleValueWriter extends BaseChunkSingleValueWriter 
    * @param compressionType Type of compression to use.
    * @param totalDocs Total number of docs to write.
    * @param numDocsPerChunk Number of documents per chunk.
-   * @param sizeOfEntry Size of entry (in bytes).
+   * @param sizeOfEntry Size of entry (in bytes)
+   * @param writerVersion writer version used to determine whether to use 8 or 4 byte chunk offsets
    * @throws FileNotFoundException Throws {@link FileNotFoundException} if the specified file is not found.
    */
   public FixedByteChunkSingleValueWriter(File file, ChunkCompressorFactory.CompressionType compressionType,
-      int totalDocs, int numDocsPerChunk, int sizeOfEntry)
+      int totalDocs, int numDocsPerChunk, int sizeOfEntry, int writerVersion)
       throws FileNotFoundException {
-
     super(file, compressionType, totalDocs, numDocsPerChunk, (sizeOfEntry * numDocsPerChunk), sizeOfEntry,
-        CURRENT_VERSION);
+        writerVersion);
     _chunkDataOffset = 0;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
@@ -63,7 +63,7 @@ public class FixedByteChunkSingleValueWriter extends BaseChunkSingleValueWriter 
    * @param totalDocs Total number of docs to write.
    * @param numDocsPerChunk Number of documents per chunk.
    * @param sizeOfEntry Size of entry (in bytes)
-   * @param writerVersion writer version used to determine whether to use 8 or 4 byte chunk offsets
+   * @param writerVersion writer format version
    * @throws FileNotFoundException Throws {@link FileNotFoundException} if the specified file is not found.
    */
   public FixedByteChunkSingleValueWriter(File file, ChunkCompressorFactory.CompressionType compressionType,

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
@@ -67,7 +67,7 @@ public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
    * @param totalDocs Total number of docs to write.
    * @param numDocsPerChunk Number of documents per chunk.
    * @param lengthOfLongestEntry Length of longest entry (in bytes)
-   * @param writerVersion writer version used to determine whether to use 8 or 4 byte chunk offsets
+   * @param writerVersion writer format version
    * @throws FileNotFoundException Throws {@link FileNotFoundException} if the specified file is not found.
    */
   public VarByteChunkSingleValueWriter(File file, ChunkCompressorFactory.CompressionType compressionType, int totalDocs,

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
@@ -53,7 +53,6 @@ import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
  */
 @NotThreadSafe
 public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
-  private static final int CURRENT_VERSION = 3;
   public static final int CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE = Integer.BYTES;
 
   private final int _chunkHeaderSize;
@@ -67,16 +66,16 @@ public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
    * @param compressionType Type of compression to use.
    * @param totalDocs Total number of docs to write.
    * @param numDocsPerChunk Number of documents per chunk.
-   * @param lengthOfLongestEntry Length of longest entry (in bytes).
+   * @param lengthOfLongestEntry Length of longest entry (in bytes)
+   * @param writerVersion writer version used to determine whether to use 8 or 4 byte chunk offsets
    * @throws FileNotFoundException Throws {@link FileNotFoundException} if the specified file is not found.
    */
   public VarByteChunkSingleValueWriter(File file, ChunkCompressorFactory.CompressionType compressionType, int totalDocs,
-      int numDocsPerChunk, int lengthOfLongestEntry)
+      int numDocsPerChunk, int lengthOfLongestEntry, int writerVersion)
       throws FileNotFoundException {
-
     super(file, compressionType, totalDocs, numDocsPerChunk,
         numDocsPerChunk * (CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE + lengthOfLongestEntry), // chunkSize
-        lengthOfLongestEntry, CURRENT_VERSION);
+        lengthOfLongestEntry, writerVersion);
 
     _chunkHeaderOffset = 0;
     _chunkHeaderSize = numDocsPerChunk * CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE;

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/RawIndexConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/RawIndexConverter.java
@@ -32,6 +32,7 @@ import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
+import org.apache.pinot.core.io.writer.impl.v1.BaseChunkSingleValueWriter;
 import org.apache.pinot.core.segment.creator.SingleValueRawIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -200,7 +201,7 @@ public class RawIndexConverter {
     int lengthOfLongestEntry = _originalSegmentMetadata.getColumnMetadataFor(columnName).getColumnMaxLength();
     try (SingleValueRawIndexCreator rawIndexCreator = SegmentColumnarIndexCreator
         .getRawIndexCreatorForColumn(_convertedIndexDir, ChunkCompressorFactory.CompressionType.SNAPPY, columnName,
-            dataType, _originalSegmentMetadata.getTotalDocs(), lengthOfLongestEntry)) {
+            dataType, _originalSegmentMetadata.getTotalDocs(), lengthOfLongestEntry, false, BaseChunkSingleValueWriter.DEFAULT_VERSION)) {
       BlockSingleValIterator iterator = (BlockSingleValIterator) dataSource.nextBlock().getBlockValueSet().iterator();
       int docId = 0;
       while (iterator.hasNext()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/fwd/SingleValueFixedByteRawIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/fwd/SingleValueFixedByteRawIndexCreator.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
 import org.apache.pinot.core.io.writer.impl.FixedByteSingleValueMultiColWriter;
+import org.apache.pinot.core.io.writer.impl.v1.BaseChunkSingleValueWriter;
 import org.apache.pinot.core.io.writer.impl.v1.FixedByteChunkSingleValueWriter;
 import org.apache.pinot.core.segment.creator.BaseSingleValueRawIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
@@ -52,9 +53,26 @@ public class SingleValueFixedByteRawIndexCreator extends BaseSingleValueRawIndex
   public SingleValueFixedByteRawIndexCreator(File baseIndexDir, ChunkCompressorFactory.CompressionType compressionType,
       String column, int totalDocs, int sizeOfEntry)
       throws IOException {
+    this(baseIndexDir, compressionType, column, totalDocs, sizeOfEntry, BaseChunkSingleValueWriter.DEFAULT_VERSION);
+  }
+
+  /**
+   * Constructor for the class
+   *
+   * @param baseIndexDir Index directory
+   * @param compressionType Type of compression to use
+   * @param column Name of column to index
+   * @param totalDocs Total number of documents to index
+   * @param sizeOfEntry Size of entry (in bytes)
+   * @param writerVersion writer format version
+   * @throws IOException
+   */
+  public SingleValueFixedByteRawIndexCreator(File baseIndexDir, ChunkCompressorFactory.CompressionType compressionType,
+      String column, int totalDocs, int sizeOfEntry, int writerVersion)
+      throws IOException {
     File file = new File(baseIndexDir, column + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
     _indexWriter =
-        new FixedByteChunkSingleValueWriter(file, compressionType, totalDocs, NUM_DOCS_PER_CHUNK, sizeOfEntry);
+        new FixedByteChunkSingleValueWriter(file, compressionType, totalDocs, NUM_DOCS_PER_CHUNK, sizeOfEntry, writerVersion);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
+import org.apache.pinot.core.io.writer.impl.v1.BaseChunkSingleValueWriter;
 import org.apache.pinot.core.io.writer.impl.v1.VarByteChunkSingleValueWriter;
 import org.apache.pinot.core.segment.creator.BaseSingleValueRawIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
@@ -33,18 +34,40 @@ public class SingleValueVarByteRawIndexCreator extends BaseSingleValueRawIndexCr
 
   private final VarByteChunkSingleValueWriter _indexWriter;
 
+  /**
+   * Create a var-byte raw index creator for the given column
+   * @param baseIndexDir Index directory
+   * @param compressionType Type of compression to use
+   * @param column Name of column to index
+   * @param totalDocs Total number of documents to index
+   * @param maxLength length of longest entry (in bytes)
+   * @throws IOException
+   */
   public SingleValueVarByteRawIndexCreator(File baseIndexDir, ChunkCompressorFactory.CompressionType compressionType,
       String column, int totalDocs, int maxLength)
       throws IOException {
-    this(baseIndexDir, compressionType, column, totalDocs, maxLength, false);
+    this(baseIndexDir, compressionType, column, totalDocs, maxLength, false,
+        BaseChunkSingleValueWriter.DEFAULT_VERSION);
   }
 
+  /**
+   * Create a var-byte raw index creator for the given column
+   * @param baseIndexDir Index directory
+   * @param compressionType Type of compression to use
+   * @param column Name of column to index
+   * @param totalDocs Total number of documents to index
+   * @param maxLength length of longest entry (in bytes)
+   * @param deriveNumDocsPerChunk true if writer should auto-derive the number of rows per chunk
+   * @param writerVersion writer format version
+   * @throws IOException
+   */
   public SingleValueVarByteRawIndexCreator(File baseIndexDir, ChunkCompressorFactory.CompressionType compressionType,
-      String column, int totalDocs, int maxLength, boolean deriveNumDocsPerChunk)
+      String column, int totalDocs, int maxLength, boolean deriveNumDocsPerChunk, int writerVersion)
       throws IOException {
     File file = new File(baseIndexDir, column + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
     int numDocsPerChunk = deriveNumDocsPerChunk ? getNumDocsPerChunk(maxLength) : DEFAULT_NUM_DOCS_PER_CHUNK;
-    _indexWriter = new VarByteChunkSingleValueWriter(file, compressionType, totalDocs, numDocsPerChunk, maxLength);
+    _indexWriter =
+        new VarByteChunkSingleValueWriter(file, compressionType, totalDocs, numDocsPerChunk, maxLength, writerVersion);
   }
 
   @VisibleForTesting

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -363,9 +363,10 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
     int dictionaryElementSize = 0;
 
     boolean deriveNumDocsPerChunk = SegmentColumnarIndexCreator.shouldDeriveNumDocsPerChunk(column, indexLoadingConfig.getColumnProperties());
+    int writerVersion = SegmentColumnarIndexCreator.rawIndexWriterVersion(column, indexLoadingConfig.getColumnProperties());
     SingleValueVarByteRawIndexCreator rawIndexCreator =
         new SingleValueVarByteRawIndexCreator(_indexDir, ChunkCompressorFactory.CompressionType.SNAPPY, column,
-            totalDocs, lengthOfLongestEntry, deriveNumDocsPerChunk);
+            totalDocs, lengthOfLongestEntry, deriveNumDocsPerChunk, writerVersion);
 
     for (int docId = 0; docId < totalDocs; docId++) {
       rawIndexCreator.index(docId, defaultValue);

--- a/pinot-core/src/test/java/org/apache/pinot/index/readerwriter/FixedByteChunkSingleValueReaderWriteTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/index/readerwriter/FixedByteChunkSingleValueReaderWriteTest.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
 import org.apache.pinot.core.io.reader.impl.ChunkReaderContext;
 import org.apache.pinot.core.io.reader.impl.v1.FixedByteChunkSingleValueReader;
+import org.apache.pinot.core.io.writer.impl.v1.BaseChunkSingleValueWriter;
 import org.apache.pinot.core.io.writer.impl.v1.FixedByteChunkSingleValueWriter;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 import org.testng.Assert;
@@ -82,33 +83,47 @@ public class FixedByteChunkSingleValueReaderWriteTest {
       expected[i] = _random.nextInt();
     }
 
-    File outFile = new File(TEST_FILE);
-    FileUtils.deleteQuietly(outFile);
+    File outFileFourByte = new File(TEST_FILE);
+    File outFileEightByte = new File(TEST_FILE + "8byte");
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
 
-    FixedByteChunkSingleValueWriter writer =
-        new FixedByteChunkSingleValueWriter(outFile, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK, Integer.BYTES);
+    // test both formats (4-byte chunk offsets and 8-byte chunk offsets)
+    FixedByteChunkSingleValueWriter fourByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileFourByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            Integer.BYTES, BaseChunkSingleValueWriter.DEFAULT_VERSION);
+    FixedByteChunkSingleValueWriter eightByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileEightByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            Integer.BYTES, BaseChunkSingleValueWriter.CURRENT_VERSION);
 
     for (int i = 0; i < NUM_VALUES; i++) {
-      writer.setInt(i, expected[i]);
+      fourByteOffsetWriter.setInt(i, expected[i]);
+      eightByteOffsetWriter.setInt(i, expected[i]);
     }
-    writer.close();
 
-    try (FixedByteChunkSingleValueReader reader = new FixedByteChunkSingleValueReader(
-        PinotDataBuffer.mapReadOnlyBigEndianFile(outFile))) {
-      ChunkReaderContext context = reader.createContext();
+    fourByteOffsetWriter.close();
+    eightByteOffsetWriter.close();
+
+    try (FixedByteChunkSingleValueReader fourByteOffsetReader = new FixedByteChunkSingleValueReader(
+        PinotDataBuffer.mapReadOnlyBigEndianFile(outFileFourByte));
+        FixedByteChunkSingleValueReader eightByteOffsetReader = new FixedByteChunkSingleValueReader(
+            PinotDataBuffer.mapReadOnlyBigEndianFile(outFileEightByte))) {
+
+      ChunkReaderContext context1 = fourByteOffsetReader.createContext();
+      ChunkReaderContext context2 = eightByteOffsetReader.createContext();
 
       for (int i = 0; i < NUM_VALUES; i++) {
-        int actual = reader.getInt(i, context);
-        Assert.assertEquals(actual, expected[i]);
-
+        Assert.assertEquals(fourByteOffsetReader.getInt(i, context1), expected[i]);
+        Assert.assertEquals(eightByteOffsetReader.getInt(i, context2), expected[i]);
         if (compressionType.equals(ChunkCompressorFactory.CompressionType.PASS_THROUGH)) {
-          actual = reader.getInt(i);
-          Assert.assertEquals(actual, expected[i]);
+          Assert.assertEquals(fourByteOffsetReader.getInt(i), expected[i]);
+          Assert.assertEquals(eightByteOffsetReader.getInt(i), expected[i]);
         }
       }
     }
 
-    FileUtils.deleteQuietly(outFile);
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
   }
 
   public void testLong(ChunkCompressorFactory.CompressionType compressionType)
@@ -118,33 +133,47 @@ public class FixedByteChunkSingleValueReaderWriteTest {
       expected[i] = _random.nextLong();
     }
 
-    File outFile = new File(TEST_FILE);
-    FileUtils.deleteQuietly(outFile);
+    File outFileFourByte = new File(TEST_FILE);
+    File outFileEightByte = new File(TEST_FILE + "8byte");
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
 
-    FixedByteChunkSingleValueWriter writer =
-        new FixedByteChunkSingleValueWriter(outFile, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK, Long.BYTES);
+    // test both formats (4-byte chunk offsets and 8-byte chunk offsets)
+    FixedByteChunkSingleValueWriter fourByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileFourByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK, Long.BYTES,
+            BaseChunkSingleValueWriter.DEFAULT_VERSION);
+    FixedByteChunkSingleValueWriter eightByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileEightByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            Long.BYTES, BaseChunkSingleValueWriter.CURRENT_VERSION);
 
     for (int i = 0; i < NUM_VALUES; i++) {
-      writer.setLong(i, expected[i]);
+      fourByteOffsetWriter.setLong(i, expected[i]);
+      eightByteOffsetWriter.setLong(i, expected[i]);
     }
-    writer.close();
 
-    try (FixedByteChunkSingleValueReader reader = new FixedByteChunkSingleValueReader(
-        PinotDataBuffer.mapReadOnlyBigEndianFile(outFile))) {
-      ChunkReaderContext context = reader.createContext();
+    fourByteOffsetWriter.close();
+    eightByteOffsetWriter.close();
+
+    try (FixedByteChunkSingleValueReader fourByteOffsetReader = new FixedByteChunkSingleValueReader(
+        PinotDataBuffer.mapReadOnlyBigEndianFile(outFileFourByte));
+        FixedByteChunkSingleValueReader eightByteOffsetReader = new FixedByteChunkSingleValueReader(
+            PinotDataBuffer.mapReadOnlyBigEndianFile(outFileEightByte))) {
+
+      ChunkReaderContext context1 = fourByteOffsetReader.createContext();
+      ChunkReaderContext context2 = eightByteOffsetReader.createContext();
 
       for (int i = 0; i < NUM_VALUES; i++) {
-        long actual = reader.getLong(i, context);
-        Assert.assertEquals(actual, expected[i]);
-
+        Assert.assertEquals(fourByteOffsetReader.getLong(i, context1), expected[i]);
+        Assert.assertEquals(eightByteOffsetReader.getLong(i, context2), expected[i]);
         if (compressionType.equals(ChunkCompressorFactory.CompressionType.PASS_THROUGH)) {
-          actual = reader.getLong(i);
-          Assert.assertEquals(actual, expected[i]);
+          Assert.assertEquals(fourByteOffsetReader.getLong(i), expected[i]);
+          Assert.assertEquals(eightByteOffsetReader.getLong(i), expected[i]);
         }
       }
     }
 
-    FileUtils.deleteQuietly(outFile);
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
   }
 
   public void testFloat(ChunkCompressorFactory.CompressionType compressionType)
@@ -154,33 +183,47 @@ public class FixedByteChunkSingleValueReaderWriteTest {
       expected[i] = _random.nextFloat();
     }
 
-    File outFile = new File(TEST_FILE);
-    FileUtils.deleteQuietly(outFile);
+    File outFileFourByte = new File(TEST_FILE);
+    File outFileEightByte = new File(TEST_FILE + "8byte");
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
 
-    FixedByteChunkSingleValueWriter writer =
-        new FixedByteChunkSingleValueWriter(outFile, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK, Float.BYTES);
+    // test both formats (4-byte chunk offsets and 8-byte chunk offsets)
+    FixedByteChunkSingleValueWriter fourByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileFourByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            Float.BYTES, BaseChunkSingleValueWriter.DEFAULT_VERSION);
+    FixedByteChunkSingleValueWriter eightByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileEightByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            Float.BYTES, BaseChunkSingleValueWriter.CURRENT_VERSION);
 
     for (int i = 0; i < NUM_VALUES; i++) {
-      writer.setFloat(i, expected[i]);
+      fourByteOffsetWriter.setFloat(i, expected[i]);
+      eightByteOffsetWriter.setFloat(i, expected[i]);
     }
-    writer.close();
 
-    try (FixedByteChunkSingleValueReader reader = new FixedByteChunkSingleValueReader(
-        PinotDataBuffer.mapReadOnlyBigEndianFile(outFile))) {
-      ChunkReaderContext context = reader.createContext();
+    fourByteOffsetWriter.close();
+    eightByteOffsetWriter.close();
+
+    try (FixedByteChunkSingleValueReader fourByteOffsetReader = new FixedByteChunkSingleValueReader(
+        PinotDataBuffer.mapReadOnlyBigEndianFile(outFileFourByte));
+        FixedByteChunkSingleValueReader eightByteOffsetReader = new FixedByteChunkSingleValueReader(
+            PinotDataBuffer.mapReadOnlyBigEndianFile(outFileEightByte))) {
+
+      ChunkReaderContext context1 = fourByteOffsetReader.createContext();
+      ChunkReaderContext context2 = eightByteOffsetReader.createContext();
 
       for (int i = 0; i < NUM_VALUES; i++) {
-        float actual = reader.getFloat(i, context);
-        Assert.assertEquals(actual, expected[i]);
-
+        Assert.assertEquals(fourByteOffsetReader.getFloat(i, context1), expected[i]);
+        Assert.assertEquals(eightByteOffsetReader.getFloat(i, context2), expected[i]);
         if (compressionType.equals(ChunkCompressorFactory.CompressionType.PASS_THROUGH)) {
-          actual = reader.getFloat(i);
-          Assert.assertEquals(actual, expected[i]);
+          Assert.assertEquals(fourByteOffsetReader.getFloat(i), expected[i]);
+          Assert.assertEquals(eightByteOffsetReader.getFloat(i), expected[i]);
         }
       }
     }
 
-    FileUtils.deleteQuietly(outFile);
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
   }
 
   public void testDouble(ChunkCompressorFactory.CompressionType compressionType)
@@ -190,33 +233,47 @@ public class FixedByteChunkSingleValueReaderWriteTest {
       expected[i] = _random.nextDouble();
     }
 
-    File outFile = new File(TEST_FILE);
-    FileUtils.deleteQuietly(outFile);
+    File outFileFourByte = new File(TEST_FILE);
+    File outFileEightByte = new File(TEST_FILE + "8byte");
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
 
-    FixedByteChunkSingleValueWriter writer =
-        new FixedByteChunkSingleValueWriter(outFile, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK, Double.BYTES);
+    // test both formats (4-byte chunk offsets and 8-byte chunk offsets)
+    FixedByteChunkSingleValueWriter fourByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileFourByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            Double.BYTES, BaseChunkSingleValueWriter.DEFAULT_VERSION);
+    FixedByteChunkSingleValueWriter eightByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileEightByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            Double.BYTES, BaseChunkSingleValueWriter.CURRENT_VERSION);
 
     for (int i = 0; i < NUM_VALUES; i++) {
-      writer.setDouble(i, expected[i]);
+      fourByteOffsetWriter.setDouble(i, expected[i]);
+      eightByteOffsetWriter.setDouble(i, expected[i]);
     }
-    writer.close();
 
-    try (FixedByteChunkSingleValueReader reader = new FixedByteChunkSingleValueReader(
-        PinotDataBuffer.mapReadOnlyBigEndianFile(outFile))) {
-      ChunkReaderContext context = reader.createContext();
+    fourByteOffsetWriter.close();
+    eightByteOffsetWriter.close();
+
+    try (FixedByteChunkSingleValueReader fourByteOffsetReader = new FixedByteChunkSingleValueReader(
+        PinotDataBuffer.mapReadOnlyBigEndianFile(outFileFourByte));
+        FixedByteChunkSingleValueReader eightByteOffsetReader = new FixedByteChunkSingleValueReader(
+            PinotDataBuffer.mapReadOnlyBigEndianFile(outFileEightByte))) {
+
+      ChunkReaderContext context1 = fourByteOffsetReader.createContext();
+      ChunkReaderContext context2 = eightByteOffsetReader.createContext();
 
       for (int i = 0; i < NUM_VALUES; i++) {
-        double actual = reader.getDouble(i, context);
-        Assert.assertEquals(actual, expected[i]);
-
+        Assert.assertEquals(fourByteOffsetReader.getDouble(i, context1), expected[i]);
+        Assert.assertEquals(eightByteOffsetReader.getDouble(i, context2), expected[i]);
         if (compressionType.equals(ChunkCompressorFactory.CompressionType.PASS_THROUGH)) {
-          actual = reader.getDouble(i);
-          Assert.assertEquals(actual, expected[i]);
+          Assert.assertEquals(fourByteOffsetReader.getDouble(i), expected[i]);
+          Assert.assertEquals(eightByteOffsetReader.getDouble(i), expected[i]);
         }
       }
     }
 
-    FileUtils.deleteQuietly(outFile);
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
   }
 
   public void testBytes(ChunkCompressorFactory.CompressionType compressionType)
@@ -226,38 +283,51 @@ public class FixedByteChunkSingleValueReaderWriteTest {
       expected[i] = RandomStringUtils.randomAscii(50).getBytes(UTF_8);
     }
 
-    File outFile = new File(TEST_FILE);
-    FileUtils.deleteQuietly(outFile);
+    File outFileFourByte = new File(TEST_FILE);
+    File outFileEightByte = new File(TEST_FILE + "8byte");
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
 
-    FixedByteChunkSingleValueWriter writer =
-        new FixedByteChunkSingleValueWriter(outFile, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK, 50);
+    // test both formats (4-byte chunk offsets and 8-byte chunk offsets)
+    FixedByteChunkSingleValueWriter fourByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileFourByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK, 50,
+            BaseChunkSingleValueWriter.DEFAULT_VERSION);
+    FixedByteChunkSingleValueWriter eightByteOffsetWriter =
+        new FixedByteChunkSingleValueWriter(outFileEightByte, compressionType, NUM_VALUES, NUM_DOCS_PER_CHUNK, 50,
+            BaseChunkSingleValueWriter.CURRENT_VERSION);
 
     for (int i = 0; i < NUM_VALUES; i++) {
-      writer.setBytes(i, expected[i]);
+      fourByteOffsetWriter.setBytes(i, expected[i]);
+      eightByteOffsetWriter.setBytes(i, expected[i]);
     }
-    writer.close();
 
-    try (FixedByteChunkSingleValueReader reader = new FixedByteChunkSingleValueReader(
-        PinotDataBuffer.mapReadOnlyBigEndianFile(outFile))) {
-      ChunkReaderContext context = reader.createContext();
+    fourByteOffsetWriter.close();
+    eightByteOffsetWriter.close();
+
+    try (FixedByteChunkSingleValueReader fourByteOffsetReader = new FixedByteChunkSingleValueReader(
+        PinotDataBuffer.mapReadOnlyBigEndianFile(outFileFourByte));
+        FixedByteChunkSingleValueReader eightByteOffsetReader = new FixedByteChunkSingleValueReader(
+            PinotDataBuffer.mapReadOnlyBigEndianFile(outFileEightByte))) {
+
+      ChunkReaderContext context1 = fourByteOffsetReader.createContext();
+      ChunkReaderContext context2 = eightByteOffsetReader.createContext();
 
       for (int i = 0; i < NUM_VALUES; i++) {
-        byte[] actual = reader.getBytes(i, context);
-        Assert.assertEquals(actual, expected[i]);
-
+        Assert.assertEquals(fourByteOffsetReader.getBytes(i, context1), expected[i]);
+        Assert.assertEquals(eightByteOffsetReader.getBytes(i, context2), expected[i]);
         if (compressionType.equals(ChunkCompressorFactory.CompressionType.PASS_THROUGH)) {
-          actual = reader.getBytes(i);
-          Assert.assertEquals(actual, expected[i]);
+          Assert.assertEquals(fourByteOffsetReader.getBytes(i), expected[i]);
+          Assert.assertEquals(eightByteOffsetReader.getBytes(i), expected[i]);
         }
       }
     }
 
-    FileUtils.deleteQuietly(outFile);
+    FileUtils.deleteQuietly(outFileFourByte);
+    FileUtils.deleteQuietly(outFileEightByte);
   }
 
   /**
    * This test ensures that the reader can read in an data file from version 1.
-   * @throws IOException
    */
   @Test
   public void testBackwardCompatibilityV1()
@@ -265,6 +335,9 @@ public class FixedByteChunkSingleValueReaderWriteTest {
     testBackwardCompatibilityHelper("data/fixedByteSVRDoubles.v1", 10009, 0);
   }
 
+  /**
+   * This test ensures that the reader can read in an data file from version 2.
+   */
   @Test
   public void testBackwardCompatibilityV2()
       throws Exception {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -33,15 +33,16 @@ public class FieldConfig extends BaseJsonConfig {
   private final IndexType _indexType;
   private final Map<String, String> _properties;
 
-  public static String BLOOM_FILTER_COLUMN_KEY = "bloom.filter";
-  public static String ON_HEAP_DICTIONARY_COLUMN_KEY = "onheap.dictionary";
-  public static String VAR_LENGTH_DICTIONARY_COLUMN_KEY = "var.length.dictionary";
-  public static String DERIVE_NUM_DOCS_PER_CHUNK_RAW_INDEX_KEY = "derive.num.docs.per.chunk.raw.index";
+  public static String BLOOM_FILTER_COLUMN_KEY = "createBloomFilter";
+  public static String ON_HEAP_DICTIONARY_COLUMN_KEY = "useOnHeapDictionary";
+  public static String VAR_LENGTH_DICTIONARY_COLUMN_KEY = "useVarLengthDictionary";
+  public static String DERIVE_NUM_DOCS_PER_CHUNK_RAW_INDEX_KEY = "deriveNumDocsPerChunkForRawIndex";
+  public static String RAW_INDEX_WRITER_VERSION = "rawIndexWriterVersion";
 
-  public static String TEXT_INDEX_REALTIME_READER_REFRESH_KEY = "text.index.realtime.reader.refresh";
+  public static String TEXT_INDEX_REALTIME_READER_REFRESH_KEY = "textIndexRealtimeReaderRefreshThreshold";
   // Lucene creates a query result cache if this option is enabled
   // the cache improves performance of repeatable queries
-  public static String TEXT_INDEX_ENABLE_QUERY_CACHE = "text.index.enable.query.cache";
+  public static String TEXT_INDEX_ENABLE_QUERY_CACHE = "enableQueryCacheForTextIndex";
 
   @JsonCreator
   public FieldConfig(@JsonProperty(value = "name", required = true) String name,

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -36,6 +36,7 @@ import org.apache.pinot.core.common.DataSourceMetadata;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
+import org.apache.pinot.core.io.writer.impl.v1.BaseChunkSingleValueWriter;
 import org.apache.pinot.core.segment.creator.SingleValueRawIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
@@ -307,7 +308,8 @@ public class DictionaryToRawIndexConverter {
     ChunkCompressorFactory.CompressionType compressionType =
         ChunkCompressorFactory.CompressionType.valueOf(_compressionType);
     SingleValueRawIndexCreator rawIndexCreator = SegmentColumnarIndexCreator
-        .getRawIndexCreatorForColumn(newSegment, compressionType, column, dataType, totalDocs, lengthOfLongestEntry);
+        .getRawIndexCreatorForColumn(newSegment, compressionType, column, dataType, totalDocs, lengthOfLongestEntry, false,
+            BaseChunkSingleValueWriter.DEFAULT_VERSION);
 
     int docId = 0;
     bvIter.reset();


### PR DESCRIPTION
## Description
In PR https://github.com/apache/incubator-pinot/pull/5285,  the raw index writer format was changed to use 8 byte offset for each chunk in the file header. The writer version was bumped to 3. This was done to support > 2GB indexes. The change was backward compatible to continue the support for reading existing/old segments using 4-byte offsets

While there is no problem with PR 5285, it prevents rollback. So if there is any orthogonal issue while rolling out a release, we can't rollback to older Pinot release since segments already
generated with 8-byte offsets can't be read by old code.

This PR introduces a config option to set the writer version (2 for using old 4-byte chunk offset and 3 which is latest for 8-byte chunk offset). This config option is **temporary**. To deploy a new version of our internal offline segment creation/push job, we would like this format to be disabled temporarily to have the flexibility of dealing with issues by rolling back the release at will. Once the roll-out is complete, this config option will be removed.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
No
Does this PR fix a zero-downtime upgrade introduced earlier?
No
Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes

## Documentation

