### PR TITLE
[TE] fix the monitoring task scheduler

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/monitor/MonitorJobScheduler.java
@@ -50,6 +50,7 @@ public class MonitorJobScheduler {
     monitorJobContext = new MonitorJobContext();
     monitorJobContext.setTaskDAO(anomalyTaskDAO);
     monitorJobContext.setMonitorConfiguration(monitorConfiguration);
+    monitorJobContext.setJobDAO(DAO_REGISTRY.getJobDAO());
 
     monitorJobRunner = new MonitorJobRunner(monitorJobContext);
     scheduledExecutorService


### PR DESCRIPTION
The monitoring task scheduler couldn't start due to a NullPointerException. This is caused by the code clean up in PR-5435. This PR fixes the issue.