### PR TITLE
Use UUID instead of nanoTime to create unique temp file

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUtils.java
@@ -23,15 +23,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
-import java.util.Random;
+
 
 public class FileUtils {
   private FileUtils() {
-  }
-  private static final Random RANDOM = new Random();
-
-  public static String getRandomFileName() {
-    return StringUtil.join("-", "tmp", String.valueOf(System.currentTimeMillis()), Long.toString(RANDOM.nextLong()));
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -32,6 +32,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -159,8 +160,8 @@ public class PinotSegmentUploadDownloadRestletResource {
             "Segment: " + segmentName + " of table: " + tableName + " not found at: " + remoteSegmentFileURI,
             Response.Status.NOT_FOUND);
       }
-      segmentFile = new File(ControllerFilePathProvider.getInstance().getFileDownloadTempDir(),
-          StringUtil.join(File.separator, tableName, segmentName + "-" + System.nanoTime()));
+      segmentFile = new File(new File(ControllerFilePathProvider.getInstance().getFileDownloadTempDir(), tableName),
+          segmentName + "-" + UUID.randomUUID());
       pinotFS.copyToLocalFile(remoteSegmentFileURI, segmentFile);
       // Streaming in the tmp file and delete it afterward.
       builder.entity((StreamingOutput) output -> {
@@ -194,7 +195,7 @@ public class PinotSegmentUploadDownloadRestletResource {
     File tempSegmentDir = null;
     try {
       ControllerFilePathProvider provider = ControllerFilePathProvider.getInstance();
-      String tempFileName = TMP_DIR_PREFIX + System.nanoTime();
+      String tempFileName = TMP_DIR_PREFIX + UUID.randomUUID();
       tempDecryptedFile = new File(provider.getFileUploadTempDir(), tempFileName);
       tempEncryptedFile = new File(provider.getFileUploadTempDir(), tempFileName + ENCRYPTED_SUFFIX);
       tempSegmentDir = new File(provider.getUntarredFileTempDir(), tempFileName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.data.recordtransformer.CompositeTransformer;
@@ -160,7 +161,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     }
 
     // Create a temporary directory used in segment creation
-    tempIndexDir = new File(indexDir, org.apache.pinot.common.utils.FileUtils.getRandomFileName());
+    tempIndexDir = new File(indexDir, "tmp-" + UUID.randomUUID());
     LOGGER.debug("tempIndexDir:{}", tempIndexDir);
   }
 

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
@@ -60,12 +60,12 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
    * @return a list of segment conversion result
    * @throws Exception
    */
-  protected abstract List<SegmentConversionResult> convert(@Nonnull PinotTaskConfig pinotTaskConfig,
-      @Nonnull List<File> originalIndexDir, @Nonnull File workingDir)
+  protected abstract List<SegmentConversionResult> convert(PinotTaskConfig pinotTaskConfig, List<File> originalIndexDir,
+      File workingDir)
       throws Exception;
 
   @Override
-  public List<SegmentConversionResult> executeTask(@Nonnull PinotTaskConfig pinotTaskConfig)
+  public List<SegmentConversionResult> executeTask(PinotTaskConfig pinotTaskConfig)
       throws Exception {
     String taskType = pinotTaskConfig.getTaskType();
     Map<String, String> configs = pinotTaskConfig.getConfigs();
@@ -78,7 +78,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     LOGGER.info("Start executing {} on table: {}, input segments: {} with downloadURLs: {}, uploadURL: {}", taskType,
         tableNameWithType, inputSegmentNames, downloadURLString, uploadURL);
 
-    File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + System.nanoTime());
+    File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + UUID.randomUUID());
     Preconditions.checkState(tempDataDir.mkdirs());
 
     try {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
@@ -75,7 +76,7 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
     LOGGER.info("Start executing {} on table: {}, segment: {} with downloadURL: {}, uploadURL: {}", taskType,
         tableNameWithType, segmentName, downloadURL, uploadURL);
 
-    File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + System.nanoTime());
+    File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + UUID.randomUUID());
     Preconditions.checkState(tempDataDir.mkdirs(), "Failed to create temporary directory: %s", tempDataDir);
     try {
       // Download the tarred segment file

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -21,6 +21,7 @@ package org.apache.pinot.plugin.ingestion.batch.hadoop;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.net.URI;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -65,7 +66,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
     String segmentGenerationJobSpecStr = _jobConf.get(SEGMENT_GENERATION_JOB_SPEC);
     _spec = yaml.loadAs(segmentGenerationJobSpecStr, SegmentGenerationJobSpec.class);
     LOGGER.info("Segment generation job spec : {}", segmentGenerationJobSpecStr);
-    _localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + System.currentTimeMillis());
+    _localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + UUID.randomUUID());
 
     // Load Pinot Plugins copied from Distributed cache.
     File localPluginsTarFile = new File(PINOT_PLUGINS_TAR_GZ);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -247,7 +248,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         }
 
         //create localTempDir for input and output
-        File localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + System.currentTimeMillis());
+        File localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + UUID.randomUUID());
         File localInputTempDir = new File(localTempDir, "input");
         FileUtils.forceMkdir(localInputTempDir);
         File localOutputTempDir = new File(localTempDir, "output");

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -25,6 +25,7 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -152,7 +153,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
       }
     }
 
-    File localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + System.currentTimeMillis());
+    File localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + UUID.randomUUID());
     try {
       //create localTempDir for input and output
       File localInputTempDir = new File(localTempDir, "input");

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -20,6 +20,7 @@ package org.apache.pinot.server.starter.helix;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
+import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
@@ -181,7 +182,7 @@ public class SegmentFetcherAndLoader {
   private String downloadSegmentToLocal(String uri, PinotCrypter crypter, String tableName, String segmentName)
       throws Exception {
     File tempDir = new File(new File(_instanceDataManager.getSegmentFileDirectory(), tableName),
-        "tmp_" + segmentName + "_" + System.nanoTime());
+        "tmp-" + segmentName + "-" + UUID.randomUUID());
     FileUtils.forceMkdir(tempDir);
     File tempDownloadFile = new File(tempDir, segmentName + ENCODED_SUFFIX);
     File tempTarFile = new File(tempDir, segmentName + TAR_GZ_SUFFIX);


### PR DESCRIPTION
Using nanoTime to create unique temp file can cause file name collision (especially in multi-threaded case)
This is causing the flakiness of the integration tests when all segments are uploaded at the same time