### PR TITLE
Remove the code of printing the query plan

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
@@ -20,9 +20,7 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.request.GroupBy;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
@@ -34,23 +32,18 @@ import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.core.startree.plan.StarTreeTransformPlanNode;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * The <code>AggregationGroupByOrderByPlanNode</code> class provides the execution plan for aggregation group-by order-by query on a
  * single segment.
  */
+@SuppressWarnings("rawtypes")
 public class AggregationGroupByOrderByPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AggregationGroupByOrderByPlanNode.class);
-
   private final IndexSegment _indexSegment;
   private final int _maxInitialResultHolderCapacity;
   private final int _numGroupsLimit;
-  private final List<AggregationInfo> _aggregationInfos;
   private final AggregationFunction[] _aggregationFunctions;
-  private final GroupBy _groupBy;
   private final TransformExpressionTree[] _groupByExpressions;
   private final TransformPlanNode _transformPlanNode;
   private final StarTreeTransformPlanNode _starTreeTransformPlanNode;
@@ -60,10 +53,8 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
     _indexSegment = indexSegment;
     _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
     _numGroupsLimit = numGroupsLimit;
-    _aggregationInfos = brokerRequest.getAggregationsInfo();
     _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(brokerRequest);
-    _groupBy = brokerRequest.getGroupBy();
-    List<String> groupByExpressions = _groupBy.getExpressions();
+    List<String> groupByExpressions = brokerRequest.getGroupBy().getExpressions();
     int numGroupByExpressions = groupByExpressions.size();
     _groupByExpressions = new TransformExpressionTree[numGroupByExpressions];
     for (int i = 0; i < numGroupByExpressions; i++) {
@@ -121,22 +112,6 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
       // Use star-tree
       return new AggregationGroupByOrderByOperator(_aggregationFunctions, _groupByExpressions,
           _maxInitialResultHolderCapacity, _numGroupsLimit, _starTreeTransformPlanNode.run(), numTotalDocs, true);
-    }
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "Aggregation Group-by Order-by Plan Node:");
-    LOGGER.debug(prefix + "Operator: AggregationGroupByOrderByOperator");
-    LOGGER.debug(prefix + "Argument 0: IndexSegment - " + _indexSegment.getSegmentName());
-    LOGGER.debug(prefix + "Argument 1: Aggregations - " + _aggregationInfos);
-    LOGGER.debug(prefix + "Argument 2: GroupBy - " + _groupBy);
-    if (_transformPlanNode != null) {
-      LOGGER.debug(prefix + "Argument 3: TransformPlanNode -");
-      _transformPlanNode.showTree(prefix + "    ");
-    } else {
-      LOGGER.debug(prefix + "Argument 3: StarTreeTransformPlanNode -");
-      _starTreeTransformPlanNode.showTree(prefix + "    ");
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -20,9 +20,7 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.request.GroupBy;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
@@ -34,23 +32,18 @@ import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.core.startree.plan.StarTreeTransformPlanNode;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * The <code>AggregationGroupByPlanNode</code> class provides the execution plan for aggregation group-by query on a
  * single segment.
  */
+@SuppressWarnings("rawtypes")
 public class AggregationGroupByPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AggregationGroupByPlanNode.class);
-
   private final IndexSegment _indexSegment;
   private final int _maxInitialResultHolderCapacity;
   private final int _numGroupsLimit;
-  private final List<AggregationInfo> _aggregationInfos;
   private final AggregationFunction[] _aggregationFunctions;
-  private final GroupBy _groupBy;
   private final TransformExpressionTree[] _groupByExpressions;
   private final TransformPlanNode _transformPlanNode;
   private final StarTreeTransformPlanNode _starTreeTransformPlanNode;
@@ -60,10 +53,8 @@ public class AggregationGroupByPlanNode implements PlanNode {
     _indexSegment = indexSegment;
     _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
     _numGroupsLimit = numGroupsLimit;
-    _aggregationInfos = brokerRequest.getAggregationsInfo();
     _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(brokerRequest);
-    _groupBy = brokerRequest.getGroupBy();
-    List<String> groupByExpressions = _groupBy.getExpressions();
+    List<String> groupByExpressions = brokerRequest.getGroupBy().getExpressions();
     int numGroupByExpressions = groupByExpressions.size();
     _groupByExpressions = new TransformExpressionTree[numGroupByExpressions];
     for (int i = 0; i < numGroupByExpressions; i++) {
@@ -121,22 +112,6 @@ public class AggregationGroupByPlanNode implements PlanNode {
       // Use star-tree
       return new AggregationGroupByOperator(_aggregationFunctions, _groupByExpressions, _maxInitialResultHolderCapacity,
           _numGroupsLimit, _starTreeTransformPlanNode.run(), numTotalDocs, true);
-    }
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "Aggregation Group-by Plan Node:");
-    LOGGER.debug(prefix + "Operator: AggregationGroupByOperator");
-    LOGGER.debug(prefix + "Argument 0: IndexSegment - " + _indexSegment.getSegmentName());
-    LOGGER.debug(prefix + "Argument 1: Aggregations - " + _aggregationInfos);
-    LOGGER.debug(prefix + "Argument 2: GroupBy - " + _groupBy);
-    if (_transformPlanNode != null) {
-      LOGGER.debug(prefix + "Argument 3: TransformPlanNode -");
-      _transformPlanNode.showTree(prefix + "    ");
-    } else {
-      LOGGER.debug(prefix + "Argument 3: StarTreeTransformPlanNode -");
-      _starTreeTransformPlanNode.showTree(prefix + "    ");
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
@@ -33,26 +32,21 @@ import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.core.startree.plan.StarTreeTransformPlanNode;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * The <code>AggregationPlanNode</code> class provides the execution plan for aggregation only query on a single
  * segment.
  */
+@SuppressWarnings("rawtypes")
 public class AggregationPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AggregationPlanNode.class);
-
   private final IndexSegment _indexSegment;
-  private final List<AggregationInfo> _aggregationInfos;
   private final AggregationFunction[] _aggregationFunctions;
   private final TransformPlanNode _transformPlanNode;
   private final StarTreeTransformPlanNode _starTreeTransformPlanNode;
 
   public AggregationPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest) {
     _indexSegment = indexSegment;
-    _aggregationInfos = brokerRequest.getAggregationsInfo();
     _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(brokerRequest);
 
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
@@ -103,21 +97,6 @@ public class AggregationPlanNode implements PlanNode {
     } else {
       // Use star-tree
       return new AggregationOperator(_aggregationFunctions, _starTreeTransformPlanNode.run(), numTotalDocs, true);
-    }
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "Aggregation Plan Node:");
-    LOGGER.debug(prefix + "Operator: AggregationOperator");
-    LOGGER.debug(prefix + "Argument 0: IndexSegment - " + _indexSegment.getSegmentName());
-    LOGGER.debug(prefix + "Argument 1: Aggregations - " + _aggregationInfos);
-    if (_transformPlanNode != null) {
-      LOGGER.debug(prefix + "Argument 2: TransformPlanNode -");
-      _transformPlanNode.showTree(prefix + "    ");
-    } else {
-      LOGGER.debug(prefix + "Argument 2: StarTreeTransformPlanNode -");
-      _starTreeTransformPlanNode.showTree(prefix + "    ");
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedAggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedAggregationPlanNode.java
@@ -22,22 +22,18 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
-import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * Dictionary based aggregation plan node.
  */
+@SuppressWarnings("rawtypes")
 public class DictionaryBasedAggregationPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DictionaryBasedAggregationPlanNode.class);
-
   private final IndexSegment _indexSegment;
   private final AggregationFunction[] _aggregationFunctions;
   private final Map<String, Dictionary> _dictionaryMap;
@@ -59,15 +55,8 @@ public class DictionaryBasedAggregationPlanNode implements PlanNode {
   }
 
   @Override
-  public Operator run() {
+  public DictionaryBasedAggregationOperator run() {
     return new DictionaryBasedAggregationOperator(_aggregationFunctions, _dictionaryMap,
         _indexSegment.getSegmentMetadata().getTotalDocs());
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug("{} Segment Level Inner-Segment Plan Node:", prefix);
-    LOGGER.debug("{} Operator: DictionaryBasedAggregationOperator", prefix);
-    LOGGER.debug("{} IndexSegment: {}", prefix, _indexSegment.getSegmentName());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
@@ -19,45 +19,29 @@
 package org.apache.pinot.core.plan;
 
 import com.google.common.base.Preconditions;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.DocIdSetOperator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class DocIdSetPlanNode implements PlanNode {
   public static int MAX_DOC_PER_CALL = 10000;
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DocIdSetPlanNode.class);
-
-  private final IndexSegment _indexSegment;
   private final FilterPlanNode _filterPlanNode;
   private final int _maxDocPerCall;
 
-  public DocIdSetPlanNode(@Nonnull IndexSegment indexSegment, @Nonnull BrokerRequest brokerRequest, int maxDocPerCall) {
+  public DocIdSetPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest, int maxDocPerCall) {
     Preconditions.checkState(maxDocPerCall > 0 && maxDocPerCall <= MAX_DOC_PER_CALL);
-    _indexSegment = indexSegment;
-    _filterPlanNode = new FilterPlanNode(_indexSegment, brokerRequest);
+    _filterPlanNode = new FilterPlanNode(indexSegment, brokerRequest);
     _maxDocPerCall = maxDocPerCall;
   }
 
-  public DocIdSetPlanNode(@Nonnull IndexSegment indexSegment, @Nonnull BrokerRequest brokerRequest) {
+  public DocIdSetPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest) {
     this(indexSegment, brokerRequest, MAX_DOC_PER_CALL);
   }
 
   @Override
   public DocIdSetOperator run() {
     return new DocIdSetOperator(_filterPlanNode.run(), _maxDocPerCall);
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "DocIdSetPlanNode Plan Node :");
-    LOGGER.debug(prefix + "Operator: DocIdSetOperator");
-    LOGGER.debug(prefix + "Argument 0: IndexSegment - " + _indexSegment.getSegmentName());
-    LOGGER.debug(prefix + "Argument 1: FilterPlanNode:");
-    _filterPlanNode.showTree(prefix + "    ");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -41,12 +41,9 @@ import org.apache.pinot.core.operator.filter.TextMatchFilterOperator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
 import org.apache.pinot.core.segment.index.readers.NullValueVectorReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class FilterPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(FilterPlanNode.class);
   private final BrokerRequest _brokerRequest;
   private final IndexSegment _segment;
 
@@ -145,13 +142,5 @@ public class FilterPlanNode implements PlanNode {
           return FilterOperatorUtils.getLeafFilterOperator(predicateEvaluator, dataSource, numDocs);
       }
     }
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    final String treeStructure =
-        prefix + "Filter Plan Node\n" + prefix + "Operator: Filter\n" + prefix + "Argument 0: " + _brokerRequest
-            .getFilterQuery();
-    LOGGER.debug(treeStructure);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GlobalPlanImplV0.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GlobalPlanImplV0.java
@@ -50,9 +50,4 @@ public class GlobalPlanImplV0 implements Plan {
     LOGGER.debug("InstanceResponseOperator.nextBlock() took: {}ms", endTime2 - endTime1);
     return instanceResponseBlock.getInstanceResponseDataTable();
   }
-
-  @Override
-  public void print() {
-    _instanceResponsePlanNode.showTree("");
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InstanceResponsePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InstanceResponsePlanNode.java
@@ -19,13 +19,9 @@
 package org.apache.pinot.core.plan;
 
 import org.apache.pinot.core.operator.InstanceResponseOperator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class InstanceResponsePlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceResponsePlanNode.class);
-
   private final CombinePlanNode _combinePlanNode;
 
   public InstanceResponsePlanNode(CombinePlanNode combinePlanNode) {
@@ -34,18 +30,6 @@ public class InstanceResponsePlanNode implements PlanNode {
 
   @Override
   public InstanceResponseOperator run() {
-    long start = System.currentTimeMillis();
-    InstanceResponseOperator instanceResponseOperator = new InstanceResponseOperator(_combinePlanNode.run());
-    long end = System.currentTimeMillis();
-    LOGGER.debug("InstanceResponsePlanNode.run took: {}ms", end - start);
-    return instanceResponseOperator;
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "Instance Level Inter-Segments Query Plan Node:");
-    LOGGER.debug(prefix + "Operator: InstanceResponseOperator");
-    LOGGER.debug(prefix + "Argument 0: Combine -");
-    _combinePlanNode.showTree(prefix + "    ");
+    return new InstanceResponseOperator(_combinePlanNode.run());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/MetadataBasedAggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/MetadataBasedAggregationPlanNode.java
@@ -19,30 +19,23 @@
 package org.apache.pinot.core.plan;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.DataSource;
-import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.MetadataBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * Metadata based aggregation plan node.
  */
+@SuppressWarnings("rawtypes")
 public class MetadataBasedAggregationPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MetadataBasedAggregationPlanNode.class);
-
   private final IndexSegment _indexSegment;
-  private final List<AggregationInfo> _aggregationInfos;
   private final AggregationFunction[] _aggregationFunctions;
   private final Map<String, DataSource> _dataSourceMap;
 
@@ -54,7 +47,6 @@ public class MetadataBasedAggregationPlanNode implements PlanNode {
    */
   public MetadataBasedAggregationPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest) {
     _indexSegment = indexSegment;
-    _aggregationInfos = brokerRequest.getAggregationsInfo();
     _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(brokerRequest);
     _dataSourceMap = new HashMap<>();
     for (AggregationFunction aggregationFunction : _aggregationFunctions) {
@@ -66,16 +58,8 @@ public class MetadataBasedAggregationPlanNode implements PlanNode {
   }
 
   @Override
-  public Operator run() {
+  public MetadataBasedAggregationOperator run() {
     return new MetadataBasedAggregationOperator(_aggregationFunctions, _indexSegment.getSegmentMetadata(),
         _dataSourceMap);
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "Segment Level Inner-Segment Plan Node:");
-    LOGGER.debug(prefix + "Operator: MetadataBasedAggregationOperator");
-    LOGGER.debug(prefix + "Argument 0: IndexSegment - " + _indexSegment.getSegmentName());
-    LOGGER.debug(prefix + "Argument 1: Aggregations - " + _aggregationInfos);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/Plan.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/Plan.java
@@ -19,20 +19,17 @@
 package org.apache.pinot.core.plan;
 
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
 
 
 /**
  * Instance level query plan.
  */
+@InterfaceAudience.Private
 public interface Plan {
 
   /**
    * Execute the query plan and get the instance response.
    */
   DataTable execute();
-
-  /**
-   * Print the query plan (for debugging only).
-   */
-  void print();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/PlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/PlanNode.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pinot.core.plan;
 
+import org.apache.pinot.core.common.Block;
 import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
 
 
 /**
  * The <code>PlanNode</code> is a single execution plan node inside the {@link Plan} tree.
  */
+@InterfaceAudience.Private
 public interface PlanNode {
 
   /**
@@ -31,12 +34,5 @@ public interface PlanNode {
    *
    * @return execution operator.
    */
-  Operator run();
-
-  /**
-   * Log the tree structure under the plan node.
-   *
-   * @param prefix prefix for each line logged.
-   */
-  void showTree(String prefix);
+  Operator<? extends Block> run();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectionPlanNode.java
@@ -21,12 +21,9 @@ package org.apache.pinot.core.plan;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.ProjectionOperator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -34,14 +31,12 @@ import org.slf4j.LoggerFactory;
  * on a single segment.
  */
 public class ProjectionPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ProjectionPlanNode.class);
-
   private final IndexSegment _indexSegment;
   private final Set<String> _projectionColumns;
   private final DocIdSetPlanNode _docIdSetPlanNode;
 
-  public ProjectionPlanNode(@Nonnull IndexSegment indexSegment, @Nonnull Set<String> projectionColumns,
-      @Nonnull DocIdSetPlanNode docIdSetPlanNode) {
+  public ProjectionPlanNode(IndexSegment indexSegment, Set<String> projectionColumns,
+      DocIdSetPlanNode docIdSetPlanNode) {
     _indexSegment = indexSegment;
     _projectionColumns = projectionColumns;
     _docIdSetPlanNode = docIdSetPlanNode;
@@ -54,15 +49,5 @@ public class ProjectionPlanNode implements PlanNode {
       dataSourceMap.put(column, _indexSegment.getDataSource(column));
     }
     return new ProjectionOperator(dataSourceMap, _docIdSetPlanNode.run());
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "Segment Level Inner-Segment Plan Node:");
-    LOGGER.debug(prefix + "Operator: ProjectionOperator");
-    LOGGER.debug(prefix + "Argument 0: IndexSegment - " + _indexSegment.getSegmentName());
-    LOGGER.debug(prefix + "Argument 1: Projection Columns - " + _projectionColumns);
-    LOGGER.debug(prefix + "Argument 2: DocIdSet - ");
-    _docIdSetPlanNode.showTree(prefix + "    ");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -27,21 +27,18 @@ import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.query.EmptySelectionOperator;
 import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.core.operator.query.SelectionOrderByOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * The <code>SelectionPlanNode</code> class provides the execution plan for selection query on a single segment.
  */
 public class SelectionPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SelectionPlanNode.class);
-
   private final IndexSegment _indexSegment;
   private final Selection _selection;
   private final TransformPlanNode _transformPlanNode;
@@ -54,7 +51,7 @@ public class SelectionPlanNode implements PlanNode {
   }
 
   @Override
-  public Operator run() {
+  public Operator<IntermediateResultsBlock> run() {
     TransformOperator transformOperator = _transformPlanNode.run();
     if (_selection.getSize() > 0) {
       if (_selection.getSelectionSortSequence() == null) {
@@ -65,24 +62,6 @@ public class SelectionPlanNode implements PlanNode {
     } else {
       return new EmptySelectionOperator(_indexSegment, _selection, transformOperator);
     }
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "Segment Level Inner-Segment Plan Node:");
-    if (_selection.getSize() > 0) {
-      if (_selection.isSetSelectionSortSequence()) {
-        LOGGER.debug(prefix + "Operator: SelectionOrderByOperator");
-      } else {
-        LOGGER.debug(prefix + "Operator: SelectionOnlyOperator");
-      }
-    } else {
-      LOGGER.debug(prefix + "Operator: LimitZeroSelectionOperator");
-    }
-    LOGGER.debug(prefix + "Argument 0: IndexSegment - " + _indexSegment.getSegmentName());
-    LOGGER.debug(prefix + "Argument 1: Selections - " + _selection);
-    LOGGER.debug(prefix + "Argument 2: Transform -");
-    _transformPlanNode.showTree(prefix + "    ");
   }
 
   private Set<TransformExpressionTree> collectExpressionsToTransform(IndexSegment indexSegment,

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
@@ -27,25 +27,18 @@ import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.transform.TransformOperator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * The <code>TransformPlanNode</code> class provides the execution plan for transforms on a single segment.
  */
 public class TransformPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TransformPlanNode.class);
-
-  private final String _segmentName;
   private final ProjectionPlanNode _projectionPlanNode;
   private final Set<TransformExpressionTree> _expressions;
   private int _maxDocPerNextCall = DocIdSetPlanNode.MAX_DOC_PER_CALL;
 
   public TransformPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest,
       Set<TransformExpressionTree> expressionsToPlan) {
-    _segmentName = indexSegment.getSegmentName();
-
     setMaxDocsForSelection(brokerRequest);
     Set<String> projectionColumns = new HashSet<>();
     extractProjectionColumns(expressionsToPlan, projectionColumns);
@@ -108,14 +101,5 @@ public class TransformPlanNode implements PlanNode {
   @Override
   public TransformOperator run() {
     return new TransformOperator(_projectionPlanNode.run(), _expressions);
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "Segment Level Inner-Segment Plan Node:");
-    LOGGER.debug(prefix + "Operator: TransformOperator");
-    LOGGER.debug(prefix + "Argument 0: IndexSegment - " + _segmentName);
-    LOGGER.debug(prefix + "Argument 1: Projection -");
-    _projectionPlanNode.showTree(prefix + "    ");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -58,7 +58,6 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public class ServerQueryExecutorV1Impl implements QueryExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerQueryExecutorV1Impl.class);
-  private static final boolean PRINT_QUERY_PLAN = false;
 
   private InstanceDataManager _instanceDataManager = null;
   private SegmentPrunerService _segmentPrunerService = null;
@@ -209,13 +208,6 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
             .makeInterSegmentPlan(segmentDataManagers, queryContext.getBrokerRequest(), executorService,
                 remainingTimeMs);
         planBuildTimer.stopAndRecord();
-
-        if (PRINT_QUERY_PLAN) {
-          LOGGER.debug("***************************** Query Plan for Request {} ***********************************",
-              queryRequest.getRequestId());
-          globalQueryPlan.print();
-          LOGGER.debug("*********************************** End Query Plan ***********************************");
-        }
 
         TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);
         dataTable = globalQueryPlan.execute();

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeDocIdSetPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeDocIdSetPlanNode.java
@@ -26,13 +26,9 @@ import org.apache.pinot.core.operator.DocIdSetOperator;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class StarTreeDocIdSetPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StarTreeDocIdSetPlanNode.class);
-
   private final StarTreeFilterPlanNode _starTreeFilterPlanNode;
 
   public StarTreeDocIdSetPlanNode(StarTreeV2 starTreeV2, @Nullable FilterQueryTree rootFilterNode,
@@ -43,13 +39,5 @@ public class StarTreeDocIdSetPlanNode implements PlanNode {
   @Override
   public DocIdSetOperator run() {
     return new DocIdSetOperator(_starTreeFilterPlanNode.run(), DocIdSetPlanNode.MAX_DOC_PER_CALL);
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "StarTree Document Id Set Plan Node:");
-    LOGGER.debug(prefix + "Operator: DocIdSetOperator");
-    LOGGER.debug(prefix + "Argument 0: StarTreeFilterPlanNode -");
-    _starTreeFilterPlanNode.showTree(prefix + "    ");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeFilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeFilterPlanNode.java
@@ -25,13 +25,9 @@ import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.startree.operator.StarTreeFilterOperator;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class StarTreeFilterPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StarTreeFilterPlanNode.class);
-
   private final StarTreeV2 _starTreeV2;
   private final FilterQueryTree _rootFilterNode;
   private final Set<String> _groupByColumns;
@@ -48,13 +44,5 @@ public class StarTreeFilterPlanNode implements PlanNode {
   @Override
   public StarTreeFilterOperator run() {
     return new StarTreeFilterOperator(_starTreeV2, _rootFilterNode, _groupByColumns, _debugOptions);
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "StarTree Filter Plan Node:");
-    LOGGER.debug(prefix + "Operator: StarTreeFilterOperator");
-    LOGGER.debug(prefix + "Argument 0: Filters - " + _rootFilterNode);
-    LOGGER.debug(prefix + "Argument 1: Group-by Columns - " + _groupByColumns);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectionPlanNode.java
@@ -27,13 +27,9 @@ import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.ProjectionOperator;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class StarTreeProjectionPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StarTreeProjectionPlanNode.class);
-
   private final Map<String, DataSource> _dataSourceMap;
   private final StarTreeDocIdSetPlanNode _starTreeDocIdSetPlanNode;
 
@@ -50,14 +46,5 @@ public class StarTreeProjectionPlanNode implements PlanNode {
   @Override
   public ProjectionOperator run() {
     return new ProjectionOperator(_dataSourceMap, _starTreeDocIdSetPlanNode.run());
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "StarTree Projection Plan Node:");
-    LOGGER.debug(prefix + "Operator: ProjectionOperator");
-    LOGGER.debug(prefix + "Argument 0: Data Sources - " + _dataSourceMap.keySet());
-    LOGGER.debug(prefix + "Argument 1: StarTreeDocIdSetPlanNode -");
-    _starTreeDocIdSetPlanNode.showTree(prefix + "    ");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
@@ -30,13 +30,9 @@ import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class StarTreeTransformPlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StarTreeTransformPlanNode.class);
-
   private final Set<TransformExpressionTree> _groupByExpressions;
   private final StarTreeProjectionPlanNode _starTreeProjectionPlanNode;
 
@@ -70,14 +66,5 @@ public class StarTreeTransformPlanNode implements PlanNode {
     //       - They are all columns (not functions or constants), where no transform is required
     //       - We never call TransformOperator.getResultMetadata() or TransformOperator.getDictionary() on them
     return new TransformOperator(_starTreeProjectionPlanNode.run(), _groupByExpressions);
-  }
-
-  @Override
-  public void showTree(String prefix) {
-    LOGGER.debug(prefix + "StarTree Transform Plan Node:");
-    LOGGER.debug(prefix + "Operator: TransformOperator");
-    LOGGER.debug(prefix + "Argument 0: Group-by Expressions - " + _groupByExpressions);
-    LOGGER.debug(prefix + "Argument 1: StarTreeProjectionPlanNode -");
-    _starTreeProjectionPlanNode.showTree(prefix + "    ");
   }
 }


### PR DESCRIPTION
## Description
Remove the code of printing the query plan for the following reasons:
- It is never enabled
- It can easily flood the log if enabled (log the exact same plan for each segment)
- We don't really need it even for debugging purpose, where enabling query trace can track all the operators
- It requires PlanNode to keep some extra member varialbes, complicates the PlanNode code, and requires extra efforts to keep it in-sync with the PlanNode