### PR TITLE
Zookeeper override fix for regression from config refactoring

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -252,8 +252,7 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public void setZkStr(String zkStr) {
-    throw new UnsupportedOperationException("Fix me!");
-    //    setProperty(ZK_STR, zkStr);
+    setProperty(ZK_STR, zkStr);
   }
 
   // A boolean to decide whether Jersey API should be the primary one. For now, we set this to be false,


### PR DESCRIPTION
PR #5608 caused a regression on `Controllerconf.setZkStr`.

Replaced leftover UnsupportedOperationException with `setProperty` call.