### PR TITLE
Update links for release 0.4.0 in the website

### DIFF
--- a/website/src/pages/download.js
+++ b/website/src/pages/download.js
@@ -44,6 +44,37 @@ function Download() {
             <div className="row">
 
               <div className="col">
+                <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz" className="panel panel--link text--center">
+                  <div className="panel--icon">
+                    <i className="feather icon-download"></i>
+                  </div>
+
+                  <div className="panel--title">0.4.0</div>
+
+                  <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-src.tar.gz" >
+                  <div className="panel--title">Official source release</div>
+                  </a>
+                  <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-src.tar.gz.sha512" >
+                  <div className="panel--subtitle">SHA512</div>
+                  </a>
+                  <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-src.tar.gz.asc" >
+                  <div className="panel--subtitle">ASC</div>
+                  </a>
+
+                  <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz" >
+                  <div className="panel--title">Official binary release</div>
+                  </a>
+                  <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz.sha512" >
+                  <div className="panel--subtitle">SHA512</div>
+                  </a>
+                  <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz.asc" >
+                  <div className="panel--subtitle">ASC </div>
+                  </a>
+
+                </a>
+              </div>
+
+              <div className="col">
                 <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-bin.tar.gz" className="panel panel--link text--center">
                   <div className="panel--icon">
                     <i className="feather icon-download"></i>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -230,7 +230,7 @@ function Installation() {
           <TabItem value="binary">
             <CodeBlock className="language-bash">
               {
-                `VERSION=0.3.0\nwget https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-$VERSION/apache-pinot-incubating-$VERSION-bin.tar.gz\ntar vxf apache-pinot-incubating-*-bin.tar.gz\ncd apache-pinot-incubating-*-bin\nbin/quick-start-batch.sh`
+                `VERSION=0.4.0\nwget https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-$VERSION/apache-pinot-incubating-$VERSION-bin.tar.gz\ntar vxf apache-pinot-incubating-*-bin.tar.gz\ncd apache-pinot-incubating-*-bin\nbin/quick-start-batch.sh`
               }
             </CodeBlock>
           </TabItem>
@@ -277,9 +277,9 @@ function Home() {
 
       <header className={classnames('hero', 'hero--full-height', styles.indexHeroBanner)}>
         <div className="container">
-          <Link to="https://docs.pinot.apache.org/releases/0.3.0" className={styles.indexAnnouncement}>
+          <Link to="https://docs.pinot.apache.org/releases/0.4.0" className={styles.indexAnnouncement}>
               <span className="badge badge-primary">release</span>
-              v0.3 has been released! Check the release notes
+              v0.4.0 has been released! Check the release notes
           </Link>
           <h1 className="hero__title">{siteConfig.title}</h1>
           <p className="hero__subtitle">{siteConfig.tagline}, designed to answer OLAP queries with low latency


### PR DESCRIPTION
## Description
Update links for 0.4.0 release in the website

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
N/A

## Documentation
Documentation has been updated: https://docs.pinot.apache.org/basics/releases/0.4.0
