### PR TITLE
Change default segment load mode to MMAP.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/ReadMode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/ReadMode.java
@@ -21,6 +21,15 @@ package org.apache.pinot.common.segment;
 import org.apache.pinot.common.utils.CommonConstants;
 
 
+/**
+ * Enum class for segment read mode:
+ * <ul>
+ *   <li> heap: Segments are loaded on direct-memory. Note, 'heap' here is a legacy misnomer, and it does not
+ *        imply JVM heap. This mode should only be used when we want faster performance than memory-mapped files,
+ *        and are also sure that we will never run into OOM. </li>
+ *   <li> mmap: Segments are loaded on memory-mapped file. This is the default mode. </li>
+ * </ul>
+ */
 public enum ReadMode {
   heap, mmap;
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -191,7 +191,7 @@ public class CommonConstants {
     public static final int DEFAULT_STARTUP_REALTIME_CONSUMPTION_CATCHUP_WAIT_MS = 0;
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
-    public static final String DEFAULT_READ_MODE = "heap";
+    public static final String DEFAULT_READ_MODE = "mmap";
     // Whether to reload consuming segment on scheme update. Will change default behavior to true when this feature is stabilized
     public static final boolean DEFAULT_RELOAD_CONSUMING_SEGMENT = false;
     public static final String DEFAULT_INSTANCE_BASE_DIR =

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -138,6 +138,9 @@ public class ImmutableSegmentLoader {
               indexContainerMap, readMode);
     }
 
-    return new ImmutableSegmentImpl(segmentDirectory, segmentMetadata, indexContainerMap, starTreeIndexContainer);
+    ImmutableSegmentImpl segment =
+        new ImmutableSegmentImpl(segmentDirectory, segmentMetadata, indexContainerMap, starTreeIndexContainer);
+    LOGGER.info("Successfully loaded segment {} with readMode: {}", segmentName, readMode);
+    return segment;
   }
 }


### PR DESCRIPTION
The load mode for segments currently defaults to `heap`. This PR
changes the load-mode to default to `mmap` instead. This is for
two reasons:

1. We have been primarly using and recommending `mmap` mode, so no
   reason why the default should be `heap`.
2. Heap mode can lead to OOMs.

Also added a log message upon successful loading of segments along
with the load mode. This was because, in absence of the log message,
we see the following misleading message:

```
        Instance Data Dir: ....
        Instance Segment Tar Dir: ....
        Bootstrap Segment Dir: null
        Read Mode: heap
```

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
In this release, we are changing the default load-mode for segments from `HEAP` (direct-memory) to `MMAP`. The `mmap` mode is the recommended way of loading segments as it performs reasonably well, and unlike `heap` mode, it does not run the risk of OOM. For instructions on how to change this setting, please refer to: https://docs.pinot.apache.org/basics/components/table#offline-table-config

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
