### PR TITLE
Moved StreamPartitionMsgOffset to be an interface

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -108,6 +108,7 @@ public class SegmentCompletionProtocol {
   public static final String COMMIT_TYPE_KEY = "isSplitCommitType";
   public static final String SEGMENT_LOCATION_KEY = "segmentLocation";
   public static final String CONTROLLER_VIP_URL_KEY = "controllerVipUrl";
+  public static final String STREAM_PARTITION_MSG_OFFSET_KEY = "streamPartitionMsgOffset";
 
   public static final String MSG_TYPE_CONSUMED = "segmentConsumed";
   public static final String MSG_TYPE_COMMIT = "segmentCommit";
@@ -459,12 +460,11 @@ public class SegmentCompletionProtocol {
     // TODO Issue 5359 Make it a JsonProperty when we are ready to move the protocol
     // This method is called in the server when the controller responds with
     // CATCH_UP response to segmentConsumed() API.
-    @JsonIgnore
+    @JsonProperty(STREAM_PARTITION_MSG_OFFSET_KEY)
     public String getStreamPartitionMsgOffset() {
       return _streamPartitionMsgOffset;
     }
 
-    @JsonIgnore
     public void setStreamPartitionMsgOffset(String streamPartitionMsgOffset) {
       _streamPartitionMsgOffset = streamPartitionMsgOffset;
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
@@ -235,7 +234,7 @@ public class SegmentCompletionProtocol {
         _segmentLocation = params.getSegmentLocation();
         _memoryUsedBytes = params.getMemoryUsedBytes();
         _segmentSizeBytes = params.getSegmentSizeBytes();
-        _streamPartitionMsgOffset = params.getStreamPartitionMsgOffset().toString();
+        _streamPartitionMsgOffset = params.getStreamPartitionMsgOffset();
       }
 
       @Deprecated
@@ -294,10 +293,10 @@ public class SegmentCompletionProtocol {
         return this;
       }
 
-      public Params withStreamPartitionMsgOffset(StreamPartitionMsgOffset offset) {
-        _streamPartitionMsgOffset = offset.toString();
+      public Params withStreamPartitionMsgOffset(String offset) {
+        _streamPartitionMsgOffset = offset;
         // Try to populate the offset if possible.
-        // TODO Remove this code once we have both sides be able to live without _offset.
+        // TODO Issue 5359 Remove this code once we have both sides be able to live without _offset.
         try {
           _offset = Long.parseLong(_streamPartitionMsgOffset);
         } catch (Exception e) {
@@ -351,11 +350,12 @@ public class SegmentCompletionProtocol {
         return _segmentSizeBytes;
       }
 
-      public StreamPartitionMsgOffset getStreamPartitionMsgOffset() {
+      public String getStreamPartitionMsgOffset() {
         if (_streamPartitionMsgOffset != null) {
-          return new StreamPartitionMsgOffset(_streamPartitionMsgOffset);
+          return _streamPartitionMsgOffset;
         } else {
-          return new StreamPartitionMsgOffset(_offset);
+          // TODO 5359 remove this once we are all upgraded in controllers and servers.
+          return Long.toString(_offset);
         }
       }
 
@@ -456,7 +456,7 @@ public class SegmentCompletionProtocol {
       return _offset;
     }
 
-    // TODO Make it a JsonProperty when we are ready to move the protocol
+    // TODO Issue 5359 Make it a JsonProperty when we are ready to move the protocol
     // This method is called in the server when the controller responds with
     // CATCH_UP response to segmentConsumed() API.
     @JsonIgnore
@@ -515,14 +515,6 @@ public class SegmentCompletionProtocol {
     @JsonProperty(SEGMENT_LOCATION_KEY)
     public void setSegmentLocation(String segmentLocation) {
       _segmentLocation = segmentLocation;
-    }
-
-    public StreamPartitionMsgOffset extractOffset() {
-      if (_streamPartitionMsgOffset != null) {
-        return new StreamPartitionMsgOffset(getStreamPartitionMsgOffset());
-      } else {
-        return new StreamPartitionMsgOffset(getOffset());
-      }
     }
 
     public String toJsonString() {
@@ -585,13 +577,13 @@ public class SegmentCompletionProtocol {
         return this;
       }
 
-      public Params withStreamPartitionMsgOffset(StreamPartitionMsgOffset offset) {
-        _streamPartitionMsgOffset = offset.toString();
-        // TODO Remove the block below once we have both parties be fine without _offset being present.
+      public Params withStreamPartitionMsgOffset(String offset) {
+        _streamPartitionMsgOffset = offset;
+        // TODO Issue 5359 Remove the block below once we have both parties be fine without _offset being present.
         try {
           _offset = Long.parseLong(_streamPartitionMsgOffset);
         } catch (Exception e) {
-          // Ignore. If the received expects _offset, it will return an error to the sender.
+          // Ignore. If the receiver expects _offset, it will return an error to the sender.
         }
         return this;
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
@@ -20,8 +20,6 @@ package org.apache.pinot.controller.helix.core.realtime.segment;
 
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
-import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
-
 
 /**
  * Class to hold properties of the committing segment
@@ -30,7 +28,7 @@ public class CommittingSegmentDescriptor {
   private String _segmentName;
   private long _segmentSizeBytes;
   private String _segmentLocation;
-  private StreamPartitionMsgOffset _nextOffset;
+  private String _nextOffset;
   private SegmentMetadataImpl _segmentMetadata;
 
   public static CommittingSegmentDescriptor fromSegmentCompletionReqParams(
@@ -50,13 +48,13 @@ public class CommittingSegmentDescriptor {
     return committingSegmentDescriptor;
   }
 
-  public CommittingSegmentDescriptor(String segmentName, StreamPartitionMsgOffset nextOffset, long segmentSizeBytes) {
+  public CommittingSegmentDescriptor(String segmentName, String nextOffset, long segmentSizeBytes) {
     _segmentName = segmentName;
     _nextOffset = nextOffset;
     _segmentSizeBytes = segmentSizeBytes;
   }
 
-  public CommittingSegmentDescriptor(String segmentName, StreamPartitionMsgOffset nextOffset, long segmentSizeBytes,
+  public CommittingSegmentDescriptor(String segmentName, String nextOffset, long segmentSizeBytes,
       String segmentLocation) {
     this(segmentName, nextOffset, segmentSizeBytes);
     _segmentLocation = segmentLocation;
@@ -86,7 +84,7 @@ public class CommittingSegmentDescriptor {
     _segmentLocation = segmentLocation;
   }
 
-  public StreamPartitionMsgOffset getNextOffset() {
+  public String getNextOffset() {
     return _nextOffset;
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/SegmentCompletionProtocolDeserTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/SegmentCompletionProtocolDeserTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
@@ -31,7 +32,7 @@ import static org.testng.Assert.assertTrue;
 
 
 public class SegmentCompletionProtocolDeserTest {
-  private final StreamPartitionMsgOffset OFFSET = new StreamPartitionMsgOffset(1);
+  private final StreamPartitionMsgOffset OFFSET = new LongMsgOffset(1L);
   private final long BUILD_TIME_MILLIS = 123;
   private final String SEGMENT_LOCATION = "file.tmp";
   private final String CONTROLLER_VIP_URL = "http://localhost:8998";
@@ -41,13 +42,13 @@ public class SegmentCompletionProtocolDeserTest {
     // Test with all params
     SegmentCompletionProtocol.Response.Params params =
         new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
-            .withStreamPartitionMsgOffset(OFFSET)
+            .withStreamPartitionMsgOffset(OFFSET.toString())
             .withSegmentLocation(SEGMENT_LOCATION).withSplitCommit(true)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
-    assertEquals(new StreamPartitionMsgOffset(response.getStreamPartitionMsgOffset()).compareTo(OFFSET), 0);
+    assertEquals(new LongMsgOffset(response.getStreamPartitionMsgOffset()).compareTo(OFFSET), 0);
     assertEquals(response.getSegmentLocation(), SEGMENT_LOCATION);
     assertTrue(response.isSplitCommit());
     assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
@@ -58,12 +59,12 @@ public class SegmentCompletionProtocolDeserTest {
     // Test with reduced params
     SegmentCompletionProtocol.Response.Params params =
         new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
-            .withStreamPartitionMsgOffset(OFFSET)
+            .withStreamPartitionMsgOffset(OFFSET.toString())
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
     assertEquals(response.getBuildTimeSeconds(), BUILD_TIME_MILLIS);
-    assertEquals(new StreamPartitionMsgOffset(response.getStreamPartitionMsgOffset()).compareTo(OFFSET), 0);
+    assertEquals(new LongMsgOffset(response.getStreamPartitionMsgOffset()).compareTo(OFFSET), 0);
     assertNull(response.getSegmentLocation());
     assertFalse(response.isSplitCommit());
     assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
@@ -74,7 +75,7 @@ public class SegmentCompletionProtocolDeserTest {
     // Test with all params
     SegmentCompletionProtocol.Response.Params params =
         new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
-            .withStreamPartitionMsgOffset(OFFSET)
+            .withStreamPartitionMsgOffset(OFFSET.toString())
             .withSegmentLocation(SEGMENT_LOCATION).withSplitCommit(true).withControllerVipUrl(CONTROLLER_VIP_URL)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
@@ -92,7 +93,7 @@ public class SegmentCompletionProtocolDeserTest {
   public void testJsonNullSegmentLocationAndVip() {
     SegmentCompletionProtocol.Response.Params params =
         new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
-            .withStreamPartitionMsgOffset(OFFSET)
+            .withStreamPartitionMsgOffset(OFFSET.toString())
             .withSplitCommit(false).withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
@@ -109,7 +110,7 @@ public class SegmentCompletionProtocolDeserTest {
   public void testJsonResponseWithoutSplitCommit() {
     SegmentCompletionProtocol.Response.Params params =
         new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
-            .withStreamPartitionMsgOffset(OFFSET)
+            .withStreamPartitionMsgOffset(OFFSET.toString())
             .withSplitCommit(false).withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
     SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(params);
@@ -127,7 +128,7 @@ public class SegmentCompletionProtocolDeserTest {
     // Should never happen because if split commit, should have both location and VIP, but testing deserialization regardless
     SegmentCompletionProtocol.Response.Params params =
         new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
-            .withStreamPartitionMsgOffset(OFFSET)
+            .withStreamPartitionMsgOffset(OFFSET.toString())
             .withSegmentLocation(SEGMENT_LOCATION).withSplitCommit(false)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 
@@ -146,7 +147,7 @@ public class SegmentCompletionProtocolDeserTest {
     // Should never happen because if split commit, should have both location and VIP, but testing deserialization regardless
     SegmentCompletionProtocol.Response.Params params =
         new SegmentCompletionProtocol.Response.Params().withBuildTimeSeconds(BUILD_TIME_MILLIS)
-            .withStreamPartitionMsgOffset(OFFSET)
+            .withStreamPartitionMsgOffset(OFFSET.toString())
             .withControllerVipUrl(CONTROLLER_VIP_URL).withSplitCommit(false)
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -56,7 +56,6 @@ import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
-import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
@@ -188,8 +187,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // Commit a segment for partition 0
     String committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
     CommittingSegmentDescriptor committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(committingSegment, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS),
-            0L);
+        new CommittingSegmentDescriptor(committingSegment, Long.toString(PARTITION_OFFSET + NUM_DOCS), 0L);
     committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
     segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
 
@@ -227,7 +225,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     consumingSegmentInstanceStateMap.entrySet().iterator().next().setValue(SegmentStateModel.OFFLINE);
     committingSegment = consumingSegment;
     committingSegmentDescriptor = new CommittingSegmentDescriptor(committingSegment,
-        new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS + NUM_DOCS), 0L);
+        Long.toString(PARTITION_OFFSET + NUM_DOCS + NUM_DOCS), 0L);
     committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
     segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
 
@@ -278,7 +276,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     for (int partitionId = 0; partitionId < 2; partitionId++) {
       String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, CURRENT_TIME_MS).getSegmentName();
       CommittingSegmentDescriptor committingSegmentDescriptor =
-          new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS), 0L);
+          new CommittingSegmentDescriptor(segmentName, Long.toString(PARTITION_OFFSET + NUM_DOCS), 0L);
       committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
       segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     }
@@ -434,7 +432,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     for (int partitionId = 0; partitionId < 2; partitionId++) {
       String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, CURRENT_TIME_MS).getSegmentName();
       CommittingSegmentDescriptor committingSegmentDescriptor =
-          new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS), 0L);
+          new CommittingSegmentDescriptor(segmentName, Long.toString(PARTITION_OFFSET + NUM_DOCS), 0L);
       committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
       segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     }
@@ -476,7 +474,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       String segmentName =
           new LLCSegmentName(RAW_TABLE_NAME, partitionId, sequenceNumber, CURRENT_TIME_MS).getSegmentName();
       CommittingSegmentDescriptor committingSegmentDescriptor =
-          new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS), 0L);
+          new CommittingSegmentDescriptor(segmentName, Long.toString(PARTITION_OFFSET + NUM_DOCS), 0L);
       committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
       segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     }
@@ -653,7 +651,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // Commit a segment for partition 0
     String committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
     CommittingSegmentDescriptor committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(committingSegment, new StreamPartitionMsgOffset(PARTITION_OFFSET + NUM_DOCS),
+        new CommittingSegmentDescriptor(committingSegment, Long.toString(PARTITION_OFFSET + NUM_DOCS),
             0L);
     committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
 
@@ -684,7 +682,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
     String segmentLocation = SCHEME + tableDir + "/" + segmentFileName;
     CommittingSegmentDescriptor committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET), 0,
+        new CommittingSegmentDescriptor(segmentName, Long.toString(PARTITION_OFFSET), 0,
             segmentLocation);
     segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     assertFalse(segmentFile.exists());
@@ -710,7 +708,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
     String segmentLocation = SCHEME + tableDir + "/" + segmentFileName;
     CommittingSegmentDescriptor committingSegmentDescriptor =
-        new CommittingSegmentDescriptor(segmentName, new StreamPartitionMsgOffset(PARTITION_OFFSET), 0,
+        new CommittingSegmentDescriptor(segmentName, Long.toString(PARTITION_OFFSET), 0,
             segmentLocation);
     segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
     assertFalse(segmentFile.exists());
@@ -823,7 +821,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
-    TableConfig getTableConfig(String realtimeTableName) {
+    public TableConfig getTableConfig(String realtimeTableName) {
       return _tableConfig;
     }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.helix.core.realtime.segment;
 import java.util.Arrays;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -162,7 +163,7 @@ public class FlushThresholdUpdaterTest {
   }
 
   private CommittingSegmentDescriptor getCommittingSegmentDescriptor(long segmentSizeBytes) {
-    return new CommittingSegmentDescriptor(null, new StreamPartitionMsgOffset(0), segmentSizeBytes);
+    return new CommittingSegmentDescriptor(null, new LongMsgOffset(0).toString(), segmentSizeBytes);
   }
 
   private LLCRealtimeSegmentZKMetadata getCommittingSegmentZKMetadata(long creationTime,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -50,7 +50,6 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
@@ -168,7 +167,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       _resourceTmpDir.mkdirs();
     }
     // create and init stream level consumer
-    StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
+    StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(_streamConfig);
     String clientId = HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getTopicName();
     _streamLevelConsumer = streamConsumerFactory
         .createStreamLevelConsumer(clientId, _tableNameWithType, SchemaUtils.extractSourceFields(schema),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -645,7 +645,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     return CompletionMode.DEFAULT;
   }
 
-  private StreamPartitionMsgOffset extractOffset(SegmentCompletionProtocol.Response response) {
+  @VisibleForTesting
+  protected StreamPartitionMsgOffset extractOffset(SegmentCompletionProtocol.Response response) {
     if (response.getStreamPartitionMsgOffset() != null) {
       return _streamPartitionMsgOffsetFactory.create(response.getStreamPartitionMsgOffset());
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
@@ -94,7 +94,7 @@ public class SegmentBuildTimeLeaseExtender {
   public void addSegment(String segmentId, long initialBuildTimeMs, StreamPartitionMsgOffset offset) {
     final long initialDelayMs = initialBuildTimeMs * 9 / 10;
     final SegmentCompletionProtocol.Request.Params reqParams = new SegmentCompletionProtocol.Request.Params();
-    reqParams.withStreamPartitionMsgOffset(offset).withSegmentName(segmentId).withExtraTimeSec(EXTRA_TIME_SECONDS)
+    reqParams.withStreamPartitionMsgOffset(offset.toString()).withSegmentName(segmentId).withExtraTimeSec(EXTRA_TIME_SECONDS)
         .withInstanceId(_instanceId);
     Future future = _executor
         .scheduleWithFixedDelay(new LeaseExtender(reqParams), initialDelayMs, REPEAT_REQUEST_PERIOD_SEC * 1000L,

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -41,10 +41,10 @@ import org.apache.pinot.core.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConsumerFactory;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamMessageDecoder;
-import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PermanentConsumerException;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -71,7 +71,7 @@ public class LLRealtimeSegmentDataManagerTest {
       new LLCSegmentName(_tableName, _partitionId, _sequenceId, _segTimeMs);
   private static final String _segmentNameStr = _segmentName.getSegmentName();
   private static final long _startOffsetValue = 19885L;
-  private static final StreamPartitionMsgOffset _startOffset = new StreamPartitionMsgOffset(_startOffsetValue);
+  private static final LongMsgOffset _startOffset = new LongMsgOffset(_startOffsetValue);
   private static final String _topicName = "someTopic";
   private static final int maxRowsInSegment = 250000;
   private static final long maxTimeForSegmentCloseMs = 64368000L;
@@ -175,12 +175,13 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
+    final LongMsgOffset endOffset = new LongMsgOffset(_startOffsetValue + 500);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(
         new SegmentCompletionProtocol.Response.Params()
-            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD).withStreamPartitionMsgOffset(endOffset));
+            .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD)
+            .withStreamPartitionMsgOffset(endOffset.toString()));
     // And then never consume as long as we get a hold response, 100 times.
     for (int i = 0; i < 100; i++) {
       segmentDataManager._responses.add(response);
@@ -204,14 +205,14 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
+    final LongMsgOffset endOffset = new LongMsgOffset(_startOffsetValue + 500);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response holdResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset.toString())
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset.toString())
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     // And then never consume as long as we get a hold response, 100 times.
     segmentDataManager._responses.add(holdResponse);
@@ -235,11 +236,11 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
+    final LongMsgOffset endOffset = new LongMsgOffset(_startOffsetValue + 500);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset.toString())
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     segmentDataManager._responses.add(commitResponse);
     segmentDataManager._failSegmentBuild = true;
@@ -256,24 +257,24 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final StreamPartitionMsgOffset firstOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
-    final StreamPartitionMsgOffset catchupOffset = new StreamPartitionMsgOffset(firstOffset.getOffset() + 10);
+    final LongMsgOffset firstOffset = new LongMsgOffset(_startOffsetValue + 500);
+    final LongMsgOffset catchupOffset = new LongMsgOffset(firstOffset.getOffset() + 10);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(firstOffset);
     segmentDataManager._consumeOffsets.add(catchupOffset); // Offset after catchup
     final SegmentCompletionProtocol.Response holdResponse1 = new SegmentCompletionProtocol.Response(
         new SegmentCompletionProtocol.Response.Params()
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD).
-            withStreamPartitionMsgOffset(firstOffset));
+            withStreamPartitionMsgOffset(firstOffset.toString()));
     final SegmentCompletionProtocol.Response catchupResponse = new SegmentCompletionProtocol.Response(
         new SegmentCompletionProtocol.Response.Params()
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP)
-            .withStreamPartitionMsgOffset(catchupOffset));
+            .withStreamPartitionMsgOffset(catchupOffset.toString()));
     final SegmentCompletionProtocol.Response holdResponse2 = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(catchupOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(catchupOffset.toString())
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(catchupOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(catchupOffset.toString())
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     // And then never consume as long as we get a hold response, 100 times.
     segmentDataManager._responses.add(holdResponse1);
@@ -299,10 +300,10 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
+    final LongMsgOffset endOffset = new LongMsgOffset(_startOffsetValue + 500);
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response discardResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset.toString())
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.DISCARD));
     segmentDataManager._responses.add(discardResponse);
 
@@ -324,10 +325,11 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
+    final LongMsgOffset endOffset = new LongMsgOffset(_startOffsetValue + 500);
     segmentDataManager._consumeOffsets.add(endOffset);
     SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params();
-    params.withStreamPartitionMsgOffset(endOffset).withStatus(SegmentCompletionProtocol.ControllerResponseStatus.KEEP);
+    params.withStreamPartitionMsgOffset(endOffset.toString()).
+        withStatus(SegmentCompletionProtocol.ControllerResponseStatus.KEEP);
     final SegmentCompletionProtocol.Response keepResponse = new SegmentCompletionProtocol.Response(params);
     segmentDataManager._responses.add(keepResponse);
 
@@ -348,11 +350,11 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
-    final StreamPartitionMsgOffset endOffset = new StreamPartitionMsgOffset(_startOffsetValue + 500);
+    final LongMsgOffset endOffset = new LongMsgOffset(_startOffsetValue + 500);
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset)
+        new SegmentCompletionProtocol.Response.Params().withStreamPartitionMsgOffset(endOffset.toString())
             .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER));
     // And then never consume as long as we get a Not leader response, 100 times.
     for (int i = 0; i < 100; i++) {
@@ -393,8 +395,8 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
     final long finalOffsetValue = _startOffsetValue + 600;
-    final StreamPartitionMsgOffset finalOffset = new StreamPartitionMsgOffset(finalOffsetValue);
-    metadata.setEndOffset(finalOffset.getOffset());
+    final LongMsgOffset finalOffset = new LongMsgOffset(finalOffsetValue);
+    metadata.setEndOffset(finalOffsetValue);
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
@@ -465,7 +467,7 @@ public class LLRealtimeSegmentDataManagerTest {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
-      segmentDataManager._consumeOffsets.add(new StreamPartitionMsgOffset(finalOffsetValue - 1));
+      segmentDataManager._consumeOffsets.add(new LongMsgOffset(finalOffsetValue - 1));
       segmentDataManager.goOnlineFromConsuming(metadata);
       Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
       Assert.assertFalse(segmentDataManager._buildAndReplaceCalled);
@@ -707,7 +709,7 @@ public class LLRealtimeSegmentDataManagerTest {
     public Field _state;
     public Field _shouldStop;
     public Field _stopReason;
-    public LinkedList<StreamPartitionMsgOffset> _consumeOffsets = new LinkedList<>();
+    public LinkedList<LongMsgOffset> _consumeOffsets = new LinkedList<>();
     public LinkedList<SegmentCompletionProtocol.Response> _responses = new LinkedList<>();
     public boolean _commitSegmentCalled = false;
     public boolean _buildSegmentCalled = false;
@@ -923,11 +925,11 @@ public class LLRealtimeSegmentDataManagerTest {
         Field field = LLRealtimeSegmentDataManager.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         StreamPartitionMsgOffset offset = (StreamPartitionMsgOffset)field.get(this);
-        if (offset == null) {
-          field.set(this, new StreamPartitionMsgOffset(value));
-        } else {
-          offset.setOffset(value);
-        }
+//        if (offset == null) {
+          field.set(this, new LongMsgOffset(value));
+//        } else {
+//          offset.setOffset(value);
+//        }
       } catch (NoSuchFieldException e) {
         Assert.fail();
       } catch (IllegalAccessException e) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -216,6 +216,7 @@ public class LLRealtimeSegmentDataManagerTest {
       StreamPartitionMsgOffset extractedOffset = segmentDataManager.extractOffset(response);
       Assert.assertEquals(extractedOffset.compareTo(new LongMsgOffset(offset)), 0);
     }
+    segmentDataManager.destroy();
   }
 
   // Test that we are in HOLDING state as long as the controller responds HOLD to our segmentConsumed() message.

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
@@ -72,7 +72,7 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
     StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs(numPartitions);
 
     // stream consumer factory
-    StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
+    StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(streamConfig);
 
     // stream metadata provider
     StreamMetadataProvider streamMetadataProvider = streamConsumerFactory.createStreamMetadataProvider(clientId);

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
@@ -125,6 +125,8 @@ public class StreamConfigTest {
     Assert.assertFalse(exception);
     Assert.assertEquals(streamConfig.getConsumerFactoryClassName(),
         StreamConfig.DEFAULT_CONSUMER_FACTORY_CLASS_NAME_STRING);
+    Assert.assertEquals(streamConfig.getPartitionOffsetFactoryClassName(),
+        StreamConfig.DEFAULT_PARTITION_OFFSET_FACTORY_CLASS_NAME_STRING);
 
     // Missing decoder class
     streamConfigMap.put(StreamConfigProperties

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTest.java
@@ -44,6 +44,7 @@ import org.apache.pinot.controller.validation.RealtimeSegmentValidationManager;
 import org.apache.pinot.server.realtime.ControllerLeaderLocator;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
@@ -143,7 +144,7 @@ public class SegmentCompletionIntegrationTest extends BaseClusterIntegrationTest
     ServerSegmentCompletionProtocolHandler protocolHandler =
         new ServerSegmentCompletionProtocolHandler(new ServerMetrics(new MetricsRegistry()), realtimeTableName);
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
-    params.withStreamPartitionMsgOffset(new StreamPartitionMsgOffset(45688L)).withSegmentName(_currentSegment)
+    params.withStreamPartitionMsgOffset(new LongMsgOffset(45688L).toString()).withSegmentName(_currentSegment)
         .withReason("RandomReason") .withInstanceId(_serverInstance);
     SegmentCompletionProtocol.Response response = protocolHandler.segmentStoppedConsuming(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
@@ -266,7 +266,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
     StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
-    final StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
+    final StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(streamConfig);
     int numPartitions =
         new KafkaStreamMetadataProvider(clientId, streamConfig).fetchPartitionCount(10000);
     for (int partition = 0; partition < numPartitions; partition++) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/LongMsgOffset.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/LongMsgOffset.java
@@ -1,3 +1,8 @@
+package org.apache.pinot.spi.stream;
+
+import com.google.common.annotations.VisibleForTesting;
+
+
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,27 +21,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.spi.stream;
+public class LongMsgOffset implements StreamPartitionMsgOffset {
+  private final long _offset;
 
-import org.apache.pinot.spi.annotations.InterfaceStability;
+  @VisibleForTesting
+  public long getOffset() {
+    return _offset;
+  }
 
-/**
- * This is a class for now (so we can make one round of changes to the code)
- * It will evolve to an interface later with different implementations for the
- * streams. Each stream needs to provide its own serde of an offset.
- *
- * For now, we will take toString as a serializer.
- * Must be thread-safe for multiple readers and one writer. Readers could get the offset
- * and the writer can update it.
- */
-@InterfaceStability.Evolving
-public interface StreamPartitionMsgOffset extends Comparable {
+  public LongMsgOffset(long offset) {
+    _offset = offset;
+  }
 
-  int compareTo(Object other);
+  public LongMsgOffset(String offset) {
+    _offset = Long.parseLong(offset);
+  }
 
-  /**
-   *  A serialized representation of the offset object as a String
-   * @return
-   */
-  String toString();
+  public LongMsgOffset(StreamPartitionMsgOffset other) {
+    _offset = ((LongMsgOffset)other)._offset;
+  }
+
+  @Override
+  public int compareTo(Object other) {
+    return Long.compare(_offset, ((LongMsgOffset)other)._offset);
+  }
+
+  @Override
+  public String toString() {
+    return Long.toString(_offset);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/LongMsgOffsetFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/LongMsgOffsetFactory.java
@@ -18,25 +18,28 @@
  */
 package org.apache.pinot.spi.stream;
 
-import org.apache.pinot.spi.annotations.InterfaceStability;
+public class LongMsgOffsetFactory implements StreamPartitionMsgOffsetFactory {
+  @Override
+  public void init(StreamConfig streamConfig) {
+  }
 
-/**
- * This is a class for now (so we can make one round of changes to the code)
- * It will evolve to an interface later with different implementations for the
- * streams. Each stream needs to provide its own serde of an offset.
- *
- * For now, we will take toString as a serializer.
- * Must be thread-safe for multiple readers and one writer. Readers could get the offset
- * and the writer can update it.
- */
-@InterfaceStability.Evolving
-public interface StreamPartitionMsgOffset extends Comparable {
+  @Override
+  public StreamPartitionMsgOffset create(String offsetStr) {
+    return new LongMsgOffset(offsetStr);
+  }
 
-  int compareTo(Object other);
+  @Override
+  public StreamPartitionMsgOffset create(StreamPartitionMsgOffset other) {
+    return new LongMsgOffset(other);
+  }
 
-  /**
-   *  A serialized representation of the offset object as a String
-   * @return
-   */
-  String toString();
+  @Override
+  public StreamPartitionMsgOffset createMaxOffset() {
+    return new LongMsgOffset(Long.MAX_VALUE);
+  }
+
+  @Override
+  public StreamPartitionMsgOffset createMinOffset() {
+    return new LongMsgOffset(-1L);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionCountFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionCountFetcher.java
@@ -38,7 +38,7 @@ public class PartitionCountFetcher implements Callable<Boolean> {
 
   public PartitionCountFetcher(StreamConfig streamConfig) {
     _streamConfig = streamConfig;
-    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
+    _streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(_streamConfig);
     _topicName = streamConfig.getTopicName();
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelConsumer.java
@@ -40,4 +40,10 @@ public interface PartitionLevelConsumer extends Closeable {
    */
   MessageBatch fetchMessages(long startOffset, long endOffset, int timeoutMillis)
       throws java.util.concurrent.TimeoutException;
+
+  default MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, int timeoutMillis)
+      throws java.util.concurrent.TimeoutException {
+    // TODO Issue 5359 remove the default implementation once kafka consumer implements return of StreamPartitionMsgOffset
+    return fetchMessages(Long.parseLong(startOffset.toString()), Long.parseLong(endOffset.toString()), timeoutMillis);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionOffsetFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionOffsetFetcher.java
@@ -44,7 +44,7 @@ public class PartitionOffsetFetcher implements Callable<Boolean> {
     _offsetCriteria = offsetCriteria;
     _partitionId = partitionId;
     _streamConfig = streamConfig;
-    _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
+    _streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(streamConfig);
     _topicName = streamConfig.getTopicName();
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -51,6 +51,7 @@ public class StreamConfig {
 
   public static final String DEFAULT_CONSUMER_FACTORY_CLASS_NAME_STRING =
       "org.apache.pinot.plugin.stream.kafka09.KafkaConsumerFactory";
+  public static final String DEFAULT_PARTITION_OFFSET_FACTORY_CLASS_NAME_STRING = LongMsgOffsetFactory.class.getName();
 
   public static final long DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS = 30_000;
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;
@@ -65,6 +66,7 @@ public class StreamConfig {
   private final OffsetCriteria _offsetCriteria;
   private final String _decoderClass;
   private final Map<String, String> _decoderProperties = new HashMap<>();
+  private final String _partitionOffsetFactoryClassName;
 
   private final long _connectionTimeoutMillis;
   private final int _fetchTimeoutMillis;
@@ -118,6 +120,12 @@ public class StreamConfig {
     } else {
       _offsetCriteria = new OffsetCriteria.OffsetCriteriaBuilder().withOffsetLargest();
     }
+
+    String partitionOffsetClassKey = StreamConfigProperties.constructStreamProperty(_type,
+        StreamConfigProperties.PARTITION_MSG_OFFSET_FACTORY_CLASS);
+    // For backward compatibility, the offset factory class is for handling kafka offsets (long type)
+    _partitionOffsetFactoryClassName = streamConfigMap.getOrDefault(partitionOffsetClassKey,
+        DEFAULT_PARTITION_OFFSET_FACTORY_CLASS_NAME_STRING);
 
     String decoderClassKey =
         StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.STREAM_DECODER_CLASS);
@@ -259,6 +267,10 @@ public class StreamConfig {
 
   public String getConsumerFactoryClassName() {
     return _consumerFactoryClassName;
+  }
+
+  public String getPartitionOffsetFactoryClassName() {
+    return _partitionOffsetFactoryClassName;
   }
 
   public OffsetCriteria getOffsetCriteria() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -43,6 +43,7 @@ public class StreamConfigProperties {
   public static final String STREAM_DECODER_CLASS = "decoder.class.name";
   public static final String DECODER_PROPS_PREFIX = "decoder.prop";
   public static final String GROUP_ID = "hlc.group.id";
+  public static final String PARTITION_MSG_OFFSET_FACTORY_CLASS = "partition.offset.factory.class.name";
 
   /**
    * Time threshold that will keep the realtime segment open for before we complete the segment

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactoryProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactoryProvider.java
@@ -21,7 +21,6 @@ package org.apache.pinot.spi.stream;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pinot.spi.plugin.PluginManager;
 
-
 /**
  * Provider class for {@link StreamConsumerFactory}
  */
@@ -32,10 +31,26 @@ public abstract class StreamConsumerFactoryProvider {
    * @param streamConfig
    * @return
    */
-  public static StreamConsumerFactory create(StreamConfig streamConfig) {
+  public static StreamConsumerFactory createConsumerFactory(StreamConfig streamConfig) {
     StreamConsumerFactory factory = null;
     try {
       factory = PluginManager.get().createInstance(streamConfig.getConsumerFactoryClassName());
+    } catch (Exception e) {
+      ExceptionUtils.rethrow(e);
+    }
+    factory.init(streamConfig);
+    return factory;
+  }
+
+  /**
+   * Cronstructs the {@link StreamPartitionMsgOffsetFactory} using {@link StreamConfig::getPartitionOffsetFactoryClassName}
+   * and initializes it
+   * @param streamConfig
+   */
+  public static StreamPartitionMsgOffsetFactory createOffsetFactory(StreamConfig streamConfig) {
+    StreamPartitionMsgOffsetFactory factory = null;
+    try {
+      factory = PluginManager.get().createInstance(streamConfig.getPartitionOffsetFactoryClassName());
     } catch (Exception e) {
       ExceptionUtils.rethrow(e);
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffsetFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffsetFactory.java
@@ -20,23 +20,18 @@ package org.apache.pinot.spi.stream;
 
 import org.apache.pinot.spi.annotations.InterfaceStability;
 
+
 /**
- * This is a class for now (so we can make one round of changes to the code)
- * It will evolve to an interface later with different implementations for the
- * streams. Each stream needs to provide its own serde of an offset.
- *
- * For now, we will take toString as a serializer.
- * Must be thread-safe for multiple readers and one writer. Readers could get the offset
- * and the writer can update it.
+ * An interface to be implemented by streams if the offset of message in a stream partition
+ * is NOT a Long (or int) type.
+ * TODO Document the methods after finalizing the interface (Issue 5359)
+ * TODO Try to avoid createMaxOffset and createMinOffset methods. (Issue 5359)
  */
 @InterfaceStability.Evolving
-public interface StreamPartitionMsgOffset extends Comparable {
-
-  int compareTo(Object other);
-
-  /**
-   *  A serialized representation of the offset object as a String
-   * @return
-   */
-  String toString();
+public interface StreamPartitionMsgOffsetFactory {
+  void init(StreamConfig streamConfig);
+  StreamPartitionMsgOffset create(String offsetStr);
+  StreamPartitionMsgOffset create(StreamPartitionMsgOffset other);
+  StreamPartitionMsgOffset createMaxOffset(); // Create an offset that compares highest with all others
+  StreamPartitionMsgOffset createMinOffset(); // Create an offset that compares lowest with all others
 }


### PR DESCRIPTION
- Changed StreamPartitionMsgOffset class to be an interface.
- Introduced a LongMsgOffsetFactory class that can be used for Kafka. Other
  streams will need to provide their own factory to create offsets of
  various types. Keeping LongMsgOffsetFactory in spi, so we can also use
  it in tests. Alternative was to introduce this for each test, but implement
  one in kafka that does the same thing.
- Introduced a new config 'stream.<type>.partition.offset.factory.class.name'
  Stream providers need to set the offset factory class with this config key.
- All classes now use StreamPartitionMsgOffset instead of 'long', except for
  cases where the offset is received from the stream or the offset is being
  read or written to persistent zk metadata.
- Marked TODOs explicity on items still to be done to complete impleemntation
  of generic offsets.

Issue #5359

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
