### PR TITLE
[TE] alert search - search by both metrics and datasets

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
@@ -38,6 +38,7 @@ export default Controller.extend({
   totalNumberOfAlerts: 0,
   user: reads('model.user'),
   rules: reads('model.rules'),
+  userMail: reads('model.userMail'),
 
   /**
    * Used to help display filter settings in page header
@@ -98,7 +99,7 @@ export default Controller.extend({
       const {
         originalAlerts,
         user
-      } = this.getProperties('originalAlerts', 'user');
+      } = this.getProperties('originalAlerts', 'userMail');
 
       return originalAlerts.filter(alert => alert.createdBy === user);
     }
@@ -343,7 +344,7 @@ export default Controller.extend({
         break;
       }
       case 'Alerts I own': {
-        paramsForAlerts['createdBy'] = this.get('user');
+        paramsForAlerts['createdBy'] = this.get('userMail');
         set(this, 'selectedGlobalFilter', [primaryFilter]);
         break;
       }

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
@@ -35,13 +35,11 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
     const alerts = enrichAlertResponseObject(alertsFromResponse);
 
-    let user = getWithDefault(get(this, 'session'), 'data.authenticated.name', null);
+    let userMail = getWithDefault(get(this, 'session'), 'data.authenticated.name', null);
     let token = config.userNameSplitToken;
-
-    user = user ? user.split(token)[0] : user;
+    let user = userMail ? userMail.split(token)[0] : userMail;
     // Add these filtered arrays to the model (they are only assigned once)
-
-    Object.assign(model, { alerts, user });
+    Object.assign(model, { alerts, user , userMail});
   },
 
   setupController(controller, model) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertResource.java
@@ -52,6 +52,9 @@ public class AlertResource {
   /**
    * Search the alerts with result pagination. It will return record from No.(offset+1) to record No.(offset + limit).
    *
+   * The endpoint will return paginated results for alerts that pass all the filters. Within each filter option,
+   * the result only need to pass either one of them.
+   *
    * @param limit the returned result limit
    * @param offset the offset of the start position
    * @param applications the applications for the alerts

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertSearcher.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/alerts/AlertSearcher.java
@@ -194,15 +194,23 @@ public class AlertSearcher {
     Set<Long> metricIds = new HashSet<>();
     if (!searchFilter.getMetrics().isEmpty()) {
       for (String metric : searchFilter.getMetrics()) {
-        metricIds =
-            this.metricDAO.findByMetricName(metric).stream().map(AbstractDTO::getId).collect(Collectors.toSet());
+        metricIds.addAll(
+            this.metricDAO.findByMetricName(metric).stream().map(AbstractDTO::getId).collect(Collectors.toSet()));
       }
     }
 
     if (!searchFilter.getDatasets().isEmpty()) {
+      Set<Long> metricIdsFromDataset = new HashSet<>();
       for (String dataset : searchFilter.getDatasets()) {
-        metricIds.retainAll(
-            this.metricDAO.findByDataset(dataset).stream().map(AbstractDTO::getId).collect(Collectors.toSet()));
+        metricIdsFromDataset.addAll(this.metricDAO.findByPredicate(Predicate.LIKE("dataset", "%" + dataset + "%"))
+            .stream()
+            .map(AbstractDTO::getId)
+            .collect(Collectors.toSet()));
+      }
+      if (!searchFilter.getMetrics().isEmpty()) {
+        metricIds.retainAll(metricIdsFromDataset);
+      } else {
+        metricIds = metricIdsFromDataset;
       }
     }
 


### PR DESCRIPTION
Previously, the alert search will return an empty result when querying with the metric and dataset name at the same time. This PR fixes the issue.