### PR TITLE
[TE][subscription] Bug fix to fix the notification pipeline when detections are disabled

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/StatefulDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/StatefulDetectionAlertFilter.java
@@ -62,7 +62,7 @@ public abstract class StatefulDetectionAlertFilter extends DetectionAlertFilter 
       // Ignore disabled detections
       DetectionConfigDTO detection = DAORegistry.getInstance().getDetectionConfigManager().findById(detectionId);
       if (detection == null || !detection.isActive()) {
-        return allAnomalies;
+        continue;
       }
 
       // No point in fetching anomalies older than MAX_ANOMALY_NOTIFICATION_LOOKBACK


### PR DESCRIPTION
Subscription pipeline has an issue of skipping some anomaly notification when one/more of the subscribed detections are disabled. This PR fixes this bug.