### PR TITLE
[CI] Adding github actions for pinot tests

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -1,0 +1,78 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Pinot Tests
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Unit Test
+        env:
+          RUN_INTEGRATION_TESTS: false
+        run: .github/workflows/scripts/.pinot_test.sh
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true
+
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Integration Test
+        env:
+          RUN_INTEGRATION_TESTS: true
+        run: .github/workflows/scripts/.pinot_test.sh
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: integrationtests
+          name: codecov-umbrella
+          fail_ci_if_error: true
+
+  quickstarts:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 1.8, 10, 11, 12, 13, 14-ea, 15-ea ]
+    name: Pinot Quickstart on JDK ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Quickstart on JDK ${{ matrix.java }}
+        run: .github/workflows/scripts/.pinot_quickstart.sh

--- a/.github/workflows/scripts/.pinot_quickstart.sh
+++ b/.github/workflows/scripts/.pinot_quickstart.sh
@@ -1,0 +1,166 @@
+#!/bin/bash -x
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Java version
+java -version
+
+# Check ThirdEye related changes
+COMMIT_BEFORE=$(jq -r ".pull_request.base.sha" "${GITHUB_EVENT_PATH}")
+COMMIT_AFTER=$(jq -r ".pull_request.head.sha" "${GITHUB_EVENT_PATH}")
+git fetch
+git diff --name-only "${COMMIT_BEFORE}...${COMMIT_AFTER}" | grep -E
+if [ $? -eq 0 ]; then
+  echo 'Skip ThirdEye tests for Quickstart'
+  exit 0
+fi
+
+# Build
+PASS=1
+for i in $(seq 1 5)
+do
+  if [ "${PASS}" -eq 0 ]; then
+    break;
+  fi
+  mvn clean install -B -DskipTests=true -Pbin-dist -Dmaven.javadoc.skip=true ${DEPLOY_BUILD_OPTS} ${KAFKA_BUILD_OPTS} > /tmp/mvn_build_log
+  if [ $? -eq 0 ]; then
+    PASS=0
+  else
+    tail -1000 /tmp/mvn_build_log
+    PASS=1
+  fi
+done
+if [ "${PASS}" != 0 ]; then
+    exit 1;
+fi
+
+# Quickstart
+DIST_BIN_DIR=$(ls -d pinot-distribution/target/apache-pinot-*/apache-pinot-*)
+cd "${DIST_BIN_DIR}" || exit
+
+# Test quick-start-batch
+bin/quick-start-batch.sh &
+PID=$!
+
+PASS=0
+sleep 30
+for i in $(seq 1 200)
+do
+  curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from baseballStats limit 1","trace":false}' http://localhost:8000/query/sql
+  COUNT_STAR_RES=$(curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from baseballStats limit 1","trace":false}' http://localhost:8000/query/sql | jq '.resultTable.rows[0][0]')
+  if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]]; then
+    if [ "${COUNT_STAR_RES}" -eq 97889 ]; then
+      PASS=1
+      break
+    fi
+  fi
+  sleep 2
+done
+
+if [ "${PASS}" -eq 0 ]; then
+  echo 'Batch Quickstart failed: Cannot get correct result for count star query.'
+  exit 1
+fi
+
+kill -9 $PID
+rm -rf /tmp/PinotAdmin/zkData
+
+# Test quick-start-streaming
+bin/quick-start-streaming.sh &
+PID=$!
+
+PASS=0
+RES_1=0
+sleep 30
+
+for i in $(seq 1 200)
+do
+  curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from meetupRsvp limit 1","trace":false}' http://localhost:8000/query/sql
+  COUNT_STAR_RES=$(curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from meetupRsvp limit 1","trace":false}' http://localhost:8000/query/sql | jq '.resultTable.rows[0][0]')
+ if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]]; then
+    if [ "${COUNT_STAR_RES}" -gt 0 ]; then
+      if [ "${RES_1}" -eq 0 ]; then
+        RES_1=${COUNT_STAR_RES}
+        continue
+      fi
+    fi
+    if [ "${COUNT_STAR_RES}" -gt "${RES_1}" ]; then
+      PASS=1
+      break
+    fi
+  fi
+  sleep 2
+done
+
+if [ "${PASS}" -eq 0 ]; then
+  if [ "${RES_1}" -eq 0 ]; then
+    echo 'Streaming Quickstart test failed: Cannot get correct result for count star query.'
+    exit 1
+  fi
+  echo 'Streaming Quickstart test failed: Cannot get incremental counts for count star query.'
+  exit 1
+fi
+
+kill -9 $PID
+rm -rf /tmp/PinotAdmin/zkData
+
+# Test quick-start-hybrid
+cd bin
+./quick-start-hybrid.sh &
+PID=$!
+
+PASS=0
+RES_1=0
+sleep 30
+for i in $(seq 1 200)
+do
+  curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from airlineStats limit 1","trace":false}' http://localhost:8000/query/sql
+  COUNT_STAR_RES=$(curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from airlineStats limit 1","trace":false}' http://localhost:8000/query/sql | jq '.resultTable.rows[0][0]')
+  if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]]; then
+    if [ "${COUNT_STAR_RES}" -gt 0 ]; then
+      if [ "${RES_1}" -eq 0 ]; then
+        RES_1=${COUNT_STAR_RES}
+        continue
+      fi
+    fi
+    if [ "${COUNT_STAR_RES}" -gt "${RES_1}" ]; then
+      PASS=1
+      break
+    fi
+  fi
+  sleep 2
+done
+
+if [ "${PASS}" -eq 0 ]; then
+  if [ "${RES_1}" -eq 0 ]; then
+    echo 'Hybrid Quickstart test failed: Cannot get correct result for count star query.'
+    exit 1
+  fi
+  echo 'Hybrid Quickstart test failed: Cannot get incremental counts for count star query.'
+  exit 1
+fi
+
+kill -9 $PID
+rm -rf /tmp/PinotAdmin/zkData
+
+cd ../../../../../
+pwd
+mvn clean > /dev/null
+
+exit 0

--- a/.github/workflows/scripts/.pinot_test.sh
+++ b/.github/workflows/scripts/.pinot_test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -x
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Java version
+java -version
+
+# Check ThirdEye related changes
+COMMIT_BEFORE=$(jq -r ".pull_request.base.sha" "${GITHUB_EVENT_PATH}")
+COMMIT_AFTER=$(jq -r ".pull_request.head.sha" "${GITHUB_EVENT_PATH}")
+git fetch
+git diff --name-only "${COMMIT_BEFORE}...${COMMIT_AFTER}" | grep -E
+if [ $? -eq 0 ]; then
+  echo 'ThirdEye changes.'
+
+  if [ "${RUN_INTEGRATION_TESTS}" == false ]; then
+    echo 'Skip ThirdEye tests when integration tests off'
+    exit 0
+  fi
+
+  cd thirdeye
+  mvn test
+  failed=$?
+  if [ $failed -eq 0 ]; then
+    exit 0
+  else
+    exit 1
+  fi
+fi
+
+passed=0
+
+# Only run integration tests if needed
+if [ "$RUN_INTEGRATION_TESTS" != false ]; then
+  mvn test -B -P travis,travis-integration-tests-only
+  if [ $? -eq 0 ]; then
+    passed=1
+  fi
+else
+  mvn test -B -P travis,travis-no-integration-tests
+  if [ $? -eq 0 ]; then
+    passed=1
+  fi
+fi


### PR DESCRIPTION
## Description

Considering the slowness experienced recently from Travis, Github Action is an alternative CI framework. Also its [Usage Limits](https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits) is much larger than what Travis provides(20 vs 5 Concurrent jobs) and single container is faster than Travis (Based on time used on unit test, it's about 20%+ faster, 30min vs 38min).

This PR:
- Add Pinot Tests/Quickstart in Github Action as a replacement of Travis.
- Only triggered by PR, not by any branch push

Followup PR:
- Once fully tested, we can remove PR tests in Travis and use Github Actions for  PR tests.
- For Branch deploy related stuffs, we can still keep them in Travis. 