### PR TITLE
[QueryContext] Use QueryContext in all PlanNodes

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
@@ -28,6 +27,8 @@ import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.core.startree.plan.StarTreeTransformPlanNode;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
@@ -48,22 +49,23 @@ public class AggregationGroupByPlanNode implements PlanNode {
   private final TransformPlanNode _transformPlanNode;
   private final StarTreeTransformPlanNode _starTreeTransformPlanNode;
 
-  public AggregationGroupByPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest,
+  public AggregationGroupByPlanNode(IndexSegment indexSegment, QueryContext queryContext,
       int maxInitialResultHolderCapacity, int numGroupsLimit) {
     _indexSegment = indexSegment;
     _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
     _numGroupsLimit = numGroupsLimit;
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(brokerRequest);
-    List<String> groupByExpressions = brokerRequest.getGroupBy().getExpressions();
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
+    List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
+    assert groupByExpressions != null;
     int numGroupByExpressions = groupByExpressions.size();
     _groupByExpressions = new TransformExpressionTree[numGroupByExpressions];
     for (int i = 0; i < numGroupByExpressions; i++) {
-      _groupByExpressions[i] = TransformExpressionTree.compileToExpressionTree(groupByExpressions.get(i));
+      _groupByExpressions[i] = groupByExpressions.get(i).toTransformExpressionTree();
     }
 
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
     if (starTrees != null) {
-      if (!StarTreeUtils.isStarTreeDisabled(brokerRequest)) {
+      if (!StarTreeUtils.isStarTreeDisabled(queryContext)) {
         int numAggregationFunctions = _aggregationFunctions.length;
         AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
             new AggregationFunctionColumnPair[numAggregationFunctions];
@@ -79,7 +81,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
           }
         }
         if (!hasUnsupportedAggregationFunction) {
-          FilterQueryTree rootFilterNode = RequestUtils.generateFilterQueryTree(brokerRequest);
+          FilterQueryTree rootFilterNode = RequestUtils.generateFilterQueryTree(queryContext.getBrokerRequest());
           for (StarTreeV2 starTreeV2 : starTrees) {
             if (StarTreeUtils
                 .isFitForStarTree(starTreeV2.getMetadata(), aggregationFunctionColumnPairs, _groupByExpressions,
@@ -87,7 +89,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
               _transformPlanNode = null;
               _starTreeTransformPlanNode =
                   new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, _groupByExpressions,
-                      rootFilterNode, brokerRequest.getDebugOptions());
+                      rootFilterNode, queryContext.getDebugOptions());
               return;
             }
           }
@@ -97,7 +99,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
 
     Set<TransformExpressionTree> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(_aggregationFunctions, _groupByExpressions);
-    _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest, expressionsToTransform);
+    _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform);
     _starTreeTransformPlanNode = null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
@@ -28,6 +27,7 @@ import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.core.startree.plan.StarTreeTransformPlanNode;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
@@ -45,13 +45,13 @@ public class AggregationPlanNode implements PlanNode {
   private final TransformPlanNode _transformPlanNode;
   private final StarTreeTransformPlanNode _starTreeTransformPlanNode;
 
-  public AggregationPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest) {
+  public AggregationPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     _indexSegment = indexSegment;
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(brokerRequest);
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
 
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
     if (starTrees != null) {
-      if (!StarTreeUtils.isStarTreeDisabled(brokerRequest)) {
+      if (!StarTreeUtils.isStarTreeDisabled(queryContext)) {
         int numAggregationFunctions = _aggregationFunctions.length;
         AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
             new AggregationFunctionColumnPair[numAggregationFunctions];
@@ -67,14 +67,14 @@ public class AggregationPlanNode implements PlanNode {
           }
         }
         if (!hasUnsupportedAggregationFunction) {
-          FilterQueryTree rootFilterNode = RequestUtils.generateFilterQueryTree(brokerRequest);
+          FilterQueryTree rootFilterNode = RequestUtils.generateFilterQueryTree(queryContext.getBrokerRequest());
           for (StarTreeV2 starTreeV2 : starTrees) {
             if (StarTreeUtils
                 .isFitForStarTree(starTreeV2.getMetadata(), aggregationFunctionColumnPairs, null, rootFilterNode)) {
               _transformPlanNode = null;
               _starTreeTransformPlanNode =
                   new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, null, rootFilterNode,
-                      brokerRequest.getDebugOptions());
+                      queryContext.getDebugOptions());
               return;
             }
           }
@@ -84,7 +84,7 @@ public class AggregationPlanNode implements PlanNode {
 
     Set<TransformExpressionTree> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(_aggregationFunctions, null);
-    _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest, expressionsToTransform);
+    _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform);
     _starTreeTransformPlanNode = null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedAggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedAggregationPlanNode.java
@@ -20,12 +20,12 @@ package org.apache.pinot.core.plan;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 
 
@@ -42,11 +42,11 @@ public class DictionaryBasedAggregationPlanNode implements PlanNode {
    * Constructor for the class.
    *
    * @param indexSegment Segment to process
-   * @param brokerRequest Broker request
+   * @param queryContext Query context
    */
-  public DictionaryBasedAggregationPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest) {
+  public DictionaryBasedAggregationPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     _indexSegment = indexSegment;
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(brokerRequest);
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
     _dictionaryMap = new HashMap<>();
     for (AggregationFunction aggregationFunction : _aggregationFunctions) {
       String column = ((TransformExpressionTree) aggregationFunction.getInputExpressions().get(0)).getValue();

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
@@ -19,9 +19,9 @@
 package org.apache.pinot.core.plan;
 
 import com.google.common.base.Preconditions;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.query.request.context.QueryContext;
 
 
 public class DocIdSetPlanNode implements PlanNode {
@@ -30,14 +30,10 @@ public class DocIdSetPlanNode implements PlanNode {
   private final FilterPlanNode _filterPlanNode;
   private final int _maxDocPerCall;
 
-  public DocIdSetPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest, int maxDocPerCall) {
+  public DocIdSetPlanNode(IndexSegment indexSegment, QueryContext queryContext, int maxDocPerCall) {
     Preconditions.checkState(maxDocPerCall > 0 && maxDocPerCall <= MAX_DOC_PER_CALL);
-    _filterPlanNode = new FilterPlanNode(indexSegment, brokerRequest);
+    _filterPlanNode = new FilterPlanNode(indexSegment, queryContext);
     _maxDocPerCall = maxDocPerCall;
-  }
-
-  public DocIdSetPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest) {
-    this(indexSegment, brokerRequest, MAX_DOC_PER_CALL);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
@@ -40,22 +39,23 @@ import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
 import org.apache.pinot.core.operator.filter.TextMatchFilterOperator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.segment.index.readers.NullValueVectorReader;
 
 
 public class FilterPlanNode implements PlanNode {
-  private final BrokerRequest _brokerRequest;
-  private final IndexSegment _segment;
+  private final IndexSegment _indexSegment;
+  private final QueryContext _queryContext;
 
-  public FilterPlanNode(IndexSegment segment, BrokerRequest brokerRequest) {
-    _segment = segment;
-    _brokerRequest = brokerRequest;
+  public FilterPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
+    _indexSegment = indexSegment;
+    _queryContext = queryContext;
   }
 
   @Override
   public BaseFilterOperator run() {
-    FilterQueryTree rootFilterNode = RequestUtils.generateFilterQueryTree(_brokerRequest);
-    return constructPhysicalOperator(rootFilterNode, _segment, _brokerRequest.getDebugOptions());
+    FilterQueryTree rootFilterNode = RequestUtils.generateFilterQueryTree(_queryContext.getBrokerRequest());
+    return constructPhysicalOperator(rootFilterNode, _indexSegment, _queryContext.getDebugOptions());
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/MetadataBasedAggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/MetadataBasedAggregationPlanNode.java
@@ -21,13 +21,13 @@ package org.apache.pinot.core.plan;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.MetadataBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.QueryContext;
 
 
 /**
@@ -43,11 +43,11 @@ public class MetadataBasedAggregationPlanNode implements PlanNode {
    * Constructor for the class.
    *
    * @param indexSegment Segment to process
-   * @param brokerRequest Broker request
+   * @param queryContext Query context
    */
-  public MetadataBasedAggregationPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest) {
+  public MetadataBasedAggregationPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     _indexSegment = indexSegment;
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(brokerRequest);
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
     _dataSourceMap = new HashMap<>();
     for (AggregationFunction aggregationFunction : _aggregationFunctions) {
       if (aggregationFunction.getType() != AggregationFunctionType.COUNT) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -18,12 +18,10 @@
  */
 package org.apache.pinot.core.plan;
 
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Selection;
-import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.indexsegment.IndexSegment;
@@ -32,7 +30,10 @@ import org.apache.pinot.core.operator.query.EmptySelectionOperator;
 import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.core.operator.query.SelectionOrderByOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
-import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 
 
 /**
@@ -40,58 +41,55 @@ import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
  */
 public class SelectionPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
-  private final Selection _selection;
+  private final QueryContext _queryContext;
   private final TransformPlanNode _transformPlanNode;
 
-  public SelectionPlanNode(IndexSegment indexSegment, BrokerRequest brokerRequest) {
+  public SelectionPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     _indexSegment = indexSegment;
-    _selection = brokerRequest.getSelections();
-    _transformPlanNode =
-        new TransformPlanNode(_indexSegment, brokerRequest, collectExpressionsToTransform(indexSegment, brokerRequest));
+    _queryContext = queryContext;
+    _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, collectExpressions());
   }
 
   @Override
   public Operator<IntermediateResultsBlock> run() {
     TransformOperator transformOperator = _transformPlanNode.run();
-    if (_selection.getSize() > 0) {
-      if (_selection.getSelectionSortSequence() == null) {
-        return new SelectionOnlyOperator(_indexSegment, _selection, transformOperator);
+    Selection selection = _queryContext.getBrokerRequest().getSelections();
+    if (_queryContext.getLimit() > 0) {
+      if (_queryContext.getOrderByExpressions() == null) {
+        return new SelectionOnlyOperator(_indexSegment, selection, transformOperator);
       } else {
-        return new SelectionOrderByOperator(_indexSegment, _selection, transformOperator);
+        return new SelectionOrderByOperator(_indexSegment, selection, transformOperator);
       }
     } else {
-      return new EmptySelectionOperator(_indexSegment, _selection, transformOperator);
+      return new EmptySelectionOperator(_indexSegment, selection, transformOperator);
     }
   }
 
-  private Set<TransformExpressionTree> collectExpressionsToTransform(IndexSegment indexSegment,
-      BrokerRequest brokerRequest) {
-
-    Set<TransformExpressionTree> expressionTrees = new LinkedHashSet<>();
-    Selection selection = brokerRequest.getSelections();
+  private Set<TransformExpressionTree> collectExpressions() {
+    Set<TransformExpressionTree> expressionTrees = new HashSet<>();
 
     // Extract selection expressions
-    List<String> selectionColumns = selection.getSelectionColumns();
-    if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
-      for (String column : indexSegment.getPhysicalColumnNames()) {
-        expressionTrees.add(new TransformExpressionTree(new IdentifierAstNode(column)));
+    List<ExpressionContext> selectExpressions = _queryContext.getSelectExpressions();
+    if (selectExpressions.size() == 1 && selectExpressions.get(0).equals(SelectionOperatorUtils.IDENTIFIER_STAR)) {
+      for (String column : _indexSegment.getPhysicalColumnNames()) {
+        expressionTrees
+            .add(new TransformExpressionTree(TransformExpressionTree.ExpressionType.IDENTIFIER, column, null));
       }
     } else {
-      for (String selectionColumn : selectionColumns) {
-        expressionTrees.add(TransformExpressionTree.compileToExpressionTree(selectionColumn));
+      for (ExpressionContext selectExpression : selectExpressions) {
+        expressionTrees.add(selectExpression.toTransformExpressionTree());
       }
     }
 
-    // Extract order-by expressions.
-    if (selection.getSize() > 0) {
-      List<SelectionSort> sortSequence = selection.getSelectionSortSequence();
-      if (sortSequence != null) {
-        for (SelectionSort selectionSort : sortSequence) {
-          String orderByColumn = selectionSort.getColumn();
-          expressionTrees.add(TransformExpressionTree.compileToExpressionTree(orderByColumn));
-        }
+    // Extract order-by expressions
+    List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();
+    // NOTE: queries with LIMIT 0 are solved by EmptySelectionOperator where order-by expressions are not required.
+    if (_queryContext.getLimit() > 0 && orderByExpressions != null) {
+      for (OrderByExpressionContext orderByExpression : orderByExpressions) {
+        expressionTrees.add(orderByExpression.getExpression().toTransformExpressionTree());
       }
     }
+
     return expressionTrees;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ExpressionContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ExpressionContext.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pinot.core.query.request.context;
 
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 
 
 /**
@@ -82,6 +86,29 @@ public class ExpressionContext {
       }
     } else if (_type == Type.FUNCTION) {
       _function.getColumns(columns);
+    }
+  }
+
+  /**
+   * Temporary helper method to help the migration from BrokerRequest to QueryContext.
+   */
+  public TransformExpressionTree toTransformExpressionTree() {
+    switch (_type) {
+      case LITERAL:
+        return new TransformExpressionTree(TransformExpressionTree.ExpressionType.LITERAL, _value, null);
+      case IDENTIFIER:
+        return new TransformExpressionTree(TransformExpressionTree.ExpressionType.IDENTIFIER, _value, null);
+      case FUNCTION:
+        Preconditions.checkState(_function.getType() == FunctionContext.Type.TRANSFORM);
+        List<ExpressionContext> arguments = _function.getArguments();
+        List<TransformExpressionTree> children = new ArrayList<>(arguments.size());
+        for (ExpressionContext argument : arguments) {
+          children.add(argument.toTransformExpressionTree());
+        }
+        return new TransformExpressionTree(TransformExpressionTree.ExpressionType.FUNCTION, _function.getFunctionName(),
+            children);
+      default:
+        throw new IllegalStateException();
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -40,6 +40,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.util.ArrayCopyUtils;
 import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -68,6 +69,7 @@ public class SelectionOperatorUtils {
   private SelectionOperatorUtils() {
   }
 
+  public static final ExpressionContext IDENTIFIER_STAR = ExpressionContext.forIdentifier("*");
   public static final int MAX_ROW_HOLDER_INITIAL_CAPACITY = 10_000;
 
   private static final String INT_PATTERN = "##########";

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.core.startree.v2.StarTreeV2Metadata;
 
@@ -37,10 +38,10 @@ public class StarTreeUtils {
   public static final String USE_STAR_TREE_KEY = "useStarTree";
 
   /**
-   * Returns whether star-tree is disabled in broker request.
+   * Returns whether star-tree is disabled for the query.
    */
-  public static boolean isStarTreeDisabled(BrokerRequest brokerRequest) {
-    Map<String, String> debugOptions = brokerRequest.getDebugOptions();
+  public static boolean isStarTreeDisabled(QueryContext queryContext) {
+    Map<String, String> debugOptions = queryContext.getDebugOptions();
     return debugOptions != null && "false".equalsIgnoreCase(debugOptions.get(USE_STAR_TREE_KEY));
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -50,6 +50,8 @@ import org.apache.pinot.core.plan.FilterPlanNode;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.core.startree.plan.StarTreeFilterPlanNode;
@@ -181,6 +183,7 @@ abstract class BaseStarTreeV2Test<R, A> {
   @SuppressWarnings("unchecked")
   void testQuery(String query) {
     BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
+    QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
 
     // Aggregations
     AggregationFunction[] aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(brokerRequest);
@@ -230,7 +233,7 @@ abstract class BaseStarTreeV2Test<R, A> {
             starTreeGroupByColumnValueSets);
 
     // Extract values without star-tree
-    PlanNode nonStarTreeFilterPlanNode = new FilterPlanNode(_indexSegment, brokerRequest);
+    PlanNode nonStarTreeFilterPlanNode = new FilterPlanNode(_indexSegment, queryContext);
     List<SingleValueSet> nonStarTreeAggregationColumnValueSets = new ArrayList<>(numAggregations);
     List<Dictionary> nonStarTreeAggregationColumnDictionaries = new ArrayList<>(numAggregations);
     for (AggregationFunctionColumnPair aggregationFunctionColumnPair : functionColumnPairs) {


### PR DESCRIPTION
## Description
Replace BrokerRequest with QueryContext in all PlanNodes
This change can save the redundant expression compilation of:
- Group by expressions
- Selection expreesions
- Order by expressions

Expressions in aggregation and filter will be addressed in the following PRs