### PR TITLE
Add more schema validations

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.assertNull;
 
 
 public class TimeBoundaryManagerTest {
-  private static final String TIME_COLUMN = "time";
+  private static final String TIME_COLUMN = "timeColumn";
 
   private ZkStarter.ZookeeperInstance _zkInstance;
   private ZkClient _zkClient;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/SchemaUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/SchemaUtils.java
@@ -189,7 +189,7 @@ public class SchemaUtils {
   public static void main(String[] args) {
     Schema schema = new Schema.SchemaBuilder().setSchemaName("testSchema")
         .addSingleValueDimension("dimension", FieldSpec.DataType.DOUBLE).addMetric("metric", FieldSpec.DataType.INT)
-        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "time"), null).build();
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "timeColumn"), null).build();
     System.out.println(postSchema("localhost", 8100, schema));
     Schema fetchedSchema = getSchema("localhost", 8100, "testSchema");
     Preconditions.checkNotNull(fetchedSchema);

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -237,10 +237,10 @@ public class SchemaTest {
       throws Exception {
     TimeGranularitySpec incomingTimeGranularitySpec =
         new TimeGranularitySpec(FieldSpec.DataType.STRING, 1, TimeUnit.DAYS,
-            TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "Date");
+            TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "DateColumn");
     TimeGranularitySpec outgoingTimeGranularitySpec =
         new TimeGranularitySpec(FieldSpec.DataType.STRING, 1, TimeUnit.DAYS,
-            TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "Date");
+            TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "DateColumn");
     Schema schema = new Schema.SchemaBuilder().setSchemaName("testSchema")
         .addTime(incomingTimeGranularitySpec, outgoingTimeGranularitySpec).build();
     String jsonSchema = schema.toSingleLineJsonString();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -176,6 +176,10 @@ public class ControllerRequestURLBuilder {
     return URIUtils.constructDownloadUrl(_baseUrl, tableName, segmentName);
   }
 
+  public String forSchemaValidate() {
+    return StringUtil.join("/", _baseUrl, "schemas/validate");
+  }
+
   public String forSegmentDelete(String resourceName, String segmentName) {
     return StringUtil.join("/", _baseUrl, "datafiles", resourceName, segmentName);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -417,7 +417,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       }
     }
     // 2. We want to get the schema errors, if any, even if isValid is false;
-    if (!SchemaUtils.validate(schema, _logger)) {
+    if (!SchemaUtils.validate(schema, false, _logger)) {
       isValid = false;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SchemaUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SchemaUtils.java
@@ -112,7 +112,7 @@ public class SchemaUtils {
    */
   private static boolean isValidFieldName(FieldSpec fieldSpec) {
     String columnName = fieldSpec.getName();
-    if (SQL_PARSER_METADATA.isReservedWord(columnName.toUpperCase(Locale.ROOT))) {
+    if (SQL_PARSER_METADATA.isReservedWord(columnName.toUpperCase())) {
       LOGGER.error("Cannot use SQL reserved word {} as field name in the schema", columnName);
       return false;
     }
@@ -126,15 +126,19 @@ public class SchemaUtils {
     String column = fieldSpec.getName();
     String transformFunction = fieldSpec.getTransformFunction();
     if (transformFunction != null) {
-      FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
-      if (functionEvaluator != null) {
-        List<String> arguments = functionEvaluator.getArguments();
+      try {
+        List<String> arguments = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec).getArguments();
         // output column used as input
         if (arguments.contains(column)) {
           LOGGER.error("The arguments of transform function: {}, should not contain the destination column: {}",
               transformFunction, column);
           return false;
         }
+      } catch (Exception e) {
+        LOGGER
+            .error("Exception in getting arguments for transform function {} for column {}", transformFunction, column,
+                e);
+        return false;
       }
     }
     return true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SchemaUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SchemaUtils.java
@@ -19,6 +19,12 @@
 package org.apache.pinot.core.util;
 
 import java.util.List;
+import java.util.Locale;
+import javax.annotation.Nullable;
+import org.apache.calcite.sql.parser.SqlAbstractParserImpl;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.babel.SqlBabelParserImpl;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.pinot.core.data.function.FunctionEvaluator;
 import org.apache.pinot.core.data.function.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -39,12 +45,16 @@ public class SchemaUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SchemaUtils.class);
 
+  private static final SqlAbstractParserImpl.Metadata SQL_PARSER_METADATA = SqlParser.create("",
+      SqlParser.configBuilder().setConformance(SqlConformanceEnum.BABEL).setParserFactory(SqlBabelParserImpl.FACTORY)
+          .build()).getMetadata();
+
   /**
    * Validates that for a field spec with transform function, the source column name and destination column name are exclusive
    * i.e. do not allow using source column name for destination column
    */
   public static boolean validate(Schema schema) {
-    return validate(schema, LOGGER);
+    return validate(schema, true, LOGGER);
   }
 
   /**
@@ -52,52 +62,81 @@ public class SchemaUtils {
    * 1) for a field spec with transform function, the source column name and destination column name are exclusive
    * i.e. do not allow using source column name for destination column
    * 2) Basic schema validations
+   *
+   * @param validateFieldNames if false, does not validate field names. This is to prevent validation failing on existing schemas with invalid field names during a schema update
    */
-  public static boolean validate(Schema schema, Logger logger) {
+  public static boolean validate(Schema schema, boolean validateFieldNames, @Nullable Logger logger) {
     try {
       for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
         if (!fieldSpec.isVirtualColumn()) {
-          String column = fieldSpec.getName();
-          String transformFunction = fieldSpec.getTransformFunction();
-          if (transformFunction != null) {
-            FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
-            if (functionEvaluator != null) {
-              List<String> arguments = functionEvaluator.getArguments();
-              // output column used as input
-              if (arguments.contains(column)) {
-                logger.error("The arguments of transform function: {}, should not contain the destination column: {}",
-                    transformFunction, column);
-                return false;
-              }
-            }
-          } else if (fieldSpec.getFieldType().equals(FieldSpec.FieldType.TIME)) {
-            TimeFieldSpec timeFieldSpec = (TimeFieldSpec) fieldSpec;
-            TimeGranularitySpec incomingGranularitySpec = timeFieldSpec.getIncomingGranularitySpec();
-            TimeGranularitySpec outgoingGranularitySpec = timeFieldSpec.getOutgoingGranularitySpec();
-
-            if (!incomingGranularitySpec.equals(outgoingGranularitySpec)) {
-              // different incoming and outgoing spec, but same name
-              if (incomingGranularitySpec.getName().equals(outgoingGranularitySpec.getName())) {
-                logger.error("Cannot convert from incoming field spec:{} to outgoing field spec:{} if name is the same",
-                    incomingGranularitySpec, outgoingGranularitySpec);
-                return false;
-              } else {
-                if (!incomingGranularitySpec.getTimeFormat().equals(TimeGranularitySpec.TimeFormat.EPOCH.toString())
-                    || !outgoingGranularitySpec.getTimeFormat()
-                    .equals(TimeGranularitySpec.TimeFormat.EPOCH.toString())) {
-                  logger.error(
-                      "When incoming and outgoing specs are different, cannot perform time conversion for time format other than EPOCH");
-                  return false;
-                }
-              }
-            }
+          if (validateFieldNames && !isValidFieldName(fieldSpec)) {
+            return false;
+          }
+          if (!isValidTransformFunction(fieldSpec)) {
+            return false;
+          }
+          if (fieldSpec.getFieldType().equals(FieldSpec.FieldType.TIME) && !isValidTimeFieldSpec(fieldSpec)) {
+            return false;
           }
         }
       }
     } catch (Exception e) {
-      logger.error("Exception in validating schema {}", schema.getSchemaName(), e);
+      LOGGER.error("Exception in validating schema {}", schema.getSchemaName(), e);
       return false;
     }
     return schema.validate(logger);
+  }
+
+  /**
+   * Checks if any of the keywords which are reserved under the sql parser are used
+   */
+  private static boolean isValidFieldName(FieldSpec fieldSpec) {
+    String columnName = fieldSpec.getName();
+    if (SQL_PARSER_METADATA.isReservedWord(columnName.toUpperCase(Locale.ROOT))) {
+      LOGGER.error("Cannot use SQL reserved word {} as field name in the schema", columnName);
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean isValidTransformFunction(FieldSpec fieldSpec) {
+    String column = fieldSpec.getName();
+    String transformFunction = fieldSpec.getTransformFunction();
+    if (transformFunction != null) {
+      FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
+      if (functionEvaluator != null) {
+        List<String> arguments = functionEvaluator.getArguments();
+        // output column used as input
+        if (arguments.contains(column)) {
+          LOGGER.error("The arguments of transform function: {}, should not contain the destination column: {}",
+              transformFunction, column);
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static boolean isValidTimeFieldSpec(FieldSpec fieldSpec) {
+    TimeFieldSpec timeFieldSpec = (TimeFieldSpec) fieldSpec;
+    TimeGranularitySpec incomingGranularitySpec = timeFieldSpec.getIncomingGranularitySpec();
+    TimeGranularitySpec outgoingGranularitySpec = timeFieldSpec.getOutgoingGranularitySpec();
+
+    if (!incomingGranularitySpec.equals(outgoingGranularitySpec)) {
+      // different incoming and outgoing spec, but same name
+      if (incomingGranularitySpec.getName().equals(outgoingGranularitySpec.getName())) {
+        LOGGER.error("Cannot convert from incoming field spec:{} to outgoing field spec:{} if name is the same",
+            incomingGranularitySpec, outgoingGranularitySpec);
+        return false;
+      } else {
+        if (!incomingGranularitySpec.getTimeFormat().equals(TimeGranularitySpec.TimeFormat.EPOCH.toString())
+            || !outgoingGranularitySpec.getTimeFormat().equals(TimeGranularitySpec.TimeFormat.EPOCH.toString())) {
+          LOGGER.error(
+              "When incoming and outgoing specs are different, cannot perform time conversion for time format other than EPOCH");
+          return false;
+        }
+      }
+    }
+    return true;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTimeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTimeTest.java
@@ -63,28 +63,28 @@ public class ExpressionTransformerTimeTest {
 
     // 2] both incoming and outgoing defined - exactly the same - Doesn't create DefaultTimeFSpecEvaluator, incoming used as is.
     pinotSchema = new Schema.SchemaBuilder()
-        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "time"),
-            new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "time")).build();
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "timeColumn"),
+            new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "timeColumn")).build();
 
     // correct value - use incoming
     expressionTransformer = new ExpressionTransformer(pinotSchema);
     genericRow = new GenericRow();
-    genericRow.putValue("time", validMillis);
+    genericRow.putValue("timeColumn", validMillis);
     expressionTransformer.transform(genericRow);
-    Assert.assertEquals(genericRow.getValue("time"), validMillis);
+    Assert.assertEquals(genericRow.getValue("timeColumn"), validMillis);
 
     // incorrect value - use whatever is
     expressionTransformer = new ExpressionTransformer(pinotSchema);
     genericRow = new GenericRow();
-    genericRow.putValue("time", -1);
+    genericRow.putValue("timeColumn", -1);
     expressionTransformer.transform(genericRow);
-    Assert.assertEquals(genericRow.getValue("time"), -1);
+    Assert.assertEquals(genericRow.getValue("timeColumn"), -1);
 
     // 3] both incoming and outgoing defined - same column name only - skip conversion - this shouldn't be allowed by validation during add schema
     try {
       pinotSchema = new Schema.SchemaBuilder()
-          .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "time"),
-              new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.HOURS, "time")).build();
+          .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "timeColumn"),
+              new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.HOURS, "timeColumn")).build();
       new ExpressionTransformer(pinotSchema);
       Assert.fail();
     } catch (Exception e) {
@@ -163,11 +163,11 @@ public class ExpressionTransformerTimeTest {
     // 5] SIMPLE_DATE_FORMAT
     // When incoming and outgoing spec are the same, any time format should work
     pinotSchema = new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS,
-        TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT.toString(), "time"), null).build();
+        TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT.toString(), "timeColumn"), null).build();
     expressionTransformer = new ExpressionTransformer(pinotSchema);
     genericRow = new GenericRow();
-    genericRow.putValue("time", 20180101);
+    genericRow.putValue("timeColumn", 20180101);
     expressionTransformer.transform(genericRow);
-    Assert.assertEquals(genericRow.getValue("time"), 20180101);
+    Assert.assertEquals(genericRow.getValue("timeColumn"), 20180101);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfigTest.java
@@ -67,12 +67,12 @@ public class SegmentGeneratorConfigTest {
   @Test
   public void testSimpleDateFormat() {
     Schema schema = new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(FieldSpec.DataType.STRING, TimeUnit.DAYS,
-        TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "Date"), null).build();
+        TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "DateColumn"), null).build();
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName("Date").build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName("DateColumn").build();
 
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
-    assertEquals(segmentGeneratorConfig.getTimeColumnName(), "Date");
+    assertEquals(segmentGeneratorConfig.getTimeColumnName(), "DateColumn");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE);
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
     assertEquals(segmentGeneratorConfig.getSimpleDateFormat(), "yyyyMMdd");
@@ -85,10 +85,10 @@ public class SegmentGeneratorConfigTest {
     assertNull(segmentGeneratorConfig.getSimpleDateFormat());
 
     schema = new Schema.SchemaBuilder()
-        .addDateTime("Date", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:DAYS").build();
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName("Date").build();
+        .addDateTime("DateColumn", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:DAYS").build();
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName("DateColumn").build();
     segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
-    assertEquals(segmentGeneratorConfig.getTimeColumnName(), "Date");
+    assertEquals(segmentGeneratorConfig.getTimeColumnName(), "DateColumn");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE);
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
     assertEquals(segmentGeneratorConfig.getSimpleDateFormat(), "yyyyMMdd");

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -72,7 +72,7 @@ public abstract class BaseTransformFunctionTest {
   protected static final String STRING_SV_COLUMN = "stringSV";
   protected static final String STRING_ALPHANUM_SV_COLUMN = "stringAlphaNumSV";
   protected static final String INT_MV_COLUMN = "intMV";
-  protected static final String TIME_COLUMN = "time";
+  protected static final String TIME_COLUMN = "timeColumn";
   protected static final String JSON_COLUMN = "json";
   protected final int[] _intSVValues = new int[NUM_ROWS];
   protected final long[] _longSVValues = new long[NUM_ROWS];

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
@@ -60,9 +60,9 @@ import org.testng.annotations.Test;
 import static org.apache.pinot.core.operator.transform.function.DateTruncTransformFunction.DateTimeZoneIndex.getDateTimeZone;
 import static org.apache.pinot.core.operator.transform.function.TimeZoneKey.UTC_KEY;
 
-
-public class DateTruncTransformFunctionTest {
-  private static final String TIME_COLUMN = "time";
+public class DateTruncTransformFunctionTest
+{
+  private static final String TIME_COLUMN = "timeColumn";
   private static final ZoneOffset WEIRD_ZONE = ZoneOffset.ofHoursMinutes(7, 9);
   private static final DateTimeZone WEIRD_DATE_TIME_ZONE = DateTimeZone.forID(WEIRD_ZONE.getId());
   private static final DateTime WEIRD_TIMESTAMP = new DateTime(2001, 8, 22, 3, 4, 5, 321, WEIRD_DATE_TIME_ZONE);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -54,7 +54,7 @@ import org.testng.annotations.Test;
 
 public class SegmentGenerationWithTimeColumnTest {
   private static final String STRING_COL_NAME = "someString";
-  private static final String TIME_COL_NAME = "date";
+  private static final String TIME_COL_NAME = "dateColumn";
   private static final String TIME_COL_FORMAT = "yyyyMMdd";
   private static final String SEGMENT_DIR_NAME =
       System.getProperty("java.io.tmpdir") + File.separator + "segmentGenTest";

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/IngestionUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/IngestionUtilsTest.java
@@ -87,10 +87,10 @@ public class IngestionUtilsTest {
     // Time field spec
     // only incoming
     schema = new Schema.SchemaBuilder()
-        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "time"), null).build();
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "timeColumn"), null).build();
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig.getIngestionConfig(), schema));
     Assert.assertEquals(extract.size(), 1);
-    Assert.assertTrue(extract.contains("time"));
+    Assert.assertTrue(extract.contains("timeColumn"));
 
     // incoming and outgoing different column name
     schema = new Schema.SchemaBuilder()
@@ -103,30 +103,30 @@ public class IngestionUtilsTest {
     // inbuilt functions
     schema = new Schema();
     dimensionFieldSpec = new DimensionFieldSpec("hoursSinceEpoch", FieldSpec.DataType.LONG, true);
-    dimensionFieldSpec.setTransformFunction("toEpochHours(timestamp)");
+    dimensionFieldSpec.setTransformFunction("toEpochHours(timestampInEpoch)");
     schema.addField(dimensionFieldSpec);
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig.getIngestionConfig(), schema));
     Assert.assertEquals(extract.size(), 2);
-    Assert.assertTrue(extract.containsAll(Arrays.asList("timestamp", "hoursSinceEpoch")));
+    Assert.assertTrue(extract.containsAll(Arrays.asList("timestampInEpoch", "hoursSinceEpoch")));
 
     // inbuilt functions with literal
     schema = new Schema();
     dimensionFieldSpec = new DimensionFieldSpec("tenMinutesSinceEpoch", FieldSpec.DataType.LONG, true);
-    dimensionFieldSpec.setTransformFunction("toEpochMinutesBucket(timestamp, 10)");
+    dimensionFieldSpec.setTransformFunction("toEpochMinutesBucket(timestampInEpoch, 10)");
     schema.addField(dimensionFieldSpec);
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig.getIngestionConfig(), schema));
     Assert.assertEquals(extract.size(), 2);
-    Assert.assertTrue(extract.containsAll(Lists.newArrayList("tenMinutesSinceEpoch", "timestamp")));
+    Assert.assertTrue(extract.containsAll(Lists.newArrayList("tenMinutesSinceEpoch", "timestampInEpoch")));
 
     // inbuilt functions on DateTimeFieldSpec
     schema = new Schema();
     DateTimeFieldSpec dateTimeFieldSpec =
-        new DateTimeFieldSpec("date", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd", "1:DAYS");
-    dateTimeFieldSpec.setTransformFunction("toDateTime(timestamp, 'yyyy-MM-dd')");
+        new DateTimeFieldSpec("dateTime", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd", "1:DAYS");
+    dateTimeFieldSpec.setTransformFunction("toDateTime(timestampInEpoch, 'yyyy-MM-dd')");
     schema.addField(dateTimeFieldSpec);
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(tableConfig.getIngestionConfig(), schema));
     Assert.assertEquals(extract.size(), 2);
-    Assert.assertTrue(extract.containsAll(Lists.newArrayList("date", "timestamp")));
+    Assert.assertTrue(extract.containsAll(Lists.newArrayList("dateTime", "timestampInEpoch")));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.util;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
@@ -157,5 +158,50 @@ public class SchemaUtilsTest {
             .addSingleValueDimension("group", FieldSpec.DataType.STRING, true)
             .build();
     Assert.assertTrue(SchemaUtils.validate(pinotSchema, false, null));
+  }
+
+  @Test
+  public void testDateTimeFieldSpec()
+      throws IOException {
+    Schema pinotSchema;
+    pinotSchema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"x:HOURS:EPOCH\",\"granularity\":\"1:HOURS\"}]}");
+    Assert.assertFalse(SchemaUtils.validate(pinotSchema));
+
+    pinotSchema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:DUMMY:EPOCH\",\"granularity\":\"1:HOURS\"}]}");
+    Assert.assertFalse(SchemaUtils.validate(pinotSchema));
+
+    pinotSchema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:HOURS:DUMMY\",\"granularity\":\"1:HOURS\"}]}");
+    Assert.assertFalse(SchemaUtils.validate(pinotSchema));
+
+    pinotSchema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:HOURS:EPOCH\",\"granularity\":\"x:HOURS\"}]}");
+    Assert.assertFalse(SchemaUtils.validate(pinotSchema));
+
+    pinotSchema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:HOURS:EPOCH\",\"granularity\":\"1:DUMMY\"}]}");
+    Assert.assertFalse(SchemaUtils.validate(pinotSchema));
+
+    pinotSchema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT\",\"granularity\":\"1:DAYS\"}]}");
+    Assert.assertFalse(SchemaUtils.validate(pinotSchema));
+
+    pinotSchema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:HOURS:EPOCH\",\"granularity\":\"1:HOURS\"}]}");
+    Assert.assertTrue(SchemaUtils.validate(pinotSchema));
+
+    pinotSchema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd\",\"granularity\":\"1:DAYS\"}]}");
+    Assert.assertTrue(SchemaUtils.validate(pinotSchema));
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatUnitSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatUnitSpec.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.data;
 
+import com.google.common.base.Preconditions;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.pinot.spi.utils.EqualityUtils;
@@ -101,9 +102,8 @@ public class DateTimeFormatUnitSpec {
   private DateTimeTransformUnit _dateTimeTransformUnit = null;
 
   public DateTimeFormatUnitSpec(String unit) {
-    if (!isValidUnitSpec(unit)) {
-      throw new IllegalArgumentException("Unit must belong to enum TimeUnit or DateTimeTransformUnit");
-    }
+    Preconditions
+        .checkArgument(isValidUnitSpec(unit), "Unit:% must belong to enum TimeUnit or DateTimeTransformUnit", unit);
     if (EnumUtils.isValidEnum(TimeUnit.class, unit)) {
       _timeUnit = TimeUnit.valueOf(unit);
     }


### PR DESCRIPTION
## Description
https://github.com/apache/incubator-pinot/issues/5640
Adding schema validations for
1. reserved keywords being used as field names
2. format and granularity string in dateTimeFieldSpec

## Release Notes
The check for reserved keywords fails the add/update/validate of schemas containing sql keywords (e.g. timestamp, Date). As a result, **updates to existing schemas containing these keywords will fail**. Validation called on these schemas will also fail.
A queryParam `validateFieldNames` has been provided to the add, update and validate schema calls. It is by default `true`. **For operations on schemas with invalid field names to be successful, this flag needs to be set to `false`.** 


