### PR TITLE
Update year in NOTICE-binary

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache Pinot (incubating)
-Copyright 2018 The Apache Software Foundation
+Copyright 2018 and onwards The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
## Description
Update year in NOTICE-binary

Ref: https://github.com/apache/spark/blob/master/NOTICE-binary

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
N/A

## Documentation
N/A
