### PR TITLE
Changed the stream and metadata interface

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/LLCRealtimeSegmentZKMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/LLCRealtimeSegmentZKMetadata.java
@@ -33,8 +33,8 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
   private static final String NUM_REPLICAS = "segment.realtime.numReplicas";
   public static final String DOWNLOAD_URL = "segment.realtime.download.url";
 
-  private long _startOffset;
-  private long _endOffset;
+  private String _startOffset;
+  private String _endOffset;
   private int _numReplicas;
 
   private String _downloadUrl = null;
@@ -45,17 +45,17 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
 
   public LLCRealtimeSegmentZKMetadata(ZNRecord znRecord) {
     super(znRecord);
-    _startOffset = Long.valueOf(znRecord.getSimpleField(START_OFFSET));
+    _startOffset = znRecord.getSimpleField(START_OFFSET);
     _numReplicas = Integer.valueOf(znRecord.getSimpleField(NUM_REPLICAS));
-    _endOffset = Long.valueOf(znRecord.getSimpleField(END_OFFSET));
+    _endOffset = znRecord.getSimpleField(END_OFFSET);
     _downloadUrl = znRecord.getSimpleField(DOWNLOAD_URL);
   }
 
-  public long getStartOffset() {
+  public String getStartOffset() {
     return _startOffset;
   }
 
-  public long getEndOffset() {
+  public String getEndOffset() {
     return _endOffset;
   }
 
@@ -63,11 +63,11 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
     return _numReplicas;
   }
 
-  public void setStartOffset(long startOffset) {
+  public void setStartOffset(String startOffset) {
     _startOffset = startOffset;
   }
 
-  public void setEndOffset(long endOffset) {
+  public void setEndOffset(String endOffset) {
     _endOffset = endOffset;
   }
 
@@ -86,8 +86,13 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
   @Override
   public ZNRecord toZNRecord() {
     ZNRecord znRecord = super.toZNRecord();
-    znRecord.setLongField(START_OFFSET, _startOffset);
-    znRecord.setLongField(END_OFFSET, _endOffset);
+    znRecord.setSimpleField(START_OFFSET, _startOffset);
+    if (_endOffset == null) {
+      // TODO Issue 5359 Keep this until all components have upgraded to a version that can handle _offset being null
+      // For backward compatibility until all components have been upgraded to deal with null value for _endOffset
+      _endOffset = Long.toString(Long.MAX_VALUE);
+    }
+    znRecord.setSimpleField(END_OFFSET, _endOffset);
     znRecord.setIntField(NUM_REPLICAS, _numReplicas);
     znRecord.setSimpleField(DOWNLOAD_URL, _downloadUrl);
     return znRecord;
@@ -141,8 +146,8 @@ public class LLCRealtimeSegmentZKMetadata extends RealtimeSegmentZKMetadata {
   @Override
   public Map<String, String> toMap() {
     Map<String, String> configMap = super.toMap();
-    configMap.put(START_OFFSET, Long.toString(_startOffset));
-    configMap.put(END_OFFSET, Long.toString(_endOffset));
+    configMap.put(START_OFFSET, _startOffset);
+    configMap.put(END_OFFSET, _endOffset);
     configMap.put(NUM_REPLICAS, Integer.toString(_numReplicas));
     configMap.put(DOWNLOAD_URL, _downloadUrl);
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -457,7 +457,6 @@ public class SegmentCompletionProtocol {
       return _offset;
     }
 
-    // TODO Issue 5359 Make it a JsonProperty when we are ready to move the protocol
     // This method is called in the server when the controller responds with
     // CATCH_UP response to segmentConsumed() API.
     @JsonProperty(STREAM_PARTITION_MSG_OFFSET_KEY)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -150,8 +150,7 @@ public class SegmentCompletionManager {
           // Also good for synchronization, because it is possible that multiple threads take this path, and we don't want
           // multiple instances of the FSM to be created for the same commit sequence at the same time.
           StreamPartitionMsgOffsetFactory factory = getStreamPartitionMsgOffsetFactory(segmentName);
-          // TODO Issue 5359: Pick the offset string from metadata
-          final StreamPartitionMsgOffset endOffset = factory.create(Long.toString(segmentMetadata.getEndOffset()));
+          final StreamPartitionMsgOffset endOffset = factory.create(segmentMetadata.getEndOffset());
           fsm = SegmentCompletionFSM
               .fsmInCommit(_segmentManager, this, segmentName, segmentMetadata.getNumReplicas(), endOffset);
         } else if (msgType.equals(SegmentCompletionProtocol.MSG_TYPE_STOPPED_CONSUMING)) {
@@ -1156,10 +1155,10 @@ public class SegmentCompletionManager {
         return true;
       } else if (now > _maxTimeToPickWinnerMs || _commitStateMap.size() == numReplicasToLookFor()) {
         LOGGER.info("{}:Picking winner time={} size={}", _state, now - _startTimeMs, _commitStateMap.size());
-        StreamPartitionMsgOffset maxOffsetSoFar = _streamPartitionMsgOffsetFactory.createMinOffset();
+        StreamPartitionMsgOffset maxOffsetSoFar = null;
         String winnerSoFar = null;
         for (Map.Entry<String, StreamPartitionMsgOffset> entry : _commitStateMap.entrySet()) {
-          if (entry.getValue().compareTo(maxOffsetSoFar) > 0) {
+          if (maxOffsetSoFar == null || entry.getValue().compareTo(maxOffsetSoFar) > 0) {
             maxOffsetSoFar = entry.getValue();
             winnerSoFar = entry.getKey();
           }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1223,7 +1223,7 @@ public class SegmentCompletionTest {
     @Override
     public void commitSegmentMetadata(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
       _segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
-      _segmentMetadata.setEndOffset(Long.parseLong(committingSegmentDescriptor.getNextOffset()));
+      _segmentMetadata.setEndOffset(committingSegmentDescriptor.getNextOffset());
       _segmentMetadata.setDownloadUrl(URIUtils.constructDownloadUrl(CONTROLLER_CONF.generateVipUrl(), rawTableName,
           committingSegmentDescriptor.getSegmentName()));
       _segmentMetadata.setEndTime(_segmentCompletionMgr.getCurrentTimeMs());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.controller.helix.core.util.ZKMetadataUtils;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.joda.time.Duration;
@@ -305,8 +306,8 @@ public class RetentionManagerTest {
   private LLCRealtimeSegmentZKMetadata createSegmentMetadata(int replicaCount, long segmentCreationTime) {
     LLCRealtimeSegmentZKMetadata segmentMetadata = new LLCRealtimeSegmentZKMetadata();
     segmentMetadata.setCreationTime(segmentCreationTime);
-    segmentMetadata.setStartOffset(0L);
-    segmentMetadata.setEndOffset(-1L);
+    segmentMetadata.setStartOffset(new LongMsgOffset(0L).toString());
+    segmentMetadata.setEndOffset(new LongMsgOffset(-1L).toString());
 
     segmentMetadata.setNumReplicas(replicaCount);
     return segmentMetadata;

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -137,7 +137,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     LLCRealtimeSegmentZKMetadata segmentZKMetadata = new LLCRealtimeSegmentZKMetadata();
     segmentZKMetadata.setSegmentName(_segmentNameStr);
-    segmentZKMetadata.setStartOffset(_startOffset.getOffset());
+    segmentZKMetadata.setStartOffset(_startOffset.toString());
     segmentZKMetadata.setCreationTime(System.currentTimeMillis());
     return segmentZKMetadata;
   }
@@ -447,7 +447,7 @@ public class LLRealtimeSegmentDataManagerTest {
     LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
     final long finalOffsetValue = _startOffsetValue + 600;
     final LongMsgOffset finalOffset = new LongMsgOffset(finalOffsetValue);
-    metadata.setEndOffset(finalOffsetValue);
+    metadata.setEndOffset(finalOffset.toString());
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
@@ -695,7 +695,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     // Now let the segment go ONLINE from CONSUMING, and ensure that the file is removed.
     LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
-    metadata.setEndOffset(finalOffset);
+    metadata.setEndOffset(new LongMsgOffset(finalOffset).toString());
     segmentDataManager._stopWaitTimeMs = 0;
     segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.HOLDING);
     segmentDataManager.goOnlineFromConsuming(metadata);

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
@@ -27,8 +27,10 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 
@@ -44,8 +46,8 @@ public class FakeStreamConfigUtils {
   private static final String AVRO_SCHEMA_FILE = "fake_stream_avro_schema.avsc";
   private static final String PINOT_SCHEMA_FILE = "fake_stream_pinot_schema.json";
 
-  private static final int SMALLEST_OFFSET = 0;
-  private static final int LARGEST_OFFSET = Integer.MAX_VALUE;
+  private static final LongMsgOffset SMALLEST_OFFSET = new LongMsgOffset(0);
+  private static final LongMsgOffset LARGEST_OFFSET = new LongMsgOffset(Integer.MAX_VALUE);
   private static final String NUM_PARTITIONS_KEY = "num.partitions";
   private static final int DEFAULT_NUM_PARTITIONS = 2;
 
@@ -72,14 +74,14 @@ public class FakeStreamConfigUtils {
   /**
    * Gets smallest offset based on data
    */
-  static int getSmallestOffset() {
+  static StreamPartitionMsgOffset getSmallestOffset() {
     return SMALLEST_OFFSET;
   }
 
   /**
    * Gets largest offset based on data
    */
-  static int getLargestOffset() {
+  static StreamPartitionMsgOffset getLargestOffset() {
     return LARGEST_OFFSET;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.apache.pinot.core.util.SchemaUtils;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionLevelConsumer;
@@ -32,6 +33,7 @@ import org.apache.pinot.spi.stream.StreamDecoderProvider;
 import org.apache.pinot.spi.stream.StreamLevelConsumer;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
 /**
@@ -83,14 +85,14 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
     int partition = 3;
     StreamMetadataProvider partitionMetadataProvider =
         streamConsumerFactory.createPartitionMetadataProvider(clientId, partition);
-    long partitionOffset =
-        partitionMetadataProvider.fetchPartitionOffset(OffsetCriteria.SMALLEST_OFFSET_CRITERIA, 10_000);
+    StreamPartitionMsgOffset partitionOffset =
+        partitionMetadataProvider.fetchStreamPartitionOffset(OffsetCriteria.SMALLEST_OFFSET_CRITERIA, 10_000);
     System.out.println(partitionOffset);
 
     // Partition level consumer
     PartitionLevelConsumer partitionLevelConsumer =
         streamConsumerFactory.createPartitionLevelConsumer(clientId, partition);
-    MessageBatch messageBatch = partitionLevelConsumer.fetchMessages(10, 40, 10_000);
+    MessageBatch messageBatch = partitionLevelConsumer.fetchMessages(new LongMsgOffset(10), new LongMsgOffset(40), 10_000);
 
     // Message decoder
     Schema pinotSchema = FakeStreamConfigUtils.getPinotSchema();

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMessageBatch.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMessageBatch.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.core.realtime.impl.fakestream;
 
 import java.util.List;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
 /**
@@ -50,7 +52,7 @@ public class FakeStreamMessageBatch implements MessageBatch<byte[]> {
     return _messageBytes.get(index).length;
   }
 
-  public long getNextStreamMessageOffsetAtIndex(int index) {
-    return _messageOffsets.get(index) + 1;
+  public StreamPartitionMsgOffset getNextStreamMessageOffsetAtIndex(int index) {
+    return new LongMsgOffset(_messageOffsets.get(index) + 1);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMetadataProvider.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMetadataProvider.java
@@ -24,6 +24,7 @@ import javax.annotation.Nonnull;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
 /**
@@ -41,8 +42,12 @@ public class FakeStreamMetadataProvider implements StreamMetadataProvider {
     return _numPartitions;
   }
 
-  @Override
   public long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis) throws TimeoutException {
+    throw new UnsupportedOperationException("This method is deprecated");
+  }
+
+  @Override
+  public StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis) throws TimeoutException {
     if (offsetCriteria.isSmallest()) {
       return FakeStreamConfigUtils.getSmallestOffset();
     } else {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaStreamMetadataProvider.java
@@ -34,9 +34,11 @@ import kafka.javaapi.TopicMetadataRequest;
 import kafka.javaapi.TopicMetadataResponse;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,6 +145,11 @@ public class KafkaStreamMetadataProvider extends KafkaConnectionHandler implemen
     throw new TimeoutException();
   }
 
+  public synchronized long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
+      throws java.util.concurrent.TimeoutException {
+    throw new UnsupportedOperationException("The use of this method s not supported");
+  }
+
   /**
    * Fetches the numeric Kafka offset for this partition for a symbolic name ("largest" or "smallest").
    *
@@ -153,7 +160,7 @@ public class KafkaStreamMetadataProvider extends KafkaConnectionHandler implemen
    * @return An offset
    */
   @Override
-  public synchronized long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
+  public synchronized StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
       throws java.util.concurrent.TimeoutException {
     Preconditions.checkState(isPartitionProvided,
         "Cannot fetch partition offset. StreamMetadataProvider created without partition information");
@@ -204,7 +211,7 @@ public class KafkaStreamMetadataProvider extends KafkaConnectionHandler implemen
           LOGGER.warn("Fetched offset of 0 for topic {} and partition {}, is this a newly created topic?", _topic,
               _partition);
         }
-        return offset;
+        return new LongMsgOffset(offset);
       } else if (errorCode == Errors.LEADER_NOT_AVAILABLE.code()) {
         // If there is no leader, it'll take some time for a new leader to be elected, wait 100 ms before retrying
         Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/SimpleConsumerMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/SimpleConsumerMessageBatch.java
@@ -20,7 +20,9 @@ package org.apache.pinot.plugin.stream.kafka09;
 
 import java.util.ArrayList;
 import kafka.message.MessageAndOffset;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
 public class SimpleConsumerMessageBatch implements MessageBatch<byte[]> {
@@ -49,7 +51,7 @@ public class SimpleConsumerMessageBatch implements MessageBatch<byte[]> {
     return messageList.get(index).message().payloadSize();
   }
 
-  public long getNextStreamMessageOffsetAtIndex(int index) {
-    return messageList.get(index).nextOffset();
+  public StreamPartitionMsgOffset getNextStreamMessageOffsetAtIndex(int index) {
+    return new LongMsgOffset(messageList.get(index).nextOffset());
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/test/java/org/apache/pinot/plugin/stream/kafka09/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/test/java/org/apache/pinot/plugin/stream/kafka09/KafkaPartitionLevelConsumerTest.java
@@ -38,6 +38,7 @@ import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.Message;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.Assert;
@@ -243,7 +244,7 @@ public class KafkaPartitionLevelConsumerTest {
     // test default value
     KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer =
         new KafkaPartitionLevelConsumer(clientId, streamConfig, 0, mockKafkaSimpleConsumerFactory);
-    kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
+    kafkaSimpleStreamConsumer.fetchMessages(new LongMsgOffset(12345L), new LongMsgOffset(23456L), 10000);
 
     Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT,
         kafkaSimpleStreamConsumer.getSimpleConsumer().bufferSize());
@@ -260,7 +261,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
     kafkaSimpleStreamConsumer =
         new KafkaPartitionLevelConsumer(clientId, streamConfig, 0, mockKafkaSimpleConsumerFactory);
-    kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
+    kafkaSimpleStreamConsumer.fetchMessages(new LongMsgOffset(12345L), new LongMsgOffset(23456L), 10000);
     Assert.assertEquals(100, kafkaSimpleStreamConsumer.getSimpleConsumer().bufferSize());
     Assert.assertEquals(1000, kafkaSimpleStreamConsumer.getSimpleConsumer().soTimeout());
   }
@@ -320,7 +321,7 @@ public class KafkaPartitionLevelConsumerTest {
     int partition = 0;
     KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer =
         new KafkaPartitionLevelConsumer(clientId, streamConfig, partition, mockKafkaSimpleConsumerFactory);
-    kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
+    kafkaSimpleStreamConsumer.fetchMessages(new LongMsgOffset(12345L), new LongMsgOffset(23456L), 10000);
   }
 
   @Test(enabled = false)
@@ -351,6 +352,6 @@ public class KafkaPartitionLevelConsumerTest {
     KafkaStreamMetadataProvider kafkaStreamMetadataProvider =
         new KafkaStreamMetadataProvider(clientId, streamConfig, partition, mockKafkaSimpleConsumerFactory);
     kafkaStreamMetadataProvider
-        .fetchPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetSmallest(), 10000);
+        .fetchStreamPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetSmallest(), 10000);
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -23,7 +23,9 @@ import java.util.List;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.pinot.plugin.stream.kafka.MessageAndOffset;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
 public class KafkaMessageBatch implements MessageBatch<byte[]> {
@@ -57,7 +59,7 @@ public class KafkaMessageBatch implements MessageBatch<byte[]> {
   }
 
   @Override
-  public long getNextStreamMessageOffsetAtIndex(int index) {
-    return messageList.get(index).getNextOffset();
+  public StreamPartitionMsgOffset getNextStreamMessageOffsetAtIndex(int index) {
+    return new LongMsgOffset(messageList.get(index).getNextOffset());
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -26,9 +26,11 @@ import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
 import org.apache.pinot.spi.stream.PartitionLevelConsumer;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +43,14 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
   }
 
   @Override
+  public MessageBatch fetchMessages(StreamPartitionMsgOffset startMsgOffset, StreamPartitionMsgOffset endMsgOffset,
+      int timeoutMillis)
+      throws TimeoutException {
+    final long startOffset = ((LongMsgOffset)startMsgOffset).getOffset();
+    final long endOffset = endMsgOffset == null ? Long.MAX_VALUE : ((LongMsgOffset)endMsgOffset).getOffset();
+    return fetchMessages(startOffset, endOffset, timeoutMillis);
+  }
+
   public MessageBatch fetchMessages(long startOffset, long endOffset, int timeoutMillis)
       throws TimeoutException {
     _consumer.seek(_topicPartition, startOffset);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.plugin.stream.kafka20.utils.MiniKafkaCluster;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionLevelConsumer;
@@ -124,7 +125,7 @@ public class KafkaPartitionLevelConsumerTest {
     // test default value
     KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer =
         new KafkaPartitionLevelConsumer(clientId, streamConfig, 0);
-    kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
+    kafkaSimpleStreamConsumer.fetchMessages(new LongMsgOffset(12345L), new LongMsgOffset(23456L), 10000);
 
     Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT,
         kafkaSimpleStreamConsumer.getKafkaPartitionLevelStreamConfig().getKafkaBufferSize());
@@ -142,7 +143,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.socket.timeout", "1000");
     streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
     kafkaSimpleStreamConsumer = new KafkaPartitionLevelConsumer(clientId, streamConfig, 0);
-    kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
+    kafkaSimpleStreamConsumer.fetchMessages(new LongMsgOffset(12345L), new LongMsgOffset(23456L), 10000);
     Assert.assertEquals(100, kafkaSimpleStreamConsumer.getKafkaPartitionLevelStreamConfig().getKafkaBufferSize());
     Assert.assertEquals(1000, kafkaSimpleStreamConsumer.getKafkaPartitionLevelStreamConfig().getKafkaSocketTimeout());
   }
@@ -203,7 +204,7 @@ public class KafkaPartitionLevelConsumerTest {
     int partition = 0;
     KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer =
         new KafkaPartitionLevelConsumer(clientId, streamConfig, partition);
-    kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
+    kafkaSimpleStreamConsumer.fetchMessages(new LongMsgOffset(12345L), new LongMsgOffset(23456L), 10000);
   }
 
   @Test
@@ -235,10 +236,12 @@ public class KafkaPartitionLevelConsumerTest {
     for (int partition = 0; partition < numPartitions; partition++) {
       KafkaStreamMetadataProvider kafkaStreamMetadataProvider =
           new KafkaStreamMetadataProvider(clientId, streamConfig, partition);
-      Assert.assertEquals(0, kafkaStreamMetadataProvider
-          .fetchPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetSmallest(), 10000));
-      Assert.assertEquals(NUM_MSG_PRODUCED_PER_PARTITION, kafkaStreamMetadataProvider
-          .fetchPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetLargest(), 10000));
+      Assert.assertEquals(new LongMsgOffset(0).compareTo(kafkaStreamMetadataProvider
+          .fetchStreamPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetSmallest(), 10000)),
+          0);
+      Assert.assertEquals(new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION).compareTo(kafkaStreamMetadataProvider
+          .fetchStreamPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetLargest(), 10000)),
+          0);
     }
   }
 
@@ -273,21 +276,24 @@ public class KafkaPartitionLevelConsumerTest {
       final PartitionLevelConsumer consumer = streamConsumerFactory.createPartitionLevelConsumer(clientId, partition);
 
       // Test consume a large batch, only 500 records will be returned.
-      final MessageBatch batch1 = consumer.fetchMessages(0, NUM_MSG_PRODUCED_PER_PARTITION, 10000);
+      final MessageBatch batch1 = consumer.fetchMessages(new LongMsgOffset(0),
+          new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION), 10000);
       Assert.assertEquals(batch1.getMessageCount(), 500);
       for (int i = 0; i < batch1.getMessageCount(); i++) {
         final byte[] msg = (byte[]) batch1.getMessageAtIndex(i);
         Assert.assertEquals(new String(msg), "sample_msg_" + i);
       }
       // Test second half batch
-      final MessageBatch batch2 = consumer.fetchMessages(500, NUM_MSG_PRODUCED_PER_PARTITION, 10000);
+      final MessageBatch batch2 = consumer.fetchMessages(new LongMsgOffset(500),
+          new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION), 10000);
       Assert.assertEquals(batch2.getMessageCount(), 500);
       for (int i = 0; i < batch2.getMessageCount(); i++) {
         final byte[] msg = (byte[]) batch2.getMessageAtIndex(i);
         Assert.assertEquals(new String(msg), "sample_msg_" + (500 + i));
       }
       // Some random range
-      final MessageBatch batch3 = consumer.fetchMessages(10, 35, 10000);
+      final MessageBatch batch3 = consumer.fetchMessages(new LongMsgOffset(10),
+          new LongMsgOffset(35), 10000);
       Assert.assertEquals(batch3.getMessageCount(), 25);
       for (int i = 0; i < batch3.getMessageCount(); i++) {
         final byte[] msg = (byte[]) batch3.getMessageAtIndex(i);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/LongMsgOffsetFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/LongMsgOffsetFactory.java
@@ -32,14 +32,4 @@ public class LongMsgOffsetFactory implements StreamPartitionMsgOffsetFactory {
   public StreamPartitionMsgOffset create(StreamPartitionMsgOffset other) {
     return new LongMsgOffset(other);
   }
-
-  @Override
-  public StreamPartitionMsgOffset createMaxOffset() {
-    return new LongMsgOffset(Long.MAX_VALUE);
-  }
-
-  @Override
-  public StreamPartitionMsgOffset createMinOffset() {
-    return new LongMsgOffset(-1L);
-  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
@@ -70,5 +70,5 @@ public interface MessageBatch<T> {
    * @param index
    * @return
    */
-  long getNextStreamMessageOffsetAtIndex(int index);
+  StreamPartitionMsgOffset getNextStreamMessageOffsetAtIndex(int index);
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionOffsetFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionOffsetFetcher.java
@@ -36,7 +36,7 @@ public class PartitionOffsetFetcher implements Callable<Boolean> {
   private final int _partitionId;
 
   private Exception _exception = null;
-  private long _offset = -1;
+  private StreamPartitionMsgOffset _offset;
   private StreamConsumerFactory _streamConsumerFactory;
   StreamConfig _streamConfig;
 
@@ -48,7 +48,7 @@ public class PartitionOffsetFetcher implements Callable<Boolean> {
     _topicName = streamConfig.getTopicName();
   }
 
-  public long getOffset() {
+  public StreamPartitionMsgOffset getOffset() {
     return _offset;
   }
 
@@ -68,7 +68,7 @@ public class PartitionOffsetFetcher implements Callable<Boolean> {
     try (StreamMetadataProvider streamMetadataProvider = _streamConsumerFactory
         .createPartitionMetadataProvider(clientId, _partitionId)) {
       _offset =
-          streamMetadataProvider.fetchPartitionOffset(_offsetCriteria, STREAM_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS);
+          streamMetadataProvider.fetchStreamPartitionOffset(_offsetCriteria, STREAM_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS);
       if (_exception != null) {
         LOGGER.info("Successfully retrieved offset({}) for stream topic {} partition {}", _offset, _topicName,
             _partitionId);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -37,6 +37,10 @@ public interface StreamMetadataProvider extends Closeable {
    */
   int fetchPartitionCount(long timeoutMillis);
 
+  // Issue 5953 Retain this interface for 0.5.0, remove in 0.6.0
+  @Deprecated
+  long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
+      throws java.util.concurrent.TimeoutException;
   /**
    * Fetches the offset for a given partition and offset criteria
    * @param offsetCriteria
@@ -44,6 +48,6 @@ public interface StreamMetadataProvider extends Closeable {
    * @return
    * @throws java.util.concurrent.TimeoutException
    */
-  long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
+  StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
       throws java.util.concurrent.TimeoutException;
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffset.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffset.java
@@ -21,21 +21,36 @@ package org.apache.pinot.spi.stream;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 
 /**
- * This is a class for now (so we can make one round of changes to the code)
- * It will evolve to an interface later with different implementations for the
- * streams. Each stream needs to provide its own serde of an offset.
+ * An interface to be implemented by streams consumed using Pinot LLC consumers.
+ * Pinot expects a stream partition to be a queue of messages. Each time a message
+ * is appended to the queue, the offset of that message should be higher than all
+ * the previous messages appended to the queue. Messages will be retrieved (by Pinot)
+ * in the order in which they were appended to the queue.
  *
- * For now, we will take toString as a serializer.
- * Must be thread-safe for multiple readers and one writer. Readers could get the offset
- * and the writer can update it.
+ * This object represents a direct reference to a message within a stream partition.
+ *
+ * The behavior of the {@link #compareTo(Object other)} method when comparing offsets
+ * across partitions is undefined. Pinot will not invoke this method to compare offsets
+ * across stream partitions
+ *
+ * It is useful to note that these comparators and serialization methods should not change
+ * across versions of the stream implementation. Pinot stores serialized version of
+ * the offset in metadata. Also, Pinot may consume a message delivered by earlier (or later)
+ * versions of the stream implementation
  */
 @InterfaceStability.Evolving
 public interface StreamPartitionMsgOffset extends Comparable {
 
+  /**
+   * Compare this offset with another one.
+   *
+   * @param other
+   * @return
+   */
   int compareTo(Object other);
 
   /**
-   *  A serialized representation of the offset object as a String
+   *  A serialized representation of the offset object as a String.
    * @return
    */
   String toString();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffsetFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffsetFactory.java
@@ -22,16 +22,28 @@ import org.apache.pinot.spi.annotations.InterfaceStability;
 
 
 /**
- * An interface to be implemented by streams if the offset of message in a stream partition
- * is NOT a Long (or int) type.
- * TODO Document the methods after finalizing the interface (Issue 5359)
- * TODO Try to avoid createMaxOffset and createMinOffset methods. (Issue 5359)
+ * An interface to be implemented by streams that are consumed using Pinot LLC consumption.
  */
 @InterfaceStability.Evolving
 public interface StreamPartitionMsgOffsetFactory {
+  /**
+   * Initialization, called once when the factory is created.
+   * @param streamConfig
+   */
   void init(StreamConfig streamConfig);
+
+  /**
+   * Construct an offset from the string provided.
+   * @param offsetStr
+   * @return StreamPartitionMsgOffset
+   */
   StreamPartitionMsgOffset create(String offsetStr);
+
+  /**
+   * Construct an offset from another one provided, of the same type.
+   *
+   * @param other
+   * @return
+   */
   StreamPartitionMsgOffset create(StreamPartitionMsgOffset other);
-  StreamPartitionMsgOffset createMaxOffset(); // Create an offset that compares highest with all others
-  StreamPartitionMsgOffset createMinOffset(); // Create an offset that compares lowest with all others
 }


### PR DESCRIPTION
Changed the interface exposed by streams to return StreamPartitionMsgOffset
instead of long.

Also changed the LLCRealtimeSegmentZKMetadat class to return String instead
of long offsets, since it is stored as a String anyway. Luckily zk metadata does
not generate java objects from json automatically (instead, parses the
fields one by one via custom code).

The segment endOffset can now be null in LLCRealtimeSegmentZKMetadata. For
backward compatibility, we store Long.toSring(Long.MAX_VALUE) in zookeeper
so that readers of the metadata do not get NPE if they are still running old
version. We will remove this workaround after we release 0.5.0

The segment completion protocol for realtime LLC segment completion will
continue to use both 'offset' and 'streamPartitionOffset' elements for
one more release, and will move to use the latter completely in 0.6.0

Interfaces PartitionLevelConsumer and StreamMetadataProvider (marked STABLE)
are now deprecating the calls that use long offsets. Instead, new calls have
been added that use StreamPartitionMsgOffset. Kafka Plugins have been updated
to use the new calls, but the old methods are preserved to make sure that any
other Kafka implementations have time to move over. These calls will be removed
in 0.6.0

The metric to show the highest offset consumed has disappeared.

Testing done:
Manually verified that LLCRealtimeClusterIntegrationTest completes segments correctly with
old server and new controller as well as with new server and old controller, using
command line starter for controller and server to start a component at a specific
revision after 0.4.0 release.

Issue #5359 

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
