### PR TITLE
Fixed backward incompatibility for existing stream implementations

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -66,7 +66,6 @@ import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.MessageBatch;
 import org.apache.pinot.spi.stream.PartitionLevelConsumer;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
@@ -506,7 +505,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
                 realtimeRowsDroppedMeter);
       }
 
-      _currentOffset = messagesAndOffsets.getNextStreamMessageOffsetAtIndex(index);
+      _currentOffset = messagesAndOffsets.getNextStreamParitionMsgOffsetAtIndex(index);
       _numRowsIndexed = _realtimeSegment.getNumDocsIndexed();
       _numRowsConsumed++;
       streamMessageCount++;

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMessageBatch.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMessageBatch.java
@@ -52,7 +52,11 @@ public class FakeStreamMessageBatch implements MessageBatch<byte[]> {
     return _messageBytes.get(index).length;
   }
 
-  public StreamPartitionMsgOffset getNextStreamMessageOffsetAtIndex(int index) {
+  public long getNextStreamMessageOffsetAtIndex(int index) {
+    throw new UnsupportedOperationException("This method is deprecated");
+  }
+
+  public StreamPartitionMsgOffset getNextStreamParitionMsgOffsetAtIndex(int index) {
     return new LongMsgOffset(_messageOffsets.get(index) + 1);
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/SimpleConsumerMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/SimpleConsumerMessageBatch.java
@@ -51,7 +51,12 @@ public class SimpleConsumerMessageBatch implements MessageBatch<byte[]> {
     return messageList.get(index).message().payloadSize();
   }
 
-  public StreamPartitionMsgOffset getNextStreamMessageOffsetAtIndex(int index) {
+  @Override
+  public long getNextStreamMessageOffsetAtIndex(int index) {
+    throw new UnsupportedOperationException("This method is deprecated");
+  }
+
+  public StreamPartitionMsgOffset getNextStreamParitionMsgOffsetAtIndex(int index) {
     return new LongMsgOffset(messageList.get(index).nextOffset());
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -59,7 +59,12 @@ public class KafkaMessageBatch implements MessageBatch<byte[]> {
   }
 
   @Override
-  public StreamPartitionMsgOffset getNextStreamMessageOffsetAtIndex(int index) {
+  public long getNextStreamMessageOffsetAtIndex(int index) {
+    throw new UnsupportedOperationException("This method is deprecated");
+  }
+
+  @Override
+  public StreamPartitionMsgOffset getNextStreamParitionMsgOffsetAtIndex(int index) {
     return new LongMsgOffset(messageList.get(index).getNextOffset());
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
@@ -70,5 +70,15 @@ public interface MessageBatch<T> {
    * @param index
    * @return
    */
-  StreamPartitionMsgOffset getNextStreamMessageOffsetAtIndex(int index);
+  @Deprecated
+  long getNextStreamMessageOffsetAtIndex(int index);
+
+  /**
+   * Returns the offset of the next message.
+   * @param index
+   * @return
+   */
+  default StreamPartitionMsgOffset getNextStreamParitionMsgOffsetAtIndex(int index) {
+    return new LongMsgOffset(getNextStreamMessageOffsetAtIndex(index));
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -48,6 +48,9 @@ public interface StreamMetadataProvider extends Closeable {
    * @return
    * @throws java.util.concurrent.TimeoutException
    */
-  StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
-      throws java.util.concurrent.TimeoutException;
+  default StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
+      throws java.util.concurrent.TimeoutException {
+    long offset = fetchPartitionOffset(offsetCriteria, timeoutMillis);
+    return new LongMsgOffset(offset);
+  }
 }


### PR DESCRIPTION
PR #5542 introduced incompatibility in the interfaces for existing
stream implementations (like eventhub or other kafka implementations)
Added default implementations so that the other streams can still
compile with pinot.

Issue #5359 
## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
