### PR TITLE
[TE] Upgrade Pinot version to 0.4.0

### DIFF
--- a/thirdeye/docs/pinot.rst
+++ b/thirdeye/docs/pinot.rst
@@ -69,7 +69,7 @@ Update the `thirdeye-pinot/config/detector.yml` file to enable auto onboarding o
     ./run-backend.sh
 
 
-Note: This process may take some time. The worker process will print log messages for each data set schema being processed. Schemas must contain a `timeFieldSpec` in order for ThirdEye to onboard it automatically
+Note: This process may take some time. The worker process will print log messages for each data set schema being processed. Schemas must contain a `timeFieldSpec` or a `dateTimeFieldSpec` in order for ThirdEye to onboard it automatically
 
 
 **4: Stop the backend worker**

--- a/thirdeye/install.sh
+++ b/thirdeye/install.sh
@@ -2,7 +2,7 @@
 
 # [Optional] Uncomment below lines to build with latest Pinot changes
 # cd ..
-# mvn install -DskipTests -pl pinot-common,pinot-core,pinot-api -am -Pbuild-shaded-jar || exit 1
+# mvn install -DskipTests -pl pinot-common,pinot-core,pinot-spi,pinot-java-client -am -Pbuild-shaded-jar || exit 1
 # cd thirdeye
 
 echo "*******************************************************"

--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -35,7 +35,7 @@
     <revision>1.0.0</revision>
     <sha1>-SNAPSHOT</sha1>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pinot.version>0.1.0</pinot.version>
+    <pinot.version>0.4.0</pinot.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.version>1.8</jdk.version>
     <dropwizard.version>1.3.12</dropwizard.version>
@@ -170,7 +170,7 @@
       <!-- project dependencies -->
       <dependency>
         <groupId>org.apache.pinot</groupId>
-        <artifactId>pinot-api</artifactId>
+        <artifactId>pinot-java-client</artifactId>
         <version>${pinot.version}</version>
           <exclusions>
             <exclusion>
@@ -200,6 +200,17 @@
               <artifactId>jersey-server</artifactId>
             </exclusion>
           </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pinot</groupId>
+        <artifactId>pinot-spi</artifactId>
+        <version>${pinot.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- hadoop specific -->

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -92,7 +92,7 @@
 
     <dependency>
       <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-api</artifactId>
+      <artifactId>pinot-spi</artifactId>
       <exclusions>
         <exclusion>
           <groupId>javax.mail</groupId>
@@ -103,6 +103,10 @@
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-java-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
@@ -204,7 +204,7 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
    */
   private void refreshOldDataset(String dataset, Schema schema, String timeColumnName,
       Map<String, String> customConfigs, DatasetConfigDTO datasetConfig) {
-    checkDimensionChanges(dataset, datasetConfig, schema, timeColumnName);
+    checkDimensionChanges(dataset, datasetConfig, schema);
     checkMetricChanges(dataset, datasetConfig, schema);
     checkTimeFieldChanges(datasetConfig, schema, timeColumnName);
     appendNewCustomConfigs(datasetConfig, customConfigs);
@@ -212,15 +212,9 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
     datasetConfig.setActive(true);
   }
 
-  private void checkDimensionChanges(String dataset, DatasetConfigDTO datasetConfig, Schema schema,
-      String timeColumnName) {
+  private void checkDimensionChanges(String dataset, DatasetConfigDTO datasetConfig, Schema schema) {
     LOG.info("Checking for dimensions changes in {}", dataset);
-    List<String> schemaDimensions = new ArrayList<>(schema.getDimensionNames());
-     for (String dateTimeColumn : schema.getDateTimeNames()) { // treat all dateTimeFields specs as dimensions, except the primary time column
-      if (!dateTimeColumn.equals(timeColumnName)) {
-        schemaDimensions.add(dateTimeColumn);
-      }
-    }
+    List<String> schemaDimensions = schema.getDimensionNames();
     List<String> datasetDimensions = datasetConfig.getDimensions();
 
     // remove blacklisted dimensions

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetadataSource.java
@@ -39,9 +39,11 @@ import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pinot.common.data.MetricFieldSpec;
-import org.apache.pinot.common.data.Schema;
-import org.apache.pinot.common.data.TimeGranularitySpec;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DateTimeFieldSpec.TimeFormat;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.apache.pinot.spi.data.MetricFieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.thirdeye.datalayer.bao.AlertConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.MetricConfigManager;
@@ -55,7 +57,7 @@ import org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.thirdeye.auto.onboard.ConfigGenerator.*;
+import static org.apache.pinot.thirdeye.auto.onboard.ConfigGenerator.checkNonAdditive;
 
 /**
  * This is a service to onboard datasets automatically to thirdeye from pinot
@@ -105,15 +107,17 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
       List<String> allDatasets = new ArrayList<>();
       Map<String, Schema> allSchemas = new HashMap<>();
       Map<String, Map<String, String>> allCustomConfigs = new HashMap<>();
-      loadDatasets(allDatasets, allSchemas, allCustomConfigs);
+      Map<String, String> datasetToTimeColumn = new HashMap<>();
+      loadDatasets(allDatasets, allSchemas, allCustomConfigs, datasetToTimeColumn);
       LOG.info("Checking all datasets");
       deactivateDatasets(allDatasets);
       for (String dataset : allDatasets) {
         LOG.info("Checking dataset {}", dataset);
         Schema schema = allSchemas.get(dataset);
         Map<String, String> customConfigs = allCustomConfigs.get(dataset);
+        String timeColumnName = datasetToTimeColumn.get(dataset);
         DatasetConfigDTO datasetConfig = datasetDAO.findByDataset(dataset);
-        addPinotDataset(dataset, schema, customConfigs, datasetConfig);
+        addPinotDataset(dataset, schema, timeColumnName, customConfigs, datasetConfig);
       }
     } catch (Exception e) {
       LOG.error("Exception in loading datasets", e);
@@ -161,31 +165,28 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
 
   /**
    * Adds a dataset to the thirdeye database
-   * @param dataset
-   * @param schema
-   * @param datasetConfig
    */
-  public void addPinotDataset(String dataset, Schema schema, Map<String, String> customConfigs,
-      DatasetConfigDTO datasetConfig) throws Exception {
+  public void addPinotDataset(String dataset, Schema schema, String timeColumnName, Map<String, String> customConfigs,
+      DatasetConfigDTO datasetConfig)
+      throws Exception {
     if (datasetConfig == null) {
       LOG.info("Dataset {} is new, adding it to thirdeye", dataset);
-      addNewDataset(dataset, schema, customConfigs);
+      addNewDataset(dataset, schema, timeColumnName, customConfigs);
     } else {
       LOG.info("Dataset {} already exists, checking for updates", dataset);
-      refreshOldDataset(dataset, schema, customConfigs, datasetConfig);
+      refreshOldDataset(dataset, schema, timeColumnName, customConfigs, datasetConfig);
     }
   }
 
   /**
    * Adds a new dataset to the thirdeye database
-   * @param dataset
-   * @param schema
    */
-  private void addNewDataset(String dataset, Schema schema, Map<String, String> customConfigs) throws Exception {
+  private void addNewDataset(String dataset, Schema schema, String timeColumnName, Map<String, String> customConfigs) {
     List<MetricFieldSpec> metricSpecs = schema.getMetricFieldSpecs();
 
     // Create DatasetConfig
-    DatasetConfigDTO datasetConfigDTO = ConfigGenerator.generateDatasetConfig(dataset, schema, customConfigs);
+    DatasetConfigDTO datasetConfigDTO =
+        ConfigGenerator.generateDatasetConfig(dataset, schema, timeColumnName, customConfigs);
     LOG.info("Creating dataset for {}", dataset);
     this.datasetDAO.save(datasetConfigDTO);
 
@@ -200,23 +201,26 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
   /**
    * Refreshes an existing dataset in the thirdeye database
    * with any dimension/metric changes from pinot schema
-   * @param dataset
-   * @param schema
-   * @param datasetConfig
    */
-  private void refreshOldDataset(String dataset, Schema schema, Map<String, String> customConfigs,
-      DatasetConfigDTO datasetConfig) throws Exception {
-    checkDimensionChanges(dataset, datasetConfig, schema);
+  private void refreshOldDataset(String dataset, Schema schema, String timeColumnName,
+      Map<String, String> customConfigs, DatasetConfigDTO datasetConfig) {
+    checkDimensionChanges(dataset, datasetConfig, schema, timeColumnName);
     checkMetricChanges(dataset, datasetConfig, schema);
-    checkTimeFieldChanges(datasetConfig, schema);
+    checkTimeFieldChanges(datasetConfig, schema, timeColumnName);
     appendNewCustomConfigs(datasetConfig, customConfigs);
     checkNonAdditive(datasetConfig);
     datasetConfig.setActive(true);
   }
 
-  private void checkDimensionChanges(String dataset, DatasetConfigDTO datasetConfig, Schema schema) {
+  private void checkDimensionChanges(String dataset, DatasetConfigDTO datasetConfig, Schema schema,
+      String timeColumnName) {
     LOG.info("Checking for dimensions changes in {}", dataset);
-    List<String> schemaDimensions = schema.getDimensionNames();
+    List<String> schemaDimensions = new ArrayList<>(schema.getDimensionNames());
+     for (String dateTimeColumn : schema.getDateTimeNames()) { // treat all dateTimeFields specs as dimensions, except the primary time column
+      if (!dateTimeColumn.equals(timeColumnName)) {
+        schemaDimensions.add(dateTimeColumn);
+      }
+    }
     List<String> datasetDimensions = datasetConfig.getDimensions();
 
     // remove blacklisted dimensions
@@ -338,16 +342,21 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
 
   }
 
-  private void checkTimeFieldChanges(DatasetConfigDTO datasetConfig, Schema schema) {
-    TimeGranularitySpec timeSpec = schema.getTimeFieldSpec().getOutgoingGranularitySpec();
-    if (!datasetConfig.getTimeColumn().equals(timeSpec.getName())
-        || !datasetConfig.getTimeFormat().equals(timeSpec.getTimeFormat())
-        || datasetConfig.bucketTimeGranularity().getUnit() != timeSpec.getTimeType()
-        || datasetConfig.bucketTimeGranularity().getSize() != timeSpec.getTimeUnitSize()) {
-      ConfigGenerator.setTimeSpecs(datasetConfig, timeSpec);
+  private void checkTimeFieldChanges(DatasetConfigDTO datasetConfig, Schema schema, String timeColumnName) {
+    DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
+    DateTimeFormatSpec formatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
+    String timeFormatStr = formatSpec.getTimeFormat().equals(TimeFormat.SIMPLE_DATE_FORMAT) ? String
+        .format("%s:%s", TimeFormat.SIMPLE_DATE_FORMAT.toString(), formatSpec.getSDFPattern())
+        : TimeFormat.EPOCH.toString();
+    if (!datasetConfig.getTimeColumn().equals(timeColumnName)
+        || !datasetConfig.getTimeFormat().equals(timeFormatStr)
+        || datasetConfig.bucketTimeGranularity().getUnit() != formatSpec.getColumnUnit()
+        || datasetConfig.bucketTimeGranularity().getSize() != formatSpec.getColumnSize()) {
+      ConfigGenerator.setDateTimeSpecs(datasetConfig, timeColumnName, timeFormatStr, formatSpec.getColumnSize(),
+          formatSpec.getColumnUnit());
       DAO_REGISTRY.getDatasetConfigDAO().update(datasetConfig);
       LOG.info("Refreshed time field. name = {}, format = {}, type = {}, unit size = {}.",
-          timeSpec.getName(), timeSpec.getTimeType(), timeSpec.getTimeType(), timeSpec.getTimeUnitSize());
+          timeColumnName, timeFormatStr, formatSpec.getColumnUnit(), formatSpec.getColumnSize());
     }
   }
 
@@ -385,28 +394,36 @@ public class AutoOnboardPinotMetadataSource extends AutoOnboard {
   }
 
   /**
-   * Reads all table names in pinot, and loads their schema
-   * @param allSchemas
-   * @param allDatasets
-   * @throws IOException
+   * For every table in Pinot, fetches the following:
+   * 1. Pinot schema
+   * 2. TimeColumnName from Pinot table config
+   * 3. Custom property map from Pinot table config
    */
   private void loadDatasets(List<String> allDatasets, Map<String, Schema> allSchemas,
-      Map<String, Map<String, String>> allCustomConfigs) throws IOException {
+      Map<String, Map<String, String>> allCustomConfigs, Map<String, String> datasetToTimeColumnMap) throws IOException {
 
     JsonNode tables = autoLoadPinotMetricsUtils.getAllTablesFromPinot();
     LOG.info("Getting all schemas");
     for (JsonNode table : tables) {
       String dataset = table.asText();
-      Map<String, String> pinotCustomProperty = autoLoadPinotMetricsUtils.getCustomConfigsFromPinotEndpoint(dataset);
       Schema schema = autoLoadPinotMetricsUtils.getSchemaFromPinot(dataset);
       if (schema != null) {
-        if (!autoLoadPinotMetricsUtils.verifySchemaCorrectness(schema)) {
-          LOG.info("Skipping {} due to incorrect schema", dataset);
-        } else {
-          allDatasets.add(dataset);
-          allSchemas.put(dataset, schema);
-          allCustomConfigs.put(dataset, pinotCustomProperty);
+        JsonNode tableConfigJson = autoLoadPinotMetricsUtils.getTableConfigFromPinotEndpoint(dataset);
+        String timeColumnName = null;
+        Map<String, String> pinotCustomProperty = null;
+        if (tableConfigJson != null && !tableConfigJson.isNull()) {
+          timeColumnName = autoLoadPinotMetricsUtils.extractTimeColumnFromPinotTable(tableConfigJson);
+          pinotCustomProperty =
+              autoLoadPinotMetricsUtils.extractCustomConfigsFromPinotTable(tableConfigJson);
         }
+        if (!autoLoadPinotMetricsUtils.verifySchemaCorrectness(schema, timeColumnName)) {
+          LOG.info("Skipping {} due to incorrect schema", dataset);
+          continue;
+        }
+        allDatasets.add(dataset);
+        allSchemas.put(dataset, schema);
+        allCustomConfigs.put(dataset, pinotCustomProperty);
+        datasetToTimeColumnMap.put(dataset, timeColumnName);
       }
     }
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
@@ -217,7 +217,7 @@ public class AutoOnboardPinotMetricsUtils {
 
   public String extractTimeColumnFromPinotTable(JsonNode tableConfigJson) {
     JsonNode timeColumnNode = tableConfigJson.get("segmentsConfig").get("timeColumnName");
-    return (timeColumnNode != null && !timeColumnNode.isNull()) ? timeColumnNode.toString() : null;
+    return (timeColumnNode != null && !timeColumnNode.isNull()) ? timeColumnNode.asText() : null;
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
@@ -19,12 +19,9 @@
 
 package org.apache.pinot.thirdeye.auto.onboard;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.pinot.common.data.Schema;
-import org.apache.pinot.thirdeye.datasource.DataSourceConfig;
-import org.apache.pinot.thirdeye.datasource.MetadataSourceConfig;
-import org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSourceConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
@@ -34,8 +31,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
@@ -47,6 +44,9 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.TrustStrategy;
 import org.apache.http.util.EntityUtils;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.thirdeye.datasource.MetadataSourceConfig;
+import org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,25 +156,18 @@ public class AutoOnboardPinotMetricsUtils {
     return schema;
   }
 
-  public boolean verifySchemaCorrectness(Schema schema) {
-    boolean isSchemaCorrect = true;
-    if (StringUtils.isBlank(schema.getSchemaName()) || schema.getTimeFieldSpec() == null
-        || schema.getTimeFieldSpec().getOutgoingGranularitySpec() == null) {
-      isSchemaCorrect = false;
+  /**
+   * Verify schema name and presence of field spec for time column
+   */
+  public boolean verifySchemaCorrectness(Schema schema, @Nullable String timeColumnName) {
+    if (StringUtils.isBlank(schema.getSchemaName()) || timeColumnName == null
+        || schema.getSpecForTimeColumn(timeColumnName) == null) {
+      return false;
     }
-    return isSchemaCorrect;
+    return true;
   }
 
-  /**
-   * Returns the map of custom configs of the given dataset from the table config on Pinot.
-   *
-   * @param dataset the target dataset
-   *
-   * @return the field, which is a Map of string to string, of custom config on Pinot's table config
-   *
-   * @throws IOException if this method fails to connect to Pinot endpoint.
-   */
-  public Map<String, String> getCustomConfigsFromPinotEndpoint(String dataset) throws IOException {
+  public JsonNode getTableConfigFromPinotEndpoint(String dataset) throws IOException {
     HttpGet request = new HttpGet(String.format(PINOT_TABLES_ENDPOINT_TEMPLATE, dataset));
     CloseableHttpResponse response = pinotControllerClient.execute(pinotControllerHost, request);
     LOG.debug("Retrieving dataset's custom config: {}", request);
@@ -196,25 +189,35 @@ public class AutoOnboardPinotMetricsUtils {
       response.close();
     }
 
-    // Parse custom config
-    Map<String, String> customConfigs = Collections.emptyMap();
+    JsonNode tableJson = null;
     if (tables != null) {
-      JsonNode table = tables.get("REALTIME");
-      if (table == null || table.isNull()) {
-        table = tables.get("OFFLINE");
-      }
-      if (table != null && !table.isNull()) {
-        try {
-          JsonNode jsonNode = table.get("metadata").get("customConfigs");
-          customConfigs = OBJECT_MAPPER.convertValue(jsonNode, HashMap.class);
-        } catch (Exception e) {
-          LOG.warn("Failed to get custom config for dataset: {}. Reason: {}", dataset, e);
-        }
-      } else {
-        LOG.debug("Dataset {} doesn't exists in Pinot.", dataset);
+      tableJson = tables.get("REALTIME");
+      if (tableJson == null || tableJson.isNull()) {
+        tableJson = tables.get("OFFLINE");
       }
     }
+    return tableJson;
+  }
+
+  /**
+   * Returns the map of custom configs of the given dataset from the Pinot table config json.
+   */
+  public Map<String, String> extractCustomConfigsFromPinotTable(JsonNode tableConfigJson) {
+
+    Map<String, String> customConfigs = Collections.emptyMap();
+    try {
+      JsonNode jsonNode = tableConfigJson.get("metadata").get("customConfigs");
+      customConfigs = OBJECT_MAPPER.convertValue(jsonNode, new TypeReference<Map<String, String>>() {
+      });
+    } catch (Exception e) {
+      LOG.warn("Failed to get custom config from table: {}. Reason: {}", tableConfigJson, e);
+    }
     return customConfigs;
+  }
+
+  public String extractTimeColumnFromPinotTable(JsonNode tableConfigJson) {
+    JsonNode timeColumnNode = tableConfigJson.get("segmentsConfig").get("timeColumnName");
+    return (timeColumnNode != null && !timeColumnNode.isNull()) ? timeColumnNode.toString() : null;
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/ConfigGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/ConfigGenerator.java
@@ -76,17 +76,12 @@ public class ConfigGenerator {
 
   public static DatasetConfigDTO generateDatasetConfig(String dataset, Schema schema, String timeColumnName,
       Map<String, String> customConfigs) {
-    List<String> dimensions = new ArrayList<>(schema.getDimensionNames());
-    for (String dateTimeColumn : schema.getDateTimeNames()) { // treat all dateTimeFields specs as dimensions, except the primary time column
-      if (!dateTimeColumn.equals(timeColumnName)) {
-        dimensions.add(dateTimeColumn);
-      }
-    }
+    List<String> dimensions = schema.getDimensionNames();
     DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
     // Create DatasetConfig
     DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO();
     datasetConfigDTO.setDataset(dataset);
-    datasetConfigDTO.setDimensions(Lists.newArrayList(dimensions));
+    datasetConfigDTO.setDimensions(dimensions);
     setDateTimeSpecs(datasetConfigDTO, dateTimeFieldSpec);
     datasetConfigDTO.setDataSource(PinotThirdEyeDataSource.DATA_SOURCE_NAME);
     datasetConfigDTO.setProperties(customConfigs);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/ConfigGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auto/onboard/ConfigGenerator.java
@@ -19,14 +19,17 @@
 
 package org.apache.pinot.thirdeye.auto.onboard;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.apache.pinot.common.data.MetricFieldSpec;
-import org.apache.pinot.common.data.Schema;
-import org.apache.pinot.common.data.TimeGranularitySpec;
-import org.apache.pinot.common.data.TimeGranularitySpec.TimeFormat;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DateTimeFieldSpec.TimeFormat;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.apache.pinot.spi.data.MetricFieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.thirdeye.common.metric.MetricType;
 import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.common.time.TimeSpec;
@@ -44,15 +47,24 @@ public class ConfigGenerator {
   private static final String NON_ADDITIVE = "non_additive";
   private static final String PINOT_PRE_AGGREGATED_KEYWORD = "*";
 
-  public static void setTimeSpecs(DatasetConfigDTO datasetConfigDTO, TimeGranularitySpec timeSpec) {
-    datasetConfigDTO.setTimeColumn(timeSpec.getName());
-    datasetConfigDTO.setTimeDuration(timeSpec.getTimeUnitSize());
-    datasetConfigDTO.setTimeUnit(timeSpec.getTimeType());
-    datasetConfigDTO.setTimeFormat(timeSpec.getTimeFormat());
-    datasetConfigDTO.setExpectedDelay(getExpectedDelayFromTimeunit(timeSpec.getTimeType()));
-    if (timeSpec.getTimeFormat().startsWith(TimeFormat.SIMPLE_DATE_FORMAT.toString()) || timeSpec.getTimeFormat().equals(TimeSpec.SINCE_EPOCH_FORMAT)) {
-      datasetConfigDTO.setTimezone(PDT_TIMEZONE);
-    }
+  public static void setDateTimeSpecs(DatasetConfigDTO datasetConfigDTO, DateTimeFieldSpec dateTimeFieldSpec) {
+    Preconditions.checkNotNull(dateTimeFieldSpec);
+    DateTimeFormatSpec formatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
+    String timeFormatStr = formatSpec.getTimeFormat().equals(TimeFormat.SIMPLE_DATE_FORMAT) ? String
+        .format("%s:%s", TimeFormat.SIMPLE_DATE_FORMAT.toString(), formatSpec.getSDFPattern())
+        : TimeFormat.EPOCH.toString();
+    setDateTimeSpecs(datasetConfigDTO, dateTimeFieldSpec.getName(), timeFormatStr, formatSpec.getColumnSize(),
+        formatSpec.getColumnUnit());
+  }
+
+  public static void setDateTimeSpecs(DatasetConfigDTO datasetConfigDTO, String timeColumnName, String timeFormatStr,
+      int columnSize, TimeUnit columnUnit) {
+    datasetConfigDTO.setTimeColumn(timeColumnName);
+    datasetConfigDTO.setTimeDuration(columnSize);
+    datasetConfigDTO.setTimeUnit(columnUnit);
+    datasetConfigDTO.setTimeFormat(timeFormatStr);
+    datasetConfigDTO.setExpectedDelay(getExpectedDelayFromTimeunit(columnUnit));
+    datasetConfigDTO.setTimezone(PDT_TIMEZONE);
     // set the data granularity of epoch timestamp dataset to minute-level
     if (datasetConfigDTO.getTimeFormat().equals(TimeSpec.SINCE_EPOCH_FORMAT) && datasetConfigDTO.getTimeUnit()
         .equals(TimeUnit.MILLISECONDS) && (datasetConfigDTO.getNonAdditiveBucketSize() == null
@@ -62,15 +74,20 @@ public class ConfigGenerator {
     }
   }
 
-  public static DatasetConfigDTO generateDatasetConfig(String dataset, Schema schema,
+  public static DatasetConfigDTO generateDatasetConfig(String dataset, Schema schema, String timeColumnName,
       Map<String, String> customConfigs) {
-    List<String> dimensions = schema.getDimensionNames();
-    TimeGranularitySpec timeSpec = schema.getTimeFieldSpec().getOutgoingGranularitySpec();
+    List<String> dimensions = new ArrayList<>(schema.getDimensionNames());
+    for (String dateTimeColumn : schema.getDateTimeNames()) { // treat all dateTimeFields specs as dimensions, except the primary time column
+      if (!dateTimeColumn.equals(timeColumnName)) {
+        dimensions.add(dateTimeColumn);
+      }
+    }
+    DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
     // Create DatasetConfig
     DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO();
     datasetConfigDTO.setDataset(dataset);
-    datasetConfigDTO.setDimensions(dimensions);
-    setTimeSpecs(datasetConfigDTO, timeSpec);
+    datasetConfigDTO.setDimensions(Lists.newArrayList(dimensions));
+    setDateTimeSpecs(datasetConfigDTO, dateTimeFieldSpec);
     datasetConfigDTO.setDataSource(PinotThirdEyeDataSource.DATA_SOURCE_NAME);
     datasetConfigDTO.setProperties(customConfigs);
     checkNonAdditive(datasetConfigDTO);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/time/TimeSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/time/TimeSpec.java
@@ -19,17 +19,17 @@
 
 package org.apache.pinot.thirdeye.common.time;
 
-import java.util.concurrent.TimeUnit;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.pinot.common.data.TimeGranularitySpec.TimeFormat;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+
 
 public class TimeSpec {
   private static final TimeGranularity DEFAULT_TIME_GRANULARITY= new TimeGranularity(1, TimeUnit.DAYS);
   private String columnName;
   private TimeGranularity dataGranularity = DEFAULT_TIME_GRANULARITY;
   private String format = SINCE_EPOCH_FORMAT; //sinceEpoch or yyyyMMdd
-  public static String SINCE_EPOCH_FORMAT  = TimeFormat.EPOCH.toString();
+  public static String SINCE_EPOCH_FORMAT  = DateTimeFieldSpec.TimeFormat.EPOCH.toString();
   public static String DEFAULT_TIMEZONE = "UTC";
 
   public TimeSpec() {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/DataFrame.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dataframe/DataFrame.java
@@ -19,8 +19,6 @@
 
 package org.apache.pinot.thirdeye.dataframe;
 
-import org.apache.pinot.client.ResultSet;
-import org.apache.pinot.client.ResultSetGroup;
 import com.udojava.evalex.Expression;
 import java.io.IOException;
 import java.io.Reader;
@@ -41,6 +39,8 @@ import java.util.regex.Pattern;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.client.ResultSet;
+import org.apache.pinot.client.ResultSetGroup;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PqlUtils.java
@@ -24,7 +24,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import org.apache.pinot.common.data.TimeGranularitySpec;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.common.time.TimeSpec;
 import org.apache.pinot.thirdeye.constant.MetricAggFunction;
@@ -246,13 +246,13 @@ public class PqlUtils {
     return builder.toString();
   }
 
-  static String getBetweenClause(DateTime start, DateTime endExclusive, TimeSpec timeFieldSpec, String dataset)
+  static String getBetweenClause(DateTime start, DateTime endExclusive, TimeSpec timeSpec, String dataset)
       throws ExecutionException {
-    TimeGranularity dataGranularity = timeFieldSpec.getDataGranularity();
+    TimeGranularity dataGranularity = timeSpec.getDataGranularity();
     long dataGranularityMillis = dataGranularity.toMillis();
 
-    String timeField = timeFieldSpec.getColumnName();
-    String timeFormat = timeFieldSpec.getFormat();
+    String timeField = timeSpec.getColumnName();
+    String timeFormat = timeSpec.getFormat();
 
     // epoch case
     if (timeFormat == null || TimeSpec.SINCE_EPOCH_FORMAT.equals(timeFormat)) {
@@ -360,7 +360,7 @@ public class PqlUtils {
     if (aggregationGranularity != null && !groups.contains(timeColumnName)) {
       // Convert the time column to 1 minute granularity if it is epoch.
       // E.g., dateTimeConvert(timestampInEpoch,'1:MILLISECONDS:EPOCH','1:MILLISECONDS:EPOCH','1:MINUTES')
-      if (timeSpec.getFormat().equals(TimeGranularitySpec.TimeFormat.EPOCH.toString())
+      if (timeSpec.getFormat().equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString())
           && !timeSpec.getDataGranularity().equals(aggregationGranularity)) {
         String groupByTimeColumnName = convertEpochToMinuteAggGranularity(timeColumnName, timeSpec);
         groups.add(groupByTimeColumnName);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
@@ -320,12 +320,12 @@ public class SqlUtils {
     return datasetName.substring(tableComponents[0].length()+tableComponents[1].length()+2);
   }
 
-  static String getBetweenClause(DateTime start, DateTime endExclusive, TimeSpec timeFieldSpec, String sourceName) {
-    TimeGranularity dataGranularity = timeFieldSpec.getDataGranularity();
+  static String getBetweenClause(DateTime start, DateTime endExclusive, TimeSpec timeSpec, String sourceName) {
+    TimeGranularity dataGranularity = timeSpec.getDataGranularity();
     long dataGranularityMillis = dataGranularity.toMillis();
 
-    String timeField = timeFieldSpec.getColumnName();
-    String timeFormat = timeFieldSpec.getFormat();
+    String timeField = timeSpec.getColumnName();
+    String timeFormat = timeSpec.getFormat();
 
     // epoch case
     if (TimeSpec.SINCE_EPOCH_FORMAT.equals(timeFormat)) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/ModelRetuneFlow.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/ModelRetuneFlow.java
@@ -23,7 +23,6 @@
 package org.apache.pinot.thirdeye.detection;
 
 import com.google.common.base.Preconditions;
-import com.sun.org.apache.xpath.internal.operations.Mod;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/ThirdEyeUtils.java
@@ -55,7 +55,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.pinot.common.data.TimeGranularitySpec.TimeFormat;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.thirdeye.common.dimension.DimensionMap;
 import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.common.time.TimeSpec;
@@ -83,7 +83,7 @@ import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.thirdeye.detection.wrapper.GrouperWrapper.*;
+import static org.apache.pinot.thirdeye.detection.wrapper.GrouperWrapper.PROP_DETECTOR_COMPONENT_NAME;
 
 
 public abstract class ThirdEyeUtils {
@@ -238,7 +238,7 @@ public abstract class ThirdEyeUtils {
 
   private static String getTimeFormatString(DatasetConfigDTO datasetConfig) {
     String timeFormat = datasetConfig.getTimeFormat();
-    if (timeFormat.startsWith(TimeFormat.SIMPLE_DATE_FORMAT.toString())) {
+    if (timeFormat.startsWith(DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT.toString())) {
       timeFormat = getSDFPatternFromTimeFormat(timeFormat);
     }
     return timeFormat;

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/pinot/PqlUtilsTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/pinot/PqlUtilsTest.java
@@ -76,8 +76,8 @@ public class PqlUtilsTest {
   }
 
   @Test(dataProvider = "betweenClauseArgs")
-  public void getBetweenClause(DateTime start, DateTime end, TimeSpec timeFieldSpec, String expected) throws ExecutionException {
-    String betweenClause = PqlUtils.getBetweenClause(start, end, timeFieldSpec, "collection");
+  public void getBetweenClause(DateTime start, DateTime end, TimeSpec timeSpec, String expected) throws ExecutionException {
+    String betweenClause = PqlUtils.getBetweenClause(start, end, timeSpec, "collection");
     Assert.assertEquals(betweenClause, expected);
   }
 


### PR DESCRIPTION
## Description
Upgrade Pinot version to 0.4.0
Starting 0.4.0, Pinot schemas can express time column as DateTimeFieldSpec. Handled that in onboarding utils.

## Release Notes
Upgrade Pinot version in TE to 0.4.0

