### PR TITLE
Add SCALAR type into TransformFunctionType

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -34,7 +34,8 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Registry for in-built Pinot functions
+ * Registry for scalar functions.
+ * <p>TODO: Merge FunctionRegistry and FunctionDefinitionRegistry to provide one single registry for all functions.
  */
 public class FunctionRegistry {
   private FunctionRegistry() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -54,7 +54,10 @@ public enum TransformFunctionType {
   DATETRUNC("dateTrunc"),
   ARRAYLENGTH("arrayLength"),
   VALUEIN("valueIn"),
-  MAPVALUE("mapValue");
+  MAPVALUE("mapValue"),
+
+  // Special type for annotation based scalar functions
+  SCALAR("scalar");
 
   private final String _name;
 
@@ -70,6 +73,9 @@ public enum TransformFunctionType {
     try {
       return TransformFunctionType.valueOf(upperCaseFunctionName);
     } catch (Exception e) {
+      if (FunctionRegistry.getFunctionByName(functionName) != null) {
+        return SCALAR;
+      }
       // Support function name of both jsonExtractScalar and json_extract_scalar
       if (upperCaseFunctionName.contains("_")) {
         return getTransformFunctionType(upperCaseFunctionName.replace("_", ""));

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class FunctionDefinitionRegistryTest {
+
+  @Test
+  public void testScalarFunction() {
+    assertFalse(FunctionDefinitionRegistry.isAggFunc("toEpochSeconds"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("toEpochSeconds"));
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/TransformFunctionTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/TransformFunctionTypeTest.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class TransformFunctionTypeTest {
+
+  @Test
+  public void testScalarFunction() {
+    assertEquals(TransformFunctionType.getTransformFunctionType("toEpochSeconds"), TransformFunctionType.SCALAR);
+  }
+}


### PR DESCRIPTION
## Description
Inside query engine, scalar function is modeled as TransformFunction (ScalarTransformFunctionWrapper)
Add SCALAR type into TransformFunctionType so that FunctionDefinitionRegistry can identify scalar function as transform function