### PR TITLE
Fixing a backward compatible issue of converting BrokerRequest to QueryContext when querying from Presto segment splits

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
@@ -104,6 +104,11 @@ public class BrokerRequestToQueryContextConverter {
         groupByExpressions = null;
         limit = brokerRequest.getLimit();
         offset = selections.getOffset();
+        // Some old Pinot clients set LIMIT and OFFSET in Selection object.
+        // E.g. Presto segment level query.
+        if (limit == 0) {
+          limit = selections.getSize();
+        }
       } else {
         // Aggregation query
         List<AggregationInfo> aggregationsInfo = brokerRequest.getAggregationsInfo();


### PR DESCRIPTION
## Description
Presto generates and sends segment level query directly to Pinot Servers.
The BrokerRequest sent only set LIMIT inside the Selections object.

Below is a sample converted QueryContext before this change, the Presto generated BrokerRequest is embedded in the `QueryContext`.

![image](https://user-images.githubusercontent.com/1202120/87099474-b920a600-c1fe-11ea-86e3-392c71c14842.png)
