### PR TITLE
Fix the failure caused by Reflections in FunctionRegistry

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -628,8 +628,7 @@ public class CalciteSqlParser {
       funcName = funcSqlNode.getOperator().getName();
     }
     if (funcName.equalsIgnoreCase(SqlKind.COUNT.toString()) && (funcSqlNode.getFunctionQuantifier() != null)
-        && funcSqlNode.getFunctionQuantifier().toValue()
-        .equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
+        && funcSqlNode.getFunctionQuantifier().toValue().equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
       funcName = AggregationFunctionType.DISTINCTCOUNT.getName();
     }
     return funcName;
@@ -667,21 +666,23 @@ public class CalciteSqlParser {
       function.getOperands().set(i, operand);
     }
     String funcName = function.getOperator();
-    if (FunctionRegistry.containsFunctionByName(funcName) && compilable) {
+    if (compilable) {
       FunctionInfo functionInfo = FunctionRegistry.getFunctionByName(funcName);
-      Object[] arguments = new Object[functionOperandsLength];
-      for (int i = 0; i < functionOperandsLength; i++) {
-        arguments[i] = function.getOperands().get(i).getLiteral().getFieldValue();
-      }
-      try {
-        FunctionInvoker invoker = new FunctionInvoker(functionInfo);
-        Object result = invoker.process(arguments);
-        if (result instanceof String) {
-          result = String.format("'%s'", result);
+      if (functionInfo != null) {
+        Object[] arguments = new Object[functionOperandsLength];
+        for (int i = 0; i < functionOperandsLength; i++) {
+          arguments[i] = function.getOperands().get(i).getLiteral().getFieldValue();
         }
-        return RequestUtils.getLiteralExpression(result);
-      } catch (Exception e) {
-        throw new SqlCompilationException(new IllegalArgumentException("Unsupported function - " + funcName, e));
+        try {
+          FunctionInvoker invoker = new FunctionInvoker(functionInfo);
+          Object result = invoker.process(arguments);
+          if (result instanceof String) {
+            result = String.format("'%s'", result);
+          }
+          return RequestUtils.getLiteralExpression(result);
+        } catch (Exception e) {
+          throw new SqlCompilationException(new IllegalArgumentException("Unsupported function - " + funcName, e));
+        }
       }
     }
     return funcExpr;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -44,6 +44,7 @@ import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.helix.task.TaskDriver;
 import org.apache.pinot.common.Utils;
+import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.MetricsHelper;
@@ -151,6 +152,9 @@ public class ControllerStarter implements ServiceStartable {
       _helixResourceManager = null;
       _executorService = null;
     } else {
+      // Initialize FunctionRegistry before starting the admin application (PinotQueryResource requires it to compile
+      // queries)
+      FunctionRegistry.init();
       _adminApp =
           new ControllerAdminApiApplication(_config.getQueryConsoleWebappPath(), _config.getQueryConsoleUseHttps());
       // Do not use this before the invocation of {@link PinotHelixResourceManager::start()}, which happens in {@link ControllerStarter::start()}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.data.function;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.pinot.common.function.FunctionInfo;
@@ -86,8 +87,9 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
       argumentTypes[i] = childNode.getReturnType();
     }
 
-    FunctionInfo functionInfo =
-        FunctionRegistry.getFunctionByNameWithApplicableArgumentTypes(transformName, argumentTypes);
+    FunctionInfo functionInfo = FunctionRegistry.getFunctionByName(transformName);
+    Preconditions.checkState(functionInfo != null && functionInfo.isApplicable(argumentTypes),
+        "Failed to find function of name: %s with argument types: %s", transformName, Arrays.toString(argumentTypes));
     return new FunctionExecutionNode(functionInfo, childNodes);
   }
 
@@ -114,8 +116,6 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
     public FunctionExecutionNode(FunctionInfo functionInfo, ExecutableNode[] argumentProviders)
         throws Exception {
-      Preconditions.checkNotNull(functionInfo);
-      Preconditions.checkNotNull(argumentProviders);
       _functionInvoker = new FunctionInvoker(functionInfo);
       _argumentProviders = argumentProviders;
       _argInputs = new Object[_argumentProviders.length];

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.data.function;
 
 import com.google.common.collect.Lists;
-import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.joda.time.DateTime;
@@ -37,11 +36,7 @@ public class InbuiltFunctionEvaluatorTest {
       throws Exception {
     MyFunc myFunc = new MyFunc();
     FunctionRegistry.registerFunction(myFunc.getClass().getDeclaredMethod("reverseString", String.class));
-    FunctionInfo functionInfo = FunctionRegistry
-        .getFunctionByNameWithApplicableArgumentTypes("reverseString", new Class<?>[]{Object.class});
-    System.out.println(functionInfo);
     String expression = "reverseString(testColumn)";
-
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
     Assert.assertEquals(evaluator.getArguments(), Lists.newArrayList("testColumn"));
     GenericRow row = new GenericRow();
@@ -91,8 +86,7 @@ public class InbuiltFunctionEvaluatorTest {
   public void testStateSharedBetweenRowsForExecution()
       throws Exception {
     MyFunc myFunc = new MyFunc();
-    FunctionRegistry
-        .registerFunction(myFunc.getClass().getDeclaredMethod("appendToStringAndReturn", String.class));
+    FunctionRegistry.registerFunction(myFunc.getClass().getDeclaredMethod("appendToStringAndReturn", String.class));
     String expression = String.format("appendToStringAndReturn('%s')", "test ");
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
     Assert.assertTrue(evaluator.getArguments().isEmpty());
@@ -101,28 +95,28 @@ public class InbuiltFunctionEvaluatorTest {
     Assert.assertEquals(evaluator.evaluate(row), "test test ");
     Assert.assertEquals(evaluator.evaluate(row), "test test test ");
   }
-}
 
-class MyFunc {
-  String reverseString(String input) {
-    return new StringBuilder(input).reverse().toString();
-  }
+  private static class MyFunc {
+    String reverseString(String input) {
+      return new StringBuilder(input).reverse().toString();
+    }
 
-  MutableDateTime EPOCH_START = new MutableDateTime();
+    MutableDateTime EPOCH_START = new MutableDateTime();
 
-  public MyFunc() {
-    EPOCH_START.setDate(0L);
-  }
+    public MyFunc() {
+      EPOCH_START.setDate(0L);
+    }
 
-  int daysSinceEpoch(String input, String format) {
-    DateTime dateTime = DateTimeFormat.forPattern(format).parseDateTime(input);
-    return Days.daysBetween(EPOCH_START, dateTime).getDays();
-  }
+    int daysSinceEpoch(String input, String format) {
+      DateTime dateTime = DateTimeFormat.forPattern(format).parseDateTime(input);
+      return Days.daysBetween(EPOCH_START, dateTime).getDays();
+    }
 
-  private String baseString = "";
+    private String baseString = "";
 
-  String appendToStringAndReturn(String addedString) {
-    baseString += addedString;
-    return baseString;
+    String appendToStringAndReturn(String addedString) {
+      baseString += addedString;
+      return baseString;
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
@@ -230,8 +230,7 @@ public class InbuiltFunctionsTest {
 
     GenericRow row1 = new GenericRow();
     jsonStr = "{\"k3\":{\"sub1\":10,\"sub2\":1.0},\"k4\":\"baz\",\"k5\":[1,2,3]}";
-    row1.putValue("jsonMap", JsonUtils
-        .stringToObject(jsonStr, Map.class));
+    row1.putValue("jsonMap", JsonUtils.stringToObject(jsonStr, Map.class));
     inputs.add(new Object[]{"toJsonMapStr(jsonMap)", Lists.newArrayList("jsonMap"), row1, jsonStr});
 
     GenericRow row2 = new GenericRow();
@@ -241,20 +240,18 @@ public class InbuiltFunctionsTest {
 
     GenericRow row3 = new GenericRow();
     jsonStr = "{\"k3\":{\"sub1\":10,\"sub2\":1.0},\"k4\":\"baz\",\"k5\":[1,2,3]}";
-    row3.putValue("jsonMap", JsonUtils
-        .stringToObject(jsonStr, Map.class));
+    row3.putValue("jsonMap", JsonUtils.stringToObject(jsonStr, Map.class));
     inputs.add(new Object[]{"json_format(jsonMap)", Lists.newArrayList("jsonMap"), row3, jsonStr});
 
     GenericRow row4 = new GenericRow();
     jsonStr = "[{\"one\":1,\"two\":\"too\"},{\"one\":11,\"two\":\"roo\"}]";
-    row4.putValue("jsonMap", JsonUtils
-        .stringToObject(jsonStr, List.class));
+    row4.putValue("jsonMap", JsonUtils.stringToObject(jsonStr, List.class));
     inputs.add(new Object[]{"json_format(jsonMap)", Lists.newArrayList("jsonMap"), row4, jsonStr});
 
     GenericRow row5 = new GenericRow();
-    jsonStr = "[{\"one\":1,\"two\":{\"sub1\":1.1,\"sub2\":1.2},\"three\":[\"a\",\"b\"]},{\"one\":11,\"two\":{\"sub1\":11.1,\"sub2\":11.2},\"three\":[\"aa\",\"bb\"]}]";
-    row5.putValue("jsonMap", JsonUtils
-        .stringToObject(jsonStr, List.class));
+    jsonStr =
+        "[{\"one\":1,\"two\":{\"sub1\":1.1,\"sub2\":1.2},\"three\":[\"a\",\"b\"]},{\"one\":11,\"two\":{\"sub1\":11.1,\"sub2\":11.2},\"three\":[\"aa\",\"bb\"]}]";
+    row5.putValue("jsonMap", JsonUtils.stringToObject(jsonStr, List.class));
     inputs.add(new Object[]{"json_format(jsonMap)", Lists.newArrayList("jsonMap"), row5, jsonStr});
 
     return inputs.toArray(new Object[0][]);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.LongAccumulator;
 import org.apache.helix.HelixManager;
+import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.metrics.MetricsHelper;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
@@ -71,6 +72,8 @@ public class ServerInstance {
     _instanceDataManager = (InstanceDataManager) Class.forName(instanceDataManagerClassName).newInstance();
     _instanceDataManager.init(serverConf.getInstanceDataManagerConfig(), helixManager, _serverMetrics);
 
+    // Initialize FunctionRegistry before starting the query executor
+    FunctionRegistry.init();
     String queryExecutorClassName = serverConf.getQueryExecutorClassName();
     LOGGER.info("Initializing query executor of class: {}", queryExecutorClassName);
     _queryExecutor = (QueryExecutor) Class.forName(queryExecutorClassName).newInstance();


### PR DESCRIPTION
##  Description
The new FunctionRegistry change of using reflection to plug in methods (introduced in #5440) is causing failure in query compilation.
The problem is caused by Reflections library not being thread-safe when multiple threads are accessing the same jar file.
We have multiple libraries (jersey, swagger) using reflection to load classes. The FunctionRegistry uses reflection in the static block, which happens when the class is loaded. If the first query arrives (first usage of FunctionRegistry which runs the static block) during the setup of the jersey server, Reflections will throw exception.
Using reflection in the static block can also cause the first query to block on reflection scanning the classes, which can potentially take seconds.
Read more about the thread-safety issue here: https://github.com/ronmamo/reflections/issues/81
Users are reporting the same issue even with the latest Reflections version 0.9.12.
A common solution is to downgrade Reflections to 0.9.9, but we have other dependencies rely on 0.9.11, so downgrading might cause other issues.

The solution here is to introduce a no-op init() method to trigger the static block so that we can control when to scan the files to avoid the thread-safety issue as well as blocking the first query.
Another benefit of using an init() method is that the exception won't be swallowed (the exception in static block will be swallowed and query engine will start getting ClassNotFoundException)

This PR also introduces a convention for the plugin methods using reflection, where the class must includes ".function." in its class path.
This can significantly reduce the time of class scanning (reduced from 4 seconds to 200 ms locally)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
In order to plug in scalar methods using annotation via reflection, please put the methods in a class that includes ".function." in its class path.