### PR TITLE
Fix backward incompatibility in StreamFactoryConsumerProvider

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -508,7 +508,8 @@ public class PinotLLCRealtimeSegmentManager {
       int numPartitions, int numReplicas) {
     String realtimeTableName = tableConfig.getTableName();
     String segmentName = newLLCSegmentName.getSegmentName();
-    StreamPartitionMsgOffsetFactory offsetFactory = StreamConsumerFactoryProvider.createOffsetFactory(streamConfig);
+    StreamPartitionMsgOffsetFactory offsetFactory =
+        StreamConsumerFactoryProvider.create(streamConfig).createStreamMsgOffsetFactory();
     StreamPartitionMsgOffset startOffset = offsetFactory.create(committingSegmentDescriptor.getNextOffset());
     LOGGER
         .info("Creating segment ZK metadata for new CONSUMING segment: {} with start offset: {} and creation time: {}",
@@ -830,7 +831,8 @@ public class PinotLLCRealtimeSegmentManager {
 
     Map<String, Map<String, String>> instanceStatesMap = idealState.getRecord().getMapFields();
     long currentTimeMs = getCurrentTimeMs();
-    StreamPartitionMsgOffsetFactory offsetFactory = StreamConsumerFactoryProvider.createOffsetFactory(streamConfig);
+    StreamPartitionMsgOffsetFactory offsetFactory =
+        StreamConsumerFactoryProvider.create(streamConfig).createStreamMsgOffsetFactory();
 
     // Get the latest segment ZK metadata for each partition
     Map<Integer, LLCRealtimeSegmentZKMetadata> latestSegmentZKMetadataMap =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -124,7 +124,7 @@ public class SegmentCompletionManager {
     TableConfig tableConfig = _segmentManager.getTableConfig(TableNameBuilder.REALTIME.tableNameWithType(rawTableName));
     PartitionLevelStreamConfig streamConfig =
         new PartitionLevelStreamConfig(tableConfig.getTableName(), tableConfig.getIndexingConfig().getStreamConfigs());
-    return StreamConsumerFactoryProvider.createOffsetFactory(streamConfig);
+    return StreamConsumerFactoryProvider.create(streamConfig).createStreamMsgOffsetFactory();
   }
 
   // We need to make sure that we never create multiple FSMs for the same segment

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -167,7 +167,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       _resourceTmpDir.mkdirs();
     }
     // create and init stream level consumer
-    StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(_streamConfig);
+    StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
     String clientId = HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getTopicName();
     _streamLevelConsumer = streamConsumerFactory
         .createStreamLevelConsumer(clientId, _tableNameWithType, SchemaUtils.extractSourceFields(schema),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1106,8 +1106,9 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // TODO Validate configs
     IndexingConfig indexingConfig = _tableConfig.getIndexingConfig();
     _partitionLevelStreamConfig = new PartitionLevelStreamConfig(_tableNameWithType, indexingConfig.getStreamConfigs());
-    _streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(_partitionLevelStreamConfig);
-    _streamPartitionMsgOffsetFactory = StreamConsumerFactoryProvider.createOffsetFactory(_partitionLevelStreamConfig);
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_partitionLevelStreamConfig);
+    _streamPartitionMsgOffsetFactory =
+        StreamConsumerFactoryProvider.create(_partitionLevelStreamConfig).createStreamMsgOffsetFactory();
     _streamTopic = _partitionLevelStreamConfig.getTopicName();
     _segmentNameStr = _segmentZKMetadata.getSegmentName();
     _llcSegmentName = llcSegmentName;

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
@@ -74,7 +74,7 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
     StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs(numPartitions);
 
     // stream consumer factory
-    StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(streamConfig);
+    StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
 
     // stream metadata provider
     StreamMetadataProvider streamMetadataProvider = streamConsumerFactory.createStreamMetadataProvider(clientId);

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
@@ -125,8 +125,6 @@ public class StreamConfigTest {
     Assert.assertFalse(exception);
     Assert.assertEquals(streamConfig.getConsumerFactoryClassName(),
         StreamConfig.DEFAULT_CONSUMER_FACTORY_CLASS_NAME_STRING);
-    Assert.assertEquals(streamConfig.getPartitionOffsetFactoryClassName(),
-        StreamConfig.DEFAULT_PARTITION_OFFSET_FACTORY_CLASS_NAME_STRING);
 
     // Missing decoder class
     streamConfigMap.put(StreamConfigProperties

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
@@ -269,7 +269,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
     StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
-    final StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(streamConfig);
+    final StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
     int numPartitions =
         new KafkaStreamMetadataProvider(clientId, streamConfig).fetchPartitionCount(10000);
     for (int partition = 0; partition < numPartitions; partition++) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionCountFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionCountFetcher.java
@@ -38,7 +38,7 @@ public class PartitionCountFetcher implements Callable<Boolean> {
 
   public PartitionCountFetcher(StreamConfig streamConfig) {
     _streamConfig = streamConfig;
-    _streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(_streamConfig);
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
     _topicName = streamConfig.getTopicName();
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionOffsetFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionOffsetFetcher.java
@@ -44,7 +44,7 @@ public class PartitionOffsetFetcher implements Callable<Boolean> {
     _offsetCriteria = offsetCriteria;
     _partitionId = partitionId;
     _streamConfig = streamConfig;
-    _streamConsumerFactory = StreamConsumerFactoryProvider.createConsumerFactory(streamConfig);
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
     _topicName = streamConfig.getTopicName();
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -51,7 +51,6 @@ public class StreamConfig {
 
   public static final String DEFAULT_CONSUMER_FACTORY_CLASS_NAME_STRING =
       "org.apache.pinot.plugin.stream.kafka09.KafkaConsumerFactory";
-  public static final String DEFAULT_PARTITION_OFFSET_FACTORY_CLASS_NAME_STRING = LongMsgOffsetFactory.class.getName();
 
   public static final long DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS = 30_000;
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;
@@ -66,7 +65,6 @@ public class StreamConfig {
   private final OffsetCriteria _offsetCriteria;
   private final String _decoderClass;
   private final Map<String, String> _decoderProperties = new HashMap<>();
-  private final String _partitionOffsetFactoryClassName;
 
   private final long _connectionTimeoutMillis;
   private final int _fetchTimeoutMillis;
@@ -120,12 +118,6 @@ public class StreamConfig {
     } else {
       _offsetCriteria = new OffsetCriteria.OffsetCriteriaBuilder().withOffsetLargest();
     }
-
-    String partitionOffsetClassKey = StreamConfigProperties.constructStreamProperty(_type,
-        StreamConfigProperties.PARTITION_MSG_OFFSET_FACTORY_CLASS);
-    // For backward compatibility, the offset factory class is for handling kafka offsets (long type)
-    _partitionOffsetFactoryClassName = streamConfigMap.getOrDefault(partitionOffsetClassKey,
-        DEFAULT_PARTITION_OFFSET_FACTORY_CLASS_NAME_STRING);
 
     String decoderClassKey =
         StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.STREAM_DECODER_CLASS);
@@ -267,10 +259,6 @@ public class StreamConfig {
 
   public String getConsumerFactoryClassName() {
     return _consumerFactoryClassName;
-  }
-
-  public String getPartitionOffsetFactoryClassName() {
-    return _partitionOffsetFactoryClassName;
   }
 
   public OffsetCriteria getOffsetCriteria() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactory.java
@@ -69,4 +69,8 @@ public abstract class StreamConsumerFactory {
    * @return
    */
   public abstract StreamMetadataProvider createStreamMetadataProvider(String clientId);
+
+  public StreamPartitionMsgOffsetFactory createStreamMsgOffsetFactory() {
+    return new LongMsgOffsetFactory();
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactoryProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactoryProvider.java
@@ -25,6 +25,14 @@ import org.apache.pinot.spi.plugin.PluginManager;
  * Provider class for {@link StreamConsumerFactory}
  */
 public abstract class StreamConsumerFactoryProvider {
+  /**
+   * This method is here for backward compatibility with older stream implementations
+   * that support 'long' type offsets.
+   */
+  @Deprecated
+  public static StreamConsumerFactory create(StreamConfig streamConfig) {
+    return createConsumerFactory(streamConfig);
+  }
 
   /**
    * Constructs the {@link StreamConsumerFactory} using the {@link StreamConfig::getConsumerFactoryClassName()} property and initializes it

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactoryProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactoryProvider.java
@@ -26,39 +26,14 @@ import org.apache.pinot.spi.plugin.PluginManager;
  */
 public abstract class StreamConsumerFactoryProvider {
   /**
-   * This method is here for backward compatibility with older stream implementations
-   * that support 'long' type offsets.
-   */
-  @Deprecated
-  public static StreamConsumerFactory create(StreamConfig streamConfig) {
-    return createConsumerFactory(streamConfig);
-  }
-
-  /**
    * Constructs the {@link StreamConsumerFactory} using the {@link StreamConfig::getConsumerFactoryClassName()} property and initializes it
    * @param streamConfig
    * @return
    */
-  public static StreamConsumerFactory createConsumerFactory(StreamConfig streamConfig) {
+  public static StreamConsumerFactory create(StreamConfig streamConfig) {
     StreamConsumerFactory factory = null;
     try {
       factory = PluginManager.get().createInstance(streamConfig.getConsumerFactoryClassName());
-    } catch (Exception e) {
-      ExceptionUtils.rethrow(e);
-    }
-    factory.init(streamConfig);
-    return factory;
-  }
-
-  /**
-   * Cronstructs the {@link StreamPartitionMsgOffsetFactory} using {@link StreamConfig::getPartitionOffsetFactoryClassName}
-   * and initializes it
-   * @param streamConfig
-   */
-  public static StreamPartitionMsgOffsetFactory createOffsetFactory(StreamConfig streamConfig) {
-    StreamPartitionMsgOffsetFactory factory = null;
-    try {
-      factory = PluginManager.get().createInstance(streamConfig.getPartitionOffsetFactoryClassName());
     } catch (Exception e) {
       ExceptionUtils.rethrow(e);
     }


### PR DESCRIPTION
PR #5542 introduced a backward incompatibility in this class that
would cause existing stream implementations to break when they use
pinot 0.5.0. This commit re-introduces the deleted method

Issue #5359 

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
