### PR TITLE
Added configurable http listeners for controller API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -20,9 +20,13 @@ package org.apache.pinot.controller;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
+import java.util.stream.Collectors;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -30,21 +34,18 @@ import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.pinot.common.utils.CommonConstants.Controller.CONFIG_OF_CONTROLLER_METRICS_PREFIX;
 import static org.apache.pinot.common.utils.CommonConstants.Controller.DEFAULT_METRICS_PREFIX;
 
 
 public class ControllerConf extends PropertiesConfiguration {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ControllerConf.class);
-
   private static final String CONTROLLER_VIP_HOST = "controller.vip.host";
   private static final String CONTROLLER_VIP_PORT = "controller.vip.port";
   private static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
   private static final String CONTROLLER_HOST = "controller.host";
   private static final String CONTROLLER_PORT = "controller.port";
+  private static final String CONTROLLER_ACCESS_PROTOCOLS = "controller.access.protocols";
   private static final String DATA_DIR = "controller.data.dir";
   // Potentially same as data dir if local
   private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
@@ -283,6 +284,23 @@ public class ControllerConf extends PropertiesConfiguration {
     return (String) getProperty(CONTROLLER_PORT);
   }
 
+  public List<String> getControllerAccessProtocols() {
+    return Optional.ofNullable(getStringArray(CONTROLLER_ACCESS_PROTOCOLS))
+
+        .map(protocols -> Arrays.stream(protocols).collect(Collectors.toList()))
+
+        // http will be defaulted only if the legacy controller.port property is not defined.
+        .orElseGet(() -> getControllerPort() == null ? Arrays.asList("http") : Arrays.asList());
+  }
+
+  public String getControllerAccessProtocolProperty(String protocol, String property) {
+    return getString(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property);
+  }
+
+  public String getControllerAccessProtocolProperty(String protocol, String property, String defaultValue) {
+    return getString(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property, defaultValue);
+  }
+
   public String getDataDir() {
     return (String) getProperty(DATA_DIR);
   }
@@ -346,7 +364,22 @@ public class ControllerConf extends PropertiesConfiguration {
     if (containsKey(CONTROLLER_VIP_PORT) && ((String) getProperty(CONTROLLER_VIP_PORT)).length() > 0) {
       return (String) getProperty(CONTROLLER_VIP_PORT);
     }
-    return getControllerPort();
+
+    // Vip port is not explicitly defined. Initiate discovery from the configured protocols.
+    return getControllerAccessProtocols().stream()
+
+        .filter(protocol -> Boolean.parseBoolean(getControllerAccessProtocolProperty(protocol, "vip", "false")))
+
+        .map(protocol -> Optional.ofNullable(getControllerAccessProtocolProperty(protocol, "port")))
+
+        .filter(Optional::isPresent)
+
+        .map(Optional::get)
+
+        .findFirst()
+
+        // No protocol defines a port as VIP. Fallback on legacy controller.port property.
+        .orElseGet(this::getControllerPort);
   }
 
   public String getControllerVipProtocol() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/listeners/ListenerConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/listeners/ListenerConfig.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.listeners;
+
+/**
+ * Provides configuration settings expected by an Http Server to 
+ * setup listeners for http and https protocols.
+ */
+public class ListenerConfig {
+  private final String name;
+  private final String host;
+  private final int port;
+  private final String protocol;
+  private final TlsConfiguration tlsConfiguration;
+
+  public ListenerConfig(String name, String host, int port, String protocol, TlsConfiguration tlsConfiguration) {
+    this.name = name;
+    this.host = host;
+    this.port = port;
+    this.protocol = protocol;
+    this.tlsConfiguration = tlsConfiguration;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getProtocol() {
+    return protocol;
+  }
+
+  public TlsConfiguration getTlsConfiguration() {
+    return tlsConfiguration;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/listeners/TlsConfiguration.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/listeners/TlsConfiguration.java
@@ -1,0 +1,63 @@
+package org.apache.pinot.controller.api.listeners;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Holds TLS configuration settings. Used as a vessel to configure Https Listeners. 
+ * 
+ * @author Daniel Lavoie
+ * @since 0.4.0
+ */
+public class TlsConfiguration {
+  private final String keyStorePath;
+  private final String keyStorePassword;
+  private final String trustStorePath;
+  private final String trustStorePassword;
+  private final boolean requiresClientAuth;
+
+  public TlsConfiguration(String keyStorePath, String keyStorePassword, String trustStorePath,
+      String trustStorePassword, boolean requiresClientAuth) {
+    this.keyStorePath = keyStorePath;
+    this.keyStorePassword = keyStorePassword;
+    this.trustStorePath = trustStorePath;
+    this.trustStorePassword = trustStorePassword;
+    this.requiresClientAuth = requiresClientAuth;
+  }
+
+  public String getKeyStorePath() {
+    return keyStorePath;
+  }
+
+  public String getKeyStorePassword() {
+    return keyStorePassword;
+  }
+
+  public String getTrustStorePath() {
+    return trustStorePath;
+  }
+
+  public String getTrustStorePassword() {
+    return trustStorePassword;
+  }
+
+  public boolean isRequiresClientAuth() {
+    return requiresClientAuth;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ListenerConfigUtil.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ListenerConfigUtil.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.listeners.ListenerConfig;
+import org.apache.pinot.controller.api.listeners.TlsConfiguration;
+
+
+/**
+ * Utility class that generates Http {@link ListenerConfig} instances 
+ * based on the properties provided by {@link ControllerConf}.
+ */
+public abstract class ListenerConfigUtil {
+
+  /**
+   * Generates {@link ListenerConfig} instances based on the compination 
+   * of propperties such as controller.port and controller.access.protocols.
+   * 
+   * @param controllerConf property holders for controller configuration
+   * @return List of {@link ListenerConfig} for which http listeners 
+   * should be created.
+   */
+  public static List<ListenerConfig> buildListenerConfigs(ControllerConf controllerConf) {
+    List<ListenerConfig> listenerConfigs = new ArrayList<>();
+
+    if (controllerConf.getControllerPort() != null) {
+      listenerConfigs.add(
+          new ListenerConfig("http", "0.0.0.0", Integer.valueOf(controllerConf.getControllerPort()), "http", null));
+    }
+
+    listenerConfigs.addAll(controllerConf.getControllerAccessProtocols().stream()
+
+        .map(protocol -> buildListenerConfig(protocol, controllerConf))
+
+        .collect(Collectors.toList()));
+
+    return listenerConfigs;
+  }
+
+  /**
+   * Will determine if the query console should be advertised as http or https.
+   * 
+   * The query console can be advertised as secured with 
+   * {@link ControllerConf#getQueryConsoleUseHttps()} for cases for only http 
+   * listeners are defined by the query console is served by a secured reverse 
+   * proxy.
+   * 
+   * @param listenerConfigs generated listener configs from {@link ListenerConfigUtil#buildListenerConfigs(ControllerConf)}
+   * @param controllerConf property holders for controller configuration
+   * @return whether the query console should be advertised as http or https.
+   */
+  public static boolean shouldAdvertiseAsHttps(List<ListenerConfig> listenerConfigs, ControllerConf controllerConf) {
+    return controllerConf.getQueryConsoleUseHttps() || !listenerConfigs.stream().map(ListenerConfig::getProtocol)
+        .filter(protocol -> protocol.equals("http")).findAny().isPresent();
+  }
+
+  private static Optional<TlsConfiguration> buildTlsConfiguration(String protocol, ControllerConf controllerConf) {
+    return Optional.ofNullable(controllerConf.getControllerAccessProtocolProperty(protocol, "tls.keystore.path"))
+
+        .map(keystore -> buildTlsConfiguration(protocol, keystore, controllerConf));
+  }
+
+  private static TlsConfiguration buildTlsConfiguration(String protocol, String keystore,
+      ControllerConf controllerConf) {
+    return new TlsConfiguration(keystore,
+        controllerConf.getControllerAccessProtocolProperty(protocol, "tls.keystore.password"),
+        controllerConf.getControllerAccessProtocolProperty(protocol, "tls.truststore.path"),
+        controllerConf.getControllerAccessProtocolProperty(protocol, "tls.truststore.password"), Boolean.parseBoolean(
+            controllerConf.getControllerAccessProtocolProperty(protocol, "tls.requires_client_auth", "false")));
+  }
+
+  private static ListenerConfig buildListenerConfig(String protocol, ControllerConf controllerConf) {
+    return new ListenerConfig(protocol,
+        getHost(controllerConf.getControllerAccessProtocolProperty(protocol, "host", "0.0.0.0")),
+        getPort(controllerConf.getControllerAccessProtocolProperty(protocol, "port")), protocol,
+        buildTlsConfiguration(protocol, controllerConf).orElse(null));
+  }
+
+  private static String getHost(String configuredHost) {
+    return Optional.ofNullable(configuredHost).filter(host -> !host.trim().isEmpty())
+        .orElseThrow(() -> new IllegalArgumentException(configuredHost + " is not a valid host"));
+  }
+
+  private static int getPort(String configuredPort) {
+    return Optional.ofNullable(configuredPort).filter(host -> !host.trim().isEmpty()).<Integer> map(Integer::valueOf)
+        .orElseThrow(() -> new IllegalArgumentException(configuredPort + " is not a valid port"));
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
@@ -1,0 +1,226 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.util;
+
+import java.util.List;
+
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.listeners.ListenerConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Asserts that {@link ListenerConfigUtil} will generated expected {@link ListenerConfig} based on the properties provided in {@link ControllerConf}
+ */
+public class ListenerConfigUtilTest {
+  /**
+   * Asserts that the protocol listeners properties are Opt-In and not initialized when nothing but controler.port is used.
+   */
+  @Test
+  public void assertControllerPortConfig() {
+    ControllerConf controllerConf = new ControllerConf();
+
+    controllerConf.setProperty("controller.port", "9000");
+    controllerConf.setProperty("controller.query.console.useHttps", "true");
+
+    List<ListenerConfig> listenerConfigs = ListenerConfigUtil.buildListenerConfigs(controllerConf);
+
+    Assert.assertEquals(listenerConfigs.size(), 1);
+
+    assertLegacyListener(listenerConfigs.get(0));
+
+    Assert.assertTrue(ListenerConfigUtil.shouldAdvertiseAsHttps(listenerConfigs, controllerConf));
+  }
+
+  /**
+   * Asserts that enabling https generates the existing legacy listener as well as the another one configured with TLS settings. 
+   */
+  @Test
+  public void assertLegacyAndHttps() {
+    ControllerConf controllerConf = new ControllerConf();
+
+    controllerConf.setProperty("controller.port", "9000");
+    controllerConf.setProperty("controller.access.protocols", "https");
+
+    configureHttpsProperties(controllerConf, "10.0.0.10", 9443);
+
+    List<ListenerConfig> listenerConfigs = ListenerConfigUtil.buildListenerConfigs(controllerConf);
+
+    Assert.assertEquals(listenerConfigs.size(), 2);
+
+    ListenerConfig legacyListener = getListener("http", listenerConfigs);
+    ListenerConfig httpsListener = getListener("https", listenerConfigs);
+
+    assertLegacyListener(legacyListener);
+    assertHttpsListener(httpsListener, "10.0.0.10", 9443);
+
+    Assert.assertFalse(ListenerConfigUtil.shouldAdvertiseAsHttps(listenerConfigs, controllerConf));
+  }
+
+  /**
+   * Asserts that controller.port can be opt-out and both http and https can be configured with seperate ports.
+   */
+  @Test
+  public void assertHttpAndHttpsConfigs() {
+    ControllerConf controllerConf = new ControllerConf();
+
+    controllerConf.setProperty("controller.access.protocols", "http,https");
+
+    configureHttpsProperties(controllerConf, 9443);
+
+    controllerConf.setProperty("controller.access.protocols.http.port", "9000");
+
+    List<ListenerConfig> listenerConfigs = ListenerConfigUtil.buildListenerConfigs(controllerConf);
+
+    Assert.assertEquals(listenerConfigs.size(), 2);
+
+    ListenerConfig httpListener = getListener("http", listenerConfigs);
+    ListenerConfig httpsListener = getListener("https", listenerConfigs);
+
+    Assert.assertEquals(httpListener.getHost(), "0.0.0.0");
+
+    assertHttpListener(httpListener, "0.0.0.0", 9000);
+    assertHttpsListener(httpsListener, "0.0.0.0", 9443);
+  }
+
+  /**
+   * Asserts that a single listener configuration is generated with a secured TLS port.
+   */
+  @Test
+  public void assertHttpsOnly() {
+    ControllerConf controllerConf = new ControllerConf();
+
+    controllerConf.setProperty("controller.access.protocols", "https");
+
+    configureHttpsProperties(controllerConf, 9443);
+
+    List<ListenerConfig> listenerConfigs = ListenerConfigUtil.buildListenerConfigs(controllerConf);
+
+    Assert.assertEquals(listenerConfigs.size(), 1);
+
+    assertHttpsListener(listenerConfigs.get(0), "0.0.0.0", 9443);
+
+    Assert.assertTrue(ListenerConfigUtil.shouldAdvertiseAsHttps(listenerConfigs, controllerConf));
+  }
+
+  /**
+   * Tests behavior when an invalid host is provided.
+   */
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void assertInvalidHost() {
+    ControllerConf controllerConf = new ControllerConf();
+
+    controllerConf.setProperty("controller.access.protocols", "https");
+
+    configureHttpsProperties(controllerConf, "", 9443);
+
+    ListenerConfigUtil.buildListenerConfigs(controllerConf);
+  }
+
+  /**
+   * Tests behavior when an invalid port is provided
+   */
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void assertInvalidPort() {
+    ControllerConf controllerConf = new ControllerConf();
+
+    controllerConf.setProperty("controller.access.protocols", "https");
+
+    configureHttpsProperties(controllerConf, "", 9443);
+    controllerConf.setProperty("controller.access.protocol.https.port", "10.10");
+
+    ListenerConfigUtil.buildListenerConfigs(controllerConf);
+  }
+
+  /**
+   * Tests behavior when an empty http port is provided.
+   */
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void assertEmptyHttpPort() {
+    ControllerConf controllerConf = new ControllerConf();
+
+    controllerConf.setProperty("controller.access.protocols", "http");
+    controllerConf.setProperty("controller.access.protocols.http.port", "");
+
+    ListenerConfigUtil.buildListenerConfigs(controllerConf);
+  }
+
+  /**
+   * Tests behavior when an empty https port is provided.
+   */
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void assertEmptyHttpsPort() {
+    ControllerConf controllerConf = new ControllerConf();
+
+    controllerConf.setProperty("controller.access.protocols", "https");
+    controllerConf.setProperty("controller.access.protocols.https.port", "");
+
+    ListenerConfigUtil.buildListenerConfigs(controllerConf);
+  }
+
+  private void assertLegacyListener(ListenerConfig legacyListener) {
+    Assert.assertEquals(legacyListener.getName(), "http");
+    Assert.assertEquals(legacyListener.getHost(), "0.0.0.0");
+    Assert.assertEquals(legacyListener.getPort(), 9000);
+    Assert.assertEquals(legacyListener.getProtocol(), "http");
+    Assert.assertNull(legacyListener.getTlsConfiguration());
+  }
+
+  private void assertHttpListener(ListenerConfig httpsListener, String host, int port) {
+    Assert.assertEquals(httpsListener.getName(), "http");
+    Assert.assertEquals(httpsListener.getHost(), host);
+    Assert.assertEquals(httpsListener.getPort(), port);
+    Assert.assertEquals(httpsListener.getProtocol(), "http");
+    Assert.assertNull(httpsListener.getTlsConfiguration());
+  }
+
+  private void assertHttpsListener(ListenerConfig httpsListener, String host, int port) {
+    Assert.assertEquals(httpsListener.getName(), "https");
+    Assert.assertEquals(httpsListener.getHost(), host);
+    Assert.assertEquals(httpsListener.getPort(), port);
+    Assert.assertEquals(httpsListener.getProtocol(), "https");
+    Assert.assertNotNull(httpsListener.getTlsConfiguration());
+    Assert.assertEquals(httpsListener.getTlsConfiguration().getKeyStorePassword(), "a-password");
+    Assert.assertEquals(httpsListener.getTlsConfiguration().getKeyStorePath(), "/some-keystore-path");
+    Assert.assertEquals(httpsListener.getTlsConfiguration().isRequiresClientAuth(), true);
+    Assert.assertEquals(httpsListener.getTlsConfiguration().getTrustStorePassword(), "a-password");
+    Assert.assertEquals(httpsListener.getTlsConfiguration().getTrustStorePath(), "/some-truststore-path");
+  }
+
+  private void configureHttpsProperties(ControllerConf controllerConf, String host, int port) {
+    if (host != null) {
+      controllerConf.setProperty("controller.access.protocols.https.host", host);
+    }
+    controllerConf.setProperty("controller.access.protocols.https.port", String.valueOf(port));
+    controllerConf.setProperty("controller.access.protocols.https.tls.keystore.password", "a-password");
+    controllerConf.setProperty("controller.access.protocols.https.tls.keystore.path", "/some-keystore-path");
+    controllerConf.setProperty("controller.access.protocols.https.tls.requires_client_auth", "true");
+    controllerConf.setProperty("controller.access.protocols.https.tls.truststore.password", "a-password");
+    controllerConf.setProperty("controller.access.protocols.https.tls.truststore.path", "/some-truststore-path");
+  }
+
+  private void configureHttpsProperties(ControllerConf controllerConf, int port) {
+    configureHttpsProperties(controllerConf, null, port);
+  }
+
+  private ListenerConfig getListener(String name, List<ListenerConfig> listenerConfigs) {
+    return listenerConfigs.stream().filter(listenerConfig -> listenerConfig.getName().equals(name)).findFirst().get();
+  }
+}


### PR DESCRIPTION
## Description

Adds support for additional Opt-In protocol listeners for `http` and `https`. See release note section for further details. 

## Upgrade Notes

This PR does not introduce breaking changes. However, if using the new protocols property, it is possible to remove `controller.port`. Keeping `controller.port` during upgrade means an operator can easily rollback in case there is an issue with the new version of Pinot.

## Release Notes

Introduces new properties for `ControllerConf` that allows dynamic configurations for the `HttpServer` listeners. These properties are opt-in and will not impact the existing `controller.port` and `controller.host` properties that are used to establish an helix identify. 

* controller.access.protocols=<comma seperated protocols http/https>
* controller.access.protocols.\<protocol\>.port=9443
* controller.access.protocols.\<protocol\>.host=0.0.0.0
* controller.access.protocols.\<protocol\>.vip=false
* controller.access.protocols.https.tls.keystore.path=some-path
* controller.access.protocols.https.tls.keystore.password=pass
* controller.access.protocols.https.tls.requires_client_auth=false
* controller.access.protocols.https.tls.truststore.path=some-path
* controller.access.protocols.https.tls.truststore.password=pass

Only the 'port' property will be mandatory if a protocol is activated
through `controller.access.protcols`. The `host` property of a defined protocol is intended to restrict the listener hostname to specific entries. This is useful to restrict the protocol usage to certain network adapter or public facing DNS hostname. This design intends for maximum flexibility and will default to `0.0.0.0` if nothing is provided.

The existing 'controller.port property' is still expected by CLI. These
new properties are opt-in and can be activated with legacy
'controller.port' for backward compatibility. If at least one protocol is defined through `controller.access.protcols`, operators have the possibility to not use `controller.port`.

## Documentation

https://github.com/pinot-contrib/pinot-docs/pull/4