### PR TITLE
Adding close method to java client connection

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -174,6 +174,16 @@ public class Connection {
     return _brokerList;
   }
 
+  /**
+   * Close the connection for further processing
+   *
+   * @throws PinotClientException when connection is already closed
+   */
+  public void close()
+      throws PinotClientException {
+    _transport.close();
+  }
+
   private static class ResultSetGroupFuture implements Future<ResultSetGroup> {
     private final Future<BrokerResponse> _responseFuture;
 

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -43,7 +43,8 @@ class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
   AsyncHttpClient _httpClient = new AsyncHttpClient();
   Map<String, String> _headers;
 
-  public JsonAsyncHttpPinotClientTransport() {}
+  public JsonAsyncHttpPinotClientTransport() {
+  }
 
   public JsonAsyncHttpPinotClientTransport(Map<String, String> headers) {
     _headers = headers;
@@ -80,13 +81,13 @@ class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
 
       AsyncHttpClient.BoundRequestBuilder requestBuilder = _httpClient.preparePost(url);
 
-      if(_headers != null) {
+      if (_headers != null) {
         _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));
       }
 
-      final Future<Response> response = requestBuilder
-          .addHeader("Content-Type", "application/json; charset=utf-8")
-          .setBody(json.toString()).execute();
+      final Future<Response> response =
+          requestBuilder.addHeader("Content-Type", "application/json; charset=utf-8").setBody(json.toString())
+              .execute();
 
       return new BrokerResponseFuture(response, request.getQuery(), url);
     } catch (Exception e) {
@@ -108,6 +109,15 @@ class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
   public Future<BrokerResponse> executeQueryAsync(String brokerAddress, Request request)
       throws PinotClientException {
     return executePinotQueryAsync(brokerAddress, request);
+  }
+
+  @Override
+  public void close()
+      throws PinotClientException {
+    if (_httpClient.isClosed()) {
+      throw new PinotClientException("Connection is already closed!");
+    }
+    _httpClient.close();
   }
 
   private static class BrokerResponseFuture implements Future<BrokerResponse> {

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/PinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/PinotClientTransport.java
@@ -36,4 +36,7 @@ interface PinotClientTransport {
 
   Future<BrokerResponse> executeQueryAsync(String brokerAddress, Request request)
       throws PinotClientException;
+
+  void close()
+      throws PinotClientException;
 }

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/PreparedStatementTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/PreparedStatementTest.java
@@ -90,6 +90,12 @@ public class PreparedStatementTest {
     public String getLastQuery() {
       return _lastQuery;
     }
+
+    @Override
+    public void close()
+        throws PinotClientException {
+
+    }
   }
 
   class DummyPinotClientTransportFactory implements PinotClientTransportFactory {

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ResultSetGroupTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ResultSetGroupTest.java
@@ -170,6 +170,12 @@ public class ResultSetGroupTest {
         throws PinotClientException {
       return null;
     }
+
+    @Override
+    public void close()
+        throws PinotClientException {
+
+    }
   }
 
   class DummyJsonTransportFactory implements PinotClientTransportFactory {


### PR DESCRIPTION
Currently Java client doesn't offer the function to close the connection.
This leads to http client's netty threads in running state even when the user has executed all the queries.