### PR TITLE
Function to round a time value

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeFunctions.java
@@ -243,7 +243,8 @@ public class DateTimeFunctions {
 
 
   /**
-   * Round the given time value to nearest rounding bucket
+   * Round the given time value to nearest multiple
+   * @return the original value but rounded to the nearest multiple of @param roundToNearest
    */
   @ScalarFunction
   static Long round(Long timeValue, Number roundToNearest) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeFunctions.java
@@ -247,7 +247,8 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   static Long round(Long timeValue, Number roundToNearest) {
-    return (timeValue / roundToNearest.intValue()) * roundToNearest.intValue();
+    long roundingValue = roundToNearest.longValue();
+    return (timeValue / roundingValue) * roundingValue;
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeFunctions.java
@@ -241,6 +241,15 @@ public class DateTimeFunctions {
     return DateTimePatternHandler.parseDateTimeStringToEpochMillis(dateTimeString, pattern);
   }
 
+
+  /**
+   * Round the given time value to nearest rounding bucket
+   */
+  @ScalarFunction
+  static Long round(Long timeValue, Number roundToNearest) {
+    return (timeValue / roundToNearest.intValue()) * roundToNearest.intValue();
+  }
+
   /**
    * Return current time as epoch millis
    */

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
@@ -47,6 +47,12 @@ public class InbuiltFunctionsTest {
   @DataProvider(name = "dateTimeFunctionsTestDataProvider")
   public Object[][] dateTimeFunctionsDataProvider() {
     List<Object[]> inputs = new ArrayList<>();
+    // round epoch millis to nearest 15 minutes
+    GenericRow row0_0 = new GenericRow();
+    row0_0.putValue("timestamp", 1578685189000L);
+    // round to 15 minutes, but keep in milliseconds: Fri Jan 10 2020 19:39:49 becomes Fri Jan 10 2020 19:30:00
+    inputs.add(new Object[]{"round(timestamp, 900000)", Lists.newArrayList(
+        "timestamp"), row0_0, 1578684600000L});
 
     // toEpochSeconds
     GenericRow row1_0 = new GenericRow();


### PR DESCRIPTION
Adding a basic function to round any time value.
For example, to round millis to nearest 15 minutes bucket use
"transformFunction": "round(timestamp, 900000)"