### PR TITLE
Refactor how Pinot controller stores segment download url in Zookeeper to deal with peer uri format

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -350,6 +350,7 @@ public class CommonConstants {
     public static final String SEGMENT_TEMP_DIR_SUFFIX = ".segment.tmp";
 
     public static final String LOCAL_SEGMENT_SCHEME = "file";
+    public static final String METADATA_URI_FOR_PEER_DOWNLOAD = "";
 
     public enum SegmentType {
       OFFLINE, REALTIME

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -319,6 +319,7 @@ public class LLCSegmentCompletionHandlers {
         }
         committingSegmentDescriptor =
             CommittingSegmentDescriptor.fromSegmentCompletionReqParamsAndMetadata(requestParams, segmentMetadata);
+        committingSegmentDescriptor.setSegmentLocation(segmentFileURI.toString());
         success = true;
       } catch (Exception e) {
         LOGGER.error("Caught exception while committing segment: {} from instance: {}", segmentName, instanceId, e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -356,7 +356,7 @@ public class PinotLLCRealtimeSegmentManager {
    * When splitCommit is enabled, segment file is uploaded to the segmentLocation in the committingSegmentDescriptor,
    * and we need to move the segment file to its permanent location before committing the segment metadata.
    * Modifies the segment location in committingSegmentDescriptor to the uri which the segment is moved to
-   * Exception: for committingSegmentDescriptor with peer download scheme in its segment location, there is no need for
+   * unless committingSegmentDescriptor has a peer download uri scheme in segment location.
    * moving.
    */
   public void commitSegmentFile(String realtimeTableName, CommittingSegmentDescriptor committingSegmentDescriptor)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -49,6 +49,7 @@ import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.CommonConstants.Segment.Realtime.Status;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -357,7 +358,6 @@ public class PinotLLCRealtimeSegmentManager {
    * and we need to move the segment file to its permanent location before committing the segment metadata.
    * Modifies the segment location in committingSegmentDescriptor to the uri which the segment is moved to
    * unless committingSegmentDescriptor has a peer download uri scheme in segment location.
-   * moving.
    */
   public void commitSegmentFile(String realtimeTableName, CommittingSegmentDescriptor committingSegmentDescriptor)
       throws Exception {
@@ -498,10 +498,10 @@ public class PinotLLCRealtimeSegmentManager {
     // TODO Issue 5953 remove the long parsing once metadata is set correctly.
     committingSegmentZKMetadata.setEndOffset(committingSegmentDescriptor.getNextOffset());
     committingSegmentZKMetadata.setStatus(Status.DONE);
-    // If the download url set by the server is a peer download url format with peer scheme, put an empty string in zk
-    // otherwise just use the location in the descriptor.
-    committingSegmentZKMetadata.setDownloadUrl(isPeerURL(committingSegmentDescriptor.getSegmentLocation()) ? ""
-        : committingSegmentDescriptor.getSegmentLocation());
+    // If the download url set by the server is a peer download url format with peer scheme, put
+    // METADATA_URI_FOR_PEER_DOWNLOAD in zk; otherwise just use the location in the descriptor.
+    committingSegmentZKMetadata.setDownloadUrl(isPeerURL(committingSegmentDescriptor.getSegmentLocation())
+        ? CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD : committingSegmentDescriptor.getSegmentLocation());
     committingSegmentZKMetadata.setCrc(Long.valueOf(segmentMetadata.getCrc()));
     committingSegmentZKMetadata.setStartTime(segmentMetadata.getTimeInterval().getStartMillis());
     committingSegmentZKMetadata.setEndTime(segmentMetadata.getTimeInterval().getEndMillis());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -355,7 +355,7 @@ public class PinotLLCRealtimeSegmentManager {
    * This method moves the segment file from another location to its permanent location.
    * When splitCommit is enabled, segment file is uploaded to the segmentLocation in the committingSegmentDescriptor,
    * and we need to move the segment file to its permanent location before committing the segment metadata.
-   * Updated the segment location to the uri which the segment is moved to.
+   * Modifies the segment location in committingSegmentDescriptor to the uri which the segment is moved to
    * Exception: for committingSegmentDescriptor with peer download scheme in its segment location, there is no need for
    * moving.
    */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -1071,12 +1071,9 @@ public class SegmentCompletionManager {
       // so we need to move the segment file to its permanent location first before committing the metadata.
       // The committingSegmentDescriptor is then updated with the permanent segment location to be saved in metadata
       // store.
-      // The exception is when the server uses the Peer segment download scheme, in such case, there is no need to
-      // move the segment.
-      if (isSplitCommit && !isPeerSegmentDownloadScheme(committingSegmentDescriptor)) {
+      if (isSplitCommit) {
         try {
-          committingSegmentDescriptor.setSegmentLocation(
-              _segmentManager.commitSegmentFile(_realtimeTableName, committingSegmentDescriptor));
+          _segmentManager.commitSegmentFile(_realtimeTableName, committingSegmentDescriptor);
         } catch (Exception e) {
           LOGGER.error("Caught exception while committing segment file for segment: {}", _segmentName.getSegmentName(),
               e);
@@ -1102,11 +1099,6 @@ public class SegmentCompletionManager {
       _state = State.COMMITTED;
       LOGGER.info("Committed segment {} at offset {} winner {}", _segmentName.getSegmentName(), offset, instanceId);
       return SegmentCompletionProtocol.RESP_COMMIT_SUCCESS;
-    }
-
-    private boolean isPeerSegmentDownloadScheme(CommittingSegmentDescriptor committingSegmentDescriptor) {
-      return !(committingSegmentDescriptor == null) && !(committingSegmentDescriptor.getSegmentLocation() == null) &&
-          committingSegmentDescriptor.getSegmentLocation().toLowerCase().startsWith("peer://");
     }
 
     private SegmentCompletionProtocol.Response processCommitWhileUploading(String instanceId,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -1072,7 +1072,7 @@ public class SegmentCompletionManager {
       // store.
       // The exception is when the server uses the Peer segment download scheme, in such case, there is no need to
       // move the segment.
-      if (isSplitCommit && isPeerSegmentDownloadScheme(committingSegmentDescriptor)) {
+      if (isSplitCommit && !isPeerSegmentDownloadScheme(committingSegmentDescriptor)) {
         try {
           committingSegmentDescriptor.setSegmentLocation(
               _segmentManager.commitSegmentFile(_realtimeTableName, committingSegmentDescriptor));
@@ -1098,7 +1098,7 @@ public class SegmentCompletionManager {
 
     private boolean isPeerSegmentDownloadScheme(CommittingSegmentDescriptor committingSegmentDescriptor) {
       return !(committingSegmentDescriptor == null) && !(committingSegmentDescriptor.getSegmentLocation() == null) &&
-          !committingSegmentDescriptor.getSegmentLocation().startsWith("peer");
+          committingSegmentDescriptor.getSegmentLocation().toLowerCase().startsWith("peer://");
     }
 
     private SegmentCompletionProtocol.Response processCommitWhileUploading(String instanceId,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -1083,6 +1084,13 @@ public class SegmentCompletionManager {
         }
       }
       try {
+        // Convert to a controller uri if the segment location uses local file scheme.
+        if (CommonConstants.Segment.LOCAL_SEGMENT_SCHEME
+            .equalsIgnoreCase(URIUtils.getUri(committingSegmentDescriptor.getSegmentLocation()).getScheme())) {
+          committingSegmentDescriptor.setSegmentLocation(URIUtils
+              .constructDownloadUrl(_controllerVipUrl, TableNameBuilder.extractRawTableName(_realtimeTableName),
+                  _segmentName.getSegmentName()));
+        }
         _segmentManager.commitSegmentMetadata(_realtimeTableName, committingSegmentDescriptor);
       } catch (Exception e) {
         LOGGER

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -689,8 +689,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     String segmentLocation = SCHEME + tableDir + "/" + segmentFileName;
     CommittingSegmentDescriptor committingSegmentDescriptor = new CommittingSegmentDescriptor(segmentName,
         PARTITION_OFFSET.toString(), 0, segmentLocation);
-    String segmentFinalLocation = segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
-    Assert.assertEquals(segmentFinalLocation, URIUtils.getUri(tableDir.toString(), URIUtils.encode(segmentName)).toString());
+    segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+    Assert.assertEquals(committingSegmentDescriptor.getSegmentLocation(),
+        URIUtils.getUri(tableDir.toString(), URIUtils.encode(segmentName)).toString());
     assertFalse(segmentFile.exists());
   }
 
@@ -715,8 +716,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     String segmentLocation = SCHEME + tableDir + "/" + segmentFileName;
     CommittingSegmentDescriptor committingSegmentDescriptor = new CommittingSegmentDescriptor(segmentName,
         PARTITION_OFFSET.toString(), 0, segmentLocation);
-    String segmentFinalLocation = segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
-    Assert.assertEquals(segmentFinalLocation, URIUtils.getUri(tableDir.toString(), URIUtils.encode(segmentName)).toString());
+    segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+    Assert.assertEquals(committingSegmentDescriptor.getSegmentLocation(),
+        URIUtils.getUri(tableDir.toString(), URIUtils.encode(segmentName)).toString());
     assertFalse(segmentFile.exists());
     assertFalse(extraSegmentFile.exists());
     assertTrue(otherSegmentFile.exists());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.common.utils.CommonConstants.Helix;
 import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.CommonConstants.Segment.Realtime.Status;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignment;
@@ -62,6 +63,7 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.joda.time.Interval;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -687,7 +689,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     String segmentLocation = SCHEME + tableDir + "/" + segmentFileName;
     CommittingSegmentDescriptor committingSegmentDescriptor = new CommittingSegmentDescriptor(segmentName,
         PARTITION_OFFSET.toString(), 0, segmentLocation);
-    segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+    String segmentFinalLocation = segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+    Assert.assertEquals(segmentFinalLocation, URIUtils.getUri(tableDir.toString(), URIUtils.encode(segmentName)).toString());
     assertFalse(segmentFile.exists());
   }
 
@@ -712,7 +715,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     String segmentLocation = SCHEME + tableDir + "/" + segmentFileName;
     CommittingSegmentDescriptor committingSegmentDescriptor = new CommittingSegmentDescriptor(segmentName,
         PARTITION_OFFSET.toString(), 0, segmentLocation);
-    segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+    String segmentFinalLocation = segmentManager.commitSegmentFile(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+    Assert.assertEquals(segmentFinalLocation, URIUtils.getUri(tableDir.toString(), URIUtils.encode(segmentName)).toString());
     assertFalse(segmentFile.exists());
     assertFalse(extraSegmentFile.exists());
     assertTrue(otherSegmentFile.exists());
@@ -767,6 +771,36 @@ public class PinotLLCRealtimeSegmentManagerTest {
     } catch (IllegalStateException e) {
       // Expected
     }
+  }
+
+  @Test
+  public void testCommitSegmentMetadata() {
+    // Set up a new table with 2 replicas, 5 instances, 4 partition
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
+    setUpNewTable(segmentManager, 2, 5, 4);
+
+    // Test case 1: segment location with vip format.
+    // Commit a segment for partition 0
+    String committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
+    String segmentLocationVIP = "http://control_vip/segments/segment1";
+    CommittingSegmentDescriptor committingSegmentDescriptor = new CommittingSegmentDescriptor(committingSegment,
+        new LongMsgOffset(PARTITION_OFFSET.getOffset() + NUM_DOCS).toString(), 0L, segmentLocationVIP);
+    committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
+    segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+
+    LLCRealtimeSegmentZKMetadata metadata = segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, committingSegment, null);
+    Assert.assertEquals(metadata.getDownloadUrl(), segmentLocationVIP);
+
+    // Test case 2: segment location with peer format: peer://segment1, verify that an empty string is stored in zk.
+    committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 1, CURRENT_TIME_MS).getSegmentName();
+    String peerSegmentLocation = "peer:///segment1";
+    committingSegmentDescriptor = new CommittingSegmentDescriptor(committingSegment,
+        new LongMsgOffset(PARTITION_OFFSET.getOffset() + NUM_DOCS).toString(), 0L, peerSegmentLocation);
+    committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
+    segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+
+    metadata = segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, committingSegment, null);
+    Assert.assertEquals(metadata.getDownloadUrl(), "");
   }
 
   //////////////////////////////////////////////////////////////////////////////////

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1243,9 +1243,8 @@ public class SegmentCompletionTest {
     }
 
     @Override
-    public String commitSegmentFile(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
+    public void commitSegmentFile(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
       Preconditions.checkState(!committingSegmentDescriptor.getSegmentLocation().equals("doNotCommitMe"));
-      return committingSegmentDescriptor.getSegmentLocation();
     }
 
     @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -306,7 +306,13 @@ public class SegmentCompletionTest {
   @Test
   public void testHappyPathSplitCommit()
       throws Exception {
-    testHappyPathSplitCommit(5L);
+    testHappyPathSplitCommit(5L, "location");
+  }
+
+  @Test
+  public void testHappyPathSplitCommitWithPeerDownloadScheme()
+      throws Exception {
+    testHappyPathSplitCommit(5L, "peer:///segment1");
   }
 
   @Test
@@ -426,7 +432,7 @@ public class SegmentCompletionTest {
     Assert.assertFalse(fsmMap.containsKey(segmentNameStr));
   }
 
-  public void testHappyPathSplitCommit(long startTime)
+  private void testHappyPathSplitCommit(long startTime, String segmentLocation)
       throws Exception {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
@@ -477,9 +483,8 @@ public class SegmentCompletionTest {
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_CONTINUE);
 
     segmentCompletionMgr._seconds += 5;
-    params = new Request.Params().withInstanceId(s2).withStreamPartitionMsgOffset(s2Offset.toString()).
-        withSegmentName(segmentNameStr)
-        .withSegmentLocation("location");
+    params = new Request.Params().withInstanceId(s2).withStreamPartitionMsgOffset(s2Offset.toString()).withSegmentName(segmentNameStr)
+        .withSegmentLocation(segmentLocation);
     response = segmentCompletionMgr
         .segmentCommitEnd(params, true, true, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
@@ -1230,8 +1235,9 @@ public class SegmentCompletionTest {
     }
 
     @Override
-    public void commitSegmentFile(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
+    public String commitSegmentFile(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
       Preconditions.checkState(!committingSegmentDescriptor.getSegmentLocation().equals("doNotCommitMe"));
+      return "final_segment_uri";
     }
 
     @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.LongMsgOffsetFactory;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -49,10 +50,12 @@ import static org.mockito.Mockito.when;
 
 
 public class SegmentCompletionTest {
+  private static final String FAKEFS_FINAL_SEGMENT_URI = "fakefs:///final_segment_uri";
   private MockPinotLLCRealtimeSegmentManager segmentManager;
   private MockSegmentCompletionManager segmentCompletionMgr;
   private Map<String, Object> fsmMap;
   private Map<String, Long> commitTimeMap;
+  private final String tableName = "someTable";
   private String segmentNameStr;
   private final String s1 = "S1";
   private final String s2 = "S2";
@@ -91,7 +94,6 @@ public class SegmentCompletionTest {
     final int partitionId = 23;
     final int seqId = 12;
     final long now = System.currentTimeMillis();
-    final String tableName = "someTable";
     final LLCSegmentName segmentName = new LLCSegmentName(tableName, partitionId, seqId, now);
     segmentNameStr = segmentName.getSegmentName();
     final LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
@@ -304,15 +306,21 @@ public class SegmentCompletionTest {
 
   // Tests happy path with split commit protocol
   @Test
-  public void testHappyPathSplitCommit()
+  public void testHappyPathSplitCommitWithLocalFS()
       throws Exception {
-    testHappyPathSplitCommit(5L, "location");
+    testHappyPathSplitCommit(5L, "/local/file", "http://null:null/segments/" + tableName + "/" + segmentNameStr);
+  }
+
+  @Test
+  public void testHappyPathSplitCommitWithDeepstore()
+      throws Exception {
+    testHappyPathSplitCommit(5L, "fakefs:///segment1", "fakefs:///segment1");
   }
 
   @Test
   public void testHappyPathSplitCommitWithPeerDownloadScheme()
       throws Exception {
-    testHappyPathSplitCommit(5L, "peer:///segment1");
+    testHappyPathSplitCommit(5L, "peer:///segment1", "peer:///segment1");
   }
 
   @Test
@@ -432,7 +440,7 @@ public class SegmentCompletionTest {
     Assert.assertFalse(fsmMap.containsKey(segmentNameStr));
   }
 
-  private void testHappyPathSplitCommit(long startTime, String segmentLocation)
+  private void testHappyPathSplitCommit(long startTime, String segmentLocation, String downloadURL)
       throws Exception {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
@@ -488,6 +496,7 @@ public class SegmentCompletionTest {
     response = segmentCompletionMgr
         .segmentCommitEnd(params, true, true, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
+    Assert.assertEquals(segmentManager.getSegmentZKMetadata(null, null,null).getDownloadUrl(), downloadURL);
 
     // Now the FSM should have disappeared from the map
     Assert.assertFalse(fsmMap.containsKey(segmentNameStr));
@@ -1229,15 +1238,14 @@ public class SegmentCompletionTest {
     public void commitSegmentMetadata(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
       _segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
       _segmentMetadata.setEndOffset(committingSegmentDescriptor.getNextOffset());
-      _segmentMetadata.setDownloadUrl(URIUtils.constructDownloadUrl(CONTROLLER_CONF.generateVipUrl(), rawTableName,
-          committingSegmentDescriptor.getSegmentName()));
+      _segmentMetadata.setDownloadUrl(committingSegmentDescriptor.getSegmentLocation());
       _segmentMetadata.setEndTime(_segmentCompletionMgr.getCurrentTimeMs());
     }
 
     @Override
     public String commitSegmentFile(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
       Preconditions.checkState(!committingSegmentDescriptor.getSegmentLocation().equals("doNotCommitMe"));
-      return "final_segment_uri";
+      return committingSegmentDescriptor.getSegmentLocation();
     }
 
     @Override


### PR DESCRIPTION
## Description
Add a description of your PR here.
As part of the deepstore by-passing [project](https://cwiki.apache.org/confluence/display/PINOT/By-passing+deep-store+requirement+for+Realtime+segment+completion), a Pinot server may pass a Peer segment location to Pinot controller (format like peer:///segment1). For such peer segment location, during the commit phase of the LLC protocol, we modify the controller behavior such that (1) controller does need to move segments during commitEnd() phase of split commit (2) controller will store an empty string '' in the zk.

@mcvsubbu 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
