### PR TITLE
Pinot Configuration Refactoring - Phase 1

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AccessControlFactory.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.broker.broker;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.broker.api.AccessControl;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,13 +28,13 @@ public abstract class AccessControlFactory {
   public static final Logger LOGGER = LoggerFactory.getLogger(AccessControlFactory.class);
   public static final String ACCESS_CONTROL_CLASS_CONFIG = "class";
 
-  public abstract void init(Configuration confguration);
+  public abstract void init(PinotConfiguration confguration);
 
   public abstract AccessControl create();
 
-  public static AccessControlFactory loadFactory(Configuration configuration) {
+  public static AccessControlFactory loadFactory(PinotConfiguration configuration) {
     AccessControlFactory accessControlFactory;
-    String accessControlFactoryClassName = configuration.getString(ACCESS_CONTROL_CLASS_CONFIG);
+    String accessControlFactoryClassName = configuration.getProperty(ACCESS_CONTROL_CLASS_CONFIG);
     if (accessControlFactoryClassName == null) {
       accessControlFactoryClassName = AllowAllAccessControlFactory.class.getName();
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pinot.broker.broker;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.RequesterIdentity;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 public class AllowAllAccessControlFactory extends AccessControlFactory {
@@ -31,7 +31,7 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
     _accessControl = new AllowAllAccessControl();
   }
 
-  public void init(Configuration configuration) {
+  public void init(PinotConfiguration configuration) {
   }
 
   public AccessControl create() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -21,9 +21,10 @@ package org.apache.pinot.broker.requesthandler;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.broker.api.RequestStatistics;
@@ -43,6 +44,7 @@ import org.apache.pinot.core.transport.QueryRouter;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.ServerResponse;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
@@ -54,7 +56,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandler {
   private final QueryRouter _queryRouter;
 
-  public SingleConnectionBrokerRequestHandler(Configuration config, RoutingManager routingManager,
+  public SingleConnectionBrokerRequestHandler(PinotConfiguration config, RoutingManager routingManager,
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, BrokerMetrics brokerMetrics,
       ZkHelixPropertyStore<ZNRecord> propertyStore) {
     super(config, routingManager, accessControlFactory, queryQuotaManager, brokerMetrics, propertyStore);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -21,8 +21,6 @@ package org.apache.pinot.broker.broker;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.Configuration;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
@@ -44,7 +42,7 @@ import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
@@ -75,9 +73,11 @@ public class HelixBrokerStarterTest extends ControllerTest {
     startZk();
     startController();
 
-    Configuration brokerConf = new BaseConfiguration();
-    brokerConf.addProperty(Helix.KEY_OF_BROKER_QUERY_PORT, 18099);
-    _brokerStarter = new HelixBrokerStarter(brokerConf, getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR);
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(Helix.KEY_OF_BROKER_QUERY_PORT, 18099);
+    
+    _brokerStarter =
+        new HelixBrokerStarter(new PinotConfiguration(properties), getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR);
     _brokerStarter.start();
 
     addFakeBrokerInstancesToAutoJoinHelixCluster(NUM_BROKERS - 1, true);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -18,19 +18,21 @@
  */
 package org.apache.pinot.broker.requesthandler;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yammer.metrics.core.MetricsRegistry;
 import java.util.Random;
-import org.apache.commons.configuration.PropertiesConfiguration;
+
 import org.apache.pinot.broker.api.RequestStatistics;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yammer.metrics.core.MetricsRegistry;
 
 
 public class LiteralOnlyBrokerRequestTest {
@@ -90,7 +92,7 @@ public class LiteralOnlyBrokerRequestTest {
   public void testBrokerRequestHandler()
       throws Exception {
     SingleConnectionBrokerRequestHandler requestHandler =
-        new SingleConnectionBrokerRequestHandler(new PropertiesConfiguration(), null, null, null,
+        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, null, null,
             new BrokerMetrics("", new MetricsRegistry(), false), null);
     long randNum = RANDOM.nextLong();
     byte[] randBytes = new byte[12];
@@ -117,7 +119,7 @@ public class LiteralOnlyBrokerRequestTest {
   public void testBrokerRequestHandlerWithAsFunction()
       throws Exception {
     SingleConnectionBrokerRequestHandler requestHandler =
-        new SingleConnectionBrokerRequestHandler(new PropertiesConfiguration(), null, null, null,
+        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, null, null,
             new BrokerMetrics("", new MetricsRegistry(), false), null);
     long currentTsMin = System.currentTimeMillis();
     JsonNode request = new ObjectMapper().readTree(

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/MetricsHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/MetricsHelper.java
@@ -30,11 +30,13 @@ import com.yammer.metrics.core.Sampling;
 import com.yammer.metrics.core.Stoppable;
 import com.yammer.metrics.core.Timer;
 import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,13 +54,10 @@ public class MetricsHelper {
    *
    * @param configuration The subset of the configuration containing the metrics-related keys
    */
-  public static void initializeMetrics(Configuration configuration) {
+  public static void initializeMetrics(PinotConfiguration configuration) {
     synchronized (MetricsHelper.class) {
-      String[] listenerClassNames = configuration.getStringArray("metricsRegistryRegistrationListeners");
-
-      if (listenerClassNames.length < 1) {
-        listenerClassNames = new String[]{JmxReporterMetricsRegistryRegistrationListener.class.getName()};
-      }
+      List<String> listenerClassNames = configuration.getProperty("metricsRegistryRegistrationListeners",
+          Arrays.asList(JmxReporterMetricsRegistryRegistrationListener.class.getName()));
 
       // Build each listener using their default constructor and add them
       for (String listenerClassName : listenerClassNames) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ClientSSLContextGenerator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ClientSSLContextGenerator.java
@@ -29,14 +29,16 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.Set;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.common.Utils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,15 +62,15 @@ public class ClientSSLContextGenerator {
     return Collections.singleton(CONFIG_OF_CLIENT_PKCS12_PASSWORD);
   }
 
-  public ClientSSLContextGenerator(Configuration sslConfig) {
-    if (sslConfig.getBoolean(CONFIG_OF_ENABLE_SERVER_VERIFICATION, true)) {
-      _serverCACertFile = sslConfig.getString(CONFIG_OF_SERVER_CA_CERT);
+  public ClientSSLContextGenerator(PinotConfiguration sslConfig) {
+    if (sslConfig.getProperty(CONFIG_OF_ENABLE_SERVER_VERIFICATION, true)) {
+      _serverCACertFile = sslConfig.getProperty(CONFIG_OF_SERVER_CA_CERT);
     } else {
       _serverCACertFile = null;
       LOGGER.warn("Https Server CA file not configured.. All servers will be trusted!");
     }
-    _keyStoreFile = sslConfig.getString(CONFIG_OF_CLIENT_PKCS12_FILE);
-    _keyStorePassword = sslConfig.getString(CONFIG_OF_CLIENT_PKCS12_PASSWORD);
+    _keyStoreFile = sslConfig.getProperty(CONFIG_OF_CLIENT_PKCS12_FILE);
+    _keyStorePassword = sslConfig.getProperty(CONFIG_OF_CLIENT_PKCS12_PASSWORD);
     if ((_keyStorePassword == null && _keyStoreFile != null) || (_keyStorePassword != null && _keyStoreFile == null)) {
       throw new IllegalArgumentException("Invalid configuration of keystore file and passowrd");
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -22,7 +22,8 @@ import java.io.File;
 import java.net.URI;
 import java.util.List;
 import java.util.Random;
-import org.apache.commons.configuration.Configuration;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,10 +47,10 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   protected int _retryDelayScaleFactor;
 
   @Override
-  public void init(Configuration config) {
-    _retryCount = config.getInt(RETRY_COUNT_CONFIG_KEY, DEFAULT_RETRY_COUNT);
-    _retryWaitMs = config.getInt(RETRY_WAIT_MS_CONFIG_KEY, DEFAULT_RETRY_WAIT_MS);
-    _retryDelayScaleFactor = config.getInt(RETRY_DELAY_SCALE_FACTOR_CONFIG_KEY, DEFAULT_RETRY_DELAY_SCALE_FACTOR);
+  public void init(PinotConfiguration config) {
+    _retryCount = config.getProperty(RETRY_COUNT_CONFIG_KEY, DEFAULT_RETRY_COUNT);
+    _retryWaitMs = config.getProperty(RETRY_WAIT_MS_CONFIG_KEY, DEFAULT_RETRY_WAIT_MS);
+    _retryDelayScaleFactor = config.getProperty(RETRY_DELAY_SCALE_FACTOR_CONFIG_KEY, DEFAULT_RETRY_DELAY_SCALE_FACTOR);
     doInit(config);
     _logger
         .info("Initialized with retryCount: {}, retryWaitMs: {}, retryDelayScaleFactor: {}", _retryCount, _retryWaitMs,
@@ -59,7 +60,7 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   /**
    * Override this for custom initialization.
    */
-  protected void doInit(Configuration config) {
+  protected void doInit(PinotConfiguration config) {
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -20,9 +20,10 @@ package org.apache.pinot.common.utils.fetcher;
 
 import java.io.File;
 import java.net.URI;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 
 
@@ -30,7 +31,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
   protected FileUploadDownloadClient _httpClient;
 
   @Override
-  protected void doInit(Configuration config) {
+  protected void doInit(PinotConfiguration config) {
     _httpClient = new FileUploadDownloadClient();
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpsSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpsSegmentFetcher.java
@@ -20,11 +20,13 @@ package org.apache.pinot.common.utils.fetcher;
 
 import java.util.Iterator;
 import java.util.Set;
+
 import javax.net.ssl.SSLContext;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.common.utils.ClientSSLContextGenerator;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /*
@@ -56,20 +58,19 @@ import org.apache.pinot.common.utils.FileUploadDownloadClient;
 public class HttpsSegmentFetcher extends HttpSegmentFetcher {
 
   @Override
-  protected void doInit(Configuration config) {
-    Configuration sslConfig = config.subset(CommonConstants.PREFIX_OF_SSL_SUBSET);
+  protected void doInit(PinotConfiguration config) {
+    PinotConfiguration sslConfig = config.subset(CommonConstants.PREFIX_OF_SSL_SUBSET);
     _logger.info("Initializing with the following ssl config:");
     Set<String> protectedConfigKeys = ClientSSLContextGenerator.getProtectedConfigKeys();
-    @SuppressWarnings("unchecked")
-    Iterator<String> iterator = sslConfig.getKeys();
-    while (iterator.hasNext()) {
-      String configKey = iterator.next();
+    
+    for (String configKey : sslConfig.getKeys()) {
       if (protectedConfigKeys.contains(configKey)) {
         _logger.info("{}: {}", configKey, "********");
       } else {
-        _logger.info("{}: {}", configKey, config.getString(configKey));
+        _logger.info("{}: {}", configKey, config.getProperty(configKey));
       }
     }
+
     SSLContext sslContext = new ClientSSLContextGenerator(sslConfig).generate();
     _httpClient = new FileUploadDownloadClient(sslContext);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcher.java
@@ -21,7 +21,8 @@ package org.apache.pinot.common.utils.fetcher;
 import java.io.File;
 import java.net.URI;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 public interface SegmentFetcher {
@@ -29,7 +30,7 @@ public interface SegmentFetcher {
   /**
    * Initializes the segment fetcher.
    */
-  void init(Configuration config);
+  void init(PinotConfiguration config);
 
   /**
    * Fetches a segment from URI location to local.

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -20,12 +20,13 @@ package org.apache.pinot.common.utils.fetcher;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +44,7 @@ public class SegmentFetcherFactory {
   private static final SegmentFetcher DEFAULT_PINOT_FS_SEGMENT_FETCHER = new PinotFSSegmentFetcher();
 
   static {
-    Configuration emptyConfig = new BaseConfiguration();
+    PinotConfiguration emptyConfig = new PinotConfiguration();
     DEFAULT_HTTP_SEGMENT_FETCHER.init(emptyConfig);
     DEFAULT_PINOT_FS_SEGMENT_FETCHER.init(emptyConfig);
   }
@@ -51,12 +52,11 @@ public class SegmentFetcherFactory {
   /**
    * Initializes the segment fetcher factory. This method should only be called once.
    */
-  public static void init(Configuration config)
+  public static void init(PinotConfiguration config)
       throws Exception {
-    @SuppressWarnings("unchecked")
-    List<String> protocols = config.getList(PROTOCOLS_KEY);
+    List<String> protocols = config.getProperty(PROTOCOLS_KEY, Arrays.asList());
     for (String protocol : protocols) {
-      String segmentFetcherClassName = config.getString(protocol + SEGMENT_FETCHER_CLASS_KEY_SUFFIX);
+      String segmentFetcherClassName = config.getProperty(protocol + SEGMENT_FETCHER_CLASS_KEY_SUFFIX);
       SegmentFetcher segmentFetcher;
       if (segmentFetcherClassName == null) {
         LOGGER.info("Segment fetcher class is not configured for protocol: {}, using default", protocol);

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/MetricsHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/MetricsHelperTest.java
@@ -18,16 +18,17 @@
  */
 package org.apache.pinot.common.metrics;
 
-import com.yammer.metrics.core.MetricName;
-import com.yammer.metrics.core.MetricsRegistry;
+import static org.testng.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertTrue;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsRegistry;
 
 
 /**
@@ -57,10 +58,11 @@ public class MetricsHelperTest {
     listenerOneOkay = false;
     listenerTwoOkay = false;
 
-    Map<String, String> configKeys = new HashMap<String, String>();
-    configKeys.put("pinot.broker.metrics.metricsRegistryRegistrationListeners",
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("pinot.broker.metrics.metricsRegistryRegistrationListeners",
         ListenerOne.class.getName() + "," + ListenerTwo.class.getName());
-    Configuration configuration = new MapConfiguration(configKeys);
+    
+    PinotConfiguration configuration = new PinotConfiguration(properties);
 
     MetricsRegistry registry = new MetricsRegistry();
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
@@ -18,18 +18,19 @@
  */
 package org.apache.pinot.common.utils.fetcher;
 
-import java.io.File;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.List;
-import javax.ws.rs.NotSupportedException;
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.Configuration;
-import org.testng.annotations.Test;
-
 import static org.apache.pinot.common.utils.CommonConstants.HTTPS_PROTOCOL;
 import static org.apache.pinot.common.utils.CommonConstants.HTTP_PROTOCOL;
 import static org.testng.Assert.assertEquals;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.Test;
 
 
 public class SegmentFetcherFactoryTest {
@@ -48,13 +49,13 @@ public class SegmentFetcherFactoryTest {
   @Test(dependsOnMethods = "testDefaultSegmentFetcherFactory")
   public void testCustomizedSegmentFetcherFactory()
       throws Exception {
-    Configuration config = new BaseConfiguration();
-    config.addProperty("foo", "bar");
-    config.addProperty("protocols", Arrays.asList(HTTP_PROTOCOL, HTTPS_PROTOCOL, TEST_PROTOCOL, "foo"));
-    config.addProperty("http.foo", "bar");
-    config.addProperty(TEST_PROTOCOL + SegmentFetcherFactory.SEGMENT_FETCHER_CLASS_KEY_SUFFIX,
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("foo", "bar");
+    properties.put("protocols", Arrays.asList(HTTP_PROTOCOL, HTTPS_PROTOCOL, TEST_PROTOCOL, "foo"));
+    properties.put("http.foo", "bar");
+    properties.put(TEST_PROTOCOL + SegmentFetcherFactory.SEGMENT_FETCHER_CLASS_KEY_SUFFIX,
         TestSegmentFetcher.class.getName());
-    SegmentFetcherFactory.init(config);
+    SegmentFetcherFactory.init(new PinotConfiguration(properties));
 
     assertEquals(SegmentFetcherFactory.getSegmentFetcher(HTTP_PROTOCOL).getClass(), HttpSegmentFetcher.class);
     assertEquals(SegmentFetcherFactory.getSegmentFetcher(HTTPS_PROTOCOL).getClass(), HttpsSegmentFetcher.class);
@@ -80,7 +81,7 @@ public class SegmentFetcherFactoryTest {
     private int _fetchFileToLocalCalled = 0;
 
     @Override
-    public void init(Configuration config) {
+    public void init(PinotConfiguration config) {
       _initCalled++;
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -18,48 +18,44 @@
  */
 package org.apache.pinot.controller;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-import java.util.stream.Collectors;
-
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
-import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
-import org.apache.pinot.common.utils.CommonConstants;
-import org.apache.pinot.common.utils.StringUtil;
-import org.apache.pinot.spi.filesystem.LocalPinotFS;
-
 import static org.apache.pinot.common.utils.CommonConstants.Controller.CONFIG_OF_CONTROLLER_METRICS_PREFIX;
 import static org.apache.pinot.common.utils.CommonConstants.Controller.DEFAULT_METRICS_PREFIX;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
 
-public class ControllerConf extends PropertiesConfiguration {
-  private static final String CONTROLLER_VIP_HOST = "controller.vip.host";
-  private static final String CONTROLLER_VIP_PORT = "controller.vip.port";
-  private static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
-  private static final String CONTROLLER_HOST = "controller.host";
-  private static final String CONTROLLER_PORT = "controller.port";
-  private static final String CONTROLLER_ACCESS_PROTOCOLS = "controller.access.protocols";
-  private static final String DATA_DIR = "controller.data.dir";
+import org.apache.commons.configuration.Configuration;
+import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
+import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+
+
+public class ControllerConf extends PinotConfiguration {
+  public static final String CONTROLLER_VIP_HOST = "controller.vip.host";
+  public static final String CONTROLLER_VIP_PORT = "controller.vip.port";
+  public static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
+  public static final String CONTROLLER_HOST = "controller.host";
+  public static final String CONTROLLER_PORT = "controller.port";
+  public static final String CONTROLLER_ACCESS_PROTOCOLS = "controller.access.protocols";
+  public static final String DATA_DIR = "controller.data.dir";
   // Potentially same as data dir if local
-  private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
-  private static final String ZK_STR = "controller.zk.str";
+  public static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
+  public static final String ZK_STR = "controller.zk.str";
   // boolean: Update the statemodel on boot?
-  private static final String UPDATE_SEGMENT_STATE_MODEL = "controller.update_segment_state_model";
-  private static final String HELIX_CLUSTER_NAME = "controller.helix.cluster.name";
-  private static final String CLUSTER_TENANT_ISOLATION_ENABLE = "cluster.tenant.isolation.enable";
-  private static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
-  private static final String CONSOLE_WEBAPP_USE_HTTPS = "controller.query.console.useHttps";
-  private static final String EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT = "controller.upload.onlineToOfflineTimeout";
-  private static final String CONTROLLER_MODE = "controller.mode";
-  private static final String LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY = "controller.resource.rebalance.strategy";
+  public static final String UPDATE_SEGMENT_STATE_MODEL = "controller.update_segment_state_model";
+  public static final String HELIX_CLUSTER_NAME = "controller.helix.cluster.name";
+  public static final String CLUSTER_TENANT_ISOLATION_ENABLE = "cluster.tenant.isolation.enable";
+  public static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
+  public static final String CONSOLE_WEBAPP_USE_HTTPS = "controller.query.console.useHttps";
+  public static final String EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT = "controller.upload.onlineToOfflineTimeout";
+  public static final String CONTROLLER_MODE = "controller.mode";
+  public static final String LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY = "controller.resource.rebalance.strategy";
 
   public enum ControllerMode {
     DUAL, PINOT_ONLY, HELIX_ONLY
@@ -67,38 +63,38 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public static class ControllerPeriodicTasksConf {
     // frequency configs
-    private static final String RETENTION_MANAGER_FREQUENCY_IN_SECONDS = "controller.retention.frequencyInSeconds";
+    public static final String RETENTION_MANAGER_FREQUENCY_IN_SECONDS = "controller.retention.frequencyInSeconds";
     @Deprecated
     // The ValidationManager has been split up into 3 separate tasks, each having their own frequency config settings
-    private static final String DEPRECATED_VALIDATION_MANAGER_FREQUENCY_IN_SECONDS =
+    public static final String DEPRECATED_VALIDATION_MANAGER_FREQUENCY_IN_SECONDS =
         "controller.validation.frequencyInSeconds";
-    private static final String OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS =
+    public static final String OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS =
         "controller.offline.segment.interval.checker.frequencyInSeconds";
-    private static final String REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS =
+    public static final String REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS =
         "controller.realtime.segment.validation.frequencyInSeconds";
-    private static final String BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS =
+    public static final String BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS =
         "controller.broker.resource.validation.frequencyInSeconds";
-    private static final String BROKER_RESOURCE_VALIDATION_INITIAL_DELAY_IN_SECONDS =
+    public static final String BROKER_RESOURCE_VALIDATION_INITIAL_DELAY_IN_SECONDS =
         "controller.broker.resource.validation.initialDelayInSeconds";
-    private static final String STATUS_CHECKER_FREQUENCY_IN_SECONDS = "controller.statuschecker.frequencyInSeconds";
-    private static final String STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS =
+    public static final String STATUS_CHECKER_FREQUENCY_IN_SECONDS = "controller.statuschecker.frequencyInSeconds";
+    public static final String STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS =
         "controller.statuschecker.waitForPushTimeInSeconds";
-    private static final String TASK_MANAGER_FREQUENCY_IN_SECONDS = "controller.task.frequencyInSeconds";
-    private static final String REALTIME_SEGMENT_RELOCATOR_FREQUENCY =
+    public static final String TASK_MANAGER_FREQUENCY_IN_SECONDS = "controller.task.frequencyInSeconds";
+    public static final String REALTIME_SEGMENT_RELOCATOR_FREQUENCY =
         "controller.realtime.segment.relocator.frequency";
     // Because segment level validation is expensive and requires heavy ZK access, we run segment level validation with a
     // separate interval
-    private static final String SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS =
+    public static final String SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS =
         "controller.segment.level.validation.intervalInSeconds";
 
     // Initial delays
-    private static final String STATUS_CHECKER_INITIAL_DELAY_IN_SECONDS =
+    public static final String STATUS_CHECKER_INITIAL_DELAY_IN_SECONDS =
         "controller.statusChecker.initialDelayInSeconds";
-    private static final String RETENTION_MANAGER_INITIAL_DELAY_IN_SECONDS =
+    public static final String RETENTION_MANAGER_INITIAL_DELAY_IN_SECONDS =
         "controller.retentionManager.initialDelayInSeconds";
-    private static final String OFFLINE_SEGMENT_INTERVAL_CHECKER_INITIAL_DELAY_IN_SECONDS =
+    public static final String OFFLINE_SEGMENT_INTERVAL_CHECKER_INITIAL_DELAY_IN_SECONDS =
         "controller.offlineSegmentIntervalChecker.initialDelayInSeconds";
-    private static final String REALTIME_SEGMENT_RELOCATION_INITIAL_DELAY_IN_SECONDS =
+    public static final String REALTIME_SEGMENT_RELOCATION_INITIAL_DELAY_IN_SECONDS =
         "controller.realtimeSegmentRelocation.initialDelayInSeconds";
 
     public static final int MIN_INITIAL_DELAY_IN_SECONDS = 120;
@@ -125,11 +121,11 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
   private static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "controller.realtime.segment.commit.timeoutSeconds";
   private static final String DELETED_SEGMENTS_RETENTION_IN_DAYS = "controller.deleted.segments.retentionInDays";
-  private static final String TABLE_MIN_REPLICAS = "table.minReplicas";
-  private static final String ENABLE_SPLIT_COMMIT = "controller.enable.split.commit";
+  public static final String TABLE_MIN_REPLICAS = "table.minReplicas";
+  public static final String ENABLE_SPLIT_COMMIT = "controller.enable.split.commit";
   private static final String JERSEY_ADMIN_API_PORT = "jersey.admin.api.port";
   private static final String JERSEY_ADMIN_IS_PRIMARY = "jersey.admin.isprimary";
-  private static final String ACCESS_CONTROL_FACTORY_CLASS = "controller.admin.access.control.factory.class";
+  public static final String ACCESS_CONTROL_FACTORY_CLASS = "controller.admin.access.control.factory.class";
   // Amount of the time the segment can take from the beginning of upload to the end of upload. Used when parallel push
   // protection is enabled. If the upload does not finish within the timeout, next upload can override the previous one.
   private static final String SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = "controller.segment.upload.timeoutInMillis";
@@ -140,10 +136,9 @@ public class ControllerConf extends PropertiesConfiguration {
   // It is used to disable the HLC realtime segment completion and disallow HLC table in the cluster. True by default.
   // If it's set to false, existing HLC realtime tables will stop consumption, and creation of new HLC tables will be disallowed.
   // Please make sure there is no HLC table running in the cluster before disallowing it.
-  private static final String ALLOW_HLC_TABLES = "controller.allow.hlc.tables";
+  public static final String ALLOW_HLC_TABLES = "controller.allow.hlc.tables";
 
   // Defines the kind of storage and the underlying PinotFS implementation
-  private static final String PINOT_FS_FACTORY_CLASS_PREFIX = "controller.storage.factory.class";
   private static final String PINOT_FS_FACTORY_CLASS_LOCAL = "controller.storage.factory.class.file";
 
   private static final long DEFAULT_EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT_MILLIS = 120_000L; // 2 minutes
@@ -165,22 +160,16 @@ public class ControllerConf extends PropertiesConfiguration {
 
   private static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
 
-  public ControllerConf(File file)
-      throws ConfigurationException {
-    super(file);
-  }
-
   public ControllerConf() {
-    super();
+    super(new HashMap<>());
+  }
+  
+  public ControllerConf(Map<String, Object> baseProperties) {
+    super(baseProperties);
   }
 
-  public ControllerConf(Configuration conf) {
-    super();
-    Iterator<String> keysIterator = conf.getKeys();
-    while(keysIterator.hasNext()) {
-      String key = keysIterator.next();
-      this.setProperty(key, conf.getProperty(key));
-    }
+  public ControllerConf(Configuration baseConfiguration) {
+    super(baseConfiguration);
   }
 
   public void setLocalTempDir(String localTempDir) {
@@ -188,7 +177,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public String getLocalTempDir() {
-    return getString(LOCAL_TEMP_DIR);
+    return getProperty(LOCAL_TEMP_DIR);
   }
 
   public void setPinotFSFactoryClasses(Configuration pinotFSFactoryClasses) {
@@ -209,10 +198,9 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public String getQueryConsoleWebappPath() {
-    if (containsKey(CONSOLE_WEBAPP_ROOT_PATH)) {
-      return (String) getProperty(CONSOLE_WEBAPP_ROOT_PATH);
-    }
-    return ControllerConf.class.getClassLoader().getResource("webapp").toExternalForm();
+    return Optional.ofNullable(getProperty(CONSOLE_WEBAPP_ROOT_PATH))
+
+        .orElseGet(() -> ControllerConf.class.getClassLoader().getResource("webapp").toExternalForm());
   }
 
   public void setQueryConsoleUseHttps(boolean useHttps) {
@@ -220,7 +208,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public boolean getQueryConsoleUseHttps() {
-    return containsKey(CONSOLE_WEBAPP_USE_HTTPS) && getBoolean(CONSOLE_WEBAPP_USE_HTTPS);
+    return getProperty(CONSOLE_WEBAPP_USE_HTTPS, false);
   }
 
   public void setJerseyAdminPrimary(String jerseyAdminPrimary) {
@@ -264,60 +252,56 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public void setZkStr(String zkStr) {
-    setProperty(ZK_STR, zkStr);
+    throw new UnsupportedOperationException("Fix me!");
+    //    setProperty(ZK_STR, zkStr);
   }
 
   // A boolean to decide whether Jersey API should be the primary one. For now, we set this to be false,
   // but we turn it on to true when we are sure that jersey api has no backward compatibility problems.
   public boolean isJerseyAdminPrimary() {
-    return getBoolean(JERSEY_ADMIN_IS_PRIMARY, true);
+    return getProperty(JERSEY_ADMIN_IS_PRIMARY, true);
   }
 
   public String getHelixClusterName() {
-    return (String) getProperty(HELIX_CLUSTER_NAME);
+    return getProperty(HELIX_CLUSTER_NAME);
   }
 
   public String getControllerHost() {
-    return (String) getProperty(CONTROLLER_HOST);
+    return getProperty(CONTROLLER_HOST);
   }
 
   public String getControllerPort() {
-    return (String) getProperty(CONTROLLER_PORT);
+    return getProperty(CONTROLLER_PORT);
   }
-
+  
   public List<String> getControllerAccessProtocols() {
-    return Optional.ofNullable(getStringArray(CONTROLLER_ACCESS_PROTOCOLS))
-
-        .map(protocols -> Arrays.stream(protocols).collect(Collectors.toList()))
-
-        // http will be defaulted only if the legacy controller.port property is not defined.
-        .orElseGet(() -> getControllerPort() == null ? Arrays.asList("http") : Arrays.asList());
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS,
+        getControllerPort() == null ? Arrays.asList("http") : Arrays.asList());
   }
 
   public String getControllerAccessProtocolProperty(String protocol, String property) {
-    return getString(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property);
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property);
   }
 
   public String getControllerAccessProtocolProperty(String protocol, String property, String defaultValue) {
-    return getString(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property, defaultValue);
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property, defaultValue);
+  }
+
+  public boolean getControllerAccessProtocolProperty(String protocol, String property, boolean defaultValue) {
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property, defaultValue);
   }
 
   public String getDataDir() {
-    return (String) getProperty(DATA_DIR);
+    return getProperty(DATA_DIR);
   }
 
   public int getSegmentCommitTimeoutSeconds() {
-    if (containsKey(SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
-      return Integer.parseInt((String) getProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS));
-    }
-    return SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds();
+    return getProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS,
+        SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds());
   }
 
   public boolean isUpdateSegmentStateModel() {
-    if (containsKey(UPDATE_SEGMENT_STATE_MODEL)) {
-      return Boolean.parseBoolean(getProperty(UPDATE_SEGMENT_STATE_MODEL).toString());
-    }
-    return false;   // Default is to leave the statemodel untouched.
+    return getProperty(UPDATE_SEGMENT_STATE_MODEL, false);
   }
 
   public String generateVipUrl() {
@@ -325,20 +309,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public String getZkStr() {
-    Object zkAddressObj = getProperty(ZK_STR);
-
-    // The set method converted comma separated string into ArrayList, so need to convert back to String here.
-    if (zkAddressObj instanceof ArrayList) {
-      List<String> zkAddressList = (ArrayList<String>) zkAddressObj;
-      String[] zkAddress = zkAddressList.toArray(new String[0]);
-      return StringUtil.join(",", zkAddress);
-    } else if (zkAddressObj instanceof String) {
-      return (String) zkAddressObj;
-    } else {
-      throw new RuntimeException(
-          "Unexpected data type for zkAddress PropertiesConfiguration, expecting String but got " + zkAddressObj
-              .getClass().getName());
-    }
+    return getProperty(ZK_STR);
   }
 
   @Override
@@ -346,55 +317,50 @@ public class ControllerConf extends PropertiesConfiguration {
     return super.toString();
   }
 
-  public Configuration getPinotFSFactoryClasses() {
-    return this.subset(PINOT_FS_FACTORY_CLASS_PREFIX);
-  }
-
   public boolean getAcceptSplitCommit() {
-    return getBoolean(ENABLE_SPLIT_COMMIT, DEFAULT_ENABLE_SPLIT_COMMIT);
+    return getProperty(ENABLE_SPLIT_COMMIT, DEFAULT_ENABLE_SPLIT_COMMIT);
   }
 
   public String getControllerVipHost() {
-    if (containsKey(CONTROLLER_VIP_HOST) && ((String) getProperty(CONTROLLER_VIP_HOST)).length() > 0) {
-      return (String) getProperty(CONTROLLER_VIP_HOST);
-    }
-    return (String) getProperty(CONTROLLER_HOST);
+    return Optional.ofNullable(getProperty(CONTROLLER_VIP_HOST))
+
+        .filter(controllerVipHost -> !controllerVipHost.isEmpty())
+
+        .orElseGet(() -> getProperty(CONTROLLER_HOST));
   }
 
   public String getControllerVipPort() {
-    if (containsKey(CONTROLLER_VIP_PORT) && ((String) getProperty(CONTROLLER_VIP_PORT)).length() > 0) {
-      return (String) getProperty(CONTROLLER_VIP_PORT);
-    }
+    return Optional.ofNullable(getProperty(CONTROLLER_VIP_PORT))
 
-    // Vip port is not explicitly defined. Initiate discovery from the configured protocols.
-    return getControllerAccessProtocols().stream()
+        .filter(controllerVipPort -> !controllerVipPort.isEmpty())
 
-        .filter(protocol -> Boolean.parseBoolean(getControllerAccessProtocolProperty(protocol, "vip", "false")))
+        .orElseGet(() -> getControllerAccessProtocols().stream()
 
-        .map(protocol -> Optional.ofNullable(getControllerAccessProtocolProperty(protocol, "port")))
+            .filter(protocol -> getControllerAccessProtocolProperty(protocol, "vip", false))
 
-        .filter(Optional::isPresent)
+            .map(protocol -> Optional.ofNullable(getControllerAccessProtocolProperty(protocol, "port")))
 
-        .map(Optional::get)
+            .filter(Optional::isPresent)
 
-        .findFirst()
+            .map(Optional::get)
 
-        // No protocol defines a port as VIP. Fallback on legacy controller.port property.
-        .orElseGet(this::getControllerPort);
-  }
+            .findFirst()
+
+            // No protocol defines a port as VIP. Fallback on legacy controller.port property.
+            .orElseGet(this::getControllerPort));
+  }  
 
   public String getControllerVipProtocol() {
-    if (containsKey(CONTROLLER_VIP_PROTOCOL) && getProperty(CONTROLLER_VIP_PROTOCOL).equals(CommonConstants.HTTPS_PROTOCOL)) {
-      return CommonConstants.HTTPS_PROTOCOL;
-    }
-    return CommonConstants.HTTP_PROTOCOL;
+    return Optional.ofNullable(getProperty(CONTROLLER_VIP_PROTOCOL))
+
+        .filter(protocol -> CommonConstants.HTTPS_PROTOCOL.equals(protocol))
+
+        .orElse(CommonConstants.HTTP_PROTOCOL);
   }
 
   public int getRetentionControllerFrequencyInSeconds() {
-    if (containsKey(ControllerPeriodicTasksConf.RETENTION_MANAGER_FREQUENCY_IN_SECONDS)) {
-      return Integer.parseInt((String) getProperty(ControllerPeriodicTasksConf.RETENTION_MANAGER_FREQUENCY_IN_SECONDS));
-    }
-    return ControllerPeriodicTasksConf.DEFAULT_RETENTION_CONTROLLER_FREQUENCY_IN_SECONDS;
+    return getProperty(ControllerPeriodicTasksConf.RETENTION_MANAGER_FREQUENCY_IN_SECONDS,
+        ControllerPeriodicTasksConf.DEFAULT_RETENTION_CONTROLLER_FREQUENCY_IN_SECONDS);
   }
 
   public void setRetentionControllerFrequencyInSeconds(int retentionFrequencyInSeconds) {
@@ -410,11 +376,7 @@ public class ControllerConf extends PropertiesConfiguration {
    * @return
    */
   public int getOfflineSegmentIntervalCheckerFrequencyInSeconds() {
-    if (containsKey(ControllerPeriodicTasksConf.OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS)) {
-      return Integer.parseInt(
-          (String) getProperty(ControllerPeriodicTasksConf.OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS));
-    }
-    return getInt(ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
+    return getProperty(ControllerPeriodicTasksConf.OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS,
         ControllerPeriodicTasksConf.DEFAULT_OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS);
   }
 
@@ -431,12 +393,12 @@ public class ControllerConf extends PropertiesConfiguration {
    * @return
    */
   public int getRealtimeSegmentValidationFrequencyInSeconds() {
-    if (containsKey(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS)) {
-      return Integer
-          .parseInt((String) getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS));
-    }
-    return getInt(ControllerPeriodicTasksConf.DEPRECATED_VALIDATION_MANAGER_FREQUENCY_IN_SECONDS,
-        ControllerPeriodicTasksConf.DEFAULT_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS);
+    return Optional
+        .ofNullable(
+            getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS, Integer.class))
+
+        .orElseGet(() -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_VALIDATION_MANAGER_FREQUENCY_IN_SECONDS,
+            ControllerPeriodicTasksConf.DEFAULT_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS));
   }
 
   public void setRealtimeSegmentValidationFrequencyInSeconds(int validationFrequencyInSeconds) {
@@ -452,12 +414,12 @@ public class ControllerConf extends PropertiesConfiguration {
    * @return
    */
   public int getBrokerResourceValidationFrequencyInSeconds() {
-    if (containsKey(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS)) {
-      return Integer
-          .parseInt((String) getProperty(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS));
-    }
-    return getInt(ControllerPeriodicTasksConf.DEPRECATED_VALIDATION_MANAGER_FREQUENCY_IN_SECONDS,
-        ControllerPeriodicTasksConf.DEFAULT_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS);
+    return Optional
+        .ofNullable(
+            getProperty(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS, Integer.class))
+
+        .orElseGet(() -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_VALIDATION_MANAGER_FREQUENCY_IN_SECONDS,
+            ControllerPeriodicTasksConf.DEFAULT_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS));
   }
 
   public void setBrokerResourceValidationFrequencyInSeconds(int validationFrequencyInSeconds) {
@@ -466,15 +428,13 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public long getBrokerResourceValidationInitialDelayInSeconds() {
-    return getLong(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_INITIAL_DELAY_IN_SECONDS,
+    return getProperty(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_INITIAL_DELAY_IN_SECONDS,
         getPeriodicTaskInitialDelayInSeconds());
   }
 
   public int getStatusCheckerFrequencyInSeconds() {
-    if (containsKey(ControllerPeriodicTasksConf.STATUS_CHECKER_FREQUENCY_IN_SECONDS)) {
-      return Integer.parseInt((String) getProperty(ControllerPeriodicTasksConf.STATUS_CHECKER_FREQUENCY_IN_SECONDS));
-    }
-    return ControllerPeriodicTasksConf.DEFAULT_STATUS_CONTROLLER_FREQUENCY_IN_SECONDS;
+    return getProperty(ControllerPeriodicTasksConf.STATUS_CHECKER_FREQUENCY_IN_SECONDS,
+        ControllerPeriodicTasksConf.DEFAULT_STATUS_CONTROLLER_FREQUENCY_IN_SECONDS);
   }
 
   public void setStatusCheckerFrequencyInSeconds(int statusCheckerFrequencyInSeconds) {
@@ -483,10 +443,8 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public String getRealtimeSegmentRelocatorFrequency() {
-    if (containsKey(ControllerPeriodicTasksConf.REALTIME_SEGMENT_RELOCATOR_FREQUENCY)) {
-      return (String) getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_RELOCATOR_FREQUENCY);
-    }
-    return ControllerPeriodicTasksConf.DEFAULT_REALTIME_SEGMENT_RELOCATOR_FREQUENCY;
+    return getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_RELOCATOR_FREQUENCY,
+        ControllerPeriodicTasksConf.DEFAULT_REALTIME_SEGMENT_RELOCATOR_FREQUENCY);
   }
 
   public void setRealtimeSegmentRelocatorFrequency(String relocatorFrequency) {
@@ -494,11 +452,8 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public int getStatusCheckerWaitForPushTimeInSeconds() {
-    if (containsKey(ControllerPeriodicTasksConf.STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS)) {
-      return Integer
-          .parseInt((String) getProperty(ControllerPeriodicTasksConf.STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS));
-    }
-    return ControllerPeriodicTasksConf.DEFAULT_STATUS_CONTROLLER_WAIT_FOR_PUSH_TIME_IN_SECONDS;
+    return getProperty(ControllerPeriodicTasksConf.STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS,
+        ControllerPeriodicTasksConf.DEFAULT_STATUS_CONTROLLER_WAIT_FOR_PUSH_TIME_IN_SECONDS);
   }
 
   public void setStatusCheckerWaitForPushTimeInSeconds(int statusCheckerWaitForPushTimeInSeconds) {
@@ -507,10 +462,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public long getExternalViewOnlineToOfflineTimeout() {
-    if (containsKey(EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT)) {
-      return Integer.parseInt((String) getProperty(EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT));
-    }
-    return DEFAULT_EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT_MILLIS;
+    return getProperty(EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT, DEFAULT_EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT_MILLIS);
   }
 
   public void setExternalViewOnlineToOfflineTimeout(long timeout) {
@@ -518,10 +470,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public boolean tenantIsolationEnabled() {
-    if (containsKey(CLUSTER_TENANT_ISOLATION_ENABLE)) {
-      return Boolean.parseBoolean(getProperty(CLUSTER_TENANT_ISOLATION_ENABLE).toString());
-    }
-    return true;
+    return getProperty(CLUSTER_TENANT_ISOLATION_ENABLE, true);
   }
 
   public void setTenantIsolationEnabled(boolean isSingleTenant) {
@@ -533,11 +482,11 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public int getServerAdminRequestTimeoutSeconds() {
-    return getInt(SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS, DEFAULT_SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS);
+    return getProperty(SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS, DEFAULT_SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS);
   }
 
   public int getDeletedSegmentsRetentionInDays() {
-    return getInt(DELETED_SEGMENTS_RETENTION_IN_DAYS, DEFAULT_DELETED_SEGMENTS_RETENTION_IN_DAYS);
+    return getProperty(DELETED_SEGMENTS_RETENTION_IN_DAYS, DEFAULT_DELETED_SEGMENTS_RETENTION_IN_DAYS);
   }
 
   public void setDeletedSegmentsRetentionInDays(int retentionInDays) {
@@ -545,7 +494,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public int getTaskManagerFrequencyInSeconds() {
-    return getInt(ControllerPeriodicTasksConf.TASK_MANAGER_FREQUENCY_IN_SECONDS,
+    return getProperty(ControllerPeriodicTasksConf.TASK_MANAGER_FREQUENCY_IN_SECONDS,
         ControllerPeriodicTasksConf.DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS);
   }
 
@@ -554,7 +503,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public int getDefaultTableMinReplicas() {
-    return getInt(TABLE_MIN_REPLICAS, DEFAULT_TABLE_MIN_REPLICAS);
+    return getProperty(TABLE_MIN_REPLICAS, DEFAULT_TABLE_MIN_REPLICAS);
   }
 
   public void setTableMinReplicas(int minReplicas) {
@@ -562,11 +511,11 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public String getJerseyAdminApiPort() {
-    return getString(JERSEY_ADMIN_API_PORT, String.valueOf(DEFAULT_JERSEY_ADMIN_PORT));
+    return getProperty(JERSEY_ADMIN_API_PORT, String.valueOf(DEFAULT_JERSEY_ADMIN_PORT));
   }
 
   public String getAccessControlFactoryClass() {
-    return getString(ACCESS_CONTROL_FACTORY_CLASS, DEFAULT_ACCESS_CONTROL_FACTORY_CLASS);
+    return getProperty(ACCESS_CONTROL_FACTORY_CLASS, DEFAULT_ACCESS_CONTROL_FACTORY_CLASS);
   }
 
   public void setAccessControlFactoryClass(String accessControlFactoryClass) {
@@ -574,7 +523,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public long getSegmentUploadTimeoutInMillis() {
-    return getLong(SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS, DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS);
+    return getProperty(SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS, DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS);
   }
 
   public void setSegmentUploadTimeoutInMillis(long segmentUploadTimeoutInMillis) {
@@ -582,7 +531,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public int getRealtimeSegmentMetadataCommitNumLocks() {
-    return getInt(REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS, DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS);
+    return getProperty(REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS, DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS);
   }
 
   public void setRealtimeSegmentMetadataCommitNumLocks(int realtimeSegmentMetadataCommitNumLocks) {
@@ -590,35 +539,35 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public boolean getEnableStorageQuotaCheck() {
-    return getBoolean(ENABLE_STORAGE_QUOTA_CHECK, DEFAULT_ENABLE_STORAGE_QUOTA_CHECK);
+    return getProperty(ENABLE_STORAGE_QUOTA_CHECK, DEFAULT_ENABLE_STORAGE_QUOTA_CHECK);
   }
 
   public boolean getEnableBatchMessageMode() {
-    return getBoolean(ENABLE_BATCH_MESSAGE_MODE, DEFAULT_ENABLE_BATCH_MESSAGE_MODE);
+    return getProperty(ENABLE_BATCH_MESSAGE_MODE, DEFAULT_ENABLE_BATCH_MESSAGE_MODE);
   }
 
   public int getSegmentLevelValidationIntervalInSeconds() {
-    return getInt(ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
+    return getProperty(ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
         ControllerPeriodicTasksConf.DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS);
   }
 
   public long getStatusCheckerInitialDelayInSeconds() {
-    return getLong(ControllerPeriodicTasksConf.STATUS_CHECKER_INITIAL_DELAY_IN_SECONDS,
+    return getProperty(ControllerPeriodicTasksConf.STATUS_CHECKER_INITIAL_DELAY_IN_SECONDS,
         ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
   }
 
   public long getRetentionManagerInitialDelayInSeconds() {
-    return getLong(ControllerPeriodicTasksConf.RETENTION_MANAGER_INITIAL_DELAY_IN_SECONDS,
+    return getProperty(ControllerPeriodicTasksConf.RETENTION_MANAGER_INITIAL_DELAY_IN_SECONDS,
         ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
   }
 
   public long getRealtimeSegmentRelocationInitialDelayInSeconds() {
-    return getLong(ControllerPeriodicTasksConf.REALTIME_SEGMENT_RELOCATION_INITIAL_DELAY_IN_SECONDS,
+    return getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_RELOCATION_INITIAL_DELAY_IN_SECONDS,
         ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
   }
 
   public long getOfflineSegmentIntervalCheckerInitialDelayInSeconds() {
-    return getLong(ControllerPeriodicTasksConf.OFFLINE_SEGMENT_INTERVAL_CHECKER_INITIAL_DELAY_IN_SECONDS,
+    return getProperty(ControllerPeriodicTasksConf.OFFLINE_SEGMENT_INTERVAL_CHECKER_INITIAL_DELAY_IN_SECONDS,
         ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
   }
 
@@ -639,7 +588,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public ControllerMode getControllerMode() {
-    return ControllerMode.valueOf(getString(CONTROLLER_MODE, DEFAULT_CONTROLLER_MODE).toUpperCase());
+    return ControllerMode.valueOf(getProperty(CONTROLLER_MODE, DEFAULT_CONTROLLER_MODE.toString()).toUpperCase());
   }
 
   public void setLeadControllerResourceRebalanceStrategy(String rebalanceStrategy) {
@@ -647,11 +596,11 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public String getLeadControllerResourceRebalanceStrategy() {
-    return getString(LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY, DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY);
+    return getProperty(LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY, DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY);
   }
 
   public boolean getHLCTablesAllowed() {
-    return getBoolean(ALLOW_HLC_TABLES, DEFAULT_ALLOW_HLC_TABLES);
+    return getProperty(ALLOW_HLC_TABLES, DEFAULT_ALLOW_HLC_TABLES);
   }
 
   public void setHLCTablesAllowed(boolean allowHLCTables) {
@@ -659,6 +608,6 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public String getMetricsPrefix() {
-    return getString(CONFIG_OF_CONTROLLER_METRICS_PREFIX, DEFAULT_METRICS_PREFIX);
+    return getProperty(CONFIG_OF_CONTROLLER_METRICS_PREFIX, DEFAULT_METRICS_PREFIX);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.io.FileUtils;
@@ -77,6 +76,7 @@ import org.apache.pinot.controller.validation.RealtimeSegmentValidationManager;
 import org.apache.pinot.core.periodictask.PeriodicTask;
 import org.apache.pinot.core.periodictask.PeriodicTaskScheduler;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
@@ -174,7 +174,7 @@ public class ControllerStarter implements ServiceStartable {
 
   private void inferHostnameIfNeeded(ControllerConf config) {
     if (config.getControllerHost() == null) {
-      if (config.getBoolean(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false)) {
+      if (config.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false)) {
         final String inferredHostname = NetUtil.getHostnameOrAddress();
         if (inferredHostname != null) {
           config.setControllerHost(inferredHostname);
@@ -198,7 +198,7 @@ public class ControllerStarter implements ServiceStartable {
     // from ZooKeeper). Setting flapping time window to a small value can avoid this from happening. Helix ignores the
     // non-positive value, so set the default value as 1.
     System.setProperty(SystemPropertyKeys.FLAPPING_TIME_WINDOW, _config
-        .getString(CommonConstants.Helix.CONFIG_OF_CONTROLLER_FLAPPING_TIME_WINDOW_MS,
+        .getProperty(CommonConstants.Helix.CONFIG_OF_CONTROLLER_FLAPPING_TIME_WINDOW_MS,
             CommonConstants.Helix.DEFAULT_FLAPPING_TIME_WINDOW_MS));
   }
 
@@ -248,7 +248,7 @@ public class ControllerStarter implements ServiceStartable {
   }
 
   @Override
-  public Configuration getConfig() {
+  public PinotConfiguration getConfig() {
     return _config;
   }
 
@@ -454,9 +454,9 @@ public class ControllerStarter implements ServiceStartable {
   }
 
   private void initPinotFSFactory() {
-    Configuration pinotFSConfig = _config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);
     LOGGER.info("Initializing PinotFSFactory");
-    PinotFSFactory.init(pinotFSConfig);
+    
+    PinotFSFactory.init(_config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY));
   }
 
   private void initControllerFilePathProvider() {
@@ -469,7 +469,7 @@ public class ControllerStarter implements ServiceStartable {
   }
 
   private void initSegmentFetcherFactory() {
-    Configuration segmentFetcherFactoryConfig =
+    PinotConfiguration segmentFetcherFactoryConfig =
         _config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY);
     LOGGER.info("Initializing SegmentFetcherFactory");
     try {
@@ -480,7 +480,7 @@ public class ControllerStarter implements ServiceStartable {
   }
 
   private void initPinotCrypterFactory() {
-    Configuration pinotCrypterConfig = _config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_CRYPTER);
+    PinotConfiguration pinotCrypterConfig = _config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_CRYPTER);
     LOGGER.info("Initializing PinotCrypterFactory");
     try {
       PinotCrypterFactory.init(pinotCrypterConfig);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/DefaultMetadataEventNotifierFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/DefaultMetadataEventNotifierFactory.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.controller.api.events;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 public class DefaultMetadataEventNotifierFactory extends MetadataEventNotifierFactory {
@@ -27,7 +27,7 @@ public class DefaultMetadataEventNotifierFactory extends MetadataEventNotifierFa
     return new DefaultMetadataEventNotifier();
   }
 
-  public void init(Configuration configuration) {
+  public void init(PinotConfiguration configuration) {
 
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/MetadataEventNotifierFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/MetadataEventNotifierFactory.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.api.events;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,16 +28,16 @@ public abstract class MetadataEventNotifierFactory {
   public static final Logger LOGGER = LoggerFactory.getLogger(MetadataEventNotifierFactory.class);
   public static final String METADATA_EVENT_CLASS_CONFIG = "factory.class";
 
-  public abstract void init(Configuration configuration);
+  public abstract void init(PinotConfiguration configuration);
 
   public abstract MetadataEventNotifier create();
 
-  public static MetadataEventNotifierFactory loadFactory(Configuration configuration) {
+  public static MetadataEventNotifierFactory loadFactory(PinotConfiguration configuration) {
     MetadataEventNotifierFactory metadataEventNotifierFactory;
-    String metadataEventNotifierClassName = configuration.getString(METADATA_EVENT_CLASS_CONFIG);
-    if (metadataEventNotifierClassName == null) {
-      metadataEventNotifierClassName = DefaultMetadataEventNotifierFactory.class.getName();
-    }
+
+    String metadataEventNotifierClassName =
+        configuration.getProperty(METADATA_EVENT_CLASS_CONFIG, DefaultMetadataEventNotifierFactory.class.getName());
+
     try {
       LOGGER.info("Instantiating metadata event notifier factory class {}", metadataEventNotifierClassName);
       metadataEventNotifierFactory =

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/AccessControlTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/AccessControlTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.controller.api;
 
 import java.io.IOException;
+import java.util.Map;
+
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
@@ -34,9 +36,11 @@ public class AccessControlTest extends ControllerTest {
   @BeforeClass
   public void setUp() {
     startZk();
-    ControllerConf config = getDefaultControllerConfiguration();
-    config.setAccessControlFactoryClass(DenyAllAccessFactory.class.getName());
-    startController(config);
+    
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.ACCESS_CONTROL_FACTORY_CLASS, DenyAllAccessFactory.class.getName());
+
+    startController(properties);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ControllerFilePathProviderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ControllerFilePathProviderTest.java
@@ -18,18 +18,19 @@
  */
 package org.apache.pinot.controller.api;
 
-import java.io.File;
-import java.net.URI;
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.io.FileUtils;
-import org.apache.pinot.controller.ControllerConf;
-import org.apache.pinot.controller.api.resources.ControllerFilePathProvider;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
-import org.testng.annotations.Test;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.resources.ControllerFilePathProvider;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.testng.annotations.Test;
 
 
 public class ControllerFilePathProviderTest {
@@ -39,10 +40,9 @@ public class ControllerFilePathProviderTest {
   private static final File LOCAL_TEMP_DIR = new File(DATA_DIR, "localTemp");
 
   @Test
-  public void testLocalTempDirConfigured()
-      throws Exception {
+  public void testLocalTempDirConfigured() throws Exception {
     FileUtils.deleteQuietly(DATA_DIR);
-    PinotFSFactory.init(new BaseConfiguration());
+    PinotFSFactory.init(new PinotConfiguration());
 
     ControllerConf controllerConf = new ControllerConf();
     controllerConf.setControllerHost(HOST);
@@ -74,10 +74,9 @@ public class ControllerFilePathProviderTest {
   }
 
   @Test
-  public void testLocalTempDirNotConfigured()
-      throws Exception {
+  public void testLocalTempDirNotConfigured() throws Exception {
     FileUtils.deleteQuietly(DATA_DIR);
-    PinotFSFactory.init(new BaseConfiguration());
+    PinotFSFactory.init(new PinotConfiguration());
 
     ControllerConf controllerConf = new ControllerConf();
     controllerConf.setControllerHost(HOST);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceAssignmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceAssignmentRestletResourceTest.java
@@ -64,9 +64,11 @@ public class PinotInstanceAssignmentRestletResourceTest extends ControllerTest {
   public void setUp()
       throws Exception {
     startZk();
-    ControllerConf config = getDefaultControllerConfiguration();
-    config.setTenantIsolationEnabled(false);
-    startController(config);
+    
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, false);
+    
+    startController(properties);
     addFakeBrokerInstancesToAutoJoinHelixCluster(1, false);
     addFakeServerInstancesToAutoJoinHelixCluster(NUM_SERVER_INSTANCES, false);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pinot.controller.api;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Map;
+
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.ControllerTest;
@@ -37,6 +37,9 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 
 /**
@@ -58,9 +61,9 @@ public class PinotTableRestletResourceTest extends ControllerTest {
   public void setUp()
       throws Exception {
     startZk();
-    ControllerConf config = getDefaultControllerConfiguration();
-    config.setTableMinReplicas(MIN_NUM_REPLICAS);
-    startController(config);
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.TABLE_MIN_REPLICAS, MIN_NUM_REPLICAS);
+    startController(properties);
     _createTableUrl = _controllerRequestURLBuilder.forTableCreate();
 
     addFakeBrokerInstancesToAutoJoinHelixCluster(NUM_BROKER_INSTANCES, true);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResourceTest.java
@@ -18,16 +18,19 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
 import java.io.File;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.spi.crypt.NoOpPinotCrypter;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.*;
 
 
 public class PinotSegmentUploadDownloadRestletResourceTest {
@@ -50,9 +53,9 @@ public class PinotSegmentUploadDownloadRestletResourceTest {
     _decryptedFile.deleteOnExit();
 
     // configure pinot crypter
-    Configuration conf = new PropertiesConfiguration();
-    conf.addProperty("class.nooppinotcrypter", NoOpPinotCrypter.class.getName());
-    PinotCrypterFactory.init(conf);
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("class.nooppinotcrypter", NoOpPinotCrypter.class.getName());
+    PinotCrypterFactory.init(new PinotConfiguration(properties));
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -18,7 +18,15 @@
  */
 package org.apache.pinot.controller.helix;
 
-import com.google.common.base.Preconditions;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.LEAD_CONTROLLER_RESOURCE_ENABLED_KEY;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.LEAD_CONTROLLER_RESOURCE_NAME;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.Instance.ADMIN_PORT_KEY;
+import static org.apache.pinot.common.utils.CommonConstants.Server.DEFAULT_ADMIN_API_PORT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -31,8 +39,10 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
@@ -78,14 +88,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 
-import static org.apache.pinot.common.utils.CommonConstants.Helix.Instance.ADMIN_PORT_KEY;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.LEAD_CONTROLLER_RESOURCE_ENABLED_KEY;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.LEAD_CONTROLLER_RESOURCE_NAME;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE;
-import static org.apache.pinot.common.utils.CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE;
-import static org.apache.pinot.common.utils.CommonConstants.Server.DEFAULT_ADMIN_API_PORT;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import com.google.common.base.Preconditions;
 
 
 /**
@@ -135,23 +138,26 @@ public abstract class ControllerTest {
     }
   }
 
-  public ControllerConf getDefaultControllerConfiguration() {
-    ControllerConf config = new ControllerConf();
-    config.setControllerHost(LOCAL_HOST);
-    config.setControllerPort(Integer.toString(DEFAULT_CONTROLLER_PORT));
-    config.setDataDir(DEFAULT_DATA_DIR);
-    config.setZkStr(ZkStarter.DEFAULT_ZK_STR);
-    config.setHelixClusterName(getHelixClusterName());
+  public Map<String, Object> getDefaultControllerConfiguration() {
+    Map<String, Object> properties = new HashMap<>();
+    
+    properties.put(ControllerConf.CONTROLLER_HOST, LOCAL_HOST);
+    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT);
+    properties.put(ControllerConf.DATA_DIR, DEFAULT_DATA_DIR);
+    properties.put(ControllerConf.ZK_STR, ZkStarter.DEFAULT_ZK_STR);
+    properties.put(ControllerConf.HELIX_CLUSTER_NAME, getHelixClusterName());
 
-    return config;
+    return properties;
   }
 
   protected void startController() {
     startController(getDefaultControllerConfiguration());
   }
 
-  protected void startController(ControllerConf config) {
+  protected void startController(Map<String, Object> properties) {
     Preconditions.checkState(_controllerStarter == null);
+    
+    ControllerConf config = new ControllerConf(properties);
 
     _controllerPort = Integer.valueOf(config.getControllerPort());
     _controllerBaseApiUrl = "http://localhost:" + _controllerPort;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeTest.java
@@ -51,9 +51,10 @@ public class PinotControllerModeTest extends ControllerTest {
   @Test
   public void testHelixOnlyController() {
     // Start a Helix-only controller
-    ControllerConf helixOnlyControllerConfig = getDefaultControllerConfiguration();
-    helixOnlyControllerConfig.setControllerMode(ControllerConf.ControllerMode.HELIX_ONLY);
-    startController(helixOnlyControllerConfig);
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.HELIX_ONLY);
+    
+    startController(properties);
     TestUtils.waitForCondition(aVoid -> _helixManager.isConnected(), TIMEOUT_IN_MS,
         "Failed to start the Helix-only controller");
 
@@ -63,9 +64,10 @@ public class PinotControllerModeTest extends ControllerTest {
   @Test
   public void testDualModeController() {
     // Start the first dual-mode controller
-    ControllerConf firstDualModeControllerConfig = getDefaultControllerConfiguration();
-    firstDualModeControllerConfig.setControllerMode(ControllerConf.ControllerMode.DUAL);
-    startController(firstDualModeControllerConfig);
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.DUAL);
+    
+    startController(properties);
 
     // Disable delay rebalance feature
     IdealState idealState = _helixResourceManager.getTableIdealState(Helix.LEAD_CONTROLLER_RESOURCE_NAME);
@@ -103,10 +105,10 @@ public class PinotControllerModeTest extends ControllerTest {
     Assert.assertTrue(firstLeadControllerManager.isLeaderForTable(secondTableName));
 
     // Start the second dual-mode controller
-    ControllerConf secondDualModeControllerConfig = getDefaultControllerConfiguration();
-    secondDualModeControllerConfig.setControllerMode(ControllerConf.ControllerMode.DUAL);
-    secondDualModeControllerConfig.setControllerPort(Integer.toString(DEFAULT_CONTROLLER_PORT + 1));
-    ControllerStarter secondDualModeController = getControllerStarter(secondDualModeControllerConfig);
+    properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.DUAL);
+    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 1);
+    ControllerStarter secondDualModeController = getControllerStarter(new ControllerConf(properties));
     secondDualModeController.start();
     TestUtils
         .waitForCondition(aVoid -> secondDualModeController.getHelixResourceManager().getHelixZkManager().isConnected(),
@@ -150,10 +152,11 @@ public class PinotControllerModeTest extends ControllerTest {
             "No cluster leader should be shown in Helix cluster");
     zkClient.close();
 
-    ControllerConf thirdDualModeControllerConfig = getDefaultControllerConfiguration();
-    thirdDualModeControllerConfig.setControllerMode(ControllerConf.ControllerMode.DUAL);
-    thirdDualModeControllerConfig.setControllerPort(Integer.toString(DEFAULT_CONTROLLER_PORT + 2));
-    ControllerStarter thirdDualModeController = getControllerStarter(thirdDualModeControllerConfig);
+    properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.DUAL);
+    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 2);
+    
+    ControllerStarter thirdDualModeController = getControllerStarter(new ControllerConf(properties));
     thirdDualModeController.start();
     PinotHelixResourceManager pinotHelixResourceManager = thirdDualModeController.getHelixResourceManager();
     _helixManager = pinotHelixResourceManager.getHelixZkManager();
@@ -189,9 +192,10 @@ public class PinotControllerModeTest extends ControllerTest {
 
   @Test
   public void testPinotOnlyController() {
-    ControllerConf firstPinotOnlyControllerConfig = getDefaultControllerConfiguration();
-    firstPinotOnlyControllerConfig.setControllerMode(ControllerConf.ControllerMode.PINOT_ONLY);
-    ControllerStarter firstPinotOnlyController = getControllerStarter(firstPinotOnlyControllerConfig);
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.PINOT_ONLY);
+    
+    ControllerStarter firstPinotOnlyController = getControllerStarter(new ControllerConf(properties));
 
     // Starting Pinot-only controller without Helix controller should fail
     try {
@@ -202,10 +206,11 @@ public class PinotControllerModeTest extends ControllerTest {
     }
 
     // Start a Helix-only controller
-    ControllerConf helixOnlyControllerConfig = getDefaultControllerConfiguration();
-    helixOnlyControllerConfig.setControllerMode(ControllerConf.ControllerMode.HELIX_ONLY);
-    helixOnlyControllerConfig.setControllerPort(Integer.toString(DEFAULT_CONTROLLER_PORT + 1));
-    ControllerStarter helixOnlyController = new ControllerStarter(helixOnlyControllerConfig);
+    properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.HELIX_ONLY);
+    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 1);
+    
+    ControllerStarter helixOnlyController = new ControllerStarter(new ControllerConf(properties));
     helixOnlyController.start();
     HelixManager helixControllerManager = helixOnlyController.getHelixControllerManager();
     HelixAdmin helixAdmin = helixControllerManager.getClusterManagmentTool();
@@ -221,10 +226,11 @@ public class PinotControllerModeTest extends ControllerTest {
     checkInstanceState(helixAdmin);
 
     // Start the second Pinot-only controller
-    ControllerConf secondPinotOnlyControllerConfig = getDefaultControllerConfiguration();
-    secondPinotOnlyControllerConfig.setControllerMode(ControllerConf.ControllerMode.PINOT_ONLY);
-    secondPinotOnlyControllerConfig.setControllerPort(Integer.toString(DEFAULT_CONTROLLER_PORT + 2));
-    ControllerStarter secondPinotOnlyController = getControllerStarter(secondPinotOnlyControllerConfig);
+    properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.PINOT_ONLY);
+    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 2);
+    
+    ControllerStarter secondPinotOnlyController = getControllerStarter(new ControllerConf(properties));
     secondPinotOnlyController.start();
     TestUtils.waitForCondition(
         aVoid -> secondPinotOnlyController.getHelixResourceManager().getHelixZkManager().isConnected(), TIMEOUT_IN_MS,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -89,9 +89,10 @@ public class PinotHelixResourceManagerTest extends ControllerTest {
   public void setUp()
       throws Exception {
     startZk();
-    ControllerConf config = getDefaultControllerConfiguration();
-    config.setTenantIsolationEnabled(false);
-    startController(config);
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, false);
+    
+    startController(properties);
     addFakeBrokerInstancesToAutoJoinHelixCluster(NUM_INSTANCES, false);
     addFakeServerInstancesToAutoJoinHelixCluster(NUM_INSTANCES, false, BASE_SERVER_ADMIN_PORT);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -18,7 +18,14 @@
  */
 package org.apache.pinot.controller.helix.core.realtime;
 
-import com.google.common.base.Preconditions;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,8 +37,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nullable;
-import org.apache.commons.configuration.BaseConfiguration;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.assignment.InstancePartitions;
@@ -53,12 +61,12 @@ import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
-import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
@@ -68,9 +76,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import com.google.common.base.Preconditions;
 
 
 public class PinotLLCRealtimeSegmentManagerTest {
@@ -678,7 +684,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
   @Test
   public void testCommitSegmentFile()
       throws Exception {
-    PinotFSFactory.init(new BaseConfiguration());
+    PinotFSFactory.init(new PinotConfiguration());
     File tableDir = new File(TEMP_DIR, RAW_TABLE_NAME);
     String segmentName = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
     String segmentFileName = SegmentCompletionUtils.generateSegmentFileName(segmentName);
@@ -698,7 +704,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
   @Test
   public void testSegmentAlreadyThereAndExtraneousFilesDeleted()
       throws Exception {
-    PinotFSFactory.init(new BaseConfiguration());
+    PinotFSFactory.init(new PinotConfiguration());
     File tableDir = new File(TEMP_DIR, RAW_TABLE_NAME);
     String segmentName = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
     String otherSegmentName = new LLCSegmentName(RAW_TABLE_NAME, 1, 0, CURRENT_TIME_MS).getSegmentName();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -18,7 +18,12 @@
  */
 package org.apache.pinot.controller.helix.core.util;
 
-import com.google.common.io.Files;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,8 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import junit.framework.Assert;
-import org.apache.commons.configuration.PropertiesConfiguration;
+
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
@@ -36,6 +40,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.controller.helix.core.SegmentDeletionManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.joda.time.DateTime;
@@ -43,11 +48,9 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.Test;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import com.google.common.io.Files;
+
+import junit.framework.Assert;
 
 
 public class SegmentDeletionManagerTest {
@@ -199,10 +202,10 @@ public class SegmentDeletionManagerTest {
   @Test
   public void testRemoveDeletedSegments()
       throws Exception {
-    PropertiesConfiguration pinotFSConfig = new PropertiesConfiguration();
-    pinotFSConfig.addProperty(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY + ".class",
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY + ".class",
         LocalPinotFS.class.getName());
-    PinotFSFactory.init(pinotFSConfig);
+    PinotFSFactory.init(new PinotConfiguration(properties));
 
     HelixAdmin helixAdmin = makeHelixAdmin();
     ZkHelixPropertyStore<ZNRecord> propertyStore = makePropertyStore();

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -74,6 +74,10 @@
       <artifactId>joda-time</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
       <exclusions>

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -21,15 +21,17 @@ package org.apache.pinot.core.data.manager;
 import java.io.File;
 import java.util.List;
 import java.util.Set;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -43,7 +45,7 @@ public interface InstanceDataManager {
    * Initializes the data manager.
    * <p>Should be called only once and before calling any other method.
    */
-  void init(Configuration config, HelixManager helixManager, ServerMetrics serverMetrics)
+  void init(PinotConfiguration config, HelixManager helixManager, ServerMetrics serverMetrics)
       throws ConfigurationException;
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -18,12 +18,12 @@
  */
 package org.apache.pinot.core.data.manager.config;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.common.segment.ReadMode;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 public interface InstanceDataManagerConfig {
-  Configuration getConfig();
+  PinotConfiguration getConfig();
 
   String getInstanceId();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -84,8 +84,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
    */
   public InstancePlanMakerImplV2(QueryExecutorConfig queryExecutorConfig) {
     _maxInitialResultHolderCapacity = queryExecutorConfig.getConfig()
-        .getInt(MAX_INITIAL_RESULT_HOLDER_CAPACITY_KEY, DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
-    _numGroupsLimit = queryExecutorConfig.getConfig().getInt(NUM_GROUPS_LIMIT, DEFAULT_NUM_GROUPS_LIMIT);
+        .getProperty(MAX_INITIAL_RESULT_HOLDER_CAPACITY_KEY, DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
+    _numGroupsLimit = queryExecutorConfig.getConfig().getProperty(NUM_GROUPS_LIMIT, DEFAULT_NUM_GROUPS_LIMIT);
     Preconditions.checkState(_maxInitialResultHolderCapacity <= _numGroupsLimit,
         "Invalid configuration: maxInitialResultHolderCapacity: %d must be smaller or equal to numGroupsLimit: %d",
         _maxInitialResultHolderCapacity, _numGroupsLimit);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/config/QueryExecutorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/config/QueryExecutorConfig.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.query.config;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -38,18 +38,17 @@ public class QueryExecutorConfig {
 
   private static final String[] REQUIRED_KEYS = {};
 
-  private Configuration _queryExecutorConfig = null;
+  private PinotConfiguration _queryExecutorConfig = null;
   private SegmentPrunerConfig _segmentPrunerConfig;
   private QueryPlannerConfig _queryPlannerConfig;
   private final long _timeOutMs;
 
-  public QueryExecutorConfig(Configuration config)
-      throws ConfigurationException {
+  public QueryExecutorConfig(PinotConfiguration config) throws ConfigurationException {
     _queryExecutorConfig = config;
     checkRequiredKeys();
     _segmentPrunerConfig = new SegmentPrunerConfig(_queryExecutorConfig.subset(QUERY_PRUNER));
     _queryPlannerConfig = new QueryPlannerConfig(_queryExecutorConfig.subset(QUERY_PLANNER));
-    _timeOutMs = _queryExecutorConfig.getLong(TIME_OUT, -1);
+    _timeOutMs = _queryExecutorConfig.getProperty(TIME_OUT, -1);
   }
 
   private void checkRequiredKeys()
@@ -61,7 +60,7 @@ public class QueryExecutorConfig {
     }
   }
 
-  public Configuration getConfig() {
+  public PinotConfiguration getConfig() {
     return _queryExecutorConfig;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/config/QueryPlannerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/config/QueryPlannerConfig.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.query.config;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -29,10 +29,10 @@ import org.apache.commons.configuration.ConfigurationException;
  */
 public class QueryPlannerConfig {
 
-  private Configuration _queryPlannerConfig;
+  private PinotConfiguration _queryPlannerConfig;
   private static String[] REQUIRED_KEYS = {};
 
-  public QueryPlannerConfig(Configuration queryPlannerConfig)
+  public QueryPlannerConfig(PinotConfiguration queryPlannerConfig)
       throws ConfigurationException {
     _queryPlannerConfig = queryPlannerConfig;
     checkRequiredKeys();
@@ -48,6 +48,6 @@ public class QueryPlannerConfig {
   }
 
   public String getQueryPlannerType() {
-    return _queryPlannerConfig.getString("type");
+    return _queryPlannerConfig.getProperty("type");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/config/SegmentPrunerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/config/SegmentPrunerConfig.java
@@ -19,8 +19,10 @@
 package org.apache.pinot.core.query.config;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -31,11 +33,11 @@ public class SegmentPrunerConfig {
 
   private final int _numSegmentPruners;
   private final List<String> _segmentPrunerNames;
-  private final List<Configuration> _segmentPrunerConfigs;
+  private final List<PinotConfiguration> _segmentPrunerConfigs;
 
-  public SegmentPrunerConfig(Configuration segmentPrunerConfig) {
-    String[] segmentPrunerNames = segmentPrunerConfig.getStringArray(SEGMENT_PRUNER_NAMES_KEY);
-    _numSegmentPruners = segmentPrunerNames.length;
+  public SegmentPrunerConfig(PinotConfiguration segmentPrunerConfig) {
+    List<String> segmentPrunerNames = segmentPrunerConfig.getProperty(SEGMENT_PRUNER_NAMES_KEY, Arrays.asList());
+    _numSegmentPruners = segmentPrunerNames.size();
     _segmentPrunerNames = new ArrayList<>(_numSegmentPruners);
     _segmentPrunerConfigs = new ArrayList<>(_numSegmentPruners);
     for (String segmentPrunerName : segmentPrunerNames) {
@@ -52,7 +54,7 @@ public class SegmentPrunerConfig {
     return _segmentPrunerNames.get(index);
   }
 
-  public Configuration getSegmentPrunerConfig(int index) {
+  public PinotConfiguration getSegmentPrunerConfig(int index) {
     return _segmentPrunerConfigs.get(index);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
@@ -19,13 +19,15 @@
 package org.apache.pinot.core.query.executor;
 
 import java.util.concurrent.ExecutorService;
+
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 @ThreadSafe
@@ -35,7 +37,7 @@ public interface QueryExecutor {
    * Initializes the query executor.
    * <p>Should be called only once and before calling any other method.
    */
-  void init(Configuration config, InstanceDataManager instanceDataManager, ServerMetrics serverMetrics)
+  void init(PinotConfiguration config, InstanceDataManager instanceDataManager, ServerMetrics serverMetrics)
       throws ConfigurationException;
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -18,14 +18,14 @@
  */
 package org.apache.pinot.core.query.executor;
 
-import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMeter;
@@ -52,8 +52,11 @@ import org.apache.pinot.core.query.request.context.TimerContext;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.apache.pinot.core.util.QueryOptions;
 import org.apache.pinot.core.util.trace.TraceContext;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 
 @ThreadSafe
@@ -67,7 +70,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   private ServerMetrics _serverMetrics;
 
   @Override
-  public synchronized void init(Configuration config, InstanceDataManager instanceDataManager,
+  public synchronized void init(PinotConfiguration config, InstanceDataManager instanceDataManager,
       ServerMetrics serverMetrics)
       throws ConfigurationException {
     _instanceDataManager = instanceDataManager;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.query.pruner;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.common.DataSourceMetadata;
 import org.apache.pinot.core.data.partition.PartitionFunction;
@@ -35,6 +35,7 @@ import org.apache.pinot.core.query.request.context.predicate.Predicate;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
 import org.apache.pinot.core.segment.index.readers.BloomFilterReader;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.BytesUtils;
 
 
@@ -61,7 +62,7 @@ import org.apache.pinot.spi.utils.BytesUtils;
 public class ColumnValueSegmentPruner implements SegmentPruner {
 
   @Override
-  public void init(Configuration config) {
+  public void init(PinotConfiguration config) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/DataSchemaSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/DataSchemaSegmentPruner.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pinot.core.query.pruner;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -30,7 +30,7 @@ import org.apache.pinot.core.query.request.ServerQueryRequest;
 public class DataSchemaSegmentPruner implements SegmentPruner {
 
   @Override
-  public void init(Configuration config) {
+  public void init(PinotConfiguration config) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPruner.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pinot.core.query.pruner;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 public interface SegmentPruner {
@@ -28,7 +28,7 @@ public interface SegmentPruner {
   /**
    * Initializes the segment pruner.
    */
-  void init(Configuration config);
+  void init(PinotConfiguration config);
 
   /**
    * Returns <code>true</code> if the segment can be pruned based on the query request.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerProvider.java
@@ -20,7 +20,8 @@ package org.apache.pinot.core.query.pruner;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.configuration.Configuration;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -40,7 +41,7 @@ public class SegmentPrunerProvider {
     PRUNER_MAP.put("validsegmentpruner", ValidSegmentPruner.class);
   }
 
-  public static SegmentPruner getSegmentPruner(String prunerClassName, Configuration segmentPrunerConfig) {
+  public static SegmentPruner getSegmentPruner(String prunerClassName, PinotConfiguration segmentPrunerConfig) {
     try {
       Class<? extends SegmentPruner> cls = PRUNER_MAP.get(prunerClassName.toLowerCase());
       if (cls != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValidSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValidSegmentPruner.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pinot.core.query.pruner;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -30,7 +30,7 @@ import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
  */
 public class ValidSegmentPruner implements SegmentPruner {
   @Override
-  public void init(Configuration config) {
+  public void init(PinotConfiguration config) {
 
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/MultiLevelPriorityQueue.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/MultiLevelPriorityQueue.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.core.query.scheduler;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,13 +26,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 
 
 /**
@@ -65,9 +68,9 @@ public class MultiLevelPriorityQueue implements SchedulerPriorityQueue {
   private final SchedulerGroupMapper groupSelector;
   private final int queryDeadlineMillis;
   private final SchedulerGroupFactory groupFactory;
-  private final Configuration config;
+  private final PinotConfiguration config;
 
-  public MultiLevelPriorityQueue(@Nonnull Configuration config, @Nonnull ResourceManager resourceManager,
+  public MultiLevelPriorityQueue(@Nonnull PinotConfiguration config, @Nonnull ResourceManager resourceManager,
       @Nonnull SchedulerGroupFactory groupFactory, @Nonnull SchedulerGroupMapper groupMapper) {
     Preconditions.checkNotNull(config);
     Preconditions.checkNotNull(resourceManager);
@@ -76,9 +79,9 @@ public class MultiLevelPriorityQueue implements SchedulerPriorityQueue {
 
     // max available tokens per millisecond equals number of threads (total execution capacity)
     // we are over provisioning tokens here because its better to keep pipe full rather than empty
-    queryDeadlineMillis = config.getInt(QUERY_DEADLINE_SECONDS_KEY, 30) * 1000;
-    wakeUpTimeMicros = config.getInt(QUEUE_WAKEUP_MICROS, DEFAULT_WAKEUP_MICROS);
-    maxPendingPerGroup = config.getInt(MAX_PENDING_PER_GROUP_KEY, 10);
+    queryDeadlineMillis = config.getProperty(QUERY_DEADLINE_SECONDS_KEY, 30) * 1000;
+    wakeUpTimeMicros = config.getProperty(QUEUE_WAKEUP_MICROS, DEFAULT_WAKEUP_MICROS);
+    maxPendingPerGroup = config.getProperty(MAX_PENDING_PER_GROUP_KEY, 10);
     this.config = config;
     this.resourceManager = resourceManager;
     this.groupFactory = groupFactory;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
@@ -18,16 +18,12 @@
  */
 package org.apache.pinot.core.query.scheduler;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListenableFutureTask;
-import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.LongAccumulator;
+
 import javax.annotation.Nonnull;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -36,8 +32,15 @@ import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.resources.QueryExecutorService;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import com.google.common.util.concurrent.MoreExecutors;
 
 
 /**
@@ -54,7 +57,7 @@ public abstract class PriorityScheduler extends QueryScheduler {
   @VisibleForTesting
   Thread scheduler;
 
-  public PriorityScheduler(@Nonnull Configuration config, @Nonnull ResourceManager resourceManager,
+  public PriorityScheduler(@Nonnull PinotConfiguration config, @Nonnull ResourceManager resourceManager,
       @Nonnull QueryExecutor queryExecutor, @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics,
       @Nonnull LongAccumulator latestQueryTime) {
     super(config, queryExecutor, resourceManager, metrics, latestQueryTime);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -18,19 +18,15 @@
  */
 package org.apache.pinot.core.query.scheduler;
 
-import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListenableFutureTask;
-import com.google.common.util.concurrent.RateLimiter;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAccumulator;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -43,8 +39,15 @@ import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.TimerContext;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import com.google.common.util.concurrent.RateLimiter;
 
 
 /**
@@ -76,7 +79,7 @@ public abstract class QueryScheduler {
    * @param resourceManager for managing server thread resources
    * @param serverMetrics server metrics collector
    */
-  public QueryScheduler(@Nonnull Configuration config, @Nonnull QueryExecutor queryExecutor,
+  public QueryScheduler(@Nonnull PinotConfiguration config, @Nonnull QueryExecutor queryExecutor,
       @Nonnull ResourceManager resourceManager, @Nonnull ServerMetrics serverMetrics,
       @Nonnull LongAccumulator latestQueryTime) {
     Preconditions.checkNotNull(config);
@@ -88,7 +91,7 @@ public abstract class QueryScheduler {
     this.resourceManager = resourceManager;
     this.queryExecutor = queryExecutor;
     this.latestQueryTime = latestQueryTime;
-    this.queryLogRateLimiter = RateLimiter.create(config.getDouble(QUERY_LOG_MAX_RATE_KEY, DEFAULT_QUERY_LOG_MAX_RATE));
+    this.queryLogRateLimiter = RateLimiter.create(config.getProperty(QUERY_LOG_MAX_RATE_KEY, DEFAULT_QUERY_LOG_MAX_RATE));
     this.numDroppedLogRateLimiter = RateLimiter.create(1.0d);
     this.numDroppedLogCounter = new AtomicInteger(0);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QuerySchedulerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QuerySchedulerFactory.java
@@ -18,19 +18,23 @@
  */
 package org.apache.pinot.core.query.scheduler;
 
-import com.google.common.base.Preconditions;
 import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.LongAccumulator;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.scheduler.fcfs.BoundedFCFSScheduler;
 import org.apache.pinot.core.query.scheduler.fcfs.FCFSQueryScheduler;
 import org.apache.pinot.core.query.scheduler.tokenbucket.TokenPriorityScheduler;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 
 /**
@@ -53,13 +57,13 @@ public class QuerySchedulerFactory {
    * @return returns an instance of query scheduler
    */
   public static @Nonnull
-  QueryScheduler create(@Nonnull Configuration schedulerConfig, @Nonnull QueryExecutor queryExecutor,
+  QueryScheduler create(@Nonnull PinotConfiguration schedulerConfig, @Nonnull QueryExecutor queryExecutor,
       ServerMetrics serverMetrics, @Nonnull LongAccumulator latestQueryTime) {
     Preconditions.checkNotNull(schedulerConfig);
     Preconditions.checkNotNull(queryExecutor);
 
     String schedulerName =
-        schedulerConfig.getString(ALGORITHM_NAME_CONFIG_KEY, DEFAULT_QUERY_SCHEDULER_ALGORITHM).toLowerCase();
+        schedulerConfig.getProperty(ALGORITHM_NAME_CONFIG_KEY, DEFAULT_QUERY_SCHEDULER_ALGORITHM).toLowerCase();
     if (schedulerName.equals(FCFS_ALGORITHM)) {
       LOGGER.info("Using FCFS query scheduler");
       return new FCFSQueryScheduler(schedulerConfig, queryExecutor, serverMetrics, latestQueryTime);
@@ -86,7 +90,7 @@ public class QuerySchedulerFactory {
   }
 
   private static @Nullable
-  QueryScheduler getQuerySchedulerByClassName(String className, Configuration schedulerConfig,
+  QueryScheduler getQuerySchedulerByClassName(String className, PinotConfiguration schedulerConfig,
       QueryExecutor queryExecutor) {
     try {
       Constructor<?> constructor =

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SchedulerGroupFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SchedulerGroupFactory.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.query.scheduler;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -32,5 +32,5 @@ public interface SchedulerGroupFactory {
    * @param groupName Scheduler group name
    * @return instance of SchedulerGroup
    */
-  SchedulerGroup create(Configuration config, String groupName);
+  SchedulerGroup create(PinotConfiguration config, String groupName);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/BoundedFCFSScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/BoundedFCFSScheduler.java
@@ -19,8 +19,9 @@
 package org.apache.pinot.core.query.scheduler.fcfs;
 
 import java.util.concurrent.atomic.LongAccumulator;
+
 import javax.annotation.Nonnull;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.scheduler.MultiLevelPriorityQueue;
@@ -31,8 +32,7 @@ import org.apache.pinot.core.query.scheduler.SchedulerPriorityQueue;
 import org.apache.pinot.core.query.scheduler.TableBasedGroupMapper;
 import org.apache.pinot.core.query.scheduler.resources.PolicyBasedResourceManager;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -41,14 +41,12 @@ import org.slf4j.LoggerFactory;
  * concrete classes. All the scheduling logic resides in {@link PriorityScheduler}
  */
 public class BoundedFCFSScheduler extends PriorityScheduler {
-  private static Logger LOGGER = LoggerFactory.getLogger(BoundedFCFSScheduler.class);
-
-  public static BoundedFCFSScheduler create(@Nonnull Configuration config, @Nonnull QueryExecutor queryExecutor,
+  public static BoundedFCFSScheduler create(@Nonnull PinotConfiguration config, @Nonnull QueryExecutor queryExecutor,
       @Nonnull ServerMetrics serverMetrics, @Nonnull LongAccumulator latestQueryTime) {
     final ResourceManager rm = new PolicyBasedResourceManager(config);
     final SchedulerGroupFactory groupFactory = new SchedulerGroupFactory() {
       @Override
-      public SchedulerGroup create(Configuration config, String groupName) {
+      public SchedulerGroup create(PinotConfiguration config, String groupName) {
         return new FCFSSchedulerGroup(groupName);
       }
     };
@@ -56,7 +54,7 @@ public class BoundedFCFSScheduler extends PriorityScheduler {
     return new BoundedFCFSScheduler(config, rm, queryExecutor, queue, serverMetrics, latestQueryTime);
   }
 
-  private BoundedFCFSScheduler(@Nonnull Configuration config, @Nonnull ResourceManager resourceManager,
+  private BoundedFCFSScheduler(@Nonnull PinotConfiguration config, @Nonnull ResourceManager resourceManager,
       @Nonnull QueryExecutor queryExecutor, @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics,
       @Nonnull LongAccumulator latestQueryTime) {
     super(config, resourceManager, queryExecutor, queue, metrics, latestQueryTime);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
@@ -18,11 +18,10 @@
  */
 package org.apache.pinot.core.query.scheduler.fcfs;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListenableFutureTask;
 import java.util.concurrent.atomic.LongAccumulator;
+
 import javax.annotation.Nonnull;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.metrics.ServerQueryPhase;
@@ -31,6 +30,10 @@ import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
 import org.apache.pinot.core.query.scheduler.resources.QueryExecutorService;
 import org.apache.pinot.core.query.scheduler.resources.UnboundedResourceManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
 
 
 /**
@@ -40,7 +43,7 @@ import org.apache.pinot.core.query.scheduler.resources.UnboundedResourceManager;
  */
 public class FCFSQueryScheduler extends QueryScheduler {
 
-  public FCFSQueryScheduler(@Nonnull Configuration config, @Nonnull QueryExecutor queryExecutor,
+  public FCFSQueryScheduler(@Nonnull PinotConfiguration config, @Nonnull QueryExecutor queryExecutor,
       @Nonnull ServerMetrics serverMetrics, @Nonnull LongAccumulator latestQueryTime) {
     super(config, queryExecutor, new UnboundedResourceManager(config), serverMetrics, latestQueryTime);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/PolicyBasedResourceManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/PolicyBasedResourceManager.java
@@ -18,12 +18,13 @@
  */
 package org.apache.pinot.core.query.scheduler.resources;
 
-import com.google.common.base.Preconditions;
-import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 
 /**
@@ -34,7 +35,7 @@ public class PolicyBasedResourceManager extends ResourceManager {
 
   private final ResourceLimitPolicy resourcePolicy;
 
-  public PolicyBasedResourceManager(Configuration config) {
+  public PolicyBasedResourceManager(PinotConfiguration config) {
     super(config);
     this.resourcePolicy = new ResourceLimitPolicy(config, numQueryWorkerThreads);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/ResourceLimitPolicy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/ResourceLimitPolicy.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.query.scheduler.resources;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +42,7 @@ public class ResourceLimitPolicy {
   private final int tableThreadsSoftLimit;
   private final int tableThreadsHardLimit;
 
-  ResourceLimitPolicy(Configuration config, int numWorkerThreads) {
+  ResourceLimitPolicy(PinotConfiguration config, int numWorkerThreads) {
     int softLimit = checkGetOrDefaultPct(config, TABLE_THREADS_SOFT_LIMIT, DEFAULT_TABLE_THREADS_SOFT_LIMIT);
     tableThreadsSoftLimit = Math.min(numWorkerThreads, Math.max(1, numWorkerThreads * softLimit / 100));
     int hardLimit = checkGetOrDefaultPct(config, TABLE_THREADS_HARD_LIMIT, DEFAULT_TABLE_THREADS_HARD_LIMIT);
@@ -59,8 +59,8 @@ public class ResourceLimitPolicy {
         tableThreadsSoftLimit, tableThreadsHardLimit);
   }
 
-  private int checkGetOrDefaultPct(Configuration schedulerConfig, String key, int defaultValue) {
-    int pct = schedulerConfig.getInt(key, defaultValue);
+  private int checkGetOrDefaultPct(PinotConfiguration schedulerConfig, String key, int defaultValue) {
+    int pct = schedulerConfig.getProperty(key, defaultValue);
     if (pct <= 0 || pct > 100) {
       LOGGER.error("Incorrect value for {}, value: {}; using default: {}", key, pct, defaultValue);
       pct = defaultValue;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/ResourceManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/ResourceManager.java
@@ -18,18 +18,20 @@
  */
 package org.apache.pinot.core.query.scheduler.resources;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import org.apache.commons.configuration.Configuration;
-import org.apache.pinot.core.query.request.ServerQueryRequest;
-import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -73,9 +75,9 @@ public abstract class ResourceManager {
   /**
    * @param config configuration for initializing resource manager
    */
-  public ResourceManager(Configuration config) {
-    numQueryRunnerThreads = config.getInt(QUERY_RUNNER_CONFIG_KEY, DEFAULT_QUERY_RUNNER_THREADS);
-    numQueryWorkerThreads = config.getInt(QUERY_WORKER_CONFIG_KEY, DEFAULT_QUERY_WORKER_THREADS);
+  public ResourceManager(PinotConfiguration config) {
+    numQueryRunnerThreads = config.getProperty(QUERY_RUNNER_CONFIG_KEY, DEFAULT_QUERY_RUNNER_THREADS);
+    numQueryWorkerThreads = config.getProperty(QUERY_WORKER_CONFIG_KEY, DEFAULT_QUERY_WORKER_THREADS);
 
     LOGGER.info("Initializing with {} query runner threads and {} worker threads", numQueryRunnerThreads,
         numQueryWorkerThreads);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/UnboundedResourceManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/UnboundedResourceManager.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pinot.core.query.scheduler.resources;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -30,7 +30,7 @@ import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
  */
 public class UnboundedResourceManager extends ResourceManager {
 
-  public UnboundedResourceManager(Configuration config) {
+  public UnboundedResourceManager(PinotConfiguration config) {
     super(config);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.segment.store.ColumnIndexType;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
 import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.core.startree.v2.StarTreeV2Constants;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -209,7 +210,7 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
     File v2MetadataFile = new File(currentDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
     File v3MetadataFile = new File(v3Dir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
 
-    final PropertiesConfiguration properties = new PropertiesConfiguration(v2MetadataFile);
+    final PropertiesConfiguration properties = CommonsConfigurationUtils.fromFile(v2MetadataFile);
     // update the segment version
     properties.setProperty(V1Constants.MetadataKeys.Segment.SEGMENT_VERSION, SegmentVersion.v3.toString());
     properties.save(v3MetadataFile);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -18,16 +18,16 @@
  */
 package org.apache.pinot.core.segment.index.loader.defaultcolumn;
 
-import com.google.common.base.Preconditions;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.StringUtil;
@@ -53,6 +53,8 @@ import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 
 public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
@@ -167,8 +169,13 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
       FileUtils.copyFile(metadataFile, metadataBackUpFile);
     }
 
-    // Save the new metadata.
-    _segmentProperties.save();
+    // Save the new metadata. 
+    // 
+    // Commons Configuration 1.10 does not support file path containing '%'. 
+    // Explicitly providing the output stream for save bypasses the problem. */
+    try (FileOutputStream fileOutputStream = new FileOutputStream(_segmentProperties.getFile())) {
+      _segmentProperties.save(fileOutputStream);
+    }
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/SegmentMetadataImpl.java
@@ -18,10 +18,20 @@
  */
 package org.apache.pinot.core.segment.index.metadata;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Preconditions;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.DATETIME_COLUMNS;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.DIMENSIONS;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.METRICS;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_CREATOR_VERSION;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_END_TIME;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_NAME;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_PADDING_CHARACTER;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_START_TIME;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_TOTAL_DOCS;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_VERSION;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.TABLE_NAME;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.TIME_COLUMN_NAME;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.TIME_UNIT;
+
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -39,8 +49,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nullable;
-import org.apache.commons.configuration.ConfigurationException;
+
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
@@ -50,6 +61,7 @@ import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.core.startree.v2.StarTreeV2Constants;
 import org.apache.pinot.core.startree.v2.StarTreeV2Metadata;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.joda.time.DateTimeZone;
@@ -58,7 +70,10 @@ import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Preconditions;
 
 
 public class SegmentMetadataImpl implements SegmentMetadata {
@@ -150,11 +165,8 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   public static PropertiesConfiguration getPropertiesConfiguration(File indexDir) {
     File metadataFile = SegmentDirectoryPaths.findMetadataFile(indexDir);
     Preconditions.checkNotNull(metadataFile, "Cannot find segment metadata file under directory: %s", indexDir);
-    try {
-      return new PropertiesConfiguration(metadataFile);
-    } catch (ConfigurationException e) {
-      throw new RuntimeException(e);
-    }
+    
+    return CommonsConfigurationUtils.fromFile(metadataFile);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/store/SingleFileIndexDirectory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.segment.store;
 
-import com.google.common.base.Preconditions;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -28,19 +27,22 @@ import java.io.PrintWriter;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.segment.creator.impl.inv.text.LuceneTextIndexCreator;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 
 // There are a couple of un-addressed issues right now
@@ -196,10 +198,9 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
       throws ConfigurationException {
     File mapFile = new File(segmentDirectory, INDEX_MAP_FILE);
 
-    PropertiesConfiguration mapConfig = new PropertiesConfiguration(mapFile);
-    Iterator keys = mapConfig.getKeys();
-    while (keys.hasNext()) {
-      String key = (String) keys.next();
+    PropertiesConfiguration mapConfig = CommonsConfigurationUtils.fromFile(mapFile);
+    
+    for (String key: CommonsConfigurationUtils.getKeys(mapConfig)) {
       // column names can have '.' in it hence scan from backwards
       // parsing names like "column.name.dictionary.startOffset"
       // or, "column.name.dictionary.endOffset" where column.name is the key

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/StarTreeV2Metadata.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/StarTreeV2Metadata.java
@@ -18,12 +18,19 @@
  */
 package org.apache.pinot.core.startree.v2;
 
+import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.DIMENSIONS_SPLIT_ORDER;
+import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.FUNCTION_COLUMN_PAIRS;
+import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.MAX_LEAF_RECORDS;
+import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.SKIP_STAR_NODE_CREATION_FOR_DIMENSIONS;
+import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.TOTAL_DOCS;
+
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.configuration.Configuration;
+import java.util.stream.Collectors;
 
-import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.*;
+import org.apache.commons.configuration.Configuration;
 
 
 /**
@@ -51,14 +58,15 @@ public class StarTreeV2Metadata {
   @SuppressWarnings("unchecked")
   public StarTreeV2Metadata(Configuration metadataProperties) {
     _numDocs = metadataProperties.getInt(TOTAL_DOCS);
-    _dimensionsSplitOrder = metadataProperties.getList(DIMENSIONS_SPLIT_ORDER);
+    _dimensionsSplitOrder = Arrays.stream(metadataProperties.getStringArray(DIMENSIONS_SPLIT_ORDER)).collect(Collectors.toList());
     _functionColumnPairs = new HashSet<>();
     for (Object functionColumnPair : metadataProperties.getList(FUNCTION_COLUMN_PAIRS)) {
       _functionColumnPairs.add(AggregationFunctionColumnPair.fromColumnName((String) functionColumnPair));
     }
     _maxLeafRecords = metadataProperties.getInt(MAX_LEAF_RECORDS);
     _skipStarNodeCreationForDimensions =
-        new HashSet<>(metadataProperties.getList(SKIP_STAR_NODE_CREATION_FOR_DIMENSIONS));
+        new HashSet<>(Arrays.stream(metadataProperties.getStringArray(SKIP_STAR_NODE_CREATION_FOR_DIMENSIONS))
+            .collect(Collectors.toList()));
   }
 
   public int getNumDocs() {

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -18,12 +18,19 @@
  */
 package org.apache.pinot.server.realtime;
 
+import static org.apache.pinot.common.utils.CommonConstants.Server.SegmentCompletionProtocol.CONFIG_OF_CONTROLLER_HTTPS_ENABLED;
+import static org.apache.pinot.common.utils.CommonConstants.Server.SegmentCompletionProtocol.CONFIG_OF_CONTROLLER_HTTPS_PORT;
+import static org.apache.pinot.common.utils.CommonConstants.Server.SegmentCompletionProtocol.CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS;
+import static org.apache.pinot.common.utils.CommonConstants.Server.SegmentCompletionProtocol.DEFAULT_OTHER_REQUESTS_TIMEOUT;
+import static org.apache.pinot.common.utils.CommonConstants.Server.SegmentCompletionProtocol.DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS;
+
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+
 import javax.net.ssl.SSLContext;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.ClientSSLContextGenerator;
@@ -32,11 +39,10 @@ import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.core.data.manager.realtime.Server2ControllerSegmentUploader;
 import org.apache.pinot.core.util.SegmentCompletionProtocolUtils;
 import org.apache.pinot.pql.parsers.utils.Pair;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.pinot.common.utils.CommonConstants.Server.SegmentCompletionProtocol.*;
 
 
 /**
@@ -57,14 +63,14 @@ public class ServerSegmentCompletionProtocolHandler {
   private final ServerMetrics _serverMetrics;
   private final String _rawTableName;
 
-  public static void init(Configuration uploaderConfig) {
-    Configuration httpsConfig = uploaderConfig.subset(HTTPS_PROTOCOL);
-    if (httpsConfig.getBoolean(CONFIG_OF_CONTROLLER_HTTPS_ENABLED, false)) {
+  public static void init(PinotConfiguration uploaderConfig) {
+    PinotConfiguration httpsConfig = uploaderConfig.subset(HTTPS_PROTOCOL);
+    if (httpsConfig.getProperty(CONFIG_OF_CONTROLLER_HTTPS_ENABLED, false)) {
       _sslContext = new ClientSSLContextGenerator(httpsConfig.subset(CommonConstants.PREFIX_OF_SSL_SUBSET)).generate();
-      _controllerHttpsPort = httpsConfig.getInt(CONFIG_OF_CONTROLLER_HTTPS_PORT);
+      _controllerHttpsPort = httpsConfig.getProperty(CONFIG_OF_CONTROLLER_HTTPS_PORT, Integer.class);
     }
     _segmentUploadRequestTimeoutMs =
-        uploaderConfig.getInt(CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS, DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS);
+        uploaderConfig.getProperty(CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS, DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS);
   }
 
   public ServerSegmentCompletionProtocolHandler(ServerMetrics serverMetrics, String tableNameWithType) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploaderTest.java
@@ -23,13 +23,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.StringUtil;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.testng.Assert;
@@ -44,11 +46,11 @@ public class PinotFSSegmentUploaderTest {
   @BeforeClass
   public void setUp()
       throws URISyntaxException, IOException, HttpErrorStatusException {
-    Configuration fsConfig = new PropertiesConfiguration();
-    fsConfig.setProperty("class.hdfs", "org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest$AlwaysSucceedPinotFS");
-    fsConfig.setProperty("class.timeout", "org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest$AlwaysTimeoutPinotFS");
-    fsConfig.setProperty("class.existing", "org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest$AlwaysExistPinotFS");
-    PinotFSFactory.init(fsConfig);
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("class.hdfs", "org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest$AlwaysSucceedPinotFS");
+    properties.put("class.timeout", "org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest$AlwaysTimeoutPinotFS");
+    properties.put("class.existing", "org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest$AlwaysExistPinotFS");
+    PinotFSFactory.init(new PinotConfiguration(properties));
     _file = FileUtils.getFile(FileUtils.getTempDirectory(), UUID.randomUUID().toString());
     _file.deleteOnExit();
     _llcSegmentName = new LLCSegmentName("test_REALTIME", 1, 0, System.currentTimeMillis());
@@ -85,7 +87,7 @@ public class PinotFSSegmentUploaderTest {
   public static class AlwaysSucceedPinotFS extends PinotFS {
 
     @Override
-    public void init(Configuration config) {
+    public void init(PinotConfiguration config) {
 
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/TestSchedulerGroupFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/TestSchedulerGroupFactory.java
@@ -18,11 +18,12 @@
  */
 package org.apache.pinot.core.query.scheduler;
 
+import static org.testng.Assert.assertNull;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.commons.configuration.Configuration;
 
-import static org.testng.Assert.assertNull;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 class TestSchedulerGroupFactory implements SchedulerGroupFactory {
@@ -30,7 +31,7 @@ class TestSchedulerGroupFactory implements SchedulerGroupFactory {
   ConcurrentHashMap<String, TestSchedulerGroup> groupMap = new ConcurrentHashMap<>();
 
   @Override
-  public SchedulerGroup create(Configuration config, String groupName) {
+  public SchedulerGroup create(PinotConfiguration config, String groupName) {
     numCalls.incrementAndGet();
     assertNull(groupMap.get(groupName));
     TestSchedulerGroup group = new TestSchedulerGroup(groupName);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/resources/ResourceManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/resources/ResourceManagerTest.java
@@ -18,16 +18,18 @@
  */
 package org.apache.pinot.core.query.scheduler.resources;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.pinot.core.query.request.ServerQueryRequest;
-import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
-import org.testng.annotations.Test;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.Test;
 
 
 public class ResourceManagerTest {
@@ -71,10 +73,10 @@ public class ResourceManagerTest {
     };
   }
 
-  private Configuration getConfig(int runners, int workers) {
-    Configuration config = new PropertiesConfiguration();
-    config.setProperty(ResourceManager.QUERY_RUNNER_CONFIG_KEY, runners);
-    config.setProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, workers);
-    return config;
+  private PinotConfiguration getConfig(int runners, int workers) {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(ResourceManager.QUERY_RUNNER_CONFIG_KEY, runners);
+    properties.put(ResourceManager.QUERY_WORKER_CONFIG_KEY, workers);
+    return new PinotConfiguration(properties);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/resources/UnboundedResourceManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/resources/UnboundedResourceManagerTest.java
@@ -18,25 +18,25 @@
  */
 package org.apache.pinot.core.query.scheduler.resources;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
-import org.testng.annotations.Test;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.Test;
+
 
 public class UnboundedResourceManagerTest {
 
   @Test
   public void testDefault() {
-    Configuration config = new PropertiesConfiguration();
-
-    UnboundedResourceManager rm = new UnboundedResourceManager(config);
+    UnboundedResourceManager rm = new UnboundedResourceManager(new PinotConfiguration());
     assertTrue(rm.getNumQueryRunnerThreads() > 1);
     assertTrue(rm.getNumQueryWorkerThreads() >= 1);
     assertEquals(rm.getTableThreadsHardLimit(), rm.getNumQueryRunnerThreads() + rm.getNumQueryWorkerThreads());
@@ -45,14 +45,14 @@ public class UnboundedResourceManagerTest {
 
   @Test
   public void testWithConfig() {
-    Configuration config = new PropertiesConfiguration();
+    Map<String, Object> properties = new HashMap<>();
     final int workers = 5;
     final int runners = 2;
 
-    config.setProperty(ResourceManager.QUERY_RUNNER_CONFIG_KEY, runners);
-    config.setProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, workers);
+    properties.put(ResourceManager.QUERY_RUNNER_CONFIG_KEY, runners);
+    properties.put(ResourceManager.QUERY_WORKER_CONFIG_KEY, workers);
 
-    UnboundedResourceManager rm = new UnboundedResourceManager(config);
+    UnboundedResourceManager rm = new UnboundedResourceManager(new PinotConfiguration(properties));
     assertEquals(rm.getNumQueryWorkerThreads(), workers);
     assertEquals(rm.getNumQueryRunnerThreads(), runners);
     assertEquals(rm.getTableThreadsHardLimit(), runners + workers);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pinot.core.segment.index.creator;
 
-import com.yammer.metrics.core.MetricsRegistry;
+import static org.apache.pinot.core.segment.index.creator.RawIndexCreatorTest.getRandomValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -31,6 +34,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -38,38 +42,37 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.request.InstanceRequest;
+import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.core.segment.index.readers.NullValueVectorReader;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.spi.data.readers.RecordReader;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
-import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
-import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
-import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
-import org.apache.pinot.core.segment.index.readers.NullValueVectorReader;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.core.segment.index.creator.RawIndexCreatorTest.getRandomValue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import com.yammer.metrics.core.MetricsRegistry;
 
 
 /**
@@ -157,7 +160,7 @@ public class SegmentGenerationWithNullValueVectorTest {
     queryExecutorConfig.setDelimiterParsingDisabled(false);
     queryExecutorConfig.load(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
-    _queryExecutor.init(queryExecutorConfig, _instanceDataManager, _serverMetrics);
+    _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), _instanceDataManager, _serverMetrics);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/executor/QueryExecutorTest.java
@@ -18,13 +18,16 @@
  */
 package org.apache.pinot.query.executor;
 
-import com.yammer.metrics.core.MetricsRegistry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
@@ -48,13 +51,13 @@ import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.segments.v1.creator.SegmentTestUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import com.yammer.metrics.core.MetricsRegistry;
 
 
 public class QueryExecutorTest {
@@ -116,7 +119,7 @@ public class QueryExecutorTest {
     queryExecutorConfig.setDelimiterParsingDisabled(false);
     queryExecutorConfig.load(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
-    _queryExecutor.init(queryExecutorConfig, instanceDataManager, _serverMetrics);
+    _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), instanceDataManager, _serverMetrics);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/spi/crypt/PinotCrypterFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/spi/crypt/PinotCrypterFactoryTest.java
@@ -19,8 +19,10 @@
 package org.apache.pinot.spi.crypt;
 
 import java.io.File;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -31,17 +33,17 @@ public class PinotCrypterFactoryTest {
 
   @Test
   public void testDefaultPinotCrypter() {
-    PinotCrypterFactory.init(new PropertiesConfiguration());
+    PinotCrypterFactory.init(new PinotConfiguration());
     Assert.assertTrue(PinotCrypterFactory.create("NoOpPinotCrypter") instanceof NoOpPinotCrypter);
     Assert.assertTrue(PinotCrypterFactory.create("nooppinotcrypter") instanceof NoOpPinotCrypter);
   }
 
   @Test
   public void testConfiguredPinotCrypter() {
-    PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
-    propertiesConfiguration.addProperty("class.testpinotcrypter", TestPinotCrypter.class.getName());
-    propertiesConfiguration.addProperty("testpinotcrypter" + "." + CONFIG_SUBSET_KEY, SAMPLE_KEYMAP_VAL);
-    PinotCrypterFactory.init(propertiesConfiguration);
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("class.testpinotcrypter", TestPinotCrypter.class.getName());
+    properties.put("testpinotcrypter" + "." + CONFIG_SUBSET_KEY, SAMPLE_KEYMAP_VAL);
+    PinotCrypterFactory.init(new PinotConfiguration(properties));
     Assert.assertTrue(PinotCrypterFactory.create(NoOpPinotCrypter.class.getSimpleName()) instanceof NoOpPinotCrypter);
     PinotCrypter testPinotCrypter = PinotCrypterFactory.create(TestPinotCrypter.class.getSimpleName());
     Assert.assertTrue(testPinotCrypter instanceof TestPinotCrypter);
@@ -50,9 +52,9 @@ public class PinotCrypterFactoryTest {
 
   public static final class TestPinotCrypter implements PinotCrypter {
     @Override
-    public void init(Configuration config) {
+    public void init(PinotConfiguration config) {
       Assert.assertTrue(config.containsKey(CONFIG_SUBSET_KEY));
-      Assert.assertTrue(config.getString(CONFIG_SUBSET_KEY).equalsIgnoreCase(SAMPLE_KEYMAP_VAL));
+      Assert.assertTrue(config.getProperty(CONFIG_SUBSET_KEY).equalsIgnoreCase(SAMPLE_KEYMAP_VAL));
     }
 
     @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -18,18 +18,19 @@
  */
 package org.apache.pinot.integration.tests;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
+import java.util.Map;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
@@ -37,6 +38,8 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 
 /**
@@ -67,7 +70,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Override
-  protected void overrideServerConf(Configuration configuration) {
+  protected void overrideServerConf(PinotConfiguration configuration) {
     configuration.setProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_RELOAD_CONSUMING_SEGMENT, true);
   }
 
@@ -115,9 +118,11 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
     startKafka();
 
     // Start the Pinot cluster
-    ControllerConf config = getDefaultControllerConfiguration();
-    config.setTenantIsolationEnabled(false);
-    startController(config);
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, false);
+
+    startController(properties);
+    
     startBroker();
     startServers(2);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTestCommandLineRunner.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTestCommandLineRunner.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.integration.tests;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Preconditions;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -27,12 +25,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.annotation.Nullable;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.broker.requesthandler.PinotQueryRequest;
 import org.apache.pinot.common.segment.ReadMode;
@@ -49,6 +50,9 @@ import org.testng.TestNG;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
 
 
 /**
@@ -330,11 +334,14 @@ public class HybridClusterIntegrationTestCommandLineRunner {
       startKafka();
 
       // Start the Pinot cluster
-      ControllerConf config = getDefaultControllerConfiguration();
-      config.setControllerPort(Integer.toString(CONTROLLER_PORT));
-      config.setZkStr(ZK_STR);
-      config.setTenantIsolationEnabled(false);
-      startController(config);
+      Map<String, Object> properties = getDefaultControllerConfiguration();
+      
+      properties.put(ControllerConf.CONTROLLER_PORT, CONTROLLER_PORT);
+      properties.put(ControllerConf.ZK_STR, ZK_STR);
+      properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, false);
+      
+      startController(properties);
+      
       startBroker(BROKER_PORT, ZK_STR);
       startServers(2, SERVER_BASE_ADMIN_API_PORT, SERVER_BASE_NETTY_PORT, ZK_STR);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -18,13 +18,16 @@
  */
 package org.apache.pinot.integration.tests;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.ZNRecord;
 import org.apache.pinot.common.segment.ReadMode;
@@ -32,14 +35,14 @@ import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import com.fasterxml.jackson.databind.JsonNode;
 
 
 /**
@@ -72,15 +75,17 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
 
   @Override
   public void startController() {
-    ControllerConf controllerConfig = getDefaultControllerConfiguration();
-    controllerConfig.setHLCTablesAllowed(false);
-    controllerConfig.setSplitCommit(_enableSplitCommit);
-    startController(controllerConfig);
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    
+    properties.put(ControllerConf.ALLOW_HLC_TABLES, false);
+    properties.put(ControllerConf.ENABLE_SPLIT_COMMIT, _enableSplitCommit);
+    
+    startController(properties);
     enableResourceConfigForLeadControllerResource(_enableLeadControllerResource);
   }
 
   @Override
-  protected void overrideServerConf(Configuration configuration) {
+  protected void overrideServerConf(PinotConfiguration configuration) {
     configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION, true);
     configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION, _isDirectAlloc);
     if (_isConsumerDirConfigured) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -18,20 +18,26 @@
  */
 package org.apache.pinot.integration.tests;
 
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.Configuration;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE;
+import static org.apache.pinot.common.utils.CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY;
+import static org.apache.pinot.common.utils.CommonConstants.Server.CONFIG_OF_INSTANCE_ID;
+import static org.testng.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.server.starter.helix.HelixServerStarter;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import static org.apache.pinot.common.utils.CommonConstants.Helix.*;
-import static org.apache.pinot.common.utils.CommonConstants.Server.CONFIG_OF_INSTANCE_ID;
-import static org.testng.Assert.assertEquals;
 
 
 public class ServerStarterIntegrationTest extends ControllerTest {
@@ -51,7 +57,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
     stopZk();
   }
 
-  private void verifyInstanceConfig(Configuration serverConf, String expectedInstanceId, String expectedHost,
+  private void verifyInstanceConfig(PinotConfiguration serverConf, String expectedInstanceId, String expectedHost,
       int expectedPort)
       throws Exception {
     HelixServerStarter helixServerStarter =
@@ -69,56 +75,63 @@ public class ServerStarterIntegrationTest extends ControllerTest {
   @Test
   public void testDefaultServerConf()
       throws Exception {
-    Configuration serverConf = new BaseConfiguration();
     String expectedHost = NetUtil.getHostAddress();
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + DEFAULT_SERVER_NETTY_PORT;
-    verifyInstanceConfig(serverConf, expectedInstanceId, expectedHost, DEFAULT_SERVER_NETTY_PORT);
+    
+    verifyInstanceConfig(new PinotConfiguration(), expectedInstanceId, expectedHost, DEFAULT_SERVER_NETTY_PORT);
   }
 
   @Test
   public void testSetInstanceIdToHostname()
       throws Exception {
-    Configuration serverConf = new BaseConfiguration();
-    serverConf.addProperty(SET_INSTANCE_ID_TO_HOSTNAME_KEY, true);
     String expectedHost = NetUtil.getHostnameOrAddress();
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + DEFAULT_SERVER_NETTY_PORT;
-    verifyInstanceConfig(serverConf, expectedInstanceId, expectedHost, DEFAULT_SERVER_NETTY_PORT);
+    
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(SET_INSTANCE_ID_TO_HOSTNAME_KEY, true);
+    
+    verifyInstanceConfig(new PinotConfiguration(properties), expectedInstanceId, expectedHost, DEFAULT_SERVER_NETTY_PORT);
   }
 
   @Test
   public void testCustomInstanceId()
-      throws Exception {
-    Configuration serverConf = new BaseConfiguration();
-    serverConf.addProperty(CONFIG_OF_INSTANCE_ID, CUSTOM_INSTANCE_ID);
-    verifyInstanceConfig(serverConf, CUSTOM_INSTANCE_ID, NetUtil.getHostAddress(), DEFAULT_SERVER_NETTY_PORT);
+      throws Exception {    
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CONFIG_OF_INSTANCE_ID, CUSTOM_INSTANCE_ID);
+    
+    verifyInstanceConfig(new PinotConfiguration(properties), CUSTOM_INSTANCE_ID, NetUtil.getHostAddress(), DEFAULT_SERVER_NETTY_PORT);
   }
 
   @Test
   public void testCustomHost()
       throws Exception {
-    Configuration serverConf = new BaseConfiguration();
-    serverConf.addProperty(KEY_OF_SERVER_NETTY_HOST, CUSTOM_HOST);
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + CUSTOM_HOST + "_" + DEFAULT_SERVER_NETTY_PORT;
-    verifyInstanceConfig(serverConf, expectedInstanceId, CUSTOM_HOST, DEFAULT_SERVER_NETTY_PORT);
+    
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(KEY_OF_SERVER_NETTY_HOST, CUSTOM_HOST);
+    
+    verifyInstanceConfig(new PinotConfiguration(properties), expectedInstanceId, CUSTOM_HOST, DEFAULT_SERVER_NETTY_PORT);
   }
 
   @Test
   public void testCustomPort()
       throws Exception {
-    Configuration serverConf = new BaseConfiguration();
-    serverConf.addProperty(KEY_OF_SERVER_NETTY_PORT, CUSTOM_PORT);
     String expectedHost = NetUtil.getHostAddress();
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + CUSTOM_PORT;
-    verifyInstanceConfig(serverConf, expectedInstanceId, expectedHost, CUSTOM_PORT);
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(KEY_OF_SERVER_NETTY_PORT, CUSTOM_PORT);
+    
+    verifyInstanceConfig(new PinotConfiguration(properties), expectedInstanceId, expectedHost, CUSTOM_PORT);
   }
 
   @Test
   public void testAllCustomServerConf()
       throws Exception {
-    Configuration serverConf = new BaseConfiguration();
-    serverConf.addProperty(CONFIG_OF_INSTANCE_ID, CUSTOM_INSTANCE_ID);
-    serverConf.addProperty(KEY_OF_SERVER_NETTY_HOST, CUSTOM_HOST);
-    serverConf.addProperty(KEY_OF_SERVER_NETTY_PORT, CUSTOM_PORT);
-    verifyInstanceConfig(serverConf, CUSTOM_INSTANCE_ID, CUSTOM_HOST, CUSTOM_PORT);
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CONFIG_OF_INSTANCE_ID, CUSTOM_INSTANCE_ID);
+    properties.put(KEY_OF_SERVER_NETTY_HOST, CUSTOM_HOST);
+    properties.put(KEY_OF_SERVER_NETTY_PORT, CUSTOM_PORT);
+    verifyInstanceConfig(new PinotConfiguration(properties), CUSTOM_INSTANCE_ID, CUSTOM_HOST, CUSTOM_PORT);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorIntegrationTest.java
@@ -65,9 +65,9 @@ public class ControllerLeaderLocatorIntegrationTest extends ControllerTest {
     // After resource config is enabled, use the lead controller in the resource.
     validateResultSet(controllerLeaderLocator, resultSet, 1, "Failed to get only one pair of controller");
 
-    ControllerConf secondControllerConfig = getDefaultControllerConfiguration();
-    secondControllerConfig.setControllerPort(Integer.toString(DEFAULT_CONTROLLER_PORT + 1));
-    ControllerStarter secondControllerStarter = new ControllerStarter(secondControllerConfig);
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 1);
+    ControllerStarter secondControllerStarter = new ControllerStarter(new ControllerConf(properties));
     secondControllerStarter.start();
 
     TestUtils

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.hadoop;
 
-import com.google.common.base.Preconditions;
+import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
+import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
+
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -31,8 +33,9 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
@@ -47,6 +50,7 @@ import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
@@ -58,8 +62,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
-import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
-import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
+import com.google.common.base.Preconditions;
 
 
 public class HadoopSegmentGenerationJobRunner extends Configured implements IngestionJobRunner, Serializable {
@@ -129,8 +132,7 @@ public class HadoopSegmentGenerationJobRunner extends Configured implements Inge
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+      new PinotConfiguration(pinotFSSpec);
     }
 
     //Get pinotFS for input

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentTarPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentTarPushJobRunner.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
@@ -36,14 +37,9 @@ import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class HadoopSegmentTarPushJobRunner implements IngestionJobRunner, Serializable {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(HadoopSegmentTarPushJobRunner.class);
-
   private SegmentGenerationJobSpec _spec;
 
   public HadoopSegmentTarPushJobRunner() {
@@ -63,8 +59,7 @@ public class HadoopSegmentTarPushJobRunner implements IngestionJobRunner, Serial
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
     //Get outputFS for writing output pinot segments

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentUriPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentUriPushJobRunner.java
@@ -25,9 +25,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
@@ -36,14 +36,9 @@ import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class HadoopSegmentUriPushJobRunner implements IngestionJobRunner, Serializable {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(HadoopSegmentUriPushJobRunner.class);
-
   private SegmentGenerationJobSpec _spec;
 
   public HadoopSegmentUriPushJobRunner() {
@@ -66,8 +61,7 @@ public class HadoopSegmentUriPushJobRunner implements IngestionJobRunner, Serial
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
     //Get outputFS for writing output Pinot segments

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -18,6 +18,12 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.spark;
 
+import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_DIR;
+import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
+import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.getFileName;
+import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_DIR_PROPERTY_NAME;
+import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -29,12 +35,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
@@ -50,12 +56,6 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_DIR;
-import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
-import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils.getFileName;
-import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_DIR_PROPERTY_NAME;
-import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
 
 
 public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Serializable {
@@ -120,8 +120,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
     //Get pinotFS for input
@@ -212,8 +211,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       final URI finalOutputDirURI = (stagingDirURI == null) ? outputDirURI : stagingDirURI;
       pathRDD.foreach(pathAndIdx -> {
         for (PinotFSSpec pinotFSSpec : _spec.getPinotFSSpecs()) {
-          Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-          PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+          PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
         }
         PinotFS finalOutputDirFS = PinotFSFactory.create(finalOutputDirURI.getScheme());
         String[] splits = pathAndIdx.split(" ");

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentTarPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentTarPushJobRunner.java
@@ -26,9 +26,9 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
@@ -40,14 +40,9 @@ import org.apache.pinot.spi.utils.retry.RetriableOperationException;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class SparkSegmentTarPushJobRunner implements IngestionJobRunner, Serializable {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(SparkSegmentTarPushJobRunner.class);
-
   private SegmentGenerationJobSpec _spec;
 
   public SparkSegmentTarPushJobRunner() {
@@ -67,8 +62,7 @@ public class SparkSegmentTarPushJobRunner implements IngestionJobRunner, Seriali
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
     //Get outputFS for writing output pinot segments
@@ -114,8 +108,7 @@ public class SparkSegmentTarPushJobRunner implements IngestionJobRunner, Seriali
       URI finalOutputDirURI = outputDirURI;
       pathRDD.foreach(segmentTarPath -> {
         for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-          Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-          PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+          PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
         }
         try {
           SegmentPushUtils.pushSegments(_spec, PinotFSFactory.create(finalOutputDirURI.getScheme()), Arrays.asList(segmentTarPath));

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentUriPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentUriPushJobRunner.java
@@ -26,9 +26,9 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
@@ -40,14 +40,8 @@ import org.apache.pinot.spi.utils.retry.RetriableOperationException;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 public class SparkSegmentUriPushJobRunner implements IngestionJobRunner, Serializable {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(SparkSegmentUriPushJobRunner.class);
-
   private SegmentGenerationJobSpec _spec;
 
   public SparkSegmentUriPushJobRunner() {
@@ -70,8 +64,7 @@ public class SparkSegmentUriPushJobRunner implements IngestionJobRunner, Seriali
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
     //Get outputFS for writing output Pinot segments

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -26,14 +26,14 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
@@ -83,8 +83,8 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
         throw new RuntimeException("Missing property 'schemaURI' in 'tableSpec'");
       }
       PinotClusterSpec pinotClusterSpec = _spec.getPinotClusterSpecs()[0];
-      String schemaURI = SegmentGenerationUtils
-          .generateSchemaURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
+      String schemaURI = SegmentGenerationUtils.generateSchemaURI(pinotClusterSpec.getControllerURI(),
+          _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setSchemaURI(schemaURI);
     }
     if (_spec.getTableSpec().getTableConfigURI() == null) {
@@ -104,8 +104,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
     //Get pinotFS for input

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
@@ -24,9 +24,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
@@ -35,14 +35,9 @@ import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class SegmentTarPushJobRunner implements IngestionJobRunner {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentTarPushJobRunner.class);
-
   private SegmentGenerationJobSpec _spec;
 
   public SegmentTarPushJobRunner() {
@@ -62,8 +57,7 @@ public class SegmentTarPushJobRunner implements IngestionJobRunner {
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
     //Get outputFS for writing output pinot segments

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentUriPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentUriPushJobRunner.java
@@ -24,9 +24,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
+
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
@@ -35,13 +35,9 @@ import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class SegmentUriPushJobRunner implements IngestionJobRunner {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentUriPushJobRunner.class);
 
   private SegmentGenerationJobSpec _spec;
 
@@ -65,8 +61,7 @@ public class SegmentUriPushJobRunner implements IngestionJobRunner {
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      Configuration config = new MapConfiguration(pinotFSSpec.getConfigs());
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), config);
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
     //Get outputFS for writing output Pinot segments

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -18,24 +18,6 @@
  */
 package org.apache.pinot.plugin.filesystem;
 
-import com.azure.core.http.rest.PagedIterable;
-import com.azure.core.util.Context;
-import com.azure.storage.blob.BlobClient;
-import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
-import com.azure.storage.common.StorageSharedKeyCredential;
-import com.azure.storage.common.Utility;
-import com.azure.storage.file.datalake.DataLakeDirectoryClient;
-import com.azure.storage.file.datalake.DataLakeFileClient;
-import com.azure.storage.file.datalake.DataLakeFileSystemClient;
-import com.azure.storage.file.datalake.DataLakeServiceClient;
-import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
-import com.azure.storage.file.datalake.models.DataLakeRequestConditions;
-import com.azure.storage.file.datalake.models.DataLakeStorageException;
-import com.azure.storage.file.datalake.models.ListPathsOptions;
-import com.azure.storage.file.datalake.models.PathHttpHeaders;
-import com.azure.storage.file.datalake.models.PathItem;
-import com.azure.storage.file.datalake.models.PathProperties;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -54,11 +36,31 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Map;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.util.Context;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.common.Utility;
+import com.azure.storage.file.datalake.DataLakeDirectoryClient;
+import com.azure.storage.file.datalake.DataLakeFileClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+import com.azure.storage.file.datalake.models.DataLakeRequestConditions;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.ListPathsOptions;
+import com.azure.storage.file.datalake.models.PathHttpHeaders;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.models.PathProperties;
 
 
 /**
@@ -95,15 +97,15 @@ public class ADLSGen2PinotFS extends PinotFS {
   private boolean _enableChecksum;
 
   @Override
-  public void init(Configuration config) {
-    _enableChecksum = config.getBoolean(ENABLE_CHECKSUM, false);
+  public void init(PinotConfiguration config) {
+    _enableChecksum = config.getProperty(ENABLE_CHECKSUM, false);
 
     // Azure storage account name
-    String accountName = config.getString(ACCOUNT_NAME);
+    String accountName = config.getProperty(ACCOUNT_NAME);
 
     // TODO: consider to add the encryption of the following config
-    String accessKey = config.getString(ACCESS_KEY);
-    String fileSystemName = config.getString(FILE_SYSTEM_NAME);
+    String accessKey = config.getProperty(ACCESS_KEY);
+    String fileSystemName = config.getProperty(FILE_SYSTEM_NAME);
 
     String dfsServiceEndpointUrl = HTTPS_URL_PREFIX + accountName + AZURE_STORAGE_DNS_SUFFIX;
     String blobServiceEndpointUrl = HTTPS_URL_PREFIX + accountName + AZURE_BLOB_DNS_SUFFIX;

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFS.java
@@ -18,13 +18,6 @@
  */
 package org.apache.pinot.plugin.filesystem;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.microsoft.azure.datalake.store.ADLStoreClient;
-import com.microsoft.azure.datalake.store.DirectoryEntry;
-import com.microsoft.azure.datalake.store.DirectoryEntryType;
-import com.microsoft.azure.datalake.store.IfExists;
-import com.microsoft.azure.datalake.store.oauth2.AccessTokenProvider;
-import com.microsoft.azure.datalake.store.oauth2.ClientCredsTokenProvider;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -38,12 +31,21 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.microsoft.azure.datalake.store.ADLStoreClient;
+import com.microsoft.azure.datalake.store.DirectoryEntry;
+import com.microsoft.azure.datalake.store.DirectoryEntryType;
+import com.microsoft.azure.datalake.store.IfExists;
+import com.microsoft.azure.datalake.store.oauth2.AccessTokenProvider;
+import com.microsoft.azure.datalake.store.oauth2.ClientCredsTokenProvider;
 
 
 /**
@@ -70,16 +72,16 @@ public class AzurePinotFS extends PinotFS {
   }
 
   @Override
-  public void init(Configuration config) {
+  public void init(PinotConfiguration config) {
     // The ADL account id. Example: {@code mystore.azuredatalakestore.net}.
-    String account = config.getString(ACCOUNT_ID);
+    String account = config.getProperty(ACCOUNT_ID);
     // The endpoint that should be used for authentication.
     // Usually of the form {@code https://login.microsoftonline.com/<tenant-id>/oauth2/token}.
-    String authEndpoint = config.getString(AUTH_ENDPOINT);
+    String authEndpoint = config.getProperty(AUTH_ENDPOINT);
     // The clientId used to authenticate this application
-    String clientId = config.getString(CLIENT_ID);
+    String clientId = config.getProperty(CLIENT_ID);
     // The secret key used to authenticate this application
-    String clientSecret = config.getString(CLIENT_SECRET);
+    String clientSecret = config.getProperty(CLIENT_SECRET);
 
     AccessTokenProvider tokenProvider = new ClientCredsTokenProvider(authEndpoint, clientId, clientSecret);
     _adlStoreClient = ADLStoreClient.createClient(account, tokenProvider);

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -18,20 +18,10 @@
  */
 package org.apache.pinot.plugin.filesystem;
 
-import com.google.api.gax.paging.Page;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.WriteChannel;
-import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.Bucket;
-import com.google.cloud.storage.CopyWriter;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
-import com.google.cloud.storage.StorageOptions;
-import com.google.common.collect.ImmutableList;
-import org.apache.commons.configuration.Configuration;
-import org.apache.pinot.spi.filesystem.PinotFS;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+import static joptsimple.internal.Strings.isNullOrEmpty;
+import static org.glassfish.jersey.internal.guava.Preconditions.checkArgument;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,10 +36,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static com.google.common.base.Preconditions.checkState;
-import static java.util.Objects.requireNonNull;
-import static joptsimple.internal.Strings.isNullOrEmpty;
-import static org.glassfish.jersey.internal.guava.Preconditions.checkArgument;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.api.gax.paging.Page;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.CopyWriter;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageOptions;
+import com.google.common.collect.ImmutableList;
 
 public class GcsPinotFS  extends PinotFS {
   public static final String PROJECT_ID = "projectId";
@@ -61,15 +62,15 @@ public class GcsPinotFS  extends PinotFS {
   private Storage storage;
 
   @Override
-  public void init(Configuration config) {
+  public void init(PinotConfiguration config) {
     LOGGER.info("Configs are: {}, {}",
             PROJECT_ID,
-            config.getString(PROJECT_ID));
+            config.getProperty(PROJECT_ID));
 
-    checkArgument(!isNullOrEmpty(config.getString(PROJECT_ID)));
-    checkArgument(!isNullOrEmpty(config.getString(GCP_KEY)));
-    String projectId = config.getString(PROJECT_ID);
-    String gcpKey = config.getString(GCP_KEY);
+    checkArgument(!isNullOrEmpty(config.getProperty(PROJECT_ID)));
+    checkArgument(!isNullOrEmpty(config.getProperty(GCP_KEY)));
+    String projectId = config.getProperty(PROJECT_ID);
+    String gcpKey = config.getProperty(GCP_KEY);
     try {
       storage = StorageOptions.newBuilder()
           .setProjectId(projectId)

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
@@ -21,38 +21,36 @@ package org.apache.pinot.plugin.filesystem;
 
 import java.io.IOException;
 import java.net.URI;
-import org.apache.commons.configuration.BaseConfiguration;
+
 import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class HadoopPinotFSTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(HadoopPinotFSTest.class);
-
   private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
 
   @Test
   public void testCopy()
       throws IOException {
     URI baseURI = URI.create(TMP_DIR + "/HadoopPinotFSTest");
-    HadoopPinotFS hadoopFS = new HadoopPinotFS();
-    hadoopFS.init(new BaseConfiguration());
-    hadoopFS.mkdir(new Path(baseURI.getPath(), "src").toUri());
-    hadoopFS.mkdir(new Path(baseURI.getPath(), "src/dir").toUri());
-    hadoopFS.touch(new Path(baseURI.getPath(), "src/dir/1").toUri());
-    hadoopFS.touch(new Path(baseURI.getPath(), "src/dir/2").toUri());
-    String[] srcFiles = hadoopFS.listFiles(new Path(baseURI.getPath(), "src").toUri(), true);
-    Assert.assertEquals(srcFiles.length, 3);
-    hadoopFS.copy(new Path(baseURI.getPath(), "src").toUri(), new Path(baseURI.getPath(), "dest").toUri());
-    Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest").toUri()));
-    Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest/dir").toUri()));
-    Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest/dir/1").toUri()));
-    Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest/dir/2").toUri()));
-    String[] destFiles = hadoopFS.listFiles(new Path(baseURI.getPath(), "dest").toUri(), true);
-    Assert.assertEquals(destFiles.length, 3);
-    hadoopFS.delete(baseURI, true);
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(new Path(baseURI.getPath(), "src").toUri());
+      hadoopFS.mkdir(new Path(baseURI.getPath(), "src/dir").toUri());
+      hadoopFS.touch(new Path(baseURI.getPath(), "src/dir/1").toUri());
+      hadoopFS.touch(new Path(baseURI.getPath(), "src/dir/2").toUri());
+      String[] srcFiles = hadoopFS.listFiles(new Path(baseURI.getPath(), "src").toUri(), true);
+      Assert.assertEquals(srcFiles.length, 3);
+      hadoopFS.copy(new Path(baseURI.getPath(), "src").toUri(), new Path(baseURI.getPath(), "dest").toUri());
+      Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest").toUri()));
+      Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest/dir").toUri()));
+      Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest/dir/1").toUri()));
+      Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest/dir/2").toUri()));
+      String[] destFiles = hadoopFS.listFiles(new Path(baseURI.getPath(), "dest").toUri(), true);
+      Assert.assertEquals(destFiles.length, 3);
+      hadoopFS.delete(baseURI, true);
+    }
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/conf/NettyServerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/conf/NettyServerConfig.java
@@ -18,29 +18,26 @@
  */
 package org.apache.pinot.server.conf;
 
-import org.apache.commons.configuration.Configuration;
+import java.util.Optional;
+
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 public class NettyServerConfig {
-
-  // Netty server port
   private static String NETTY_SERVER_PORT = "port";
 
-  private Configuration _serverNettyConfig;
+  private final int port;
 
-  public NettyServerConfig(Configuration serverNettyConfig)
-      throws ConfigurationException {
-    _serverNettyConfig = serverNettyConfig;
-    if (!_serverNettyConfig.containsKey(NETTY_SERVER_PORT)) {
-      throw new ConfigurationException("Cannot find Key : " + NETTY_SERVER_PORT);
-    }
+  public NettyServerConfig(PinotConfiguration serverNettyConfig) throws ConfigurationException {
+    this.port = Optional.ofNullable(serverNettyConfig.getProperty(NETTY_SERVER_PORT, Integer.class))
+        .orElseThrow(() -> new ConfigurationException("Cannot find Key : " + NETTY_SERVER_PORT));
   }
 
   /**
    * @return Netty server port
    */
   public int getPort() {
-    return _serverNettyConfig.getInt(NETTY_SERVER_PORT);
+    return port;
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/conf/ServerConf.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/conf/ServerConf.java
@@ -18,24 +18,23 @@
  */
 package org.apache.pinot.server.conf;
 
-import org.apache.commons.configuration.Configuration;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
  * The config used for Server.
  */
 public class ServerConf {
-
   private static final String PINOT_ = "pinot.";
   private static final String PINOT_SERVER_INSTANCE = "pinot.server.instance";
   private static final String PINOT_SERVER_METRICS = "pinot.server.metrics";
   private static final String PINOT_SERVER_METRICS_PREFIX = "pinot.server.metrics.prefix";
   private static final String PINOT_SERVER_TABLE_LEVEL_METRICS = "pinot.server.enableTableLevelMetrics";
-  // List of metrics to always send table level metrics even if table level metrics is disabled
-  private static final String PINOT_SERVER_TABLE_LEVEL_METRICS_LIST = "pinot.server.tablelevel.metrics.whitelist";
   private static final String PINOT_SERVER_QUERY = "pinot.server.query.executor";
   private static final String PINOT_SERVER_REQUEST = "pinot.server.request";
   private static final String PINOT_SERVER_NETTY = "pinot.server.netty";
@@ -45,29 +44,29 @@ public class ServerConf {
 
   private static final String PINOT_QUERY_SCHEDULER_PREFIX = "pinot.query.scheduler";
 
-  private Configuration _serverConf;
+  private PinotConfiguration _serverConf;
 
-  public ServerConf(Configuration serverConfig) {
+  public ServerConf(PinotConfiguration serverConfig) {
     _serverConf = serverConfig;
   }
 
-  public void init(Configuration serverConfig) {
+  public void init(PinotConfiguration serverConfig) {
     _serverConf = serverConfig;
   }
 
-  public Configuration getInstanceDataManagerConfig() {
+  public PinotConfiguration getInstanceDataManagerConfig() {
     return _serverConf.subset(PINOT_SERVER_INSTANCE);
   }
 
-  public Configuration getQueryExecutorConfig() {
+  public PinotConfiguration getQueryExecutorConfig() {
     return _serverConf.subset(PINOT_SERVER_QUERY);
   }
 
-  public Configuration getRequestConfig() {
+  public PinotConfiguration getRequestConfig() {
     return _serverConf.subset(PINOT_SERVER_REQUEST);
   }
 
-  public Configuration getMetricsConfig() {
+  public PinotConfiguration getMetricsConfig() {
     return _serverConf.subset(PINOT_SERVER_METRICS);
   }
 
@@ -76,35 +75,35 @@ public class ServerConf {
     return new NettyServerConfig(_serverConf.subset(PINOT_SERVER_NETTY));
   }
 
-  public Configuration getConfig(String component) {
+  public PinotConfiguration getConfig(String component) {
     return _serverConf.subset(PINOT_ + component);
   }
 
   public String getInstanceDataManagerClassName() {
-    return _serverConf.getString(PINOT_SERVER_INSTANCE_DATA_MANAGER_CLASS);
+    return _serverConf.getProperty(PINOT_SERVER_INSTANCE_DATA_MANAGER_CLASS);
   }
 
   public String getQueryExecutorClassName() {
-    return _serverConf.getString(PINOT_SERVER_QUERY_EXECUTOR_CLASS);
+    return _serverConf.getProperty(PINOT_SERVER_QUERY_EXECUTOR_CLASS);
   }
 
-  public Configuration getSchedulerConfig() {
+  public PinotConfiguration getSchedulerConfig() {
     return _serverConf.subset(PINOT_QUERY_SCHEDULER_PREFIX);
   }
 
   /**
-   * Returns an array of transform function names as defined in the config
-   * @return String array of transform functions
+   * Returns a list of transform function names as defined in the config
+   * @return List of transform functions
    */
-  public String[] getTransformFunctions() {
-    return _serverConf.getStringArray(PINOT_SERVER_TRANSFORM_FUNCTIONS);
+  public List<String> getTransformFunctions() {
+    return _serverConf.getProperty(PINOT_SERVER_TRANSFORM_FUNCTIONS, Arrays.asList());
   }
 
   public boolean emitTableLevelMetrics() {
-    return _serverConf.getBoolean(PINOT_SERVER_TABLE_LEVEL_METRICS, true);
+    return _serverConf.getProperty(PINOT_SERVER_TABLE_LEVEL_METRICS, true);
   }
 
   public String getMetricsPrefix() {
-    return _serverConf.getString(PINOT_SERVER_METRICS_PREFIX, CommonConstants.Server.DEFAULT_METRICS_PREFIX);
+    return _serverConf.getProperty(PINOT_SERVER_METRICS_PREFIX, CommonConstants.Server.DEFAULT_METRICS_PREFIX);
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/DefaultHelixStarterServerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/DefaultHelixStarterServerConfig.java
@@ -18,11 +18,9 @@
  */
 package org.apache.pinot.server.starter.helix;
 
-import java.util.Iterator;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.server.conf.ServerConf;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,20 +28,20 @@ import org.slf4j.LoggerFactory;
 public class DefaultHelixStarterServerConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHelixStarterServerConfig.class);
 
-  public static ServerConf getDefaultHelixServerConfig(Configuration externalConfigs) {
-    Configuration defaultConfigs = loadDefaultServerConf();
-    @SuppressWarnings("unchecked")
-    Iterator<String> iterable = externalConfigs.getKeys();
-    while (iterable.hasNext()) {
-      String key = iterable.next();
-      defaultConfigs.setProperty(key, externalConfigs.getProperty(key));
+  public static ServerConf getDefaultHelixServerConfig(PinotConfiguration externalConfigs) {
+    PinotConfiguration defaultConfigs = loadDefaultServerConf();
+    
+    for (String key: externalConfigs.getKeys()) {
+      defaultConfigs.setProperty(key, externalConfigs.getRawProperty(key));
+      
       LOGGER.info("External config key: {}, value: {}", key, externalConfigs.getProperty(key));
     }
     return new ServerConf(defaultConfigs);
   }
 
-  public static Configuration loadDefaultServerConf() {
-    Configuration serverConf = new PropertiesConfiguration();
+  public static PinotConfiguration loadDefaultServerConf() {
+    PinotConfiguration serverConf = new PinotConfiguration();
+    
     serverConf.addProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_DATA_DIR,
         CommonConstants.Server.DEFAULT_INSTANCE_DATA_DIR);
     serverConf.addProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR,

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.server.starter.helix;
 
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,9 +25,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
@@ -50,8 +50,11 @@ import org.apache.pinot.core.segment.index.loader.LoaderUtils;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 
 /**
@@ -72,7 +75,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
   @Override
-  public synchronized void init(Configuration config, HelixManager helixManager, ServerMetrics serverMetrics)
+  public synchronized void init(PinotConfiguration config, HelixManager helixManager, ServerMetrics serverMetrics)
       throws ConfigurationException {
     LOGGER.info("Initializing Helix instance data manager");
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -18,12 +18,13 @@
  */
 package org.apache.pinot.server.starter.helix;
 
-import java.util.Iterator;
-import org.apache.commons.configuration.Configuration;
+import java.util.Optional;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.CommonConstants.Server;
 import org.apache.pinot.core.data.manager.config.InstanceDataManagerConfig;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,104 +94,104 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final String MAX_PARALLEL_REFRESH_THREADS = "max.parallel.refresh.threads";
 
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID, INSTANCE_DATA_DIR, READ_MODE};
-  private Configuration _instanceDataManagerConfiguration = null;
+  private PinotConfiguration _instanceDataManagerConfiguration = null;
 
-  public HelixInstanceDataManagerConfig(Configuration serverConfig)
+  public HelixInstanceDataManagerConfig(PinotConfiguration serverConfig)
       throws ConfigurationException {
     _instanceDataManagerConfiguration = serverConfig;
-    Iterator keysIterator = serverConfig.getKeys();
-    while (keysIterator.hasNext()) {
-      String key = (String) keysIterator.next();
+
+    for (String key: serverConfig.getKeys()) {
       LOGGER.info("InstanceDataManagerConfig, key: {} , value: {}", key, serverConfig.getProperty(key));
     }
+    
     checkRequiredKeys();
   }
 
   private void checkRequiredKeys()
       throws ConfigurationException {
     for (String keyString : REQUIRED_KEYS) {
-      if (!_instanceDataManagerConfiguration.containsKey(keyString)) {
-        throw new ConfigurationException("Cannot find required key : " + keyString);
-      }
+      Optional.ofNullable(_instanceDataManagerConfiguration.getProperty(keyString))
+
+          .orElseThrow(() -> new ConfigurationException("Cannot find required key : " + keyString));
     }
   }
 
   @Override
-  public Configuration getConfig() {
+  public PinotConfiguration getConfig() {
     return _instanceDataManagerConfiguration;
   }
 
   @Override
   public String getInstanceId() {
-    return _instanceDataManagerConfiguration.getString(INSTANCE_ID);
+    return _instanceDataManagerConfiguration.getProperty(INSTANCE_ID);
   }
 
   @Override
   public String getInstanceDataDir() {
-    return _instanceDataManagerConfiguration.getString(INSTANCE_DATA_DIR);
+    return _instanceDataManagerConfiguration.getProperty(INSTANCE_DATA_DIR);
   }
 
   @Override
   public String getConsumerDir() {
-    return _instanceDataManagerConfiguration.getString(CONSUMER_DIR);
+    return _instanceDataManagerConfiguration.getProperty(CONSUMER_DIR);
   }
 
   @Override
   public String getInstanceSegmentTarDir() {
-    return _instanceDataManagerConfiguration.getString(INSTANCE_SEGMENT_TAR_DIR);
+    return _instanceDataManagerConfiguration.getProperty(INSTANCE_SEGMENT_TAR_DIR);
   }
 
   @Override
   public String getInstanceBootstrapSegmentDir() {
-    return _instanceDataManagerConfiguration.getString(INSTANCE_BOOTSTRAP_SEGMENT_DIR);
+    return _instanceDataManagerConfiguration.getProperty(INSTANCE_BOOTSTRAP_SEGMENT_DIR);
   }
 
   @Override
   public ReadMode getReadMode() {
-    return ReadMode.valueOf(_instanceDataManagerConfiguration.getString(READ_MODE));
+    return ReadMode.valueOf(_instanceDataManagerConfiguration.getProperty(READ_MODE));
   }
 
   @Override
   public String getSegmentFormatVersion() {
-    return _instanceDataManagerConfiguration.getString(SEGMENT_FORMAT_VERSION);
+    return _instanceDataManagerConfiguration.getProperty(SEGMENT_FORMAT_VERSION);
   }
 
   @Override
   public boolean isEnableSplitCommit() {
-    return _instanceDataManagerConfiguration.getBoolean(ENABLE_SPLIT_COMMIT, false);
+    return _instanceDataManagerConfiguration.getProperty(ENABLE_SPLIT_COMMIT, false);
   }
 
   @Override
   public boolean isEnableSplitCommitEndWithMetadata() {
-    return _instanceDataManagerConfiguration.getBoolean(ENABLE_SPLIT_COMMIT_END_WITH_METADATA, true);
+    return _instanceDataManagerConfiguration.getProperty(ENABLE_SPLIT_COMMIT_END_WITH_METADATA, true);
   }
 
   @Override
   public boolean isRealtimeOffHeapAllocation() {
-    return _instanceDataManagerConfiguration.getBoolean(REALTIME_OFFHEAP_ALLOCATION, false);
+    return _instanceDataManagerConfiguration.getProperty(REALTIME_OFFHEAP_ALLOCATION, false);
   }
 
   @Override
   public boolean isDirectRealtimeOffheapAllocation() {
-    return _instanceDataManagerConfiguration.getBoolean(DIRECT_REALTIME_OFFHEAP_ALLOCATION, false);
+    return _instanceDataManagerConfiguration.getProperty(DIRECT_REALTIME_OFFHEAP_ALLOCATION, false);
   }
 
   public boolean shouldReloadConsumingSegment() {
     return _instanceDataManagerConfiguration
-        .getBoolean(INSTANCE_RELOAD_CONSUMING_SEGMENT, Server.DEFAULT_RELOAD_CONSUMING_SEGMENT);
+        .getProperty(INSTANCE_RELOAD_CONSUMING_SEGMENT, Server.DEFAULT_RELOAD_CONSUMING_SEGMENT);
   }
 
   @Override
   public String getAvgMultiValueCount() {
-    return _instanceDataManagerConfiguration.getString(AVERAGE_MV_COUNT, null);
+    return _instanceDataManagerConfiguration.getProperty(AVERAGE_MV_COUNT);
   }
 
   public int getMaxParallelRefreshThreads() {
-    return _instanceDataManagerConfiguration.getInt(MAX_PARALLEL_REFRESH_THREADS, 1);
+    return _instanceDataManagerConfiguration.getProperty(MAX_PARALLEL_REFRESH_THREADS, 1);
   }
 
   public int getMaxParallelSegmentBuilds() {
-    return _instanceDataManagerConfiguration.getInt(MAX_PARALLEL_SEGMENT_BUILDS, 0);
+    return _instanceDataManagerConfiguration.getProperty(MAX_PARALLEL_SEGMENT_BUILDS, 0);
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -18,12 +18,12 @@
  */
 package org.apache.pinot.server.starter.helix;
 
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
+
 import javax.annotation.Nullable;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
@@ -38,9 +38,12 @@ import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.crypt.PinotCrypter;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 
 public class SegmentFetcherAndLoader {
@@ -51,14 +54,14 @@ public class SegmentFetcherAndLoader {
 
   private final InstanceDataManager _instanceDataManager;
 
-  public SegmentFetcherAndLoader(Configuration config, InstanceDataManager instanceDataManager)
+  public SegmentFetcherAndLoader(PinotConfiguration config, InstanceDataManager instanceDataManager)
       throws Exception {
     _instanceDataManager = instanceDataManager;
 
-    Configuration pinotFSConfig = config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);
-    Configuration segmentFetcherFactoryConfig =
+    PinotConfiguration pinotFSConfig = config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);
+    PinotConfiguration segmentFetcherFactoryConfig =
         config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY);
-    Configuration pinotCrypterConfig = config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_PINOT_CRYPTER);
+    PinotConfiguration pinotCrypterConfig = config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_PINOT_CRYPTER);
 
     PinotFSFactory.init(pinotFSConfig);
     SegmentFetcherFactory.init(segmentFetcherFactoryConfig);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/crypt/NoOpPinotCrypter.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/crypt/NoOpPinotCrypter.java
@@ -20,8 +20,9 @@ package org.apache.pinot.spi.crypt;
 
 import java.io.File;
 import java.io.IOException;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ public class NoOpPinotCrypter implements PinotCrypter {
   public static final Logger LOGGER = LoggerFactory.getLogger(NoOpPinotCrypter.class);
 
   @Override
-  public void init(Configuration config) {
+  public void init(PinotConfiguration config) {
 
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/crypt/PinotCrypter.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/crypt/PinotCrypter.java
@@ -19,7 +19,8 @@
 package org.apache.pinot.spi.crypt;
 
 import java.io.File;
-import org.apache.commons.configuration.Configuration;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -32,7 +33,7 @@ public interface PinotCrypter {
    * Initializes a crypter with any configurations it might need.
    * @param config
    */
-  void init(Configuration config);
+  void init(PinotConfiguration config);
 
   /**
    * Encrypts the file into the file location provided. The implementation should clean up file after any failures.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.env;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+
+
+/**
+ * Provide utility functions to manipulate Apache Commons {@link Configuration} instances.
+ *
+ */
+public abstract class CommonsConfigurationUtils {
+  /**
+   * Instantiate a {@link PropertiesConfiguration} from a {@link File}.
+   * @param file containing properties
+   * @return a {@link PropertiesConfiguration} instance. Empty if file does not exist.
+   */
+  public static PropertiesConfiguration fromFile(File file) {
+    try {
+      PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+
+      // Commons Configuration 1.10 does not support file path containing '%'. 
+      // Explicitly providing the input stream on load bypasses the problem. 
+      propertiesConfiguration.setFile(file);
+      if (file.exists()) {
+        propertiesConfiguration.load(new FileInputStream(file));
+      }
+
+      return propertiesConfiguration;
+    } catch (ConfigurationException | FileNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Iterable<String> getIterable(Iterator<String> keys) {
+    return () -> keys;
+  }
+
+  /**
+   * Provides a stream of all the keys found in a {@link Configuration}.
+   * @param configuration to iterate on keys
+   * @return a stream of keys
+   */
+  public static Stream<String> getKeysStream(Configuration configuration) {
+    return StreamSupport.stream(getIterable(configuration.getKeys()).spliterator(), false);
+  }
+
+  /**
+   * Provides a list of all the keys found in a {@link Configuration}.
+   * @param configuration to iterate on keys
+   * @return a list of keys
+   */
+  public static List<String> getKeys(Configuration configuration) {
+    return getKeysStream(configuration).collect(Collectors.toList());
+  }
+
+  /**
+   * @return a key-value {@link Map} found in the provided {@link Configuration}
+   */
+  public static Map<String, Object> toMap(Configuration configuration) {
+    return getKeysStream(configuration).collect(Collectors.toMap(key -> key, key -> mapValue(key, configuration)));
+  }
+
+  private static Object mapValue(String key, Configuration configuration) {
+    return Optional.of(configuration.getStringArray(key)).filter(values -> values.length > 1)
+        .<Object> map(values -> Arrays.stream(values).collect(Collectors.joining(",")))
+        .orElseGet(() -> configuration.getProperty(key));
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/ConfigFilePropertyReader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/ConfigFilePropertyReader.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.env;
+
+import java.io.Reader;
+
+import org.apache.commons.configuration.PropertiesConfiguration.PropertiesReader;
+
+
+public class ConfigFilePropertyReader extends PropertiesReader {
+
+  public ConfigFilePropertyReader(Reader reader, char listDelimiter) {
+    super(reader, listDelimiter);
+  }
+
+  @Override
+  public String getPropertyName() {
+    return super.getPropertyName().replace("-", "");
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/ConfigFilePropertyReaderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/ConfigFilePropertyReaderFactory.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.env;
+
+import java.io.Reader;
+
+import org.apache.commons.configuration.PropertiesConfiguration.DefaultIOFactory;
+import org.apache.commons.configuration.PropertiesConfiguration.PropertiesReader;
+
+
+public class ConfigFilePropertyReaderFactory extends DefaultIOFactory {
+  @Override
+  public PropertiesReader createPropertiesReader(Reader in, char delimiter) {
+    return new ConfigFilePropertyReader(in, delimiter);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/Environment.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/Environment.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.env;
+
+import java.util.Map;
+
+public interface Environment {
+  Map<String, String> getEnvironmentVariables();
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -1,0 +1,418 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.env;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+
+
+/**
+ * <p>
+ * Provides a configuration abstraction for Pinot to decouple services from configuration sources and frameworks.
+ * </p>
+ * <p>
+ * Pinot services may retreived configurations from PinotConfiguration independently from any source of configuration. 
+ * {@link PinotConfiguration} currently supports configuration loaded from the following sources :
+ * 
+ * <ul>
+ * <li>Apache Commons {@link Configuration} (see {@link #PinotConfiguration(Configuration)})</li>
+ * <li>Generic key-value properties provided with a {@link Map} (see {@link PinotConfiguration#PinotConfiguration(Map)}</li>
+ * <li>Environment variables (see {@link PinotConfiguration#PinotConfiguration(Map, Map)}</li>
+ * <li>{@link PinotFSSpec} (see {@link PinotConfiguration#PinotConfiguration(PinotFSSpec)}</li>
+ * </ul>
+ * </p>
+ * <p>
+ * These different sources will all merged in an underlying {@link CompositeConfiguration} for which all configuration keys will have been sanitized. 
+ * Through this mechanism, properties can be configured and retrieved with kebab case, camel case, snake case and environment variable conventions.
+ * </p>
+ * <table>
+ * <tr>
+ * <th>Property</th>
+ * <th>Note</th>
+ * </tr>
+ * <tr>
+ * <td>module.sub-module.alerts.email-address</td>
+ * <td>Kebab case, which is recommended for use in .properties and .yml files.</td>
+ * </tr>
+ * <tr>
+ * <td>module.subModule.alerts.emailAddress</td>
+ * <td>Standard camel case syntax.</td>
+ * </tr>
+ * <tr>
+ * <td>controller.sub_module.alerts.email_address</td>
+ * <td>Snake case notation, which is an alternative format for use in .properties and .yml files.</td>
+ * </tr>
+ * <tr>
+ * <td>PINOT_MODULE_SUBMODULE_ALERTS_EMAILADDRESS</td>
+ * <td>Upper case format, which is recommended when using system environment variables.</td>
+ * </tr>
+ * </table>
+ *
+ */
+public class PinotConfiguration {
+  public static final String CONFIG_PATHS_KEY = "config.paths";
+
+  private final CompositeConfiguration configuration;
+
+  /**
+   * Creates an empty instance.
+   */
+  public PinotConfiguration() {
+    this(new HashMap<>());
+  }
+
+  /**
+   * Builds a new instance out of an existing Apache Commons {@link Configuration} instance. Will apply property key sanitization to enable relaxed binding.
+   * Properties from the base configuration will be copied and won't be linked.
+   * 
+   * @param baseConfiguration an existing {@link Configuration} for which all properties will be duplicated and sanitized for relaxed binding. 
+   */
+  public PinotConfiguration(Configuration baseConfiguration) {
+    this.configuration =
+        new CompositeConfiguration(computeConfigurationsFromSources(baseConfiguration, new HashMap<>()));
+  }
+
+  /**
+   * Creates a new instance with existing properties provided through a map.
+   * 
+   * @param baseProperties to provide programmatically through a {@link Map}.
+   */
+  public PinotConfiguration(Map<String, Object> baseProperties) {
+    this(baseProperties, new HashMap<>());
+  }
+
+  /**
+   * Creates a new instance with existing properties provided through a map as well as environment variables. 
+   * Base properties will have priority offers properties defined in environment variables. Keys will be 
+   * sanitized for relaxed binding. See {@link PinotConfiguration} for further details. 
+   * 
+   * @param baseProperties with highest precedences (e.g. CLI arguments)
+   * @param environmentVariables as a {@link Map}. Can be provided with {@link SystemEnvironment}
+   */
+  public PinotConfiguration(Map<String, Object> baseProperties, Map<String, String> environmentVariables) {
+    this.configuration =
+        new CompositeConfiguration(computeConfigurationsFromSources(baseProperties, environmentVariables));
+  }
+
+  /**
+   * Helper constructor to create an instance from configurations found in a PinotFSSpec instance. 
+   * Intended for use by Job Runners
+   * 
+   * @param pinotFSSpec
+   */
+  public PinotConfiguration(PinotFSSpec pinotFSSpec) {
+    this(Optional.ofNullable(pinotFSSpec.getConfigs())
+        .map(configs -> configs.entrySet().stream().collect(
+            Collectors.<Entry<String, String>, String, Object> toMap(Entry::getKey, entry -> entry.getValue())))
+        .orElseGet(() -> new HashMap<>()));
+  }
+
+  private static List<Configuration> computeConfigurationsFromSources(Configuration baseConfiguration,
+      Map<String, String> environmentVariables) {
+    return computeConfigurationsFromSources(relaxConfigurationKeys(baseConfiguration), environmentVariables);
+  }
+
+  private static List<Configuration> computeConfigurationsFromSources(Map<String, Object> baseProperties,
+      Map<String, String> environmentVariables) {
+    Map<String, Object> relaxedBaseProperties = relaxProperties(baseProperties);
+    Map<String, String> relaxedEnvVariables = relaxEnvironmentVariables(environmentVariables);
+
+    Stream<Configuration> propertiesFromConfigPaths = Stream
+        .of(Optional.ofNullable(relaxedBaseProperties.get(CONFIG_PATHS_KEY)).map(Object::toString),
+            Optional.ofNullable(relaxedEnvVariables.get(CONFIG_PATHS_KEY)))
+
+        .filter(Optional::isPresent).map(Optional::get)
+
+        .flatMap(configPaths -> Arrays.stream(configPaths.split(",")))
+
+        .map(PinotConfiguration::loadProperties);
+
+    return Stream.concat(Stream.of(relaxedBaseProperties, relaxedEnvVariables).map(MapConfiguration::new),
+        propertiesFromConfigPaths).collect(Collectors.toList());
+  }
+
+  private static String getProperty(String name, Configuration configuration) {
+    return Optional.of(configuration.getStringArray(relaxPropertyName(name)))
+
+        .filter(values -> values.length > 0)
+
+        .map(Arrays::stream)
+
+        .map(stream -> stream.collect(Collectors.joining(",")))
+
+        .orElse(null);
+  }
+
+  private static Configuration loadProperties(String configPath) {
+    try {
+      PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+
+      propertiesConfiguration.setIOFactory(new ConfigFilePropertyReaderFactory());
+      if (configPath.startsWith("classpath:")) {
+        propertiesConfiguration
+            .load(PinotConfiguration.class.getResourceAsStream(configPath.substring("classpath:".length())));
+      } else {
+        propertiesConfiguration.load(configPath);
+      }
+
+      return propertiesConfiguration;
+    } catch (ConfigurationException e) {
+      throw new RuntimeException("Could not read properties from " + configPath, e);
+    }
+  }
+
+  private static Map<String, Object> relaxConfigurationKeys(Configuration configuration) {
+    return CommonsConfigurationUtils.getKeysStream(configuration)
+
+        .collect(Collectors.toMap(PinotConfiguration::relaxPropertyName, key -> getProperty(key, configuration)));
+  }
+
+  private static Map<String, String> relaxEnvironmentVariables(Map<String, String> environmentVariables) {
+    return environmentVariables.entrySet().stream().filter(entry -> entry.getKey().startsWith("PINOT_"))
+        .collect(Collectors.toMap(PinotConfiguration::relaxEnvVarName, Entry::getValue));
+  }
+
+  private static String relaxEnvVarName(Entry<String, String> envVarEntry) {
+    return envVarEntry.getKey().substring(6).replace("_", ".").toLowerCase();
+  }
+
+  private static Map<String, Object> relaxProperties(Map<String, Object> properties) {
+    return properties.entrySet().stream()
+        .collect(Collectors.toMap(PinotConfiguration::relaxPropertyName, Entry::getValue));
+  }
+
+  private static String relaxPropertyName(Entry<String, Object> propertyEntry) {
+    return relaxPropertyName(propertyEntry.getKey());
+  }
+
+  private static String relaxPropertyName(String propertyName) {
+    return propertyName.replace("-", "").replace("_", "").toLowerCase();
+  }
+
+  /**
+   * Overwrites a property value in memory.
+   * 
+   * @param name of the property to append in memory. Applies relaxed binding on the property name.
+   * @param value to overwrite in memory
+   * 
+   * @deprecated Configurations should be immutable. Prefer creating a new {@link #PinotConfiguration} with base properties to overwrite properties.
+   */
+  public void addProperty(String name, Object value) {
+    configuration.addProperty(relaxPropertyName(name), value);
+  }
+
+  /**
+   * Creates a new instance of {@link PinotConfiguration} by closing the underlying {@link CompositeConfiguration}. 
+   * Useful to mutate configurations {@link PinotConfiguration} without impacting the original configurations.
+   * 
+   *  @return a new {@link PinotConfiguration} instance with a cloned {@link CompositeConfiguration}.
+   */
+  public PinotConfiguration clone() {
+    return new PinotConfiguration(configuration);
+  }
+
+  /**
+   * Check if the configuration contains the specified key after being sanitized.
+   * @param key to sanitized and lookup 
+   * @return true if key exists.
+   */
+  public boolean containsKey(String key) {
+    return configuration.containsKey(relaxPropertyName(key));
+  }
+
+  /**
+   * @return all the sanitized keys defined in the underlying {@link CompositeConfiguration}.
+   */
+  public List<String> getKeys() {
+    return CommonsConfigurationUtils.getKeys(configuration);
+  }
+
+  /**
+   * Retrieves a String value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * If multiple properties exists with the same key, all values will be joined as a comma separated String.
+   * 
+   * @param name of the property to retrieve a value. Property name will be sanitized. 
+   * @return the property String value. Null if missing.
+   */
+  public String getProperty(String name) {
+    return getProperty(name, configuration);
+  }
+
+  /**
+   * Retrieves a boolean value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * @param name of the property to retrieve a value. Property name will be sanitized. 
+   * @return the property boolean value. Fallback to default value if missing.
+   */
+  public boolean getProperty(String name, boolean defaultValue) {
+    return getProperty(name, defaultValue, Boolean.class);
+  }
+
+  /**
+   * Retrieves a typed value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * @param name of the property to retrieve a value. Property name will be sanitized.
+   * @param returnType a class reference of the value type.
+   * @return the typed configuration value. Null if missing. 
+   */
+  public <T> T getProperty(String name, Class<T> returnType) {
+    return getProperty(name, null, returnType);
+  }
+
+  /**
+   * Retrieves a double value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * @param name of the property to retrieve a value. Property name will be sanitized. 
+   * @return the property double value. Fallback to default value if missing.
+   */
+  public double getProperty(String name, double defaultValue) {
+    return getProperty(name, defaultValue, Double.class);
+  }
+
+  /**
+   * Retrieves a integer value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * @param name of the property to retrieve a value. Property name will be sanitized. 
+   * @return the property integer value. Fallback to default value if missing.
+   */
+  public int getProperty(String name, int defaultValue) {
+    return getProperty(name, defaultValue, Integer.class);
+  }
+
+  /**
+   * Retrieves a list of String values with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * @param name of the property to retrieve a list of values. Property name will be sanitized. 
+   * @return the property String value. Fallback to the provided default values if no property is found.
+   */
+  public List<String> getProperty(String name, List<String> defaultValues) {
+    return Optional
+        .of(Arrays.stream(configuration.getStringArray(relaxPropertyName(name))).collect(Collectors.toList()))
+        .filter(list -> !list.isEmpty()).orElse(defaultValues);
+  }
+
+  /**
+   * Retrieves a long value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * @param name of the property to retrieve a value. Property name will be sanitized. 
+   * @return the property long value. Fallback to default value if missing.
+   */
+  public long getProperty(String name, long defaultValue) {
+    return getProperty(name, defaultValue, Long.class);
+  }
+
+  /**
+   * Retrieves a String value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * @param name of the property to retrieve a value. Property name will be sanitized. 
+   * @return the property String value. Fallback to default value if missing.
+   */
+  public String getProperty(String name, String defaultValue) {
+    return getRawProperty(name, defaultValue).toString();
+  }
+
+  private <T> T getProperty(String name, T defaultValue, Class<T> returnType) {
+    String relaxedPropertyName = relaxPropertyName(name);
+    if (!configuration.containsKey(relaxedPropertyName)) {
+      return defaultValue;
+    }
+
+    return PropertyConverter.convert(getRawProperty(name, defaultValue), returnType);
+  }
+
+  /**
+   * Returns the raw object stored within the underlying {@link CompositeConfiguration}. 
+   * 
+   * See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * @param name of the property to retrieve a raw object value. Property name will be sanitized.
+   * @return the object referenced. Null if key is not found.
+   */
+  public Object getRawProperty(String name) {
+    return getRawProperty(name, null);
+  }
+
+  /**
+   * Returns the raw object stored within the underlying {@link CompositeConfiguration}. 
+   * 
+   * See {@link PinotConfiguration} for supported key naming conventions.
+   * 
+   * @param name of the property to retrieve a raw object value. Property name will be sanitized.
+   * @return the object referenced. Fallback to provided default value if key is not found.
+   */
+  public Object getRawProperty(String name, Object defaultValue) {
+    String relaxedPropertyName = relaxPropertyName(name);
+    if (!configuration.containsKey(relaxedPropertyName)) {
+      return defaultValue;
+    }
+
+    return configuration.getProperty(relaxedPropertyName);
+  }
+
+  /**
+   * Overwrites a property value in memory.
+   * 
+   * @param name of the property to overwrite in memory. Applies relaxed binding on the property name.
+   * @param value to overwrite in memory
+   * 
+   * @deprecated Configurations should be immutable. Prefer creating a new {@link #PinotConfiguration} with base properties to overwrite properties.
+   */
+  public void setProperty(String name, Object value) {
+    configuration.setProperty(relaxPropertyName(name), value);
+  }
+
+  /**
+   * <p>
+   * Creates a copy of the configuration only containing properties matching a property prefix. 
+   * Changes made on the source {@link PinotConfiguration} will not be available in the subset instance
+   * since properties are copied.
+   * </p>
+   * 
+   * <p>
+   * The prefix is removed from the keys in the subset. See {@link Configuration#subset(String)} for further details.
+   * </p>
+   * 
+   * @param prefix of the properties to copy. Applies relaxed binding on the properties prefix.
+   * @return a new {@link PinotConfiguration} instance with 
+   */
+  public PinotConfiguration subset(String prefix) {
+    return new PinotConfiguration(configuration.subset(relaxPropertyName(prefix)));
+  }
+
+  /**
+   * @return a key-value {@link Map} found in the underlying {@link CompositeConfiguration}
+   */
+  public Map<String, Object> toMap() {
+    return CommonsConfigurationUtils.toMap(configuration);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PropertyConverter.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PropertyConverter.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.env;
+
+public abstract class PropertyConverter {
+  @SuppressWarnings("unchecked")
+  public static <T> T convert(Object value, Class<T> returnType) {
+    if (Integer.class.equals(returnType)) {
+      return (T) Integer.valueOf(value.toString());
+    } else if (Boolean.class.equals(returnType)) {
+      return (T) Boolean.valueOf(value.toString());
+    } else if (Long.class.equals(returnType)) {
+      return (T) Long.valueOf(value.toString());
+    } else if (Double.class.equals(returnType)) {
+      return (T) Double.valueOf(value.toString());
+    } else {
+      throw new IllegalArgumentException(returnType + " is not a supported type for conversion.");
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/SystemEnvironment.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/SystemEnvironment.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.env;
+
+import java.util.Map;
+
+
+public class SystemEnvironment implements Environment {
+
+  @Override
+  public Map<String, String> getEnvironmentVariables() {
+    return System.getenv();
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -30,8 +30,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -41,7 +42,7 @@ import org.apache.commons.io.FileUtils;
 public class LocalPinotFS extends PinotFS {
 
   @Override
-  public void init(Configuration configuration) {
+  public void init(PinotConfiguration configuration) {
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -27,9 +27,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.apache.commons.configuration.Configuration;
+
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * Initializes the configurations specific to that filesystem. For instance, any security related parameters can be
    * initialized here and will not be logged.
    */
-  public abstract void init(Configuration config);
+  public abstract void init(PinotConfiguration config);
 
   /**
    * Creates a new directory. If parent directories are not created, it will create them.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/services/ServiceStartable.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/services/ServiceStartable.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.spi.services;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -31,7 +31,7 @@ public interface ServiceStartable {
 
   String getInstanceId();
 
-  Configuration getConfig();
+  PinotConfiguration getConfig();
 
   void start()
       throws Exception;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.env;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class PinotConfigurationTest {
+  @Test
+  public void assertPropertyPriorities() throws IOException {
+    Map<String, Object> cliArguments = new HashMap<>();
+    Map<String, String> mockedEnvironmentVariables = new HashMap<>();
+
+    String configFile2 = File.createTempFile("pinot-configuration-test-2", ".properties").getAbsolutePath();
+    String configFile3 = File.createTempFile("pinot-configuration-test-3", ".properties").getAbsolutePath();
+
+    cliArguments.put("controller.host", "cli-argument-controller-host");
+    cliArguments.put("config.paths", "classpath:/pinot-configuration-1.properties");
+    mockedEnvironmentVariables.put("PINOT_CONTROLLER_HOST", "env-var-controller-host");
+    mockedEnvironmentVariables.put("PINOT_CONTROLLER_PORT", "env-var-controller-port");
+    mockedEnvironmentVariables.put("PINOT_RELAXEDPROPERTY_TEST", "true");
+    mockedEnvironmentVariables.put("PINOT_CONFIG_PATHS", configFile2 + "," + configFile3);
+
+    copyClasspathResource("/pinot-configuration-2.properties", configFile2);
+    copyClasspathResource("/pinot-configuration-3.properties", configFile3);
+
+    PinotConfiguration configuration = new PinotConfiguration(cliArguments, mockedEnvironmentVariables);
+
+    // Tests that cli arguments have the highest priority.
+    Assert.assertEquals(configuration.getProperty("controller.host"), "cli-argument-controller-host");
+
+    // Tests that environment variable have priority overs config.paths properties.
+    Assert.assertEquals(configuration.getProperty("controller.port"), "env-var-controller-port");
+
+    // Tests that config.paths properties provided through cli arguments are prioritized.
+    Assert.assertEquals(configuration.getProperty("controller.cluster-name"), "config-path-1-cluster-name");
+
+    // Tests that config.paths properties provided through environment variables are available.
+    Assert.assertEquals(configuration.getProperty("controller.timeout"), "config-path-2-timeout");
+
+    // Tests a priority of a property available in both config files of a config.paths array. 
+    Assert.assertEquals(configuration.getProperty("controller.config-paths-multi-value-test-1"),
+        "config-path-2-config-paths-multi-value-test-1");
+
+    // Tests properties provided through the last config file of a config.paths array. 
+    Assert.assertEquals(configuration.getProperty("controller.config-paths-multi-value-test-2"),
+        "config-path-3-config-paths-multi-value-test-2");
+
+    // Tests relaxed binding on environment variables
+    Assert.assertEquals(configuration.getProperty("relaxed-property.test"), "true");
+  }
+
+  private void copyClasspathResource(String classpathResource, String target) throws IOException {
+    try (InputStream inputStream = PinotConfigurationTest.class.getResourceAsStream(classpathResource)) {
+      Files.copy(inputStream, Paths.get(target), StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
@@ -22,8 +22,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.Configuration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,16 +34,16 @@ public class PinotFSFactoryTest {
 
   @Test
   public void testDefaultPinotFSFactory() {
-    PinotFSFactory.init(new BaseConfiguration());
+    PinotFSFactory.init(new PinotConfiguration());
     Assert.assertTrue(PinotFSFactory.create("file") instanceof LocalPinotFS);
   }
 
   @Test
   public void testCustomizedSegmentFetcherFactory() {
-    Configuration config = new BaseConfiguration();
-    config.addProperty("class.file", LocalPinotFS.class.getName());
-    config.addProperty("class.test", TestPinotFS.class.getName());
-    PinotFSFactory.init(config);
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("class.file", LocalPinotFS.class.getName());
+    properties.put("class.test", TestPinotFS.class.getName());
+    PinotFSFactory.init(new PinotConfiguration(properties));
 
     PinotFS testPinotFS = PinotFSFactory.create("test");
     Assert.assertTrue(testPinotFS instanceof TestPinotFS);
@@ -58,7 +60,7 @@ public class PinotFSFactoryTest {
     }
 
     @Override
-    public void init(Configuration configuration) {
+    public void init(PinotConfiguration configuration) {
       initCalled++;
     }
 

--- a/pinot-spi/src/test/resources/pinot-configuration-1.properties
+++ b/pinot-spi/src/test/resources/pinot-configuration-1.properties
@@ -1,0 +1,3 @@
+controller.host=config-path-1-controller-host
+controller.port=config-path-1-controller-port
+controller.cluster-name=config-path-1-cluster-name

--- a/pinot-spi/src/test/resources/pinot-configuration-2.properties
+++ b/pinot-spi/src/test/resources/pinot-configuration-2.properties
@@ -1,0 +1,5 @@
+controller.host=config-path-2-controller-host
+controller.port=config-path-2-controller-port
+controller.cluster-name=config-path-2-cluster-name
+controller.timeout=config-path-2-timeout
+controller.config-paths-multi-value-test-1=config-path-2-config-paths-multi-value-test-1

--- a/pinot-spi/src/test/resources/pinot-configuration-3.properties
+++ b/pinot-spi/src/test/resources/pinot-configuration-3.properties
@@ -1,0 +1,2 @@
+controller.config-paths-multi-value-test-1=config-path-3-config-paths-multi-value-test-1
+controller.config-paths-multi-value-test-2=config-path-3-config-paths-multi-value-test-2

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -29,8 +29,9 @@ import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.utils.PinotConfigUtils;
 
@@ -107,7 +108,7 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     pidFile.close();
   }
 
-  PropertiesConfiguration readConfigFromFile(String configFileName)
+  Map<String, Object> readConfigFromFile(String configFileName)
       throws ConfigurationException {
     return PinotConfigUtils.readConfigFromFile(configFileName);
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -19,7 +19,8 @@
 package org.apache.pinot.tools.admin.command;
 
 import java.io.File;
-import org.apache.commons.configuration.Configuration;
+import java.util.Map;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
 import org.apache.pinot.common.utils.CommonConstants;
@@ -120,7 +121,7 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
     }
   }
 
-  private Configuration getBrokerConf()
+  private Map<String, Object> getBrokerConf()
       throws ConfigurationException {
     if (_configFileName != null) {
       return PinotConfigUtils.readConfigFromFile(_configFileName);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -21,7 +21,8 @@ package org.apache.pinot.tools.admin.command;
 import java.io.File;
 import java.net.SocketException;
 import java.net.UnknownHostException;
-import org.apache.commons.configuration.Configuration;
+import java.util.Map;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.controller.ControllerConf;
@@ -137,19 +138,19 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
     }
   }
 
-  private Configuration getControllerConf()
+  private Map<String, Object> getControllerConf()
       throws ConfigurationException, SocketException, UnknownHostException {
-    ControllerConf conf;
+    Map<String, Object> properties;
     if (_configFileName != null) {
-      conf = PinotConfigUtils.generateControllerConf(_configFileName);
+      properties = PinotConfigUtils.generateControllerConf(_configFileName);
     } else {
       if (_controllerHost == null) {
         _controllerHost = NetUtil.getHostAddress();
       }
-      conf = PinotConfigUtils
+      properties = PinotConfigUtils
           .generateControllerConf(_zkAddress, _clusterName, _controllerHost, _controllerPort, _dataDir, _controllerMode,
               _tenantIsolation);
     }
-    return conf;
+    return properties;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -21,7 +21,8 @@ package org.apache.pinot.tools.admin.command;
 import java.io.File;
 import java.net.SocketException;
 import java.net.UnknownHostException;
-import org.apache.commons.configuration.Configuration;
+import java.util.Map;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.spi.services.ServiceRole;
@@ -145,7 +146,7 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
   }
 
 
-  private Configuration getServerConf()
+  private Map<String, Object> getServerConf()
       throws ConfigurationException, SocketException, UnknownHostException {
     if (_configFileName != null) {
       return PinotConfigUtils.readConfigFromFile(_configFileName);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkDriver.java
@@ -18,24 +18,23 @@
  */
 package org.apache.pinot.tools.filesystem;
 
-import com.google.common.base.Preconditions;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.security.MessageDigest;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
-import org.apache.pinot.spi.plugin.PluginManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 
 public class PinotFSBenchmarkDriver {
@@ -56,7 +55,7 @@ public class PinotFSBenchmarkDriver {
   public PinotFSBenchmarkDriver(String mode, String configFilePath, String baseDirectoryUri, String localTempDir,
       Integer numSegmentsForListFilesTest, Integer dataSizeInMBsForCopyTest, Integer numOps) throws ConfigurationException {
     Configuration configuration = new PropertiesConfiguration(new File(configFilePath));
-    PinotFSFactory.init(configuration);
+    PinotFSFactory.init(new PinotConfiguration(configuration));
     _mode = mode;
     _baseDirectoryUri = URI.create(baseDirectoryUri);
     _pinotFS = PinotFSFactory.create(_baseDirectoryUri.getScheme());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
@@ -18,25 +18,26 @@
  */
 package org.apache.pinot.tools.service;
 
-import com.google.common.collect.ImmutableList;
+import static org.apache.pinot.tools.utils.PinotConfigUtils.getAvailablePort;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
+
 import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
 import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerStarter;
 import org.apache.pinot.server.starter.helix.HelixServerStarter;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
 import org.apache.pinot.tools.service.api.resources.PinotInstanceStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.tools.utils.PinotConfigUtils.getAvailablePort;
+import com.google.common.collect.ImmutableList;
 
 
 /**
@@ -82,15 +83,15 @@ public class PinotServiceManager {
     pinotServiceManager.start();
   }
 
-  public String startRole(ServiceRole role, Configuration conf)
+  public String startRole(ServiceRole role, Map<String, Object> properties)
       throws Exception {
     switch (role) {
       case CONTROLLER:
-        return startController(new ControllerConf(conf));
+        return startController(new ControllerConf(properties));
       case BROKER:
-        return startBroker(conf);
+        return startBroker(new PinotConfiguration(properties));
       case SERVER:
-        return startServer(conf);
+        return startServer(new PinotConfiguration(properties));
     }
     return null;
   }
@@ -116,10 +117,10 @@ public class PinotServiceManager {
     return instanceId;
   }
 
-  public String startBroker(Configuration brokerConf)
+  public String startBroker(PinotConfiguration brokerConf)
       throws Exception {
     LOGGER.info("Trying to start Pinot Broker...");
-    String brokerHost = brokerConf.getString("broker.host");
+    String brokerHost = brokerConf.getProperty("broker.host");
     HelixBrokerStarter brokerStarter;
     try {
       brokerStarter = new HelixBrokerStarter(brokerConf, _clusterName, _zkAddress, brokerHost);
@@ -139,7 +140,7 @@ public class PinotServiceManager {
     return instanceId;
   }
 
-  public String startServer(Configuration serverConf)
+  public String startServer(PinotConfiguration serverConf)
       throws Exception {
     LOGGER.info("Trying to start Pinot Server...");
     HelixServerStarter serverStarter = new HelixServerStarter(_clusterName, _zkAddress, serverConf);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotInstanceStatus.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotInstanceStatus.java
@@ -19,24 +19,24 @@
 package org.apache.pinot.tools.service.api.resources;
 
 import java.util.Map;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationConverter;
+
 import org.apache.pinot.common.utils.ServiceStatus;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.services.ServiceRole;
 
 
 public class PinotInstanceStatus {
   private final ServiceRole _serviceRole;
   private final String _instanceId;
-  private final Map _config;
+  private final Map<String, Object> _config;
   private final ServiceStatus.Status _serviceStatus;
   private final String _statusDescription;
 
-  public PinotInstanceStatus(ServiceRole serviceRole, String instanceId, Configuration config,
+  public PinotInstanceStatus(ServiceRole serviceRole, String instanceId, PinotConfiguration config,
       ServiceStatus.Status serviceStatus, String statusDescription) {
     _serviceRole = serviceRole;
     _instanceId = instanceId;
-    _config = ConfigurationConverter.getMap(config);
+    _config = config.toMap();
     _serviceStatus = serviceStatus;
     _statusDescription = statusDescription;
   }
@@ -53,7 +53,11 @@ public class PinotInstanceStatus {
     return _instanceId;
   }
 
-  public Map getConfig() {
+  public Map<String, Object> getConfig() {
     return _config;
+  }
+
+  public ServiceStatus.Status getServiceStatus() {
+    return _serviceStatus;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -398,10 +398,15 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.5</version>
       </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.1</version>
+    </dependency>
       <dependency>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
-        <version>1.6</version>
+        <version>1.10</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
## Description

**DISCLAIMER** : This PR looks scarier than it is :)

This change introduces configuration externalization to work with different environments. Properties can now be loaded from properties files, YAML files, environment variables, and command-line arguments to externalize configuration independently.  Properties are now accessible from a `PinotConfiguration` class which act has an adapter to Apache Commons  Configuration. This initial phase does not change how services are started and how they are configured. A future commit will enable properties loaded from `PINOT_X` environment variables. 

## Motivation

In order to ease cloud native deployments of Pinot, it is a general best practice to allow software to be configured with environment variables or CLI arguments. Config file based configuration is not considered best practice as it requires additional effort to mount volumes and maintain the property files. CLI arguments and environment variables are easily referred in an helm chart, a docker-compose manifest or simple docker run commands.

## Features:

### Configuration overwrite priority:

Constructing a `PinotConfiguration` instance offers the opportunity to provide base properties and environment variables. Properties will also be loaded from any config file referenced with a `config.paths` property found in the base properties or  environment variables. The priority is established as follow: `Base properties > Env variables > Config Files`

As explained previously, this initial phase only loads properties from existing CLI commands and config files (`Base properties > Config Files`).

### Property relaxed binding

The `PinotConfiguration` class introduces a relaxed property binding mechanism to help, as much as possible, to follow support different property naming conventions such as kebab case, camel case, snake case and system environment variables for operating system with strict rules. For example, Linux shell variables can contain only letters (a to z or A to Z), numbers (0 to 9) or the underscore character (_). By convention, Unix shell variables will also have their names in UPPERCASE. 

The following table provides example of all valid combination to define the `controller.submodule.alerts.emailaddress` property. Any the supported naming convention can be used to define and retrieve properties.

Property | Note
-- | --
controller.sub-module.alerts.email-address | Kebab case, which is recommended for use in .properties and .yml files.
controller.subModule.alerts.emailAddress | Standard camel case syntax.
controller.sub_module.alerts.email_address | Snake case notation, which is an alternative format for use in .properties and .yml files.
PINOT_CONTROLLER_SUBMODULE_ALERTS_EMAILADDRESS | Upper case format, which is recommended when using system environment variables.

## Side effects of the change:

This first phase of the refactoring only introduces the new `PinotConfiguration` abstraction. The dependency  `org.apache.commons.configuration.Configuration` used to be to be referred in a big portion of the Pinot codebase. It has  been replaced by the Pinot specific `PinotConfiguration` class. This change will simplify a future upgrade of Apache Commons Configuration from 1.x to 2.x that introduces new package namespaces and breaking changes.

## Breaking change and upgrade notes

No impact or configuration changes on standard deployments. With Apache Commons Configuration, duplicate properties may be defined and will be made available as string array values. Prior to this change, retrieving a property with `getString` would return the first occurrences of the duplicate property. Using `getStringArray` would return all occurrences. With this new change, duplicate properties defined from multiple sources (eg: env variables and properties files) will be overwritten using the overwrite priority described earlier. Array properties now needs to be defined as a comma separated string from a single properties. Duplicate properties from difference sources will not be merged to an array property. Only the property highest priority source will be available from `PinotConfiguration.getProperty`.

## Notes for reviewers:

The change impacts a large portion of the codebase. While it can be scary, the changes represents mostly a replacement of `org.apache.commons.configuration.Configuration` to `org.apache.pinot.spi.env.PinotConfiguration`. The following classes should be the main area of attention for the review:
* `org.apache.pinot.spi.env.PinotConfiguration`
* `org.apache.pinot.controller.ControllerConf`
* `org.apache.pinot.tools.utils.PinotConfigUtils`
* `org.apache.pinot.spi.env.CommonsConfigurationUtils`
* `org.apache.pinot.spi.env.Environment`
* `org.apache.pinot.spi.env.SystemEnvironment`

## Release Notes

No release note required since these changes are not user facing yet.

## Documentation

No documentation change required since these changes are not user facing yet. Future phase of this refactoring will enable environment variables properties and include documentation changes to expose the relaxed binding mechanism.