### PR TITLE
Fixing ControllerConf casting issue

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import org.apache.commons.configuration.Configuration;
@@ -169,6 +170,15 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public ControllerConf() {
     super();
+  }
+
+  public ControllerConf(Configuration conf) {
+    super();
+    Iterator<String> keysIterator = conf.getKeys();
+    while(keysIterator.hasNext()) {
+      String key = keysIterator.next();
+      this.setProperty(key, conf.getProperty(key));
+    }
   }
 
   public void setLocalTempDir(String localTempDir) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
 import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ServiceStatus;
@@ -85,7 +86,7 @@ public class PinotServiceManager {
       throws Exception {
     switch (role) {
       case CONTROLLER:
-        return startController((ControllerConf) conf);
+        return startController(new ControllerConf(conf));
       case BROKER:
         return startBroker(conf);
       case SERVER:


### PR DESCRIPTION
## Description
Adding method to init ControllerConf with a Configuration Objecct.

Sample stacktrace
```
INFO: [HttpServer] Started.
2020/06/17 17:45:20.750 ERROR [StartServiceManagerCommand] [main] Failed to start a [ CONTROLLER ] Service
java.lang.ClassCastException: org.apache.commons.configuration.PropertiesConfiguration cannot be cast to org.apache.pinot.controller.ControllerConf
	at org.apache.pinot.tools.service.PinotServiceManager.startRole(PinotServiceManager.java:88) ~[pinot-all-0.5.0-SNAPSHOT-jar-with-dependencies.jar:0.5.0-SNAPSHOT-0251892e14887a71300ead0364617c9f8074735f]
	at org.apache.pinot.tools.admin.command.StartServiceManagerCommand.startPinotService(StartServiceManagerCommand.java:199) [pinot-all-0.5.0-SNAPSHOT-jar-with-dependencies.jar:0.5.0-SNAPSHOT-0251892e14887a71300ead0364617c9f8074735f]
	at 
```