### PR TITLE
SQL Compilation Fixes

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/parsers/utils/ParserUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/parsers/utils/ParserUtils.java
@@ -54,6 +54,8 @@ public class ParserUtils {
     FILTER_OPERATOR_MAP.put(FilterKind.IN, FilterOperator.IN);
     FILTER_OPERATOR_MAP.put(FilterKind.NOT_IN, FilterOperator.NOT_IN);
     FILTER_OPERATOR_MAP.put(FilterKind.REGEXP_LIKE, FilterOperator.REGEXP_LIKE);
+    FILTER_OPERATOR_MAP.put(FilterKind.IS_NULL, FilterOperator.IS_NULL);
+    FILTER_OPERATOR_MAP.put(FilterKind.IS_NOT_NULL, FilterOperator.IS_NOT_NULL);
     FILTER_OPERATOR_MAP.put(FilterKind.TEXT_MATCH, FilterOperator.TEXT_MATCH);
   }
 
@@ -67,6 +69,18 @@ public class ParserUtils {
   public static FilterOperator getFilterType(Expression expression) {
     String operator = expression.getFunctionCall().getOperator();
     return filterKindToOperator(FilterKind.valueOf(operator));
+  }
+
+  /**
+   * Utility method that returns the {@link FilterKind} for a given expression.
+   * Assumes that the passed in expression is a filter expression.
+   *
+   * @param expression Expression for which to get the filter type
+   * @return Filter Kind for the given Expression.
+   */
+  public static FilterKind getFilterKind(Expression expression) {
+    String operator = expression.getFunctionCall().getOperator();
+    return FilterKind.valueOf(operator);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -247,11 +247,10 @@ public class PinotQuery2BrokerRequestConverter {
       case IDENTIFIER:
         break;
       case FUNCTION:
-        Function functionCall = filterExpression.getFunctionCall();
-        String operator = functionCall.getOperator();
-        FilterKind filterKind = FilterKind.valueOf(operator);
+        FilterKind filterKind = ParserUtils.getFilterKind(filterExpression);
         FilterOperator filterOperator = ParserUtils.filterKindToOperator(filterKind);
         filterQuery.setOperator(filterOperator);
+        Function functionCall = filterExpression.getFunctionCall();
         List<Expression> operands = functionCall.getOperands();
         switch (filterOperator) {
           case AND:
@@ -272,7 +271,11 @@ public class PinotQuery2BrokerRequestConverter {
             filterQuery.setColumn(ParserUtils.standardizeExpression(operands.get(0), false));
             filterQuery.setValue(ParserUtils.getFilterValues(filterKind, operands));
             break;
-
+          case IS_NULL:
+          case IS_NOT_NULL:
+            //first operand is the always the column
+            filterQuery.setColumn(ParserUtils.standardizeExpression(operands.get(0), false));
+            break;
           default:
             throw new UnsupportedOperationException("Filter UDF not supported");
         }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -662,7 +662,9 @@ public class CalciteSqlParser {
   private static String extractFunctionName(SqlBasicCall funcSqlNode) {
     String funcName = funcSqlNode.getOperator().getKind().name();
     if (funcSqlNode.getOperator().getKind() == SqlKind.OTHER_FUNCTION) {
-      funcName = funcSqlNode.getOperator().getName();
+      // in-built functions like REGEXP_LIKE, TEXT_MATCH that are not natively
+      // supported by Calcite grammar
+      funcName = funcSqlNode.getOperator().getName().toUpperCase();
     }
     if (funcName.equalsIgnoreCase(SqlKind.COUNT.toString()) && (funcSqlNode.getFunctionQuantifier() != null)
         && funcSqlNode.getFunctionQuantifier().toValue().equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -662,7 +662,7 @@ public class CalciteSqlParser {
   private static String extractFunctionName(SqlBasicCall funcSqlNode) {
     String funcName = funcSqlNode.getOperator().getKind().name();
     if (funcSqlNode.getOperator().getKind() == SqlKind.OTHER_FUNCTION) {
-      // in-built functions like REGEXP_LIKE, TEXT_MATCH that are not natively
+      // in-built functions like REGEXP_LIKE, TEXT_MATCH, timeConvert etc that are not natively
       // supported by Calcite grammar
       funcName = funcSqlNode.getOperator().getName().toUpperCase();
     }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -173,7 +173,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 80L);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where regexp_like(E, '^U.*')");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), "regexp_like");
+    Assert.assertEquals(func.getOperator(), "REGEXP_LIKE");
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "E");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getStringValue(), "^U.*");
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where f LIKE '%potato%'");
@@ -252,16 +252,16 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
     Assert
         .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-            "foo1");
+            "FOO1");
     Assert
         .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
-            "foo2");
+            "FOO2");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "bar1");
+            .getFunctionCall().getOperator(), "BAR1");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "bar2");
+            .getFunctionCall().getOperator(), "BAR2");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
@@ -292,16 +292,16 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
     Assert
         .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-            "foo1");
+            "FOO1");
     Assert
         .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
-            "foo2");
+            "FOO2");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "bar1");
+            .getFunctionCall().getOperator(), "BAR1");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "bar2");
+            .getFunctionCall().getOperator(), "BAR2");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
@@ -652,7 +652,7 @@ public class CalciteSqlCompilerTest {
             .getLiteral().getStringValue(), "bar");
     groupbyList = pinotQuery.getGroupByList();
     Assert.assertEquals(groupbyList.size(), 2);
-    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperator(), "sub");
+    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperator(), "SUB");
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "bar");
@@ -711,7 +711,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "timeConvert");
+        "TIMECONVERT");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "DaysSinceEpoch");
@@ -730,7 +730,7 @@ public class CalciteSqlCompilerTest {
   public void testSelectionTransformFunction() {
     PinotQuery pinotQuery = CalciteSqlParser
         .compileToPinotQuery("  select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "mapKey");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "MAPKEY");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "mapField");
     Assert.assertEquals(
@@ -739,7 +739,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "mapKey");
+        "MAPKEY");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "mapField");
@@ -943,7 +943,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(distinctFunction.getOperands().size(), 1);
 
     Function add = distinctFunction.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(add.getOperator(), "add");
+    Assert.assertEquals(add.getOperator(), "ADD");
     Assert.assertEquals(add.getOperands().size(), 2);
     c1 = add.getOperands().get(0).getIdentifier();
     c2 = add.getOperands().get(1).getIdentifier();
@@ -972,13 +972,13 @@ public class CalciteSqlCompilerTest {
 
     // check for DISTINCT's first operand ADD(....)
     add = distinctFunction.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(add.getOperator(), "add");
+    Assert.assertEquals(add.getOperator(), "ADD");
     Assert.assertEquals(add.getOperands().size(), 2);
     Function div = add.getOperands().get(0).getFunctionCall();
     Function mul = add.getOperands().get(1).getFunctionCall();
 
     // check for ADD's first operand DIV(...)
-    Assert.assertEquals(div.getOperator(), "div");
+    Assert.assertEquals(div.getOperator(), "DIV");
     Assert.assertEquals(div.getOperands().size(), 2);
     c1 = div.getOperands().get(0).getIdentifier();
     c2 = div.getOperands().get(1).getIdentifier();
@@ -986,7 +986,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(c2.getName(), "col2");
 
     // check for ADD's second operand MUL(...)
-    Assert.assertEquals(mul.getOperator(), "mul");
+    Assert.assertEquals(mul.getOperator(), "MUL");
     Assert.assertEquals(mul.getOperands().size(), 2);
     c1 = mul.getOperands().get(0).getIdentifier();
     c2 = mul.getOperands().get(1).getIdentifier();
@@ -995,7 +995,7 @@ public class CalciteSqlCompilerTest {
 
     // check for DISTINCT's second operand SUB(...)
     Function sub = distinctFunction.getOperands().get(1).getFunctionCall();
-    Assert.assertEquals(sub.getOperator(), "sub");
+    Assert.assertEquals(sub.getOperator(), "SUB");
     Assert.assertEquals(sub.getOperands().size(), 2);
     c1 = sub.getOperands().get(0).getIdentifier();
     c2 = sub.getOperands().get(1).getIdentifier();
@@ -1026,13 +1026,13 @@ public class CalciteSqlCompilerTest {
 
     // check for DISTINCT's first operand ADD(....)
     add = distinctFunction.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(add.getOperator(), "add");
+    Assert.assertEquals(add.getOperator(), "ADD");
     Assert.assertEquals(add.getOperands().size(), 2);
     div = add.getOperands().get(0).getFunctionCall();
     mul = add.getOperands().get(1).getFunctionCall();
 
     // check for ADD's first operand DIV(...)
-    Assert.assertEquals(div.getOperator(), "div");
+    Assert.assertEquals(div.getOperator(), "DIV");
     Assert.assertEquals(div.getOperands().size(), 2);
     c1 = div.getOperands().get(0).getIdentifier();
     c2 = div.getOperands().get(1).getIdentifier();
@@ -1040,7 +1040,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(c2.getName(), "col2");
 
     // check for ADD's second operand MUL(...)
-    Assert.assertEquals(mul.getOperator(), "mul");
+    Assert.assertEquals(mul.getOperator(), "MUL");
     Assert.assertEquals(mul.getOperands().size(), 2);
     c1 = mul.getOperands().get(0).getIdentifier();
     c2 = mul.getOperands().get(1).getIdentifier();
@@ -1049,7 +1049,7 @@ public class CalciteSqlCompilerTest {
 
     // check for DISTINCT's second operand SUB(...)
     sub = distinctFunction.getOperands().get(1).getFunctionCall();
-    Assert.assertEquals(sub.getOperator(), "sub");
+    Assert.assertEquals(sub.getOperator(), "SUB");
     Assert.assertEquals(sub.getOperands().size(), 2);
     c1 = sub.getOperands().get(0).getIdentifier();
     c2 = sub.getOperands().get(1).getIdentifier();
@@ -1527,7 +1527,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
-    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "distinctCount");
+    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "DISTINCTCOUNT");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
@@ -1557,17 +1557,17 @@ public class CalciteSqlCompilerTest {
   public void testNoArgFunction() {
     String query = "SELECT noArgFunc() FROM foo ";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "noArgFunc");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "NOARGFUNC");
 
     query = "SELECT a FROM foo where time_col > noArgFunc()";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Function greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
     Function minus = greaterThan.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(minus.getOperands().get(1).getFunctionCall().getOperator(), "noArgFunc");
+    Assert.assertEquals(minus.getOperands().get(1).getFunctionCall().getOperator(), "NOARGFUNC");
 
     query = "SELECT sum(a), noArgFunc() FROM foo group by noArgFunc()";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "noArgFunc");
+    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "NOARGFUNC");
   }
 
   @Test
@@ -1632,13 +1632,13 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(expression.getFunctionCall() != null);
     expression = CalciteSqlParser.invokeCompileTimeFunctionExpression(expression);
     Assert.assertTrue(expression.getFunctionCall() != null);
-    Assert.assertEquals(expression.getFunctionCall().getOperator(), "toDateTime");
+    Assert.assertEquals(expression.getFunctionCall().getOperator(), "TODATETIME");
     Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "playerName");
     expression = CalciteSqlParser.compileToExpression("reverse(playerName)");
     Assert.assertTrue(expression.getFunctionCall() != null);
     expression = CalciteSqlParser.invokeCompileTimeFunctionExpression(expression);
     Assert.assertTrue(expression.getFunctionCall() != null);
-    Assert.assertEquals(expression.getFunctionCall().getOperator(), "reverse");
+    Assert.assertEquals(expression.getFunctionCall().getOperator(), "REVERSE");
     Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "playerName");
     expression = CalciteSqlParser.compileToExpression("reverse('playerName')");
     Assert.assertTrue(expression.getFunctionCall() != null);


### PR DESCRIPTION
Two fixes:

- Make in-built functions like TEXT_MATCH, REGEXP_LIKE case insensitive on SQL path. Should be converted to upper case since that is what is there in enum definitions and is also followed by Calcite for all functions/operators part of it's grammar. 
- Add support for converting PinotQuery to BrokerRequest for IS NULL and IS NOT NULL. Calcite supports these natively as part of it's grammar but we missed handling them when converting FilterExpression to FilterQuery.