### PR TITLE
Return Select only Literal Expression at Broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -506,6 +506,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     return brokerResponse;
   }
 
+  // TODO(xiangfu): Move Literal function computation here from Calcite Parser.
   private void computeResultsForExpression(Expression e, List<String> columnNames, List<DataSchema.ColumnDataType> columnTypes,
       List<Object> row) {
     if (e.getType() == ExpressionType.LITERAL) {
@@ -567,6 +568,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * Fixes the case-insensitive column names to the actual column names in the given broker request.
    */
   private void handleCaseSensitivity(BrokerRequest brokerRequest) {
+    if (brokerRequest.getQuerySource() == null || brokerRequest.getQuerySource().getTableName() == null) {
+      return;
+    }
     String inputTableName = brokerRequest.getQuerySource().getTableName();
     String actualTableName = _tableCache.getActualTableName(inputTableName);
     brokerRequest.getQuerySource().setTableName(actualTableName);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.ZNRecord;
@@ -55,23 +56,30 @@ import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.BrokerQueryPhase;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.FilterQuery;
 import org.apache.pinot.common.request.FilterQueryMap;
+import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Broker;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.helix.TableCache;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.reduce.BrokerReduceService;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.util.QueryOptions;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,6 +191,18 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1);
       requestStatistics.setErrorCode(QueryException.PQL_PARSING_ERROR_CODE);
       return new BrokerResponseNative(QueryException.getException(QueryException.PQL_PARSING_ERROR, e));
+    }
+    if (isLiteralOnlyQuery(brokerRequest)) {
+      LOGGER.info("Request {} contains only Literal, skipping server query: {}", requestId, query);
+      try {
+        BrokerResponse brokerResponse =
+            processLiteralOnlyBrokerRequest(brokerRequest, compilationStartTimeNs, requestStatistics);
+        return brokerResponse;
+      } catch (IllegalStateException e) {
+        LOGGER
+            .warn("Unable to execute literal request {}: {} at broker, fallback to server query. {}", requestId, query,
+                e.getMessage());
+      }
     }
     String tableName = brokerRequest.getQuerySource().getTableName();
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
@@ -432,6 +452,116 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
           brokerRequest.getPinotQuery().setLimit(queryLimit);
         }
       }
+    }
+  }
+
+  /**
+   * Check if a SQL parsed BrokerRequest is a literal only query.
+   * @param brokerRequest
+   * @return true if this query selects only Literals
+   *
+   */
+  @VisibleForTesting
+  static boolean isLiteralOnlyQuery(BrokerRequest brokerRequest) {
+    if (brokerRequest.getPinotQuery() != null) {
+      for (Expression e: brokerRequest.getPinotQuery().getSelectList()) {
+        if (!CalciteSqlParser.isLiteralOnlyExpression(e)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Compute BrokerResponse for literal only query.
+   *
+   * @param brokerRequest
+   * @param compilationStartTimeNs
+   * @param requestStatistics
+   * @return BrokerResponse
+   */
+  private BrokerResponse processLiteralOnlyBrokerRequest(BrokerRequest brokerRequest, long compilationStartTimeNs,
+      RequestStatistics requestStatistics)
+      throws IllegalStateException {
+    System.out.println("brokerRequest = " + brokerRequest.toString());
+    BrokerResponseNative brokerResponse = new BrokerResponseNative();
+    List<String> columnNames = new ArrayList<>();
+    List<DataSchema.ColumnDataType> columnTypes = new ArrayList<>();
+    List<Object> row = new ArrayList<>();
+    for (Expression e : brokerRequest.getPinotQuery().getSelectList()) {
+      computeResultsForExpression(e, columnNames, columnTypes, row);
+    }
+    DataSchema dataSchema =
+        new DataSchema(columnNames.toArray(new String[0]), columnTypes.toArray(new DataSchema.ColumnDataType[0]));
+    List<Object[]> rows = new ArrayList<>();
+    rows.add(row.toArray());
+    ResultTable resultTable = new ResultTable(dataSchema, rows);
+    brokerResponse.setResultTable(resultTable);
+
+    long totalTimeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - compilationStartTimeNs);
+    brokerResponse.setTimeUsedMs(totalTimeMs);
+    requestStatistics.setQueryProcessingTime(totalTimeMs);
+    requestStatistics.setStatistics(brokerResponse);
+    return brokerResponse;
+  }
+
+  private void computeResultsForExpression(Expression e, List<String> columnNames, List<DataSchema.ColumnDataType> columnTypes,
+      List<Object> row) {
+    if (e.getType() == ExpressionType.LITERAL) {
+      computeResultsForLiteral(e.getLiteral(), columnNames, columnTypes, row);
+    }
+    if (e.getType() == ExpressionType.FUNCTION) {
+      if (e.getFunctionCall().getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
+        String columnName = e.getFunctionCall().getOperands().get(1).getIdentifier().getName();
+        computeResultsForExpression(e.getFunctionCall().getOperands().get(0), columnNames, columnTypes, row);
+        columnNames.set(columnNames.size() - 1, columnName);
+      } else {
+        throw new IllegalStateException(
+            "No able to compute results for function - " + e.getFunctionCall().getOperator());
+      }
+    }
+  }
+
+  private void computeResultsForLiteral(Literal literal, List<String> columnNames, List<DataSchema.ColumnDataType> columnTypes,
+      List<Object> row) {
+    Object fieldValue = literal.getFieldValue();
+    columnNames.add(fieldValue.toString());
+    switch (literal.getSetField()) {
+      case SHORT_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.INT);
+        row.add((int) literal.getShortValue());
+        break;
+      case INT_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.INT);
+        row.add(literal.getIntValue());
+        break;
+      case LONG_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.LONG);
+        row.add(literal.getLongValue());
+        break;
+      case DOUBLE_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.DOUBLE);
+        row.add(literal.getDoubleValue());
+        break;
+      case BOOL_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.STRING);
+        row.add(new Boolean(literal.getBoolValue()).toString());
+        break;
+      case STRING_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.STRING);
+        System.out.println("literal.getStringValue() = " + literal.getStringValue());
+        row.add(literal.getStringValue());
+        break;
+      case BINARY_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.BYTES);
+        row.add(BytesUtils.toHexString(literal.getBinaryValue()));
+        break;
+      case BYTE_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.BYTES);
+        row.add(BytesUtils.toHexString(new byte[]{literal.getByteValue()}));
+        break;
     }
   }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -49,6 +49,17 @@ public class LiteralOnlyBrokerRequestTest {
   }
 
   @Test
+  public void testSelectStarBrokerRequestFromSQL() {
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT '*'")));
+    Assert.assertTrue(BaseBrokerRequestHandler
+        .isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT '*' FROM myTable")));
+    Assert.assertFalse(
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT *")));
+    Assert.assertFalse(
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT * FROM myTable")));
+  }
+
+  @Test
   public void testNumberLiteralBrokerRequestFromSQL() {
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 1")));
     Assert.assertTrue(

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yammer.metrics.core.MetricsRegistry;
+import java.util.Random;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.pinot.broker.api.RequestStatistics;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class LiteralOnlyBrokerRequestTest {
+  private static final Random RANDOM = new Random(System.currentTimeMillis());
+  private static final CalciteSqlCompiler SQL_COMPILER = new CalciteSqlCompiler();
+
+  @Test
+  public void testStringLiteralBrokerRequestFromSQL() {
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 'a'")));
+    Assert.assertTrue(
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 'a', 'b'")));
+    Assert.assertTrue(
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 'a' FROM myTable")));
+    Assert.assertTrue(BaseBrokerRequestHandler
+        .isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 'a', 'b' FROM myTable")));
+  }
+
+  @Test
+  public void testNumberLiteralBrokerRequestFromSQL() {
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 1")));
+    Assert.assertTrue(
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 1, '2', 3")));
+    Assert.assertTrue(
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 1 FROM myTable")));
+    Assert.assertTrue(BaseBrokerRequestHandler
+        .isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 1, '2', 3 FROM myTable")));
+  }
+
+  @Test
+  public void testLiteralOnlyTransformBrokerRequestFromSQL() {
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT now()")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(
+        SQL_COMPILER.compileToBrokerRequest("SELECT now(), fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z')")));
+    Assert.assertTrue(
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT now() FROM myTable")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER
+        .compileToBrokerRequest("SELECT now(), fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') FROM myTable")));
+  }
+
+  @Test
+  public void testLiteralOnlyWithAsBrokerRequestFromSQL() {
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest(
+        "SELECT now() AS currentTs, fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') AS firstDayOf2020")));
+  }
+
+  @Test
+  public void testBrokerRequestHandler()
+      throws Exception {
+    SingleConnectionBrokerRequestHandler requestHandler =
+        new SingleConnectionBrokerRequestHandler(new PropertiesConfiguration(), null, null, null,
+            new BrokerMetrics("", new MetricsRegistry(), false), null);
+    long randNum = RANDOM.nextLong();
+    byte[] randBytes = new byte[12];
+    RANDOM.nextBytes(randBytes);
+    String ranStr = BytesUtils.toHexString(randBytes);
+    JsonNode request = new ObjectMapper().readTree(String.format("{\"sql\":\"SELECT %d, '%s'\"}", randNum, ranStr));
+    RequestStatistics requestStats = new RequestStatistics();
+    BrokerResponseNative brokerResponse =
+        (BrokerResponseNative) requestHandler.handleRequest(request, null, requestStats);
+    System.out.println("brokerResponse = " + brokerResponse.toJsonString());
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), String.format("%d", randNum));
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(0),
+        DataSchema.ColumnDataType.LONG);
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(1), ranStr);
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(1),
+        DataSchema.ColumnDataType.STRING);
+    Assert.assertEquals(brokerResponse.getResultTable().getRows().size(), 1);
+    Assert.assertEquals(brokerResponse.getResultTable().getRows().get(0).length, 2);
+    Assert.assertEquals(brokerResponse.getResultTable().getRows().get(0)[0], randNum);
+    Assert.assertEquals(brokerResponse.getResultTable().getRows().get(0)[1], ranStr);
+    Assert.assertEquals(brokerResponse.getTotalDocs(), 0);
+  }
+
+  @Test
+  public void testBrokerRequestHandlerWithAsFunction()
+      throws Exception {
+    SingleConnectionBrokerRequestHandler requestHandler =
+        new SingleConnectionBrokerRequestHandler(new PropertiesConfiguration(), null, null, null,
+            new BrokerMetrics("", new MetricsRegistry(), false), null);
+    long currentTsMin = System.currentTimeMillis();
+    JsonNode request = new ObjectMapper().readTree(
+        "{\"sql\":\"SELECT now() as currentTs, fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') as firstDayOf2020\"}");
+    RequestStatistics requestStats = new RequestStatistics();
+    BrokerResponseNative brokerResponse =
+        (BrokerResponseNative) requestHandler.handleRequest(request, null, requestStats);
+    long currentTsMax = System.currentTimeMillis();
+    System.out.println("brokerResponse = " + brokerResponse.toJsonString());
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), "currentTs");
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(0),
+        DataSchema.ColumnDataType.LONG);
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(1), "firstDayOf2020");
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(1),
+        DataSchema.ColumnDataType.LONG);
+    Assert.assertEquals(brokerResponse.getResultTable().getRows().size(), 1);
+    Assert.assertEquals(brokerResponse.getResultTable().getRows().get(0).length, 2);
+    Assert.assertTrue(Long.parseLong(brokerResponse.getResultTable().getRows().get(0)[0].toString()) > currentTsMin);
+    Assert.assertTrue(Long.parseLong(brokerResponse.getResultTable().getRows().get(0)[0].toString()) < currentTsMax);
+    Assert.assertEquals(brokerResponse.getResultTable().getRows().get(0)[1], 1577836800000L);
+    Assert.assertEquals(brokerResponse.getTotalDocs(), 0);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -128,7 +128,7 @@ public class PinotQuery2BrokerRequestConverter {
           if (selection == null) {
             selection = new Selection();
           }
-          selection.addToSelectionColumns(String.format("'%s'", expression.getLiteral().getFieldValue().toString()));
+          selection.addToSelectionColumns('\'' + expression.getLiteral().getFieldValue().toString() + '\'');
           break;
         case IDENTIFIER:
           if (selection == null) {

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -128,7 +128,7 @@ public class PinotQuery2BrokerRequestConverter {
           if (selection == null) {
             selection = new Selection();
           }
-          selection.addToSelectionColumns(expression.getLiteral().getFieldValue().toString());
+          selection.addToSelectionColumns(String.format("'%s'", expression.getLiteral().getFieldValue().toString()));
           break;
         case IDENTIFIER:
           if (selection == null) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -279,7 +279,9 @@ public class CalciteSqlParser {
           pinotQuery.setOffset(Integer.valueOf(((SqlNumericLiteral) selectSqlNode.getOffset()).toValue()));
         }
         DataSource dataSource = new DataSource();
-        dataSource.setTableName(selectSqlNode.getFrom().toString());
+        if (selectSqlNode.getFrom() != null) {
+          dataSource.setTableName(selectSqlNode.getFrom().toString());
+        }
         pinotQuery.setDataSource(dataSource);
         if (selectSqlNode.getModifierNode(SqlSelectKeyword.DISTINCT) != null) {
           if (selectSqlNode.getGroup() != null) {
@@ -711,9 +713,6 @@ public class CalciteSqlParser {
         try {
           FunctionInvoker invoker = new FunctionInvoker(functionInfo);
           Object result = invoker.process(arguments);
-          if (result instanceof String) {
-            result = String.format("'%s'", result);
-          }
           return RequestUtils.getLiteralExpression(result);
         } catch (Exception e) {
           throw new SqlCompilationException(new IllegalArgumentException("Unsupported function - " + funcName, e));
@@ -721,5 +720,19 @@ public class CalciteSqlParser {
       }
     }
     return funcExpr;
+  }
+
+  public static boolean isLiteralOnlyExpression(Expression e) {
+    if (e.getType() == ExpressionType.LITERAL) {
+      return true;
+    }
+    if (e.getType() == ExpressionType.FUNCTION) {
+      Function functionCall = e.getFunctionCall();
+      if (functionCall.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
+        return isLiteralOnlyExpression(functionCall.getOperands().get(0));
+      }
+      return true;
+    }
+    return false;
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -144,7 +144,7 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
-  public void testFilterCaluses() {
+  public void testFilterClauses() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where a > 1.5");
     Function func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), SqlKind.GREATER_THAN.name());
@@ -192,7 +192,7 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
-  public void testFilterCalusesWithRightExpression() {
+  public void testFilterClausesWithRightExpression() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where a > b");
     Function func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), SqlKind.GREATER_THAN.name());

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -371,7 +371,7 @@ public class CalciteSqlCompilerTest {
     BrokerRequest tempBrokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(tempBrokerRequest.getQuerySource().getTableName(), "mytable");
     Assert.assertEquals(tempBrokerRequest.getSelections().getSelectionColumns().get(0),
-        literal.getFieldValue().toString());
+        String.format("'%s'", literal.getFieldValue().toString()));
   }
 
   @Test
@@ -1603,7 +1603,7 @@ public class CalciteSqlCompilerTest {
     Function greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
     String today = greaterThan.getOperands().get(1).getLiteral().getStringValue();
     String expectedTodayStr =
-        "'" + Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z")) + "'";
+        Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z"));
     Assert.assertEquals(today, expectedTodayStr);
   }
 
@@ -1626,7 +1626,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(expression.getLiteral() != null);
     String today = expression.getLiteral().getStringValue();
     String expectedTodayStr =
-        "'" + Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z")) + "'";
+        Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z"));
     Assert.assertEquals(today, expectedTodayStr);
     expression = CalciteSqlParser.compileToExpression("toDateTime(playerName)");
     Assert.assertTrue(expression.getFunctionCall() != null);
@@ -1644,7 +1644,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(expression.getFunctionCall() != null);
     expression = CalciteSqlParser.invokeCompileTimeFunctionExpression(expression);
     Assert.assertTrue(expression.getLiteral() != null);
-    Assert.assertEquals(expression.getLiteral().getFieldValue(), "'emaNreyalp'");
+    Assert.assertEquals(expression.getLiteral().getFieldValue(), "emaNreyalp");
     expression = CalciteSqlParser.compileToExpression("count(*)");
     Assert.assertTrue(expression.getFunctionCall() != null);
     expression = CalciteSqlParser.invokeCompileTimeFunctionExpression(expression);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -318,6 +318,37 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   }
 
   @Test
+  public void testLiteralOnlyFunc()
+      throws Exception {
+    long currentTsMin = System.currentTimeMillis();
+    String sqlQuery = "SELECT 1, now() as currentTs, 'abc', toDateTime(now(), 'yyyy-MM-dd z') as today";
+    JsonNode response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
+    long currentTsMax = System.currentTimeMillis();
+
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(0).asText(), "1");
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(1).asText(), "currentTs");
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(2).asText(), "abc");
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(3).asText(), "today");
+
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG");
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(1).asText(), "LONG");
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(2).asText(), "STRING");
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(3).asText(), "STRING");
+
+    int first = response.get("resultTable").get("rows").get(0).get(0).asInt();
+    long second = response.get("resultTable").get("rows").get(0).get(1).asLong();
+    String third = response.get("resultTable").get("rows").get(0).get(2).asText();
+    Assert.assertEquals(first, 1);
+    Assert.assertTrue(second > currentTsMin);
+    Assert.assertTrue(second < currentTsMax);
+    Assert.assertEquals(third, "abc");
+    String todayStr = response.get("resultTable").get("rows").get(0).get(3).asText();
+    String expectedTodayStr =
+        Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z"));
+    Assert.assertEquals(todayStr, expectedTodayStr);
+  }
+
+  @Test
   public void testRangeIndexTriggering()
       throws Exception {
     long numTotalDocs = getCountStarResult();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -321,31 +321,37 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   public void testLiteralOnlyFunc()
       throws Exception {
     long currentTsMin = System.currentTimeMillis();
-    String sqlQuery = "SELECT 1, now() as currentTs, 'abc', toDateTime(now(), 'yyyy-MM-dd z') as today";
+    String sqlQuery = "SELECT 1, now() as currentTs, 'abc', toDateTime(now(), 'yyyy-MM-dd z') as today, now()";
     JsonNode response = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
     long currentTsMax = System.currentTimeMillis();
 
-    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(0).asText(), "1");
-    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(1).asText(), "currentTs");
-    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(2).asText(), "abc");
-    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(3).asText(), "today");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(0).asText(), "1");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(1).asText(), "currentTs");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(2).asText(), "abc");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(3).asText(), "today");
+    String nowColumnName = response.get("resultTable").get("dataSchema").get("columnNames").get(4).asText();
+    assertTrue(Long.parseLong(nowColumnName) > currentTsMin);
+    assertTrue(Long.parseLong(nowColumnName) < currentTsMax);
 
-    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG");
-    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(1).asText(), "LONG");
-    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(2).asText(), "STRING");
-    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(3).asText(), "STRING");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(1).asText(), "LONG");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(2).asText(), "STRING");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(3).asText(), "STRING");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(4).asText(), "LONG");
 
     int first = response.get("resultTable").get("rows").get(0).get(0).asInt();
     long second = response.get("resultTable").get("rows").get(0).get(1).asLong();
     String third = response.get("resultTable").get("rows").get(0).get(2).asText();
-    Assert.assertEquals(first, 1);
-    Assert.assertTrue(second > currentTsMin);
-    Assert.assertTrue(second < currentTsMax);
-    Assert.assertEquals(third, "abc");
+    assertEquals(first, 1);
+    assertTrue(second > currentTsMin);
+    assertTrue(second < currentTsMax);
+    assertEquals(third, "abc");
     String todayStr = response.get("resultTable").get("rows").get(0).get(3).asText();
     String expectedTodayStr =
         Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z"));
-    Assert.assertEquals(todayStr, expectedTodayStr);
+    assertEquals(todayStr, expectedTodayStr);
+    long nowValue = response.get("resultTable").get("rows").get(0).get(4).asLong();
+    assertEquals(nowValue, Long.parseLong(nowColumnName));
   }
 
   @Test


### PR DESCRIPTION
## Description
Current behavior of Selection with only literal expressions will be executed at pinot server.
E.g. `SELECT 1 FROM myTable LIMIT 10` will scan 10 records in pinot server and generate the response.

This change will identify literal only expressions and directly return the results from broker.

Also for literal only query, `FROM [TABLE]` clause is not a must.

This PR could help user run simple queries to verify some function results or verify server stats:
E.g.
Get Pinot broker time: `SELECT now()`
Superset tests database connection by sending: `SELECT 1`

Please note that this feature only available in SQL mode not PQL.

## Release Notes
Move the computation logic of Selection with only Literal expressions to Pinot Broker.
