### PR TITLE
Re-implement TarGzCompressionUtils

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/TarGzCompressionUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/TarGzCompressionUtilsTest.java
@@ -18,152 +18,219 @@
  */
 package org.apache.pinot.common.utils;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
-import org.apache.commons.compress.archivers.ArchiveException;
+import java.util.List;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
 
 public class TarGzCompressionUtilsTest {
-  private static final String SEGMENT_NAME = "mysegment";
-
-  private File TEST_DIR;
-  private File dataDir;
-  private File tarDir;
-  private File untarDir;
-  private File segmentDir;
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "TarGzCompressionUtilsTest");
+  private static final File DATA_DIR = new File(TEMP_DIR, "dataDir");
+  private static final File TAR_DIR = new File(TEMP_DIR, "tarDir");
+  private static final File UNTAR_DIR = new File(TEMP_DIR, "untarDir");
 
   @BeforeMethod
-  public void setUpTest()
+  public void setUp()
       throws IOException {
-    TEST_DIR = Files.createTempDirectory(TarGzCompressionUtils.class.getName()).toFile();
-    TEST_DIR.deleteOnExit();
-    dataDir = new File(TEST_DIR, "dataDir");
-    tarDir = new File(TEST_DIR, "tarDir");
-    untarDir = new File(TEST_DIR, "untarDir");
-    segmentDir = new File(dataDir, SEGMENT_NAME);
-    FileUtils.forceMkdir(dataDir);
-    FileUtils.forceMkdir(tarDir);
-    FileUtils.forceMkdir(untarDir);
-    FileUtils.forceMkdir(segmentDir);
+    FileUtils.deleteQuietly(TEMP_DIR);
+    FileUtils.forceMkdir(DATA_DIR);
+    FileUtils.forceMkdir(TAR_DIR);
+    FileUtils.forceMkdir(UNTAR_DIR);
   }
 
   @AfterMethod
-  public void tearDownTest() {
-    if (TEST_DIR != null) {
-      FileUtils.deleteQuietly(TEST_DIR);
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(TEMP_DIR);
+  }
+
+  @Test
+  public void testFile()
+      throws IOException {
+    String fileName = "data";
+    String fileContent = "fileContent";
+    File dataFile = new File(DATA_DIR, fileName);
+    FileUtils.write(dataFile, fileContent);
+
+    File tarGzFile = new File(TAR_DIR, fileName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    TarGzCompressionUtils.createTarGzFile(dataFile, tarGzFile);
+
+    List<File> untarredFiles = TarGzCompressionUtils.untar(tarGzFile, UNTAR_DIR);
+    assertEquals(untarredFiles.size(), 1);
+    File untarredFile = untarredFiles.get(0);
+    assertEquals(untarredFile, new File(UNTAR_DIR, fileName));
+    assertEquals(FileUtils.readFileToString(untarredFile), fileContent);
+
+    untarredFile = new File(UNTAR_DIR, "untarred");
+    TarGzCompressionUtils.untarOneFile(tarGzFile, fileName, untarredFile);
+    assertEquals(FileUtils.readFileToString(untarredFile), fileContent);
+  }
+
+  @Test
+  public void testDirectory()
+      throws IOException {
+    String dirName = "dir";
+    File dir = new File(DATA_DIR, dirName);
+    String fileName1 = "data1";
+    String fileContent1 = "fileContent1";
+    String fileName2 = "data2";
+    String fileContent2 = "fileContent2";
+    FileUtils.write(new File(dir, fileName1), fileContent1);
+    FileUtils.write(new File(dir, fileName2), fileContent2);
+
+    File tarGzFile = new File(TAR_DIR, dirName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    TarGzCompressionUtils.createTarGzFile(dir, tarGzFile);
+
+    List<File> untarredFiles = TarGzCompressionUtils.untar(tarGzFile, UNTAR_DIR);
+    assertEquals(untarredFiles.size(), 3);
+    File untarredFile = untarredFiles.get(0);
+    assertEquals(untarredFile, new File(UNTAR_DIR, dirName));
+    File[] files = untarredFile.listFiles();
+    assertNotNull(files);
+    assertEquals(files.length, 2);
+    assertEquals(FileUtils.readFileToString(new File(untarredFile, fileName1)), fileContent1);
+    assertEquals(FileUtils.readFileToString(new File(untarredFile, fileName2)), fileContent2);
+
+    untarredFile = new File(UNTAR_DIR, "untarred");
+    TarGzCompressionUtils.untarOneFile(tarGzFile, fileName1, untarredFile);
+    assertEquals(FileUtils.readFileToString(untarredFile), fileContent1);
+    TarGzCompressionUtils.untarOneFile(tarGzFile, fileName2, untarredFile);
+    assertEquals(FileUtils.readFileToString(untarredFile), fileContent2);
+    try {
+      TarGzCompressionUtils.untarOneFile(tarGzFile, dirName, untarredFile);
+      fail();
+    } catch (IOException e) {
+      // Expected
     }
   }
 
   @Test
-  public void testBasic()
-      throws IOException, InterruptedException, ArchiveException {
-    File metaFile = new File(segmentDir, "metadata.properties");
-    metaFile.createNewFile();
-    File tarGzPath = new File(tarDir, SEGMENT_NAME + ".tar.gz");
-    TarGzCompressionUtils.createTarGzOfDirectory(segmentDir.getPath(), tarGzPath.getPath(), "segmentId_");
-    TarGzCompressionUtils.unTar(tarGzPath, untarDir);
-    File[] files = untarDir.listFiles();
-    Assert.assertNotNull(files);
-    Assert.assertEquals(files.length, 1);
-    File[] subFiles = files[0].listFiles();
-    Assert.assertNotNull(subFiles);
-    Assert.assertEquals(subFiles.length, 1);
-    Assert.assertEquals(subFiles[0].getName(), "metadata.properties");
-  }
-
-  @Test
   public void testSubDirectories()
-      throws IOException, ArchiveException, InterruptedException {
-    new File(segmentDir, "metadata.properties").createNewFile();
-    File v3Dir = new File(segmentDir, "v3");
-    FileUtils.forceMkdir(v3Dir);
-    new File(v3Dir, "creation.meta").createNewFile();
+      throws IOException {
+    String dirName = "dir";
+    File dir = new File(DATA_DIR, dirName);
+    String subDirName1 = "subDir1";
+    File subDir1 = new File(dir, subDirName1);
+    String subDirName2 = "subDir2";
+    File subDir2 = new File(dir, subDirName2);
+    String fileName1 = "data1";
+    String fileContent1 = "fileContent1";
+    String fileName2 = "data2";
+    String fileContent2 = "fileContent2";
+    FileUtils.write(new File(subDir1, fileName1), fileContent1);
+    FileUtils.write(new File(subDir2, fileName2), fileContent2);
 
-    File tarGzPath = new File(tarDir, SEGMENT_NAME + ".tar.gz");
-    TarGzCompressionUtils.createTarGzOfDirectory(segmentDir.getPath(), tarGzPath.getPath());
-    TarGzCompressionUtils.unTar(tarGzPath, untarDir);
-    File[] segments = untarDir.listFiles();
-    Assert.assertNotNull(segments);
-    Assert.assertEquals(segments.length, 1);
-    File[] segmentFiles = segments[0].listFiles();
-    Assert.assertNotNull(segmentFiles);
-    Assert.assertEquals(segmentFiles.length, 2);
-    for (File segmentFile : segmentFiles) {
-      String name = segmentFile.getName();
-      Assert.assertTrue(name.equals("v3") || name.equals("metadata.properties"));
-      if (name.equals("v3")) {
-        Assert.assertTrue(segmentFile.isDirectory());
-        File[] v3Files = v3Dir.listFiles();
-        Assert.assertNotNull(v3Files);
-        Assert.assertEquals(v3Files.length, 1);
-        Assert.assertEquals(v3Files[0].getName(), "creation.meta");
-      }
+    File tarGzFile = new File(TAR_DIR, dirName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    TarGzCompressionUtils.createTarGzFile(dir, tarGzFile);
+
+    List<File> untarredFiles = TarGzCompressionUtils.untar(tarGzFile, UNTAR_DIR);
+    assertEquals(untarredFiles.size(), 5);
+    File untarredFile = untarredFiles.get(0);
+    assertEquals(untarredFile, new File(UNTAR_DIR, dirName));
+    File[] files = untarredFile.listFiles();
+    assertNotNull(files);
+    assertEquals(files.length, 2);
+    assertEquals(FileUtils.readFileToString(new File(new File(untarredFile, subDirName1), fileName1)), fileContent1);
+    assertEquals(FileUtils.readFileToString(new File(new File(untarredFile, subDirName2), fileName2)), fileContent2);
+
+    untarredFile = new File(UNTAR_DIR, "untarred");
+    TarGzCompressionUtils.untarOneFile(tarGzFile, fileName1, untarredFile);
+    assertEquals(FileUtils.readFileToString(untarredFile), fileContent1);
+    TarGzCompressionUtils.untarOneFile(tarGzFile, fileName2, untarredFile);
+    assertEquals(FileUtils.readFileToString(untarredFile), fileContent2);
+    try {
+      TarGzCompressionUtils.untarOneFile(tarGzFile, dirName, untarredFile);
+      fail();
+    } catch (IOException e) {
+      // Expected
+    }
+    try {
+      TarGzCompressionUtils.untarOneFile(tarGzFile, subDirName1, untarredFile);
+      fail();
+    } catch (IOException e) {
+      // Expected
+    }
+    try {
+      TarGzCompressionUtils.untarOneFile(tarGzFile, subDirName2, untarredFile);
+      fail();
+    } catch (IOException e) {
+      // Expected
     }
   }
 
   @Test
   public void testEmptyDirectory()
-      throws IOException, ArchiveException {
-    File tarGzPath = new File(tarDir, SEGMENT_NAME + ".tar.gz");
-    TarGzCompressionUtils.createTarGzOfDirectory(segmentDir.getPath(), tarGzPath.getPath());
-    TarGzCompressionUtils.unTar(tarGzPath, untarDir);
-    File[] segments = untarDir.listFiles();
-    Assert.assertNotNull(segments);
-    Assert.assertEquals(segments.length, 1);
-    File[] segmentFiles = segments[0].listFiles();
-    Assert.assertNotNull(segmentFiles);
-    Assert.assertEquals(segmentFiles.length, 0);
+      throws IOException {
+    String dirName = "dir";
+    File dir = new File(DATA_DIR, dirName);
+    FileUtils.forceMkdir(dir);
+
+    File tarGzFile = new File(TAR_DIR, dirName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    TarGzCompressionUtils.createTarGzFile(dir, tarGzFile);
+
+    List<File> untarredFiles = TarGzCompressionUtils.untar(tarGzFile, UNTAR_DIR);
+    assertEquals(untarredFiles.size(), 1);
+    File untarredFile = untarredFiles.get(0);
+    assertEquals(untarredFile, new File(UNTAR_DIR, dirName));
+    File[] files = untarredFile.listFiles();
+    assertNotNull(files);
+    assertEquals(files.length, 0);
+
+    untarredFile = new File(UNTAR_DIR, "untarred");
+    try {
+      TarGzCompressionUtils.untarOneFile(tarGzFile, dirName, untarredFile);
+      fail();
+    } catch (IOException e) {
+      // Expected
+    }
   }
 
   @Test
   public void testBadFilePath()
-      throws Exception {
-    File metaFile = new File(segmentDir, "metadata.properties");
-    metaFile.createNewFile();
+      throws IOException {
+    String fileName = "data";
+    String fileContent = "fileContent";
+    File dataFile = new File(DATA_DIR, fileName);
+    FileUtils.write(dataFile, fileContent);
 
-    // We guarantee metaFile isn't a directory.
-    Assert.assertFalse(metaFile.isDirectory());
-
-    File tarGzPath = new File(tarDir, SEGMENT_NAME + ".tar.gz");
-    createInvalidTarFile(metaFile, tarGzPath);
+    File badTarGzFile = new File(TAR_DIR, "bad" + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    try (OutputStream fileOut = Files.newOutputStream(badTarGzFile.toPath());
+        OutputStream gzipOut = new GzipCompressorOutputStream(fileOut);
+        TarArchiveOutputStream tarGzOut = new TarArchiveOutputStream(gzipOut)) {
+      tarGzOut.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+      TarArchiveEntry entry = new TarArchiveEntry(dataFile, "../bad/path/data");
+      tarGzOut.putArchiveEntry(entry);
+      try (InputStream in = Files.newInputStream(dataFile.toPath())) {
+        IOUtils.copy(in, tarGzOut);
+      }
+      tarGzOut.closeArchiveEntry();
+    }
 
     try {
-      TarGzCompressionUtils.unTar(tarGzPath, untarDir);
-      Assert.fail("Did not get exception!!");
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof IOException);
-      Assert.assertTrue(e.getMessage().startsWith("Tar file must not"));
-    }
-  }
-
-  private void createInvalidTarFile(File nonDirFile, File tarGzPath) {
-    try (FileOutputStream fOut = new FileOutputStream(new File(tarGzPath.getPath()));
-        BufferedOutputStream bOut = new BufferedOutputStream(fOut);
-        GzipCompressorOutputStream gzOut = new GzipCompressorOutputStream(bOut);
-        TarArchiveOutputStream tOut = new TarArchiveOutputStream(gzOut)) {
-      tOut.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
-
-      // Mock the file that doesn't use the correct file name.
-      String badEntryName = "../foo/bar";
-      TarArchiveEntry tarEntry = new TarArchiveEntry(nonDirFile, badEntryName);
-      tOut.putArchiveEntry(tarEntry);
-      IOUtils.copy(new FileInputStream(nonDirFile), tOut);
-      tOut.closeArchiveEntry();
+      TarGzCompressionUtils.untar(badTarGzFile, UNTAR_DIR);
+      fail();
     } catch (IOException e) {
-      Assert.fail("Unexpected Exception!!");
+      // Expected
     }
+
+    // Allow untar one file to the given destination
+    File untarredFile = new File(UNTAR_DIR, "untarred");
+    TarGzCompressionUtils.untarOneFile(badTarGzFile, fileName, untarredFile);
+    assertEquals(FileUtils.readFileToString(untarredFile), fileContent);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -21,7 +21,6 @@ package org.apache.pinot.controller.api.resources;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -466,21 +465,12 @@ public class LLCSegmentCompletionHandlers {
       FileUtils.forceMkdir(tempIndexDir);
 
       // Extract metadata.properties
-      try (InputStream metadataPropertiesInputStream = TarGzCompressionUtils
-          .unTarOneFile(new FileInputStream(segmentFile), V1Constants.MetadataKeys.METADATA_FILE_NAME)) {
-        Preconditions.checkState(metadataPropertiesInputStream != null, "Failed to find: %s from: %s",
-            V1Constants.MetadataKeys.METADATA_FILE_NAME, segmentFile);
-        Files.copy(metadataPropertiesInputStream,
-            new File(tempIndexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME).toPath());
-      }
+      TarGzCompressionUtils.untarOneFile(segmentFile, V1Constants.MetadataKeys.METADATA_FILE_NAME,
+          new File(tempIndexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME));
 
       // Extract creation.meta
-      try (InputStream metadataPropertiesInputStream = TarGzCompressionUtils
-          .unTarOneFile(new FileInputStream(segmentFile), V1Constants.SEGMENT_CREATION_META)) {
-        Preconditions.checkState(metadataPropertiesInputStream != null, "Failed to find: %s from: %s",
-            V1Constants.SEGMENT_CREATION_META, segmentFile);
-        Files.copy(metadataPropertiesInputStream, new File(tempIndexDir, V1Constants.SEGMENT_CREATION_META).toPath());
-      }
+      TarGzCompressionUtils.untarOneFile(segmentFile, V1Constants.SEGMENT_CREATION_META,
+          new File(tempIndexDir, V1Constants.SEGMENT_CREATION_META));
 
       // Load segment metadata
       return new SegmentMetadataImpl(tempIndexDir);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/DefaultSegmentCommitter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/DefaultSegmentCommitter.java
@@ -41,8 +41,9 @@ public class DefaultSegmentCommitter implements SegmentCommitter {
   }
 
   @Override
-  public SegmentCompletionProtocol.Response commit(LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor) {
-    final File segmentTarFile = new File(segmentBuildDescriptor.getSegmentTarFilePath());
+  public SegmentCompletionProtocol.Response commit(
+      LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor) {
+    File segmentTarFile = segmentBuildDescriptor.getSegmentTarFile();
 
     SegmentCompletionProtocol.Response response = _protocolHandler.segmentCommit(_params, segmentTarFile);
     if (!response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
@@ -58,6 +59,7 @@ import org.apache.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
@@ -143,22 +145,20 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   @VisibleForTesting
   public class SegmentBuildDescriptor {
-    final String _segmentTarFilePath;
+    final File _segmentTarFile;
     final Map<String, File> _metadataFileMap;
     final StreamPartitionMsgOffset _offset;
     final long _waitTimeMillis;
     final long _buildTimeMillis;
-    final String _segmentDirPath;
     final long _segmentSizeBytes;
 
-    public SegmentBuildDescriptor(String segmentTarFilePath, Map<String, File> metadataFileMap, StreamPartitionMsgOffset offset,
-        String segmentDirPath, long buildTimeMillis, long waitTimeMillis, long segmentSizeBytes) {
-      _segmentTarFilePath = segmentTarFilePath;
+    public SegmentBuildDescriptor(@Nullable File segmentTarFile, @Nullable Map<String, File> metadataFileMap,
+        StreamPartitionMsgOffset offset, long buildTimeMillis, long waitTimeMillis, long segmentSizeBytes) {
+      _segmentTarFile = segmentTarFile;
       _metadataFileMap = metadataFileMap;
       _offset = _streamPartitionMsgOffsetFactory.create(offset);
       _buildTimeMillis = buildTimeMillis;
       _waitTimeMillis = waitTimeMillis;
-      _segmentDirPath = segmentDirPath;
       _segmentSizeBytes = segmentSizeBytes;
     }
 
@@ -174,8 +174,14 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       return _waitTimeMillis;
     }
 
-    public String getSegmentTarFilePath() {
-      return _segmentTarFilePath;
+    @Nullable
+    public File getSegmentTarFile() {
+      return _segmentTarFile;
+    }
+
+    @Nullable
+    public Map<String, File> getMetadataFiles() {
+      return _metadataFileMap;
     }
 
     public long getSegmentSizeBytes() {
@@ -183,15 +189,9 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
 
     public void deleteSegmentFile() {
-      // If segment build fails with an exception then we will not be able to create a segment file and
-      // the file name will be null.
-      if (_segmentTarFilePath != null) {
-        FileUtils.deleteQuietly(new File(_segmentTarFilePath));
+      if (_segmentTarFile != null) {
+        FileUtils.deleteQuietly(_segmentTarFile);
       }
-    }
-
-    public Map<String, File> getMetadataFiles() {
-      return _metadataFileMap;
     }
   }
 
@@ -667,18 +667,14 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
   }
 
-  private File makeSegmentDirPath() {
-    return new File(_resourceDataDir, _segmentZKMetadata.getSegmentName());
-  }
-
   // Side effect: Modifies _segmentBuildDescriptor if we do not have a valid built segment file and we
   // built the segment successfully.
   protected void buildSegmentForCommit(long buildTimeLeaseMs) {
     try {
       if (_segmentBuildDescriptor != null && _segmentBuildDescriptor.getOffset().compareTo(_currentOffset) == 0) {
         // Double-check that we have the file, just in case.
-        String segTarFile = _segmentBuildDescriptor.getSegmentTarFilePath();
-        if (new File(segTarFile).exists()) {
+        File segmentTarFile = _segmentBuildDescriptor.getSegmentTarFile();
+        if (segmentTarFile != null && segmentTarFile.exists()) {
           return;
         }
       }
@@ -753,53 +749,62 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       final long waitTimeMillis = lockAquireTimeMillis - startTimeMillis;
       segmentLogger
           .info("Successfully built segment in {} ms, after lockWaitTime {} ms", buildTimeMillis, waitTimeMillis);
-      File destDir = makeSegmentDirPath();
-      FileUtils.deleteQuietly(destDir);
-      try {
-        FileUtils.moveDirectory(tempSegmentFolder.listFiles()[0], destDir);
-        if (forCommit) {
-          TarGzCompressionUtils.createTarGzOfDirectory(destDir.getAbsolutePath());
-        }
-      } catch (IOException e) {
-        segmentLogger.error("Exception during move/tar segment", e);
-        FileUtils.deleteQuietly(tempSegmentFolder);
-        return null;
-      }
-      final long segmentSizeBytes = FileUtils.sizeOfDirectory(destDir);
-      FileUtils.deleteQuietly(tempSegmentFolder);
 
+      File dataDir = new File(_resourceDataDir);
+      File indexDir = new File(dataDir, _segmentNameStr);
+      FileUtils.deleteQuietly(indexDir);
+
+      File[] tempFiles = tempSegmentFolder.listFiles();
+      assert tempFiles != null;
+      File tempIndexDir = tempFiles[0];
+      try {
+        FileUtils.moveDirectory(tempIndexDir, indexDir);
+      } catch (IOException e) {
+        segmentLogger.error("Caught exception while moving index directory from: {} to: {}", tempIndexDir, indexDir, e);
+        return null;
+      } finally {
+        FileUtils.deleteQuietly(tempSegmentFolder);
+      }
+
+      long segmentSizeBytes = FileUtils.sizeOfDirectory(indexDir);
       _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.LAST_REALTIME_SEGMENT_CREATION_DURATION_SECONDS,
           TimeUnit.MILLISECONDS.toSeconds(buildTimeMillis));
       _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.LAST_REALTIME_SEGMENT_CREATION_WAIT_TIME_SECONDS,
           TimeUnit.MILLISECONDS.toSeconds(waitTimeMillis));
 
       if (forCommit) {
-        File[] segmentfiles = destDir.listFiles();
-        if (segmentfiles == null || segmentfiles.length == 0) {
-          segmentLogger.error("The index dir is empty: {}", destDir);
-          return null;
-        }
-        // segmentfiles[0] is the sub directory with version name (e.g., V3).
-        File metadataFileName = new File(segmentfiles[0], V1Constants.MetadataKeys.METADATA_FILE_NAME);
-        if (!metadataFileName.exists()) {
+        File segmentTarFile = new File(dataDir, _segmentNameStr + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+        try {
+          TarGzCompressionUtils.createTarGzFile(indexDir, segmentTarFile);
+        } catch (IOException e) {
           segmentLogger
-              .error("File does not exist in {} for {}.", destDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
-          return null;
-        }
-        File creationMetaFile = new File(segmentfiles[0], V1Constants.SEGMENT_CREATION_META);
-        if (!creationMetaFile.exists()) {
-          segmentLogger.error("File does not exist in {} for {}.", destDir, V1Constants.SEGMENT_CREATION_META);
+              .error("Caught exception while taring index directory from: {} to: {}", indexDir, segmentTarFile, e);
           return null;
         }
 
+        File metadataFile = SegmentDirectoryPaths.findMetadataFile(indexDir);
+        if (metadataFile == null) {
+          segmentLogger
+              .error("Failed to find file: {} under index directory: {}", V1Constants.MetadataKeys.METADATA_FILE_NAME,
+                  indexDir);
+          return null;
+        }
+        File creationMetaFile = SegmentDirectoryPaths.findCreationMetaFile(indexDir);
+        if (creationMetaFile == null) {
+          segmentLogger
+              .error("Failed to find file: {} under index directory: {}", V1Constants.SEGMENT_CREATION_META, indexDir);
+          return null;
+        }
         Map<String, File> metadataFiles = new HashMap<>();
-        metadataFiles.put(V1Constants.MetadataKeys.METADATA_FILE_NAME, metadataFileName);
+        metadataFiles.put(V1Constants.MetadataKeys.METADATA_FILE_NAME, metadataFile);
         metadataFiles.put(V1Constants.SEGMENT_CREATION_META, creationMetaFile);
-        return new SegmentBuildDescriptor(destDir.getAbsolutePath() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION,
-            metadataFiles, _currentOffset, null, buildTimeMillis, waitTimeMillis, segmentSizeBytes);
+
+        return new SegmentBuildDescriptor(segmentTarFile, metadataFiles, _currentOffset, buildTimeMillis,
+            waitTimeMillis, segmentSizeBytes);
+      } else {
+        return new SegmentBuildDescriptor(null, null, _currentOffset, buildTimeMillis, waitTimeMillis,
+            segmentSizeBytes);
       }
-      return new SegmentBuildDescriptor(null, null, _currentOffset, destDir.getAbsolutePath(), buildTimeMillis,
-          waitTimeMillis, segmentSizeBytes);
     } catch (InterruptedException e) {
       segmentLogger.error("Interrupted while waiting for semaphore");
       return null;
@@ -813,10 +818,9 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   }
 
   protected boolean commitSegment(String controllerVipUrl, boolean isSplitCommit) {
-    final String segTarFileName = _segmentBuildDescriptor.getSegmentTarFilePath();
-    File segTarFile = new File(segTarFileName);
-    if (!segTarFile.exists()) {
-      throw new RuntimeException("Segment file does not exist:" + segTarFileName);
+    File segmentTarFile = _segmentBuildDescriptor.getSegmentTarFile();
+    if (segmentTarFile == null || !segmentTarFile.exists()) {
+      throw new RuntimeException("Segment file does not exist: " + segmentTarFile);
     }
     SegmentCompletionProtocol.Response commitResponse = commit(controllerVipUrl, isSplitCommit);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
@@ -46,7 +45,6 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.apache.pinot.common.utils.SegmentName;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
-import org.apache.pinot.core.util.PeerServerSegmentFinder;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.core.data.manager.BaseTableDataManager;
 import org.apache.pinot.core.data.manager.SegmentDataManager;
@@ -55,6 +53,7 @@ import org.apache.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.core.segment.index.loader.LoaderUtils;
 import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory;
+import org.apache.pinot.core.util.PeerServerSegmentFinder;
 import org.apache.pinot.core.util.SchemaUtils;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -95,6 +94,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   // the minimum interval between updates to RealtimeSegmentStatsHistory as 30 minutes. This way it is
   // likely that we get fresh data each time instead of multiple copies of roughly same data.
   private static final int MIN_INTERVAL_BETWEEN_STATS_UPDATES_MINUTES = 30;
+
   public RealtimeTableDataManager(Semaphore segmentBuildSemaphore) {
     _segmentBuildSemaphore = segmentBuildSemaphore;
   }
@@ -297,32 +297,39 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   private void downloadSegmentFromDeepStore(String segmentName, IndexLoadingConfig indexLoadingConfig, String uri) {
-    File tempSegmentFolder = new File(_indexDir, "tmp-" + segmentName + "." + System.currentTimeMillis());
-    File tempFile = new File(_indexDir, segmentName + ".tar.gz");
+    File segmentTarFile = new File(_indexDir, segmentName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
     try {
-      SegmentFetcherFactory.fetchSegmentToLocal(uri, tempFile);
-      _logger.info("Downloaded file from {} to {}; Length of downloaded file: {}", uri, tempFile, tempFile.length());
-      untarAndMoveSegment(segmentName, indexLoadingConfig, tempSegmentFolder, tempFile);
+      SegmentFetcherFactory.fetchSegmentToLocal(uri, segmentTarFile);
+      _logger.info("Downloaded file from {} to {}; Length of downloaded file: {}", uri, segmentTarFile,
+          segmentTarFile.length());
+      untarAndMoveSegment(segmentName, indexLoadingConfig, segmentTarFile);
     } catch (Exception e) {
       _logger.warn("Failed to download segment {} from deep store: ", segmentName, e);
       throw new RuntimeException(e);
     } finally {
-      FileUtils.deleteQuietly(tempFile);
-      FileUtils.deleteQuietly(tempSegmentFolder);
+      FileUtils.deleteQuietly(segmentTarFile);
     }
   }
 
-  // Uncompressed a tared tempFile into tmp dir tempSegmentFolder and replace the existing segment.
-  private void untarAndMoveSegment(String segmentName, IndexLoadingConfig indexLoadingConfig, File tempSegmentFolder,
-      File tempFile)
-      throws IOException, ArchiveException {
-    TarGzCompressionUtils.unTar(tempFile, tempSegmentFolder);
-    _logger.info("Uncompressed file {} into tmp dir {}", tempFile, tempSegmentFolder);
-    final File segmentFolder = new File(_indexDir, segmentName);
-    FileUtils.deleteQuietly(segmentFolder);
-    FileUtils.moveDirectory(tempSegmentFolder.listFiles()[0], segmentFolder);
-    _logger.info("Replacing LLC Segment {}", segmentName);
-    replaceLLSegment(segmentName, indexLoadingConfig);
+  /**
+   * Untars the new segment and replaces the existing segment.
+   */
+  private void untarAndMoveSegment(String segmentName, IndexLoadingConfig indexLoadingConfig, File segmentTarFile)
+      throws IOException {
+    // TODO: This could leave temporary directories in _indexDir if JVM shuts down before the temporary directory is
+    //       deleted. Consider cleaning up all temporary directories when starting the server.
+    File tempSegmentDir = new File(_indexDir, "tmp-" + segmentName + "." + System.currentTimeMillis());
+    try {
+      File tempIndexDir = TarGzCompressionUtils.untar(segmentTarFile, tempSegmentDir).get(0);
+      _logger.info("Uncompressed file {} into tmp dir {}", segmentTarFile, tempSegmentDir);
+      File indexDir = new File(_indexDir, segmentName);
+      FileUtils.deleteQuietly(indexDir);
+      FileUtils.moveDirectory(tempIndexDir, indexDir);
+      _logger.info("Replacing LLC Segment {}", segmentName);
+      replaceLLSegment(segmentName, indexLoadingConfig);
+    } finally {
+      FileUtils.deleteQuietly(tempSegmentDir);
+    }
   }
 
   private boolean isPeerSegmentDownloadEnabled(TableConfig tableConfig) {
@@ -334,22 +341,20 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   private void downloadSegmentFromPeer(String segmentName, String downloadScheme,
       IndexLoadingConfig indexLoadingConfig) {
-    File tempSegmentFolder = new File(_indexDir, "tmp-" + segmentName + "." + System.currentTimeMillis());
-    File tempFile = new File(_indexDir, segmentName + ".tar.gz");
+    File segmentTarFile = new File(_indexDir, segmentName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
     try {
       // First find servers hosting the segment in a ONLINE state.
       List<URI> peerSegmentURIs = PeerServerSegmentFinder.getPeerServerURIs(segmentName, downloadScheme, _helixManager);
       // Next download the segment from a randomly chosen server using configured scheme.
-      SegmentFetcherFactory.getSegmentFetcher(downloadScheme).fetchSegmentToLocal(peerSegmentURIs, tempFile);
-      _logger.info("Fetched segment {} from: {} to: {} of size: {}", segmentName, peerSegmentURIs, tempFile,
-          tempFile.length());
-      untarAndMoveSegment(segmentName, indexLoadingConfig, tempSegmentFolder, tempFile);
+      SegmentFetcherFactory.getSegmentFetcher(downloadScheme).fetchSegmentToLocal(peerSegmentURIs, segmentTarFile);
+      _logger.info("Fetched segment {} from: {} to: {} of size: {}", segmentName, peerSegmentURIs, segmentTarFile,
+          segmentTarFile.length());
+      untarAndMoveSegment(segmentName, indexLoadingConfig, segmentTarFile);
     } catch (Exception e) {
       _logger.warn("Download and move segment {} from peer with scheme {} failed.", segmentName, downloadScheme, e);
       throw new RuntimeException(e);
     } finally {
-      FileUtils.deleteQuietly(tempFile);
-      FileUtils.deleteQuietly(tempSegmentFolder);
+      FileUtils.deleteQuietly(segmentTarFile);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SplitSegmentCommitter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SplitSegmentCommitter.java
@@ -45,8 +45,9 @@ public class SplitSegmentCommitter implements SegmentCommitter {
   }
 
   @Override
-  public SegmentCompletionProtocol.Response commit(LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor) {
-    final File segmentTarFile = new File(segmentBuildDescriptor.getSegmentTarFilePath());
+  public SegmentCompletionProtocol.Response commit(
+      LLRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor) {
+    File segmentTarFile = segmentBuildDescriptor.getSegmentTarFile();
 
     SegmentCompletionProtocol.Response segmentCommitStartResponse = _protocolHandler.segmentCommitStart(_params);
     if (!segmentCommitStartResponse.getStatus()

--- a/pinot-core/src/main/java/org/apache/pinot/core/metadata/DefaultMetadataExtractor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/metadata/DefaultMetadataExtractor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.metadata;
 
-import com.google.common.base.Preconditions;
 import java.io.File;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
@@ -30,15 +29,13 @@ import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
  * By default, the metadata extractor we will use will assume that we are provided a .tar.gz pinot segment file.
  */
 public class DefaultMetadataExtractor implements MetadataExtractor {
+
   @Override
   public SegmentMetadata extractMetadata(File tarredSegmentFile, File unzippedSegmentDir)
       throws Exception {
-    // While there is TarGzCompressionUtils.unTarOneFile, we use unTar here to unpack all files
-    // in the segment in order to ensure the segment is not corrupted
-    TarGzCompressionUtils.unTar(tarredSegmentFile, unzippedSegmentDir);
-    File[] files = unzippedSegmentDir.listFiles();
-    Preconditions.checkState(files != null && files.length == 1);
-    File indexDir = files[0];
+    // NOTE: While there is TarGzCompressionUtils.untarOneFile(), we use untar() here to unpack all files in the segment
+    //       in order to ensure the segment is not corrupted.
+    File indexDir = TarGzCompressionUtils.untar(tarredSegmentFile, unzippedSegmentDir).get(0);
     return new SegmentMetadataImpl(indexDir);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -653,20 +653,21 @@ public class LLRealtimeSegmentDataManagerTest {
     final long leaseTime = 50000L;
 
     // The first time we invoke build, it should go ahead and build the segment.
-    String segTarFileName = segmentDataManager.invokeBuildForCommit(leaseTime).getSegmentTarFilePath();
+    File segmentTarFile = segmentDataManager.invokeBuildForCommit(leaseTime).getSegmentTarFile();
+    Assert.assertNotNull(segmentTarFile);
     Assert.assertTrue(segmentDataManager._buildSegmentCalled);
-    Assert.assertFalse(segmentDataManager.invokeCommit(segTarFileName));
-    Assert.assertTrue(new File(segTarFileName).exists());
+    Assert.assertFalse(segmentDataManager.invokeCommit());
+    Assert.assertTrue(segmentTarFile.exists());
 
     segmentDataManager._buildSegmentCalled = false;
 
     // This time around it should not build the segment.
-    String segTarFileName1 = segmentDataManager.invokeBuildForCommit(leaseTime).getSegmentTarFilePath();
+    File segmentTarFile1 = segmentDataManager.invokeBuildForCommit(leaseTime).getSegmentTarFile();
     Assert.assertFalse(segmentDataManager._buildSegmentCalled);
-    Assert.assertEquals(segTarFileName1, segTarFileName);
-    Assert.assertTrue(new File(segTarFileName).exists());
-    Assert.assertTrue(segmentDataManager.invokeCommit(segTarFileName1));
-    Assert.assertFalse(new File(segTarFileName).exists());
+    Assert.assertEquals(segmentTarFile1, segmentTarFile);
+    Assert.assertTrue(segmentTarFile.exists());
+    Assert.assertTrue(segmentDataManager.invokeCommit());
+    Assert.assertFalse(segmentTarFile.exists());
     segmentDataManager.destroy();
   }
 
@@ -688,10 +689,11 @@ public class LLRealtimeSegmentDataManagerTest {
     segmentDataManager.setCurrentOffset(finalOffset);
 
     // We have set up commit to fail, so we should carry over the segment file.
-    String segTarFileName = segmentDataManager.invokeBuildForCommit(leaseTime).getSegmentTarFilePath();
+    File segmentTarFile = segmentDataManager.invokeBuildForCommit(leaseTime).getSegmentTarFile();
+    Assert.assertNotNull(segmentTarFile);
     Assert.assertTrue(segmentDataManager._buildSegmentCalled);
-    Assert.assertFalse(segmentDataManager.invokeCommit(segTarFileName));
-    Assert.assertTrue(new File(segTarFileName).exists());
+    Assert.assertFalse(segmentDataManager.invokeCommit());
+    Assert.assertTrue(segmentTarFile.exists());
 
     // Now let the segment go ONLINE from CONSUMING, and ensure that the file is removed.
     LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
@@ -699,7 +701,7 @@ public class LLRealtimeSegmentDataManagerTest {
     segmentDataManager._stopWaitTimeMs = 0;
     segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.HOLDING);
     segmentDataManager.goOnlineFromConsuming(metadata);
-    Assert.assertFalse(new File(segTarFileName).exists());
+    Assert.assertFalse(segmentTarFile.exists());
     segmentDataManager.destroy();
   }
 
@@ -821,7 +823,7 @@ public class LLRealtimeSegmentDataManagerTest {
       return getSegmentBuildDescriptor();
     }
 
-    public boolean invokeCommit(String segTarFileName) {
+    public boolean invokeCommit() {
       SegmentCompletionProtocol.Response response = mock(SegmentCompletionProtocol.Response.class);
       when(response.isSplitCommit()).thenReturn(false);
       return super.commitSegment(response.getControllerVipUrl(), false);
@@ -894,16 +896,15 @@ public class LLRealtimeSegmentDataManagerTest {
         return null;
       }
       if (!forCommit) {
-        return new SegmentBuildDescriptor(null, null, getCurrentOffset(), _segmentDir, 0, 0, -1);
+        return new SegmentBuildDescriptor(null, null, getCurrentOffset(), 0, 0, -1);
       }
-      final String segTarFileName = _segmentDir + "/" + "segmentFile";
-      File segmentTgzFile = new File(segTarFileName);
+      File segmentTarFile = new File(_segmentDir, "segmentFile");
       try {
-        segmentTgzFile.createNewFile();
+        segmentTarFile.createNewFile();
       } catch (IOException e) {
-        Assert.fail("Could not create file " + segmentTgzFile);
+        Assert.fail("Could not create file " + segmentTarFile);
       }
-      return new SegmentBuildDescriptor(segTarFileName, null, getCurrentOffset(), null, 0, 0, -1);
+      return new SegmentBuildDescriptor(segmentTarFile, null, getCurrentOffset(), 0, 0, -1);
     }
 
     @Override
@@ -979,9 +980,9 @@ public class LLRealtimeSegmentDataManagerTest {
       try {
         Field field = LLRealtimeSegmentDataManager.class.getDeclaredField(fieldName);
         field.setAccessible(true);
-        StreamPartitionMsgOffset offset = (StreamPartitionMsgOffset)field.get(this);
+        StreamPartitionMsgOffset offset = (StreamPartitionMsgOffset) field.get(this);
 //        if (offset == null) {
-          field.set(this, new LongMsgOffset(value));
+        field.set(this, new LongMsgOffset(value));
 //        } else {
 //          offset.setOffset(value);
 //        }
@@ -990,9 +991,9 @@ public class LLRealtimeSegmentDataManagerTest {
       } catch (IllegalAccessException e) {
         Assert.fail();
       }
-  }
+    }
 
-  private void setInt(int value, String fieldName) {
+    private void setInt(int value, String fieldName) {
       try {
         Field field = LLRealtimeSegmentDataManager.class.getDeclaredField(fieldName);
         field.setAccessible(true);

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamConfigUtils.java
@@ -97,7 +97,7 @@ public class FakeStreamConfigUtils {
       FileUtils.deleteDirectory(outputDir);
     }
     File avroTarFile = getResourceFile(AVRO_TAR_FILE);
-    return TarGzCompressionUtils.unTar(avroTarFile, outputDir);
+    return TarGzCompressionUtils.untar(avroTarFile, outputDir);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderTest.java
@@ -23,7 +23,6 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
@@ -157,8 +156,8 @@ public class LoaderTest {
     // Old Format
     URL resourceUrl = LoaderTest.class.getClassLoader().getResource(PADDING_OLD);
     Assert.assertNotNull(resourceUrl);
-    TarGzCompressionUtils.unTar(new File(TestUtils.getFileFromResourceUrl(resourceUrl)), INDEX_DIR);
-    File segmentDirectory = new File(INDEX_DIR, "paddingOld");
+    File segmentDirectory =
+        TarGzCompressionUtils.untar(new File(TestUtils.getFileFromResourceUrl(resourceUrl)), INDEX_DIR).get(0);
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segmentDirectory);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor("name");
     Assert.assertEquals(columnMetadata.getPaddingCharacter(), V1Constants.Str.LEGACY_STRING_PAD_CHAR);
@@ -178,8 +177,8 @@ public class LoaderTest {
     // New Format Padding character %
     resourceUrl = LoaderTest.class.getClassLoader().getResource(PADDING_PERCENT);
     Assert.assertNotNull(resourceUrl);
-    TarGzCompressionUtils.unTar(new File(TestUtils.getFileFromResourceUrl(resourceUrl)), INDEX_DIR);
-    segmentDirectory = new File(INDEX_DIR, "paddingPercent");
+    segmentDirectory =
+        TarGzCompressionUtils.untar(new File(TestUtils.getFileFromResourceUrl(resourceUrl)), INDEX_DIR).get(0);
     segmentMetadata = new SegmentMetadataImpl(segmentDirectory);
     columnMetadata = segmentMetadata.getColumnMetadataFor("name");
     Assert.assertEquals(columnMetadata.getPaddingCharacter(), V1Constants.Str.LEGACY_STRING_PAD_CHAR);
@@ -198,8 +197,8 @@ public class LoaderTest {
     // New Format Padding character Null
     resourceUrl = LoaderTest.class.getClassLoader().getResource(PADDING_NULL);
     Assert.assertNotNull(resourceUrl);
-    TarGzCompressionUtils.unTar(new File(TestUtils.getFileFromResourceUrl(resourceUrl)), INDEX_DIR);
-    segmentDirectory = new File(INDEX_DIR, "paddingNull");
+    segmentDirectory =
+        TarGzCompressionUtils.untar(new File(TestUtils.getFileFromResourceUrl(resourceUrl)), INDEX_DIR).get(0);
     segmentMetadata = new SegmentMetadataImpl(segmentDirectory);
     columnMetadata = segmentMetadata.getColumnMetadataFor("name");
     Assert.assertEquals(columnMetadata.getPaddingCharacter(), V1Constants.Str.DEFAULT_STRING_PAD_CHAR);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -398,7 +398,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
       throws Exception {
     URL resourceUrl = BaseClusterIntegrationTest.class.getClassLoader().getResource(getAvroTarFileName());
     Assert.assertNotNull(resourceUrl);
-    return TarGzCompressionUtils.unTar(new File(resourceUrl.getFile()), outputDir);
+    return TarGzCompressionUtils.untar(new File(resourceUrl.getFile()), outputDir);
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -291,8 +291,9 @@ public class ClusterIntegrationTestUtils {
 
     // Tar the segment
     String segmentName = driver.getSegmentName();
-    File indexDir = new File(segmentDir, driver.getSegmentName());
-    TarGzCompressionUtils.createTarGzOfDirectory(indexDir.getPath(), new File(tarDir, segmentName).getPath());
+    File indexDir = new File(segmentDir, segmentName);
+    File segmentTarFile = new File(tarDir, segmentName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    TarGzCompressionUtils.createTarGzFile(indexDir, segmentTarFile);
   }
 
   /**

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
@@ -91,10 +91,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
 
         // Un-tar the segment file
         File segmentDir = new File(tempDataDir, "segmentDir_" + i);
-        TarGzCompressionUtils.unTar(tarredSegmentFile, segmentDir);
-        File[] files = segmentDir.listFiles();
-        Preconditions.checkState(files != null && files.length == 1);
-        File indexDir = files[0];
+        File indexDir = TarGzCompressionUtils.untar(tarredSegmentFile, segmentDir).get(0);
         inputSegmentFiles.add(indexDir);
       }
 
@@ -109,14 +106,13 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
 
       int numOutputSegments = segmentConversionResults.size();
       List<File> tarredSegmentFiles = new ArrayList<>(numOutputSegments);
-      for (int i = 0; i < numOutputSegments; i++) {
+      for (SegmentConversionResult segmentConversionResult : segmentConversionResults) {
         // Tar the converted segment
-        SegmentConversionResult segmentConversionResult = segmentConversionResults.get(i);
         File convertedIndexDir = segmentConversionResult.getFile();
-        File convertedTarredSegmentFile = new File(TarGzCompressionUtils
-            .createTarGzOfDirectory(convertedIndexDir.getPath(),
-                new File(convertedTarredSegmentDir, segmentConversionResult.getSegmentName()).getPath()));
-        tarredSegmentFiles.add(convertedTarredSegmentFile);
+        File convertedSegmentTarFile = new File(convertedTarredSegmentDir,
+            segmentConversionResult.getSegmentName() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+        TarGzCompressionUtils.createTarGzFile(convertedIndexDir, convertedSegmentTarFile);
+        tarredSegmentFiles.add(convertedSegmentTarFile);
       }
 
       // Check whether the task get cancelled before uploading the segment

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
@@ -86,10 +86,7 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
 
       // Un-tar the segment file
       File segmentDir = new File(tempDataDir, "segmentDir");
-      TarGzCompressionUtils.unTar(tarredSegmentFile, segmentDir);
-      File[] files = segmentDir.listFiles();
-      Preconditions.checkState(files != null && files.length == 1);
-      File indexDir = files[0];
+      File indexDir = TarGzCompressionUtils.untar(tarredSegmentFile, segmentDir).get(0);
 
       // Convert the segment
       File workingDir = new File(tempDataDir, "workingDir");
@@ -100,9 +97,8 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
           segmentConversionResult.getSegmentName(), segmentName);
 
       // Tar the converted segment
-      File convertedTarredSegment = new File(TarGzCompressionUtils
-          .createTarGzOfDirectory(segmentConversionResult.getFile().getPath(),
-              new File(tempDataDir, "convertedTarredSegment").getPath()));
+      File convertedSegmentTarFile = new File(tempDataDir, segmentName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+      TarGzCompressionUtils.createTarGzFile(segmentConversionResult.getFile(), convertedSegmentTarFile);
 
       // Check whether the task get cancelled before uploading the segment
       if (_cancelled) {
@@ -134,7 +130,7 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
 
       // Upload the tarred segment
       SegmentConversionUtils.uploadSegment(configs, httpHeaders, parameters, tableNameWithType, segmentName, uploadURL,
-          convertedTarredSegment);
+          convertedSegmentTarFile);
 
       LOGGER.info("Done executing {} on table: {}, segment: {}", taskType, tableNameWithType, segmentName);
       return segmentConversionResult;

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkOfflineIndexReader.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkOfflineIndexReader.java
@@ -103,7 +103,7 @@ public class BenchmarkOfflineIndexReader {
     FileUtils.deleteQuietly(TEMP_DIR);
 
     File avroDir = new File(TEMP_DIR, "avro");
-    TarGzCompressionUtils.unTar(new File(TestUtils.getFileFromResourceUrl(RESOURCE_URL)), avroDir);
+    TarGzCompressionUtils.untar(new File(TestUtils.getFileFromResourceUrl(RESOURCE_URL)), avroDir);
     File avroFile = new File(avroDir, AVRO_FILE_NAME);
 
     File dataDir = new File(TEMP_DIR, "index");

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -73,7 +73,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
     if (localPluginsTarFile.exists()) {
       File pluginsDirFile = new File(PINOT_PLUGINS_DIR);
       try {
-        TarGzCompressionUtils.unTar(localPluginsTarFile, pluginsDirFile);
+        TarGzCompressionUtils.untar(localPluginsTarFile, pluginsDirFile);
       } catch (Exception e) {
         LOGGER.error("Failed to untar local Pinot plugins tarball file [{}]", localPluginsTarFile, e);
         throw new RuntimeException(e);
@@ -164,7 +164,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
       String segmentTarFileName = segmentName + Constants.TAR_GZ_FILE_EXT;
       File localSegmentTarFile = new File(localOutputTempDir, segmentTarFileName);
       LOGGER.info("Tarring segment from: {} to: {}", localSegmentDir, localSegmentTarFile);
-      TarGzCompressionUtils.createTarGzOfDirectory(localSegmentDir.getPath(), localSegmentTarFile.getPath());
+      TarGzCompressionUtils.createTarGzFile(localSegmentDir, localSegmentTarFile);
       long uncompressedSegmentSize = FileUtils.sizeOf(localSegmentDir);
       long compressedSegmentSize = FileUtils.sizeOf(localSegmentTarFile);
       LOGGER.info("Size for segment: {}, uncompressed: {}, compressed: {}", segmentName,

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
@@ -282,11 +282,11 @@ public class HadoopSegmentGenerationJobRunner extends Configured implements Inge
   }
 
   protected void packPluginsToDistributedCache(Job job) {
-    String pluginsRootDir = PluginManager.get().getPluginsRootDir();
-    if (new File(pluginsRootDir).exists()) {
+    File pluginsRootDir = new File(PluginManager.get().getPluginsRootDir());
+    if (pluginsRootDir.exists()) {
       File pluginsTarGzFile = new File(PINOT_PLUGINS_TAR_GZ);
       try {
-        TarGzCompressionUtils.createTarGzOfDirectory(pluginsRootDir, pluginsTarGzFile.getPath());
+        TarGzCompressionUtils.createTarGzFile(pluginsRootDir, pluginsTarGzFile);
       } catch (IOException e) {
         LOGGER.error("Failed to tar plugins directory", e);
         throw new RuntimeException(e);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -222,7 +222,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         if (localPluginsTarFile.exists()) {
           File pluginsDirFile = new File(PINOT_PLUGINS_DIR + "-" + idx);
           try {
-            TarGzCompressionUtils.unTar(localPluginsTarFile, pluginsDirFile);
+            TarGzCompressionUtils.untar(localPluginsTarFile, pluginsDirFile);
           } catch (Exception e) {
             LOGGER.error("Failed to untar local Pinot plugins tarball file [{}]", localPluginsTarFile, e);
             throw new RuntimeException(e);
@@ -276,7 +276,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         String segmentTarFileName = segmentName + Constants.TAR_GZ_FILE_EXT;
         File localSegmentTarFile = new File(localOutputTempDir, segmentTarFileName);
         LOGGER.info("Tarring segment from: {} to: {}", localSegmentDir, localSegmentTarFile);
-        TarGzCompressionUtils.createTarGzOfDirectory(localSegmentDir.getPath(), localSegmentTarFile.getPath());
+        TarGzCompressionUtils.createTarGzFile(localSegmentDir, localSegmentTarFile);
         long uncompressedSegmentSize = FileUtils.sizeOf(localSegmentDir);
         long compressedSegmentSize = FileUtils.sizeOf(localSegmentTarFile);
         LOGGER.info("Size for segment: {}, uncompressed: {}, compressed: {}", segmentName,
@@ -331,15 +331,16 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
   }
 
   protected void packPluginsToDistributedCache(JavaSparkContext sparkContext) {
-    String pluginsRootDir = PluginManager.get().getPluginsRootDir();
-    if (pluginsRootDir == null) {
+    String pluginsRootDirPath = PluginManager.get().getPluginsRootDir();
+    if (pluginsRootDirPath == null) {
       LOGGER.warn("Local Pinot plugins directory is null, skip packaging...");
       return;
     }
-    if (new File(pluginsRootDir).exists()) {
+    File pluginsRootDir = new File(pluginsRootDirPath);
+    if (pluginsRootDir.exists()) {
       File pluginsTarGzFile = new File(PINOT_PLUGINS_TAR_GZ);
       try {
-        TarGzCompressionUtils.createTarGzOfDirectory(pluginsRootDir, pluginsTarGzFile.getPath());
+        TarGzCompressionUtils.createTarGzFile(pluginsRootDir, pluginsTarGzFile);
       } catch (IOException e) {
         LOGGER.error("Failed to tar plugins directory", e);
       }
@@ -349,7 +350,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         sparkContext.getConf().set(PLUGINS_INCLUDE_PROPERTY_NAME, pluginsIncludes);
       }
     } else {
-      LOGGER.warn("Cannot find local Pinot plugins directory at [{}]", pluginsRootDir);
+      LOGGER.warn("Cannot find local Pinot plugins directory at [{}]", pluginsRootDirPath);
     }
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -194,7 +194,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
         String segmentTarFileName = segmentName + Constants.TAR_GZ_FILE_EXT;
         File localSegmentTarFile = new File(localOutputTempDir, segmentTarFileName);
         LOGGER.info("Tarring segment from: {} to: {}", localSegmentDir, localSegmentTarFile);
-        TarGzCompressionUtils.createTarGzOfDirectory(localSegmentDir.getPath(), localSegmentTarFile.getPath());
+        TarGzCompressionUtils.createTarGzFile(localSegmentDir, localSegmentTarFile);
         long uncompressedSegmentSize = FileUtils.sizeOf(localSegmentDir);
         long compressedSegmentSize = FileUtils.sizeOf(localSegmentTarFile);
         LOGGER.info("Size for segment: {}, uncompressed: {}, compressed: {}", segmentName,

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotRecordWriter.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotRecordWriter.java
@@ -113,7 +113,7 @@ public class PinotRecordWriter<T> extends RecordWriter<NullWritable, T> {
 
     File segmentTarFile = new File(_segmentTarDir, segmentName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
     LOGGER.info("Tarring segment: {} from directory: {} to: {}", segmentName, indexDir, segmentTarFile);
-    TarGzCompressionUtils.createTarGzOfDirectory(indexDir.getPath(), segmentTarFile.getPath());
+    TarGzCompressionUtils.createTarGzFile(indexDir, segmentTarFile);
 
     Path hdfsSegmentTarPath = new Path(_outputDir, segmentTarFile.getName());
     LOGGER.info("Copying segment tar file from local: {} to HDFS: {}", segmentTarFile, hdfsSegmentTarPath);

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -50,9 +49,7 @@ import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.apache.pinot.spi.utils.DataSizeUtils;
@@ -273,7 +270,7 @@ public class SegmentCreationMapper extends Mapper<LongWritable, Text, LongWritab
     String segmentTarFileName = segmentName + JobConfigConstants.TAR_GZ_FILE_EXT;
     File localSegmentTarFile = new File(_localSegmentTarDir, segmentTarFileName);
     _logger.info("Tarring segment from: {} to: {}", localSegmentDir, localSegmentTarFile);
-    TarGzCompressionUtils.createTarGzOfDirectory(localSegmentDir.getPath(), localSegmentTarFile.getPath());
+    TarGzCompressionUtils.createTarGzFile(localSegmentDir, localSegmentTarFile);
 
     long uncompressedSegmentSize = FileUtils.sizeOf(localSegmentDir);
     long compressedSegmentSize = FileUtils.sizeOf(localSegmentTarFile);

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/test/java/org/apache/pinot/hadoop/io/PinotOutputFormatTest.java
@@ -91,9 +91,8 @@ public class PinotOutputFormatTest {
 
     String segmentName = RAW_TABLE_NAME + "_0";
     File segmentDir = new File(TEMP_DIR, "segment");
-    TarGzCompressionUtils
-        .unTar(new File(outputDir, segmentName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION), segmentDir);
-    File indexDir = new File(segmentDir, segmentName);
+    File indexDir = TarGzCompressionUtils
+        .untar(new File(outputDir, segmentName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION), segmentDir).get(0);
     RecordReader recordReader = new PinotSegmentRecordReader(indexDir, null, null);
     for (Employee record : records) {
       GenericRow row = recordReader.next();

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationFunction.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationFunction.java
@@ -26,7 +26,6 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -47,9 +46,7 @@ import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.apache.pinot.spi.utils.DataSizeUtils;
@@ -241,7 +238,7 @@ public class SparkSegmentCreationFunction implements Serializable {
     String segmentTarFileName = segmentName + JobConfigConstants.TAR_GZ_FILE_EXT;
     File localSegmentTarFile = new File(_localSegmentTarDir, segmentTarFileName);
     _logger.info("Tarring segment from: {} to: {}", localSegmentDir, localSegmentTarFile);
-    TarGzCompressionUtils.createTarGzOfDirectory(localSegmentDir.getPath(), localSegmentTarFile.getPath());
+    TarGzCompressionUtils.createTarGzFile(localSegmentDir, localSegmentTarFile);
 
     long uncompressedSegmentSize = FileUtils.sizeOf(localSegmentDir);
     long compressedSegmentSize = FileUtils.sizeOf(localSegmentTarFile);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -204,11 +204,7 @@ public class SegmentFetcherAndLoader {
 
       // If an exception is thrown when untarring, it means the tar file is broken OR not found after the retry.
       // Thus, there's no need to retry again.
-      TarGzCompressionUtils.unTar(tempTarFile, tempSegmentDir);
-
-      File[] files = tempSegmentDir.listFiles();
-      Preconditions.checkState(files != null && files.length == 1);
-      File tempIndexDir = files[0];
+      File tempIndexDir = TarGzCompressionUtils.untar(tempTarFile, tempSegmentDir).get(0);
 
       File indexDir = new File(new File(_instanceDataManager.getSegmentDataDirectory(), tableName), segmentName);
       if (indexDir.exists()) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/SegmentInfoProvider.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/SegmentInfoProvider.java
@@ -26,13 +26,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 
 
 /**
@@ -96,9 +96,7 @@ public class SegmentInfoProvider {
     if (segmentFile.isFile()) {
       tmpDir = File.createTempFile(SEGMENT_INFO_PROVIDER, null, new File(TMP_DIR));
       FileUtils.deleteQuietly(tmpDir);
-      tmpDir.mkdir();
-      TarGzCompressionUtils.unTar(segmentFile, tmpDir);
-      segmentDir = tmpDir.listFiles()[0];
+      segmentDir = TarGzCompressionUtils.untar(segmentFile, tmpDir).get(0);
     } else {
       segmentDir = segmentFile;
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -204,14 +204,13 @@ public class DictionaryToRawIndexConverter {
     if (segmentDir.isFile()) {
       if (segmentDir.getName().endsWith(".tar.gz") || segmentDir.getName().endsWith(".tgz")) {
         LOGGER.info("Uncompressing input segment '{}'", segmentDir);
-        newSegment = TarGzCompressionUtils.unTar(segmentDir, outputDir).get(0);
+        newSegment = TarGzCompressionUtils.untar(segmentDir, outputDir).get(0);
       } else {
         LOGGER.warn("Skipping non-segment file '{}'", segmentDir.getAbsoluteFile());
         return false;
       }
     } else {
       newSegment = new File(outputDir, segmentDir.getName());
-      newSegment.mkdir();
       FileUtils.copyDirectory(segmentDir, newSegment);
     }
 
@@ -226,7 +225,8 @@ public class DictionaryToRawIndexConverter {
 
     if (compressOutput) {
       LOGGER.info("Compressing segment '{}'", newSegment);
-      TarGzCompressionUtils.createTarGzOfDirectory(newSegment.getAbsolutePath(), newSegment.getAbsolutePath());
+      File segmentTarFile = new File(outputDir, newSegment.getName() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+      TarGzCompressionUtils.createTarGzFile(newSegment, segmentTarFile);
       FileUtils.deleteQuietly(newSegment);
     }
     return true;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentConvertCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentConvertCommand.java
@@ -108,7 +108,7 @@ public class PinotSegmentConvertCommand extends AbstractBaseCommand implements C
           segmentPath.put(fileName, file.getAbsolutePath());
         } else if (fileName.toLowerCase().endsWith(".tar.gz") || fileName.toLowerCase().endsWith(".tgz")) {
           // Compressed segment.
-          File segment = TarGzCompressionUtils.unTar(file, new File(tempDir, fileName)).get(0);
+          File segment = TarGzCompressionUtils.untar(file, new File(tempDir, fileName)).get(0);
           String segmentName = segment.getName();
           if (segmentPath.containsKey(segmentName)) {
             throw new RuntimeException("Multiple segments with the same segment name: " + fileName);

--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.9</version>
+        <version>1.20</version>
       </dependency>
       <dependency>
         <groupId>org.apache.thrift</groupId>


### PR DESCRIPTION
Currently several tests are flaky because of the tar-gz compression

In thie PR:
- Upgrade commons-compress to 1.20 for the bug in this ticket: https://issues.apache.org/jira/browse/COMPRESS-417
- Re-implement TarGzCompressionUtils following the library user guide: https://commons.apache.org/proper/commons-compress/examples.html
- With the re-implemented TarGzCompressionUtils, simplify the code for the caller