### PR TITLE
Filtering during ingestion

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.helix.ZNRecord;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.IngestionConfig;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
@@ -124,9 +125,15 @@ public class TableConfigUtils {
       upsertConfig = JsonUtils.stringToObject(upsertConfigString, UpsertConfig.class);
     }
 
+    IngestionConfig ingestionConfig = null;
+    String ingestionConfigString = simpleFields.get(TableConfig.INGESTION_CONFIG_KEY);
+    if (ingestionConfigString != null) {
+      ingestionConfig = JsonUtils.stringToObject(ingestionConfigString, IngestionConfig.class);
+    }
+
     return new TableConfig(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig,
         quotaConfig, taskConfig, routingConfig, queryConfig, instanceAssignmentConfigMap, fieldConfigList,
-        upsertConfig);
+        upsertConfig, ingestionConfig);
   }
 
   public static ZNRecord toZNRecord(TableConfig tableConfig)
@@ -171,6 +178,10 @@ public class TableConfigUtils {
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     if (upsertConfig != null) {
       simpleFields.put(TableConfig.UPSERT_CONFIG_KEY, JsonUtils.objectToString(upsertConfig));
+    }
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig != null) {
+      simpleFields.put(TableConfig.INGESTION_CONFIG_KEY, JsonUtils.objectToString(ingestionConfig));
     }
 
     ZNRecord znRecord = new ZNRecord(tableConfig.getTableName());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/function/FunctionEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/function/FunctionEvaluatorFactory.java
@@ -85,7 +85,7 @@ public class FunctionEvaluatorFactory {
     return functionEvaluator;
   }
 
-  private static FunctionEvaluator getExpressionEvaluator(String transformExpression) {
+  public static FunctionEvaluator getExpressionEvaluator(String transformExpression) {
     FunctionEvaluator functionEvaluator;
     try {
       if (transformExpression.startsWith(GroovyFunctionEvaluator.getGroovyExpressionPrefix())) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -44,7 +44,7 @@ import org.apache.pinot.core.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
-import org.apache.pinot.core.util.SchemaUtils;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -108,7 +108,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       throws Exception {
     super();
     _segmentVersion = indexLoadingConfig.getSegmentVersion();
-    _recordTransformer = CompositeTransformer.getDefaultTransformer(schema);
+    _recordTransformer = CompositeTransformer.getDefaultTransformer(tableConfig, schema);
     _serverMetrics = serverMetrics;
     _segmentName = realtimeSegmentZKMetadata.getSegmentName();
     _tableNameWithType = tableConfig.getTableName();
@@ -169,9 +169,9 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // create and init stream level consumer
     StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
     String clientId = HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getTopicName();
-    _streamLevelConsumer = streamConsumerFactory
-        .createStreamLevelConsumer(clientId, _tableNameWithType, SchemaUtils.extractSourceFields(schema),
-            instanceMetadata.getGroupId(_tableNameWithType));
+    _streamLevelConsumer = streamConsumerFactory.createStreamLevelConsumer(clientId, _tableNameWithType,
+        IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema),
+        instanceMetadata.getGroupId(_tableNameWithType));
     _streamLevelConsumer.start();
     _tableStreamName = _tableNameWithType + "_" + _streamConfig.getTopicName();
 
@@ -245,7 +245,8 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             if (consumedRow != null) {
               try {
                 GenericRow transformedRow = _recordTransformer.transform(consumedRow);
-                if (transformedRow != null) {
+                // FIXME: MULTIPLE_RECORDS_KEY is not handled here
+                if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
                   // we currently do not get ingestion data through stream-consumer
                   notFull = _realtimeSegment.index(transformedRow, null);
                   exceptionSleepMillis = 50L;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -169,8 +169,8 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // create and init stream level consumer
     StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
     String clientId = HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getTopicName();
-    _streamLevelConsumer = streamConsumerFactory.createStreamLevelConsumer(clientId, _tableNameWithType,
-        IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema),
+    Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(tableConfig.getIngestionConfig(), schema);
+    _streamLevelConsumer = streamConsumerFactory.createStreamLevelConsumer(clientId, _tableNameWithType, fieldsToRead,
         instanceMetadata.getGroupId(_tableNameWithType));
     _streamLevelConsumer.start();
     _tableStreamName = _tableNameWithType + "_" + _streamConfig.getTopicName();
@@ -245,8 +245,8 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             if (consumedRow != null) {
               try {
                 GenericRow transformedRow = _recordTransformer.transform(consumedRow);
-                // FIXME: MULTIPLE_RECORDS_KEY is not handled here
-                if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
+                // FIXME: handle MULTIPLE_RECORDS_KEY for HLL
+                if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
                   // we currently do not get ingestion data through stream-consumer
                   notFull = _realtimeSegment.index(transformedRow, null);
                   exceptionSleepMillis = 50L;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -471,7 +471,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           if (decodedRow.getValue(GenericRow.MULTIPLE_RECORDS_KEY) != null) {
             for (Object singleRow : (Collection) decodedRow.getValue(GenericRow.MULTIPLE_RECORDS_KEY)) {
               GenericRow transformedRow = _recordTransformer.transform((GenericRow) singleRow);
-              if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
+              if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
                 realtimeRowsConsumedMeter = _serverMetrics
                     .addMeteredTableValue(_metricKeyName, ServerMeter.REALTIME_ROWS_CONSUMED, 1, realtimeRowsConsumedMeter);
                 indexedMessageCount++;
@@ -484,7 +484,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             }
           } else {
             GenericRow transformedRow = _recordTransformer.transform(decodedRow);
-            if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
+            if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
               realtimeRowsConsumedMeter = _serverMetrics
                   .addMeteredTableValue(_metricKeyName, ServerMeter.REALTIME_ROWS_CONSUMED, 1, realtimeRowsConsumedMeter);
               indexedMessageCount++;
@@ -1185,8 +1185,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             .setConsumerDir(consumerDir);
 
     // Create message decoder
-    _messageDecoder = StreamDecoderProvider
-        .create(_partitionLevelStreamConfig, IngestionUtils.getFieldsForRecordExtractor(_tableConfig, _schema));
+    Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig.getIngestionConfig(), _schema);
+    _messageDecoder = StreamDecoderProvider.create(_partitionLevelStreamConfig, fieldsToRead);
     _clientId = _streamTopic + "-" + _streamPartitionId;
 
     // Create record transformer

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/CompositeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/CompositeTransformer.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
@@ -38,7 +39,10 @@ public class CompositeTransformer implements RecordTransformer {
    * <p>NOTE: DO NOT CHANGE THE ORDER OF THE RECORD TRANSFORMERS
    * <ul>
    *   <li>
-   *     We put {@link ExpressionTransformer} before everyone else, so that we get the real columns for other transformers to work on
+   *     {@link ExpressionTransformer} before everyone else, so that we get the real columns for other transformers to work on
+   *   </li>
+   *   <li>
+   *     {@link FilterTransformer} after ExpressionTransformer, so that we have source as well as destination columns
    *   </li>
    *   <li>
    *     We put {@link SanitizationTransformer} after {@link DataTypeTransformer} so that before sanitation, all values
@@ -46,10 +50,10 @@ public class CompositeTransformer implements RecordTransformer {
    *   </li>
    * </ul>
    */
-  public static CompositeTransformer getDefaultTransformer(Schema schema) {
+  public static CompositeTransformer getDefaultTransformer(TableConfig tableConfig, Schema schema) {
     return new CompositeTransformer(Arrays
-        .asList(new ExpressionTransformer(schema), new NullValueTransformer(schema), new DataTypeTransformer(schema),
-            new SanitizationTransformer(schema)));
+        .asList(new ExpressionTransformer(schema), new FilterTransformer(tableConfig), new NullValueTransformer(schema),
+            new DataTypeTransformer(schema), new SanitizationTransformer(schema)));
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/FilterTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/FilterTransformer.java
@@ -30,15 +30,14 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  */
 public class FilterTransformer implements RecordTransformer {
 
-  private FunctionEvaluator _evaluator = null;
+  private final FunctionEvaluator _evaluator;
 
   public FilterTransformer(TableConfig tableConfig) {
+    String filterFunction = null;
     if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getFilterConfig() != null) {
-      String filterFunction = tableConfig.getIngestionConfig().getFilterConfig().getFilterFunction();
-      if (filterFunction != null) {
-        _evaluator = FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
-      }
+      filterFunction = tableConfig.getIngestionConfig().getFilterConfig().getFilterFunction();
     }
+    _evaluator = (filterFunction != null) ? FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction) : null;
   }
 
   @Override
@@ -46,7 +45,7 @@ public class FilterTransformer implements RecordTransformer {
     if (_evaluator != null) {
       Object result = _evaluator.evaluate(record);
       if (Boolean.TRUE.equals(result)) {
-        record.putValue(GenericRow.FILTER_RECORD_KEY, true);
+        record.putValue(GenericRow.SKIP_RECORD_KEY, true);
       }
     }
     return record;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/FilterTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/FilterTransformer.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.recordtransformer;
+
+import org.apache.pinot.core.data.function.FunctionEvaluator;
+import org.apache.pinot.core.data.function.FunctionEvaluatorFactory;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
+/**
+ * Based on filter config, decide whether to skip or allow this record.
+ * If record should be skipped, puts a special key in the record.
+ */
+public class FilterTransformer implements RecordTransformer {
+
+  private FunctionEvaluator _evaluator = null;
+
+  public FilterTransformer(TableConfig tableConfig) {
+    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getFilterConfig() != null) {
+      String filterFunction = tableConfig.getIngestionConfig().getFilterConfig().getFilterFunction();
+      if (filterFunction != null) {
+        _evaluator = FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
+      }
+    }
+  }
+
+  @Override
+  public GenericRow transform(GenericRow record) {
+    if (_evaluator != null) {
+      Object result = _evaluator.evaluate(record);
+      if (Boolean.TRUE.equals(result)) {
+        record.putValue(GenericRow.FILTER_RECORD_KEY, true);
+      }
+    }
+    return record;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -67,6 +67,7 @@ public class SegmentGeneratorConfig {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentGeneratorConfig.class);
 
+  private TableConfig _tableConfig;
   private Map<String, String> _customProperties = new HashMap<>();
   private Set<String> _rawIndexCreationColumns = new HashSet<>();
   private Map<String, ChunkCompressorFactory.CompressionType> _rawIndexCompressionType = new HashMap<>();
@@ -122,6 +123,8 @@ public class SegmentGeneratorConfig {
     Preconditions.checkNotNull(schema);
     Preconditions.checkNotNull(tableConfig);
     setSchema(schema);
+
+    _tableConfig = tableConfig;
 
     // NOTE: SegmentGeneratorConfig#setSchema doesn't set the time column anymore. timeColumnName is expected to be read from table config.
     String timeColumnName = null;
@@ -198,7 +201,7 @@ public class SegmentGeneratorConfig {
   /**
    * Set time column details using the given time column
    */
-  public void setTime(@Nullable String timeColumnName, Schema schema) {
+  private void setTime(@Nullable String timeColumnName, Schema schema) {
     if (timeColumnName != null) {
       DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
       if (dateTimeFieldSpec != null) {
@@ -483,7 +486,11 @@ public class SegmentGeneratorConfig {
     return _schema;
   }
 
-  public void setSchema(Schema schema) {
+  public TableConfig getTableConfig() {
+    return _tableConfig;
+  }
+
+  private void setSchema(Schema schema) {
     Preconditions.checkNotNull(schema);
     _schema = schema;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
@@ -62,13 +62,13 @@ public class RecordReaderSegmentCreationDataSource implements SegmentCreationDat
         if (reuse.getValue(GenericRow.MULTIPLE_RECORDS_KEY) != null) {
           for (Object singleRow : (Collection) reuse.getValue(GenericRow.MULTIPLE_RECORDS_KEY)) {
             GenericRow transformedRow = recordTransformer.transform((GenericRow) singleRow);
-            if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
+            if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
               collector.collectRow(transformedRow);
             }
           }
         } else {
           GenericRow transformedRow = recordTransformer.transform(reuse);
-          if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
+          if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
             collector.collectRow(transformedRow);
           }
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
@@ -18,12 +18,9 @@
  */
 package org.apache.pinot.core.segment.creator;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import org.apache.pinot.common.Utils;
-import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.core.data.recordtransformer.CompositeTransformer;
@@ -50,8 +47,8 @@ public class RecordReaderSegmentCreationDataSource implements SegmentCreationDat
   @Override
   public SegmentPreIndexStatsCollector gatherStats(StatsCollectorConfig statsCollectorConfig) {
     try {
-      RecordTransformer recordTransformer =
-          CompositeTransformer.getDefaultTransformer(statsCollectorConfig.getSchema());
+      RecordTransformer recordTransformer = CompositeTransformer
+          .getDefaultTransformer(statsCollectorConfig.getTableConfig(), statsCollectorConfig.getSchema());
 
       SegmentPreIndexStatsCollector collector = new SegmentPreIndexStatsCollectorImpl(statsCollectorConfig);
       collector.init();
@@ -65,13 +62,13 @@ public class RecordReaderSegmentCreationDataSource implements SegmentCreationDat
         if (reuse.getValue(GenericRow.MULTIPLE_RECORDS_KEY) != null) {
           for (Object singleRow : (Collection) reuse.getValue(GenericRow.MULTIPLE_RECORDS_KEY)) {
             GenericRow transformedRow = recordTransformer.transform((GenericRow) singleRow);
-            if (transformedRow != null) {
+            if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
               collector.collectRow(transformedRow);
             }
           }
         } else {
           GenericRow transformedRow = recordTransformer.transform(reuse);
-          if (transformedRow != null) {
+          if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
             collector.collectRow(transformedRow);
           }
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/StatsCollectorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/StatsCollectorConfig.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.data.partition.PartitionFunction;
 import org.apache.pinot.core.data.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 
@@ -35,6 +36,7 @@ import org.apache.pinot.spi.data.Schema;
 public class StatsCollectorConfig {
 
   private final Schema _schema;
+  private final TableConfig _tableConfig;
   private final SegmentPartitionConfig _segmentPartitionConfig;
 
   /**
@@ -42,9 +44,11 @@ public class StatsCollectorConfig {
    * @param schema Data schema
    * @param segmentPartitionConfig Segment partitioning config
    */
-  public StatsCollectorConfig(@Nonnull Schema schema, SegmentPartitionConfig segmentPartitionConfig) {
+  public StatsCollectorConfig(Schema schema, TableConfig tableConfig, @Nullable SegmentPartitionConfig segmentPartitionConfig) {
     Preconditions.checkNotNull(schema);
+    Preconditions.checkNotNull(tableConfig);
     _schema = schema;
+    _tableConfig = tableConfig;
     _segmentPartitionConfig = segmentPartitionConfig;
   }
 
@@ -76,8 +80,11 @@ public class StatsCollectorConfig {
         : SegmentPartitionConfig.INVALID_NUM_PARTITIONS;
   }
 
-  @Nonnull
   public Schema getSchema() {
     return _schema;
+  }
+
+  public TableConfig getTableConfig() {
+    return _tableConfig;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/StatsCollectorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/StatsCollectorConfig.java
@@ -35,8 +35,8 @@ import org.apache.pinot.spi.data.Schema;
  */
 public class StatsCollectorConfig {
 
-  private final Schema _schema;
   private final TableConfig _tableConfig;
+  private final Schema _schema;
   private final SegmentPartitionConfig _segmentPartitionConfig;
 
   /**
@@ -44,11 +44,11 @@ public class StatsCollectorConfig {
    * @param schema Data schema
    * @param segmentPartitionConfig Segment partitioning config
    */
-  public StatsCollectorConfig(Schema schema, TableConfig tableConfig, @Nullable SegmentPartitionConfig segmentPartitionConfig) {
-    Preconditions.checkNotNull(schema);
+  public StatsCollectorConfig(TableConfig tableConfig, Schema schema, @Nullable SegmentPartitionConfig segmentPartitionConfig) {
     Preconditions.checkNotNull(tableConfig);
-    _schema = schema;
+    Preconditions.checkNotNull(schema);
     _tableConfig = tableConfig;
+    _schema = schema;
     _segmentPartitionConfig = segmentPartitionConfig;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -143,7 +143,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
 
     // Initialize stats collection
     segmentStats = dataSource
-        .gatherStats(new StatsCollectorConfig(dataSchema, config.getTableConfig(), config.getSegmentPartitionConfig()));
+        .gatherStats(new StatsCollectorConfig(config.getTableConfig(), dataSchema, config.getSegmentPartitionConfig()));
     totalDocs = segmentStats.getTotalDocCount();
 
     // Initialize index creation

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -102,8 +102,8 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     TableConfig tableConfig = segmentGeneratorConfig.getTableConfig();
     FileFormat fileFormat = segmentGeneratorConfig.getFormat();
     String recordReaderClassName = segmentGeneratorConfig.getRecordReaderPath();
-    Set<String> sourceFields =
-        IngestionUtils.getFieldsForRecordExtractor(tableConfig, segmentGeneratorConfig.getSchema());
+    Set<String> sourceFields = IngestionUtils
+        .getFieldsForRecordExtractor(tableConfig.getIngestionConfig(), segmentGeneratorConfig.getSchema());
 
     // Allow for instantiation general record readers from a record reader path passed into segment generator config
     // If this is set, this will override the file format
@@ -195,7 +195,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
             GenericRow transformedRow = _recordTransformer.transform((GenericRow) singleRow);
             recordReadStopTime = System.currentTimeMillis();
             totalRecordReadTime += (recordReadStopTime - recordReadStartTime);
-            if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
+            if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
               indexCreator.indexRow(transformedRow);
               indexStopTime = System.currentTimeMillis();
               totalIndexTime += (indexStopTime - recordReadStopTime);
@@ -205,7 +205,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
           GenericRow transformedRow = _recordTransformer.transform(decodedRow);
           recordReadStopTime = System.currentTimeMillis();
           totalRecordReadTime += (recordReadStopTime - recordReadStartTime);
-          if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
+          if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
             indexCreator.indexRow(transformedRow);
             indexStopTime = System.currentTimeMillis();
             totalIndexTime += (indexStopTime - recordReadStopTime);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -25,14 +25,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.data.recordtransformer.CompositeTransformer;
 import org.apache.pinot.core.data.recordtransformer.RecordTransformer;
@@ -55,7 +53,8 @@ import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.core.startree.v2.builder.MultipleTreesBuilder;
 import org.apache.pinot.core.startree.v2.builder.StarTreeV2BuilderConfig;
 import org.apache.pinot.core.util.CrcUtils;
-import org.apache.pinot.core.util.SchemaUtils;
+import org.apache.pinot.core.util.IngestionUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
@@ -100,9 +99,11 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     Preconditions.checkState(dataFile.exists(), "Input file: " + dataFile.getAbsolutePath() + " does not exist");
 
     Schema schema = segmentGeneratorConfig.getSchema();
+    TableConfig tableConfig = segmentGeneratorConfig.getTableConfig();
     FileFormat fileFormat = segmentGeneratorConfig.getFormat();
     String recordReaderClassName = segmentGeneratorConfig.getRecordReaderPath();
-    Set<String> sourceFields = SchemaUtils.extractSourceFields(segmentGeneratorConfig.getSchema());
+    Set<String> sourceFields =
+        IngestionUtils.getFieldsForRecordExtractor(tableConfig, segmentGeneratorConfig.getSchema());
 
     // Allow for instantiation general record readers from a record reader path passed into segment generator config
     // If this is set, this will override the file format
@@ -128,7 +129,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
 
   public void init(SegmentGeneratorConfig config, RecordReader recordReader) {
     init(config, new RecordReaderSegmentCreationDataSource(recordReader),
-        CompositeTransformer.getDefaultTransformer(config.getSchema()));
+        CompositeTransformer.getDefaultTransformer(config.getTableConfig(), config.getSchema()));
   }
 
   public void init(SegmentGeneratorConfig config, SegmentCreationDataSource dataSource,
@@ -141,7 +142,8 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     _recordTransformer = recordTransformer;
 
     // Initialize stats collection
-    segmentStats = dataSource.gatherStats(new StatsCollectorConfig(dataSchema, config.getSegmentPartitionConfig()));
+    segmentStats = dataSource
+        .gatherStats(new StatsCollectorConfig(dataSchema, config.getTableConfig(), config.getSegmentPartitionConfig()));
     totalDocs = segmentStats.getTotalDocCount();
 
     // Initialize index creation
@@ -193,7 +195,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
             GenericRow transformedRow = _recordTransformer.transform((GenericRow) singleRow);
             recordReadStopTime = System.currentTimeMillis();
             totalRecordReadTime += (recordReadStopTime - recordReadStartTime);
-            if (transformedRow != null) {
+            if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
               indexCreator.indexRow(transformedRow);
               indexStopTime = System.currentTimeMillis();
               totalIndexTime += (indexStopTime - recordReadStopTime);
@@ -203,7 +205,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
           GenericRow transformedRow = _recordTransformer.transform(decodedRow);
           recordReadStopTime = System.currentTimeMillis();
           totalRecordReadTime += (recordReadStopTime - recordReadStartTime);
-          if (transformedRow != null) {
+          if (transformedRow != null && IngestionUtils.passedFilter(transformedRow)) {
             indexCreator.indexRow(transformedRow);
             indexStopTime = System.currentTimeMillis();
             totalIndexTime += (indexStopTime - recordReadStopTime);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/IngestionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/IngestionUtils.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.util;
+
+import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.core.data.function.FunctionEvaluator;
+import org.apache.pinot.core.data.function.FunctionEvaluatorFactory;
+import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
+/**
+ * Utility methods for extracting source and destination fields from ingestion configs
+ */
+public class IngestionUtils {
+
+  /**
+   * Extracts all fields required by the {@link org.apache.pinot.spi.data.readers.RecordExtractor} from the given TableConfig and Schema
+   */
+  public static Set<String> getFieldsForRecordExtractor(TableConfig tableConfig, Schema schema) {
+    Set<String> fieldsForRecordExtractor = new HashSet<>();
+    fieldsForRecordExtractor.addAll(getFieldsForRecordExtractor(tableConfig.getIngestionConfig()));
+    fieldsForRecordExtractor.addAll(getFieldsForRecordExtractor(schema));
+    return fieldsForRecordExtractor;
+  }
+
+  /**
+   * Extracts all the fields needed by the {@link org.apache.pinot.spi.data.readers.RecordExtractor} from the given Schema
+   * TODO: for now, we assume that arguments to transform function are in the source i.e. no columns are derived from transformed columns
+   */
+  private static Set<String> getFieldsForRecordExtractor(Schema schema) {
+    Set<String> fieldNames = new HashSet<>();
+
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isVirtualColumn()) {
+        FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
+        if (functionEvaluator != null) {
+          fieldNames.addAll(functionEvaluator.getArguments());
+        }
+        fieldNames.add(fieldSpec.getName());
+      }
+    }
+    return fieldNames;
+  }
+
+  /**
+   * Extracts the fields needed by a RecordExtractor from given {@link IngestionConfig}
+   */
+  private static Set<String> getFieldsForRecordExtractor(@Nullable IngestionConfig ingestionConfig) {
+    if (ingestionConfig != null && ingestionConfig.getFilterConfig() != null) {
+      String filterFunction = ingestionConfig.getFilterConfig().getFilterFunction();
+      if (filterFunction != null) {
+        FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
+        if (functionEvaluator != null) {
+          return Sets.newHashSet(functionEvaluator.getArguments());
+        }
+      }
+    }
+    return Collections.emptySet();
+  }
+
+  /**
+   * Returns true if the record doesn not contain key {@link GenericRow#FILTER_RECORD_KEY} with value true
+   */
+  public static boolean passedFilter(GenericRow genericRow) {
+    return !Boolean.TRUE.equals(genericRow.getValue(GenericRow.FILTER_RECORD_KEY));
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SchemaUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SchemaUtils.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pinot.core.util;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.apache.pinot.core.data.function.FunctionEvaluator;
 import org.apache.pinot.core.data.function.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -40,28 +38,6 @@ public class SchemaUtils {
   public static final String MAP_VALUE_COLUMN_SUFFIX = "__VALUES";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SchemaUtils.class);
-
-  /**
-   * Extracts the source fields and destination fields from the schema
-   * For field specs with a transform expression defined, use the arguments provided to the function
-   * By default, add the field spec name
-   *
-   * TODO: for now, we assume that arguments to transform function are in the source i.e. there's no columns which are derived from transformed columns
-   */
-  public static Set<String> extractSourceFields(Schema schema) {
-    Set<String> sourceFieldNames = new HashSet<>();
-
-    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-      if (!fieldSpec.isVirtualColumn()) {
-        FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
-        if (functionEvaluator != null) {
-          sourceFieldNames.addAll(functionEvaluator.getArguments());
-        }
-        sourceFieldNames.add(fieldSpec.getName());
-      }
-    }
-    return sourceFieldNames;
-  }
 
   /**
    * Validates that for a field spec with transform function, the source column name and destination column name are exclusive

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/RecordReaderSampleDataTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/RecordReaderSampleDataTest.java
@@ -24,12 +24,15 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Map;
 import org.apache.pinot.core.data.recordtransformer.CompositeTransformer;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFactory;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -55,11 +58,12 @@ public class RecordReaderSampleDataTest {
       .addSingleValueDimension("unknown_dimension", FieldSpec.DataType.STRING)
       .addMetric("met_impressionCount", FieldSpec.DataType.LONG).addMetric("unknown_metric", FieldSpec.DataType.DOUBLE)
       .build();
+  private final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
 
   @Test
   public void testRecordReaders()
       throws Exception {
-    CompositeTransformer defaultTransformer = CompositeTransformer.getDefaultTransformer(SCHEMA);
+    CompositeTransformer defaultTransformer = CompositeTransformer.getDefaultTransformer(TABLE_CONFIG, SCHEMA);
     try (RecordReader avroRecordReader = RecordReaderFactory
         .getRecordReader(FileFormat.AVRO, AVRO_SAMPLE_DATA_FILE, SCHEMA.getColumnNames(), null);
         RecordReader csvRecordReader = RecordReaderFactory

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/RecordTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/RecordTransformerTest.java
@@ -82,21 +82,21 @@ public class RecordTransformerTest {
     tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({svInt > 123}, svInt)")));
     RecordTransformer transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
-    Assert.assertFalse(genericRow.getFieldToValueMap().containsKey(GenericRow.FILTER_RECORD_KEY));
+    Assert.assertFalse(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
 
     // expression true, filtered
     genericRow = getRecord();
     tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({svInt <= 123}, svInt)")));
     transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
-    Assert.assertTrue(genericRow.getFieldToValueMap().containsKey(GenericRow.FILTER_RECORD_KEY));
+    Assert.assertTrue(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
 
     // value not found
     genericRow = getRecord();
     tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({notPresent == 123}, notPresent)")));
     transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
-    Assert.assertFalse(genericRow.getFieldToValueMap().containsKey(GenericRow.FILTER_RECORD_KEY));
+    Assert.assertFalse(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
 
     // invalid function
     tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy(svInt == 123)")));
@@ -112,7 +112,7 @@ public class RecordTransformerTest {
     tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({svFloat.max() < 500}, svFloat)")));
     transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
-    Assert.assertTrue(genericRow.getFieldToValueMap().containsKey(GenericRow.FILTER_RECORD_KEY));
+    Assert.assertTrue(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
 
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplNullValueVectorTest.java
@@ -26,11 +26,14 @@ import java.util.List;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.data.recordtransformer.CompositeTransformer;
 import org.apache.pinot.core.segment.index.readers.NullValueVectorReader;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFactory;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -41,6 +44,7 @@ public class MutableSegmentImplNullValueVectorTest {
   private static final String DATA_FILE = "data/test_null_value_vector_data.json";
   private static CompositeTransformer _recordTransformer;
   private static Schema _schema;
+  private static TableConfig _tableConfig;
   private static MutableSegmentImpl _mutableSegmentImpl;
   private static List<String> _finalNullColumns;
 
@@ -50,7 +54,8 @@ public class MutableSegmentImplNullValueVectorTest {
     URL schemaResourceUrl = this.getClass().getClassLoader().getResource(PINOT_SCHEMA_FILE_PATH);
     URL dataResourceUrl = this.getClass().getClassLoader().getResource(DATA_FILE);
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
-    _recordTransformer = CompositeTransformer.getDefaultTransformer(_schema);
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
     _mutableSegmentImpl = MutableSegmentImplTestUtils
         .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
@@ -25,12 +25,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 
@@ -45,6 +48,7 @@ public class FakeStreamConfigUtils {
   // This avro schema file must be in sync with the avro data
   private static final String AVRO_SCHEMA_FILE = "fake_stream_avro_schema.avsc";
   private static final String PINOT_SCHEMA_FILE = "fake_stream_pinot_schema.json";
+  private static final String TIME_COLUMN_NAME = "DaysSinceEpoch";
 
   private static final LongMsgOffset SMALLEST_OFFSET = new LongMsgOffset(0);
   private static final LongMsgOffset LARGEST_OFFSET = new LongMsgOffset(Integer.MAX_VALUE);
@@ -109,6 +113,14 @@ public class FakeStreamConfigUtils {
   static Schema getPinotSchema() throws IOException {
     File schemaFile = getResourceFile(PINOT_SCHEMA_FILE);
     return Schema.fromFile(schemaFile);
+  }
+
+  /**
+   * Gets pinot table
+   */
+  static TableConfig getTableConfig() {
+    return new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME_WITH_TYPE)
+        .setTimeColumnName(TIME_COLUMN_NAME).build();
   }
 
   private static File getResourceFile(String fileName) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
@@ -19,7 +19,8 @@
 package org.apache.pinot.core.realtime.impl.fakestream;
 
 import java.util.Set;
-import org.apache.pinot.core.util.SchemaUtils;
+import org.apache.pinot.core.util.IngestionUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.LongMsgOffset;
@@ -96,8 +97,9 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
 
     // Message decoder
     Schema pinotSchema = FakeStreamConfigUtils.getPinotSchema();
-    StreamMessageDecoder streamMessageDecoder =
-        StreamDecoderProvider.create(streamConfig, SchemaUtils.extractSourceFields(pinotSchema));
+    TableConfig tableConfig = FakeStreamConfigUtils.getTableConfig();
+    StreamMessageDecoder streamMessageDecoder = StreamDecoderProvider
+        .create(streamConfig, IngestionUtils.getFieldsForRecordExtractor(tableConfig, pinotSchema));
     GenericRow decodedRow = new GenericRow();
     streamMessageDecoder.decode(messageBatch.getMessageAtIndex(0), decodedRow);
     System.out.println(decodedRow);

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConsumerFactory.java
@@ -98,8 +98,8 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
     // Message decoder
     Schema pinotSchema = FakeStreamConfigUtils.getPinotSchema();
     TableConfig tableConfig = FakeStreamConfigUtils.getTableConfig();
-    StreamMessageDecoder streamMessageDecoder = StreamDecoderProvider
-        .create(streamConfig, IngestionUtils.getFieldsForRecordExtractor(tableConfig, pinotSchema));
+    StreamMessageDecoder streamMessageDecoder = StreamDecoderProvider.create(streamConfig,
+        IngestionUtils.getFieldsForRecordExtractor(tableConfig.getIngestionConfig(), pinotSchema));
     GenericRow decodedRow = new GenericRow();
     streamMessageDecoder.decode(messageBatch.getMessageAtIndex(0), decodedRow);
     System.out.println(decodedRow);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
@@ -331,7 +331,6 @@ public class SegmentGenerationWithBytesTypeTest {
     config.setInputFilePath(dirName + File.separator + avroName);
     config.setOutDir(dirName);
     config.setSegmentName(segmentName);
-    config.setSchema(schema);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithFilterRecordsKey.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithFilterRecordsKey.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.index.creator;
+
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.core.segment.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class SegmentGenerationWithFilterRecordsKey {
+  private static final String STRING_COLUMN = "col1";
+  private static final String[] STRING_VALUES = {"A", "B", "C", "D", "E"};
+  private static final String LONG_COLUMN = "col2";
+  private static final long[] LONG_VALUES =
+      {1588316400000L, 1588489200000L, 1588662000000L, 1588834800000L, 1589007600000L};
+  private static final String MV_INT_COLUMN = "col3";
+  private static final ArrayList[] MV_INT_VALUES =
+      {Lists.newArrayList(1, 2, 3), Lists.newArrayList(4), Lists.newArrayList(5, 1), Lists.newArrayList(
+          2), Lists.newArrayList(3, 4, 5)};
+  private static final String SEGMENT_DIR_NAME =
+      FileUtils.getTempDirectoryPath() + File.separator + "segmentFilterRecordsTest";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  private Schema _schema;
+  private TableConfig _tableConfig;
+
+  @BeforeClass
+  public void setup() {
+    String filterFunction = "Groovy({((col2 < 1589007600000L) &&  (col3.max() < 4)) || col1 == \"B\"}, col1, col2, col3)";
+    IngestionConfig ingestionConfig = new IngestionConfig(new FilterConfig(filterFunction));
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setIngestionConfig(ingestionConfig).build();
+    _schema = new Schema.SchemaBuilder().addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
+        .addMetric(LONG_COLUMN, FieldSpec.DataType.LONG).addMultiValueDimension(MV_INT_COLUMN, FieldSpec.DataType.INT)
+        .build();
+  }
+
+  @BeforeMethod
+  public void reset() {
+    FileUtils.deleteQuietly(new File(SEGMENT_DIR_NAME));
+  }
+
+  @Test
+  public void testNumDocs()
+      throws Exception {
+    File segmentDir = buildSegment(_tableConfig, _schema);
+    SegmentMetadataImpl metadata = SegmentDirectory.loadSegmentMetadata(segmentDir);
+    Assert.assertEquals(metadata.getTotalDocs(), 2);
+    PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader(segmentDir);
+    GenericRow next = segmentRecordReader.next();
+    Assert.assertEquals(next.getValue(STRING_COLUMN), "C");
+    next = segmentRecordReader.next();
+    Assert.assertEquals(next.getValue(STRING_COLUMN), "E");
+  }
+
+  private File buildSegment(final TableConfig tableConfig, final Schema schema)
+      throws Exception {
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(SEGMENT_DIR_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+
+    List<GenericRow> rows = new ArrayList<>(3);
+    for (int i = 0; i < 5; i++) {
+      GenericRow row = new GenericRow();
+      row.putValue(STRING_COLUMN, STRING_VALUES[i]);
+      row.putValue(LONG_COLUMN, LONG_VALUES[i]);
+      row.putValue(MV_INT_COLUMN, MV_INT_VALUES[i]);
+      rows.add(row);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+    driver.getOutputDirectory().deleteOnExit();
+    return driver.getOutputDirectory();
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithMultipleRecordsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithMultipleRecordsTest.java
@@ -19,20 +19,20 @@
 package org.apache.pinot.core.segment.index.creator;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.math.RandomUtils;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
-import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
-import org.apache.pinot.spi.config.table.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -43,18 +43,14 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
-public class SegmentGenerationWithFilterRecordsKey {
-  private static final String STRING_COLUMN = "col1";
-  private static final String[] STRING_VALUES = {"A", "B", "C", "D", "E"};
-  private static final String LONG_COLUMN = "col2";
-  private static final long[] LONG_VALUES =
-      {1588316400000L, 1588489200000L, 1588662000000L, 1588834800000L, 1589007600000L};
-  private static final String MV_INT_COLUMN = "col3";
-  private static final ArrayList[] MV_INT_VALUES =
-      {Lists.newArrayList(1, 2, 3), Lists.newArrayList(4), Lists.newArrayList(5, 1), Lists.newArrayList(
-          2), Lists.newArrayList(3, 4, 5)};
+/**
+ * Tests many to one flattening based on presence of MULTIPLE_RECORDS_KEY in GenericRow
+ */
+public class SegmentGenerationWithMultipleRecordsTest {
+  private static final String SUB_COLUMN_1 = "sub1";
+  private static final String SUB_COLUMN_2 = "sub2";
   private static final String SEGMENT_DIR_NAME =
-      FileUtils.getTempDirectoryPath() + File.separator + "segmentFilterRecordsTest";
+      System.getProperty("java.io.tmpdir") + File.separator + "segmentMultipleRecordsTest";
   private static final String SEGMENT_NAME = "testSegment";
 
   private Schema _schema;
@@ -62,12 +58,9 @@ public class SegmentGenerationWithFilterRecordsKey {
 
   @BeforeClass
   public void setup() {
-    String filterFunction = "Groovy({((col2 < 1589007600000L) &&  (col3.max() < 4)) || col1 == \"B\"}, col1, col2, col3)";
-    IngestionConfig ingestionConfig = new IngestionConfig(new FilterConfig(filterFunction));
-    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setIngestionConfig(ingestionConfig).build();
-    _schema = new Schema.SchemaBuilder().addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
-        .addMetric(LONG_COLUMN, FieldSpec.DataType.LONG).addMultiValueDimension(MV_INT_COLUMN, FieldSpec.DataType.INT)
-        .build();
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build();
+    _schema = new Schema.SchemaBuilder().addSingleValueDimension(SUB_COLUMN_1, FieldSpec.DataType.STRING)
+        .addMetric(SUB_COLUMN_2, FieldSpec.DataType.LONG).build();
   }
 
   @BeforeMethod
@@ -80,12 +73,8 @@ public class SegmentGenerationWithFilterRecordsKey {
       throws Exception {
     File segmentDir = buildSegment(_tableConfig, _schema);
     SegmentMetadataImpl metadata = SegmentDirectory.loadSegmentMetadata(segmentDir);
-    Assert.assertEquals(metadata.getTotalDocs(), 2);
-    PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader(segmentDir);
-    GenericRow next = segmentRecordReader.next();
-    Assert.assertEquals(next.getValue(STRING_COLUMN), "C");
-    next = segmentRecordReader.next();
-    Assert.assertEquals(next.getValue(STRING_COLUMN), "E");
+    Assert.assertEquals(metadata.getTotalDocs(), 6);
+    Assert.assertTrue(metadata.getAllColumns().containsAll(Sets.newHashSet(SUB_COLUMN_1, SUB_COLUMN_2)));
   }
 
   private File buildSegment(final TableConfig tableConfig, final Schema schema)
@@ -95,18 +84,30 @@ public class SegmentGenerationWithFilterRecordsKey {
     config.setSegmentName(SEGMENT_NAME);
 
     List<GenericRow> rows = new ArrayList<>(3);
-    for (int i = 0; i < 5; i++) {
-      GenericRow row = new GenericRow();
-      row.putValue(STRING_COLUMN, STRING_VALUES[i]);
-      row.putValue(LONG_COLUMN, LONG_VALUES[i]);
-      row.putValue(MV_INT_COLUMN, MV_INT_VALUES[i]);
-      rows.add(row);
-    }
+
+    GenericRow genericRow1 = new GenericRow();
+    genericRow1.putValue(GenericRow.MULTIPLE_RECORDS_KEY,
+        Lists.newArrayList(getRandomArrayElement(), getRandomArrayElement(), getRandomArrayElement()));
+    rows.add(genericRow1);
+    GenericRow genericRow2 = new GenericRow();
+    genericRow2.putValue(GenericRow.MULTIPLE_RECORDS_KEY, Lists.newArrayList(getRandomArrayElement()));
+    rows.add(genericRow2);
+    GenericRow genericRow3 = new GenericRow();
+    genericRow3.putValue(GenericRow.MULTIPLE_RECORDS_KEY,
+        Lists.newArrayList(getRandomArrayElement(), getRandomArrayElement()));
+    rows.add(genericRow3);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
     driver.getOutputDirectory().deleteOnExit();
     return driver.getOutputDirectory();
+  }
+
+  private GenericRow getRandomArrayElement() {
+    GenericRow element = new GenericRow();
+    element.putValue(SUB_COLUMN_1, RandomStringUtils.randomAlphabetic(4));
+    element.putValue(SUB_COLUMN_2, RandomUtils.nextLong());
+    return element;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/IngestionUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/IngestionUtilsTest.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.util;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests fields extraction from Schema dna TableConfig for ingestion
+ */
+public class IngestionUtilsTest {
+
+  @Test
+  public void testExtractFieldsSchema() {
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    Schema schema;
+
+    // from groovy function
+    schema = new Schema();
+    DimensionFieldSpec dimensionFieldSpec = new DimensionFieldSpec("d1", FieldSpec.DataType.STRING, true);
+    dimensionFieldSpec.setTransformFunction("Groovy({function}, argument1, argument2)");
+    schema.addField(dimensionFieldSpec);
+    List<String> extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema));
+    Assert.assertEquals(extract.size(), 3);
+    Assert.assertTrue(extract.containsAll(Arrays.asList("d1", "argument1", "argument2")));
+
+    // groovy function, no arguments
+    schema = new Schema();
+    dimensionFieldSpec = new DimensionFieldSpec("d1", FieldSpec.DataType.STRING, true);
+    dimensionFieldSpec.setTransformFunction("Groovy({function})");
+    schema.addField(dimensionFieldSpec);
+    extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema));
+    Assert.assertEquals(extract.size(), 1);
+    Assert.assertTrue(extract.contains("d1"));
+
+    // Map implementation for Avro - map__KEYS indicates map is source column
+    schema = new Schema();
+    dimensionFieldSpec = new DimensionFieldSpec("map__KEYS", FieldSpec.DataType.INT, false);
+    schema.addField(dimensionFieldSpec);
+    extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema));
+    Assert.assertEquals(extract.size(), 2);
+    Assert.assertTrue(extract.containsAll(Arrays.asList("map", "map__KEYS")));
+
+    // Map implementation for Avro - map__VALUES indicates map is source column
+    schema = new Schema();
+    dimensionFieldSpec = new DimensionFieldSpec("map__VALUES", FieldSpec.DataType.LONG, false);
+    schema.addField(dimensionFieldSpec);
+    extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema));
+    Assert.assertEquals(extract.size(), 2);
+    Assert.assertTrue(extract.containsAll(Arrays.asList("map", "map__VALUES")));
+
+    // Time field spec
+    // only incoming
+    schema = new Schema.SchemaBuilder()
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "time"), null).build();
+    extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema));
+    Assert.assertEquals(extract.size(), 1);
+    Assert.assertTrue(extract.contains("time"));
+
+    // incoming and outgoing different column name
+    schema = new Schema.SchemaBuilder()
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "in"),
+            new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "out")).build();
+    extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema));
+    Assert.assertEquals(extract.size(), 2);
+    Assert.assertTrue(extract.containsAll(Arrays.asList("in", "out")));
+
+    // inbuilt functions
+    schema = new Schema();
+    dimensionFieldSpec = new DimensionFieldSpec("hoursSinceEpoch", FieldSpec.DataType.LONG, true);
+    dimensionFieldSpec.setTransformFunction("toEpochHours(timestamp)");
+    schema.addField(dimensionFieldSpec);
+    extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema));
+    Assert.assertEquals(extract.size(), 2);
+    Assert.assertTrue(extract.containsAll(Arrays.asList("timestamp", "hoursSinceEpoch")));
+
+    // inbuilt functions with literal
+    schema = new Schema();
+    dimensionFieldSpec = new DimensionFieldSpec("tenMinutesSinceEpoch", FieldSpec.DataType.LONG, true);
+    dimensionFieldSpec.setTransformFunction("toEpochMinutesBucket(timestamp, 10)");
+    schema.addField(dimensionFieldSpec);
+    extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema));
+    Assert.assertEquals(extract.size(), 2);
+    Assert.assertTrue(extract.containsAll(Lists.newArrayList("tenMinutesSinceEpoch", "timestamp")));
+
+    // inbuilt functions on DateTimeFieldSpec
+    schema = new Schema();
+    DateTimeFieldSpec dateTimeFieldSpec =
+        new DateTimeFieldSpec("date", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd", "1:DAYS");
+    dateTimeFieldSpec.setTransformFunction("toDateTime(timestamp, 'yyyy-MM-dd')");
+    schema.addField(dateTimeFieldSpec);
+    extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema));
+    Assert.assertEquals(extract.size(), 2);
+    Assert.assertTrue(extract.containsAll(Lists.newArrayList("date", "timestamp")));
+  }
+
+  @Test
+  public void testExtractFieldsIngestionConfig() {
+    Schema schema = new Schema();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({x > 100}, x)")));
+
+    Set<String> fields = IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema);
+    Assert.assertEquals(fields.size(), 1);
+    Assert.assertTrue(fields.containsAll(Sets.newHashSet("x")));
+
+    schema.addField(new DimensionFieldSpec("y", FieldSpec.DataType.STRING, true));
+    fields = IngestionUtils.getFieldsForRecordExtractor(tableConfig, schema);
+    Assert.assertEquals(fields.size(), 2);
+    Assert.assertTrue(fields.containsAll(Sets.newHashSet("x", "y")));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
@@ -31,6 +31,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -57,6 +59,7 @@ import org.apache.pinot.core.segment.index.readers.FloatDictionary;
 import org.apache.pinot.core.segment.index.readers.IntDictionary;
 import org.apache.pinot.core.segment.index.readers.LongDictionary;
 import org.apache.pinot.core.segment.index.readers.StringDictionary;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -70,6 +73,8 @@ public class DictionariesTest {
   static Map<String, Set<Object>> uniqueEntries;
 
   private static File segmentDirectory;
+
+  private static TableConfig _tableConfig ;
 
   @AfterClass
   public static void cleanup() {
@@ -88,6 +93,7 @@ public class DictionariesTest {
     final SegmentGeneratorConfig config = SegmentTestUtils
         .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "time_day", TimeUnit.DAYS,
             "test");
+    _tableConfig = config.getTableConfig();
 
     // The segment generation code in SegmentColumnarIndexCreator will throw
     // exception if start and end time in time column are not in acceptable
@@ -441,7 +447,7 @@ public class DictionariesTest {
   private AbstractColumnStatisticsCollector buildStatsCollector(String column, DataType dataType) {
     Schema schema = new Schema();
     schema.addField(new DimensionFieldSpec(column, dataType, true));
-    StatsCollectorConfig statsCollectorConfig = new StatsCollectorConfig(schema, null);
+    StatsCollectorConfig statsCollectorConfig = new StatsCollectorConfig(schema, _tableConfig, null);
 
     switch (dataType) {
       case INT:

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/DictionariesTest.java
@@ -447,7 +447,7 @@ public class DictionariesTest {
   private AbstractColumnStatisticsCollector buildStatsCollector(String column, DataType dataType) {
     Schema schema = new Schema();
     schema.addField(new DimensionFieldSpec(column, dataType, true));
-    StatsCollectorConfig statsCollectorConfig = new StatsCollectorConfig(schema, _tableConfig, null);
+    StatsCollectorConfig statsCollectorConfig = new StatsCollectorConfig(_tableConfig, schema, null);
 
     switch (dataType) {
       case INT:

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.hadoop.io;
 
 import java.io.IOException;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.Job;
@@ -107,8 +108,10 @@ public class PinotOutputFormat<T> extends FileOutputFormat<NullWritable, T> {
       throws IOException {
     SegmentGeneratorConfig segmentGeneratorConfig = getSegmentGeneratorConfig(job);
     FieldExtractor<T> fieldExtractor = getFieldExtractor(job);
-    fieldExtractor.init(job.getConfiguration(), IngestionUtils
-        .getFieldsForRecordExtractor(segmentGeneratorConfig.getTableConfig(), segmentGeneratorConfig.getSchema()));
+    Set<String> fieldsToRead = IngestionUtils
+        .getFieldsForRecordExtractor(segmentGeneratorConfig.getTableConfig().getIngestionConfig(),
+            segmentGeneratorConfig.getSchema());
+    fieldExtractor.init(job.getConfiguration(), fieldsToRead);
     return new PinotRecordWriter<>(job, segmentGeneratorConfig, fieldExtractor);
   }
 

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
-import org.apache.pinot.core.util.SchemaUtils;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
@@ -107,7 +107,8 @@ public class PinotOutputFormat<T> extends FileOutputFormat<NullWritable, T> {
       throws IOException {
     SegmentGeneratorConfig segmentGeneratorConfig = getSegmentGeneratorConfig(job);
     FieldExtractor<T> fieldExtractor = getFieldExtractor(job);
-    fieldExtractor.init(job.getConfiguration(), SchemaUtils.extractSourceFields(segmentGeneratorConfig.getSchema()));
+    fieldExtractor.init(job.getConfiguration(), IngestionUtils
+        .getFieldsForRecordExtractor(segmentGeneratorConfig.getTableConfig(), segmentGeneratorConfig.getSchema()));
     return new PinotRecordWriter<>(job, segmentGeneratorConfig, fieldExtractor);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IngestionConfig.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
+
+
+/**
+ * Class representing table ingestion configuration. For example, configs needed for
+ * decoding, data source configs, ingestion transformations (flattening, filtering, transformations etc.)
+ * TODO: To begin with, we only have FilterConfig. We will soon add TransformConfig (and move the transform function definitions from schema to this config)
+ */
+public class IngestionConfig extends BaseJsonConfig {
+
+  @JsonPropertyDescription("Config related to filtering records during ingestion")
+  private final FilterConfig _filterConfig;
+
+  // TODO: Add a TransformConfig for transform functions
+
+  @JsonCreator
+  public IngestionConfig(@JsonProperty("filterConfig") @Nullable FilterConfig filterConfig) {
+    _filterConfig = filterConfig;
+  }
+
+  @Nullable
+  public FilterConfig getFilterConfig() {
+    return _filterConfig;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -46,6 +46,7 @@ public class TableConfig extends BaseJsonConfig {
   public static final String INSTANCE_ASSIGNMENT_CONFIG_MAP_KEY = "instanceAssignmentConfigMap";
   public static final String FIELD_CONFIG_LIST_KEY = "fieldConfigList";
   public static final String UPSERT_CONFIG_KEY = "upsertConfig";
+  public static final String INGESTION_CONFIG_KEY = "ingestionConfig";
 
   // Double underscore is reserved for real-time segment name delimiter
   private static final String TABLE_NAME_FORBIDDEN_SUBSTRING = "__";
@@ -79,6 +80,9 @@ public class TableConfig extends BaseJsonConfig {
   @JsonPropertyDescription(value = "upsert related config")
   private UpsertConfig _upsertConfig;
 
+  @JsonPropertyDescription(value = "Config related to table ingestion")
+  private IngestionConfig _ingestionConfig;
+
   @JsonCreator
   public TableConfig(@JsonProperty(value = TABLE_NAME_KEY, required = true) String tableName,
       @JsonProperty(value = TABLE_TYPE_KEY, required = true) String tableType,
@@ -92,7 +96,8 @@ public class TableConfig extends BaseJsonConfig {
       @JsonProperty(QUERY_CONFIG_KEY) @Nullable QueryConfig queryConfig,
       @JsonProperty(INSTANCE_ASSIGNMENT_CONFIG_MAP_KEY) @Nullable Map<InstancePartitionsType, InstanceAssignmentConfig> instanceAssignmentConfigMap,
       @JsonProperty(FIELD_CONFIG_LIST_KEY) @Nullable List<FieldConfig> fieldConfigList,
-      @JsonProperty(UPSERT_CONFIG_KEY) @Nullable UpsertConfig upsertConfig) {
+      @JsonProperty(UPSERT_CONFIG_KEY) @Nullable UpsertConfig upsertConfig,
+      @JsonProperty(INGESTION_CONFIG_KEY) @Nullable IngestionConfig ingestionConfig) {
     Preconditions.checkArgument(tableName != null, "'tableName' must be configured");
     Preconditions.checkArgument(!tableName.contains(TABLE_NAME_FORBIDDEN_SUBSTRING),
         "'tableName' cannot contain double underscore ('__')");
@@ -116,6 +121,7 @@ public class TableConfig extends BaseJsonConfig {
     _instanceAssignmentConfigMap = instanceAssignmentConfigMap;
     _fieldConfigList = fieldConfigList;
     _upsertConfig = upsertConfig;
+    _ingestionConfig = ingestionConfig;
   }
 
   @JsonProperty(TABLE_NAME_KEY)
@@ -232,5 +238,15 @@ public class TableConfig extends BaseJsonConfig {
 
   public void setUpsertConfig(UpsertConfig upsertConfig) {
     _upsertConfig = upsertConfig;
+  }
+
+  @JsonProperty(INGESTION_CONFIG_KEY)
+  @Nullable
+  public IngestionConfig getIngestionConfig() {
+    return _ingestionConfig;
+  }
+
+  public void setIngestionConfig(IngestionConfig ingestionConfig) {
+    _ingestionConfig = ingestionConfig;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -80,7 +80,7 @@ public class TableConfig extends BaseJsonConfig {
   @JsonPropertyDescription(value = "upsert related config")
   private UpsertConfig _upsertConfig;
 
-  @JsonPropertyDescription(value = "Config related to table ingestion")
+  @JsonPropertyDescription(value = "Config related to ingesting data into the table")
   private IngestionConfig _ingestionConfig;
 
   @JsonCreator

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/FilterConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/FilterConfig.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table.ingestion;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.BaseJsonConfig;
+
+
+/**
+ * Configs related to filtering records during ingestion
+ */
+public class FilterConfig extends BaseJsonConfig {
+
+  @JsonPropertyDescription("Filter function string. Filter out records during ingestion, if this evaluates to true")
+  private final String _filterFunction;
+
+  @JsonCreator
+  public FilterConfig(@JsonProperty("filterFunction") @Nullable String filterFunction) {
+    _filterFunction = filterFunction;
+  }
+
+  @Nullable
+  public String getFilterFunction() {
+    return _filterFunction;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -50,6 +50,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
 public class GenericRow {
 
   public static final String MULTIPLE_RECORDS_KEY = "$MULTIPLE_RECORDS_KEY$";
+  public static final String FILTER_RECORD_KEY = "$FILTER_RECORD_KEY$";
 
   private final Map<String, Object> _fieldToValueMap = new HashMap<>();
   private final Set<String> _nullValueFields = new HashSet<>();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -56,10 +56,10 @@ public class GenericRow {
    */
   public static final String MULTIPLE_RECORDS_KEY = "$MULTIPLE_RECORDS_KEY$";
   /**
-   * This key is used by the FilterTransformer to handle filtering out of records during ingestion
-   * The FilterTransformer puts this key into the GenericRow with value true, if the record matches the filtering out criteria, based on FilterConfig
+   * This key is used by the FilterTransformer to skip records during ingestion
+   * The FilterTransformer puts this key into the GenericRow with value true, if the record matches the filtering criteria, based on FilterConfig
    */
-  public static final String FILTER_RECORD_KEY = "$FILTER_RECORD_KEY$";
+  public static final String SKIP_RECORD_KEY = "$SKIP_RECORD_KEY$";
 
   private final Map<String, Object> _fieldToValueMap = new HashMap<>();
   private final Set<String> _nullValueFields = new HashSet<>();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -49,7 +49,16 @@ import org.apache.pinot.spi.utils.JsonUtils;
  */
 public class GenericRow {
 
+  /**
+   * This key is used by a Decoder/RecordReader to handle 1 record to many records flattening.
+   * If a Decoder/RecordReader produces multiple GenericRows from the given record, they must be put into the destination GenericRow as a List<GenericRow> with this key
+   * The segment generation drivers handle this key as a special case and process the multiple records
+   */
   public static final String MULTIPLE_RECORDS_KEY = "$MULTIPLE_RECORDS_KEY$";
+  /**
+   * This key is used by the FilterTransformer to handle filtering out of records during ingestion
+   * The FilterTransformer puts this key into the GenericRow with value true, if the record matches the filtering out criteria, based on FilterConfig
+   */
   public static final String FILTER_RECORD_KEY = "$FILTER_RECORD_KEY$";
 
   private final Map<String, Object> _fieldToValueMap = new HashMap<>();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.pinot.spi.config.table.CompletionConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.IngestionConfig;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
@@ -95,6 +96,7 @@ public class TableConfigBuilder {
   private List<FieldConfig> _fieldConfigList;
 
   private UpsertConfig _upsertConfig;
+  private IngestionConfig _ingestionConfig;
 
   public TableConfigBuilder(TableType tableType) {
     _tableType = tableType;
@@ -293,6 +295,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setIngestionConfig(IngestionConfig ingestionConfig) {
+    _ingestionConfig = ingestionConfig;
+    return this;
+  }
+
   public TableConfig build() {
     // Validation config
     SegmentsValidationAndRetentionConfig validationConfig = new SegmentsValidationAndRetentionConfig();
@@ -337,6 +344,6 @@ public class TableConfigBuilder {
 
     return new TableConfig(_tableName, _tableType.toString(), validationConfig, tenantConfig, indexingConfig,
         _customConfig, _quotaConfig, _taskConfig, _routingConfig, _queryConfig, _instanceAssignmentConfigMap,
-        _fieldConfigList, _upsertConfig);
+        _fieldConfigList, _upsertConfig, _ingestionConfig);
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -77,7 +77,7 @@ public class RealtimeQuickStart {
     _kafkaStarter.start();
     _kafkaStarter.createTopic("meetupRSVPEvents", KafkaStarterUtils.getTopicCreationProps(10));
     printStatus(Color.CYAN, "***** Starting meetup data stream and publishing to Kafka *****");
-    MeetupRsvpStream meetupRSVPProvider = new MeetupRsvpStream(schemaFile);
+    MeetupRsvpStream meetupRSVPProvider = new MeetupRsvpStream();
     meetupRSVPProvider.run();
     printStatus(Color.CYAN, "***** Starting Zookeeper, controller, server and broker *****");
     runner.startAll();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpStream.java
@@ -20,7 +20,6 @@ package org.apache.pinot.tools.streams;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -30,12 +29,8 @@ import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 import javax.websocket.MessageHandler;
 import javax.websocket.Session;
-import org.apache.pinot.core.util.SchemaUtils;
-import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.StreamDataProducer;
 import org.apache.pinot.spi.stream.StreamDataProvider;
-import org.apache.pinot.spi.stream.StreamMessageDecoder;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
 import org.glassfish.tyrus.client.ClientManager;
@@ -43,14 +38,12 @@ import org.glassfish.tyrus.client.ClientManager;
 
 public class MeetupRsvpStream {
 
-  private Schema schema;
   private StreamDataProducer producer;
   private boolean keepPublishing = true;
   private ClientManager client;
 
-  public MeetupRsvpStream(File schemaFile)
+  public MeetupRsvpStream()
       throws Exception {
-    schema = Schema.fromFile(schemaFile);
     Properties properties = new Properties();
     properties.put("metadata.broker.list", KafkaStarterUtils.DEFAULT_KAFKA_BROKER);
     properties.put("serializer.class", "kafka.serializer.DefaultEncoder");
@@ -67,9 +60,6 @@ public class MeetupRsvpStream {
   public void run() {
     try {
       ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
-      StreamMessageDecoder decoder =
-          PluginManager.get().createInstance(KafkaStarterUtils.KAFKA_JSON_MESSAGE_DECODER_CLASS_NAME);
-      decoder.init(null, SchemaUtils.extractSourceFields(schema), null);
       client = ClientManager.createClient();
       client.connectToServer(new Endpoint() {
 


### PR DESCRIPTION
## Description
Added support for filtering during ingestion

Design doc: https://docs.google.com/document/d/1Cahnas3nh0XErETH0KHLaecN6xCnRVYWNKO3rDn7qcI/edit?usp=sharing

Issue: https://github.com/apache/incubator-pinot/issues/5268

**TLDR**
- New config added:
```
tableConfig: {
    tableName: ...,
    tableType: ...,
    ingestionConfig: {
        filterConfig: {
            filterFunction: “<expression>”
        }
    }
}
```
For example, Consider a table with a string column campaign and a multi-value column double column prices. To filter out records where campaign = X or Y and sum of all elements in prices is less than 100
```
ingestionConfig: {
    filterConfig: {
        filterFunction: “Groovy({(campaign == \"X\" || campaign == \"Y\") && prices.sum() < 100}, prices, campaign)”
    }
}
```

The expressions allowed here will be within the scope of the transform functions support that we have in Pinot today i.e. Groovy expressions, or any inbuilt functions.
- Filtering has been modeled as a RecordTransformer called `FilterTransformer`.
- In order to filter the record, we will use a special key `$FILTER_RECORD_KEY$` Inside the `FilterTransformer`, if `filterFunction` evaluates to true, this key will be put into the `GenericRow`, with value `true`.

**Followup items**
- Move transform functions from schema to IngestionConfig
- Integration test to test all ingestion configs

## Release Notes
- Added support for filtering during ingestion
- Removed `SchemaUtils#extractSourceFields(Schema schema)` method. Use `IngestionUtils#getFieldsForRecordExtractor(IngestionConfig ingestionConfig, Schema schema)` instead

## Documentation
TBD