### PR TITLE
Enhance quickstart script for CI tests

### DIFF
--- a/.github/workflows/scripts/.pinot_quickstart.sh
+++ b/.github/workflows/scripts/.pinot_quickstart.sh
@@ -51,21 +51,23 @@ if [ "${PASS}" != 0 ]; then
 fi
 
 # Quickstart
-DIST_BIN_DIR=$(ls -d pinot-distribution/target/apache-pinot-*/apache-pinot-*)
-cd "${DIST_BIN_DIR}" || exit
+DIST_BIN_DIR=`ls -d pinot-distribution/target/apache-pinot-*/apache-pinot-*`
+cd "${DIST_BIN_DIR}"
 
 # Test quick-start-batch
 bin/quick-start-batch.sh &
 PID=$!
 
 PASS=0
+
+# Wait for 30 seconds for table to be set up, then at most 5 minutes to reach the desired state
 sleep 30
-for i in $(seq 1 200)
+for i in $(seq 1 150)
 do
-  curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from baseballStats limit 1","trace":false}' http://localhost:8000/query/sql
-  COUNT_STAR_RES=$(curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from baseballStats limit 1","trace":false}' http://localhost:8000/query/sql | jq '.resultTable.rows[0][0]')
-  if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]]; then
-    if [ "${COUNT_STAR_RES}" -eq 97889 ]; then
+  QUERY_RES=`curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from baseballStats limit 1","trace":false}' http://localhost:8000/query/sql`
+  if [ $? -eq 0 ]; then
+    COUNT_STAR_RES=`echo "${QUERY_RES}" | jq '.resultTable.rows[0][0]'`
+    if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]] && [ "${COUNT_STAR_RES}" -eq 97889 ]; then
       PASS=1
       break
     fi
@@ -73,13 +75,23 @@ do
   sleep 2
 done
 
+cleanup () {
+  # Terminate the process and wait for the clean up to be done
+  kill "$1"
+  while true;
+  do
+    kill -0 "$1" && sleep 1 || break
+  done
+
+  # Delete ZK directory
+  rm -rf '/tmp/PinotAdmin/zkData'
+}
+
+cleanup "${PID}"
 if [ "${PASS}" -eq 0 ]; then
   echo 'Batch Quickstart failed: Cannot get correct result for count star query.'
   exit 1
 fi
-
-kill -9 $PID
-rm -rf /tmp/PinotAdmin/zkData
 
 # Test quick-start-streaming
 bin/quick-start-streaming.sh &
@@ -87,27 +99,28 @@ PID=$!
 
 PASS=0
 RES_1=0
-sleep 30
 
-for i in $(seq 1 200)
+# Wait for 30 seconds for table to be set up, then at most 5 minutes to reach the desired state
+sleep 30
+for i in $(seq 1 150)
 do
-  curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from meetupRsvp limit 1","trace":false}' http://localhost:8000/query/sql
-  COUNT_STAR_RES=$(curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from meetupRsvp limit 1","trace":false}' http://localhost:8000/query/sql | jq '.resultTable.rows[0][0]')
- if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]]; then
-    if [ "${COUNT_STAR_RES}" -gt 0 ]; then
+  QUERY_RES=`curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from meetupRsvp limit 1","trace":false}' http://localhost:8000/query/sql`
+  if [ $? -eq 0 ]; then
+    COUNT_STAR_RES=`echo "${QUERY_RES}" | jq '.resultTable.rows[0][0]'`
+    if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]] && [ "${COUNT_STAR_RES}" -gt 0 ]; then
       if [ "${RES_1}" -eq 0 ]; then
-        RES_1=${COUNT_STAR_RES}
+        RES_1="${COUNT_STAR_RES}"
         continue
+      elif [ "${COUNT_STAR_RES}" -gt "${RES_1}" ]; then
+        PASS=1
+        break
       fi
-    fi
-    if [ "${COUNT_STAR_RES}" -gt "${RES_1}" ]; then
-      PASS=1
-      break
     fi
   fi
   sleep 2
 done
 
+cleanup "${PID}"
 if [ "${PASS}" -eq 0 ]; then
   if [ "${RES_1}" -eq 0 ]; then
     echo 'Streaming Quickstart test failed: Cannot get correct result for count star query.'
@@ -117,9 +130,6 @@ if [ "${PASS}" -eq 0 ]; then
   exit 1
 fi
 
-kill -9 $PID
-rm -rf /tmp/PinotAdmin/zkData
-
 # Test quick-start-hybrid
 cd bin
 ./quick-start-hybrid.sh &
@@ -127,26 +137,28 @@ PID=$!
 
 PASS=0
 RES_1=0
+
+# Wait for 30 seconds for table to be set up, then at most 5 minutes to reach the desired state
 sleep 30
-for i in $(seq 1 200)
+for i in $(seq 1 150)
 do
-  curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from airlineStats limit 1","trace":false}' http://localhost:8000/query/sql
-  COUNT_STAR_RES=$(curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from airlineStats limit 1","trace":false}' http://localhost:8000/query/sql | jq '.resultTable.rows[0][0]')
-  if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]]; then
-    if [ "${COUNT_STAR_RES}" -gt 0 ]; then
+  QUERY_RES=`curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from airlineStats limit 1","trace":false}' http://localhost:8000/query/sql`
+  if [ $? -eq 0 ]; then
+    COUNT_STAR_RES=`echo "${QUERY_RES}" | jq '.resultTable.rows[0][0]'`
+    if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]] && [ "${COUNT_STAR_RES}" -gt 0 ]; then
       if [ "${RES_1}" -eq 0 ]; then
-        RES_1=${COUNT_STAR_RES}
+        RES_1="${COUNT_STAR_RES}"
         continue
+      elif [ "${COUNT_STAR_RES}" -gt "${RES_1}" ]; then
+        PASS=1
+        break
       fi
-    fi
-    if [ "${COUNT_STAR_RES}" -gt "${RES_1}" ]; then
-      PASS=1
-      break
     fi
   fi
   sleep 2
 done
 
+cleanup "${PID}"
 if [ "${PASS}" -eq 0 ]; then
   if [ "${RES_1}" -eq 0 ]; then
     echo 'Hybrid Quickstart test failed: Cannot get correct result for count star query.'
@@ -155,9 +167,6 @@ if [ "${PASS}" -eq 0 ]; then
   echo 'Hybrid Quickstart test failed: Cannot get incremental counts for count star query.'
   exit 1
 fi
-
-kill -9 $PID
-rm -rf /tmp/PinotAdmin/zkData
 
 cd ../../../../../
 pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
-os:
-  - linux
+os: linux
 dist: trusty
 
 before_install:

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -165,25 +165,21 @@ public class Quickstart {
 
     printStatus(Color.CYAN, "***** Starting Zookeeper, controller, broker and server *****");
     runner.startAll();
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      try {
+        printStatus(Color.GREEN, "***** Shutting down offline quick start *****");
+        runner.stop();
+        FileUtils.deleteDirectory(quickstartTmpDir);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }));
     printStatus(Color.CYAN, "***** Adding baseballStats table *****");
     runner.addTable();
     printStatus(Color.CYAN, "***** Launch data ingestion job to build index segment for baseballStats and push to controller *****");
     runner.launchDataIngestionJob();
     printStatus(Color.CYAN, "***** Waiting for 5 seconds for the server to fetch the assigned segment *****");
     Thread.sleep(5000);
-
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      @Override
-      public void run() {
-        try {
-          printStatus(Color.GREEN, "***** Shutting down offline quick start *****");
-          runner.stop();
-          FileUtils.deleteDirectory(quickstartTmpDir);
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-      }
-    });
 
     printStatus(Color.YELLOW, "***** Offline quickstart setup complete *****");
 


### PR DESCRIPTION
- For all the Quickstarts, add shutdown hook once the instances are set up so that the hook can always be executed
- Use TERM signal instead of KILL so that process can execute the shutdown hook
- Wait for process to fully terminate before starting the next one
- Correctly handle query response before the table being ready