### PR TITLE
Allow star-tree creation during segment load

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -30,14 +30,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
 import org.apache.pinot.core.segment.name.FixedSegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SimpleSegmentNameGenerator;
-import org.apache.pinot.core.startree.v2.builder.StarTreeV2BuilderConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
@@ -48,8 +46,6 @@ import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeFieldSpec;
-import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.joda.time.format.DateTimeFormat;
@@ -90,8 +86,8 @@ public class SegmentGeneratorConfig {
   private SegmentVersion _segmentVersion = SegmentVersion.v3;
   private Schema _schema = null;
   private RecordReaderConfig _readerConfig = null;
+  private List<StarTreeIndexConfig> _starTreeIndexConfigs = null;
   private boolean _enableDefaultStarTree = false;
-  private List<StarTreeV2BuilderConfig> _starTreeV2BuilderConfigs = null;
   private String _creatorVersion = null;
   private SegmentNameGenerator _segmentNameGenerator = null;
   private SegmentPartitionConfig _segmentPartitionConfig = null;
@@ -159,16 +155,9 @@ public class SegmentGeneratorConfig {
       }
       _segmentPartitionConfig = indexingConfig.getSegmentPartitionConfig();
 
-      // Star-tree V2 configs
+      // Star-tree configs
+      setStarTreeIndexConfigs(indexingConfig.getStarTreeIndexConfigs());
       setEnableDefaultStarTree(indexingConfig.isEnableDefaultStarTree());
-      List<StarTreeIndexConfig> starTreeIndexConfigs = indexingConfig.getStarTreeIndexConfigs();
-      if (starTreeIndexConfigs != null && !starTreeIndexConfigs.isEmpty()) {
-        List<StarTreeV2BuilderConfig> starTreeV2BuilderConfigs = new ArrayList<>(starTreeIndexConfigs.size());
-        for (StarTreeIndexConfig starTreeIndexConfig : starTreeIndexConfigs) {
-          starTreeV2BuilderConfigs.add(StarTreeV2BuilderConfig.fromIndexConfig(starTreeIndexConfig));
-        }
-        setStarTreeV2BuilderConfigs(starTreeV2BuilderConfigs);
-      }
 
       // NOTE: There are 2 ways to configure creating inverted index during segment generation:
       //       - Set 'generate.inverted.index.before.push' to 'true' in custom config (deprecated)
@@ -193,7 +182,6 @@ public class SegmentGeneratorConfig {
     }
   }
 
-  @Nonnull
   public Map<String, Map<String, String>> getColumnProperties() {
     return _columnProperties;
   }
@@ -244,7 +232,7 @@ public class SegmentGeneratorConfig {
     _customProperties.putAll(properties);
   }
 
-  public void setSimpleDateFormat(@Nonnull String simpleDateFormat) {
+  public void setSimpleDateFormat(String simpleDateFormat) {
     _timeColumnType = TimeColumnType.SIMPLE_DATE;
     try {
       DateTimeFormat.forPattern(simpleDateFormat);
@@ -516,20 +504,21 @@ public class SegmentGeneratorConfig {
     _readerConfig = readerConfig;
   }
 
+  @Nullable
+  public List<StarTreeIndexConfig> getStarTreeIndexConfigs() {
+    return _starTreeIndexConfigs;
+  }
+
+  public void setStarTreeIndexConfigs(List<StarTreeIndexConfig> starTreeIndexConfigs) {
+    _starTreeIndexConfigs = starTreeIndexConfigs;
+  }
+
   public boolean isEnableDefaultStarTree() {
     return _enableDefaultStarTree;
   }
 
   public void setEnableDefaultStarTree(boolean enableDefaultStarTree) {
     _enableDefaultStarTree = enableDefaultStarTree;
-  }
-
-  public List<StarTreeV2BuilderConfig> getStarTreeV2BuilderConfigs() {
-    return _starTreeV2BuilderConfigs;
-  }
-
-  public void setStarTreeV2BuilderConfigs(List<StarTreeV2BuilderConfig> starTreeV2BuilderConfigs) {
-    _starTreeV2BuilderConfigs = starTreeV2BuilderConfigs;
   }
 
   public SegmentNameGenerator getSegmentNameGenerator() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/MultipleTreesBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/builder/MultipleTreesBuilder.java
@@ -18,18 +18,16 @@
  */
 package org.apache.pinot.core.startree.v2.builder;
 
-import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.INDEX_FILE_NAME;
-import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.INDEX_MAP_FILE_NAME;
-import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.STAR_TREE_TEMP_DIR;
-
+import com.google.common.base.Preconditions;
+import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
+import javax.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -39,32 +37,32 @@ import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
+import org.apache.pinot.core.startree.v2.StarTreeV2Constants;
 import org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey;
 import org.apache.pinot.core.startree.v2.store.StarTreeIndexMapUtils;
 import org.apache.pinot.core.startree.v2.store.StarTreeIndexMapUtils.IndexKey;
 import org.apache.pinot.core.startree.v2.store.StarTreeIndexMapUtils.IndexValue;
+import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
-
 
 /**
  * The {@code MultipleTreesBuilder} class is the top level star-tree builder that takes a list of
- * {@link StarTreeV2BuilderConfig}s and builds multiple star-trees with the given {@link BuildMode} ({@code ON_HEAP} or
- * {@code OFF_HEAP}).
+ * {@link StarTreeIndexConfig}s and a boolean flag for the default star-tree, and builds multiple star-trees with the
+ * given {@link BuildMode} ({@code ON_HEAP} or {@code OFF_HEAP}).
  * <p>The indexes for all star-trees will be stored in a single index file, and there will be an extra index map file to
  * mark the offset and size of each index in the index file.
  */
-public class MultipleTreesBuilder {
+public class MultipleTreesBuilder implements Closeable {
   private static final Logger LOGGER = LoggerFactory.getLogger(MultipleTreesBuilder.class);
 
-  private final List<StarTreeV2BuilderConfig> _builderConfigs;
-  private final ImmutableSegment _segment;
+  private final BuildMode _buildMode;
   private final File _segmentDirectory;
   private final PropertiesConfiguration _metadataProperties;
-  private final BuildMode _buildMode;
+  private final ImmutableSegment _segment;
+  private final List<StarTreeV2BuilderConfig> _builderConfigs = new ArrayList<>();
 
   public enum BuildMode {
     ON_HEAP, OFF_HEAP
@@ -73,29 +71,38 @@ public class MultipleTreesBuilder {
   /**
    * Constructor for the multiple star-trees builder.
    *
-   * @param builderConfigs List of builder configs that might contain {@code null} element for default star-tree
+   * @param indexConfigs List of index configs
+   * @param enableDefaultStarTree Whether to enable the default star-tree
    * @param indexDir Index directory
    * @param buildMode Build mode (ON_HEAP or OFF_HEAP)
    */
-  public MultipleTreesBuilder(List<StarTreeV2BuilderConfig> builderConfigs, File indexDir, BuildMode buildMode)
+  public MultipleTreesBuilder(@Nullable List<StarTreeIndexConfig> indexConfigs, boolean enableDefaultStarTree,
+      File indexDir, BuildMode buildMode)
       throws Exception {
+    Preconditions.checkArgument(CollectionUtils.isNotEmpty(indexConfigs) || enableDefaultStarTree,
+        "Must provide star-tree index configs or enable default star-tree");
+    _buildMode = buildMode;
     _segmentDirectory = SegmentDirectoryPaths.findSegmentDirectory(indexDir);
-    _segment = ImmutableSegmentLoader.load(indexDir, ReadMode.mmap);
     _metadataProperties =
         CommonsConfigurationUtils.fromFile(new File(_segmentDirectory, V1Constants.MetadataKeys.METADATA_FILE_NAME));
-    Preconditions
-        .checkState(!_metadataProperties.containsKey(MetadataKey.STAR_TREE_COUNT), "Star-tree v2 already exists");
-    _buildMode = buildMode;
-    _builderConfigs = new ArrayList<>(builderConfigs.size());
-    for (StarTreeV2BuilderConfig builderConfig : builderConfigs) {
-      if (builderConfig != null) {
-        _builderConfigs.add(builderConfig);
-      } else {
+    // TODO: Support removing/modifying star-trees
+    Preconditions.checkState(!_metadataProperties.containsKey(MetadataKey.STAR_TREE_COUNT), "Star-tree already exists");
+    _segment = ImmutableSegmentLoader.load(indexDir, ReadMode.mmap);
+    try {
+      if (indexConfigs != null) {
+        for (StarTreeIndexConfig indexConfig : indexConfigs) {
+          _builderConfigs.add(StarTreeV2BuilderConfig.fromIndexConfig(indexConfig));
+        }
+      }
+      if (enableDefaultStarTree) {
         StarTreeV2BuilderConfig defaultConfig =
             StarTreeV2BuilderConfig.generateDefaultConfig((SegmentMetadataImpl) _segment.getSegmentMetadata());
         LOGGER.info("Generated default star-tree config: {}", defaultConfig);
         _builderConfigs.add(defaultConfig);
       }
+    } catch (Exception e) {
+      _segment.destroy();
+      throw e;
     }
   }
 
@@ -109,9 +116,9 @@ public class MultipleTreesBuilder {
     LOGGER.info("Starting building {} star-trees with configs: {} using {} builder", numStarTrees, _builderConfigs,
         _buildMode);
 
-    try (
-        StarTreeIndexCombiner indexCombiner = new StarTreeIndexCombiner(new File(_segmentDirectory, INDEX_FILE_NAME))) {
-      File starTreeIndexDir = new File(_segmentDirectory, STAR_TREE_TEMP_DIR);
+    try (StarTreeIndexCombiner indexCombiner = new StarTreeIndexCombiner(
+        new File(_segmentDirectory, StarTreeV2Constants.INDEX_FILE_NAME))) {
+      File starTreeIndexDir = new File(_segmentDirectory, StarTreeV2Constants.STAR_TREE_TEMP_DIR);
       FileUtils.forceMkdir(starTreeIndexDir);
       _metadataProperties.addProperty(MetadataKey.STAR_TREE_COUNT, numStarTrees);
       List<Map<IndexKey, IndexValue>> indexMaps = new ArrayList<>(numStarTrees);
@@ -133,7 +140,8 @@ public class MultipleTreesBuilder {
       try (FileOutputStream fileOutputStream = new FileOutputStream(_metadataProperties.getFile())) {
         _metadataProperties.save(fileOutputStream);
       }
-      StarTreeIndexMapUtils.storeToFile(indexMaps, new File(_segmentDirectory, INDEX_MAP_FILE_NAME));
+      StarTreeIndexMapUtils
+          .storeToFile(indexMaps, new File(_segmentDirectory, StarTreeV2Constants.INDEX_MAP_FILE_NAME));
       FileUtils.forceDelete(starTreeIndexDir);
     }
 
@@ -148,5 +156,10 @@ public class MultipleTreesBuilder {
     } else {
       return new OffHeapSingleTreeBuilder(builderConfig, outputDir, segment, metadataProperties);
     }
+  }
+
+  @Override
+  public void close() {
+    _segment.destroy();
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -18,9 +18,6 @@
  */
 package org.apache.pinot.integration.tests;
 
-import org.testng.annotations.Test;
-
-
 /**
  * Integration test that extends OfflineClusterIntegrationTest but start multiple brokers and servers.
  */
@@ -36,72 +33,5 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
   @Override
   protected int getNumServers() {
     return NUM_SERVERS;
-  }
-
-  @Test
-  @Override
-  public void testHardcodedQueries()
-      throws Exception {
-    super.testHardcodedQueries();
-  }
-
-  @Test
-  @Override
-  public void testHardcodedSqlQueries()
-      throws Exception {
-    super.testHardcodedSqlQueries();
-  }
-
-  @Test
-  @Override
-  public void testQueriesFromQueryFile()
-      throws Exception {
-    super.testQueriesFromQueryFile();
-  }
-
-  @Test
-  @Override
-  public void testSqlQueriesFromQueryFile()
-      throws Exception {
-    super.testSqlQueriesFromQueryFile();
-  }
-
-  @Test
-  @Override
-  public void testGeneratedQueriesWithMultiValues()
-      throws Exception {
-    super.testGeneratedQueriesWithMultiValues();
-  }
-
-  @Test
-  @Override
-  public void testQueryExceptions()
-      throws Exception {
-    super.testQueryExceptions();
-  }
-
-  @Test
-  @Override
-  public void testInstanceShutdown()
-      throws Exception {
-    super.testInstanceShutdown();
-  }
-
-  // Disabled because with multiple servers, there is no way to check and guarantee that all servers get all segments
-  // reloaded, which cause the flakiness of the tests.
-  @Test(enabled = false)
-  @Override
-  public void testInvertedIndexTriggering()
-      throws Exception {
-    // Ignored
-  }
-
-  // Disabled because with multiple servers, there is no way to check and guarantee that all servers get all segments
-  // reloaded, which cause the flakiness of the tests.
-  @Test(enabled = false)
-  @Override
-  public void testDefaultColumns()
-      throws Exception {
-    // Ignored
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -40,6 +40,8 @@ public class IndexingConfig extends BaseJsonConfig {
   private List<String> _onHeapDictionaryColumns;
   private boolean _enableDefaultStarTree;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
+  // Whether to allow creating star-tree when server loads the segment
+  private boolean _enableDynamicStarTreeCreation;
   private SegmentPartitionConfig _segmentPartitionConfig;
   private boolean _aggregateMetrics;
   private boolean _nullHandlingEnabled;
@@ -189,6 +191,14 @@ public class IndexingConfig extends BaseJsonConfig {
 
   public void setStarTreeIndexConfigs(List<StarTreeIndexConfig> starTreeIndexConfigs) {
     _starTreeIndexConfigs = starTreeIndexConfigs;
+  }
+
+  public boolean isEnableDynamicStarTreeCreation() {
+    return _enableDynamicStarTreeCreation;
+  }
+
+  public void setEnableDynamicStarTreeCreation(boolean enableDynamicStarTreeCreation) {
+    _enableDynamicStarTreeCreation = enableDynamicStarTreeCreation;
   }
 
   @Nullable


### PR DESCRIPTION
## Description
Allow star-tree creation during segment load (and reload).
With this, star-tree can be added on the fly after updating the table config via reload.

NOTE:
- This feature only applies to adding star-tree index config and generate star-trees to the existing segments (modifying/removing star-tree index config is not supported now)
- Because the star-tree creation could consume a lot of system resources, added a boolean config `enableDynamicStarTreeeCreation` in `IndexingConfig` to enable/disable this feature (disabled by default).
- This feature should only be enabled for testing purpose or in cluster without too much load on the servers and with relatively small segments and simple star-tree index config (servers need to have free system resources to create the star-tree).

Other changes:
- Pass in `enableDefaultStarTree` into MultipleTreesBuilder instead of using null as a placeholder for default star-tree to enhance the readability
- Make MultipleTreesBuilder closeable to close the segment properly

## Release Notes
Introduced a new boolean config `enableDynamicStarTreeeCreation` in `IndexingConfig` to enable/disable star-tree creation during segment load.