### PR TITLE
Fix LocalPinotFSTest that fails on fast hardware

### DIFF
--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -188,7 +188,7 @@ public class LocalPinotFSTest {
     localPinotFS.touch(nonExistingFile.toURI());
     Assert.assertTrue(nonExistingFile.exists());
     long currentTime = System.currentTimeMillis();
-    Assert.assertTrue(localPinotFS.lastModified(nonExistingFile.toURI()) < currentTime);
+    Assert.assertTrue(localPinotFS.lastModified(nonExistingFile.toURI()) <= currentTime);
     Thread.sleep(1000L);
     // update last modified.
     localPinotFS.touch(nonExistingFile.toURI());


### PR DESCRIPTION
## Description

The unit test would fail if the assertion is be executed in the same millisecond than the file modification. Mostly encountered when running from command line build.