### PR TITLE
Optimize selection order-by when not all selected expressions are ordered

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/RowBasedBlockValueFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/RowBasedBlockValueFetcher.java
@@ -42,6 +42,12 @@ public class RowBasedBlockValueFetcher {
     return row;
   }
 
+  public void getRow(int docId, Object[] buffer, int startIndex) {
+    for (ValueFetcher valueFetcher : _valueFetchers) {
+      buffer[startIndex++] = valueFetcher.getValue(docId);
+    }
+  }
+
   private ValueFetcher createFetcher(BlockValSet blockValSet) {
     DataType valueType = blockValSet.getValueType();
     if (blockValSet.isSingleValue()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
@@ -20,7 +20,7 @@ package org.apache.pinot.core.operator;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.pinot.core.common.Block;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataBlockCache;
 import org.apache.pinot.core.common.DataFetcher;
 import org.apache.pinot.core.common.DataSource;
@@ -37,7 +37,8 @@ public class ProjectionOperator extends BaseOperator<ProjectionBlock> {
   private final BaseOperator<DocIdSetBlock> _docIdSetOperator;
   private final DataBlockCache _dataBlockCache;
 
-  public ProjectionOperator(Map<String, DataSource> dataSourceMap, BaseOperator<DocIdSetBlock> docIdSetOperator) {
+  public ProjectionOperator(Map<String, DataSource> dataSourceMap,
+      @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator) {
     _dataSourceMap = dataSourceMap;
     _dataSourceMetadataMap = new HashMap<>(dataSourceMap.size());
     for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
@@ -58,6 +59,8 @@ public class ProjectionOperator extends BaseOperator<ProjectionBlock> {
 
   @Override
   protected ProjectionBlock getNextBlock() {
+    // NOTE: Should not be called when _docIdSetOperator is null.
+    assert _docIdSetOperator != null;
     DocIdSetBlock docIdSetBlock = _docIdSetOperator.nextBlock();
     if (docIdSetBlock == null) {
       return null;
@@ -74,6 +77,6 @@ public class ProjectionOperator extends BaseOperator<ProjectionBlock> {
 
   @Override
   public ExecutionStatistics getExecutionStatistics() {
-    return _docIdSetOperator.getExecutionStatistics();
+    return _docIdSetOperator != null ? _docIdSetOperator.getExecutionStatistics() : new ExecutionStatistics(0, 0, 0, 0);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -248,10 +248,11 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
     MutableRoaringBitmap docIds = new MutableRoaringBitmap();
     for (Object[] row : _rows) {
       rowList.add(row);
-      docIds.add((int) row[numOrderByExpressions]);
+      int docId = (int) row[numOrderByExpressions];
+      docIds.add(docId);
     }
 
-    // Sort the rows so that the docIds are in ascending order (bitmap always returns values in ascending order)
+    // Sort the rows with docIds to match the order of the bitmap (bitmap always returns values in ascending order)
     rowList.sort(Comparator.comparingInt(o -> (int) o[numOrderByExpressions]));
 
     // Construct a new TransformOperator to fetch the non-order-by expressions for the top rows

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -20,72 +20,97 @@ package org.apache.pinot.core.operator.query;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.Set;
+import org.apache.pinot.common.utils.CommonConstants.Segment.BuiltInVirtualColumn;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.common.RowBasedBlockValueFetcher;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.roaringbitmap.IntIterator;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
+/**
+ * Operator for selection order-by queries.
+ * <p>The operator uses a priority queue to sort the rows and return the top rows based on the order-by expressions.
+ * <p>It is optimized to fetch only the values needed for the ordering purpose and the final result:
+ * <ul>
+ *   <li>
+ *     When all the output expressions are ordered, the operator fetches all the output expressions and insert them into
+ *     the priority queue because all the values are needed for ordering.
+ *   </li>
+ *   <li>
+ *     Otherwise, the operator fetches only the order-by expressions and the virtual document id column and insert them
+ *     into the priority queue. After getting the top rows, the operator does a second round scan only on the document
+ *     ids for the top rows for the non-order-by output expressions. This optimization can significantly reduce the
+ *     scanning and improve the query performance when most/all of the output expressions are not ordered (e.g. SELECT *
+ *     FROM table ORDER BY col).
+ *   </li>
+ * </ul>
+ */
 public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBlock> {
   private static final String OPERATOR_NAME = "SelectionOrderByOperator";
 
   private final IndexSegment _indexSegment;
-  private final TransformOperator _transformOperator;
+  // Deduped order-by expressions followed by output expressions from SelectionOperatorUtils.extractExpressions()
   private final List<ExpressionContext> _expressions;
-  private final TransformResultMetadata[] _expressionMetadata;
-  private final DataSchema _dataSchema;
+  private final TransformOperator _transformOperator;
+  private final List<OrderByExpressionContext> _orderByExpressions;
+  private final TransformResultMetadata[] _orderByExpressionMetadata;
   private final int _numRowsToKeep;
   private final PriorityQueue<Object[]> _rows;
 
   private int _numDocsScanned = 0;
+  private long _numEntriesScannedPostFilter = 0;
 
   public SelectionOrderByOperator(IndexSegment indexSegment, QueryContext queryContext,
       List<ExpressionContext> expressions, TransformOperator transformOperator) {
     _indexSegment = indexSegment;
-    _transformOperator = transformOperator;
     _expressions = expressions;
+    _transformOperator = transformOperator;
 
-    int numExpressions = _expressions.size();
-    _expressionMetadata = new TransformResultMetadata[numExpressions];
-    String[] columnNames = new String[numExpressions];
-    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numExpressions];
-    for (int i = 0; i < numExpressions; i++) {
-      ExpressionContext expression = _expressions.get(i);
-      TransformResultMetadata expressionMetadata = _transformOperator.getResultMetadata(expression);
-      _expressionMetadata[i] = expressionMetadata;
-      columnNames[i] = expression.toString();
-      columnDataTypes[i] =
-          DataSchema.ColumnDataType.fromDataType(expressionMetadata.getDataType(), expressionMetadata.isSingleValue());
+    _orderByExpressions = queryContext.getOrderByExpressions();
+    assert _orderByExpressions != null;
+    int numOrderByExpressions = _orderByExpressions.size();
+    _orderByExpressionMetadata = new TransformResultMetadata[numOrderByExpressions];
+    for (int i = 0; i < numOrderByExpressions; i++) {
+      ExpressionContext expression = _orderByExpressions.get(i).getExpression();
+      _orderByExpressionMetadata[i] = _transformOperator.getResultMetadata(expression);
     }
-    _dataSchema = new DataSchema(columnNames, columnDataTypes);
 
-    List<OrderByExpressionContext> orderByExpressions = queryContext.getOrderByExpressions();
-    assert orderByExpressions != null;
     _numRowsToKeep = queryContext.getOffset() + queryContext.getLimit();
     _rows = new PriorityQueue<>(Math.min(_numRowsToKeep, SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY),
-        getComparator(orderByExpressions));
+        getComparator());
   }
 
-  private Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions) {
+  private Comparator<Object[]> getComparator() {
     // Compare all single-value columns
-    int numOrderByExpressions = orderByExpressions.size();
+    int numOrderByExpressions = _orderByExpressions.size();
     List<Integer> valueIndexList = new ArrayList<>(numOrderByExpressions);
     for (int i = 0; i < numOrderByExpressions; i++) {
-      if (_expressionMetadata[i].isSingleValue()) {
+      if (_orderByExpressionMetadata[i].isSingleValue()) {
         valueIndexList.add(i);
       }
     }
@@ -98,8 +123,8 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
     for (int i = 0; i < numValuesToCompare; i++) {
       int valueIndex = valueIndexList.get(i);
       valueIndices[i] = valueIndex;
-      dataTypes[i] = _expressionMetadata[valueIndex].getDataType();
-      multipliers[i] = orderByExpressions.get(valueIndex).isAsc() ? -1 : 1;
+      dataTypes[i] = _orderByExpressionMetadata[valueIndex].getDataType();
+      multipliers[i] = _orderByExpressions.get(valueIndex).isAsc() ? -1 : 1;
     }
 
     return (o1, o2) -> {
@@ -143,24 +168,145 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
 
   @Override
   protected IntermediateResultsBlock getNextBlock() {
+    if (_expressions.size() == _orderByExpressions.size()) {
+      return computeAllOrdered();
+    } else {
+      return computePartiallyOrdered();
+    }
+  }
+
+  /**
+   * Helper method to compute the result when all the output expressions are ordered.
+   */
+  private IntermediateResultsBlock computeAllOrdered() {
+    int numExpressions = _expressions.size();
+
+    // Fetch all the expressions and insert them into the priority queue
+    BlockValSet[] blockValSets = new BlockValSet[numExpressions];
     TransformBlock transformBlock;
     while ((transformBlock = _transformOperator.nextBlock()) != null) {
-      int numExpressions = _expressions.size();
-      BlockValSet[] blockValSets = new BlockValSet[numExpressions];
       for (int i = 0; i < numExpressions; i++) {
         ExpressionContext expression = _expressions.get(i);
         blockValSets[i] = transformBlock.getBlockValueSet(expression);
       }
       RowBasedBlockValueFetcher blockValueFetcher = new RowBasedBlockValueFetcher(blockValSets);
-
       int numDocsFetched = transformBlock.getNumDocs();
       _numDocsScanned += numDocsFetched;
       for (int i = 0; i < numDocsFetched; i++) {
         SelectionOperatorUtils.addToPriorityQueue(blockValueFetcher.getRow(i), _rows, _numRowsToKeep);
       }
     }
+    _numEntriesScannedPostFilter = (long) _numDocsScanned * _transformOperator.getNumColumnsProjected();
 
-    return new IntermediateResultsBlock(_dataSchema, _rows);
+    // Create the data schema
+    String[] columnNames = new String[numExpressions];
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numExpressions];
+    for (int i = 0; i < numExpressions; i++) {
+      columnNames[i] = _expressions.get(i).toString();
+      TransformResultMetadata expressionMetadata = _orderByExpressionMetadata[i];
+      columnDataTypes[i] =
+          DataSchema.ColumnDataType.fromDataType(expressionMetadata.getDataType(), expressionMetadata.isSingleValue());
+    }
+    DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
+
+    return new IntermediateResultsBlock(dataSchema, _rows);
+  }
+
+  /**
+   * Helper method to compute the result when not all the output expressions are ordered.
+   */
+  private IntermediateResultsBlock computePartiallyOrdered() {
+    int numExpressions = _expressions.size();
+    int numOrderByExpressions = _orderByExpressions.size();
+
+    // Fetch the order-by expressions and docIds and insert them into the priority queue
+    BlockValSet[] blockValSets = new BlockValSet[numOrderByExpressions + 1];
+    TransformBlock transformBlock;
+    while ((transformBlock = _transformOperator.nextBlock()) != null) {
+      for (int i = 0; i < numOrderByExpressions; i++) {
+        ExpressionContext expression = _orderByExpressions.get(i).getExpression();
+        blockValSets[i] = transformBlock.getBlockValueSet(expression);
+      }
+      blockValSets[numOrderByExpressions] = transformBlock.getBlockValueSet(BuiltInVirtualColumn.DOCID);
+      RowBasedBlockValueFetcher blockValueFetcher = new RowBasedBlockValueFetcher(blockValSets);
+      int numDocsFetched = transformBlock.getNumDocs();
+      _numDocsScanned += numDocsFetched;
+      for (int i = 0; i < numDocsFetched; i++) {
+        // NOTE: We pre-allocate the complete row so that we can fill up the non-order-by output expression values later
+        //       without creating extra rows or re-constructing the priority queue. We can change the values in-place
+        //       because the comparator only compare the values for the order-by expressions.
+        Object[] row = new Object[numExpressions];
+        blockValueFetcher.getRow(i, row, 0);
+        SelectionOperatorUtils.addToPriorityQueue(row, _rows, _numRowsToKeep);
+      }
+    }
+
+    // Copy the rows (shallow copy so that any modification will also be reflected to the priority queue) into a list,
+    // and store the document ids into a bitmap
+    int numRows = _rows.size();
+    List<Object[]> rowList = new ArrayList<>(numRows);
+    MutableRoaringBitmap docIds = new MutableRoaringBitmap();
+    for (Object[] row : _rows) {
+      rowList.add(row);
+      docIds.add((int) row[numOrderByExpressions]);
+    }
+
+    // Sort the rows so that the docIds are in ascending order (bitmap always returns values in ascending order)
+    rowList.sort(Comparator.comparingInt(o -> (int) o[numOrderByExpressions]));
+
+    // Construct a new TransformOperator to fetch the non-order-by expressions for the top rows
+    List<ExpressionContext> nonOrderByExpressions = _expressions.subList(numOrderByExpressions, numExpressions);
+    Set<String> columns = new HashSet<>();
+    for (ExpressionContext expressionContext : nonOrderByExpressions) {
+      expressionContext.getColumns(columns);
+    }
+    Map<String, DataSource> dataSourceMap = new HashMap<>();
+    for (String column : columns) {
+      dataSourceMap.put(column, _indexSegment.getDataSource(column));
+    }
+    ProjectionOperator projectionOperator =
+        new ProjectionOperator(dataSourceMap, new BitmapDocIdSetOperator(docIds, numRows));
+    TransformOperator transformOperator = new TransformOperator(projectionOperator, nonOrderByExpressions);
+
+    // Fill the non-order-by expression values
+    int numNonOrderByExpressions = nonOrderByExpressions.size();
+    blockValSets = new BlockValSet[numNonOrderByExpressions];
+    int rowBaseId = 0;
+    while ((transformBlock = transformOperator.nextBlock()) != null) {
+      for (int i = 0; i < numNonOrderByExpressions; i++) {
+        ExpressionContext expression = nonOrderByExpressions.get(i);
+        blockValSets[i] = transformBlock.getBlockValueSet(expression);
+      }
+      RowBasedBlockValueFetcher blockValueFetcher = new RowBasedBlockValueFetcher(blockValSets);
+      int numDocsFetched = transformBlock.getNumDocs();
+      for (int i = 0; i < numDocsFetched; i++) {
+        blockValueFetcher.getRow(i, rowList.get(rowBaseId + i), numOrderByExpressions);
+      }
+      rowBaseId += numDocsFetched;
+    }
+    _numEntriesScannedPostFilter =
+        (long) _numDocsScanned * _transformOperator.getNumColumnsProjected() + (long) numRows * transformOperator
+            .getNumColumnsProjected();
+
+    // Create the data schema
+    String[] columnNames = new String[numExpressions];
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numExpressions];
+    for (int i = 0; i < numExpressions; i++) {
+      columnNames[i] = _expressions.get(i).toString();
+    }
+    for (int i = 0; i < numOrderByExpressions; i++) {
+      TransformResultMetadata expressionMetadata = _orderByExpressionMetadata[i];
+      columnDataTypes[i] =
+          DataSchema.ColumnDataType.fromDataType(expressionMetadata.getDataType(), expressionMetadata.isSingleValue());
+    }
+    for (int i = 0; i < numNonOrderByExpressions; i++) {
+      TransformResultMetadata expressionMetadata = transformOperator.getResultMetadata(nonOrderByExpressions.get(i));
+      columnDataTypes[numOrderByExpressions + i] =
+          DataSchema.ColumnDataType.fromDataType(expressionMetadata.getDataType(), expressionMetadata.isSingleValue());
+    }
+    DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
+
+    return new IntermediateResultsBlock(dataSchema, _rows);
   }
 
   @Override
@@ -171,9 +317,38 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
   @Override
   public ExecutionStatistics getExecutionStatistics() {
     long numEntriesScannedInFilter = _transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
-    long numEntriesScannedPostFilter = (long) _numDocsScanned * _transformOperator.getNumColumnsProjected();
     int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
-    return new ExecutionStatistics(_numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+    return new ExecutionStatistics(_numDocsScanned, numEntriesScannedInFilter, _numEntriesScannedPostFilter,
         numTotalDocs);
+  }
+
+  private static class BitmapDocIdSetOperator extends BaseOperator<DocIdSetBlock> {
+    static final String OPERATOR_NAME = "BitmapDocIdSetOperator";
+
+    final IntIterator _docIdIterator;
+    final int[] _docIdBuffer;
+
+    BitmapDocIdSetOperator(ImmutableRoaringBitmap docIds, int numDocs) {
+      _docIdIterator = docIds.getIntIterator();
+      _docIdBuffer = new int[Math.min(numDocs, DocIdSetPlanNode.MAX_DOC_PER_CALL)];
+    }
+
+    @Override
+    protected DocIdSetBlock getNextBlock() {
+      int numDocIdsFilled = 0;
+      while (numDocIdsFilled < DocIdSetPlanNode.MAX_DOC_PER_CALL && _docIdIterator.hasNext()) {
+        _docIdBuffer[numDocIdsFilled++] = _docIdIterator.next();
+      }
+      if (numDocIdsFilled > 0) {
+        return new DocIdSetBlock(_docIdBuffer, numDocIdsFilled);
+      } else {
+        return null;
+      }
+    }
+
+    @Override
+    public String getOperatorName() {
+      return OPERATOR_NAME;
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
@@ -93,7 +93,8 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
 
     Set<ExpressionContext> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(_aggregationFunctions, _groupByExpressions);
-    _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform);
+    _transformPlanNode =
+        new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform, DocIdSetPlanNode.MAX_DOC_PER_CALL);
     _starTreeTransformPlanNode = null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -93,7 +93,8 @@ public class AggregationGroupByPlanNode implements PlanNode {
 
     Set<ExpressionContext> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(_aggregationFunctions, _groupByExpressions);
-    _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform);
+    _transformPlanNode =
+        new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform, DocIdSetPlanNode.MAX_DOC_PER_CALL);
     _starTreeTransformPlanNode = null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -83,7 +83,8 @@ public class AggregationPlanNode implements PlanNode {
 
     Set<ExpressionContext> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(_aggregationFunctions, null);
-    _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform);
+    _transformPlanNode =
+        new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform, DocIdSetPlanNode.MAX_DOC_PER_CALL);
     _starTreeTransformPlanNode = null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectionPlanNode.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.plan;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.ProjectionOperator;
@@ -36,7 +37,7 @@ public class ProjectionPlanNode implements PlanNode {
   private final DocIdSetPlanNode _docIdSetPlanNode;
 
   public ProjectionPlanNode(IndexSegment indexSegment, Set<String> projectionColumns,
-      DocIdSetPlanNode docIdSetPlanNode) {
+      @Nullable DocIdSetPlanNode docIdSetPlanNode) {
     _indexSegment = indexSegment;
     _projectionColumns = projectionColumns;
     _docIdSetPlanNode = docIdSetPlanNode;
@@ -48,6 +49,6 @@ public class ProjectionPlanNode implements PlanNode {
     for (String column : _projectionColumns) {
       dataSourceMap.put(column, _indexSegment.getDataSource(column));
     }
-    return new ProjectionOperator(dataSourceMap, _docIdSetPlanNode.run());
+    return new ProjectionOperator(dataSourceMap, _docIdSetPlanNode != null ? _docIdSetPlanNode.run() : null);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.core.plan;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.apache.pinot.common.utils.CommonConstants.Segment.BuiltInVirtualColumn;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -27,6 +29,7 @@ import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.core.operator.query.SelectionOrderByOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 
@@ -44,7 +47,35 @@ public class SelectionPlanNode implements PlanNode {
     _indexSegment = indexSegment;
     _queryContext = queryContext;
     _expressions = SelectionOperatorUtils.extractExpressions(queryContext, indexSegment);
-    _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, _expressions);
+    int limit = queryContext.getLimit();
+    if (limit > 0) {
+      List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();
+      if (orderByExpressions == null) {
+        // Selection only
+        _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, _expressions,
+            Math.min(limit, DocIdSetPlanNode.MAX_DOC_PER_CALL));
+      } else {
+        // Selection order-by
+        if (orderByExpressions.size() == _expressions.size()) {
+          // All output expressions are ordered
+          _transformPlanNode =
+              new TransformPlanNode(_indexSegment, queryContext, _expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL);
+        } else {
+          // Not all output expressions are ordered, only fetch the order-by expressions and docId to avoid the
+          // unnecessary data fetch
+          List<ExpressionContext> expressionsToTransform = new ArrayList<>(orderByExpressions.size() + 1);
+          for (OrderByExpressionContext orderByExpression : orderByExpressions) {
+            expressionsToTransform.add(orderByExpression.getExpression());
+          }
+          expressionsToTransform.add(ExpressionContext.forIdentifier(BuiltInVirtualColumn.DOCID));
+          _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, expressionsToTransform,
+              DocIdSetPlanNode.MAX_DOC_PER_CALL);
+        }
+      }
+    } else {
+      // Empty selection (LIMIT 0)
+      _transformPlanNode = new TransformPlanNode(_indexSegment, queryContext, _expressions, 0);
+    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
@@ -21,8 +21,10 @@ package org.apache.pinot.core.query.request.context.utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.request.AggregationInfo;
@@ -150,23 +152,30 @@ public class BrokerRequestToQueryContextConverter {
     if (pinotQuery != null) {
       List<Expression> orderByList = pinotQuery.getOrderByList();
       if (CollectionUtils.isNotEmpty(orderByList)) {
+        // Deduplicate the order-by expressions
         orderByExpressions = new ArrayList<>(orderByList.size());
+        Set<ExpressionContext> expressionSet = new HashSet<>();
         for (Expression orderBy : orderByList) {
           // NOTE: Order-by is always a Function with the ordering of the Expression
           Function thriftFunction = orderBy.getFunctionCall();
-          boolean isAsc = thriftFunction.getOperator().equalsIgnoreCase("ASC");
           ExpressionContext expression = QueryContextConverterUtils.getExpression(thriftFunction.getOperands().get(0));
-          orderByExpressions.add(new OrderByExpressionContext(expression, isAsc));
+          if (expressionSet.add(expression)) {
+            boolean isAsc = thriftFunction.getOperator().equalsIgnoreCase("ASC");
+            orderByExpressions.add(new OrderByExpressionContext(expression, isAsc));
+          }
         }
       }
     } else {
       List<SelectionSort> orderBy = brokerRequest.getOrderBy();
       if (CollectionUtils.isNotEmpty(orderBy)) {
+        // Deduplicate the order-by expressions
         orderByExpressions = new ArrayList<>(orderBy.size());
+        Set<ExpressionContext> expressionSet = new HashSet<>();
         for (SelectionSort selectionSort : orderBy) {
-          orderByExpressions.add(
-              new OrderByExpressionContext(QueryContextConverterUtils.getExpression(selectionSort.getColumn()),
-                  selectionSort.isIsAsc()));
+          ExpressionContext expression = QueryContextConverterUtils.getExpression(selectionSort.getColumn());
+          if (expressionSet.add(expression)) {
+            orderByExpressions.add(new OrderByExpressionContext(expression, selectionSort.isIsAsc()));
+          }
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -98,12 +98,13 @@ public class SelectionOperatorUtils {
 
     List<OrderByExpressionContext> orderByExpressions = queryContext.getOrderByExpressions();
     if (orderByExpressions != null && queryContext.getLimit() > 0) {
-      // NOTE: Order-by expressions are ignored for queries with LIMIT 0.
+      // NOTE:
+      //   1. Order-by expressions are ignored for queries with LIMIT 0.
+      //   2. Order-by expressions are already deduped in QueryContext.
       for (OrderByExpressionContext orderByExpression : orderByExpressions) {
         ExpressionContext expression = orderByExpression.getExpression();
-        if (expressionSet.add(expression)) {
-          expressions.add(expression);
-        }
+        expressionSet.add(expression);
+        expressions.add(expression);
       }
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
@@ -200,7 +200,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     ExecutionStatistics executionStatistics = selectionOrderByOperator.getExecutionStatistics();
     Assert.assertEquals(executionStatistics.getNumDocsScanned(), 100000L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
-    Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 400000L);
+    // 100000 * (2 order-by columns + 1 docId column) + 10 * (2 non-order-by columns)
+    Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 300020L);
     Assert.assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
     DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
@@ -225,7 +226,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     executionStatistics = selectionOrderByOperator.getExecutionStatistics();
     Assert.assertEquals(executionStatistics.getNumDocsScanned(), 15620L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 275416L);
-    Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 62480L);
+    // 15620 * (2 order-by columns + 1 docId column) + 10 * (2 non-order-by columns)
+    Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 46880L);
     Assert.assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
     selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SelectionOnlyEarlyTerminationTest.java
@@ -97,7 +97,6 @@ public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTes
   public void testSelectWithOrderByQuery() {
     int numSegmentsPerServer = getNumSegments();
     String query = "SELECT column11, column18, column1 FROM testTable ORDER BY column11";
-    int numColumnsInSelection = 3;
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     assertNotNull(brokerResponse.getSelectionResults());
     assertNull(brokerResponse.getResultTable());
@@ -105,8 +104,9 @@ public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTes
     assertEquals(brokerResponse.getNumSegmentsMatched(), numSegmentsPerServer * NUM_SERVERS);
     assertEquals(brokerResponse.getNumDocsScanned(), numSegmentsPerServer * NUM_SERVERS * NUM_DOCS_PER_SEGMENT);
     assertEquals(brokerResponse.getNumEntriesScannedInFilter(), 0);
+    // numDocsScanned * (1 order-by columns + 1 docId column) + 10 * (2 non-order-by columns) per segment
     assertEquals(brokerResponse.getNumEntriesScannedPostFilter(),
-        brokerResponse.getNumDocsScanned() * numColumnsInSelection);
+        brokerResponse.getNumDocsScanned() * 2 + 20 * numSegmentsPerServer * NUM_SERVERS);
     assertEquals(brokerResponse.getTotalDocs(), numSegmentsPerServer * NUM_SERVERS * NUM_DOCS_PER_SEGMENT);
 
     brokerResponse = getBrokerResponseForSqlQuery(query);
@@ -116,8 +116,9 @@ public class SelectionOnlyEarlyTerminationTest extends BaseSingleValueQueriesTes
     assertEquals(brokerResponse.getNumSegmentsMatched(), numSegmentsPerServer * NUM_SERVERS);
     assertEquals(brokerResponse.getNumDocsScanned(), numSegmentsPerServer * NUM_SERVERS * NUM_DOCS_PER_SEGMENT);
     assertEquals(brokerResponse.getNumEntriesScannedInFilter(), 0);
+    // numDocsScanned * (1 order-by columns + 1 docId column) + 10 * (2 non-order-by columns) per segment
     assertEquals(brokerResponse.getNumEntriesScannedPostFilter(),
-        brokerResponse.getNumDocsScanned() * numColumnsInSelection);
+        brokerResponse.getNumDocsScanned() * 2 + 20 * numSegmentsPerServer * NUM_SERVERS);
     assertEquals(brokerResponse.getTotalDocs(), numSegmentsPerServer * NUM_SERVERS * NUM_DOCS_PER_SEGMENT);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.plan.TransformPlanNode;
 import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.query.aggregation.groupby.DictionaryBasedGroupKeyGenerator;
@@ -154,7 +155,8 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     for (String column : MV_COLUMNS) {
       expressions.add(ExpressionContext.forIdentifier(column));
     }
-    TransformPlanNode transformPlanNode = new TransformPlanNode(indexSegment, queryContext, expressions);
+    TransformPlanNode transformPlanNode =
+        new TransformPlanNode(indexSegment, queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL);
     _transformOperator = transformPlanNode.run();
     _transformBlock = _transformOperator.nextBlock();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.plan.TransformPlanNode;
 import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
@@ -99,7 +100,8 @@ public class NoDictionaryGroupKeyGeneratorTest {
     for (String column : COLUMN_NAMES) {
       expressions.add(ExpressionContext.forIdentifier(column));
     }
-    TransformPlanNode transformPlanNode = new TransformPlanNode(indexSegment, queryContext, expressions);
+    TransformPlanNode transformPlanNode =
+        new TransformPlanNode(indexSegment, queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL);
     _transformOperator = transformPlanNode.run();
     _transformBlock = _transformOperator.nextBlock();
   }


### PR DESCRIPTION
## Description
Currently for selection order-by queries, we always read all output and order-by expressions and insert them into the priority queue. This is very inefficient because most values won't be preserved in the priority queue, especially in cases where most/all of the output expressions are not ordered (e.g. `SELECT * FROM table ORDER BY col`).

To resolve the inefficiency, this PR enhanced the `SelectionOrderByOperator` to only read order-by expressions and virtual document id column when not all output expressions are ordered. After getting the final top documents, it does a second round scan to read the non-order-by output expressions to construct the final result.

Minor optimization:
For selection `LIMIT 0` query, skip constructing `DocIdSetPlanNode` and `FilterPlanNode` and the corresponding operators.

For `select * from baseballStats order by teamID limit 10` on quickstart:
- Before:
  - `numEntriesScannedPostFilter`: 2447225 (97889 (`numDocsScanned`) * 25 columns)
  - `timeUsedMs`: 55ms
- After:
  - `numEntriesScannedPostFilter`: 196018 (97889 (`numDocsScanned`) * 2 (`teamID` & `$docId`) + 10 * 24 non-order-by columns)
  - `timeUsedMs`: 15ms