### PR TITLE
Fetch Columns and DataType from ResultSet

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultTableResultSet.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultTableResultSet.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -59,6 +61,33 @@ class ResultTableResultSet extends AbstractResultSet {
     } else {
       return jsonValue.toString();
     }
+  }
+
+  public List<String> getAllColumns() {
+    List<String> columns = new ArrayList<>();
+    if (_columnNamesArray == null) {
+      return columns;
+    }
+
+    for (JsonNode column : _columnNamesArray) {
+      columns.add(column.textValue());
+    }
+
+    return columns;
+  }
+
+
+  public List<String> getAllColumnsDataTypes() {
+    List<String> columnDataTypes = new ArrayList<>();
+    if (_columnDataTypesArray == null) {
+      return columnDataTypes;
+    }
+
+    for (JsonNode columnDataType : _columnDataTypesArray) {
+      columnDataTypes.add(columnDataType.textValue());
+    }
+
+    return columnDataTypes;
   }
 
   @Override


### PR DESCRIPTION
The patch is needed to provide ResultSet metadata to JDBC driver.
The driver requires a column data type in response and currently there is not way to fetch that.