### PR TITLE
Add segment encryption on Controller based on table config

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
@@ -131,11 +131,9 @@ public class TableConfigUtils {
       ingestionConfig = JsonUtils.stringToObject(ingestionConfigString, IngestionConfig.class);
     }
 
-    String crypterClassName = simpleFields.get(TableConfig.CRYPTER_CLASS_NAME_KEY);
-
     return new TableConfig(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig,
-        quotaConfig, taskConfig, routingConfig, queryConfig, instanceAssignmentConfigMap, fieldConfigList,
-        upsertConfig, ingestionConfig, crypterClassName);
+        quotaConfig, taskConfig, routingConfig, queryConfig, instanceAssignmentConfigMap, fieldConfigList, upsertConfig,
+        ingestionConfig);
   }
 
   public static ZNRecord toZNRecord(TableConfig tableConfig)
@@ -185,10 +183,6 @@ public class TableConfigUtils {
     if (ingestionConfig != null) {
       simpleFields.put(TableConfig.INGESTION_CONFIG_KEY, JsonUtils.objectToString(ingestionConfig));
     }
-    String crypterClassName = tableConfig.getCrypterClassName();
-    if (crypterClassName != null) {
-      simpleFields.put(TableConfig.CRYPTER_CLASS_NAME_KEY, crypterClassName);
-    }
 
     ZNRecord znRecord = new ZNRecord(tableConfig.getTableName());
     znRecord.setSimpleFields(simpleFields);
@@ -234,8 +228,10 @@ public class TableConfigUtils {
       }
       String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
       if (peerSegmentDownloadScheme != null) {
-        if (!"http".equalsIgnoreCase(peerSegmentDownloadScheme) && !"https".equalsIgnoreCase(peerSegmentDownloadScheme)) {
-          throw new IllegalStateException("Invalid value '" + peerSegmentDownloadScheme + "' for peerSegmentDownloadScheme. Must be one of http nor https" );
+        if (!"http".equalsIgnoreCase(peerSegmentDownloadScheme) && !"https"
+            .equalsIgnoreCase(peerSegmentDownloadScheme)) {
+          throw new IllegalStateException("Invalid value '" + peerSegmentDownloadScheme
+              + "' for peerSegmentDownloadScheme. Must be one of http nor https");
         }
       }
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
@@ -131,9 +131,11 @@ public class TableConfigUtils {
       ingestionConfig = JsonUtils.stringToObject(ingestionConfigString, IngestionConfig.class);
     }
 
+    String crypterClassName = simpleFields.get(TableConfig.CRYPTER_CLASS_NAME_KEY);
+
     return new TableConfig(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig,
         quotaConfig, taskConfig, routingConfig, queryConfig, instanceAssignmentConfigMap, fieldConfigList,
-        upsertConfig, ingestionConfig);
+        upsertConfig, ingestionConfig, crypterClassName);
   }
 
   public static ZNRecord toZNRecord(TableConfig tableConfig)
@@ -182,6 +184,10 @@ public class TableConfigUtils {
     IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
     if (ingestionConfig != null) {
       simpleFields.put(TableConfig.INGESTION_CONFIG_KEY, JsonUtils.objectToString(ingestionConfig));
+    }
+    String crypterClassName = tableConfig.getCrypterClassName();
+    if (crypterClassName != null) {
+      simpleFields.put(TableConfig.CRYPTER_CLASS_NAME_KEY, crypterClassName);
     }
 
     ZNRecord znRecord = new ZNRecord(tableConfig.getTableName());

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
@@ -81,7 +81,7 @@ public class TableCache {
   }
 
   public TableConfig getTableConfig(String tableName) {
-    return _tableConfigChangeListener._tableConfigMap.get(tableName.toLowerCase());
+    return _tableConfigChangeListener._tableConfigMap.get(tableName);
   }
 
   class TableConfigChangeListener implements IZkChildListener, IZkDataListener {
@@ -102,7 +102,7 @@ public class TableCache {
             try {
               TableConfig tableConfig = TableConfigUtils.fromZNRecord(znRecord);
               String tableNameWithType = tableConfig.getTableName();
-              _tableConfigMap.put(tableNameWithType.toLowerCase(), tableConfig);
+              _tableConfigMap.put(tableNameWithType, tableConfig);
               String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
               //create case insensitive mapping
               _tableNameMap.put(tableNameWithType.toLowerCase(), tableNameWithType);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
@@ -64,11 +64,11 @@ public class TableCache {
   }
 
   public String getActualTableName(String tableName) {
-    return _tableConfigChangeListener._tableNameMap.getOrDefault(canonicalize(tableName), tableName);
+    return _tableConfigChangeListener._tableNameMap.getOrDefault(tableName.toLowerCase(), tableName);
   }
 
   public String getActualColumnName(String tableName, String columnName) {
-    String schemaName = _tableConfigChangeListener._table2SchemaConfigMap.get(canonicalize(tableName));
+    String schemaName = _tableConfigChangeListener._table2SchemaConfigMap.get(tableName.toLowerCase());
     if (schemaName != null) {
       String actualColumnName = _schemaChangeListener.getColumnName(schemaName, columnName);
       // If actual column name doesn't exist in schema, then return the origin column name.
@@ -81,11 +81,7 @@ public class TableCache {
   }
 
   public TableConfig getTableConfig(String tableName) {
-    return _tableConfigChangeListener._tableConfigMap.get(canonicalize(tableName));
-  }
-
-  private String canonicalize(String name) {
-    return name.toLowerCase();
+    return _tableConfigChangeListener._tableConfigMap.get(tableName.toLowerCase());
   }
 
   class TableConfigChangeListener implements IZkChildListener, IZkDataListener {
@@ -106,14 +102,14 @@ public class TableCache {
             try {
               TableConfig tableConfig = TableConfigUtils.fromZNRecord(znRecord);
               String tableNameWithType = tableConfig.getTableName();
-              _tableConfigMap.put(canonicalize(tableNameWithType), tableConfig);
+              _tableConfigMap.put(tableNameWithType.toLowerCase(), tableConfig);
               String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
               //create case insensitive mapping
-              _tableNameMap.put(canonicalize(tableNameWithType), tableNameWithType);
-              _tableNameMap.put(canonicalize(rawTableName), rawTableName);
+              _tableNameMap.put(tableNameWithType.toLowerCase(), tableNameWithType);
+              _tableNameMap.put(rawTableName.toLowerCase(), rawTableName);
               //create case insensitive mapping between table name and schemaName
-              _table2SchemaConfigMap.put(canonicalize(tableNameWithType), rawTableName);
-              _table2SchemaConfigMap.put(canonicalize(rawTableName), rawTableName);
+              _table2SchemaConfigMap.put(tableNameWithType.toLowerCase(), rawTableName);
+              _table2SchemaConfigMap.put(rawTableName.toLowerCase(), rawTableName);
             } catch (Exception e) {
               LOGGER.warn("Exception loading table config for: {}: {}", znRecord.getId(), e.getMessage());
               //ignore
@@ -159,12 +155,12 @@ public class TableCache {
           for (ZNRecord znRecord : children) {
             try {
               Schema schema = SchemaUtils.fromZNRecord(znRecord);
-              String schemaNameLowerCase = canonicalize(schema.getSchemaName());
+              String schemaNameLowerCase = schema.getSchemaName().toLowerCase();
               Collection<FieldSpec> allFieldSpecs = schema.getAllFieldSpecs();
               ConcurrentHashMap<String, String> columnNameMap = new ConcurrentHashMap<>();
               _schemaColumnMap.put(schemaNameLowerCase, columnNameMap);
               for (FieldSpec fieldSpec : allFieldSpecs) {
-                columnNameMap.put(canonicalize(fieldSpec.getName()), fieldSpec.getName());
+                columnNameMap.put(fieldSpec.getName().toLowerCase(), fieldSpec.getName());
               }
             } catch (Exception e) {
               LOGGER.warn("Exception loading schema for: {}: {}", znRecord.getId(), e.getMessage());
@@ -179,9 +175,9 @@ public class TableCache {
     }
 
     String getColumnName(String schemaName, String columnName) {
-      Map<String, String> columnNameMap = _schemaColumnMap.get(canonicalize(schemaName));
+      Map<String, String> columnNameMap = _schemaColumnMap.get(schemaName.toLowerCase());
       if (columnNameMap != null) {
-        return columnNameMap.get(canonicalize(columnName));
+        return columnNameMap.get(columnName.toLowerCase());
       }
       return columnName;
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -267,6 +267,14 @@ public class TableConfigSerDeTest {
       assertEquals(tableConfigToCompare, tableConfig);
       checkIngestionConfig(tableConfigToCompare);
     }
+    {
+      // with crypter class name
+      TableConfig origTableConfig = tableConfigBuilder.setCrypterClassName("AdvancedCrypter").build();
+      TableConfig serDeTableConfig = JsonUtils.stringToObject(origTableConfig.toJsonString(), TableConfig.class);
+      assertEquals(serDeTableConfig.getCrypterClassName(), "AdvancedCrypter");
+      serDeTableConfig = TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(origTableConfig));
+      assertEquals(serDeTableConfig.getCrypterClassName(), "AdvancedCrypter");
+    }
   }
 
   private void checkSegmentsValidationAndRetentionConfig(TableConfig tableConfig) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -248,8 +248,10 @@ public class TableConfigSerDeTest {
     {
       // with SegmentsValidationAndRetentionConfig
       TableConfig tableConfig = tableConfigBuilder.setPeerSegmentDownloadScheme("http").build();
-      checkSegmentsValidationAndRetentionConfig(JsonUtils.stringToObject(tableConfig.toJsonString(), TableConfig.class));
-      checkSegmentsValidationAndRetentionConfig(TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(tableConfig)));
+      checkSegmentsValidationAndRetentionConfig(
+          JsonUtils.stringToObject(tableConfig.toJsonString(), TableConfig.class));
+      checkSegmentsValidationAndRetentionConfig(
+          TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(tableConfig)));
     }
     {
       // With ingestion config
@@ -266,14 +268,6 @@ public class TableConfigSerDeTest {
       tableConfigToCompare = TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(tableConfig));
       assertEquals(tableConfigToCompare, tableConfig);
       checkIngestionConfig(tableConfigToCompare);
-    }
-    {
-      // with crypter class name
-      TableConfig origTableConfig = tableConfigBuilder.setCrypterClassName("AdvancedCrypter").build();
-      TableConfig serDeTableConfig = JsonUtils.stringToObject(origTableConfig.toJsonString(), TableConfig.class);
-      assertEquals(serDeTableConfig.getCrypterClassName(), "AdvancedCrypter");
-      serDeTableConfig = TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(origTableConfig));
-      assertEquals(serDeTableConfig.getCrypterClassName(), "AdvancedCrypter");
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -313,7 +313,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       return out;
     }
 
-    if (isUploadedSegmentEncrypted && !crypterClassNameInTableConfig.equalsIgnoreCase(crypterUsedInUploadedSegment)) {
+    if (isUploadedSegmentEncrypted && !crypterClassNameInTableConfig.equals(crypterUsedInUploadedSegment)) {
       throw new ControllerApplicationException(LOGGER, String
           .format("Uploaded segment is encrypted with '%s' while table config requires '%s' as crypter "
                   + "(segment name = '%s', table name = '%s').", crypterUsedInUploadedSegment,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -322,7 +322,7 @@ public class PinotSegmentUploadDownloadRestletResource {
 
     // encrypt segment
     PinotCrypter pinotCrypter = PinotCrypterFactory.create(crypterClassNameInTableConfig);
-    LOGGER.info("Using crypter class '{}' for encrypting '{}' to '{}' (segment name = '{}}', table name = '{}').",
+    LOGGER.info("Using crypter class '{}' for encrypting '{}' to '{}' (segment name = '{}', table name = '{}').",
         crypterClassNameInTableConfig, tempDecryptedFile, tempEncryptedFile, segmentName, tableName);
     pinotCrypter.encrypt(tempDecryptedFile, tempEncryptedFile);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import com.google.common.base.Strings;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -54,6 +55,8 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.CommonConstants;
@@ -71,7 +74,6 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.metadata.DefaultMetadataExtractor;
 import org.apache.pinot.core.metadata.MetadataExtractorFactory;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
-import org.apache.pinot.spi.crypt.NoOpPinotCrypter;
 import org.apache.pinot.spi.crypt.PinotCrypter;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
 import org.apache.pinot.spi.filesystem.PinotFS;
@@ -177,13 +179,13 @@ public class PinotSegmentUploadDownloadRestletResource {
   private SuccessResponse uploadSegment(@Nullable String tableName, FormDataMultiPart multiPart,
       boolean enableParallelPushProtection, HttpHeaders headers, Request request, boolean moveSegmentToFinalLocation) {
     String uploadTypeStr = null;
-    String crypterClassName = null;
+    String crypterClassNameInHeader = null;
     String downloadUri = null;
     if (headers != null) {
       extractHttpHeader(headers, CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER);
       extractHttpHeader(headers, CommonConstants.Controller.TABLE_NAME_HTTP_HEADER);
       uploadTypeStr = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE);
-      crypterClassName = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.CRYPTER);
+      crypterClassNameInHeader = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.CRYPTER);
       downloadUri = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI);
     }
 
@@ -194,37 +196,31 @@ public class PinotSegmentUploadDownloadRestletResource {
       ControllerFilePathProvider provider = ControllerFilePathProvider.getInstance();
       String tempFileName = TMP_DIR_PREFIX + System.nanoTime();
       tempDecryptedFile = new File(provider.getFileUploadTempDir(), tempFileName);
+      tempEncryptedFile = new File(provider.getFileUploadTempDir(), tempFileName + ENCRYPTED_SUFFIX);
       tempSegmentDir = new File(provider.getUntarredFileTempDir(), tempFileName);
 
-      // Set default crypter to the noop crypter when no crypter header is sent
-      // In this case, the noop crypter will not do any operations, so the encrypted and decrypted file will have the same
-      // file path.
-      if (crypterClassName == null) {
-        crypterClassName = NoOpPinotCrypter.class.getSimpleName();
-        tempEncryptedFile = new File(provider.getFileUploadTempDir(), tempFileName);
-      } else {
-        tempEncryptedFile = new File(provider.getFileUploadTempDir(), tempFileName + ENCRYPTED_SUFFIX);
-      }
+      boolean uploadedSegmentIsEncrypted = !Strings.isNullOrEmpty(crypterClassNameInHeader);
 
-      // TODO: Change when metadata upload added
-      String metadataProviderClass = DefaultMetadataExtractor.class.getName();
-
-      SegmentMetadata segmentMetadata;
+      File dstFile = uploadedSegmentIsEncrypted ? tempEncryptedFile : tempDecryptedFile;
       FileUploadDownloadClient.FileUploadType uploadType = getUploadType(uploadTypeStr);
       switch (uploadType) {
         case URI:
-          segmentMetadata =
-              getMetadataForURI(crypterClassName, downloadUri, tempEncryptedFile, tempDecryptedFile, tempSegmentDir,
-                  metadataProviderClass);
+          getSegmentFileFromURI(downloadUri, dstFile);
           break;
         case SEGMENT:
-          getFileFromMultipart(multiPart, tempEncryptedFile);
-          segmentMetadata = getSegmentMetadata(crypterClassName, tempEncryptedFile, tempDecryptedFile, tempSegmentDir,
-              metadataProviderClass);
+          getSegmentFileFromMultipart(multiPart, dstFile);
           break;
         default:
           throw new UnsupportedOperationException("Unsupported upload type: " + uploadType);
       }
+
+      if (uploadedSegmentIsEncrypted) {
+        decryptFile(crypterClassNameInHeader, tempEncryptedFile, tempDecryptedFile);
+      }
+
+      // TODO: Change when metadata upload added
+      String metadataProviderClass = DefaultMetadataExtractor.class.getName();
+      SegmentMetadata segmentMetadata = getSegmentMetadata(tempDecryptedFile, tempSegmentDir, metadataProviderClass);
 
       // Fetch segment name
       String segmentName = segmentMetadata.getName();
@@ -251,6 +247,20 @@ public class PinotSegmentUploadDownloadRestletResource {
           _controllerMetrics, _leadControllerManager.isLeaderForTable(offlineTableName))
           .validateOfflineSegment(offlineTableName, segmentMetadata, tempSegmentDir);
 
+      Pair<Boolean, String> encryptionInfo =
+          encryptSegmentIfNeeded(offlineTableName, tempDecryptedFile, tempEncryptedFile, uploadedSegmentIsEncrypted);
+
+      // crypter class name
+      String crypterClassNameInTableConfig = encryptionInfo.getRight();
+      String crypterClassName = Strings.isNullOrEmpty(crypterClassNameInTableConfig) ? crypterClassNameInHeader
+          : crypterClassNameInTableConfig;
+
+      // final segment file
+      Boolean segmentGotEncrypted = encryptionInfo.getLeft();
+      File finalSegmentFile =
+          (uploadedSegmentIsEncrypted || segmentGotEncrypted) ? tempEncryptedFile : tempDecryptedFile;
+
+      // ZK download URI
       String zkDownloadUri;
       // This boolean is here for V1 segment upload, where we keep the segment in the downloadURI sent in the header.
       // We will deprecate this behavior eventually.
@@ -264,8 +274,8 @@ public class PinotSegmentUploadDownloadRestletResource {
       }
 
       // Zk operations
-      completeZkOperations(enableParallelPushProtection, headers, tempEncryptedFile, rawTableName, segmentMetadata,
-          segmentName, zkDownloadUri, moveSegmentToFinalLocation);
+      completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, rawTableName, segmentMetadata,
+          segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName);
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentName + " of table: " + rawTableName);
     } catch (WebApplicationException e) {
@@ -290,6 +300,28 @@ public class PinotSegmentUploadDownloadRestletResource {
     return value;
   }
 
+  private Pair<Boolean, String> encryptSegmentIfNeeded(String offlineTableName, File tempDecryptedFile, File tempEncryptedFile,
+      boolean uploadedSegmentIsEncrypted) {
+
+    // get crypter class name from table config
+    String crypterClassName = _pinotHelixResourceManager.getCrypterClassNameFromTableConfig(offlineTableName);
+
+    boolean segmentNeedsEncryption = !Strings.isNullOrEmpty(crypterClassName);
+    if (segmentNeedsEncryption && uploadedSegmentIsEncrypted) {
+      throw new ControllerApplicationException(LOGGER, String.format(
+          "Uploaded segment is encrypted while non-empty crypterClassName in table config '%s' triggers segment encryption.",
+          crypterClassName), Response.Status.INTERNAL_SERVER_ERROR);
+    }
+
+    if (segmentNeedsEncryption) {
+      PinotCrypter pinotCrypter = PinotCrypterFactory.create(crypterClassName);
+      LOGGER.info("Using crypter class {} for encryption.", pinotCrypter.getClass().getName());
+      pinotCrypter.encrypt(tempDecryptedFile, tempEncryptedFile);
+    }
+
+    return ImmutablePair.of(segmentNeedsEncryption, crypterClassName);
+  }
+
   private String getZkDownloadURIForSegmentUpload(String rawTableName, String segmentName) {
     ControllerFilePathProvider provider = ControllerFilePathProvider.getInstance();
     URI dataDirURI = provider.getDataDirURI();
@@ -303,46 +335,37 @@ public class PinotSegmentUploadDownloadRestletResource {
     }
   }
 
-  private SegmentMetadata getMetadataForURI(String crypterClassHeader, String currentSegmentLocationURI,
-      File tempEncryptedFile, File tempDecryptedFile, File tempSegmentDir, String metadataProviderClass)
+  private void getSegmentFileFromURI(String currentSegmentLocationURI, File destFile)
       throws Exception {
-    SegmentMetadata segmentMetadata;
     if (currentSegmentLocationURI == null || currentSegmentLocationURI.isEmpty()) {
       throw new ControllerApplicationException(LOGGER, "Failed to get downloadURI, needed for URI upload",
           Response.Status.BAD_REQUEST);
     }
-    LOGGER.info("Downloading segment from {} to {}", currentSegmentLocationURI, tempEncryptedFile.getAbsolutePath());
-    SegmentFetcherFactory.fetchSegmentToLocal(currentSegmentLocationURI, tempEncryptedFile);
-    segmentMetadata = getSegmentMetadata(crypterClassHeader, tempEncryptedFile, tempDecryptedFile, tempSegmentDir,
-        metadataProviderClass);
-    return segmentMetadata;
+    LOGGER.info("Downloading segment from {} to {}", currentSegmentLocationURI, destFile.getAbsolutePath());
+    SegmentFetcherFactory.fetchSegmentToLocal(currentSegmentLocationURI, destFile);
   }
 
-  private SegmentMetadata getSegmentMetadata(String crypterClassHeader, File tempEncryptedFile, File tempDecryptedFile,
-      File tempSegmentDir, String metadataProviderClass)
+  private SegmentMetadata getSegmentMetadata(File tempDecryptedFile, File tempSegmentDir, String metadataProviderClass)
       throws Exception {
-
-    decryptFile(crypterClassHeader, tempEncryptedFile, tempDecryptedFile);
-
     // Call metadata provider to extract metadata with file object uri
     return MetadataExtractorFactory.create(metadataProviderClass).extractMetadata(tempDecryptedFile, tempSegmentDir);
   }
 
-  private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File tempEncryptedFile,
+  private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File uploadedSegmentFile,
       String rawTableName, SegmentMetadata segmentMetadata, String segmentName, String zkDownloadURI,
-      boolean moveSegmentToFinalLocation)
+      boolean moveSegmentToFinalLocation, String crypter)
       throws Exception {
     URI finalSegmentLocationURI = URIUtils
         .getUri(ControllerFilePathProvider.getInstance().getDataDirURI().toString(), rawTableName,
             URIUtils.encode(segmentName));
     ZKOperator zkOperator = new ZKOperator(_pinotHelixResourceManager, _controllerConf, _controllerMetrics);
-    zkOperator.completeSegmentOperations(rawTableName, segmentMetadata, finalSegmentLocationURI, tempEncryptedFile,
-        enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation);
+    zkOperator.completeSegmentOperations(rawTableName, segmentMetadata, finalSegmentLocationURI, uploadedSegmentFile,
+        enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation, crypter);
   }
 
-  private void decryptFile(String crypterClassHeader, File tempEncryptedFile, File tempDecryptedFile) {
-    PinotCrypter pinotCrypter = PinotCrypterFactory.create(crypterClassHeader);
-    LOGGER.info("Using crypter class {}", pinotCrypter.getClass().getName());
+  private void decryptFile(String crypterClassName, File tempEncryptedFile, File tempDecryptedFile) {
+    PinotCrypter pinotCrypter = PinotCrypterFactory.create(crypterClassName);
+    LOGGER.info("Using crypter class {} for decryption.", pinotCrypter.getClass().getName());
     pinotCrypter.decrypt(tempEncryptedFile, tempDecryptedFile);
   }
 
@@ -422,7 +445,7 @@ public class PinotSegmentUploadDownloadRestletResource {
     }
   }
 
-  private File getFileFromMultipart(FormDataMultiPart multiPart, File dstFile)
+  private File getSegmentFileFromMultipart(FormDataMultiPart multiPart, File dstFile)
       throws IOException {
     // Read segment file or segment metadata file and directly use that information to update zk
     Map<String, List<FormDataBodyPart>> segmentMetadataMap = multiPart.getFields();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -59,7 +59,7 @@ public class ZKOperator {
 
   public void completeSegmentOperations(String rawTableName, SegmentMetadata segmentMetadata,
       URI finalSegmentLocationURI, File currentSegmentLocation, boolean enableParallelPushProtection,
-      HttpHeaders headers, String zkDownloadURI, boolean moveSegmentToFinalLocation)
+      HttpHeaders headers, String zkDownloadURI, boolean moveSegmentToFinalLocation, String crypter)
       throws Exception {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
     String segmentName = segmentMetadata.getName();
@@ -69,7 +69,6 @@ public class ZKOperator {
         _pinotHelixResourceManager.getSegmentMetadataZnRecord(offlineTableName, segmentName);
     if (segmentMetadataZnRecord == null) {
       LOGGER.info("Adding new segment {} from table {}", segmentName, rawTableName);
-      String crypter = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER);
       processNewSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation, zkDownloadURI, crypter,
           rawTableName, segmentName, moveSegmentToFinalLocation);
       return;
@@ -78,13 +77,14 @@ public class ZKOperator {
     LOGGER.info("Segment {} from table {} already exists, refreshing if necessary", segmentName, rawTableName);
 
     processExistingSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation,
-        enableParallelPushProtection, headers, zkDownloadURI, offlineTableName, segmentName, segmentMetadataZnRecord,
-        moveSegmentToFinalLocation);
+        enableParallelPushProtection, headers, zkDownloadURI, crypter, offlineTableName, segmentName,
+        segmentMetadataZnRecord, moveSegmentToFinalLocation);
   }
 
   private void processExistingSegment(SegmentMetadata segmentMetadata, URI finalSegmentLocationURI,
       File currentSegmentLocation, boolean enableParallelPushProtection, HttpHeaders headers, String zkDownloadURI,
-      String offlineTableName, String segmentName, ZNRecord znRecord, boolean moveSegmentToFinalLocation)
+      String crypter, String offlineTableName, String segmentName, ZNRecord znRecord,
+      boolean moveSegmentToFinalLocation)
       throws Exception {
 
     OfflineSegmentZKMetadata existingSegmentZKMetadata = new OfflineSegmentZKMetadata(znRecord);
@@ -170,7 +170,6 @@ public class ZKOperator {
               zkDownloadURI);
         }
 
-        String crypter = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER);
         _pinotHelixResourceManager
             .refreshSegment(offlineTableName, segmentMetadata, existingSegmentZKMetadata, zkDownloadURI, crypter);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -458,6 +458,18 @@ public class PinotHelixResourceManager {
   public String getActualColumnName(String tableName, String columnName) {
     return _tableCache.getActualColumnName(tableName, columnName);
   }
+
+  /**
+   * Given a table name in any case, returns crypter class name defined in table config
+   * @param tableName table name in any case
+   * @return crypter class name
+   */
+  public String getCrypterClassNameFromTableConfig(String tableName) {
+    TableConfig tableConfig = _tableCache.getTableConfig(tableName);
+    Preconditions.checkNotNull(tableConfig, "Table config is not available for table '%s'", tableName);
+    return tableConfig.getCrypterClassName();
+  }
+
   /**
    * Table related APIs
    */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -467,7 +467,7 @@ public class PinotHelixResourceManager {
   public String getCrypterClassNameFromTableConfig(String tableName) {
     TableConfig tableConfig = _tableCache.getTableConfig(tableName);
     Preconditions.checkNotNull(tableConfig, "Table config is not available for table '%s'", tableName);
-    return tableConfig.getCrypterClassName();
+    return tableConfig.getValidationConfig().getCrypterClassName();
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResourceTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.controller.api.resources;
 
 import java.io.File;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResourceTest.java
@@ -1,0 +1,107 @@
+package org.apache.pinot.controller.api.resources;
+
+import java.io.File;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.spi.crypt.NoOpPinotCrypter;
+import org.apache.pinot.spi.crypt.PinotCrypterFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class PinotSegmentUploadDownloadRestletResourceTest {
+
+  private static final String TABLE_NAME = "table_abc";
+  private static final String SEGMENT_NAME = "segment_xyz";
+
+  private PinotSegmentUploadDownloadRestletResource _resource = new PinotSegmentUploadDownloadRestletResource();
+  private File _encryptedFile;
+  private File _decryptedFile;
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+
+    // create temp files
+    _encryptedFile = File.createTempFile("segment", ".enc");
+    _decryptedFile = File.createTempFile("segment", ".dec");
+    _encryptedFile.deleteOnExit();
+    _decryptedFile.deleteOnExit();
+
+    // configure pinot crypter
+    Configuration conf = new PropertiesConfiguration();
+    conf.addProperty("class.nooppinotcrypter", NoOpPinotCrypter.class.getName());
+    PinotCrypterFactory.init(conf);
+  }
+
+  @Test
+  public void testEncryptSegmentIfNeeded_crypterInTableConfig() {
+
+    // arrange
+    boolean uploadedSegmentIsEncrypted = false;
+    String crypterClassNameInTableConfig = "NoOpPinotCrypter";
+    String crypterClassNameUsedInUploadedSegment = null;
+
+    // act
+    Pair<String, File> encryptionInfo = _resource
+        .encryptSegmentIfNeeded(_decryptedFile, _encryptedFile, uploadedSegmentIsEncrypted,
+            crypterClassNameUsedInUploadedSegment, crypterClassNameInTableConfig, SEGMENT_NAME, TABLE_NAME);
+
+    // assert
+    assertEquals("NoOpPinotCrypter", encryptionInfo.getLeft());
+    assertEquals(_encryptedFile, encryptionInfo.getRight());
+  }
+
+  @Test
+  public void testEncryptSegmentIfNeeded_uploadedSegmentIsEncrypted() {
+
+    // arrange
+    boolean uploadedSegmentIsEncrypted = true;
+    String crypterClassNameInTableConfig = "NoOpPinotCrypter";
+    String crypterClassNameUsedInUploadedSegment = "NoOpPinotCrypter";
+
+    // act
+    Pair<String, File> encryptionInfo = _resource
+        .encryptSegmentIfNeeded(_decryptedFile, _encryptedFile, uploadedSegmentIsEncrypted,
+            crypterClassNameUsedInUploadedSegment, crypterClassNameInTableConfig, SEGMENT_NAME, TABLE_NAME);
+
+    // assert
+    assertEquals("NoOpPinotCrypter", encryptionInfo.getLeft());
+    assertEquals(_encryptedFile, encryptionInfo.getRight());
+  }
+
+  @Test(expectedExceptions = ControllerApplicationException.class, expectedExceptionsMessageRegExp = "Uploaded segment"
+      + " is encrypted with 'FancyCrypter' while table config requires 'NoOpPinotCrypter' as crypter .*")
+  public void testEncryptSegmentIfNeeded_differentCrypters() {
+
+    // arrange
+    boolean uploadedSegmentIsEncrypted = true;
+    String crypterClassNameInTableConfig = "NoOpPinotCrypter";
+    String crypterClassNameUsedInUploadedSegment = "FancyCrypter";
+
+    // act
+    _resource.encryptSegmentIfNeeded(_decryptedFile, _encryptedFile, uploadedSegmentIsEncrypted,
+        crypterClassNameUsedInUploadedSegment, crypterClassNameInTableConfig, SEGMENT_NAME, TABLE_NAME);
+  }
+
+  @Test
+  public void testEncryptSegmentIfNeeded_noEncryption() {
+
+    // arrange
+    boolean uploadedSegmentIsEncrypted = false;
+    String crypterClassNameInTableConfig = null;
+    String crypterClassNameUsedInUploadedSegment = null;
+
+    // act
+    Pair<String, File> encryptionInfo = _resource
+        .encryptSegmentIfNeeded(_decryptedFile, _encryptedFile, uploadedSegmentIsEncrypted,
+            crypterClassNameUsedInUploadedSegment, crypterClassNameInTableConfig, SEGMENT_NAME, TABLE_NAME);
+
+    // assert
+    assertNull(encryptionInfo.getLeft());
+    assertEquals(_decryptedFile, encryptionInfo.getRight());
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
@@ -66,9 +66,8 @@ public class ZKOperatorTest extends ControllerTest {
     when(segmentMetadata.getCrc()).thenReturn("12345");
     when(segmentMetadata.getIndexCreationTime()).thenReturn(123L);
     HttpHeaders httpHeaders = mock(HttpHeaders.class);
-    when(httpHeaders.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER)).thenReturn("crypter");
     zkOperator.completeSegmentOperations(RAW_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders, "downloadUrl",
-        false);
+        false, "crypter");
 
     OfflineSegmentZKMetadata segmentZKMetadata =
         _helixResourceManager.getOfflineSegmentZKMetadata(RAW_TABLE_NAME, SEGMENT_NAME);
@@ -84,7 +83,7 @@ public class ZKOperatorTest extends ControllerTest {
     when(httpHeaders.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn("123");
     try {
       zkOperator.completeSegmentOperations(RAW_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders,
-          "otherDownloadUrl", false);
+          "otherDownloadUrl", false, null);
       fail();
     } catch (Exception e) {
       // Expected
@@ -94,10 +93,9 @@ public class ZKOperatorTest extends ControllerTest {
     // downloadURL and crypter
     when(httpHeaders.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn("12345");
     when(segmentMetadata.getIndexCreationTime()).thenReturn(456L);
-    when(httpHeaders.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER)).thenReturn("otherCrypter");
     zkOperator
         .completeSegmentOperations(RAW_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders, "otherDownloadUrl",
-            false);
+            false, "otherCrypter");
     segmentZKMetadata = _helixResourceManager.getOfflineSegmentZKMetadata(RAW_TABLE_NAME, SEGMENT_NAME);
     assertEquals(segmentZKMetadata.getCrc(), 12345L);
     // Push time should not change
@@ -113,12 +111,11 @@ public class ZKOperatorTest extends ControllerTest {
     // Refresh the segment with a different segment (different CRC)
     when(segmentMetadata.getCrc()).thenReturn("23456");
     when(segmentMetadata.getIndexCreationTime()).thenReturn(789L);
-    when(httpHeaders.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER)).thenReturn("otherCrypter");
     // Add a tiny sleep to guarantee that refresh time is different from the previous round
     Thread.sleep(10L);
     zkOperator
         .completeSegmentOperations(RAW_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders, "otherDownloadUrl",
-            false);
+            false, "otherCrypter");
     segmentZKMetadata = _helixResourceManager.getOfflineSegmentZKMetadata(RAW_TABLE_NAME, SEGMENT_NAME);
     assertEquals(segmentZKMetadata.getCrc(), 23456L);
     // Push time should not change

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -39,6 +39,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _segmentAssignmentStrategy;
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
   private CompletionConfig _completionConfig;
+  private String _crypterClassName;
   // Possible values can be http or https. If this field is set, a Pinot server can download segments from peer servers
   // using the specified download scheme. Both realtime tables and offline tables can set this field.
   // For more usage of this field, please refer to this design doc:
@@ -158,9 +159,19 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     return Integer.parseInt(_replicasPerPartition);
   }
 
-  public String getPeerSegmentDownloadScheme() { return _peerSegmentDownloadScheme; }
+  public String getPeerSegmentDownloadScheme() {
+    return _peerSegmentDownloadScheme;
+  }
 
   public void setPeerSegmentDownloadScheme(String peerSegmentDownloadScheme) {
     _peerSegmentDownloadScheme = peerSegmentDownloadScheme;
+  }
+
+  public String getCrypterClassName() {
+    return _crypterClassName;
+  }
+
+  public void setCrypterClassName(String crypterClassName) {
+    _crypterClassName = crypterClassName;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -47,6 +47,7 @@ public class TableConfig extends BaseJsonConfig {
   public static final String FIELD_CONFIG_LIST_KEY = "fieldConfigList";
   public static final String UPSERT_CONFIG_KEY = "upsertConfig";
   public static final String INGESTION_CONFIG_KEY = "ingestionConfig";
+  public static final String CRYPTER_CLASS_NAME_KEY = "crypterClassName";
 
   // Double underscore is reserved for real-time segment name delimiter
   private static final String TABLE_NAME_FORBIDDEN_SUBSTRING = "__";
@@ -83,6 +84,8 @@ public class TableConfig extends BaseJsonConfig {
   @JsonPropertyDescription(value = "Config related to ingesting data into the table")
   private IngestionConfig _ingestionConfig;
 
+  private String _crypterClassName;
+
   @JsonCreator
   public TableConfig(@JsonProperty(value = TABLE_NAME_KEY, required = true) String tableName,
       @JsonProperty(value = TABLE_TYPE_KEY, required = true) String tableType,
@@ -97,7 +100,8 @@ public class TableConfig extends BaseJsonConfig {
       @JsonProperty(INSTANCE_ASSIGNMENT_CONFIG_MAP_KEY) @Nullable Map<InstancePartitionsType, InstanceAssignmentConfig> instanceAssignmentConfigMap,
       @JsonProperty(FIELD_CONFIG_LIST_KEY) @Nullable List<FieldConfig> fieldConfigList,
       @JsonProperty(UPSERT_CONFIG_KEY) @Nullable UpsertConfig upsertConfig,
-      @JsonProperty(INGESTION_CONFIG_KEY) @Nullable IngestionConfig ingestionConfig) {
+      @JsonProperty(INGESTION_CONFIG_KEY) @Nullable IngestionConfig ingestionConfig,
+      @JsonProperty(CRYPTER_CLASS_NAME_KEY) @Nullable String crypterClassName) {
     Preconditions.checkArgument(tableName != null, "'tableName' must be configured");
     Preconditions.checkArgument(!tableName.contains(TABLE_NAME_FORBIDDEN_SUBSTRING),
         "'tableName' cannot contain double underscore ('__')");
@@ -122,6 +126,7 @@ public class TableConfig extends BaseJsonConfig {
     _fieldConfigList = fieldConfigList;
     _upsertConfig = upsertConfig;
     _ingestionConfig = ingestionConfig;
+    _crypterClassName = crypterClassName;
   }
 
   @JsonProperty(TABLE_NAME_KEY)
@@ -248,5 +253,15 @@ public class TableConfig extends BaseJsonConfig {
 
   public void setIngestionConfig(IngestionConfig ingestionConfig) {
     _ingestionConfig = ingestionConfig;
+  }
+
+  @JsonProperty(CRYPTER_CLASS_NAME_KEY)
+  @Nullable
+  public String getCrypterClassName() {
+    return _crypterClassName;
+  }
+
+  public void setCrypterClassName(String crypterClassName) {
+    _crypterClassName = crypterClassName;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -47,7 +47,6 @@ public class TableConfig extends BaseJsonConfig {
   public static final String FIELD_CONFIG_LIST_KEY = "fieldConfigList";
   public static final String UPSERT_CONFIG_KEY = "upsertConfig";
   public static final String INGESTION_CONFIG_KEY = "ingestionConfig";
-  public static final String CRYPTER_CLASS_NAME_KEY = "crypterClassName";
 
   // Double underscore is reserved for real-time segment name delimiter
   private static final String TABLE_NAME_FORBIDDEN_SUBSTRING = "__";
@@ -84,8 +83,6 @@ public class TableConfig extends BaseJsonConfig {
   @JsonPropertyDescription(value = "Config related to ingesting data into the table")
   private IngestionConfig _ingestionConfig;
 
-  private String _crypterClassName;
-
   @JsonCreator
   public TableConfig(@JsonProperty(value = TABLE_NAME_KEY, required = true) String tableName,
       @JsonProperty(value = TABLE_TYPE_KEY, required = true) String tableType,
@@ -100,8 +97,7 @@ public class TableConfig extends BaseJsonConfig {
       @JsonProperty(INSTANCE_ASSIGNMENT_CONFIG_MAP_KEY) @Nullable Map<InstancePartitionsType, InstanceAssignmentConfig> instanceAssignmentConfigMap,
       @JsonProperty(FIELD_CONFIG_LIST_KEY) @Nullable List<FieldConfig> fieldConfigList,
       @JsonProperty(UPSERT_CONFIG_KEY) @Nullable UpsertConfig upsertConfig,
-      @JsonProperty(INGESTION_CONFIG_KEY) @Nullable IngestionConfig ingestionConfig,
-      @JsonProperty(CRYPTER_CLASS_NAME_KEY) @Nullable String crypterClassName) {
+      @JsonProperty(INGESTION_CONFIG_KEY) @Nullable IngestionConfig ingestionConfig) {
     Preconditions.checkArgument(tableName != null, "'tableName' must be configured");
     Preconditions.checkArgument(!tableName.contains(TABLE_NAME_FORBIDDEN_SUBSTRING),
         "'tableName' cannot contain double underscore ('__')");
@@ -126,7 +122,6 @@ public class TableConfig extends BaseJsonConfig {
     _fieldConfigList = fieldConfigList;
     _upsertConfig = upsertConfig;
     _ingestionConfig = ingestionConfig;
-    _crypterClassName = crypterClassName;
   }
 
   @JsonProperty(TABLE_NAME_KEY)
@@ -253,15 +248,5 @@ public class TableConfig extends BaseJsonConfig {
 
   public void setIngestionConfig(IngestionConfig ingestionConfig) {
     _ingestionConfig = ingestionConfig;
-  }
-
-  @JsonProperty(CRYPTER_CLASS_NAME_KEY)
-  @Nullable
-  public String getCrypterClassName() {
-    return _crypterClassName;
-  }
-
-  public void setCrypterClassName(String crypterClassName) {
-    _crypterClassName = crypterClassName;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/crypt/NoOpPinotCrypter.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/crypt/NoOpPinotCrypter.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.spi.crypt;
 
 import java.io.File;
+import java.io.IOException;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,11 +39,21 @@ public class NoOpPinotCrypter implements PinotCrypter {
 
   @Override
   public void encrypt(File decryptedFile, File encryptedFile) {
-    return;
+    try {
+      FileUtils.copyFile(decryptedFile, encryptedFile);
+    } catch (IOException e) {
+      LOGGER.warn("Could not encrypt file");
+      FileUtils.deleteQuietly(encryptedFile);
+    }
   }
 
   @Override
   public void decrypt(File encryptedFile, File decryptedFile) {
-    return;
+    try {
+      FileUtils.copyFile(encryptedFile, decryptedFile);
+    } catch (IOException e) {
+      LOGGER.warn("Could not decrypt file");
+      FileUtils.deleteQuietly(decryptedFile);
+    }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -97,6 +97,7 @@ public class TableConfigBuilder {
 
   private UpsertConfig _upsertConfig;
   private IngestionConfig _ingestionConfig;
+  private String _crypterClassName;
 
   public TableConfigBuilder(TableType tableType) {
     _tableType = tableType;
@@ -300,6 +301,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setCrypterClassName(String crypterClassName) {
+    _crypterClassName = crypterClassName;
+    return this;
+  }
+
   public TableConfig build() {
     // Validation config
     SegmentsValidationAndRetentionConfig validationConfig = new SegmentsValidationAndRetentionConfig();
@@ -344,6 +350,6 @@ public class TableConfigBuilder {
 
     return new TableConfig(_tableName, _tableType.toString(), validationConfig, tenantConfig, indexingConfig,
         _customConfig, _quotaConfig, _taskConfig, _routingConfig, _queryConfig, _instanceAssignmentConfigMap,
-        _fieldConfigList, _upsertConfig, _ingestionConfig);
+        _fieldConfigList, _upsertConfig, _ingestionConfig, _crypterClassName);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -68,6 +68,7 @@ public class TableConfigBuilder {
   private String _peerSegmentDownloadScheme;
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
   private CompletionConfig _completionConfig;
+  private String _crypterClassName;
 
   // Tenant config related
   private String _brokerTenant;
@@ -97,7 +98,6 @@ public class TableConfigBuilder {
 
   private UpsertConfig _upsertConfig;
   private IngestionConfig _ingestionConfig;
-  private String _crypterClassName;
 
   public TableConfigBuilder(TableType tableType) {
     _tableType = tableType;
@@ -171,6 +171,11 @@ public class TableConfigBuilder {
 
   public TableConfigBuilder setCompletionConfig(CompletionConfig completionConfig) {
     _completionConfig = completionConfig;
+    return this;
+  }
+
+  public TableConfigBuilder setCrypterClassName(String crypterClassName) {
+    _crypterClassName = crypterClassName;
     return this;
   }
 
@@ -301,11 +306,6 @@ public class TableConfigBuilder {
     return this;
   }
 
-  public TableConfigBuilder setCrypterClassName(String crypterClassName) {
-    _crypterClassName = crypterClassName;
-    return this;
-  }
-
   public TableConfig build() {
     // Validation config
     SegmentsValidationAndRetentionConfig validationConfig = new SegmentsValidationAndRetentionConfig();
@@ -324,6 +324,7 @@ public class TableConfigBuilder {
     if (_isLLC) {
       validationConfig.setReplicasPerPartition(_numReplicas);
     }
+    validationConfig.setCrypterClassName(_crypterClassName);
 
     // Tenant config
     TenantConfig tenantConfig = new TenantConfig(_brokerTenant, _serverTenant, _tagOverrideConfig);
@@ -350,6 +351,6 @@ public class TableConfigBuilder {
 
     return new TableConfig(_tableName, _tableType.toString(), validationConfig, tenantConfig, indexingConfig,
         _customConfig, _quotaConfig, _taskConfig, _routingConfig, _queryConfig, _instanceAssignmentConfigMap,
-        _fieldConfigList, _upsertConfig, _ingestionConfig, _crypterClassName);
+        _fieldConfigList, _upsertConfig, _ingestionConfig);
   }
 }


### PR DESCRIPTION
### Description
Currently if one wants to have their segments encrypted on Pinot cluster, they need to encrypt the segments before upload and then on the upload http request, `CRYPTER` header with crypter class name as the value needs to be set. In this PR, encryption is added on Controller side by introducing an optional config `crypterClassName` int table config. In UploadSegment path of Controller's REST API, this config is retrieved and if its value is not null, it triggers segment encryption using the specified crypter. 
Note that to have less pressure on ZK for retrieving table config on each segment upload, an existing cache for table configs, `TableCache` in `HelixResourceManager` is being used.

### Testing Done
Ran Controller, Server, and Broker locally with the new changes and verified the desired behavior in different scenarios for uploading segments:
1. `CRYPTER` header set to `NoOpPinotCrypter`
2. `crypterClassName` config set to `NoOpPinotCrypter`
3. Both 1 and 2
4. Neither

Also in each scenario, checked the value of crypter property of the uploaded segment ZK metadata.