### PR TITLE
Fixing code to fetch the fsConfig from the right parent

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
@@ -132,7 +132,7 @@ public class HadoopSegmentGenerationJobRunner extends Configured implements Inge
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      new PinotConfiguration(pinotFSSpec);
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
     //Get pinotFS for input

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -33,6 +33,8 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -186,14 +188,14 @@ public class PinotConfiguration {
 
       return propertiesConfiguration;
     } catch (ConfigurationException e) {
-      throw new RuntimeException("Could not read properties from " + configPath, e);
+      throw new IllegalArgumentException("Could not read properties from " + configPath, e);
     }
   }
 
   private static Map<String, Object> relaxConfigurationKeys(Configuration configuration) {
-    return CommonsConfigurationUtils.getKeysStream(configuration)
+    return CommonsConfigurationUtils.getKeysStream(configuration).distinct()
 
-        .collect(Collectors.toMap(PinotConfiguration::relaxPropertyName, key -> getProperty(key, configuration)));
+        .collect(Collectors.toMap(PinotConfiguration::relaxPropertyName, key -> configuration.getProperty(key)));
   }
 
   private static Map<String, String> relaxEnvironmentVariables(Map<String, String> environmentVariables) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
@@ -47,12 +47,11 @@ public class PinotFSFactory {
     }
   };
 
-
-  public static void register(String scheme, String fsClassName, PinotConfiguration configuration) {
+  public static void register(String scheme, String fsClassName, PinotConfiguration fsConfiguration) {
     try {
       LOGGER.info("Initializing PinotFS for scheme {}, classname {}", scheme, fsClassName);
       PinotFS pinotFS = PluginManager.get().createInstance(fsClassName);
-      pinotFS.init(configuration);
+      pinotFS.init(fsConfiguration);
       PINOT_FS_MAP.put(scheme, pinotFS);
     } catch (Exception e) {
       LOGGER.error("Could not instantiate file system for class {} with scheme {}", fsClassName, scheme, e);
@@ -60,18 +59,18 @@ public class PinotFSFactory {
     }
   }
 
-  public static void init(PinotConfiguration config) {
+  public static void init(PinotConfiguration fsFactoryConfig) {
     // Get schemes and their respective classes
-    PinotConfiguration schemesConfiguration = config.subset(CLASS);
+    PinotConfiguration schemesConfiguration = fsFactoryConfig.subset(CLASS);
     List<String> schemes = schemesConfiguration.getKeys();
     if (!schemes.isEmpty()) {
       LOGGER.info("Did not find any fs classes in the configuration");
     }
-    
-    for(String scheme : schemes){
+
+    for (String scheme : schemes) {
       String fsClassName = schemesConfiguration.getProperty(scheme);
-      PinotConfiguration fsConfiguration = config.subset(scheme);
-      LOGGER.info("Got scheme {}, initializing class {} with config : {} ", scheme, fsClassName, fsConfiguration.toMap());
+      PinotConfiguration fsConfiguration = fsFactoryConfig.subset(scheme);
+      LOGGER.info("Got scheme {}, initializing class {}", scheme, fsClassName);
       register(scheme, fsClassName, fsConfiguration);
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
@@ -60,19 +60,19 @@ public class PinotFSFactory {
     }
   }
 
-  public static void init(PinotConfiguration fsConfig) {
+  public static void init(PinotConfiguration config) {
     // Get schemes and their respective classes
-    PinotConfiguration schemesConfiguration = fsConfig.subset(CLASS);
+    PinotConfiguration schemesConfiguration = config.subset(CLASS);
     List<String> schemes = schemesConfiguration.getKeys();
     if (!schemes.isEmpty()) {
       LOGGER.info("Did not find any fs classes in the configuration");
     }
     
     for(String scheme : schemes){
-      String fsClassName = (String) schemesConfiguration.getProperty(scheme);
-      
-      LOGGER.info("Got scheme {}, classname {}, starting to initialize", scheme, fsClassName);
-      register(scheme, fsClassName, schemesConfiguration.subset(scheme));
+      String fsClassName = schemesConfiguration.getProperty(scheme);
+      PinotConfiguration fsConfiguration = config.subset(scheme);
+      LOGGER.info("Got scheme {}, initializing class {} with config : {} ", scheme, fsClassName, fsConfiguration.toMap());
+      register(scheme, fsClassName, fsConfiguration);
     }
   }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
@@ -42,18 +42,26 @@ public class PinotFSFactoryTest {
   public void testCustomizedSegmentFetcherFactory() {
     Map<String, Object> properties = new HashMap<>();
     properties.put("class.file", LocalPinotFS.class.getName());
+
     properties.put("class.test", TestPinotFS.class.getName());
+    properties.put("test.accessKey", "v1");
+    properties.put("test.secretKey", "V2");
+    properties.put("test.region", "us-east");
     PinotFSFactory.init(new PinotConfiguration(properties));
 
     PinotFS testPinotFS = PinotFSFactory.create("test");
     Assert.assertTrue(testPinotFS instanceof TestPinotFS);
     Assert.assertEquals(((TestPinotFS) testPinotFS).getInitCalled(), 1);
+    Assert.assertEquals(((TestPinotFS) testPinotFS).getConfiguration().getProperty("accessKey"), "v1");
+    Assert.assertEquals(((TestPinotFS) testPinotFS).getConfiguration().getProperty("secretKey"), "V2");
+    Assert.assertEquals(((TestPinotFS) testPinotFS).getConfiguration().getProperty("region"), "us-east");
 
     Assert.assertTrue(PinotFSFactory.create("file") instanceof LocalPinotFS);
   }
 
   public static class TestPinotFS extends PinotFS {
     public int initCalled = 0;
+    private PinotConfiguration _configuration;
 
     public int getInitCalled() {
       return initCalled;
@@ -61,7 +69,12 @@ public class PinotFSFactoryTest {
 
     @Override
     public void init(PinotConfiguration configuration) {
+      _configuration = configuration;
       initCalled++;
+    }
+
+    public PinotConfiguration getConfiguration() {
+      return _configuration;
     }
 
     @Override

--- a/pinot-spi/src/test/resources/pinot-configuration-1.properties
+++ b/pinot-spi/src/test/resources/pinot-configuration-1.properties
@@ -1,3 +1,9 @@
 controller.host=config-path-1-controller-host
 controller.port=config-path-1-controller-port
 controller.cluster-name=config-path-1-cluster-name
+
+pinot.server.storage.factory.class.s3=org.apache.pinot.plugin.filesystem.S3PinotFS
+pinot.server.segment.fetcher.protocols=file,http,s3
+pinot.server.segment.fetcher.s3.class=org.apache.pinot.common.utils.fetcher.PinotFSSegmentFetcher
+pinot.server.instance.dataDir=/home/ubuntu/pinot/data
+pinot.server.instance.segmentTarDir=/home/ubuntu/pinot/segments


### PR DESCRIPTION
## Description

We were initializing the pinot fs class with incorrect configuration.

Before: 

> Got scheme s3, initializing class org.apache.pinot.plugin.filesystem.LocalFS with config : {=org.apache.pinot.plugin.filesystem.LocalFS} 

After

> Got scheme s3, initializing class org.apache.pinot.plugin.filesystem.LocalFS with config : {secretkey=secret, accesskey=access, region=myregion} 

Added test case
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
