### PR TITLE
Don't override tenantConfig in singleTenantCluster mode, if user explicitly set tenantConfig

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -35,6 +35,7 @@ import org.apache.pinot.common.utils.CommonConstants.Helix;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -48,6 +49,7 @@ import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -163,6 +165,16 @@ public class HelixBrokerStarterTest extends ControllerTest {
     String newOfflineTableName = TableNameBuilder.OFFLINE.tableNameWithType(newRawTableName);
     TableConfig newTableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(newRawTableName).setBrokerTenant("testBroker").build();
+    try {
+      _helixResourceManager.addTable(newTableConfig);
+      Assert.fail("Table creation should fail as testBroker does not exist");
+    } catch (PinotHelixResourceManager.InvalidTableConfigException e) {
+      // expected
+    }
+
+    // Add a new table with same broker tenant
+    newTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(newRawTableName)
+        .setServerTenant(TagNameUtils.DEFAULT_TENANT_NAME).build();
     _helixResourceManager.addTable(newTableConfig);
 
     // Broker tenant should be overridden to DefaultTenant

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1043,6 +1043,13 @@ public class PinotHelixResourceManager {
    */
   public void addTable(TableConfig tableConfig)
       throws IOException {
+    if (isSingleTenantCluster()) {
+      TenantConfig tenantConfig = tableConfig.getTenantConfig();
+      String brokerTag = tenantConfig.getBroker() == null ? TagNameUtils.DEFAULT_TENANT_NAME : tenantConfig.getBroker();
+      String serverTag = tenantConfig.getServer() == null ? TagNameUtils.DEFAULT_TENANT_NAME : tenantConfig.getServer();
+      tableConfig
+          .setTenantConfig(new TenantConfig(brokerTag, serverTag, tenantConfig.getTagOverrideConfig()));
+    }
     validateTableTenantConfig(tableConfig);
 
     String tableNameWithType = tableConfig.getTableName();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1043,10 +1043,7 @@ public class PinotHelixResourceManager {
    */
   public void addTable(TableConfig tableConfig)
       throws IOException {
-    TenantConfig tenantConfig = tableConfig.getTenantConfig();
-    // set DefaultTenant tenantConfig, if singleTenantCluster and tenantConfig not provided
-    if (isSingleTenantCluster() && (tenantConfig == null || tenantConfig.getServer() == null
-        || tenantConfig.getBroker() == null)) {
+    if (isSingleTenantCluster() && tableConfig.getTenantConfig() == null) {
       tableConfig
           .setTenantConfig(new TenantConfig(TagNameUtils.DEFAULT_TENANT_NAME, TagNameUtils.DEFAULT_TENANT_NAME, null));
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1043,10 +1043,6 @@ public class PinotHelixResourceManager {
    */
   public void addTable(TableConfig tableConfig)
       throws IOException {
-    if (isSingleTenantCluster() && tableConfig.getTenantConfig() == null) {
-      tableConfig
-          .setTenantConfig(new TenantConfig(TagNameUtils.DEFAULT_TENANT_NAME, TagNameUtils.DEFAULT_TENANT_NAME, null));
-    }
     validateTableTenantConfig(tableConfig);
 
     String tableNameWithType = tableConfig.getTableName();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1043,7 +1043,10 @@ public class PinotHelixResourceManager {
    */
   public void addTable(TableConfig tableConfig)
       throws IOException {
-    if (isSingleTenantCluster()) {
+    TenantConfig tenantConfig = tableConfig.getTenantConfig();
+    // set DefaultTenant tenantConfig, if singleTenantCluster and tenantConfig not provided
+    if (isSingleTenantCluster() && (tenantConfig == null || tenantConfig.getServer() == null
+        || tenantConfig.getBroker() == null)) {
       tableConfig
           .setTenantConfig(new TenantConfig(TagNameUtils.DEFAULT_TENANT_NAME, TagNameUtils.DEFAULT_TENANT_NAME, null));
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2063,10 +2063,6 @@ public class PinotHelixResourceManager {
     return getHelixInstanceConfig(instanceName) != null;
   }
 
-  public boolean isSingleTenantCluster() {
-    return _isSingleTenantCluster;
-  }
-
   /**
    * Computes the broker nodes that are untagged and free to be used.
    * @return List of online untagged broker instances.


### PR DESCRIPTION
## Description
We have a flag that can be set when starting the controller called `cluster.tenant.isolation`. It is by default `true`. It indicates that the cluster has only 1 tenant called `DefaultTenant`. If this is set to true, any brokers/servers added to the cluster will have tag `DefaultTenant`, otherwise they'll have tag `server_untagged/broker_untagged`. Practically, this flag is true only in testing/quickstart/test setups. All productionized environments would set this to false, and create their own tenants.

In quickstart, after initial run, often times users edit the `tenantConfig` (add another tenant or add `tagOverrideConfig`). But those settings get overridden because of this flag.

In this pR, Allowing changes to tenant config to come through, even in singleTenantCluster mode
