### PR TITLE
[QueryContext] Refactor PlanMaker to use QueryContext

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
@@ -20,36 +20,27 @@ package org.apache.pinot.core.plan.maker;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.core.data.manager.SegmentDataManager;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.plan.Plan;
 import org.apache.pinot.core.plan.PlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
 
 
 /**
- * The <code>PlanMaker</code> provides interfaces to make segment level and instance level execution plan.
+ * The {@code PlanMaker} makes logical execution plan for the queries.
  */
+@InterfaceAudience.Private
 public interface PlanMaker {
 
   /**
-   * Make segment level {@link PlanNode} which contains execution plan on only one segment.
-   *
-   * @param indexSegment index segment.
-   * @param brokerRequest broker request.
-   * @return segment level plan node.
+   * Returns an instance level {@link Plan} which contains the logical execution plan for multiple segments.
    */
-  PlanNode makeInnerSegmentPlan(IndexSegment indexSegment, BrokerRequest brokerRequest);
+  Plan makeInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext, ExecutorService executorService,
+      long timeoutMs);
 
   /**
-   * Make instance level {@link Plan} which contains execution plan on multiple segments.
-   *
-   * @param segmentDataManagers list of segment data manager.
-   * @param brokerRequest broker request.
-   * @param executorService executor service.
-   * @param timeOutMs time out in milliseconds.
-   * @return instance level plan.
+   * Returns a segment level {@link PlanNode} which contains the logical execution plan for one segment.
    */
-  Plan makeInterSegmentPlan(List<SegmentDataManager> segmentDataManagers, BrokerRequest brokerRequest,
-      ExecutorService executorService, long timeOutMs);
+  PlanNode makeSegmentPlanNode(IndexSegment indexSegment, QueryContext queryContext);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.executor;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -205,9 +206,12 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
         metadata.put(DataTable.NUM_SEGMENTS_MATCHED, "0");
       } else {
         TimerContext.Timer planBuildTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.BUILD_QUERY_PLAN);
-        Plan globalQueryPlan = _planMaker
-            .makeInterSegmentPlan(segmentDataManagers, queryContext.getBrokerRequest(), executorService,
-                remainingTimeMs);
+        List<IndexSegment> indexSegments = new ArrayList<>(numSegmentsMatchedAfterPruning);
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          indexSegments.add(segmentDataManager.getSegment());
+        }
+        Plan globalQueryPlan =
+            _planMaker.makeInstancePlan(indexSegments, queryContext, executorService, remainingTimeMs);
         planBuildTimer.stopAndRecord();
 
         if (PRINT_QUERY_PLAN) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -36,6 +36,8 @@ import org.apache.pinot.core.plan.DictionaryBasedAggregationPlanNode;
 import org.apache.pinot.core.plan.MetadataBasedAggregationPlanNode;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.plan.SelectionPlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
@@ -46,13 +48,16 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class MetadataAndDictionaryAggregationPlanMakerTest {
@@ -72,7 +77,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
 
     // Get resource file path.
     URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
-    Assert.assertNotNull(resource);
+    assertNotNull(resource);
     String filePath = resource.getFile();
 
     // Build the segment schema.
@@ -128,8 +133,9 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   @Test(dataProvider = "testPlanNodeMakerDataProvider")
   public void testInstancePlanMakerForMetadataAndDictionaryPlan(String query, Class<? extends PlanNode> planNodeClass) {
     BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
-    PlanNode plan = PLAN_MAKER.makeInnerSegmentPlan(_indexSegment, brokerRequest);
-    Assert.assertTrue(planNodeClass.isInstance(plan));
+    QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
+    PlanNode plan = PLAN_MAKER.makeSegmentPlanNode(_indexSegment, queryContext);
+    assertTrue(planNodeClass.isInstance(plan));
   }
 
   @DataProvider(name = "testPlanNodeMakerDataProvider")
@@ -171,18 +177,15 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   public void testIsFitFor(String query, IndexSegment indexSegment, boolean expectedIsFitForMetadata,
       boolean expectedIsFitForDictionary) {
     BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
-
-    boolean isFitForMetadataBasedPlan = InstancePlanMakerImplV2.isFitForMetadataBasedPlan(brokerRequest, indexSegment);
-    boolean isFitForDictionaryBasedPlan =
-        InstancePlanMakerImplV2.isFitForDictionaryBasedPlan(brokerRequest, indexSegment);
-    Assert.assertEquals(isFitForMetadataBasedPlan, expectedIsFitForMetadata);
-    Assert.assertEquals(isFitForDictionaryBasedPlan, expectedIsFitForDictionary);
+    QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
+    assertEquals(InstancePlanMakerImplV2.isFitForMetadataBasedPlan(queryContext), expectedIsFitForMetadata);
+    assertEquals(InstancePlanMakerImplV2.isFitForDictionaryBasedPlan(queryContext, indexSegment),
+        expectedIsFitForDictionary);
   }
 
   @DataProvider(name = "isFitForPlanDataProvider")
   public Object[][] provideDataForIsFitChecks() {
     List<Object[]> entries = new ArrayList<>();
-    entries.add(new Object[]{"select * from testTable", _indexSegment, false, false});
     entries.add(
         new Object[]{"select count(*) from testTable", _indexSegment, true, false /* count* from metadata, even if star tree present */});
     entries.add(
@@ -192,11 +195,6 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     entries.add(
         new Object[]{"select count(*),max(daysSinceEpoch) from testTable", _indexSegment, false, false /* count* and max(time) from metadata*/});
     entries.add(new Object[]{"select sum(column1) from testTable", _indexSegment, false, false});
-    entries.add(new Object[]{"select count(*) from testTable group by daysSinceEpoch", _indexSegment, false, false});
-    entries.add(new Object[]{"select count(*) from testTable where daysSinceEpoch > 1", _indexSegment, false, false});
-    entries.add(
-        new Object[]{"select max(column5) from testTable where daysSinceEpoch > 100", _indexSegment, false, false});
-    entries.add(new Object[]{"select column1 from testTable", _indexSegment, false, false});
     return entries.toArray(new Object[entries.size()][]);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
@@ -24,19 +24,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.segment.ReadMode;
-import org.apache.pinot.core.data.manager.SegmentDataManager;
-import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
@@ -76,7 +74,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
 
   private IndexSegment _indexSegment;
   // Contains 2 identical index segments.
-  private List<SegmentDataManager> _segmentDataManagers;
+  private List<IndexSegment> _indexSegments;
 
   @BeforeTest
   public void buildSegment()
@@ -96,8 +94,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
         .addMultiValueDimension("column7", FieldSpec.DataType.INT)
         .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
         .addMetric("column10", FieldSpec.DataType.INT)
-        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), null)
-        .build();
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), null).build();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName("daysSinceEpoch").build();
 
@@ -125,8 +122,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
       throws Exception {
     ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     _indexSegment = immutableSegment;
-    _segmentDataManagers = Arrays
-        .asList(new ImmutableSegmentDataManager(immutableSegment), new ImmutableSegmentDataManager(immutableSegment));
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
   }
 
   @AfterClass
@@ -150,7 +146,7 @@ public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
   }
 
   @Override
-  protected List<SegmentDataManager> getSegmentDataManagers() {
-    return _segmentDataManagers;
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.segment.ReadMode;
-import org.apache.pinot.core.data.manager.SegmentDataManager;
-import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
@@ -70,7 +68,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
   private static final String AVRO_DATA = "data" + File.separator + "test_data-sv.avro";
   private static final String SEGMENT_NAME = "testTable_126164076_167572854";
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "SingleValueQueriesTest");
-  private static final int NUM_SEGMENT_DATA_MANAGERS = 2;
+  private static final int NUM_SEGMENTS = 2;
 
   // Hard-coded query filter.
   private static final String QUERY_FILTER =
@@ -79,7 +77,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
 
   private IndexSegment _indexSegment;
   // Contains 2 identical index segments.
-  private List<SegmentDataManager> _segmentDataManagers;
+  private List<IndexSegment> _indexSegments;
 
   @BeforeTest
   public void buildSegment()
@@ -100,8 +98,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
         .addSingleValueDimension("column11", FieldSpec.DataType.STRING)
         .addSingleValueDimension("column12", FieldSpec.DataType.STRING).addMetric("column17", FieldSpec.DataType.INT)
         .addMetric("column18", FieldSpec.DataType.INT)
-        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), null)
-        .build();
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), null).build();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName("daysSinceEpoch").build();
 
@@ -130,15 +127,15 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
       throws Exception {
     ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     _indexSegment = immutableSegment;
-    int numSegmentDataManagers = getNumSegmentDataManagers();
-    _segmentDataManagers = new ArrayList<>(numSegmentDataManagers);
-    for (int i = 0; i < numSegmentDataManagers; i++) {
-      _segmentDataManagers.add(new ImmutableSegmentDataManager(immutableSegment));
+    int numSegments = getNumSegments();
+    _indexSegments = new ArrayList<>(numSegments);
+    for (int i = 0; i < numSegments; i++) {
+      _indexSegments.add(immutableSegment);
     }
   }
 
-  protected int getNumSegmentDataManagers() {
-    return NUM_SEGMENT_DATA_MANAGERS;
+  protected int getNumSegments() {
+    return NUM_SEGMENTS;
   }
 
   @AfterClass
@@ -162,7 +159,7 @@ public abstract class BaseSingleValueQueriesTest extends BaseQueriesTest {
   }
 
   @Override
-  protected List<SegmentDataManager> getSegmentDataManagers() {
-    return _segmentDataManagers;
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -27,8 +27,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.segment.ReadMode;
-import org.apache.pinot.core.data.manager.SegmentDataManager;
-import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
@@ -85,7 +83,7 @@ public class FastHllQueriesTest extends BaseQueriesTest {
 
   private IndexSegment _indexSegment;
   // Contains 2 identical index segments
-  private List<SegmentDataManager> _segmentDataManagers;
+  private List<IndexSegment> _indexSegments;
 
   @Override
   protected String getFilter() {
@@ -98,8 +96,8 @@ public class FastHllQueriesTest extends BaseQueriesTest {
   }
 
   @Override
-  protected List<SegmentDataManager> getSegmentDataManagers() {
-    return _segmentDataManagers;
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
   }
 
   @Test
@@ -196,8 +194,7 @@ public class FastHllQueriesTest extends BaseQueriesTest {
 
     ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     _indexSegment = immutableSegment;
-    _segmentDataManagers = Arrays
-        .asList(new ImmutableSegmentDataManager(immutableSegment), new ImmutableSegmentDataManager(immutableSegment));
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
   }
 
   private void deleteSegment() {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
@@ -31,21 +31,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.MetricFieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.GroupByResult;
 import org.apache.pinot.common.segment.ReadMode;
-import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.core.data.manager.SegmentDataManager;
-import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
-import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
@@ -57,6 +47,14 @@ import org.apache.pinot.core.query.aggregation.function.PercentileTDigestAggrega
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.MetricFieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -92,8 +90,8 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
   protected static final Random RANDOM = new Random(RANDOM_SEED);
   protected static final String ERROR_MESSAGE = "Random seed: " + RANDOM_SEED;
 
-  private ImmutableSegment _indexSegment;
-  private List<SegmentDataManager> _segmentDataManagers;
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
 
   @Override
   protected String getFilter() {
@@ -106,8 +104,8 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
   }
 
   @Override
-  protected List<SegmentDataManager> getSegmentDataManagers() {
-    return _segmentDataManagers;
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
   }
 
   @BeforeClass
@@ -116,9 +114,9 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
     FileUtils.deleteQuietly(INDEX_DIR);
 
     buildSegment();
-    _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
-    _segmentDataManagers =
-        Arrays.asList(new ImmutableSegmentDataManager(_indexSegment), new ImmutableSegmentDataManager(_indexSegment));
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
   }
 
   protected void buildSegment()

--- a/pinot-core/src/test/java/org/apache/pinot/queries/RangePredicateWithSortedInvertedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/RangePredicateWithSortedInvertedIndexTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.queries;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -27,7 +28,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.Pairs;
-import org.apache.pinot.core.data.manager.SegmentDataManager;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
@@ -43,66 +43,37 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
 
 public class RangePredicateWithSortedInvertedIndexTest extends BaseQueriesTest {
-  private static final int NUM_ROWS = 30000;
-
-  private List<GenericRow> _rows = new ArrayList<>();
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), "RangePredicateWithSortedInvertedIndexTest");
+  private static final String TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
 
   private static final String D1 = "STRING_COL";
   private static final String M1 = "INT_COL"; // sorted column
   private static final String M2 = "LONG_COL";
 
+  private static final int NUM_ROWS = 30000;
   private static final int INT_BASE_VALUE = 0;
 
-  private static final String TABLE_NAME = "TestTable";
-  private static final int NUM_SEGMENTS = 1;
-  private static final String SEGMENT_NAME_1 = TABLE_NAME + "_100000000_200000000";
-  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "SortedRangeTest");
+  private static final long RANDOM_SEED = System.nanoTime();
+  private static final Random RANDOM = new Random(RANDOM_SEED);
+  private static final String ERROR_MESSAGE = "Random seed: " + RANDOM_SEED;
 
-  private List<IndexSegment> _indexSegments = new ArrayList<>(NUM_SEGMENTS);
-  private final String[] stringValues = new String[NUM_ROWS];
-  private final long[] longValues = new long[NUM_ROWS];
+  private final String[] _stringValues = new String[NUM_ROWS];
+  private final long[] _longValues = new long[NUM_ROWS];
 
-  private Schema _schema;
-  private TableConfig _tableConfig;
-
-  @BeforeClass
-  public void setUp() {
-    createPinotTableSchema();
-    createTestData();
-  }
-
-  @AfterClass
-  public void tearDown() {
-    FileUtils.deleteQuietly(INDEX_DIR);
-  }
-
-  private void createPinotTableSchema() {
-    _schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension(D1, FieldSpec.DataType.STRING)
-            .addMetric(M1, FieldSpec.DataType.INT).addMetric(M2, FieldSpec.DataType.LONG).build();
-    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
-  }
-
-  private void createTestData() {
-    Random random = new Random();
-    for (int rowIndex = 0; rowIndex < NUM_ROWS; rowIndex++) {
-      GenericRow row = new GenericRow();
-      stringValues[rowIndex] = RandomStringUtils.randomAlphanumeric(10);
-      row.putValue(D1, stringValues[rowIndex]);
-      row.putValue(M1, INT_BASE_VALUE + rowIndex);
-      longValues[rowIndex] = random.nextLong();
-      row.putValue(M2, longValues[rowIndex]);
-      _rows.add(row);
-    }
-  }
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
 
   @Override
   protected String getFilter() {
@@ -111,121 +82,134 @@ public class RangePredicateWithSortedInvertedIndexTest extends BaseQueriesTest {
 
   @Override
   protected IndexSegment getIndexSegment() {
-    return _indexSegments.get(0);
+    return _indexSegment;
   }
 
   @Override
-  protected List<SegmentDataManager> getSegmentDataManagers() {
-    return null;
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
   }
 
-  private void createSegment(TableConfig tableConfig, Schema schema, RecordReader recordReader, String segmentName,
-      String tableName)
+  @BeforeClass
+  public void setUp()
       throws Exception {
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
-    segmentGeneratorConfig.setTableName(tableName);
-    segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
-    segmentGeneratorConfig.setSegmentName(segmentName);
+    FileUtils.deleteQuietly(INDEX_DIR);
+
+    buildSegment();
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _indexSegment.destroy();
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  private void buildSegment()
+      throws Exception {
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    for (int rowIndex = 0; rowIndex < NUM_ROWS; rowIndex++) {
+      GenericRow row = new GenericRow();
+      _stringValues[rowIndex] = RandomStringUtils.randomAlphanumeric(10);
+      row.putValue(D1, _stringValues[rowIndex]);
+      row.putValue(M1, INT_BASE_VALUE + rowIndex);
+      _longValues[rowIndex] = RANDOM.nextLong();
+      row.putValue(M2, _longValues[rowIndex]);
+      rows.add(row);
+    }
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension(D1, FieldSpec.DataType.STRING)
+            .addMetric(M1, FieldSpec.DataType.INT).addMetric(M2, FieldSpec.DataType.LONG).build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(SEGMENT_NAME);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(segmentGeneratorConfig, recordReader);
-    driver.build();
-
-    File segmentIndexDir = new File(INDEX_DIR.getAbsolutePath(), segmentName);
-    if (!segmentIndexDir.exists()) {
-      throw new IllegalStateException("Segment generation failed");
+    try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
+      driver.init(config, recordReader);
+      driver.build();
     }
-  }
-
-  private ImmutableSegment loadSegment(String segmentName)
-      throws Exception {
-    return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName), ReadMode.heap);
   }
 
   @Test
-  public void testInnerSegmentQuery()
-      throws Exception {
-    Random random = new Random();
-    try (RecordReader recordReader = new GenericRowRecordReader(_rows)) {
-      createSegment(_tableConfig, _schema, recordReader, SEGMENT_NAME_1, TABLE_NAME);
-      final ImmutableSegment immutableSegment = loadSegment(SEGMENT_NAME_1);
-      _indexSegments.add(immutableSegment);
+  public void testInnerSegmentQuery() {
+    String query = "SELECT STRING_COL, INT_COL FROM testTable WHERE INT_COL >= 20000 LIMIT 100000";
+    Pairs.IntPair pair = new Pairs.IntPair(20000, 29999);
+    runQuery(query, 10000, Lists.newArrayList(pair), 2);
 
-      String query = "SELECT STRING_COL, INT_COL FROM TestTable WHERE INT_COL >= 20000 LIMIT 100000";
-      Pairs.IntPair pair = new Pairs.IntPair(20000, 29999);
-      runQuery(query, 10000, Lists.newArrayList(pair), 2);
+    query = "SELECT STRING_COL, INT_COL FROM testTable WHERE INT_COL >= 20000 AND INT_COL <= 23666 LIMIT 100000";
+    pair = new Pairs.IntPair(20000, 23666);
+    runQuery(query, 3667, Lists.newArrayList(pair), 2);
 
-      query = "SELECT STRING_COL, INT_COL FROM TestTable WHERE INT_COL >= 20000 AND INT_COL <= 23666 LIMIT 100000";
-      pair = new Pairs.IntPair(20000, 23666);
-      runQuery(query, 3667, Lists.newArrayList(pair), 2);
+    query = "SELECT STRING_COL, INT_COL FROM testTable WHERE INT_COL <= 20000 LIMIT 100000";
+    pair = new Pairs.IntPair(0, 20000);
+    runQuery(query, 20001, Lists.newArrayList(pair), 2);
 
-      query = "SELECT STRING_COL, INT_COL FROM TestTable WHERE INT_COL <= 20000 LIMIT 100000";
-      pair = new Pairs.IntPair(0, 20000);
-      runQuery(query, 20001, Lists.newArrayList(pair), 2);
+    String filter = "WHERE (INT_COL >= 15000 AND INT_COL <= 16665) OR (INT_COL >= 18000 AND INT_COL <= 19887)";
+    query = "SELECT STRING_COL, INT_COL FROM testTable " + filter + " LIMIT 100000";
+    pair = new Pairs.IntPair(15000, 16665);
+    Pairs.IntPair pair1 = new Pairs.IntPair(18000, 19987);
+    runQuery(query, 3554, Lists.newArrayList(pair, pair1), 2);
 
-      String filter = "WHERE (INT_COL >= 15000 AND INT_COL <= 16665) OR (INT_COL >= 18000 AND INT_COL <= 19887)";
-      query = "SELECT STRING_COL, INT_COL FROM TestTable " + filter + " LIMIT 100000";
-      pair = new Pairs.IntPair(15000, 16665);
-      Pairs.IntPair pair1 = new Pairs.IntPair(18000, 19987);
-      runQuery(query, 3554, Lists.newArrayList(pair, pair1), 2);
-
-      // range predicate on sorted column which will use sorted inverted index based iterator
-      // along with range predicate on unsorted column that uses scan based iterator
-      int index = random.nextInt(NUM_ROWS + 1);
-      long longPredicateValue = longValues[index];
-      int count = 0;
-      List<Pairs.IntPair> pairs = new ArrayList<>();
-      Pairs.IntPair current = null;
-      for (int i = 0 ; i < longValues.length; i++) {
-        if (longValues[i] >= longPredicateValue && i >= 15000 && i <= 16665) {
-          if (current == null) {
-            current = new Pairs.IntPair(i, i);
+    // range predicate on sorted column which will use sorted inverted index based iterator
+    // along with range predicate on unsorted column that uses scan based iterator
+    int index = RANDOM.nextInt(NUM_ROWS);
+    long longPredicateValue = _longValues[index];
+    int count = 0;
+    List<Pairs.IntPair> pairs = new ArrayList<>();
+    Pairs.IntPair current = null;
+    for (int i = 0; i < _longValues.length; i++) {
+      if (_longValues[i] >= longPredicateValue && i >= 15000 && i <= 16665) {
+        if (current == null) {
+          current = new Pairs.IntPair(i, i);
+        } else {
+          if (i == current.getRight() + 1) {
+            current.setRight(i);
           } else {
-            if (i == current.getRight() + 1) {
-              current.setRight(i);
-            } else {
-              if (i <= longValues.length - 2) {
-                pairs.add(current);
-                current = new Pairs.IntPair(i, i);
-              }
+            if (i <= _longValues.length - 2) {
+              pairs.add(current);
+              current = new Pairs.IntPair(i, i);
             }
           }
-          count++;
         }
+        count++;
       }
-      pairs.add(current);
-      filter = "WHERE INT_COL >= 15000 AND INT_COL <= 16665 AND LONG_COL >= " + longPredicateValue;
-      query = "SELECT STRING_COL, INT_COL, LONG_COL FROM TestTable " + filter + " LIMIT 100000";
-      runQuery(query, count, pairs, 3);
-
-      // empty resultset
-      query = "SELECT STRING_COL, INT_COL FROM TestTable WHERe INT_COL < 0 LIMIT 100000";
-      runQuery(query, 0, null, 0);
-
-      // empty resultset
-      query = "SELECT STRING_COL, INT_COL FROM TestTable WHERE INT_COL > 30000 LIMIT 100000";
-      runQuery(query, 0, null, 0);
-    } finally {
-      destroySegments();
     }
+    pairs.add(current);
+    filter = "WHERE INT_COL >= 15000 AND INT_COL <= 16665 AND LONG_COL >= " + longPredicateValue;
+    query = "SELECT STRING_COL, INT_COL, LONG_COL FROM testTable " + filter + " LIMIT 100000";
+    runQuery(query, count, pairs, 3);
+
+    // empty resultset
+    query = "SELECT STRING_COL, INT_COL FROM testTable WHERe INT_COL < 0 LIMIT 100000";
+    runQuery(query, 0, null, 0);
+
+    // empty resultset
+    query = "SELECT STRING_COL, INT_COL FROM testTable WHERE INT_COL > 30000 LIMIT 100000";
+    runQuery(query, 0, null, 0);
   }
 
   private void runQuery(String query, int count, List<Pairs.IntPair> intPairs, int numColumns) {
     SelectionOnlyOperator operator = getOperatorForQuery(query);
     IntermediateResultsBlock block = operator.nextBlock();
     Collection<Object[]> rows = block.getSelectionResult();
-    Assert.assertNotNull(rows);
-    Assert.assertEquals(rows.size(), count);
+    assertNotNull(rows, ERROR_MESSAGE);
+    assertEquals(rows.size(), count, ERROR_MESSAGE);
     if (count > 0) {
       Pairs.IntPair pair = intPairs.get(0);
       int startPos = pair.getLeft();
       int pairPos = 0;
       for (Object[] row : rows) {
-        Assert.assertEquals(numColumns, row.length);
-        Assert.assertEquals(row[0], stringValues[startPos]);
-        Assert.assertEquals(row[1], startPos);
+        assertEquals(numColumns, row.length, ERROR_MESSAGE);
+        assertEquals(row[0], _stringValues[startPos], ERROR_MESSAGE);
+        assertEquals(row[1], startPos, ERROR_MESSAGE);
         if (numColumns == 3) {
-          Assert.assertEquals(row[2], longValues[startPos]);
+          assertEquals(row[2], _longValues[startPos], ERROR_MESSAGE);
         }
         startPos++;
         if (startPos > pair.getRight() && pairPos <= intPairs.size() - 2) {
@@ -235,14 +219,5 @@ public class RangePredicateWithSortedInvertedIndexTest extends BaseQueriesTest {
         }
       }
     }
-  }
-
-  private void destroySegments() {
-    for (IndexSegment indexSegment : _indexSegments) {
-      if (indexSegment != null) {
-        indexSegment.destroy();
-      }
-    }
-    _indexSegments.clear();
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
@@ -40,7 +40,7 @@ public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTes
    * (2 * MAX_NUM_THREADS_PER_QUERY) segments per server.
    */
   @Override
-  protected int getNumSegmentDataManagers() {
+  protected int getNumSegments() {
     return CombineOperator.MAX_NUM_THREADS_PER_QUERY * 2;
   }
 
@@ -52,7 +52,7 @@ public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTes
   @Test
   public void testSelectOnlyQuery() {
     int numThreadsPerServer = CombineOperator.MAX_NUM_THREADS_PER_QUERY;
-    int numSegmentsPerServer = getNumSegmentDataManagers();
+    int numSegmentsPerServer = getNumSegments();
 
     // LIMIT = 5, 10, 20, 40, 80, 160, 320, 640, 1280, 2560, 5120, 10240, 20480
     for (int limit = 5; limit < NUM_DOCS_PER_SEGMENT; limit *= 2) {
@@ -95,7 +95,7 @@ public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTes
    */
   @Test
   public void testSelectWithOrderByQuery() {
-    int numSegmentsPerServer = getNumSegmentDataManagers();
+    int numSegmentsPerServer = getNumSegments();
     String query = "SELECT column11, column18, column1 FROM testTable ORDER BY column11";
     int numColumnsInSelection = 3;
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
@@ -29,20 +29,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec.DataType;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.GroupByResult;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
-import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.core.data.manager.SegmentDataManager;
-import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
-import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
@@ -56,6 +48,12 @@ import org.apache.pinot.core.query.aggregation.function.customobject.QuantileDig
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -111,8 +109,8 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
   private final QuantileDigest[] _quantileDigests = new QuantileDigest[NUM_ROWS];
   private final TDigest[] _tDigests = new TDigest[NUM_ROWS];
 
-  private ImmutableSegment _indexSegment;
-  private List<SegmentDataManager> _segmentDataManagers;
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
 
   @Override
   protected String getFilter() {
@@ -125,8 +123,8 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
   }
 
   @Override
-  protected List<SegmentDataManager> getSegmentDataManagers() {
-    return _segmentDataManagers;
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
   }
 
   @BeforeClass
@@ -135,9 +133,9 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
     FileUtils.deleteQuietly(INDEX_DIR);
 
     buildSegment();
-    _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
-    _segmentDataManagers =
-        Arrays.asList(new ImmutableSegmentDataManager(_indexSegment), new ImmutableSegmentDataManager(_indexSegment));
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
   }
 
   private void buildSegment()


### PR DESCRIPTION
## Description
Refactor PlanMaker to use QueryContext
- Also addressed the TODO to directly use List<IndexSegment> instead of List<SegmentDataManager> for the instance level Plan
- Modified and simplied tests to apply the interface change