### PR TITLE
Handle case sensitivity for PinotQuery within BrokerRequest

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.broker.helix;
 import com.google.common.collect.ImmutableList;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -188,11 +189,16 @@ public class HelixBrokerStarter implements ServiceStartable {
     ConfigAccessor configAccessor = _spectatorHelixManager.getConfigAccessor();
     HelixConfigScope helixConfigScope =
         new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(_clusterName).build();
-    String enableCaseInsensitivePql = configAccessor.get(helixConfigScope, Helix.ENABLE_CASE_INSENSITIVE_PQL_KEY);
-    _brokerConf.setProperty(Helix.ENABLE_CASE_INSENSITIVE_PQL_KEY, Boolean.valueOf(enableCaseInsensitivePql));
-    String enableQueryLimitOverride =
-        configAccessor.get(helixConfigScope, Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE);
-    _brokerConf.setProperty(Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, Boolean.valueOf(enableQueryLimitOverride));
+    Map<String, String> configMap = configAccessor.get(helixConfigScope, Arrays
+        .asList(Helix.ENABLE_CASE_INSENSITIVE_KEY, Helix.DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY,
+            Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE));
+    if (Boolean.parseBoolean(configMap.get(Helix.ENABLE_CASE_INSENSITIVE_KEY)) || Boolean
+        .parseBoolean(configMap.get(Helix.DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY))) {
+      _brokerConf.setProperty(Helix.ENABLE_CASE_INSENSITIVE_KEY, true);
+    }
+    if (Boolean.parseBoolean(configMap.get(Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE))) {
+      _brokerConf.setProperty(Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, true);
+    }
 
     LOGGER.info("Setting up broker request handler");
     // Set up metric registry and broker metrics

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -40,7 +40,9 @@ public class CommonConstants {
     public static final String LEAD_CONTROLLER_RESOURCE_NAME = "leadControllerResource";
 
     public static final String LEAD_CONTROLLER_RESOURCE_ENABLED_KEY = "RESOURCE_ENABLED";
-    public static final String ENABLE_CASE_INSENSITIVE_PQL_KEY = "enable.case.insensitive.pql";
+
+    public static final String ENABLE_CASE_INSENSITIVE_KEY = "enable.case.insensitive";
+    public static final String DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY = "enable.case.insensitive.pql";
 
     // More information on why these numbers are set can be found in the following doc:
     // https://cwiki.apache.org/confluence/display/PINOT/Controller+Separation+between+Helix+and+Pinot

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -19,7 +19,8 @@
 package org.apache.pinot.controller.helix.core.util;
 
 import com.google.common.base.Preconditions;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
@@ -74,9 +75,11 @@ public class HelixSetupUtils {
       // Enable Auto-Join for the cluster
       HelixConfigScope configScope =
           new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(helixClusterName).build();
-      admin.setConfig(configScope, Collections.singletonMap(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true"));
-      admin.setConfig(configScope, Collections.singletonMap(ENABLE_CASE_INSENSITIVE_PQL_KEY, Boolean.FALSE.toString()));
-      admin.setConfig(configScope, Collections.singletonMap(CommonConstants.Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, Boolean.FALSE.toString()));
+      Map<String, String> configMap = new HashMap<>();
+      configMap.put(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, Boolean.toString(true));
+      configMap.put(ENABLE_CASE_INSENSITIVE_KEY, Boolean.toString(false));
+      configMap.put(CommonConstants.Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, Boolean.toString(false));
+      admin.setConfig(configScope, configMap);
       LOGGER.info("New Helix cluster: {} created", helixClusterName);
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -184,7 +184,7 @@ public abstract class ControllerTest {
         break;
     }
     //enable case insensitive pql for test cases.
-    configAccessor.set(scope, CommonConstants.Helix.ENABLE_CASE_INSENSITIVE_PQL_KEY, Boolean.TRUE.toString());
+    configAccessor.set(scope, CommonConstants.Helix.ENABLE_CASE_INSENSITIVE_KEY, Boolean.toString(true));
   }
 
   protected ControllerStarter getControllerStarter(ControllerConf config) {


### PR DESCRIPTION
## Description
Currently the case sensitivity handling only applies to the BrokerRequest, but not to the PinotQuery inside the BrokerRequest.
This will cause inconsistent and unexpected behavior when the query engine uses PinotQuery.

Fix this issue by extending the case sensitivity handling to the PinotQuery if it exists.
Note that because SQL queries are also compiled to BrokerRequest, the case sensitivity handling already applies to both PQL and SQL.

Deprecate the config key `enable.case.insensitive.pql` in Helix cluster config and replace it with `enable.case.insensitive`, but keep backward compatibility.

## Upgrade Notes
Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
Config key `enable.case.insensitive.pql` in Helix cluster config is deprecated, and replaced with `enable.case.insensitive`.