### PR TITLE
Remove updateExistedSegment method

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableCustomConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableCustomConfig.java
@@ -27,8 +27,6 @@ import javax.annotation.Nullable;
 
 
 public class TableCustomConfig extends BaseJsonConfig {
-  public static final String MESSAGE_BASED_REFRESH_KEY = "messageBasedRefresh";
-
   private final Map<String, String> _customConfigs;
 
   @JsonCreator


### PR DESCRIPTION
This PR removes updateExistedSegment method, since it's a legacy code and it's unused and will lead to race condition.