### PR TITLE
Using dictionary based aggregation operator when there is no filter/g…

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.query;
 
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +73,13 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
         case MINMAXRANGE:
           aggregationResults.add(
               new MinMaxRangePair(dictionary.getDoubleValue(0), dictionary.getDoubleValue(dictionary.length() - 1)));
+          break;
+        case DISTINCTCOUNT:
+          IntOpenHashSet set = new IntOpenHashSet(128);
+          for (int dictId = 0; dictId < dictionary.length(); dictId++) {
+            set.add(dictionary.get(dictId).hashCode());
+          }
+          aggregationResults.add(set);
           break;
         default:
           throw new IllegalStateException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -164,7 +164,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     for (ExpressionContext expression : selectExpressions) {
       FunctionContext function = expression.getFunction();
       String functionName = function.getFunctionName();
-      if (!functionName.equals("min") && !functionName.equals("max") && !functionName.equals("minmaxrange")) {
+      if (!functionName.equals("min") && !functionName.equals("max") && !functionName.equals("minmaxrange")
+          && !functionName.equals("distinctcount")) {
         return false;
       }
       ExpressionContext argument = function.getArguments().get(0);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -35,6 +35,7 @@ import org.apache.pinot.core.plan.MetadataBasedAggregationPlanNode;
 import org.apache.pinot.core.plan.Plan;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.plan.SelectionPlanNode;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.config.QueryExecutorConfig;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.FunctionContext;
@@ -156,7 +157,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
   /**
    * Returns {@code true} if the given aggregation-only without filter QueryContext can be solved with dictionary,
    * {@code false} otherwise.
-   * <p>Aggregations supported: MIN, MAX, MINMAXRANGE
+   * <p>Aggregations supported: MIN, MAX, MINMAXRANGE, DISTINCTCOUNT
    */
   @VisibleForTesting
   static boolean isFitForDictionaryBasedPlan(QueryContext queryContext, IndexSegment indexSegment) {
@@ -164,10 +165,10 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     for (ExpressionContext expression : selectExpressions) {
       FunctionContext function = expression.getFunction();
       String functionName = function.getFunctionName();
-      if (!functionName.equals("min") && !functionName.equals("max") && !functionName.equals("minmaxrange")
-          && !functionName.equals("distinctcount")) {
+      if(!AggregationFunctionUtils.isFitForDictionaryBasedComputation(functionName)) {
         return false;
       }
+
       ExpressionContext argument = function.getArguments().get(0);
       if (argument.getType() != ExpressionContext.Type.IDENTIFIER) {
         return false;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -207,4 +207,14 @@ public class AggregationFunctionUtils {
     BlockValSet blockValSet = transformBlock.getBlockValueSet(aggregationFunctionColumnPair.toColumnName());
     return Collections.singletonMap(expression, blockValSet);
   }
+
+  public static boolean isFitForDictionaryBasedComputation(String functionName) {
+    if (functionName.equalsIgnoreCase(AggregationFunctionType.MIN.name()) ||  //
+        functionName.equalsIgnoreCase(AggregationFunctionType.MAX.name()) || //
+        functionName.equalsIgnoreCase(AggregationFunctionType.MINMAXRANGE.name()) || //
+        functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNT.name())) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
@@ -174,7 +174,8 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     String query = "SELECT DISTINCTCOUNT(column1), DISTINCTCOUNT(column3) FROM testTable";
 
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 240000L, 120000L,
+    //without filter, we should be using dictionary for distinctcount
+    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L,
         new String[]{"6582", "21910"});
 
     brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
@@ -347,8 +347,9 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     rows = new ArrayList<>();
     rows.add(new Object[]{6582, 21910});
     expectedResultsSize = 1;
+    //without filter, distinctCount must be solved using dictionary. expectedNumEntriesScannedPostFilter is 0L
     QueriesTestUtils
-        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 240000L, 120000L, rows, expectedResultsSize,
+        .testInterSegmentResultTable(brokerResponse, 120000L, 0L, 0L, 120000L, rows, expectedResultsSize,
             dataSchema);
 
     brokerResponse = getBrokerResponseForPqlQuery(query + getFilter(), queryOptions);


### PR DESCRIPTION
…roup by

## Description
```  select distinctcount(league) from baseballStats limit 10```
This query can be answered by going over the dictionary instead of scanning the entire forward index.

We already have the code to check if a query can be answered just based on the dictionary for min/max. Enhanced it to support distinctcount as well.

`select distinctcount(league) from baseballStats limit 10`

Before
```
{
    "resultTable": {
        "dataSchema": {
            "columnDataTypes": ["INT"],
            "columnNames": ["distinctcount(league)"]
        },
        "rows": [
            [7]
        ]
    },
    "exceptions": [],
    "numServersQueried": 1,
    "numServersResponded": 1,
    "numSegmentsQueried": 1,
    "numSegmentsProcessed": 1,
    "numSegmentsMatched": 1,
    "numConsumingSegmentsQueried": 0,
    "numDocsScanned": 97889,
    "numEntriesScannedInFilter": 0,
    "numEntriesScannedPostFilter": 97889,
    "numGroupsLimitReached": false,
    "totalDocs": 97889,
    "timeUsedMs": 20,
    "segmentStatistics": [],
    "traceInfo": {},
    "minConsumingFreshnessTimeMs": 0
}
```
After this change
```

{
    "resultTable": {
        "dataSchema": {
            "columnDataTypes": ["INT"],
            "columnNames": ["distinctcount(league)"]
        },
        "rows": [
            [7]
        ]
    },
    "exceptions": [],
    "numServersQueried": 1,
    "numServersResponded": 1,
    "numSegmentsQueried": 1,
    "numSegmentsProcessed": 1,
    "numSegmentsMatched": 1,
    "numConsumingSegmentsQueried": 0,
    "numDocsScanned": 97889,
    "numEntriesScannedInFilter": 0,
    "numEntriesScannedPostFilter": 0,
    "numGroupsLimitReached": false,
    "totalDocs": 97889,
    "timeUsedMs": 15,
    "segmentStatistics": [],
    "traceInfo": {},
    "minConsumingFreshnessTimeMs": 0
}
```

> Before : "numEntriesScannedPostFilter": 97889,
> After: "numEntriesScannedPostFilter": 0,
> 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
