### PR TITLE
PINOT-9:Broken links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Pinot also provides k8s integration with interactive query engine [Presto](kuber
 ## Documentation
 Check out [Pinot documentation](https://docs.pinot.apache.org/) for a complete description of Pinot's features.
 - [Quick Demo](https://docs.pinot.apache.org/getting-started/running-pinot-locally)
-- [Pinot Architecture](https://docs.pinot.apache.org/concepts/architecture)
-- [Pinot Query Language](https://docs.pinot.apache.org/pinot-user-guide/pinot-query-language)
+- [Pinot Architecture](https://docs.pinot.apache.org/basics/architecture)
+- [Pinot Query Language](https://docs.pinot.apache.org/users/user-guide-query/pinot-query-language)
 
 ## Pinot Query Clients
 


### PR DESCRIPTION
## Description
Fixed the broken links on readme file for accessing 'Architecture' and 'User guide' web links.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [*] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
