### PR TITLE
In ServerQueryRequest and ColumnValueSegmentPruner, replace BrokerRequest with QueryContext

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
@@ -18,23 +18,15 @@
  */
 package org.apache.pinot.core.query.request;
 
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nullable;
-import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.request.GroupBy;
 import org.apache.pinot.common.request.InstanceRequest;
-import org.apache.pinot.common.request.Selection;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
-import org.apache.pinot.common.utils.request.FilterQueryTree;
-import org.apache.pinot.common.utils.request.RequestUtils;
-import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.TimerContext;
+import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
+import org.apache.pinot.core.query.request.context.utils.QueryContextUtils;
 
 
 /**
@@ -45,7 +37,6 @@ import org.apache.pinot.core.query.request.context.TimerContext;
  */
 public class ServerQueryRequest {
   private final long _requestId;
-  private final BrokerRequest _brokerRequest;
   private final String _tableNameWithType;
   private final List<String> _segmentsToQuery;
   private final boolean _enableTrace;
@@ -55,102 +46,25 @@ public class ServerQueryRequest {
   private final TimerContext _timerContext;
 
   // Pre-computed segment independent information
+  private final QueryContext _queryContext;
   private final Set<String> _allColumns;
-  private final FilterQueryTree _filterQueryTree;
-  private final Set<String> _filterColumns;
-  private final Set<TransformExpressionTree> _aggregationExpressions;
-  private final Set<String> _aggregationColumns;
-  private final Set<TransformExpressionTree> _groupByExpressions;
-  private final Set<String> _groupByColumns;
-  private final Set<String> _selectionColumns;
-  private final Set<TransformExpressionTree> _selectionExpressions;
-
-  // Query processing context
-  private volatile int _segmentCountAfterPruning = -1;
 
   public ServerQueryRequest(InstanceRequest instanceRequest, ServerMetrics serverMetrics, long queryArrivalTimeMs) {
     _requestId = instanceRequest.getRequestId();
-    _brokerRequest = instanceRequest.getQuery();
-    _tableNameWithType = _brokerRequest.getQuerySource().getTableName();
+    BrokerRequest brokerRequest = instanceRequest.getQuery();
+    _tableNameWithType = brokerRequest.getQuerySource().getTableName();
     _segmentsToQuery = instanceRequest.getSearchSegments();
     _enableTrace = instanceRequest.isEnableTrace();
     _brokerId = instanceRequest.getBrokerId() != null ? instanceRequest.getBrokerId() : "unknown";
     _timerContext = new TimerContext(_tableNameWithType, serverMetrics, queryArrivalTimeMs);
 
     // Pre-compute segment independent information
-    _allColumns = new HashSet<>();
-
-    // Filter
-    _filterQueryTree = RequestUtils.generateFilterQueryTree(_brokerRequest);
-    if (_filterQueryTree != null) {
-      _filterColumns = RequestUtils.extractFilterColumns(_filterQueryTree);
-      _allColumns.addAll(_filterColumns);
-    } else {
-      _filterColumns = null;
-    }
-
-    // Aggregation
-    List<AggregationInfo> aggregationsInfo = _brokerRequest.getAggregationsInfo();
-    if (aggregationsInfo != null) {
-      _aggregationExpressions = new HashSet<>();
-      for (AggregationInfo aggregationInfo : aggregationsInfo) {
-        String aggregationType = aggregationInfo.getAggregationType();
-
-        // TODO: Remove special casing of theta-sketch.
-        // This is needed as a work-around because only aggregation functions know how to interpret the expressions.
-        // The code below assumes that all expressions have columns in them, which may not be true. But only Aggregation
-        // functions have that knowledge, and have not been instantiated yet. A clean fix would be to instantiate
-        // aggregation functions upfront to interpret the expressions.
-        if (!aggregationType.equalsIgnoreCase(AggregationFunctionType.COUNT.getName()) && !aggregationType
-            .equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNTTHETASKETCH.getName())) {
-          for (String expressions : AggregationFunctionUtils.getArguments(aggregationInfo)) {
-            _aggregationExpressions.add(TransformExpressionTree.compileToExpressionTree(expressions));
-          }
-        }
-      }
-      _aggregationColumns = RequestUtils.extractColumnsFromExpressions(_aggregationExpressions);
-      _allColumns.addAll(_aggregationColumns);
-    } else {
-      _aggregationExpressions = null;
-      _aggregationColumns = null;
-    }
-
-    // Group-by
-    GroupBy groupBy = _brokerRequest.getGroupBy();
-    if (groupBy != null) {
-      _groupByExpressions = new HashSet<>();
-      for (String expression : groupBy.getExpressions()) {
-        _groupByExpressions.add(TransformExpressionTree.compileToExpressionTree(expression));
-      }
-      _groupByColumns = RequestUtils.extractColumnsFromExpressions(_groupByExpressions);
-      _allColumns.addAll(_groupByColumns);
-    } else {
-      _groupByExpressions = null;
-      _groupByColumns = null;
-    }
-
-    // Selection
-    Selection selection = _brokerRequest.getSelections();
-    if (selection != null) {
-      _selectionExpressions = new LinkedHashSet<>();
-      Set<String> selectionColumns = RequestUtils.extractSelectionColumns(selection);
-      for (String expression : selectionColumns) {
-        _selectionExpressions.add(TransformExpressionTree.compileToExpressionTree(expression));
-      }
-      _selectionColumns = RequestUtils.extractColumnsFromExpressions(_selectionExpressions);
-      _allColumns.addAll(_selectionColumns);
-    } else {
-      _selectionColumns = null;
-      _selectionExpressions = null;
-    }
+    _queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
+    _allColumns = QueryContextUtils.getAllColumns(_queryContext);
   }
 
   public long getRequestId() {
     return _requestId;
-  }
-
-  public BrokerRequest getBrokerRequest() {
-    return _brokerRequest;
   }
 
   public String getTableNameWithType() {
@@ -173,47 +87,11 @@ public class ServerQueryRequest {
     return _timerContext;
   }
 
+  public QueryContext getQueryContext() {
+    return _queryContext;
+  }
+
   public Set<String> getAllColumns() {
     return _allColumns;
-  }
-
-  @Nullable
-  public FilterQueryTree getFilterQueryTree() {
-    return _filterQueryTree;
-  }
-
-  @Nullable
-  public Set<String> getFilterColumns() {
-    return _filterColumns;
-  }
-
-  @Nullable
-  public Set<TransformExpressionTree> getAggregationExpressions() {
-    return _aggregationExpressions;
-  }
-
-  @Nullable
-  public Set<String> getAggregationColumns() {
-    return _aggregationColumns;
-  }
-
-  @Nullable
-  public Set<TransformExpressionTree> getGroupByExpressions() {
-    return _groupByExpressions;
-  }
-
-  @Nullable
-  public Set<String> getGroupByColumns() {
-    return _groupByColumns;
-  }
-
-  @Nullable
-  public Set<String> getSelectionColumns() {
-    return _selectionColumns;
-  }
-
-  @Nullable
-  public Set<TransformExpressionTree> getSelectionExpressions() {
-    return _selectionExpressions;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -20,13 +20,13 @@ package org.apache.pinot.core.query.pruner;
 
 import java.util.Collections;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.utils.request.FilterQueryTree;
-import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.common.DataSourceMetadata;
 import org.apache.pinot.core.data.partition.PartitionFunctionFactory;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.Test;
@@ -119,9 +119,9 @@ public class ColumnValueSegmentPrunerTest {
 
   private boolean runPruner(IndexSegment indexSegment, String query) {
     BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
-    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+    QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
     ServerQueryRequest queryRequest = mock(ServerQueryRequest.class);
-    when(queryRequest.getFilterQueryTree()).thenReturn(filterQueryTree);
+    when(queryRequest.getQueryContext()).thenReturn(queryContext);
     return PRUNER.prune(indexSegment, queryRequest);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/TestHelper.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/TestHelper.java
@@ -19,10 +19,12 @@
 package org.apache.pinot.core.query.scheduler;
 
 import java.util.Arrays;
+import java.util.Collections;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.InstanceRequest;
 import org.apache.pinot.common.request.QuerySource;
+import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 
 
@@ -39,6 +41,9 @@ public class TestHelper {
     QuerySource qs = new QuerySource();
     qs.setTableName(table);
     br.setQuerySource(qs);
+    Selection selection = new Selection();
+    selection.setSelectionColumns(Collections.singletonList("*"));
+    br.setSelections(selection);
     request.setQuery(br);
     return new ServerQueryRequest(request, metrics, queryArrivalTimeMs);
   }


### PR DESCRIPTION
ColumnValueSegmentPruner can directly use the Predicate in QueryContext instead of creating new ones for each segment