### PR TITLE
Fix ORC Record reader to ignore extra fields

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
@@ -324,7 +324,7 @@ public class ORCRecordReader implements RecordReader {
         }
       default:
         // Unsupported types
-        throw new IllegalStateException("Unsupported field type: " + category + " for field " + field);
+        throw new IllegalStateException("Unsupported field type: " + category + " for field: " + field);
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
@@ -97,8 +97,8 @@ public class ORCRecordReader implements RecordReader {
         if (category == TypeDescription.Category.LIST) {
           // Multi-value field
           TypeDescription.Category childCategory = fieldType.getChildren().get(0).getCategory();
-          Preconditions.checkState(isSupportedSingleValueType(childCategory), "Illegal multi-value field type: %s",
-              childCategory);
+          Preconditions.checkState(isSupportedSingleValueType(childCategory), "Illegal multi-value field type: %s (field %s)",
+              childCategory, field);
           // NOTE: LIST is stored as 2 vectors
           int fieldId = fieldType.getId();
           orcReaderInclude[fieldId] = true;
@@ -108,10 +108,10 @@ public class ORCRecordReader implements RecordReader {
           List<TypeDescription> children = fieldType.getChildren();
           TypeDescription.Category keyCategory = children.get(0).getCategory();
           Preconditions
-              .checkState(isSupportedSingleValueType(keyCategory), "Illegal map key field type: %s", keyCategory);
+              .checkState(isSupportedSingleValueType(keyCategory), "Illegal map key field type: %s (field %s)", keyCategory, field);
           TypeDescription.Category valueCategory = children.get(1).getCategory();
           Preconditions
-              .checkState(isSupportedSingleValueType(valueCategory), "Illegal map value field type: %s", valueCategory);
+              .checkState(isSupportedSingleValueType(valueCategory), "Illegal map value field type: %s (field %s)", valueCategory, field);
           // NOTE: MAP is stored as 3 vectors
           int fieldId = fieldType.getId();
           orcReaderInclude[fieldId] = true;
@@ -120,11 +120,11 @@ public class ORCRecordReader implements RecordReader {
         } else {
           // Single-value field
           Preconditions
-              .checkState(isSupportedSingleValueType(category), "Illegal single-value field type: %s", category);
+              .checkState(isSupportedSingleValueType(category), "Illegal single-value field type: %s (field %s)", category, field);
           orcReaderInclude[fieldType.getId()] = true;
         }
+        _includeOrcFields[i] = true;
       }
-      _includeOrcFields[i] = true;
     }
 
     _orcRecordReader = orcReader.rows(new Reader.Options().include(orcReaderInclude));
@@ -186,7 +186,7 @@ public class ORCRecordReader implements RecordReader {
           int length = (int) listColumnVector.lengths[rowId];
           List<Object> values = new ArrayList<>(length);
           for (int j = 0; j < length; j++) {
-            Object value = extractSingleValue(listColumnVector.child, offset + j, childCategory);
+            Object value = extractSingleValue(field, listColumnVector.child, offset + j, childCategory);
             // NOTE: Only keep non-null values
             // TODO: Revisit
             if (value != null) {
@@ -216,8 +216,8 @@ public class ORCRecordReader implements RecordReader {
           Map<Object, Object> map = new HashMap<>();
           for (int j = 0; j < length; j++) {
             int childRowId = offset + j;
-            Object key = extractSingleValue(mapColumnVector.keys, childRowId, keyCategory);
-            Object value = extractSingleValue(mapColumnVector.values, childRowId, valueCategory);
+            Object key = extractSingleValue(field, mapColumnVector.keys, childRowId, keyCategory);
+            Object value = extractSingleValue(field, mapColumnVector.values, childRowId, valueCategory);
             map.put(key, value);
           }
           reuse.putValue(field, map);
@@ -226,7 +226,7 @@ public class ORCRecordReader implements RecordReader {
         }
       } else {
         // Single-value field
-        reuse.putValue(field, extractSingleValue(_rowBatch.cols[i], _nextRowId, category));
+        reuse.putValue(field, extractSingleValue(field, _rowBatch.cols[i], _nextRowId, category));
       }
     }
 
@@ -238,7 +238,7 @@ public class ORCRecordReader implements RecordReader {
   }
 
   @Nullable
-  private static Object extractSingleValue(ColumnVector columnVector, int rowId, TypeDescription.Category category) {
+  private static Object extractSingleValue(String field, ColumnVector columnVector, int rowId, TypeDescription.Category category) {
     if (columnVector.isRepeating) {
       rowId = 0;
     }
@@ -324,7 +324,7 @@ public class ORCRecordReader implements RecordReader {
         }
       default:
         // Unsupported types
-        throw new IllegalStateException("Unsupported field type: " + category);
+        throw new IllegalStateException("Unsupported field type: " + category + " for field " + field);
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
@@ -52,7 +52,7 @@ public class ORCRecordReaderTest extends AbstractRecordReaderTest {
   protected void writeRecordsToFile(List<Map<String, Object>> recordsToWrite)
       throws Exception {
     TypeDescription schema = TypeDescription.fromString(
-        "struct<dim_sv_int:int,dim_sv_long:bigint,dim_sv_float:float,dim_sv_double:double,dim_sv_string:string,dim_mv_int:array<int>,dim_mv_long:array<bigint>,dim_mv_float:array<float>,dim_mv_double:array<double>,dim_mv_string:array<string>,met_int:int,met_long:bigint,met_float:float,met_double:double>");
+        "struct<dim_sv_int:int,dim_sv_long:bigint,dim_sv_float:float,dim_sv_double:double,dim_sv_string:string,dim_mv_int:array<int>,dim_mv_long:array<bigint>,dim_mv_float:array<float>,dim_mv_double:array<double>,dim_mv_string:array<string>,met_int:int,met_long:bigint,met_float:float,met_double:double,extra_field:struct<f1:int,f2:int>>");
     Writer writer = OrcFile.createWriter(new Path(_dataFile.getAbsolutePath()),
         OrcFile.writerOptions(new Configuration()).setSchema(schema));
 


### PR DESCRIPTION
Fixing an issue introduced in PR #5267
We should not be validating the type of fields that we don't care about.
Cleaned up the messages and exceptions thrown so that we know which
field is the problematic one.

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
