### PR TITLE
[QueryContext] Use QueryContext in functions

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -466,7 +466,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (functionCall == null) {
       return;
     }
-    switch (functionCall.getOperator()) {
+    switch (functionCall.getOperator().toUpperCase()) {
       case "DISTINCTCOUNTHLL":
       case "DISTINCTCOUNTHLLMV":
       case "DISTINCTCOUNTRAWHLL":

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/FilterQueryTree.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/FilterQueryTree.java
@@ -20,12 +20,10 @@ package org.apache.pinot.common.utils.request;
 
 import java.util.List;
 import org.apache.pinot.common.request.FilterOperator;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 
 
 public class FilterQueryTree {
   private final String column;
-  private final TransformExpressionTree _expression;
   private final List<String> value;
   private final FilterOperator operator;
   private final List<FilterQueryTree> children;
@@ -35,19 +33,10 @@ public class FilterQueryTree {
     this.value = value;
     this.operator = operator;
     this.children = children;
-    if (column != null) {
-      _expression = TransformExpressionTree.compileToExpressionTree(column);
-    } else {
-      _expression = null;
-    }
   }
 
   public String getColumn() {
     return column;
-  }
-
-  public TransformExpressionTree getExpression() {
-    return _expression;
   }
 
   public List<String> getValue() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -20,12 +20,8 @@ package org.apache.pinot.common.utils.request;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.commons.lang.mutable.MutableInt;
@@ -37,9 +33,6 @@ import org.apache.pinot.common.request.FilterQueryMap;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.Literal;
-import org.apache.pinot.common.request.Selection;
-import org.apache.pinot.common.request.SelectionSort;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.pql.parsers.pql2.ast.AstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.FloatingPointLiteralAstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.FunctionCallAstNode;
@@ -244,59 +237,6 @@ public class RequestUtils {
     }
 
     return new FilterQueryTree(q.getColumn(), q.getValue(), q.getOperator(), c);
-  }
-
-  /**
-   * Extracts all columns from the given filter query tree.
-   */
-  public static Set<String> extractFilterColumns(FilterQueryTree root) {
-    Set<String> filterColumns = new HashSet<>();
-    if (root.getChildren() == null) {
-      root.getExpression().getColumns(filterColumns);
-    } else {
-      Stack<FilterQueryTree> stack = new Stack<>();
-      stack.add(root);
-      while (!stack.empty()) {
-        FilterQueryTree node = stack.pop();
-        for (FilterQueryTree child : node.getChildren()) {
-          if (child.getChildren() == null) {
-            child.getExpression().getColumns(filterColumns);
-          } else {
-            stack.push(child);
-          }
-        }
-      }
-    }
-    return filterColumns;
-  }
-
-  /**
-   * Extracts all columns from the given expressions.
-   */
-  public static Set<String> extractColumnsFromExpressions(Set<TransformExpressionTree> expressions) {
-    Set<String> expressionColumns = new HashSet<>();
-    for (TransformExpressionTree expression : expressions) {
-      expression.getColumns(expressionColumns);
-    }
-    return expressionColumns;
-  }
-
-  /**
-   * Extracts all columns from the given selection, '*' will be ignored.
-   */
-  public static Set<String> extractSelectionColumns(Selection selection) {
-    Set<String> selectionColumns = new LinkedHashSet<>();
-    for (String selectionColumn : selection.getSelectionColumns()) {
-      if (!selectionColumn.equals("*")) {
-        selectionColumns.add(selectionColumn);
-      }
-    }
-    if (selection.getSelectionSortSequence() != null) {
-      for (SelectionSort selectionSort : selection.getSelectionSortSequence()) {
-        selectionColumns.add(selectionSort.getColumn());
-      }
-    }
-    return selectionColumns;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOperator.java
@@ -105,8 +105,7 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
     AtomicInteger numGroups = new AtomicInteger();
     ConcurrentLinkedQueue<ProcessingException> mergedProcessingExceptions = new ConcurrentLinkedQueue<>();
 
-    AggregationFunction[] aggregationFunctions =
-        AggregationFunctionUtils.getAggregationFunctions(_queryContext.getBrokerRequest());
+    AggregationFunction[] aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(_queryContext);
     int numAggregationFunctions = aggregationFunctions.length;
 
     // We use a CountDownLatch to track if all Futures are finished by the query timeout, and cancel the unfinished

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/CombineGroupByOrderByOperator.java
@@ -98,8 +98,7 @@ public class CombineGroupByOrderByOperator extends BaseOperator<IntermediateResu
    */
   @Override
   protected IntermediateResultsBlock getNextBlock() {
-    AggregationFunction[] aggregationFunctions =
-        AggregationFunctionUtils.getAggregationFunctions(_queryContext.getBrokerRequest());
+    AggregationFunction[] aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(_queryContext);
     int numAggregationFunctions = aggregationFunctions.length;
     assert _queryContext.getGroupByExpressions() != null;
     int numGroupByExpressions = _queryContext.getGroupByExpressions().size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/TransformBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/TransformBlock.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.core.operator.blocks;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.Block;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.BlockDocIdValueSet;
@@ -28,6 +26,7 @@ import org.apache.pinot.core.common.BlockMetadata;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.docvalsets.TransformBlockValSet;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 /**
@@ -36,10 +35,10 @@ import org.apache.pinot.core.operator.transform.function.TransformFunction;
  */
 public class TransformBlock implements Block {
   private final ProjectionBlock _projectionBlock;
-  private final Map<TransformExpressionTree, TransformFunction> _transformFunctionMap;
+  private final Map<ExpressionContext, TransformFunction> _transformFunctionMap;
 
-  public TransformBlock(@Nonnull ProjectionBlock projectionBlock,
-      @Nonnull Map<TransformExpressionTree, TransformFunction> transformFunctionMap) {
+  public TransformBlock(ProjectionBlock projectionBlock,
+      Map<ExpressionContext, TransformFunction> transformFunctionMap) {
     _projectionBlock = projectionBlock;
     _transformFunctionMap = transformFunctionMap;
   }
@@ -48,9 +47,9 @@ public class TransformBlock implements Block {
     return _projectionBlock.getNumDocs();
   }
 
-  public BlockValSet getBlockValueSet(TransformExpressionTree expression) {
-    if (expression.isColumn()) {
-      return _projectionBlock.getBlockValueSet(expression.getValue());
+  public BlockValSet getBlockValueSet(ExpressionContext expression) {
+    if (expression.getType() == ExpressionContext.Type.IDENTIFIER) {
+      return _projectionBlock.getBlockValueSet(expression.getIdentifier());
     } else {
       return new TransformBlockValSet(_projectionBlock, _transformFunctionMap.get(expression));
     }
@@ -80,7 +79,7 @@ public class TransformBlock implements Block {
     throw new UnsupportedOperationException();
   }
 
-  public DocIdSetBlock getDocIdSetBlock(){
+  public DocIdSetBlock getDocIdSetBlock() {
     return _projectionBlock.getDocIdSetBlock();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
@@ -53,7 +53,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
       _dataSourceMap.put(column, segment.getDataSource(column));
     }
 
-    _transformFunction = TransformFunctionFactory.get(lhs.toTransformExpressionTree(), _dataSourceMap);
+    _transformFunction = TransformFunctionFactory.get(lhs, _dataSourceMap);
     _predicateEvaluator = PredicateEvaluatorProvider
         .getPredicateEvaluator(predicate, _transformFunction.getDictionary(),
             _transformFunction.getResultMetadata().getDataType());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOperator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator.query;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -27,6 +26,7 @@ import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.DefaultGroupByExecutor;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByExecutor;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.startree.executor.StarTreeGroupByExecutor;
 
 
@@ -34,11 +34,12 @@ import org.apache.pinot.core.startree.executor.StarTreeGroupByExecutor;
  * The <code>AggregationGroupByOperator</code> class provides the operator for aggregation group-by query on a single
  * segment.
  */
+@SuppressWarnings("rawtypes")
 public class AggregationGroupByOperator extends BaseOperator<IntermediateResultsBlock> {
   private static final String OPERATOR_NAME = "AggregationGroupByOperator";
 
   private final AggregationFunction[] _aggregationFunctions;
-  private final TransformExpressionTree[] _groupByExpressions;
+  private final ExpressionContext[] _groupByExpressions;
   private final int _maxInitialResultHolderCapacity;
   private final int _numGroupsLimit;
   private final TransformOperator _transformOperator;
@@ -47,9 +48,9 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
 
   private int _numDocsScanned = 0;
 
-  public AggregationGroupByOperator(AggregationFunction[] aggregationFunctions,
-      TransformExpressionTree[] groupByExpressions, int maxInitialResultHolderCapacity, int numGroupsLimit,
-      TransformOperator transformOperator, long numTotalDocs, boolean useStarTree) {
+  public AggregationGroupByOperator(AggregationFunction[] aggregationFunctions, ExpressionContext[] groupByExpressions,
+      int maxInitialResultHolderCapacity, int numGroupsLimit, TransformOperator transformOperator, long numTotalDocs,
+      boolean useStarTree) {
     _aggregationFunctions = aggregationFunctions;
     _groupByExpressions = groupByExpressions;
     _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator.query;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -28,6 +27,7 @@ import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.DefaultGroupByExecutor;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByExecutor;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.startree.executor.StarTreeGroupByExecutor;
 
 
@@ -35,23 +35,23 @@ import org.apache.pinot.core.startree.executor.StarTreeGroupByExecutor;
  * The <code>AggregationGroupByOrderByOperator</code> class provides the operator for aggregation group-by query on a
  * single segment.
  */
+@SuppressWarnings("rawtypes")
 public class AggregationGroupByOrderByOperator extends BaseOperator<IntermediateResultsBlock> {
   private static final String OPERATOR_NAME = "AggregationGroupByOrderByOperator";
 
-  private final DataSchema _dataSchema;
-
   private final AggregationFunction[] _aggregationFunctions;
-  private final TransformExpressionTree[] _groupByExpressions;
+  private final ExpressionContext[] _groupByExpressions;
   private final int _maxInitialResultHolderCapacity;
   private final int _numGroupsLimit;
   private final TransformOperator _transformOperator;
   private final long _numTotalDocs;
   private final boolean _useStarTree;
+  private final DataSchema _dataSchema;
 
   private int _numDocsScanned = 0;
 
   public AggregationGroupByOrderByOperator(AggregationFunction[] aggregationFunctions,
-      TransformExpressionTree[] groupByExpressions, int maxInitialResultHolderCapacity, int numGroupsLimit,
+      ExpressionContext[] groupByExpressions, int maxInitialResultHolderCapacity, int numGroupsLimit,
       TransformOperator transformOperator, long numTotalDocs, boolean useStarTree) {
     _aggregationFunctions = aggregationFunctions;
     _groupByExpressions = groupByExpressions;
@@ -70,7 +70,7 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
 
     // Extract column names and data types for group-by columns
     for (int i = 0; i < numGroupByExpressions; i++) {
-      TransformExpressionTree groupByExpression = groupByExpressions[i];
+      ExpressionContext groupByExpression = groupByExpressions[i];
       columnNames[i] = groupByExpression.toString();
       columnDataTypes[i] = DataSchema.ColumnDataType
           .fromDataTypeSV(_transformOperator.getResultMetadata(groupByExpression).getDataType());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
@@ -32,6 +32,7 @@ import org.apache.pinot.core.startree.executor.StarTreeAggregationExecutor;
 /**
  * The <code>AggregationOperator</code> class provides the operator for aggregation only query on a single segment.
  */
+@SuppressWarnings("rawtypes")
 public class AggregationOperator extends BaseOperator<IntermediateResultsBlock> {
   private static final String OPERATOR_NAME = "AggregationOperator";
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -21,12 +21,12 @@ package org.apache.pinot.core.operator.query;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 
 
@@ -40,6 +40,7 @@ import org.apache.pinot.core.segment.index.readers.Dictionary;
  * For min value, we use the first value from the dictionary
  * For max value we use the last value from dictionary
  */
+@SuppressWarnings("rawtypes")
 public class DictionaryBasedAggregationOperator extends BaseOperator<IntermediateResultsBlock> {
   private static final String OPERATOR_NAME = "DictionaryBasedAggregationOperator";
 
@@ -59,7 +60,7 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
     int numAggregationFunctions = _aggregationFunctions.length;
     List<Object> aggregationResults = new ArrayList<>(numAggregationFunctions);
     for (AggregationFunction aggregationFunction : _aggregationFunctions) {
-      String column = ((TransformExpressionTree) aggregationFunction.getInputExpressions().get(0)).getValue();
+      String column = ((ExpressionContext) aggregationFunction.getInputExpressions().get(0)).getIdentifier();
       Dictionary dictionary = _dictionaryMap.get(column);
       switch (aggregationFunction.getType()) {
         case MAX:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/EmptySelectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/EmptySelectionOperator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.query;
 
 import java.util.Collections;
 import java.util.List;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -28,8 +27,7 @@ import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 /**
@@ -43,16 +41,13 @@ public class EmptySelectionOperator extends BaseOperator<IntermediateResultsBloc
   private final DataSchema _dataSchema;
   private final ExecutionStatistics _executionStatistics;
 
-  public EmptySelectionOperator(IndexSegment indexSegment, QueryContext queryContext,
+  public EmptySelectionOperator(IndexSegment indexSegment, List<ExpressionContext> expressions,
       TransformOperator transformOperator) {
-    List<TransformExpressionTree> expressions =
-        SelectionOperatorUtils.extractExpressions(queryContext.getSelectExpressions(), indexSegment);
-
     int numExpressions = expressions.size();
     String[] columnNames = new String[numExpressions];
     DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numExpressions];
     for (int i = 0; i < numExpressions; i++) {
-      TransformExpressionTree expression = expressions.get(i);
+      ExpressionContext expression = expressions.get(i);
       TransformResultMetadata expressionMetadata = transformOperator.getResultMetadata(expression);
       columnNames[i] = expression.toString();
       columnDataTypes[i] =

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/MetadataBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/MetadataBasedAggregationOperator.java
@@ -34,6 +34,7 @@ import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 /**
  * Aggregation operator that utilizes metadata for serving aggregation queries.
  */
+@SuppressWarnings("rawtypes")
 public class MetadataBasedAggregationOperator extends BaseOperator<IntermediateResultsBlock> {
   private static final String OPERATOR_NAME = "MetadataBasedAggregationOperator";
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.query;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.RowBasedBlockValueFetcher;
@@ -31,6 +30,7 @@ import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 
@@ -40,7 +40,7 @@ public class SelectionOnlyOperator extends BaseOperator<IntermediateResultsBlock
 
   private final IndexSegment _indexSegment;
   private final TransformOperator _transformOperator;
-  private final List<TransformExpressionTree> _expressions;
+  private final List<ExpressionContext> _expressions;
   private final BlockValSet[] _blockValSets;
   private final DataSchema _dataSchema;
   private final int _numRowsToKeep;
@@ -49,17 +49,17 @@ public class SelectionOnlyOperator extends BaseOperator<IntermediateResultsBlock
   private int _numDocsScanned = 0;
 
   public SelectionOnlyOperator(IndexSegment indexSegment, QueryContext queryContext,
-      TransformOperator transformOperator) {
+      List<ExpressionContext> expressions, TransformOperator transformOperator) {
     _indexSegment = indexSegment;
     _transformOperator = transformOperator;
-    _expressions = SelectionOperatorUtils.extractExpressions(queryContext.getSelectExpressions(), indexSegment);
+    _expressions = expressions;
 
     int numExpressions = _expressions.size();
     _blockValSets = new BlockValSet[numExpressions];
     String[] columnNames = new String[numExpressions];
     DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numExpressions];
     for (int i = 0; i < numExpressions; i++) {
-      TransformExpressionTree expression = _expressions.get(i);
+      ExpressionContext expression = _expressions.get(i);
       TransformResultMetadata expressionMetadata = _transformOperator.getResultMetadata(expression);
       columnNames[i] = expression.toString();
       columnDataTypes[i] =

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.operator.transform;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -30,6 +29,7 @@ import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunctionFactory;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 
 
@@ -41,18 +41,18 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
 
   private final ProjectionOperator _projectionOperator;
   private final Map<String, DataSource> _dataSourceMap;
-  private final Map<TransformExpressionTree, TransformFunction> _transformFunctionMap = new HashMap<>();
+  private final Map<ExpressionContext, TransformFunction> _transformFunctionMap = new HashMap<>();
 
   /**
    * Constructor for the class
    *
    * @param projectionOperator Projection operator
-   * @param expressions Set of expressions to evaluate
+   * @param expressions Collection of expressions to evaluate
    */
-  public TransformOperator(ProjectionOperator projectionOperator, Collection<TransformExpressionTree> expressions) {
+  public TransformOperator(ProjectionOperator projectionOperator, Collection<ExpressionContext> expressions) {
     _projectionOperator = projectionOperator;
     _dataSourceMap = projectionOperator.getDataSourceMap();
-    for (TransformExpressionTree expression : expressions) {
+    for (ExpressionContext expression : expressions) {
       TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
       _transformFunctionMap.put(expression, transformFunction);
     }
@@ -73,7 +73,7 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
    * @param expression Expression
    * @return Transform result metadata
    */
-  public TransformResultMetadata getResultMetadata(TransformExpressionTree expression) {
+  public TransformResultMetadata getResultMetadata(ExpressionContext expression) {
     return _transformFunctionMap.get(expression).getResultMetadata();
   }
 
@@ -83,7 +83,7 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
    *
    * @return Dictionary
    */
-  public Dictionary getDictionary(TransformExpressionTree expression) {
+  public Dictionary getDictionary(ExpressionContext expression) {
     return _transformFunctionMap.get(expression).getDictionary();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.AggregationGroupByOrderByOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
@@ -44,7 +43,7 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
   private final int _maxInitialResultHolderCapacity;
   private final int _numGroupsLimit;
   private final AggregationFunction[] _aggregationFunctions;
-  private final TransformExpressionTree[] _groupByExpressions;
+  private final ExpressionContext[] _groupByExpressions;
   private final TransformPlanNode _transformPlanNode;
   private final StarTreeTransformPlanNode _starTreeTransformPlanNode;
 
@@ -53,14 +52,10 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
     _indexSegment = indexSegment;
     _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
     _numGroupsLimit = numGroupsLimit;
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext);
     List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
     assert groupByExpressions != null;
-    int numGroupByExpressions = groupByExpressions.size();
-    _groupByExpressions = new TransformExpressionTree[numGroupByExpressions];
-    for (int i = 0; i < numGroupByExpressions; i++) {
-      _groupByExpressions[i] = groupByExpressions.get(i).toTransformExpressionTree();
-    }
+    _groupByExpressions = groupByExpressions.toArray(new ExpressionContext[0]);
 
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
     if (starTrees != null) {
@@ -96,7 +91,7 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
       }
     }
 
-    Set<TransformExpressionTree> expressionsToTransform =
+    Set<ExpressionContext> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(_aggregationFunctions, _groupByExpressions);
     _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform);
     _starTreeTransformPlanNode = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
@@ -44,7 +43,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
   private final int _maxInitialResultHolderCapacity;
   private final int _numGroupsLimit;
   private final AggregationFunction[] _aggregationFunctions;
-  private final TransformExpressionTree[] _groupByExpressions;
+  private final ExpressionContext[] _groupByExpressions;
   private final TransformPlanNode _transformPlanNode;
   private final StarTreeTransformPlanNode _starTreeTransformPlanNode;
 
@@ -53,14 +52,10 @@ public class AggregationGroupByPlanNode implements PlanNode {
     _indexSegment = indexSegment;
     _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
     _numGroupsLimit = numGroupsLimit;
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext);
     List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
     assert groupByExpressions != null;
-    int numGroupByExpressions = groupByExpressions.size();
-    _groupByExpressions = new TransformExpressionTree[numGroupByExpressions];
-    for (int i = 0; i < numGroupByExpressions; i++) {
-      _groupByExpressions[i] = groupByExpressions.get(i).toTransformExpressionTree();
-    }
+    _groupByExpressions = groupByExpressions.toArray(new ExpressionContext[0]);
 
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
     if (starTrees != null) {
@@ -96,7 +91,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
       }
     }
 
-    Set<TransformExpressionTree> expressionsToTransform =
+    Set<ExpressionContext> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(_aggregationFunctions, _groupByExpressions);
     _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform);
     _starTreeTransformPlanNode = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -20,11 +20,11 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.StarTreeUtils;
@@ -46,7 +46,7 @@ public class AggregationPlanNode implements PlanNode {
 
   public AggregationPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     _indexSegment = indexSegment;
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext);
 
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
     if (starTrees != null) {
@@ -81,7 +81,7 @@ public class AggregationPlanNode implements PlanNode {
       }
     }
 
-    Set<TransformExpressionTree> expressionsToTransform =
+    Set<ExpressionContext> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(_aggregationFunctions, null);
     _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform);
     _starTreeTransformPlanNode = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedAggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedAggregationPlanNode.java
@@ -20,11 +20,11 @@ package org.apache.pinot.core.plan;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 
@@ -46,10 +46,10 @@ public class DictionaryBasedAggregationPlanNode implements PlanNode {
    */
   public DictionaryBasedAggregationPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     _indexSegment = indexSegment;
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext);
     _dictionaryMap = new HashMap<>();
     for (AggregationFunction aggregationFunction : _aggregationFunctions) {
-      String column = ((TransformExpressionTree) aggregationFunction.getInputExpressions().get(0)).getValue();
+      String column = ((ExpressionContext) aggregationFunction.getInputExpressions().get(0)).getIdentifier();
       _dictionaryMap.computeIfAbsent(column, k -> _indexSegment.getDataSource(k).getDictionary());
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/MetadataBasedAggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/MetadataBasedAggregationPlanNode.java
@@ -21,12 +21,12 @@ package org.apache.pinot.core.plan;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.query.MetadataBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 
 
@@ -47,11 +47,11 @@ public class MetadataBasedAggregationPlanNode implements PlanNode {
    */
   public MetadataBasedAggregationPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     _indexSegment = indexSegment;
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext);
     _dataSourceMap = new HashMap<>();
     for (AggregationFunction aggregationFunction : _aggregationFunctions) {
       if (aggregationFunction.getType() != AggregationFunctionType.COUNT) {
-        String column = ((TransformExpressionTree) aggregationFunction.getInputExpressions().get(0)).getValue();
+        String column = ((ExpressionContext) aggregationFunction.getInputExpressions().get(0)).getIdentifier();
         _dataSourceMap.computeIfAbsent(column, _indexSegment::getDataSource);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -18,10 +18,7 @@
  */
 package org.apache.pinot.core.plan;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -30,7 +27,6 @@ import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.core.operator.query.SelectionOrderByOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
-import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 
@@ -41,12 +37,14 @@ import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 public class SelectionPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
   private final QueryContext _queryContext;
+  private final List<ExpressionContext> _expressions;
   private final TransformPlanNode _transformPlanNode;
 
   public SelectionPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     _indexSegment = indexSegment;
     _queryContext = queryContext;
-    _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, collectExpressions());
+    _expressions = SelectionOperatorUtils.extractExpressions(queryContext, indexSegment);
+    _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, _expressions);
   }
 
   @Override
@@ -54,40 +52,12 @@ public class SelectionPlanNode implements PlanNode {
     TransformOperator transformOperator = _transformPlanNode.run();
     if (_queryContext.getLimit() > 0) {
       if (_queryContext.getOrderByExpressions() == null) {
-        return new SelectionOnlyOperator(_indexSegment, _queryContext, transformOperator);
+        return new SelectionOnlyOperator(_indexSegment, _queryContext, _expressions, transformOperator);
       } else {
-        return new SelectionOrderByOperator(_indexSegment, _queryContext, transformOperator);
+        return new SelectionOrderByOperator(_indexSegment, _queryContext, _expressions, transformOperator);
       }
     } else {
-      return new EmptySelectionOperator(_indexSegment, _queryContext, transformOperator);
+      return new EmptySelectionOperator(_indexSegment, _expressions, transformOperator);
     }
-  }
-
-  private Set<TransformExpressionTree> collectExpressions() {
-    Set<TransformExpressionTree> expressionTrees = new HashSet<>();
-
-    // Extract selection expressions
-    List<ExpressionContext> selectExpressions = _queryContext.getSelectExpressions();
-    if (selectExpressions.size() == 1 && selectExpressions.get(0).equals(SelectionOperatorUtils.IDENTIFIER_STAR)) {
-      for (String column : _indexSegment.getPhysicalColumnNames()) {
-        expressionTrees
-            .add(new TransformExpressionTree(TransformExpressionTree.ExpressionType.IDENTIFIER, column, null));
-      }
-    } else {
-      for (ExpressionContext selectExpression : selectExpressions) {
-        expressionTrees.add(selectExpression.toTransformExpressionTree());
-      }
-    }
-
-    // Extract order-by expressions
-    List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();
-    // NOTE: queries with LIMIT 0 are solved by EmptySelectionOperator where order-by expressions are not required.
-    if (_queryContext.getLimit() > 0 && orderByExpressions != null) {
-      for (OrderByExpressionContext orderByExpression : orderByExpressions) {
-        expressionTrees.add(orderByExpression.getExpression().toTransformExpressionTree());
-      }
-    }
-
-    return expressionTrees;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -21,11 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 /**
@@ -34,6 +34,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
  * @param <IntermediateResult> Intermediate result generated from segment
  * @param <FinalResult> Final result used in broker response
  */
+@SuppressWarnings("rawtypes")
 public interface AggregationFunction<IntermediateResult, FinalResult extends Comparable> {
 
   /**
@@ -53,9 +54,8 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
 
   /**
    * Returns a list of input expressions needed for performing aggregation.
-   *
    */
-  List<TransformExpressionTree> getInputExpressions();
+  List<ExpressionContext> getInputExpressions();
 
   /**
    * Accepts an aggregation function visitor to visit.
@@ -77,21 +77,21 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
    * Performs aggregation on the given block value sets (aggregation only).
    */
   void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap);
+      Map<ExpressionContext, BlockValSet> blockValSetMap);
 
   /**
    * Performs aggregation on the given group key array and block value sets (aggregation group-by on single-value
    * columns).
    */
   void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap);
+      Map<ExpressionContext, BlockValSet> blockValSetMap);
 
   /**
    * Performs aggregation on the given group keys array and block value sets (aggregation group-by on multi-value
    * columns).
    */
   void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap);
+      Map<ExpressionContext, BlockValSet> blockValSetMap);
 
   /**
    * Extracts the intermediate result from the aggregation result holder (aggregation only).

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import com.google.common.base.Preconditions;
 import com.google.common.math.DoubleMath;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,10 +32,11 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.request.AggregationInfo;
-import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.FunctionContext;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.parsers.CompilerConstants;
 
@@ -43,6 +44,7 @@ import org.apache.pinot.parsers.CompilerConstants;
 /**
  * The <code>AggregationFunctionUtils</code> class provides utility methods for aggregation function.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class AggregationFunctionUtils {
   private AggregationFunctionUtils() {
   }
@@ -66,17 +68,19 @@ public class AggregationFunctionUtils {
   }
 
   /**
-   * Creates an array of {@link AggregationFunction}s based on the given {@link BrokerRequest}.
+   * Creates an array of {@link AggregationFunction}s based on the given {@link QueryContext}.
    */
-  public static AggregationFunction[] getAggregationFunctions(BrokerRequest brokerRequest) {
-    List<AggregationInfo> aggregationInfos = brokerRequest.getAggregationsInfo();
-    int numAggregationFunctions = aggregationInfos.size();
-    AggregationFunction[] aggregationFunctions = new AggregationFunction[numAggregationFunctions];
-    for (int i = 0; i < numAggregationFunctions; i++) {
-      aggregationFunctions[i] =
-          AggregationFunctionFactory.getAggregationFunction(aggregationInfos.get(i), brokerRequest);
+  public static AggregationFunction[] getAggregationFunctions(QueryContext queryContext) {
+    List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
+    List<AggregationFunction> aggregationFunctions = new ArrayList<>(selectExpressions.size());
+    for (ExpressionContext selectExpression : selectExpressions) {
+      if (selectExpression.getType() == ExpressionContext.Type.FUNCTION
+          && selectExpression.getFunction().getType() == FunctionContext.Type.AGGREGATION) {
+        aggregationFunctions
+            .add(AggregationFunctionFactory.getAggregationFunction(selectExpression.getFunction(), queryContext));
+      }
     }
-    return aggregationFunctions;
+    return aggregationFunctions.toArray(new AggregationFunction[0]);
   }
 
   /**
@@ -91,12 +95,11 @@ public class AggregationFunctionUtils {
     if (aggregationFunctionType == AggregationFunctionType.COUNT) {
       return AggregationFunctionColumnPair.COUNT_STAR;
     }
-    //noinspection unchecked
-    List<TransformExpressionTree> inputExpressions = aggregationFunction.getInputExpressions();
+    List<ExpressionContext> inputExpressions = aggregationFunction.getInputExpressions();
     if (inputExpressions.size() == 1) {
-      TransformExpressionTree inputExpression = inputExpressions.get(0);
-      if (inputExpression.isColumn()) {
-        return new AggregationFunctionColumnPair(aggregationFunctionType, inputExpression.getValue());
+      ExpressionContext inputExpression = inputExpressions.get(0);
+      if (inputExpression.getType() == ExpressionContext.Type.IDENTIFIER) {
+        return new AggregationFunctionColumnPair(aggregationFunctionType, inputExpression.getIdentifier());
       }
     }
     return null;
@@ -128,26 +131,6 @@ public class AggregationFunctionUtils {
   }
 
   /**
-   * Utility function to parse percentile value from string.
-   * <p>Asserts that percentile value is within 0 and 100.
-   * <p>NOTE: When percentileString is from the second argument (e.g. percentile(foo, 99), percentileTDigest(bar, 95),
-   *          etc.), it might be standardized into single-quoted format.
-   *
-   * @param percentileString Input String
-   * @return Percentile value parsed from String.
-   */
-  public static int parsePercentile(String percentileString) {
-    int percentile;
-    if (percentileString.charAt(0) == '\'') {
-      percentile = Integer.parseInt(percentileString.substring(1, percentileString.length() - 1));
-    } else {
-      percentile = Integer.parseInt(percentileString);
-    }
-    Preconditions.checkState(percentile >= 0 && percentile <= 100);
-    return percentile;
-  }
-
-  /**
    * Helper function to concatenate arguments using separator.
    *
    * @param arguments Arguments to concatenate
@@ -163,11 +146,10 @@ public class AggregationFunctionUtils {
    * <p>NOTE: We don't need to consider order-by columns here as the ordering is only allowed for aggregation functions
    *          or group-by expressions.
    */
-  public static Set<TransformExpressionTree> collectExpressionsToTransform(AggregationFunction[] aggregationFunctions,
-      @Nullable TransformExpressionTree[] groupByExpressions) {
-    Set<TransformExpressionTree> expressions = new HashSet<>();
+  public static Set<ExpressionContext> collectExpressionsToTransform(AggregationFunction[] aggregationFunctions,
+      @Nullable ExpressionContext[] groupByExpressions) {
+    Set<ExpressionContext> expressions = new HashSet<>();
     for (AggregationFunction aggregationFunction : aggregationFunctions) {
-      //noinspection unchecked
       expressions.addAll(aggregationFunction.getInputExpressions());
     }
     if (groupByExpressions != null) {
@@ -180,20 +162,20 @@ public class AggregationFunctionUtils {
    * Creates a map from expression required by the {@link AggregationFunction} to {@link BlockValSet} fetched from the
    * {@link TransformBlock}.
    */
-  public static Map<TransformExpressionTree, BlockValSet> getBlockValSetMap(AggregationFunction aggregationFunction,
+  public static Map<ExpressionContext, BlockValSet> getBlockValSetMap(AggregationFunction aggregationFunction,
       TransformBlock transformBlock) {
     //noinspection unchecked
-    List<TransformExpressionTree> expressions = aggregationFunction.getInputExpressions();
+    List<ExpressionContext> expressions = aggregationFunction.getInputExpressions();
     int numExpressions = expressions.size();
     if (numExpressions == 0) {
       return Collections.emptyMap();
     }
     if (numExpressions == 1) {
-      TransformExpressionTree expression = expressions.get(0);
+      ExpressionContext expression = expressions.get(0);
       return Collections.singletonMap(expression, transformBlock.getBlockValueSet(expression));
     }
-    Map<TransformExpressionTree, BlockValSet> blockValSetMap = new HashMap<>();
-    for (TransformExpressionTree expression : expressions) {
+    Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
+    for (ExpressionContext expression : expressions) {
       blockValSetMap.put(expression, transformBlock.getBlockValueSet(expression));
     }
     return blockValSetMap;
@@ -205,10 +187,9 @@ public class AggregationFunctionUtils {
    * <p>NOTE: We construct the map with original column name as the key but fetch BlockValSet with the aggregation
    *          function pair so that the aggregation result column name is consistent with or without star-tree.
    */
-  public static Map<TransformExpressionTree, BlockValSet> getBlockValSetMap(
+  public static Map<ExpressionContext, BlockValSet> getBlockValSetMap(
       AggregationFunctionColumnPair aggregationFunctionColumnPair, TransformBlock transformBlock) {
-    TransformExpressionTree expression = new TransformExpressionTree(TransformExpressionTree.ExpressionType.IDENTIFIER,
-        aggregationFunctionColumnPair.getColumn(), null);
+    ExpressionContext expression = ExpressionContext.forIdentifier(aggregationFunctionColumnPair.getColumn());
     BlockValSet blockValSet = transformBlock.getBlockValueSet(aggregationFunctionColumnPair.toColumnName());
     return Collections.singletonMap(expression, blockValSet);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -29,14 +28,15 @@ import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<AvgPair, Double> {
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
-  public AvgAggregationFunction(String column) {
-    super(column);
+  public AvgAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -61,7 +61,7 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     if (blockValSet.getValueType() != DataType.BYTES) {
@@ -96,7 +96,7 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     if (blockValSet.getValueType() != DataType.BYTES) {
@@ -116,7 +116,7 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     if (blockValSet.getValueType() != DataType.BYTES) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
@@ -20,16 +20,16 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
-  public AvgMVAggregationFunction(String column) {
-    super(column);
+  public AvgMVAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     double sum = 0.0;
     long count = 0L;
@@ -60,7 +60,7 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       aggregateOnGroupKey(groupKeyArray[i], groupByResultHolder, valuesArray[i]);
@@ -69,7 +69,7 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseSingleInputAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseSingleInputAggregationFunction.java
@@ -20,38 +20,36 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Collections;
 import java.util.List;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 /**
  * Base implementation of {@link AggregationFunction} with single input expression.
  */
 public abstract class BaseSingleInputAggregationFunction<I, F extends Comparable> implements AggregationFunction<I, F> {
-  protected final String _column;
-  protected final TransformExpressionTree _expression;
+  protected final ExpressionContext _expression;
 
   /**
    * Constructor for the class.
    *
-   * @param column Column to aggregate on (could be column name or transform function).
+   * @param expression Expression to aggregate on.
    */
-  public BaseSingleInputAggregationFunction(String column) {
-    _column = column;
-    _expression = TransformExpressionTree.compileToExpressionTree(column);
+  public BaseSingleInputAggregationFunction(ExpressionContext expression) {
+    _expression = expression;
   }
 
   @Override
   public String getColumnName() {
-    return getType().getName() + "_" + _column;
+    return getType().getName() + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return getType().getName().toLowerCase() + "(" + _column + ")";
+    return getType().getName().toLowerCase() + "(" + _expression + ")";
   }
 
   @Override
-  public List<TransformExpressionTree> getInputExpressions() {
+  public List<ExpressionContext> getInputExpressions() {
     return Collections.singletonList(_expression);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -22,13 +22,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.DoubleAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.DoubleGroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 
 
@@ -37,9 +37,8 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
   private static final String RESULT_COLUMN_NAME = "count(*)";
   private static final double DEFAULT_INITIAL_VALUE = 0.0;
   // Special expression used by star-tree to pass in BlockValSet
-  private static final TransformExpressionTree STAR_TREE_COUNT_STAR_EXPRESSION =
-      new TransformExpressionTree(TransformExpressionTree.ExpressionType.IDENTIFIER, AggregationFunctionColumnPair.STAR,
-          null);
+  private static final ExpressionContext STAR_TREE_COUNT_STAR_EXPRESSION =
+      ExpressionContext.forIdentifier(AggregationFunctionColumnPair.STAR);
 
   @Override
   public AggregationFunctionType getType() {
@@ -57,7 +56,7 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
   }
 
   @Override
-  public List<TransformExpressionTree> getInputExpressions() {
+  public List<ExpressionContext> getInputExpressions() {
     return Collections.emptyList();
   }
 
@@ -78,7 +77,7 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     if (blockValSetMap.size() == 0) {
       aggregationResultHolder.setValue(aggregationResultHolder.getDoubleResult() + length);
     } else {
@@ -94,7 +93,7 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     if (blockValSetMap.size() == 0) {
       for (int i = 0; i < length; i++) {
         int groupKey = groupKeyArray[i];
@@ -112,7 +111,7 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     if (blockValSetMap.size() == 0) {
       for (int i = 0; i < length; i++) {
         for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -22,24 +22,22 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class CountMVAggregationFunction extends CountAggregationFunction {
-  private final String _column;
-  private final TransformExpressionTree _expression;
+  private final ExpressionContext _expression;
 
   /**
    * Constructor for the class.
    *
-   * @param column Column to aggregate on (could be column name or transform function).
+   * @param expression Expression to aggregate on.
    */
-  public CountMVAggregationFunction(String column) {
-    _column = column;
-    _expression = TransformExpressionTree.compileToExpressionTree(column);
+  public CountMVAggregationFunction(ExpressionContext expression) {
+    _expression = expression;
   }
 
   @Override
@@ -49,16 +47,16 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.COUNTMV.getName() + "_" + _column;
+    return AggregationFunctionType.COUNTMV.getName() + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.COUNTMV.getName().toLowerCase() + "(" + _column + ")";
+    return AggregationFunctionType.COUNTMV.getName().toLowerCase() + "(" + _expression + ")";
   }
 
   @Override
-  public List<TransformExpressionTree> getInputExpressions() {
+  public List<ExpressionContext> getInputExpressions() {
     return Collections.singletonList(_expression);
   }
 
@@ -69,7 +67,7 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     int[] valueArray = blockValSetMap.get(_expression).getNumMVEntries();
     long count = 0L;
     for (int i = 0; i < length; i++) {
@@ -80,7 +78,7 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     int[] valueArray = blockValSetMap.get(_expression).getNumMVEntries();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
@@ -90,7 +88,7 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     int[] valueArray = blockValSetMap.get(_expression).getNumMVEntries();
     for (int i = 0; i < length; i++) {
       int value = valueArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -21,20 +21,20 @@ package org.apache.pinot.core.query.aggregation.function;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class DistinctCountAggregationFunction extends BaseSingleInputAggregationFunction<IntOpenHashSet, Integer> {
 
-  public DistinctCountAggregationFunction(String column) {
-    super(column);
+  public DistinctCountAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -59,7 +59,7 @@ public class DistinctCountAggregationFunction extends BaseSingleInputAggregation
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     IntOpenHashSet valueSet = getValueSet(aggregationResultHolder);
 
@@ -102,7 +102,7 @@ public class DistinctCountAggregationFunction extends BaseSingleInputAggregation
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     FieldSpec.DataType valueType = blockValSet.getValueType();
 
@@ -144,7 +144,7 @@ public class DistinctCountAggregationFunction extends BaseSingleInputAggregation
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     FieldSpec.DataType valueType = blockValSet.getValueType();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -22,16 +22,16 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggregationFunction {
 
-  public DistinctCountHLLMVAggregationFunction(List<String> arguments) {
+  public DistinctCountHLLMVAggregationFunction(List<ExpressionContext> arguments) {
     super(arguments);
   }
 
@@ -47,7 +47,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     HyperLogLog hyperLogLog = getDefaultHyperLogLog(aggregationResultHolder);
 
     BlockValSet blockValSet = blockValSetMap.get(_expression);
@@ -101,7 +101,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     DataType valueType = blockValSet.getValueType();
 
@@ -159,7 +159,7 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     DataType valueType = blockValSet.getValueType();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
@@ -21,17 +21,17 @@ package org.apache.pinot.core.query.aggregation.function;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class DistinctCountMVAggregationFunction extends DistinctCountAggregationFunction {
 
-  public DistinctCountMVAggregationFunction(String column) {
-    super(column);
+  public DistinctCountMVAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -46,7 +46,7 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     IntOpenHashSet valueSet = getValueSet(aggregationResultHolder);
 
     BlockValSet blockValSet = blockValSetMap.get(_expression);
@@ -98,7 +98,7 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     FieldSpec.DataType valueType = blockValSet.getValueType();
 
@@ -155,7 +155,7 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     FieldSpec.DataType valueType = blockValSet.getValueType();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -22,24 +22,24 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.customobject.SerializedHLL;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class DistinctCountRawHLLAggregationFunction extends BaseSingleInputAggregationFunction<HyperLogLog, SerializedHLL> {
   private final DistinctCountHLLAggregationFunction _distinctCountHLLAggregationFunction;
 
-  public DistinctCountRawHLLAggregationFunction(List<String> arguments) {
+  public DistinctCountRawHLLAggregationFunction(List<ExpressionContext> arguments) {
     this(arguments.get(0), new DistinctCountHLLAggregationFunction(arguments));
   }
 
-  DistinctCountRawHLLAggregationFunction(String column,
+  DistinctCountRawHLLAggregationFunction(ExpressionContext expression,
       DistinctCountHLLAggregationFunction distinctCountHLLAggregationFunction) {
-    super(column);
+    super(expression);
     _distinctCountHLLAggregationFunction = distinctCountHLLAggregationFunction;
   }
 
@@ -65,19 +65,19 @@ public class DistinctCountRawHLLAggregationFunction extends BaseSingleInputAggre
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     _distinctCountHLLAggregationFunction.aggregate(length, aggregationResultHolder, blockValSetMap);
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     _distinctCountHLLAggregationFunction.aggregateGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap);
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     _distinctCountHLLAggregationFunction
         .aggregateGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
@@ -20,11 +20,12 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class DistinctCountRawHLLMVAggregationFunction extends DistinctCountRawHLLAggregationFunction {
 
-  public DistinctCountRawHLLMVAggregationFunction(List<String> arguments) {
+  public DistinctCountRawHLLMVAggregationFunction(List<ExpressionContext> arguments) {
     super(arguments.get(0), new DistinctCountHLLMVAggregationFunction(arguments));
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawThetaSketchAggregationFunction.java
@@ -23,11 +23,11 @@ import java.util.Map;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.datasketches.theta.Sketch;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.spi.utils.ByteArray;
 
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.BYTES;
@@ -44,7 +44,7 @@ import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.BYTES;
 public class DistinctCountRawThetaSketchAggregationFunction implements AggregationFunction<Map<String, Sketch>, ByteArray> {
   private final DistinctCountThetaSketchAggregationFunction _thetaSketchAggregationFunction;
 
-  public DistinctCountRawThetaSketchAggregationFunction(List<String> arguments)
+  public DistinctCountRawThetaSketchAggregationFunction(List<ExpressionContext> arguments)
       throws SqlParseException {
     _thetaSketchAggregationFunction = new DistinctCountThetaSketchAggregationFunction(arguments);
   }
@@ -65,7 +65,7 @@ public class DistinctCountRawThetaSketchAggregationFunction implements Aggregati
   }
 
   @Override
-  public List<TransformExpressionTree> getInputExpressions() {
+  public List<ExpressionContext> getInputExpressions() {
     return _thetaSketchAggregationFunction.getInputExpressions();
   }
 
@@ -86,19 +86,19 @@ public class DistinctCountRawThetaSketchAggregationFunction implements Aggregati
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     _thetaSketchAggregationFunction.aggregate(length, aggregationResultHolder, blockValSetMap);
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     _thetaSketchAggregationFunction.aggregateGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap);
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     _thetaSketchAggregationFunction.aggregateGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap);
   }
 
@@ -134,7 +134,7 @@ public class DistinctCountRawThetaSketchAggregationFunction implements Aggregati
 
   @Override
   public ByteArray extractFinalResult(Map<String, Sketch> intermediateResult) {
-    Sketch sketch = _thetaSketchAggregationFunction.extractFinalSketch(intermediateResult);
-    return new ByteArray(sketch.compact().toByteArray());
+    Sketch finalSketch = _thetaSketchAggregationFunction.extractFinalSketch(intermediateResult);
+    return new ByteArray(finalSketch.compact().toByteArray());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -22,7 +22,6 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -30,6 +29,7 @@ import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 /**
@@ -40,8 +40,8 @@ public class FastHLLAggregationFunction extends BaseSingleInputAggregationFuncti
   public static final int DEFAULT_LOG2M = 8;
   private static final int BYTE_TO_CHAR_OFFSET = 129;
 
-  public FastHLLAggregationFunction(String column) {
-    super(column);
+  public FastHLLAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -66,7 +66,7 @@ public class FastHLLAggregationFunction extends BaseSingleInputAggregationFuncti
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     String[] values = blockValSetMap.get(_expression).getStringValuesSV();
     try {
       HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
@@ -88,7 +88,7 @@ public class FastHLLAggregationFunction extends BaseSingleInputAggregationFuncti
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     String[] values = blockValSetMap.get(_expression).getStringValuesSV();
     try {
       for (int i = 0; i < length; i++) {
@@ -108,7 +108,7 @@ public class FastHLLAggregationFunction extends BaseSingleInputAggregationFuncti
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     String[] values = blockValSetMap.get(_expression).getStringValuesSV();
     try {
       for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -20,20 +20,20 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.DoubleAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.DoubleGroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<Double, Double> {
   private static final double DEFAULT_INITIAL_VALUE = Double.NEGATIVE_INFINITY;
 
-  public MaxAggregationFunction(String column) {
-    super(column);
+  public MaxAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -58,7 +58,7 @@ public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<D
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     double max = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
@@ -72,7 +72,7 @@ public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<D
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
@@ -85,7 +85,7 @@ public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<D
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
@@ -20,16 +20,16 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
-  public MaxMVAggregationFunction(String column) {
-    super(column);
+  public MaxMVAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     double max = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
@@ -59,7 +59,7 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
@@ -75,7 +75,7 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -20,20 +20,20 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.DoubleAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.DoubleGroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class MinAggregationFunction extends BaseSingleInputAggregationFunction<Double, Double> {
   private static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
 
-  public MinAggregationFunction(String column) {
-    super(column);
+  public MinAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -58,7 +58,7 @@ public class MinAggregationFunction extends BaseSingleInputAggregationFunction<D
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     double min = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
@@ -72,7 +72,7 @@ public class MinAggregationFunction extends BaseSingleInputAggregationFunction<D
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
@@ -85,7 +85,7 @@ public class MinAggregationFunction extends BaseSingleInputAggregationFunction<D
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
@@ -20,16 +20,16 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class MinMVAggregationFunction extends MinAggregationFunction {
 
-  public MinMVAggregationFunction(String column) {
-    super(column);
+  public MinMVAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     double min = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
@@ -59,7 +59,7 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
@@ -75,7 +75,7 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -29,13 +28,14 @@ import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class MinMaxRangeAggregationFunction extends BaseSingleInputAggregationFunction<MinMaxRangePair, Double> {
 
-  public MinMaxRangeAggregationFunction(String column) {
-    super(column);
+  public MinMaxRangeAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -60,7 +60,7 @@ public class MinMaxRangeAggregationFunction extends BaseSingleInputAggregationFu
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
 
@@ -105,7 +105,7 @@ public class MinMaxRangeAggregationFunction extends BaseSingleInputAggregationFu
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     if (blockValSet.getValueType() != DataType.BYTES) {
       double[] doubleValues = blockValSet.getDoubleValuesSV();
@@ -125,7 +125,7 @@ public class MinMaxRangeAggregationFunction extends BaseSingleInputAggregationFu
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     if (blockValSet.getValueType() != DataType.BYTES) {
       double[] doubleValues = blockValSet.getDoubleValuesSV();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
@@ -20,16 +20,16 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunction {
 
-  public MinMaxRangeMVAggregationFunction(String column) {
-    super(column);
+  public MinMaxRangeMVAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
@@ -64,7 +64,7 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       aggregateOnGroupKey(groupKeyArray[i], groupByResultHolder, valuesArray[i]);
@@ -73,7 +73,7 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -22,13 +22,13 @@ import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class PercentileAggregationFunction extends BaseSingleInputAggregationFunction<DoubleArrayList, Double> {
@@ -36,8 +36,8 @@ public class PercentileAggregationFunction extends BaseSingleInputAggregationFun
 
   protected final int _percentile;
 
-  public PercentileAggregationFunction(String column, int percentile) {
-    super(column);
+  public PercentileAggregationFunction(ExpressionContext expression, int percentile) {
+    super(expression);
     _percentile = percentile;
   }
 
@@ -48,12 +48,12 @@ public class PercentileAggregationFunction extends BaseSingleInputAggregationFun
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "_" + _column;
+    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILE.getName().toLowerCase() + _percentile + "(" + _column + ")";
+    return AggregationFunctionType.PERCENTILE.getName().toLowerCase() + _percentile + "(" + _expression + ")";
   }
 
   @Override
@@ -73,7 +73,7 @@ public class PercentileAggregationFunction extends BaseSingleInputAggregationFun
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     DoubleArrayList valueList = getValueList(aggregationResultHolder);
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
@@ -83,7 +83,7 @@ public class PercentileAggregationFunction extends BaseSingleInputAggregationFun
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       DoubleArrayList valueList = getValueList(groupByResultHolder, groupKeyArray[i]);
@@ -93,7 +93,7 @@ public class PercentileAggregationFunction extends BaseSingleInputAggregationFun
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -29,6 +28,7 @@ import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.customobject.QuantileDigest;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -37,8 +37,8 @@ public class PercentileEstAggregationFunction extends BaseSingleInputAggregation
 
   protected final int _percentile;
 
-  public PercentileEstAggregationFunction(String column, int percentile) {
-    super(column);
+  public PercentileEstAggregationFunction(ExpressionContext expression, int percentile) {
+    super(expression);
     _percentile = percentile;
   }
 
@@ -49,12 +49,12 @@ public class PercentileEstAggregationFunction extends BaseSingleInputAggregation
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "_" + _column;
+    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + _percentile + "(" + _column + ")";
+    return AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + _percentile + "(" + _expression + ")";
   }
 
   @Override
@@ -74,7 +74,7 @@ public class PercentileEstAggregationFunction extends BaseSingleInputAggregation
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     if (blockValSet.getValueType() != DataType.BYTES) {
       long[] longValues = blockValSet.getLongValuesSV();
@@ -102,7 +102,7 @@ public class PercentileEstAggregationFunction extends BaseSingleInputAggregation
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     if (blockValSet.getValueType() != DataType.BYTES) {
       long[] longValues = blockValSet.getLongValuesSV();
@@ -127,7 +127,7 @@ public class PercentileEstAggregationFunction extends BaseSingleInputAggregation
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     if (blockValSet.getValueType() != DataType.BYTES) {
       long[] longValues = blockValSet.getLongValuesSV();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -20,17 +20,17 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.customobject.QuantileDigest;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class PercentileEstMVAggregationFunction extends PercentileEstAggregationFunction {
 
-  public PercentileEstMVAggregationFunction(String column, int percentile) {
-    super(column, percentile);
+  public PercentileEstMVAggregationFunction(ExpressionContext expression, int percentile) {
+    super(expression, percentile);
   }
 
   @Override
@@ -40,12 +40,12 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV_" + _column;
+    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + _percentile + "mv(" + _column + ")";
+    return AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + _percentile + "mv(" + _expression + ")";
   }
 
   @Override
@@ -55,7 +55,7 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     long[][] valuesArray = blockValSetMap.get(_expression).getLongValuesMV();
     QuantileDigest quantileDigest = getDefaultQuantileDigest(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
@@ -67,7 +67,7 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     long[][] valuesArray = blockValSetMap.get(_expression).getLongValuesMV();
     for (int i = 0; i < length; i++) {
       QuantileDigest quantileDigest = getDefaultQuantileDigest(groupByResultHolder, groupKeyArray[i]);
@@ -79,7 +79,7 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     long[][] valuesArray = blockValSetMap.get(_expression).getLongValuesMV();
     for (int i = 0; i < length; i++) {
       long[] values = valuesArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -21,16 +21,16 @@ package org.apache.pinot.core.query.aggregation.function;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class PercentileMVAggregationFunction extends PercentileAggregationFunction {
 
-  public PercentileMVAggregationFunction(String column, int percentile) {
-    super(column, percentile);
+  public PercentileMVAggregationFunction(ExpressionContext expression, int percentile) {
+    super(expression, percentile);
   }
 
   @Override
@@ -40,12 +40,12 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "MV_" + _column;
+    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "MV_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILE.getName().toLowerCase() + _percentile + "mv(" + _column + ")";
+    return AggregationFunctionType.PERCENTILE.getName().toLowerCase() + _percentile + "mv(" + _expression + ")";
   }
 
   @Override
@@ -55,7 +55,7 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     DoubleArrayList valueList = getValueList(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
@@ -67,7 +67,7 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       DoubleArrayList valueList = getValueList(groupByResultHolder, groupKeyArray[i]);
@@ -79,7 +79,7 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.query.aggregation.function;
 import com.tdunning.math.stats.TDigest;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -29,6 +28,7 @@ import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -40,8 +40,8 @@ public class PercentileTDigestAggregationFunction extends BaseSingleInputAggrega
 
   protected final int _percentile;
 
-  public PercentileTDigestAggregationFunction(String column, int percentile) {
-    super(column);
+  public PercentileTDigestAggregationFunction(ExpressionContext expression, int percentile) {
+    super(expression);
     _percentile = percentile;
   }
 
@@ -52,12 +52,12 @@ public class PercentileTDigestAggregationFunction extends BaseSingleInputAggrega
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "_" + _column;
+    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + _percentile + "(" + _column + ")";
+    return AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + _percentile + "(" + _expression + ")";
   }
 
   @Override
@@ -77,7 +77,7 @@ public class PercentileTDigestAggregationFunction extends BaseSingleInputAggrega
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     if (blockValSet.getValueType() != DataType.BYTES) {
       double[] doubleValues = blockValSet.getDoubleValuesSV();
@@ -105,7 +105,7 @@ public class PercentileTDigestAggregationFunction extends BaseSingleInputAggrega
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     if (blockValSet.getValueType() != DataType.BYTES) {
       double[] doubleValues = blockValSet.getDoubleValuesSV();
@@ -130,7 +130,7 @@ public class PercentileTDigestAggregationFunction extends BaseSingleInputAggrega
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     if (blockValSet.getValueType() != DataType.BYTES) {
       double[] doubleValues = blockValSet.getDoubleValuesSV();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -21,16 +21,16 @@ package org.apache.pinot.core.query.aggregation.function;
 import com.tdunning.math.stats.TDigest;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAggregationFunction {
 
-  public PercentileTDigestMVAggregationFunction(String column, int percentile) {
-    super(column, percentile);
+  public PercentileTDigestMVAggregationFunction(ExpressionContext expression, int percentile) {
+    super(expression, percentile);
   }
 
   @Override
@@ -40,12 +40,12 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV_" + _column;
+    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + _percentile + "mv(" + _column + ")";
+    return AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + _percentile + "mv(" + _expression + ")";
   }
 
   @Override
@@ -55,7 +55,7 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     TDigest tDigest = getDefaultTDigest(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
@@ -67,7 +67,7 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       TDigest tDigest = getDefaultTDigest(groupByResultHolder, groupKeyArray[i]);
@@ -79,7 +79,7 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -20,20 +20,20 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.DoubleAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.DoubleGroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class SumAggregationFunction extends BaseSingleInputAggregationFunction<Double, Double> {
   private static final double DEFAULT_VALUE = 0.0;
 
-  public SumAggregationFunction(String column) {
-    super(column);
+  public SumAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -58,7 +58,7 @@ public class SumAggregationFunction extends BaseSingleInputAggregationFunction<D
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     double sum = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
@@ -69,7 +69,7 @@ public class SumAggregationFunction extends BaseSingleInputAggregationFunction<D
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
@@ -79,7 +79,7 @@ public class SumAggregationFunction extends BaseSingleInputAggregationFunction<D
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -20,16 +20,16 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 public class SumMVAggregationFunction extends SumAggregationFunction {
 
-  public SumMVAggregationFunction(String column) {
-    super(column);
+  public SumMVAggregationFunction(ExpressionContext expression) {
+    super(expression);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     double sum = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
@@ -57,7 +57,7 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
@@ -71,7 +71,7 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<TransformExpressionTree, BlockValSet> blockValSetMap) {
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
     double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.query.aggregation.groupby;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
@@ -28,6 +27,7 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
 /**
@@ -65,14 +65,13 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
    * @param numGroupsLimit Limit on number of aggregation groups returned in the result
    * @param transformOperator Transform operator
    */
-  public DefaultGroupByExecutor(AggregationFunction[] aggregationFunctions,
-      TransformExpressionTree[] groupByExpressions, int maxInitialResultHolderCapacity, int numGroupsLimit,
-      TransformOperator transformOperator) {
+  public DefaultGroupByExecutor(AggregationFunction[] aggregationFunctions, ExpressionContext[] groupByExpressions,
+      int maxInitialResultHolderCapacity, int numGroupsLimit, TransformOperator transformOperator) {
     _aggregationFunctions = aggregationFunctions;
 
     boolean hasMVGroupByExpression = false;
     boolean hasNoDictionaryGroupByExpression = false;
-    for (TransformExpressionTree groupByExpression : groupByExpressions) {
+    for (ExpressionContext groupByExpression : groupByExpressions) {
       TransformResultMetadata transformResultMetadata = transformOperator.getResultMetadata(groupByExpression);
       hasMVGroupByExpression |= !transformResultMetadata.isSingleValue();
       hasNoDictionaryGroupByExpression |= !transformResultMetadata.hasDictionary();
@@ -134,7 +133,7 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
 
   protected void aggregate(TransformBlock transformBlock, int length, int functionIndex) {
     AggregationFunction aggregationFunction = _aggregationFunctions[functionIndex];
-    Map<TransformExpressionTree, BlockValSet> blockValSetMap =
+    Map<ExpressionContext, BlockValSet> blockValSetMap =
         AggregationFunctionUtils.getBlockValSetMap(aggregationFunction, transformBlock);
 
     GroupByResultHolder groupByResultHolder = _groupByResultHolders[functionIndex];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.aggregation.groupby;
 
 import java.util.Iterator;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 
 
@@ -46,7 +45,7 @@ public interface GroupKeyGenerator {
    * @param transformBlock Transform block
    * @param groupKeys Buffer to return the results
    */
-  void generateKeysForBlock(@Nonnull TransformBlock transformBlock, @Nonnull int[] groupKeys);
+  void generateKeysForBlock(TransformBlock transformBlock, int[] groupKeys);
 
   /**
    * Generate group keys on the given transform block and returns the result to the given buffer.
@@ -55,7 +54,7 @@ public interface GroupKeyGenerator {
    * @param transformBlock Transform block
    * @param groupKeys Buffer to return the results
    */
-  void generateKeysForBlock(@Nonnull TransformBlock transformBlock, @Nonnull int[][] groupKeys);
+  void generateKeysForBlock(TransformBlock transformBlock, int[][] groupKeys);
 
   /**
    * Get the current upper bound of the group key. All group keys already generated should be less than this value. This

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
@@ -30,12 +30,11 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Iterator;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 /**
@@ -44,7 +43,7 @@ import org.apache.pinot.core.operator.transform.TransformOperator;
  *
  */
 public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenerator {
-  private final TransformExpressionTree _groupByExpression;
+  private final ExpressionContext _groupByExpression;
   private final FieldSpec.DataType _dataType;
   private final Map _groupKeyMap;
   private final int _globalGroupIdUpperBound;
@@ -52,7 +51,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   private int _numGroups = 0;
 
   public NoDictionarySingleColumnGroupKeyGenerator(TransformOperator transformOperator,
-      TransformExpressionTree groupByExpression, int numGroupsLimit) {
+      ExpressionContext groupByExpression, int numGroupsLimit) {
     _groupByExpression = groupByExpression;
     _dataType = transformOperator.getResultMetadata(_groupByExpression).getDataType();
     _groupKeyMap = createGroupKeyMap(_dataType);
@@ -65,7 +64,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   }
 
   @Override
-  public void generateKeysForBlock(@Nonnull TransformBlock transformBlock, @Nonnull int[] groupKeys) {
+  public void generateKeysForBlock(TransformBlock transformBlock, int[] groupKeys) {
     BlockValSet blockValSet = transformBlock.getBlockValueSet(_groupByExpression);
     int numDocs = transformBlock.getNumDocs();
 
@@ -152,7 +151,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   }
 
   @Override
-  public void generateKeysForBlock(@Nonnull TransformBlock transformBlock, @Nonnull int[][] groupKeys) {
+  public void generateKeysForBlock(TransformBlock transformBlock, int[][] groupKeys) {
     // TODO: Support generating keys for multi-valued columns.
     throw new UnsupportedOperationException("Operation not supported");
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -195,7 +195,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       int numSegmentsMatchedAfterPruning = segmentDataManagers.size();
       LOGGER.debug("Matched {} segments after pruning", numSegmentsMatchedAfterPruning);
       if (numSegmentsMatchedAfterPruning == 0) {
-        dataTable = DataTableUtils.buildEmptyDataTable(queryContext.getBrokerRequest());
+        dataTable = DataTableUtils.buildEmptyDataTable(queryContext);
         Map<String, String> metadata = dataTable.getMetadata();
         metadata.put(DataTable.TOTAL_DOCS_METADATA_KEY, String.valueOf(numTotalDocs));
         metadata.put(DataTable.NUM_DOCS_SCANNED_METADATA_KEY, "0");

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ResultReducerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ResultReducerFactory.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.reduce;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextUtils;
 
@@ -40,13 +41,12 @@ public final class ResultReducerFactory {
       return new SelectionDataTableReducer(queryContext);
     } else {
       // Aggregation query
-      AggregationFunction[] aggregationFunctions =
-          AggregationFunctionUtils.getAggregationFunctions(queryContext.getBrokerRequest());
+      AggregationFunction[] aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(queryContext);
       if (queryContext.getGroupByExpressions() == null) {
         // Aggregation only query
         if (aggregationFunctions.length == 1 && aggregationFunctions[0].getType() == AggregationFunctionType.DISTINCT) {
           // Distinct query
-          return new DistinctDataTableReducer(queryContext);
+          return new DistinctDataTableReducer(queryContext, (DistinctAggregationFunction) aggregationFunctions[0]);
         } else {
           return new AggregationDataTableReducer(queryContext, aggregationFunctions);
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ExpressionContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ExpressionContext.java
@@ -18,12 +18,8 @@
  */
 package org.apache.pinot.core.query.request.context;
 
-import com.google.common.base.Preconditions;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 
 
 /**
@@ -86,29 +82,6 @@ public class ExpressionContext {
       }
     } else if (_type == Type.FUNCTION) {
       _function.getColumns(columns);
-    }
-  }
-
-  /**
-   * Temporary helper method to help the migration from BrokerRequest to QueryContext.
-   */
-  public TransformExpressionTree toTransformExpressionTree() {
-    switch (_type) {
-      case LITERAL:
-        return new TransformExpressionTree(TransformExpressionTree.ExpressionType.LITERAL, _value, null);
-      case IDENTIFIER:
-        return new TransformExpressionTree(TransformExpressionTree.ExpressionType.IDENTIFIER, _value, null);
-      case FUNCTION:
-        Preconditions.checkState(_function.getType() == FunctionContext.Type.TRANSFORM);
-        List<ExpressionContext> arguments = _function.getArguments();
-        List<TransformExpressionTree> children = new ArrayList<>(arguments.size());
-        for (ExpressionContext argument : arguments) {
-          children.add(argument.toTransformExpressionTree());
-        }
-        return new TransformExpressionTree(TransformExpressionTree.ExpressionType.FUNCTION, _function.getFunctionName(),
-            children);
-      default:
-        throw new IllegalStateException();
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
@@ -111,10 +111,11 @@ public class BrokerRequestToQueryContextConverter {
           List<String> stringExpressions = aggregationInfo.getExpressions();
           int numArguments = stringExpressions.size();
           List<ExpressionContext> arguments = new ArrayList<>(numArguments);
-          if (functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNTTHETASKETCH.getName())) {
-            // NOTE: For DistinctCountThetaSketch, because of the legacy behavior of PQL compiler treating string
-            //       literal as identifier in aggregation, here we treat all expressions except for the first one as
-            //       string literal.
+          if (functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNTTHETASKETCH.getName()) || functionName
+              .equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNTRAWTHETASKETCH.getName())) {
+            // NOTE: For DistinctCountThetaSketch and DistinctCountRawThetaSketch, because of the legacy behavior of PQL
+            //       compiler treating string literal as identifier in aggregation, here we treat all expressions except
+            //       for the first one as string literal.
             arguments.add(QueryContextConverterUtils.getExpression(stringExpressions.get(0)));
             for (int i = 1; i < numArguments; i++) {
               arguments.add(ExpressionContext.forLiteral(stringExpressions.get(i)));

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -55,8 +54,8 @@ public class StarTreeUtils {
    * </ul>
    */
   public static boolean isFitForStarTree(StarTreeV2Metadata starTreeV2Metadata,
-      AggregationFunctionColumnPair[] aggregationFunctionColumnPairs,
-      @Nullable TransformExpressionTree[] groupByExpressions, @Nullable FilterContext filter) {
+      AggregationFunctionColumnPair[] aggregationFunctionColumnPairs, @Nullable ExpressionContext[] groupByExpressions,
+      @Nullable FilterContext filter) {
     // Check aggregations
     for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {
       if (!starTreeV2Metadata.containsFunctionColumnPair(aggregationFunctionColumnPair)) {
@@ -68,7 +67,7 @@ public class StarTreeUtils {
     Set<String> starTreeDimensions = new HashSet<>(starTreeV2Metadata.getDimensionsSplitOrder());
     if (groupByExpressions != null) {
       Set<String> groupByColumns = new HashSet<>();
-      for (TransformExpressionTree groupByExpression : groupByExpressions) {
+      for (ExpressionContext groupByExpression : groupByExpressions) {
         groupByExpression.getColumns(groupByColumns);
       }
       if (!starTreeDimensions.containsAll(groupByColumns)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/executor/StarTreeGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/executor/StarTreeGroupByExecutor.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.startree.executor;
 
 import java.util.Map;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
@@ -27,6 +26,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.groupby.DefaultGroupByExecutor;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 
 
@@ -41,9 +41,8 @@ import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 public class StarTreeGroupByExecutor extends DefaultGroupByExecutor {
   private final AggregationFunctionColumnPair[] _aggregationFunctionColumnPairs;
 
-  public StarTreeGroupByExecutor(AggregationFunction[] aggregationFunctions,
-      TransformExpressionTree[] groupByExpressions, int maxInitialResultHolderCapacity, int numGroupsLimit,
-      TransformOperator transformOperator) {
+  public StarTreeGroupByExecutor(AggregationFunction[] aggregationFunctions, ExpressionContext[] groupByExpressions,
+      int maxInitialResultHolderCapacity, int numGroupsLimit, TransformOperator transformOperator) {
     super(aggregationFunctions, groupByExpressions, maxInitialResultHolderCapacity, numGroupsLimit, transformOperator);
 
     int numAggregationFunctions = aggregationFunctions.length;
@@ -58,7 +57,7 @@ public class StarTreeGroupByExecutor extends DefaultGroupByExecutor {
   protected void aggregate(TransformBlock transformBlock, int length, int functionIndex) {
     AggregationFunction aggregationFunction = _aggregationFunctions[functionIndex];
     GroupByResultHolder groupByResultHolder = _groupByResultHolders[functionIndex];
-    Map<TransformExpressionTree, BlockValSet> blockValSetMap =
+    Map<ExpressionContext, BlockValSet> blockValSetMap =
         AggregationFunctionUtils.getBlockValSetMap(_aggregationFunctionColumnPairs[functionIndex], transformBlock);
     if (_hasMVGroupByExpression) {
       aggregationFunction.aggregateGroupByMV(length, _mvGroupKeys, groupByResultHolder, blockValSetMap);

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
@@ -21,39 +21,39 @@ package org.apache.pinot.core.startree.plan;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.plan.PlanNode;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
 
 
 public class StarTreeTransformPlanNode implements PlanNode {
-  private final Set<TransformExpressionTree> _groupByExpressions;
+  private final List<ExpressionContext> _groupByExpressions;
   private final StarTreeProjectionPlanNode _starTreeProjectionPlanNode;
 
   public StarTreeTransformPlanNode(StarTreeV2 starTreeV2,
-      AggregationFunctionColumnPair[] aggregationFunctionColumnPairs,
-      @Nullable TransformExpressionTree[] groupByExpressions, @Nullable FilterContext filter,
-      @Nullable Map<String, String> debugOptions) {
+      AggregationFunctionColumnPair[] aggregationFunctionColumnPairs, @Nullable ExpressionContext[] groupByExpressions,
+      @Nullable FilterContext filter, @Nullable Map<String, String> debugOptions) {
     Set<String> projectionColumns = new HashSet<>();
     for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {
       projectionColumns.add(aggregationFunctionColumnPair.toColumnName());
     }
     Set<String> groupByColumns;
     if (groupByExpressions != null) {
-      _groupByExpressions = new HashSet<>(Arrays.asList(groupByExpressions));
+      _groupByExpressions = Arrays.asList(groupByExpressions);
       groupByColumns = new HashSet<>();
-      for (TransformExpressionTree groupByExpression : groupByExpressions) {
+      for (ExpressionContext groupByExpression : groupByExpressions) {
         groupByExpression.getColumns(groupByColumns);
       }
       projectionColumns.addAll(groupByColumns);
     } else {
-      _groupByExpressions = Collections.emptySet();
+      _groupByExpressions = Collections.emptyList();
       groupByColumns = null;
     }
     _starTreeProjectionPlanNode =

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/AggregationFunctionColumnPair.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/AggregationFunctionColumnPair.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.startree.v2;
 
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.function.AggregationFunctionType;
 
 
@@ -27,12 +26,11 @@ public class AggregationFunctionColumnPair {
   public static final String STAR = "*";
   public static final AggregationFunctionColumnPair COUNT_STAR =
       new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, STAR);
-  public static final String COUNT_STAR_COLUMN_NAME = COUNT_STAR.toColumnName();
 
   private final AggregationFunctionType _functionType;
   private final String _column;
 
-  public AggregationFunctionColumnPair(@Nonnull AggregationFunctionType functionType, @Nonnull String column) {
+  public AggregationFunctionColumnPair(AggregationFunctionType functionType, String column) {
     _functionType = functionType;
     if (functionType == AggregationFunctionType.COUNT) {
       _column = STAR;
@@ -41,28 +39,23 @@ public class AggregationFunctionColumnPair {
     }
   }
 
-  @Nonnull
   public AggregationFunctionType getFunctionType() {
     return _functionType;
   }
 
-  @Nonnull
   public String getColumn() {
     return _column;
   }
 
-  @Nonnull
   public String toColumnName() {
     return toColumnName(_functionType, _column);
   }
 
-  @Nonnull
   public static String toColumnName(AggregationFunctionType functionType, String column) {
     return functionType.getName() + DELIMITER + column;
   }
 
-  @Nonnull
-  public static AggregationFunctionColumnPair fromColumnName(@Nonnull String columnName) {
+  public static AggregationFunctionColumnPair fromColumnName(String columnName) {
     String[] parts = columnName.split(DELIMITER, 2);
     AggregationFunctionType functionType = AggregationFunctionType.valueOf(parts[0].toUpperCase());
     if (functionType == AggregationFunctionType.COUNT) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -35,6 +35,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.MaxAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.SumAggregationFunction;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
@@ -53,8 +54,8 @@ public class IndexedTableTest {
       throws InterruptedException, TimeoutException, ExecutionException {
     DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "d3", "sum(m1)", "max(m2)"},
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
-    AggregationFunction[] aggregationFunctions =
-        new AggregationFunction[]{new SumAggregationFunction("m1"), new MaxAggregationFunction("m2")};
+    AggregationFunction[] aggregationFunctions = new AggregationFunction[]{new SumAggregationFunction(
+        ExpressionContext.forIdentifier("m1")), new MaxAggregationFunction(ExpressionContext.forIdentifier("m2"))};
     List<OrderByExpressionContext> orderByExpressions = Collections
         .singletonList(new OrderByExpressionContext(QueryContextConverterUtils.getExpression("sum(m1)"), true));
     IndexedTable indexedTable = new ConcurrentIndexedTable(dataSchema, aggregationFunctions, orderByExpressions, 5);
@@ -123,8 +124,8 @@ public class IndexedTableTest {
   public void testNonConcurrentIndexedTable(List<OrderByExpressionContext> orderByExpressions, List<String> survivors) {
     DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "d3", "d4", "sum(m1)", "max(m2)"},
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
-    AggregationFunction[] aggregationFunctions =
-        new AggregationFunction[]{new SumAggregationFunction("m1"), new MaxAggregationFunction("m2")};
+    AggregationFunction[] aggregationFunctions = new AggregationFunction[]{new SumAggregationFunction(
+        ExpressionContext.forIdentifier("m1")), new MaxAggregationFunction(ExpressionContext.forIdentifier("m2"))};
 
     // Test SimpleIndexedTable
     IndexedTable simpleIndexedTable = new SimpleIndexedTable(dataSchema, aggregationFunctions, orderByExpressions, 5);
@@ -272,8 +273,8 @@ public class IndexedTableTest {
   public void testNoMoreNewRecords() {
     DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "d3", "sum(m1)", "max(m2)"},
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
-    AggregationFunction[] aggregationFunctions =
-        new AggregationFunction[]{new SumAggregationFunction("m1"), new MaxAggregationFunction("m2")};
+    AggregationFunction[] aggregationFunctions = new AggregationFunction[]{new SumAggregationFunction(
+        ExpressionContext.forIdentifier("m1")), new MaxAggregationFunction(ExpressionContext.forIdentifier("m2"))};
 
     IndexedTable indexedTable = new SimpleIndexedTable(dataSchema, aggregationFunctions, null, 5);
     testNoMoreNewRecordsInTable(indexedTable);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.core.query.aggregation.function.DistinctCountAggregation
 import org.apache.pinot.core.query.aggregation.function.MaxAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.SumAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
@@ -56,8 +57,10 @@ public class TableResizerTest {
   public void setUp() {
     _dataSchema = new DataSchema(new String[]{"d1", "d2", "d3", "sum(m1)", "max(m2)", "distinctcount(m3)", "avg(m4)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.OBJECT, DataSchema.ColumnDataType.OBJECT});
-    _aggregationFunctions = new AggregationFunction[]{new SumAggregationFunction("m1"), new MaxAggregationFunction(
-        "m2"), new DistinctCountAggregationFunction("m3"), new AvgAggregationFunction("m4")};
+    _aggregationFunctions = new AggregationFunction[]{new SumAggregationFunction(
+        ExpressionContext.forIdentifier("m1")), new MaxAggregationFunction(
+        ExpressionContext.forIdentifier("m2")), new DistinctCountAggregationFunction(
+        ExpressionContext.forIdentifier("m3")), new AvgAggregationFunction(ExpressionContext.forIdentifier("m4"))};
 
     IntOpenHashSet i1 = new IntOpenHashSet();
     i1.add(1);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,7 +30,7 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testAdditionTransformFunction() {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(String
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String
         .format("add(%s,%s,%s,%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN, FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN,
             STRING_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -43,7 +44,7 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree.compileToExpressionTree(String
+    expression = QueryContextConverterUtils.getExpression(String
         .format("add(add(12,%s),%s,add(add(%s,%s),0.34,%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN, FLOAT_SV_COLUMN,
             LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -57,7 +58,7 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunctionTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -30,8 +31,8 @@ public class ArrayLengthTransformFunctionTest extends BaseTransformFunctionTest 
 
   @Test
   public void testLengthTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("arrayLength(%s)", INT_MV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("arrayLength(%s)", INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ArrayLengthTransformFunction);
     Assert.assertEquals(transformFunction.getName(), ArrayLengthTransformFunction.FUNCTION_NAME);
@@ -47,15 +48,14 @@ public class ArrayLengthTransformFunctionTest extends BaseTransformFunctionTest 
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 
   @DataProvider(name = "testIllegalArguments")
   public Object[][] testIllegalArguments() {
-    return new Object[][]{
-        new Object[]{String.format("arrayLength(%s,1)", INT_MV_COLUMN)},
-        new Object[]{"arrayLength(2)"},
-        new Object[]{String.format("arrayLength(%s)", LONG_SV_COLUMN)}};
+    return new Object[][]{new Object[]{String.format("arrayLength(%s,1)",
+        INT_MV_COLUMN)}, new Object[]{"arrayLength(2)"}, new Object[]{String.format("arrayLength(%s)",
+        LONG_SV_COLUMN)}};
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -47,8 +48,8 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
 
   @Test
   public void testBinaryOperatorTransformFunction() {
-    TransformExpressionTree expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("%s(%s, %d)", getFuncName(), INT_SV_COLUMN, _intSVValues[0]));
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("%s(%s, %d)", getFuncName(), INT_SV_COLUMN, _intSVValues[0]));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertEquals(transformFunction.getName(), getFuncName().toLowerCase());
     int[] expectedIntValues = new int[NUM_ROWS];
@@ -57,8 +58,8 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
     }
     testTransformFunction(transformFunction, expectedIntValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("%s(%s, %d)", getFuncName(), LONG_SV_COLUMN, _longSVValues[0]));
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("%s(%s, %d)", getFuncName(), LONG_SV_COLUMN, _longSVValues[0]));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[] expectedLongValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -66,8 +67,8 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
     }
     testTransformFunction(transformFunction, expectedLongValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("%s(%s, %f)", getFuncName(), FLOAT_SV_COLUMN, _floatSVValues[0]));
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("%s(%s, %f)", getFuncName(), FLOAT_SV_COLUMN, _floatSVValues[0]));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[] expectedFloatValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -75,8 +76,8 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
     }
     testTransformFunction(transformFunction, expectedFloatValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("%s(%s, %.20f)", getFuncName(), DOUBLE_SV_COLUMN, _doubleSVValues[0]));
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("%s(%s, %.20f)", getFuncName(), DOUBLE_SV_COLUMN, _doubleSVValues[0]));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[] expectedDoubleValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -84,8 +85,8 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
     }
     testTransformFunction(transformFunction, expectedDoubleValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("%s(%s, '%s')", getFuncName(), STRING_SV_COLUMN, _stringSVValues[0]));
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("%s(%s, '%s')", getFuncName(), STRING_SV_COLUMN, _stringSVValues[0]));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[] expectedStringValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -96,7 +97,7 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
@@ -20,8 +20,9 @@ package org.apache.pinot.core.operator.transform.function;
 
 import java.util.Random;
 import org.apache.pinot.common.function.TransformFunctionType;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -92,9 +93,8 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
   }
 
   private void testCaseQueryWithIntResults(String predicate, int[] expectedValues) {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("CASE(%s, 100, 10)", predicate));
-    expression.getChildren().set(0, TransformExpressionTree.compileToExpressionTree(predicate));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("CASE(%s, 100, 10)", predicate));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
@@ -102,9 +102,8 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
   }
 
   private void testCaseQueryWithDoubleResults(String predicate, double[] expectedValues) {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("CASE(%s, 100.0, 10.0)", predicate));
-    expression.getChildren().set(0, TransformExpressionTree.compileToExpressionTree(predicate));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("CASE(%s, 100.0, 10.0)", predicate));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
@@ -112,9 +111,8 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
   }
 
   private void testCaseQueryWithStringResults(String predicate, String[] expectedValues) {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("CASE(%s, 'aaa', 'bbb')", predicate));
-    expression.getChildren().set(0, TransformExpressionTree.compileToExpressionTree(predicate));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("CASE(%s, 'aaa', 'bbb')", predicate));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
@@ -123,7 +121,7 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,8 +30,8 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testCastTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("cast(%s,%s)", INT_SV_COLUMN, "'String'"));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("cast(%s,%s)", INT_SV_COLUMN, "'String'"));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CastTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CastTransformFunction.FUNCTION_NAME);
@@ -40,7 +41,7 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree.compileToExpressionTree(
+    expression = QueryContextConverterUtils.getExpression(
         String.format("cast(add(cast(%s, 'STRING'), %s), 'string')", STRING_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CastTransformFunction);
@@ -49,7 +50,7 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree.compileToExpressionTree(
+    expression = QueryContextConverterUtils.getExpression(
         String.format("cast(cast(add(cast(%s, 'STRING'), %s), 'string'), 'double')", STRING_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CastTransformFunction);
@@ -62,7 +63,7 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
@@ -19,8 +19,9 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import java.util.concurrent.TimeUnit;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,7 +32,7 @@ public class DateTimeConversionTransformFunctionTest extends BaseTransformFuncti
   @Test
   public void testDateTimeConversionTransformFunction() {
     // NOTE: functionality of DateTimeConverter is covered in DateTimeConverterTest
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(
         String.format("dateTimeConvert(%s,'1:MILLISECONDS:EPOCH','1:MINUTES:EPOCH','1:MINUTES')", TIME_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DateTimeConversionTransformFunction);
@@ -53,7 +54,7 @@ public class DateTimeConversionTransformFunctionTest extends BaseTransformFuncti
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,8 +30,8 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testDivisionTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("div(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("div(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     Assert.assertEquals(transformFunction.getName(), DivisionTransformFunction.FUNCTION_NAME);
@@ -40,8 +41,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("div(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("div(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -50,7 +50,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("div(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
+        QueryContextConverterUtils.getExpression(String.format("div(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -58,8 +58,8 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("div(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+    expression =
+        QueryContextConverterUtils.getExpression(String.format("div(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -67,8 +67,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("div(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("div(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -76,7 +75,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree.compileToExpressionTree(String
+    expression = QueryContextConverterUtils.getExpression(String
         .format("div(div(div(div(div(12,%s),%s),div(div(%s,%s),0.34)),%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -91,7 +90,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -22,8 +22,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.Assert;
@@ -36,7 +37,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   @Test(dataProvider = "testJsonPathTransformFunctionArguments")
   public void testJsonPathTransformFunction(String expressionStr, FieldSpec.DataType resultsDataType,
       boolean isSingleValue) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -104,7 +105,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   public void testJsonPathTransformFunctionWithPredicate() {
     String jsonPathExpressionStr =
         String.format("jsonExtractScalar(json,'[?($.stringSV==''%s'')]','STRING')", _stringSVValues[0]);
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(jsonPathExpressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(jsonPathExpressionStr);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -118,7 +119,8 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
             Assert.assertEquals(_intMVValues[i][j], ((List) resultMap.get(0).get("intMV")).get(j));
           }
           Assert.assertEquals(_longSVValues[i], resultMap.get(0).get("longSV"));
-          Assert.assertEquals(Float.compare(_floatSVValues[i], ((Double) resultMap.get(0).get("floatSV")).floatValue()), 0);
+          Assert.assertEquals(Float.compare(_floatSVValues[i], ((Double) resultMap.get(0).get("floatSV")).floatValue()),
+              0);
           Assert.assertEquals(_doubleSVValues[i], resultMap.get(0).get("doubleSV"));
           Assert.assertEquals(_stringSVValues[i], resultMap.get(0).get("stringSV"));
         } catch (IOException e) {
@@ -132,8 +134,8 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @Test
   public void testJsonPathTransformFunctionForIntMV() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree("jsonExtractScalar(json,'$.intMV','INT_ARRAY')");
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression("jsonExtractScalar(json,'$.intMV','INT_ARRAY')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -148,8 +150,8 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @Test
   public void testJsonPathTransformFunctionForLong() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree("jsonExtractScalar(json,'$.longSV','LONG')");
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression("jsonExtractScalar(json,'$.longSV','LONG')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -161,8 +163,8 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @Test
   public void testJsonPathTransformFunctionForFloat() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree("jsonExtractScalar(json,'$.floatSV','FLOAT')");
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression("jsonExtractScalar(json,'$.floatSV','FLOAT')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -174,8 +176,8 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @Test
   public void testJsonPathTransformFunctionForDouble() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree("jsonExtractScalar(json,'$.doubleSV','DOUBLE')");
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression("jsonExtractScalar(json,'$.doubleSV','DOUBLE')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -187,8 +189,8 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @Test
   public void testJsonPathTransformFunctionForString() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree("jsonExtractScalar(json,'$.stringSV','STRING')");
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression("jsonExtractScalar(json,'$.stringSV','STRING')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -200,7 +202,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @Test
   public void testJsonPathKeyTransformFunction() {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree("jsonExtractKey(json,'$.*')");
+    ExpressionContext expression = QueryContextConverterUtils.getExpression("jsonExtractKey(json,'$.*')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractKeyTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractKeyTransformFunction.FUNCTION_NAME);
@@ -219,7 +221,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunctionTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,8 +30,8 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testModuloTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("mod(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("mod(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     Assert.assertEquals(transformFunction.getName(), ModuloTransformFunction.FUNCTION_NAME);
@@ -40,8 +41,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("mod(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("mod(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -50,7 +50,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("mod(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
+        QueryContextConverterUtils.getExpression(String.format("mod(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -58,8 +58,8 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("mod(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+    expression =
+        QueryContextConverterUtils.getExpression(String.format("mod(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -67,8 +67,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("mod(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("mod(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -76,7 +75,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree.compileToExpressionTree(String
+    expression = QueryContextConverterUtils.getExpression(String
         .format("mod(mod(mod(mod(mod(12,%s),%s),mod(mod(%s,%s),0.34)),%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -91,7 +90,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunctionTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,7 +30,7 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
 
   @Test
   public void testMultiplicationTransformFunction() {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(String
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String
         .format("mult(%s,%s,%s,%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN, FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN,
             STRING_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -43,7 +44,7 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree.compileToExpressionTree(String
+    expression = QueryContextConverterUtils.getExpression(String
         .format("mult(mult(12,%s),%s,mult(mult(%s,%s),0.34,%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -57,7 +58,7 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -19,7 +19,8 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -28,8 +29,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringLowerTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("lower(%s)", STRING_ALPHANUM_SV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("lower(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "lower");
@@ -42,8 +43,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringUpperTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("upper(%s)", STRING_ALPHANUM_SV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("upper(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "upper");
@@ -56,8 +57,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringReverseTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("reverse(%s)", STRING_ALPHANUM_SV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("reverse(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "reverse");
@@ -70,8 +71,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringSubStrTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("substr(%s, 0, 2)", STRING_ALPHANUM_SV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("substr(%s, 0, 2)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "substr");
@@ -81,7 +82,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree.compileToExpressionTree(String.format("substr(%s, 2, -1)", STRING_ALPHANUM_SV_COLUMN));
+    expression =
+        QueryContextConverterUtils.getExpression(String.format("substr(%s, 2, -1)", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "substr");
@@ -94,8 +96,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringConcatTransformFunction() {
-    TransformExpressionTree expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("concat(%s, %s, '-')", STRING_ALPHANUM_SV_COLUMN, STRING_ALPHANUM_SV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("concat(%s, %s, '-')", STRING_ALPHANUM_SV_COLUMN, STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "concat");
@@ -108,8 +110,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringReplaceTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("replace(%s, 'A', 'B')", STRING_ALPHANUM_SV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("replace(%s, 'A', 'B')", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "replace");
@@ -122,10 +124,10 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringPadTransformFunction() {
-    Integer padLength = 50;
+    int padLength = 50;
     String padString = "#";
-    TransformExpressionTree expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("lpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("lpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "lpad");
@@ -135,8 +137,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("rpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("rpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "rpad");
@@ -149,22 +151,22 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringTrimTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ltrim(lpad(%s, 50, ' '))", STRING_ALPHANUM_SV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("ltrim(lpad(%s, 50, ' '))", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "ltrim");
     testTransformFunction(transformFunction, _stringAlphaNumericSVValues);
 
     expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("rtrim(rpad(%s, 50, ' '))", STRING_ALPHANUM_SV_COLUMN));
+        QueryContextConverterUtils.getExpression(String.format("rtrim(rpad(%s, 50, ' '))", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "rtrim");
     testTransformFunction(transformFunction, _stringAlphaNumericSVValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("trim(rpad(lpad(%s, 50, ' '), 100, ' '))", STRING_ALPHANUM_SV_COLUMN));
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("trim(rpad(lpad(%s, 50, ' '), 100, ' '))", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "trim");

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
@@ -18,11 +18,15 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
-import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.*;
-import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.AbsTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.CeilTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.ExpTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.FloorTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.LnTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SqrtTransformFunction;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -30,8 +34,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testAbsTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("abs(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("abs(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     Assert.assertEquals(transformFunction.getName(), AbsTransformFunction.FUNCTION_NAME);
@@ -41,8 +44,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("abs(%s)", LONG_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("abs(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -50,8 +52,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("abs(%s)", FLOAT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("abs(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -59,8 +60,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("abs(%s)", DOUBLE_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("abs(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -68,8 +68,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("abs(%s)", STRING_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("abs(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -80,8 +79,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testCeilTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ceil(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("ceil(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CeilTransformFunction.FUNCTION_NAME);
@@ -91,8 +89,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ceil(%s)", LONG_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("ceil(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -100,8 +97,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ceil(%s)", FLOAT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("ceil(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -109,8 +105,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("ceil(%s)", DOUBLE_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("ceil(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -118,8 +113,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ceil(%s)", STRING_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("ceil(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -130,8 +124,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testExpTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("exp(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("exp(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     Assert.assertEquals(transformFunction.getName(), ExpTransformFunction.FUNCTION_NAME);
@@ -141,8 +134,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("exp(%s)", LONG_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("exp(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -150,8 +142,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("exp(%s)", FLOAT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("exp(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -159,8 +150,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("exp(%s)", DOUBLE_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("exp(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -168,8 +158,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("exp(%s)", STRING_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("exp(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -177,11 +166,10 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
   }
-  
+
   @Test
   public void testFloorTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("floor(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("floor(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     Assert.assertEquals(transformFunction.getName(), FloorTransformFunction.FUNCTION_NAME);
@@ -191,8 +179,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("floor(%s)", LONG_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("floor(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -200,8 +187,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("floor(%s)", FLOAT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("floor(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -209,8 +195,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("floor(%s)", DOUBLE_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("floor(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -218,8 +203,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("floor(%s)", STRING_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("floor(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -230,8 +214,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testLnTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ln(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("ln(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     Assert.assertEquals(transformFunction.getName(), LnTransformFunction.FUNCTION_NAME);
@@ -241,8 +224,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ln(%s)", LONG_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("ln(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -250,8 +232,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ln(%s)", FLOAT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("ln(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -259,8 +240,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("ln(%s)", DOUBLE_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("ln(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -268,8 +248,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("ln(%s)", STRING_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("ln(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -280,8 +259,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testSqrtTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sqrt(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("sqrt(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     Assert.assertEquals(transformFunction.getName(), SqrtTransformFunction.FUNCTION_NAME);
@@ -291,8 +269,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sqrt(%s)", LONG_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("sqrt(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -300,8 +277,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sqrt(%s)", FLOAT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("sqrt(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -309,8 +285,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("sqrt(%s)", DOUBLE_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("sqrt(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -318,8 +293,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sqrt(%s)", STRING_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("sqrt(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunctionTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,8 +30,8 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
 
   @Test
   public void testSubtractionTransformFunction() {
-    TransformExpressionTree expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sub(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("sub(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     Assert.assertEquals(transformFunction.getName(), SubtractionTransformFunction.FUNCTION_NAME);
@@ -40,8 +41,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sub(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("sub(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -50,7 +50,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sub(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
+        QueryContextConverterUtils.getExpression(String.format("sub(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -58,8 +58,8 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree
-        .compileToExpressionTree(String.format("sub(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+    expression =
+        QueryContextConverterUtils.getExpression(String.format("sub(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -67,8 +67,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        TransformExpressionTree.compileToExpressionTree(String.format("sub(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+    expression = QueryContextConverterUtils.getExpression(String.format("sub(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -76,7 +75,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = TransformExpressionTree.compileToExpressionTree(String
+    expression = QueryContextConverterUtils.getExpression(String
         .format("sub(sub(sub(sub(sub(12,%s),%s),sub(sub(%s,%s),0.34)),%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -91,7 +90,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunctionTest.java
@@ -19,8 +19,9 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import java.util.concurrent.TimeUnit;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ public class TimeConversionTransformFunctionTest extends BaseTransformFunctionTe
 
   @Test(dataProvider = "testTimeConversionTransformFunction")
   public void testTimeConversionTransformFunction(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof TimeConversionTransformFunction);
     Assert.assertEquals(transformFunction.getName(), TimeConversionTransformFunction.FUNCTION_NAME);
@@ -51,20 +52,22 @@ public class TimeConversionTransformFunctionTest extends BaseTransformFunctionTe
 
   @DataProvider(name = "testTimeConversionTransformFunction")
   public Object[][] testTimeConversionTransformFunction() {
-    return new Object[][]{new Object[]{String.format("timeConvert(%s,'MILLISECONDS','DAYS')", TIME_COLUMN)}, new Object[]{String.format(
+    return new Object[][]{new Object[]{String.format("timeConvert(%s,'MILLISECONDS','DAYS')",
+        TIME_COLUMN)}, new Object[]{String.format(
         "timeConvert(timeConvert(timeConvert(%s,'MILLISECONDS','SECONDS'),'SECONDS','HOURS'),'HOURS','DAYS')",
         TIME_COLUMN)}};
   }
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 
   @DataProvider(name = "testIllegalArguments")
   public Object[][] testIllegalArguments() {
-    return new Object[][]{new Object[]{String.format("timeConvert(%s,'MILLISECONDS')", TIME_COLUMN)}, new Object[]{"timeConvert(5,'MILLISECONDS','DAYS')"}, new Object[]{String.format(
+    return new Object[][]{new Object[]{String.format("timeConvert(%s,'MILLISECONDS')",
+        TIME_COLUMN)}, new Object[]{"timeConvert(5,'MILLISECONDS','DAYS')"}, new Object[]{String.format(
         "timeConvert(%s,'MILLISECONDS','DAYS')", INT_MV_COLUMN)}, new Object[]{String.format(
         "timeConvert(%s,'MILLISECONDS','1:DAYS')", TIME_COLUMN)}, new Object[]{String.format(
         "timeConvert(%s,%s,'DAYS')", TIME_COLUMN, INT_SV_COLUMN)}};

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunctionTest.java
@@ -20,8 +20,9 @@ package org.apache.pinot.core.operator.transform.function;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -32,7 +33,7 @@ public class ValueInTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testValueInTransformFunction")
   public void testValueInTransformFunction(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ValueInTransformFunction);
     Assert.assertEquals(transformFunction.getName(), ValueInTransformFunction.FUNCTION_NAME);
@@ -75,7 +76,7 @@ public class ValueInTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    TransformExpressionTree expression = TransformExpressionTree.compileToExpressionTree(expressionStr);
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
@@ -29,14 +29,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import junit.framework.Assert;
 import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.annotations.Test;
 
 
 public class CombinePlanNodeTest {
-  private final QueryContext _queryContext =
-      BrokerRequestToQueryContextConverter.convert(new Pql2Compiler().compileToBrokerRequest("SELECT * FROM table"));
+  private final QueryContext _queryContext = QueryContextConverterUtils.getQueryContextFromPQL("SELECT * FROM table");
   private final ExecutorService _executorService = Executors.newFixedThreadPool(10);
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
@@ -37,10 +36,9 @@ import org.apache.pinot.core.plan.MetadataBasedAggregationPlanNode;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.plan.SelectionPlanNode;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -66,7 +64,6 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   private static final File INDEX_DIR =
       new File(FileUtils.getTempDirectory(), "MetadataAndDictionaryAggregationPlanMakerTest");
 
-  private static final Pql2Compiler COMPILER = new Pql2Compiler();
   private static final InstancePlanMakerImplV2 PLAN_MAKER = new InstancePlanMakerImplV2();
   private IndexSegment _indexSegment = null;
 
@@ -132,8 +129,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
 
   @Test(dataProvider = "testPlanNodeMakerDataProvider")
   public void testInstancePlanMakerForMetadataAndDictionaryPlan(String query, Class<? extends PlanNode> planNodeClass) {
-    BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
-    QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
     PlanNode plan = PLAN_MAKER.makeSegmentPlanNode(_indexSegment, queryContext);
     assertTrue(planNodeClass.isInstance(plan));
   }
@@ -176,8 +172,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   @Test(dataProvider = "isFitForPlanDataProvider")
   public void testIsFitFor(String query, IndexSegment indexSegment, boolean expectedIsFitForMetadata,
       boolean expectedIsFitForDictionary) {
-    BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
-    QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
     assertEquals(InstancePlanMakerImplV2.isFitForMetadataBasedPlan(queryContext), expectedIsFitForMetadata);
     assertEquals(InstancePlanMakerImplV2.isFitForDictionaryBasedPlan(queryContext, indexSegment),
         expectedIsFitForDictionary);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
@@ -18,265 +18,214 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import java.util.Arrays;
-import java.util.Collections;
 import org.apache.pinot.common.function.AggregationFunctionType;
-import org.apache.pinot.common.request.AggregationInfo;
-import org.apache.pinot.common.request.BrokerRequest;
-import org.testng.Assert;
+import org.apache.pinot.core.query.request.context.FunctionContext;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
+
+@SuppressWarnings("rawtypes")
 public class AggregationFunctionFactoryTest {
-  private static final String COLUMN = "column";
+  private static final String ARGUMENT = "(column)";
+  private static final QueryContext DUMMY_QUERY_CONTEXT =
+      QueryContextConverterUtils.getQueryContextFromPQL("SELECT * FROM testTable");
 
   @Test
   public void testGetAggregationFunction() {
-    AggregationFunction aggregationFunction;
+    FunctionContext function = getFunction("CoUnT");
+    AggregationFunction aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof CountAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNT);
+    assertEquals(aggregationFunction.getColumnName(), "count_star");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    BrokerRequest brokerRequest = new BrokerRequest();
-    String column;
+    function = getFunction("MiN");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof MinAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.MIN);
+    assertEquals(aggregationFunction.getColumnName(), "min_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    AggregationInfo aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("CoUnT");
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof CountAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNT);
-    Assert.assertEquals(aggregationFunction.getColumnName(), "count_star");
+    function = getFunction("MaX");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof MaxAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAX);
+    assertEquals(aggregationFunction.getColumnName(), "max_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("MiN");
-    column = "min_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof MinAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MIN);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("SuM");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof SumAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUM);
+    assertEquals(aggregationFunction.getColumnName(), "sum_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("MaX");
-    column = "max_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof MaxAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAX);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("AvG");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof AvgAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVG);
+    assertEquals(aggregationFunction.getColumnName(), "avg_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("SuM");
-    column = "sum_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof SumAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUM);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("MiNmAxRaNgE");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof MinMaxRangeAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGE);
+    assertEquals(aggregationFunction.getColumnName(), "minMaxRange_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("AvG");
-    column = "avg_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof AvgAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVG);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("DiStInCtCoUnT");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof DistinctCountAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNT);
+    assertEquals(aggregationFunction.getColumnName(), "distinctCount_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("MiNmAxRaNgE");
-    column = "minMaxRange_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof MinMaxRangeAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGE);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("DiStInCtCoUnThLl");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof DistinctCountHLLAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLL);
+    assertEquals(aggregationFunction.getColumnName(), "distinctCountHLL_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("DiStInCtCoUnT");
-    column = "distinctCount_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof DistinctCountAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNT);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("DiStInCtCoUnTrAwHlL");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof DistinctCountRawHLLAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLL);
+    assertEquals(aggregationFunction.getColumnName(), "distinctCountRawHLL_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("DiStInCtCoUnThLl");
-    column = "distinctCountHLL_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof DistinctCountHLLAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLL);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("FaStHlL");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof FastHLLAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.FASTHLL);
+    assertEquals(aggregationFunction.getColumnName(), "fastHLL_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("DiStInCtCoUnTrAwHlL");
-    column = "distinctCountRawHLL_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof DistinctCountRawHLLAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLL);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("PeRcEnTiLe5");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
+    assertEquals(aggregationFunction.getColumnName(), "percentile5_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("FaStHlL");
-    column = "fastHLL_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof FastHLLAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.FASTHLL);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("PeRcEnTiLeEsT50");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
+    assertEquals(aggregationFunction.getColumnName(), "percentileEst50_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("PeRcEnTiLe5");
-    column = "percentile5_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("PeRcEnTiLeTdIgEsT99");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
+    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest99_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("PeRcEnTiLeEsT50");
-    column = "percentileEst50_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("CoUnTmV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof CountMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNTMV);
+    assertEquals(aggregationFunction.getColumnName(), "countMV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("PeRcEnTiLeTdIgEsT99");
-    column = "percentileTDigest99_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("MiNmV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof MinMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMV);
+    assertEquals(aggregationFunction.getColumnName(), "minMV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("CoUnTmV");
-    column = "countMV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof CountMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNTMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("MaXmV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof MaxMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAXMV);
+    assertEquals(aggregationFunction.getColumnName(), "maxMV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("MiNmV");
-    column = "minMV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof MinMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("SuMmV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof SumMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUMMV);
+    assertEquals(aggregationFunction.getColumnName(), "sumMV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("MaXmV");
-    column = "maxMV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof MaxMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAXMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("AvGmV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof AvgMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVGMV);
+    assertEquals(aggregationFunction.getColumnName(), "avgMV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("SuMmV");
-    column = "sumMV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof SumMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUMMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("MiNmAxRaNgEmV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof MinMaxRangeMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGEMV);
+    assertEquals(aggregationFunction.getColumnName(), "minMaxRangeMV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("AvGmV");
-    column = "avgMV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof AvgMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVGMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("DiStInCtCoUnTmV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof DistinctCountMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTMV);
+    assertEquals(aggregationFunction.getColumnName(), "distinctCountMV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("MiNmAxRaNgEmV");
-    column = "minMaxRangeMV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof MinMaxRangeMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGEMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("DiStInCtCoUnThLlMv");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof DistinctCountHLLMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLMV);
+    assertEquals(aggregationFunction.getColumnName(), "distinctCountHLLMV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("DiStInCtCoUnTmV");
-    column = "distinctCountMV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof DistinctCountMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("DiStInCtCoUnTrAwHlLmV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof DistinctCountRawHLLMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLLMV);
+    assertEquals(aggregationFunction.getColumnName(), "distinctCountRawHLLMV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("DiStInCtCoUnThLlMv");
-    column = "distinctCountHLLMV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof DistinctCountHLLMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("PeRcEnTiLe10Mv");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEMV);
+    assertEquals(aggregationFunction.getColumnName(), "percentile10MV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("DiStInCtCoUnTrAwHlLmV");
-    column = "distinctCountRawHLLMV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof DistinctCountRawHLLMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLLMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("PeRcEnTiLeEsT90mV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileEstMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEESTMV);
+    assertEquals(aggregationFunction.getColumnName(), "percentileEst90MV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("PeRcEnTiLe10Mv");
-    column = "percentile10MV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof PercentileMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+    function = getFunction("PeRcEnTiLeTdIgEsT95mV");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
+    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest95MV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
+  }
 
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("PeRcEnTiLeEsT90mV");
-    column = "percentileEst90MV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof PercentileEstMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEESTMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
-
-    aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType("PeRcEnTiLeTdIgEsT95mV");
-    column = "percentileTDigest95MV_column";
-    aggregationInfo.setExpressions(Collections.singletonList(COLUMN));
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
-    Assert.assertEquals(aggregationFunction.getColumnName(), column);
+  private FunctionContext getFunction(String functionName) {
+    return QueryContextConverterUtils.getExpression(functionName + ARGUMENT).getFunction();
   }
 
   @Test
   public void testAggregationFunctionWithMultipleArgs() {
-    // Test using new field `expressions` in AggregationInfo.
-    BrokerRequest brokerRequest = new BrokerRequest();
-    AggregationInfo aggregationInfo = new AggregationInfo();
-
-    aggregationInfo.setAggregationType("distinct");
-    String[] arguments = new String[]{"column1", "column2", "column3"};
-    String expected = "distinct_" + AggregationFunctionUtils.concatArgs(arguments);
-    aggregationInfo.setExpressions(Arrays.asList(arguments));
-
-    AggregationFunction aggregationFunction =
-        AggregationFunctionFactory.getAggregationFunction(aggregationInfo, brokerRequest);
-    Assert.assertTrue(aggregationFunction instanceof DistinctAggregationFunction);
-    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCT);
-    Assert.assertEquals(aggregationFunction.getColumnName(), expected);
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContextFromPQL("SELECT distinct(column1, column2, column3) FROM testTable");
+    AggregationFunction aggregationFunction = AggregationFunctionFactory
+        .getAggregationFunction(queryContext.getSelectExpressions().get(0).getFunction(), queryContext);
+    assertTrue(aggregationFunction instanceof DistinctAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCT);
+    assertEquals(aggregationFunction.getColumnName(), "distinct_column1:column2:column3");
+    assertEquals(aggregationFunction.getResultColumnName(), "distinct(column1:column2:column3)");
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -19,15 +19,13 @@
 package org.apache.pinot.core.query.pruner;
 
 import java.util.Collections;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.common.DataSourceMetadata;
 import org.apache.pinot.core.data.partition.PartitionFunctionFactory;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.Test;
 
@@ -38,7 +36,6 @@ import static org.mockito.Mockito.when;
 
 
 public class ColumnValueSegmentPrunerTest {
-  private static final Pql2Compiler COMPILER = new Pql2Compiler();
   private static final ColumnValueSegmentPruner PRUNER = new ColumnValueSegmentPruner();
 
   @Test
@@ -118,8 +115,7 @@ public class ColumnValueSegmentPrunerTest {
   }
 
   private boolean runPruner(IndexSegment indexSegment, String query) {
-    BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest(query);
-    QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
     ServerQueryRequest queryRequest = mock(ServerQueryRequest.class);
     when(queryRequest.getQueryContext()).thenReturn(queryContext);
     return PRUNER.prune(indexSegment, queryRequest);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.plan.maker.PlanMaker;
 import org.apache.pinot.core.query.reduce.BrokerReduceService;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.config.table.TableType;
@@ -64,8 +65,7 @@ public abstract class BaseQueriesTest {
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
   protected <T extends Operator> T getOperatorForQuery(String pqlQuery) {
-    BrokerRequest brokerRequest = PQL_COMPILER.compileToBrokerRequest(pqlQuery);
-    QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(pqlQuery);
     return (T) PLAN_MAKER.makeSegmentPlanNode(getIndexSegment(), queryContext).run();
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountThetaSketchTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountThetaSketchTest.java
@@ -284,19 +284,20 @@ public class DistinctCountThetaSketchTest extends BaseQueriesTest {
 
       sb.append("'");
       if (thetaSketchParams != null) {
-        sb.append(thetaSketchParams);
+        sb.append(thetaSketchParams.replace("'", "''"));
       }
       sb.append("', ");
 
       for (String predicate : thetaSketchPredicates) {
-        sb.append("\"");
-        sb.append(predicate);
-        sb.append("\"");
+        sb.append('\'');
+        sb.append(predicate.replace("'", "''"));
+        sb.append('\'');
         sb.append(", ");
       }
-      sb.append("\"");
-      sb.append(postAggregationExpression);
-      sb.append("\"");
+
+      sb.append('\'');
+      sb.append(postAggregationExpression.replace("'", "''"));
+      sb.append('\'');
     }
 
     sb.append(") from ");

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -51,6 +51,7 @@ import org.apache.pinot.core.query.aggregation.function.customobject.DistinctTab
 import org.apache.pinot.core.query.reduce.BrokerReduceService;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -603,8 +604,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
         String sqlQuery =
             "SELECT DISTINCT longColumn FROM testTable WHERE doubleColumn < 200 ORDER BY longColumn DESC LIMIT 5";
 
-        BrokerRequest pqlBrokerRequest = PQL_COMPILER.compileToBrokerRequest(pqlQuery);
-        QueryContext pqlQueryContext = BrokerRequestToQueryContextConverter.convert(pqlBrokerRequest);
+        QueryContext pqlQueryContext = QueryContextConverterUtils.getQueryContextFromPQL(pqlQuery);
         BrokerResponseNative pqlResponse = queryServersWithDifferentSegments(pqlQueryContext, segment0, segment1);
         BrokerRequest sqlBrokerRequest = SQL_COMPILER.compileToBrokerRequest(sqlQuery);
         sqlBrokerRequest.setQueryOptions(Collections.singletonMap("responseFormat", "sql"));

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/AggregationGroupByTrimmingServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/AggregationGroupByTrimmingServiceTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.aggregation.groupby;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -28,27 +27,27 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.apache.commons.lang.RandomStringUtils;
-import org.apache.pinot.common.request.AggregationInfo;
-import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.response.broker.GroupByResult;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import org.apache.pinot.core.query.aggregation.function.DistinctCountAggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.SumAggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class AggregationGroupByTrimmingServiceTest {
   private static final long RANDOM_SEED = System.currentTimeMillis();
   private static final Random RANDOM = new Random(RANDOM_SEED);
   private static final String ERROR_MESSAGE = "Random seed: " + RANDOM_SEED;
 
-  private static final AggregationFunction SUM = createAggregationFunction("SUM", "sumColumn");
-  private static final AggregationFunction DISTINCTCOUNT = createAggregationFunction("DISTINCTCOUNT", "distinctColumn");
-
-  private static final AggregationFunction[] AGGREGATION_FUNCTIONS = {SUM, DISTINCTCOUNT};
+  private static final AggregationFunction[] AGGREGATION_FUNCTIONS =
+      {new SumAggregationFunction(ExpressionContext.forIdentifier("sumColumn")), new DistinctCountAggregationFunction(
+          ExpressionContext.forIdentifier("distinctColumn"))};
   private static final int NUM_GROUP_KEYS = 3;
   private static final int GROUP_BY_TOP_N = 100;
   private static final int NUM_GROUPS = 50000;
@@ -81,7 +80,6 @@ public class AggregationGroupByTrimmingServiceTest {
     _trimmingService = new AggregationGroupByTrimmingService(AGGREGATION_FUNCTIONS, GROUP_BY_TOP_N);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void testTrimming() {
     // Test Server side trimming
@@ -141,12 +139,5 @@ public class AggregationGroupByTrimmingServiceTest {
       groupStringBuilder.append(group.get(i));
     }
     return groupStringBuilder.toString();
-  }
-
-  private static AggregationFunction createAggregationFunction(String aggregationType, String column) {
-    AggregationInfo aggregationInfo = new AggregationInfo();
-    aggregationInfo.setAggregationType(aggregationType);
-    aggregationInfo.setExpressions(Collections.singletonList(column));
-    return AggregationFunctionFactory.getAggregationFunction(aggregationInfo, new BrokerRequest());
   }
 }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
@@ -45,10 +45,9 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.query.utils.Pair;
 import org.apache.pinot.core.util.GroupByUtils;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -100,9 +99,9 @@ public class BenchmarkCombineGroupBy {
       _d2.add(i);
     }
 
-    _queryContext = BrokerRequestToQueryContextConverter.convert(new Pql2Compiler()
-        .compileToBrokerRequest("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) TOP 500"));
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(_queryContext.getBrokerRequest());
+    _queryContext = QueryContextConverterUtils
+        .getQueryContextFromPQL("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) TOP 500");
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(_queryContext);
     _dataSchema = new DataSchema(new String[]{"d1", "d2", "sum(m1)", "max(m2)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -40,9 +40,8 @@ import org.apache.pinot.core.data.table.SimpleIndexedTable;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.util.trace.TraceRunnable;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -90,9 +89,9 @@ public class BenchmarkIndexedTable {
       _d2.add(i);
     }
 
-    _queryContext = BrokerRequestToQueryContextConverter.convert(new Pql2Compiler()
-        .compileToBrokerRequest("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) TOP 500"));
-    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(_queryContext.getBrokerRequest());
+    _queryContext = QueryContextConverterUtils
+        .getQueryContextFromPQL("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) TOP 500");
+    _aggregationFunctions = AggregationFunctionUtils.getAggregationFunctions(_queryContext);
     _dataSchema = new DataSchema(new String[]{"d1", "d2", "sum(m1)", "max(m2)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
 


### PR DESCRIPTION
## Description
Replace `BrokerRequest` classes (`AggregationInfo`, `TransformExpressionTree`) with QueryContext classes (`FunctionContext`, `ExpressionContext`) for aggregation and transform functions
This is the last PR of removing `BrokerRequest` classes from the query execution path. After this PR, the query engine will be independent of `BrokerRequest` and only access `QueryContext` classes, and all the redundant expression parsing will be saved.

Besides replacing `BrokerRequest` classes, also refactored `DistinctCountThetaSketchAggregationFunction` to use the `QueryContext` classes, which solves the TODO of standardizing the predicate strings and simplifies the predicate handling.

Minor bug-fixes:
- Fix HLL log2m override for SQL query and make it case insensitive (In `BaseBrokerRequestHandler`)
- Add special argument handling for `DistinctCountRawThetaSketch` (In `BrokerRequestToQueryContextConverter`)
- Always use single argument `*` for `COUNT` when converting `FunctionCallAstNode ` to `FunctionContext` (In `QueryContextConverterUtils`)

## Upgrade Notes
Because of the standardization of the `DistinctCountThetaSketch` predicate strings, please upgrade Broker before Server. The new Broker can handle both standard and non-standard predicate strings for backward-compatibility.
