### PR TITLE
[QueryContext] Use QueryContext in Operators and DataTableReducers

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
@@ -27,9 +27,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.apache.pinot.common.request.SelectionSort;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,6 @@ import org.slf4j.LoggerFactory;
  * Thread safe {@link Table} implementation for aggregating Records based on combination of keys
  */
 public class ConcurrentIndexedTable extends IndexedTable {
-
   private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentIndexedTable.class);
 
   private ConcurrentMap<Key, Record> _lookupMap;
@@ -53,12 +53,12 @@ public class ConcurrentIndexedTable extends IndexedTable {
    * Initializes the data structures needed for this Table
    * @param dataSchema data schema of the record's keys and values
    * @param aggregationFunctions aggregation functions for the record's values
-   * @param orderBy list of {@link SelectionSort} defining the order by
+   * @param orderByExpressions list of {@link OrderByExpressionContext} defining the order by
    * @param capacity the capacity of the table
    */
   public ConcurrentIndexedTable(DataSchema dataSchema, AggregationFunction[] aggregationFunctions,
-      List<SelectionSort> orderBy, int capacity) {
-    super(dataSchema, aggregationFunctions, orderBy, capacity);
+      @Nullable List<OrderByExpressionContext> orderByExpressions, int capacity) {
+    super(dataSchema, aggregationFunctions, orderByExpressions, capacity);
 
     _lookupMap = new ConcurrentHashMap<>();
     _readWriteLock = new ReentrantReadWriteLock();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -20,25 +20,25 @@ package org.apache.pinot.core.data.table;
 
 import java.util.Arrays;
 import java.util.List;
-import org.apache.pinot.common.request.SelectionSort;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 
 
 /**
  * Base implementation of Map-based Table for indexed lookup
  */
 public abstract class IndexedTable extends BaseTable {
-
   private final KeyExtractor _keyExtractor;
   final int _numKeyColumns;
 
   /**
    * Initializes the variables and comparators needed for the table
    */
-  IndexedTable(DataSchema dataSchema, AggregationFunction[] aggregationFunctions, List<SelectionSort> orderBy,
-      int capacity) {
-    super(dataSchema, aggregationFunctions, orderBy, capacity);
+  IndexedTable(DataSchema dataSchema, AggregationFunction[] aggregationFunctions,
+      @Nullable List<OrderByExpressionContext> orderByExpressions, int capacity) {
+    super(dataSchema, aggregationFunctions, orderByExpressions, capacity);
 
     _numKeyColumns = dataSchema.size() - _numAggregations;
     _keyExtractor = new KeyExtractor(_numKeyColumns);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
@@ -23,10 +23,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
-import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,12 +50,12 @@ public class SimpleIndexedTable extends IndexedTable {
    * Initializes the data structures needed for this Table
    * @param dataSchema data schema of the record's keys and values
    * @param aggregationFunctions aggregation functions for the record's values
-   * @param orderBy list of {@link SelectionSort} defining the order by
+   * @param orderByExpressions list of {@link OrderByExpressionContext} defining the order by
    * @param capacity the capacity of the table
    */
   public SimpleIndexedTable(DataSchema dataSchema, AggregationFunction[] aggregationFunctions,
-      List<SelectionSort> orderBy, int capacity) {
-    super(dataSchema, aggregationFunctions, orderBy, capacity);
+      @Nullable List<OrderByExpressionContext> orderByExpressions, int capacity) {
+    super(dataSchema, aggregationFunctions, orderByExpressions, capacity);
 
     _lookupMap = new HashMap<>();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator;
 
-import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -33,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.common.exception.QueryException;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -43,6 +41,7 @@ import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.core.query.exception.EarlyTerminationException;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +50,7 @@ import org.slf4j.LoggerFactory;
 /**
  * The <code>CombineGroupByOperator</code> class is the operator to combine aggregation group-by results.
  */
+@SuppressWarnings("rawtypes")
 public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBlock> {
   private static final Logger LOGGER = LoggerFactory.getLogger(CombineGroupByOperator.class);
   private static final String OPERATOR_NAME = "CombineGroupByOperator";
@@ -62,19 +62,17 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
   private static final int INTER_SEGMENT_NUM_GROUPS_LIMIT_FACTOR = 2;
 
   private final List<Operator> _operators;
-  private final BrokerRequest _brokerRequest;
+  private final QueryContext _queryContext;
   private final ExecutorService _executorService;
   private final long _timeOutMs;
   // Limit on number of groups stored, beyond which no new group will be created
   private final int _innerSegmentNumGroupsLimit;
   private final int _interSegmentNumGroupsLimit;
 
-  public CombineGroupByOperator(List<Operator> operators, BrokerRequest brokerRequest, ExecutorService executorService,
+  public CombineGroupByOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
       long timeOutMs, int innerSegmentNumGroupsLimit) {
-    Preconditions.checkArgument(brokerRequest.isSetAggregationsInfo() && brokerRequest.isSetGroupBy());
-
     _operators = operators;
-    _brokerRequest = brokerRequest;
+    _queryContext = queryContext;
     _executorService = executorService;
     _timeOutMs = timeOutMs;
     _innerSegmentNumGroupsLimit = innerSegmentNumGroupsLimit;
@@ -107,7 +105,8 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
     AtomicInteger numGroups = new AtomicInteger();
     ConcurrentLinkedQueue<ProcessingException> mergedProcessingExceptions = new ConcurrentLinkedQueue<>();
 
-    AggregationFunction[] aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(_brokerRequest);
+    AggregationFunction[] aggregationFunctions =
+        AggregationFunctionUtils.getAggregationFunctions(_queryContext.getBrokerRequest());
     int numAggregationFunctions = aggregationFunctions.length;
 
     // We use a CountDownLatch to track if all Futures are finished by the query timeout, and cancel the unfinished
@@ -174,8 +173,9 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
           } catch (EarlyTerminationException e) {
             // Early-terminated because query times out or is already satisfied
           } catch (Exception e) {
-            LOGGER.error("Exception processing CombineGroupBy for index {}, operator {}, brokerRequest {}", index,
-                _operators.get(index).getClass().getName(), _brokerRequest, e);
+            LOGGER.error(
+                "Caught exception while processing and combining group-by for index: {}, operator: {}, queryContext: {}",
+                index, _operators.get(index).getClass().getName(), _queryContext, e);
             mergedProcessingExceptions.add(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
           } finally {
             operatorLatch.countDown();
@@ -189,16 +189,16 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       boolean opCompleted = operatorLatch.await(_timeOutMs, TimeUnit.MILLISECONDS);
       if (!opCompleted) {
         // If this happens, the broker side should already timed out, just log the error and return
-        String errorMessage =
-            String.format("Timed out while combining group-by results after %dms, brokerRequest = %s", _timeOutMs,
-                _brokerRequest);
+        String errorMessage = String
+            .format("Timed out while combining group-by results after %dms, queryContext = %s", _timeOutMs,
+                _queryContext);
         LOGGER.error(errorMessage);
         return new IntermediateResultsBlock(new TimeoutException(errorMessage));
       }
 
       // Trim the results map.
       AggregationGroupByTrimmingService aggregationGroupByTrimmingService =
-          new AggregationGroupByTrimmingService(aggregationFunctions, (int) _brokerRequest.getGroupBy().getTopN());
+          new AggregationGroupByTrimmingService(aggregationFunctions, _queryContext.getLimit());
       List<Map<String, Object>> trimmedResults =
           aggregationGroupByTrimmingService.trimIntermediateResultsMap(resultsMap);
       IntermediateResultsBlock mergedBlock = new IntermediateResultsBlock(aggregationFunctions, trimmedResults, true);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/EmptySelectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/EmptySelectionOperator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.query;
 
 import java.util.Collections;
 import java.util.List;
-import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.indexsegment.IndexSegment;
@@ -29,6 +28,7 @@ import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 
 
@@ -43,9 +43,10 @@ public class EmptySelectionOperator extends BaseOperator<IntermediateResultsBloc
   private final DataSchema _dataSchema;
   private final ExecutionStatistics _executionStatistics;
 
-  public EmptySelectionOperator(IndexSegment indexSegment, Selection selection, TransformOperator transformOperator) {
+  public EmptySelectionOperator(IndexSegment indexSegment, QueryContext queryContext,
+      TransformOperator transformOperator) {
     List<TransformExpressionTree> expressions =
-        SelectionOperatorUtils.extractExpressions(selection.getSelectionColumns(), indexSegment);
+        SelectionOperatorUtils.extractExpressions(queryContext.getSelectExpressions(), indexSegment);
 
     int numExpressions = expressions.size();
     String[] columnNames = new String[numExpressions];

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.query;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
@@ -32,6 +31,7 @@ import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 
 
@@ -48,10 +48,11 @@ public class SelectionOnlyOperator extends BaseOperator<IntermediateResultsBlock
 
   private int _numDocsScanned = 0;
 
-  public SelectionOnlyOperator(IndexSegment indexSegment, Selection selection, TransformOperator transformOperator) {
+  public SelectionOnlyOperator(IndexSegment indexSegment, QueryContext queryContext,
+      TransformOperator transformOperator) {
     _indexSegment = indexSegment;
     _transformOperator = transformOperator;
-    _expressions = SelectionOperatorUtils.extractExpressions(selection.getSelectionColumns(), indexSegment);
+    _expressions = SelectionOperatorUtils.extractExpressions(queryContext.getSelectExpressions(), indexSegment);
 
     int numExpressions = _expressions.size();
     _blockValSets = new BlockValSet[numExpressions];
@@ -66,7 +67,7 @@ public class SelectionOnlyOperator extends BaseOperator<IntermediateResultsBlock
     }
     _dataSchema = new DataSchema(columnNames, columnDataTypes);
 
-    _numRowsToKeep = selection.getSize();
+    _numRowsToKeep = queryContext.getLimit();
     _rows = new ArrayList<>(Math.min(_numRowsToKeep, SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY));
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -164,14 +164,12 @@ public class CombinePlanNode implements PlanNode {
       QueryOptions queryOptions = new QueryOptions(_queryContext.getQueryOptions());
       // new Combine operator only when GROUP_BY_MODE explicitly set to SQL
       if (queryOptions.isGroupByModeSQL()) {
-        return new CombineGroupByOrderByOperator(operators, _queryContext.getBrokerRequest(), _executorService,
-            _timeOutMs);
+        return new CombineGroupByOrderByOperator(operators, _queryContext, _executorService, _timeOutMs);
       }
-      return new CombineGroupByOperator(operators, _queryContext.getBrokerRequest(), _executorService, _timeOutMs,
-          _numGroupsLimit);
+      return new CombineGroupByOperator(operators, _queryContext, _executorService, _timeOutMs, _numGroupsLimit);
     } else {
       // Selection or aggregation only query
-      return new CombineOperator(operators, _executorService, _timeOutMs, _queryContext.getBrokerRequest());
+      return new CombineOperator(operators, _queryContext, _executorService, _timeOutMs);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.plan;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.indexsegment.IndexSegment;
@@ -53,15 +52,14 @@ public class SelectionPlanNode implements PlanNode {
   @Override
   public Operator<IntermediateResultsBlock> run() {
     TransformOperator transformOperator = _transformPlanNode.run();
-    Selection selection = _queryContext.getBrokerRequest().getSelections();
     if (_queryContext.getLimit() > 0) {
       if (_queryContext.getOrderByExpressions() == null) {
-        return new SelectionOnlyOperator(_indexSegment, selection, transformOperator);
+        return new SelectionOnlyOperator(_indexSegment, _queryContext, transformOperator);
       } else {
-        return new SelectionOrderByOperator(_indexSegment, selection, transformOperator);
+        return new SelectionOrderByOperator(_indexSegment, _queryContext, transformOperator);
       }
     } else {
-      return new EmptySelectionOperator(_indexSegment, selection, transformOperator);
+      return new EmptySelectionOperator(_indexSegment, _queryContext, transformOperator);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -102,15 +102,6 @@ public class AggregationFunctionUtils {
     return null;
   }
 
-  public static boolean[] getAggregationFunctionsSelectStatus(List<AggregationInfo> aggregationInfos) {
-    int numAggregationFunctions = aggregationInfos.size();
-    boolean[] aggregationFunctionsStatus = new boolean[numAggregationFunctions];
-    for (int i = 0; i < numAggregationFunctions; i++) {
-      aggregationFunctionsStatus[i] = aggregationInfos.get(i).isIsInSelectList();
-    }
-    return aggregationFunctionsStatus;
-  }
-
   public static String formatValue(Object value) {
     if (value instanceof Double) {
       double doubleValue = (double) value;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -35,6 +35,7 @@ import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.function.customobject.DistinctTable;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.util.QueryOptions;
@@ -48,9 +49,9 @@ public class DistinctDataTableReducer implements DataTableReducer {
   private final boolean _responseFormatSql;
 
   // TODO: queryOptions.isPreserveType() is ignored for DISTINCT queries.
-  DistinctDataTableReducer(BrokerRequest brokerRequest, QueryOptions queryOptions) {
-    _brokerRequest = brokerRequest;
-    _responseFormatSql = queryOptions.isResponseFormatSQL();
+  DistinctDataTableReducer(QueryContext queryContext) {
+    _brokerRequest = queryContext.getBrokerRequest();
+    _responseFormatSql = new QueryOptions(queryContext.getQueryOptions()).isResponseFormatSQL();
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -167,6 +167,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
     List<Object[]> rows = new ArrayList<>(limit);
 
     if (_sqlQuery) {
+      // SQL query with SQL group-by mode and response format
       // NOTE: For SQL query, need to reorder the columns in the data table based on the select expressions.
 
       int[] selectExpressionIndexMap = getSelectExpressionIndexMap();
@@ -196,6 +197,8 @@ public class GroupByDataTableReducer implements DataTableReducer {
         rows.add(reorderedValues);
       }
     } else {
+      // PQL query with SQL group-by mode and response format
+
       while (rows.size() < limit && sortedIterator.hasNext()) {
         Record nextRecord = sortedIterator.next();
         Object[] values = nextRecord.getValues();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.request.context;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -72,7 +73,7 @@ public class QueryContext {
       int offset, @Nullable Map<String, String> queryOptions, @Nullable Map<String, String> debugOptions,
       BrokerRequest brokerRequest) {
     _selectExpressions = selectExpressions;
-    _aliasMap = aliasMap;
+    _aliasMap = Collections.unmodifiableMap(aliasMap);
     _filter = filter;
     _groupByExpressions = groupByExpressions;
     _orderByExpressions = orderByExpressions;
@@ -92,11 +93,10 @@ public class QueryContext {
   }
 
   /**
-   * Returns the alias of the given expression, or {@code null} if it does not have an alias.
+   * Returns an unmodifiable map from the expression to its alias.
    */
-  @Nullable
-  public String getAlias(ExpressionContext expression) {
-    return _aliasMap.get(expression);
+  public Map<ExpressionContext, String> getAliasMap() {
+    return _aliasMap;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
@@ -69,8 +69,12 @@ public class QueryContextUtils {
    * Returns {@code true} if the given query is an aggregation query, {@code false} otherwise.
    */
   public static boolean isAggregationQuery(QueryContext query) {
-    ExpressionContext firstSelectExpression = query.getSelectExpressions().get(0);
-    return firstSelectExpression.getType() == ExpressionContext.Type.FUNCTION
-        && firstSelectExpression.getFunction().getType() == FunctionContext.Type.AGGREGATION;
+    for (ExpressionContext selectExpression : query.getSelectExpressions()) {
+      if (selectExpression.getType() == ExpressionContext.Type.FUNCTION
+          && selectExpression.getFunction().getType() == FunctionContext.Type.AGGREGATION) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -23,6 +23,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -31,8 +32,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
-import java.util.stream.Collectors;
-import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.response.broker.SelectionResults;
@@ -41,8 +40,9 @@ import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.util.ArrayCopyUtils;
-import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
 import org.apache.pinot.spi.utils.ByteArray;
 
 
@@ -90,30 +90,33 @@ public class SelectionOperatorUtils {
   /**
    * Extracts the expressions from a selection-only query, expands {@code 'SELECT *'} to all physical columns if
    * applies.
+   * <p>The expressions returned are deduplicated.
    * <p>NOTE: DO NOT change the order of the expressions returned because broker relies on that to process the query.
    */
-  public static List<TransformExpressionTree> extractExpressions(List<String> selectionColumns,
+  public static List<TransformExpressionTree> extractExpressions(List<ExpressionContext> selectExpressions,
       IndexSegment indexSegment) {
-    if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
-      // For 'SELECT *', sort all physical columns so that the order is deterministic
-      selectionColumns = new ArrayList<>(
-          // For "select *" queries, ignore columns that start with "$"
-          indexSegment.getColumnNames().stream().filter(column -> column.charAt(0) != '$')
-              .collect(Collectors.toList()));
-      selectionColumns.sort(null);
-
-      List<TransformExpressionTree> expressions = new ArrayList<>(selectionColumns.size());
-      for (String selectionColumn : selectionColumns) {
-        expressions.add(new TransformExpressionTree(new IdentifierAstNode(selectionColumn)));
+    int numSelectExpressions = selectExpressions.size();
+    if (numSelectExpressions == 1 && selectExpressions.get(0).equals(IDENTIFIER_STAR)) {
+      // For 'SELECT *', sort all columns (ignore columns that start with '$') so that the order is deterministic
+      Set<String> allColumns = indexSegment.getColumnNames();
+      List<String> selectColumns = new ArrayList<>(allColumns.size());
+      for (String column : allColumns) {
+        if (column.charAt(0) != '$') {
+          selectColumns.add(column);
+        }
+      }
+      selectColumns.sort(null);
+      List<TransformExpressionTree> expressions = new ArrayList<>(selectColumns.size());
+      for (String column : selectColumns) {
+        expressions.add(new TransformExpressionTree(TransformExpressionTree.ExpressionType.IDENTIFIER, column, null));
       }
       return expressions;
     } else {
-      // Note: selection expressions have been standardized during query compilation
-      Set<String> selectionColumnSet = new HashSet<>();
-      List<TransformExpressionTree> expressions = new ArrayList<>(selectionColumns.size());
-      for (String selectionColumn : selectionColumns) {
-        if (selectionColumnSet.add(selectionColumn)) {
-          expressions.add(TransformExpressionTree.compileToExpressionTree(selectionColumn));
+      Set<ExpressionContext> expressionSet = new HashSet<>();
+      List<TransformExpressionTree> expressions = new ArrayList<>(numSelectExpressions);
+      for (ExpressionContext selectExpression : selectExpressions) {
+        if (expressionSet.add(selectExpression)) {
+          expressions.add(selectExpression.toTransformExpressionTree());
         }
       }
       return expressions;
@@ -126,34 +129,38 @@ public class SelectionOperatorUtils {
    * <p>Order-by expressions will be put at the front. The expressions returned are deduplicated.
    * <p>NOTE: DO NOT change the order of the expressions returned because broker relies on that to process the query.
    */
-  public static List<TransformExpressionTree> extractExpressions(List<String> selectionColumns,
-      IndexSegment indexSegment, List<SelectionSort> sortSequence) {
-    Set<String> columnSet = new HashSet<>();
+  public static List<TransformExpressionTree> extractExpressions(List<ExpressionContext> selectExpressions,
+      List<OrderByExpressionContext> orderByExpressions, IndexSegment indexSegment) {
+    Set<ExpressionContext> expressionSet = new HashSet<>();
     List<TransformExpressionTree> expressions = new ArrayList<>();
 
-    // NOTE: order-by expressions have been standardized and deduplicated during query compilation
-    for (SelectionSort selectionSort : sortSequence) {
-      String orderByColumn = selectionSort.getColumn();
-      columnSet.add(orderByColumn);
-      expressions.add(TransformExpressionTree.compileToExpressionTree(orderByColumn));
+    for (OrderByExpressionContext orderByExpression : orderByExpressions) {
+      ExpressionContext expression = orderByExpression.getExpression();
+      if (expressionSet.add(expression)) {
+        expressions.add(expression.toTransformExpressionTree());
+      }
     }
 
-    if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
-      // For 'SELECT *', sort all physical columns so that the order is deterministic
-      selectionColumns = new ArrayList<>(indexSegment.getColumnNames());
-      selectionColumns.sort(null);
-
-      for (String selectionColumn : selectionColumns) {
-        if (!columnSet.contains(selectionColumn) && selectionColumn.charAt(0) != '$') {
-          // For "select *" queries, ignore columns that start with "$"
-          expressions.add(new TransformExpressionTree(new IdentifierAstNode(selectionColumn)));
+    if (selectExpressions.size() == 1 && selectExpressions.get(0).equals(IDENTIFIER_STAR)) {
+      // For 'SELECT *', sort all columns (ignore columns that start with '$') so that the order is deterministic
+      Set<String> allColumns = indexSegment.getColumnNames();
+      List<String> selectColumns = new ArrayList<>(allColumns.size());
+      for (String column : allColumns) {
+        if (column.charAt(0) != '$') {
+          selectColumns.add(column);
+        }
+      }
+      selectColumns.sort(null);
+      for (String column : selectColumns) {
+        ExpressionContext expression = ExpressionContext.forIdentifier(column);
+        if (!expressionSet.contains(expression)) {
+          expressions.add(expression.toTransformExpressionTree());
         }
       }
     } else {
-      // Note: selection expressions have been standardized during query compilation
-      for (String selectionColumn : selectionColumns) {
-        if (columnSet.add(selectionColumn)) {
-          expressions.add(TransformExpressionTree.compileToExpressionTree(selectionColumn));
+      for (ExpressionContext selectExpression : selectExpressions) {
+        if (expressionSet.add(selectExpression)) {
+          expressions.add(selectExpression.toTransformExpressionTree());
         }
       }
     }
@@ -165,28 +172,32 @@ public class SelectionOperatorUtils {
    * Expands {@code 'SELECT *'} to all columns (excluding transform functions) within {@link DataSchema} with
    * alphabetical order if applies.
    */
-  public static List<String> getSelectionColumns(List<String> selectionColumns, DataSchema dataSchema) {
-    if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
+  public static List<String> getSelectionColumns(List<ExpressionContext> selectExpressions, DataSchema dataSchema) {
+    int numSelectExpressions = selectExpressions.size();
+    if (numSelectExpressions == 1 && selectExpressions.get(0).equals(IDENTIFIER_STAR)) {
       String[] columnNames = dataSchema.getColumnNames();
       int numColumns = columnNames.length;
 
       // Note: The data schema might be generated from DataTableBuilder.buildEmptyDataTable(), where for 'SELECT *' it
-      // will contain a single column "*". In such case, return as is to build the empty selection result.
+      //       contains a single column "*". In such case, return as is to build the empty selection result.
       if (numColumns == 1 && columnNames[0].equals("*")) {
-        return selectionColumns;
+        return Collections.singletonList("*");
       }
 
       List<String> allColumns = new ArrayList<>(numColumns);
       for (String column : columnNames) {
-        if (TransformExpressionTree.compileToExpressionTree(column).getExpressionType()
-            == TransformExpressionTree.ExpressionType.IDENTIFIER) {
+        if (QueryContextConverterUtils.getExpression(column).getType() == ExpressionContext.Type.IDENTIFIER) {
           allColumns.add(column);
         }
       }
       allColumns.sort(null);
       return allColumns;
     } else {
-      return selectionColumns;
+      List<String> columns = new ArrayList<>(numSelectExpressions);
+      for (ExpressionContext selectExpression : selectExpressions) {
+        columns.add(selectExpression.toString());
+      }
+      return columns;
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.data.table;
 
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -30,12 +30,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.MaxAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.SumAggregationFunction;
+import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -44,6 +45,7 @@ import org.testng.annotations.Test;
 /**
  * Tests the {@link Table} operations
  */
+@SuppressWarnings({"rawtypes"})
 public class IndexedTableTest {
 
   @Test
@@ -53,12 +55,9 @@ public class IndexedTableTest {
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
     AggregationFunction[] aggregationFunctions =
         new AggregationFunction[]{new SumAggregationFunction("m1"), new MaxAggregationFunction("m2")};
-    SelectionSort selectionSort = new SelectionSort();
-    selectionSort.setColumn("sum(m1)");
-    selectionSort.setIsAsc(true);
-    List<SelectionSort> orderBy = Collections.singletonList(selectionSort);
-
-    IndexedTable indexedTable = new ConcurrentIndexedTable(dataSchema, aggregationFunctions, orderBy, 5);
+    List<OrderByExpressionContext> orderByExpressions = Collections
+        .singletonList(new OrderByExpressionContext(QueryContextConverterUtils.getExpression("sum(m1)"), true));
+    IndexedTable indexedTable = new ConcurrentIndexedTable(dataSchema, aggregationFunctions, orderByExpressions, 5);
 
     // 3 threads upsert together
     // a inserted 6 times (60), b inserted 5 times (50), d inserted 2 times (20)
@@ -107,7 +106,7 @@ public class IndexedTableTest {
         return null;
       };
 
-      List<Future<Void>> futures = executorService.invokeAll(Lists.newArrayList(c1, c2, c3));
+      List<Future<Void>> futures = executorService.invokeAll(Arrays.asList(c1, c2, c3));
       for (Future future : futures) {
         future.get(10, TimeUnit.SECONDS);
       }
@@ -121,16 +120,16 @@ public class IndexedTableTest {
   }
 
   @Test(dataProvider = "initDataProvider")
-  public void testNonConcurrentIndexedTable(List<SelectionSort> orderBy, List<String> survivors) {
+  public void testNonConcurrentIndexedTable(List<OrderByExpressionContext> orderByExpressions, List<String> survivors) {
     DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "d3", "d4", "sum(m1)", "max(m2)"},
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
     AggregationFunction[] aggregationFunctions =
         new AggregationFunction[]{new SumAggregationFunction("m1"), new MaxAggregationFunction("m2")};
 
     // Test SimpleIndexedTable
-    IndexedTable simpleIndexedTable = new SimpleIndexedTable(dataSchema, aggregationFunctions, orderBy, 5);
+    IndexedTable simpleIndexedTable = new SimpleIndexedTable(dataSchema, aggregationFunctions, orderByExpressions, 5);
     // merge table
-    IndexedTable mergeTable = new SimpleIndexedTable(dataSchema, aggregationFunctions, orderBy, 10);
+    IndexedTable mergeTable = new SimpleIndexedTable(dataSchema, aggregationFunctions, orderByExpressions, 10);
     testNonConcurrent(simpleIndexedTable, mergeTable);
 
     // finish
@@ -138,8 +137,9 @@ public class IndexedTableTest {
     checkSurvivors(simpleIndexedTable, survivors);
 
     // Test ConcurrentIndexedTable
-    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(dataSchema, aggregationFunctions, orderBy, 5);
-    mergeTable = new SimpleIndexedTable(dataSchema, aggregationFunctions, orderBy, 10);
+    IndexedTable concurrentIndexedTable =
+        new ConcurrentIndexedTable(dataSchema, aggregationFunctions, orderByExpressions, 5);
+    mergeTable = new SimpleIndexedTable(dataSchema, aggregationFunctions, orderByExpressions, 10);
     testNonConcurrent(concurrentIndexedTable, mergeTable);
 
     // finish
@@ -149,59 +149,42 @@ public class IndexedTableTest {
 
   @DataProvider(name = "initDataProvider")
   public Object[][] initDataProvider() {
-
     List<Object[]> data = new ArrayList<>();
 
-    SelectionSort sel1;
-    SelectionSort sel2;
-    List<SelectionSort> orderBy;
+    List<OrderByExpressionContext> orderByExpressions;
     List<String> survivors;
 
     // d1 desc
-    sel1 = new SelectionSort();
-    sel1.setColumn("d1");
-    sel1.setIsAsc(false);
-    orderBy = Lists.newArrayList(sel1);
-    survivors = Lists.newArrayList("m", "l", "k", "j", "i");
-    data.add(new Object[]{orderBy, survivors});
+    orderByExpressions =
+        Collections.singletonList(new OrderByExpressionContext(QueryContextConverterUtils.getExpression("d1"), false));
+    survivors = Arrays.asList("m", "l", "k", "j", "i");
+    data.add(new Object[]{orderByExpressions, survivors});
 
     // d1 asc
-    sel1 = new SelectionSort();
-    sel1.setColumn("d1");
-    sel1.setIsAsc(true);
-    orderBy = Lists.newArrayList(sel1);
-    survivors = Lists.newArrayList("a", "b", "c", "d", "e");
-    data.add(new Object[]{orderBy, survivors});
+    orderByExpressions =
+        Collections.singletonList(new OrderByExpressionContext(QueryContextConverterUtils.getExpression("d1"), true));
+    survivors = Arrays.asList("a", "b", "c", "d", "e");
+    data.add(new Object[]{orderByExpressions, survivors});
 
     // sum(m1) desc, d1 asc
-    sel1 = new SelectionSort();
-    sel1.setColumn("sum(m1)");
-    sel1.setIsAsc(false);
-    sel2 = new SelectionSort();
-    sel2.setColumn("d1");
-    sel2.setIsAsc(true);
-    orderBy = Lists.newArrayList(sel1, sel2);
-    survivors = Lists.newArrayList("m", "h", "i", "a", "b");
-    data.add(new Object[]{orderBy, survivors});
+    orderByExpressions = Arrays
+        .asList(new OrderByExpressionContext(QueryContextConverterUtils.getExpression("sum(m1)"), false),
+            new OrderByExpressionContext(QueryContextConverterUtils.getExpression("d1"), true));
+    survivors = Arrays.asList("m", "h", "i", "a", "b");
+    data.add(new Object[]{orderByExpressions, survivors});
 
     // d2 desc
-    sel1 = new SelectionSort();
-    sel1.setColumn("d2");
-    sel1.setIsAsc(false);
-    orderBy = Lists.newArrayList(sel1);
-    survivors = Lists.newArrayList("m", "l", "k", "j", "i");
-    data.add(new Object[]{orderBy, survivors});
+    orderByExpressions =
+        Collections.singletonList(new OrderByExpressionContext(QueryContextConverterUtils.getExpression("d2"), false));
+    survivors = Arrays.asList("m", "l", "k", "j", "i");
+    data.add(new Object[]{orderByExpressions, survivors});
 
     // d4 asc, d1 asc
-    sel1 = new SelectionSort();
-    sel1.setColumn("d4");
-    sel1.setIsAsc(true);
-    sel2 = new SelectionSort();
-    sel2.setColumn("d1");
-    sel2.setIsAsc(true);
-    orderBy = Lists.newArrayList(sel1, sel2);
-    survivors = Lists.newArrayList("a", "b", "c", "d", "e");
-    data.add(new Object[]{orderBy, survivors});
+    orderByExpressions = Arrays
+        .asList(new OrderByExpressionContext(QueryContextConverterUtils.getExpression("d4"), true),
+            new OrderByExpressionContext(QueryContextConverterUtils.getExpression("d1"), true));
+    survivors = Arrays.asList("a", "b", "c", "d", "e");
+    data.add(new Object[]{orderByExpressions, survivors});
 
     return data.toArray(new Object[data.size()][]);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/CombineSlowOperatorsTest.java
@@ -30,6 +30,7 @@ import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.query.exception.EarlyTerminationException;
+import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -62,8 +63,9 @@ public class CombineSlowOperatorsTest {
   @Test
   public void testCombineOperator() {
     List<Operator> operators = getOperators();
-    CombineOperator combineOperator = new CombineOperator(operators, _executorService, TIMEOUT_MS,
-        COMPILER.compileToBrokerRequest("SELECT * FROM table"));
+    CombineOperator combineOperator = new CombineOperator(operators,
+        BrokerRequestToQueryContextConverter.convert(COMPILER.compileToBrokerRequest("SELECT * FROM table")),
+        _executorService, TIMEOUT_MS);
     testCombineOperator(operators, combineOperator);
   }
 
@@ -71,8 +73,9 @@ public class CombineSlowOperatorsTest {
   public void testCombineGroupByOperator() {
     List<Operator> operators = getOperators();
     CombineGroupByOperator combineGroupByOperator = new CombineGroupByOperator(operators,
-        COMPILER.compileToBrokerRequest("SELECT COUNT(*) FROM table GROUP BY column"), _executorService, TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
+        BrokerRequestToQueryContextConverter
+            .convert(COMPILER.compileToBrokerRequest("SELECT COUNT(*) FROM table GROUP BY column")), _executorService,
+        TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
     testCombineOperator(operators, combineGroupByOperator);
   }
 
@@ -80,7 +83,9 @@ public class CombineSlowOperatorsTest {
   public void testCombineGroupByOrderByOperator() {
     List<Operator> operators = getOperators();
     CombineGroupByOrderByOperator combineGroupByOrderByOperator = new CombineGroupByOrderByOperator(operators,
-        COMPILER.compileToBrokerRequest("SELECT COUNT(*) FROM table GROUP BY column"), _executorService, TIMEOUT_MS);
+        BrokerRequestToQueryContextConverter
+            .convert(COMPILER.compileToBrokerRequest("SELECT COUNT(*) FROM table GROUP BY column")), _executorService,
+        TIMEOUT_MS);
     testCombineOperator(operators, combineGroupByOrderByOperator);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/query/selection/SelectionOperatorServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/selection/SelectionOperatorServiceTest.java
@@ -26,15 +26,19 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
-import org.apache.pinot.common.request.Selection;
-import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.response.broker.SelectionResults;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.query.selection.SelectionOperatorService;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -74,28 +78,25 @@ public class SelectionOperatorServiceTest {
   private final Object[] _compatibleRow2 =
       {11L, 12.0F, 13.0, 14, "15", new long[]{16L}, new float[]{17.0F}, new double[]{18.0}, new int[]{19}, new String[]{"20"}, BytesUtils.toByteArray(
           "7000")};
-  private final Selection _selectionOrderBy = new Selection();
+  private QueryContext _queryContext;
 
   @BeforeClass
   public void setUp() {
-    // SELECT * FROM table ORDER BY int DESC LIMIT 1, 2
-    _selectionOrderBy.setSelectionColumns(Arrays.asList(_columnNames));
-    SelectionSort selectionSort = new SelectionSort();
-    selectionSort.setColumn("int");
-    selectionSort.setIsAsc(false);
-    _selectionOrderBy.setSelectionSortSequence(Collections.singletonList(selectionSort));
-    _selectionOrderBy.setSize(2);
-    _selectionOrderBy.setOffset(1);
+    _queryContext = BrokerRequestToQueryContextConverter.convert(new Pql2Compiler().compileToBrokerRequest(
+        "SELECT " + String.join(", ", _columnNames) + " FROM testTable ORDER BY int DESC LIMIT 1, 2"));
   }
 
   @Test
   public void testExtractExpressions() {
     // For non 'SELECT *' select only queries, should return deduplicated selection expressions
-    List<String> selectionColumns = Arrays.asList("add(foo,'1')", "foo", "sub(bar,'2')", "bar", "foo", "foobar", "bar");
+    List<ExpressionContext> selectExpressions = Arrays.asList(QueryContextConverterUtils.getExpression("add(foo,'1')"),
+        QueryContextConverterUtils.getExpression("foo"), QueryContextConverterUtils.getExpression("sub(bar,'2')"),
+        QueryContextConverterUtils.getExpression("bar"), QueryContextConverterUtils.getExpression("foo"),
+        QueryContextConverterUtils.getExpression("foobar"), QueryContextConverterUtils.getExpression("bar"));
     IndexSegment indexSegment = mock(IndexSegment.class);
     when(indexSegment.getColumnNames()).thenReturn(new HashSet<>(Arrays.asList("foo", "bar", "foobar")));
     List<TransformExpressionTree> expressions =
-        SelectionOperatorUtils.extractExpressions(selectionColumns, indexSegment);
+        SelectionOperatorUtils.extractExpressions(selectExpressions, indexSegment);
     assertEquals(expressions.size(), 5);
     assertEquals(expressions.get(0).toString(), "add(foo,'1')");
     assertEquals(expressions.get(1).toString(), "foo");
@@ -104,7 +105,8 @@ public class SelectionOperatorServiceTest {
     assertEquals(expressions.get(4).toString(), "foobar");
 
     // For 'SELECT *' select only queries, should return all physical columns in alphabetical order
-    expressions = SelectionOperatorUtils.extractExpressions(Collections.singletonList("*"), indexSegment);
+    expressions = SelectionOperatorUtils
+        .extractExpressions(Collections.singletonList(SelectionOperatorUtils.IDENTIFIER_STAR), indexSegment);
     assertEquals(expressions.size(), 3);
     assertEquals(expressions.get(0).toString(), "bar");
     assertEquals(expressions.get(1).toString(), "foo");
@@ -112,12 +114,10 @@ public class SelectionOperatorServiceTest {
 
     // For non 'SELECT *' select order-by queries, should return deduplicated order-by expressions followed by selection
     // expressions
-    SelectionSort selectionSort1 = new SelectionSort();
-    selectionSort1.setColumn("foo");
-    SelectionSort selectionSort2 = new SelectionSort();
-    selectionSort2.setColumn("sub(bar,'2')");
-    List<SelectionSort> sortSequence = Arrays.asList(selectionSort1, selectionSort2);
-    expressions = SelectionOperatorUtils.extractExpressions(selectionColumns, indexSegment, sortSequence);
+    List<OrderByExpressionContext> orderByExpressions = Arrays
+        .asList(new OrderByExpressionContext(QueryContextConverterUtils.getExpression("foo"), true),
+            new OrderByExpressionContext(QueryContextConverterUtils.getExpression("sub(bar,'2')"), false));
+    expressions = SelectionOperatorUtils.extractExpressions(selectExpressions, orderByExpressions, indexSegment);
     assertEquals(expressions.size(), 5);
     assertEquals(expressions.get(0).toString(), "foo");
     assertEquals(expressions.get(1).toString(), "sub(bar,'2')");
@@ -127,7 +127,9 @@ public class SelectionOperatorServiceTest {
 
     // For 'SELECT *' select order-by queries, should return deduplicated order-by expressions followed by all physical
     // columns in alphabetical order
-    expressions = SelectionOperatorUtils.extractExpressions(Collections.singletonList("*"), indexSegment, sortSequence);
+    expressions = SelectionOperatorUtils
+        .extractExpressions(Collections.singletonList(SelectionOperatorUtils.IDENTIFIER_STAR), orderByExpressions,
+            indexSegment);
     assertEquals(expressions.size(), 4);
     assertEquals(expressions.get(0).toString(), "foo");
     assertEquals(expressions.get(1).toString(), "sub(bar,'2')");
@@ -139,18 +141,22 @@ public class SelectionOperatorServiceTest {
   public void testGetSelectionColumns() {
     // For non 'SELECT *', should return selection columns as is
     DataSchema dataSchema = mock(DataSchema.class);
-    List<String> selectionColumns =
-        SelectionOperatorUtils.getSelectionColumns(Arrays.asList("add(foo,'1')", "sub(bar,'2')", "foobar"), dataSchema);
+    List<String> selectionColumns = SelectionOperatorUtils.getSelectionColumns(Arrays
+        .asList(QueryContextConverterUtils.getExpression("add(foo,'1')"),
+            QueryContextConverterUtils.getExpression("sub(bar,'2')"),
+            QueryContextConverterUtils.getExpression("foobar")), dataSchema);
     assertEquals(selectionColumns, Arrays.asList("add(foo,'1')", "sub(bar,'2')", "foobar"));
 
     // 'SELECT *' should return columns (no transform expressions) in alphabetical order
     when(dataSchema.getColumnNames()).thenReturn(new String[]{"add(foo,'1')", "sub(bar,'2')", "foo", "bar", "foobar"});
-    selectionColumns = SelectionOperatorUtils.getSelectionColumns(Collections.singletonList("*"), dataSchema);
+    selectionColumns = SelectionOperatorUtils
+        .getSelectionColumns(Collections.singletonList(SelectionOperatorUtils.IDENTIFIER_STAR), dataSchema);
     assertEquals(selectionColumns, Arrays.asList("bar", "foo", "foobar"));
 
     // Test data schema from DataTableBuilder.buildEmptyDataTable()
     when(dataSchema.getColumnNames()).thenReturn(new String[]{"*"});
-    selectionColumns = SelectionOperatorUtils.getSelectionColumns(Collections.singletonList("*"), dataSchema);
+    selectionColumns = SelectionOperatorUtils
+        .getSelectionColumns(Collections.singletonList(SelectionOperatorUtils.IDENTIFIER_STAR), dataSchema);
     assertEquals(selectionColumns, Collections.singletonList("*"));
   }
 
@@ -171,9 +177,9 @@ public class SelectionOperatorServiceTest {
 
   @Test
   public void testCompatibleRowsMergeWithOrdering() {
-    SelectionOperatorService selectionOperatorService = new SelectionOperatorService(_selectionOrderBy, _dataSchema);
+    SelectionOperatorService selectionOperatorService = new SelectionOperatorService(_queryContext, _dataSchema);
     PriorityQueue<Object[]> mergedRows = selectionOperatorService.getRows();
-    int maxNumRows = _selectionOrderBy.getOffset() + _selectionOrderBy.getSize();
+    int maxNumRows = _queryContext.getOffset() + _queryContext.getLimit();
     Collection<Object[]> rowsToMerge1 = new ArrayList<>(2);
     rowsToMerge1.add(_row1);
     rowsToMerge1.add(_row2);
@@ -238,7 +244,7 @@ public class SelectionOperatorServiceTest {
   @Test
   public void testCompatibleRowsRenderSelectionResultsWithOrdering() {
     SelectionOperatorService selectionOperatorService =
-        new SelectionOperatorService(_selectionOrderBy, _upgradedDataSchema);
+        new SelectionOperatorService(_queryContext, _upgradedDataSchema);
     PriorityQueue<Object[]> rows = selectionOperatorService.getRows();
     rows.offer(_row1);
     rows.offer(_compatibleRow1);
@@ -252,7 +258,7 @@ public class SelectionOperatorServiceTest {
     assertTrue(Arrays.deepEquals(resultRows.get(0), expectedRow1));
     assertTrue(Arrays.deepEquals(resultRows.get(1), expectedRow2));
 
-    selectionOperatorService = new SelectionOperatorService(_selectionOrderBy, _upgradedDataSchema);
+    selectionOperatorService = new SelectionOperatorService(_queryContext, _upgradedDataSchema);
     rows = selectionOperatorService.getRows();
     rows.offer(_row1);
     rows.offer(_compatibleRow1);


### PR DESCRIPTION
## Description
Replace BrokerRequest with QueryContext in Operators (server side) and DataTableReducers (broker side)
The reason to put these 2 part in one PR is because they share the same code for selection queries
The change is backward-compatible because it does not involve any change on the wiring layer

Changes for QueryContext:
- Select expressions will contain both aggregation and non-aggregation expressions so that the columns in the result table can be correctly ordered
- Change method signature from `getAlias(ExpressionContext expression)` to `getAliasMap()` and return an unmodifiable map to make it easier to use