### PR TITLE
[TE] Added a getting started doc to setup ThirdEye with MySQL persistence

### DIFF
--- a/thirdeye/docs/Makefile
+++ b/thirdeye/docs/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+SPHINXAUTOBUILD   = sphinx-autobuild
 SOURCEDIR     = .
 BUILDDIR      = _build
 
@@ -12,6 +13,11 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
+
+
+livedocs:
+	@$(SPHINXAUTOBUILD) $(SOURCEDIR) $(BUILDDIR)/html
+
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/thirdeye/docs/README.md
+++ b/thirdeye/docs/README.md
@@ -27,9 +27,9 @@ This directory contains the documentation for ThirdEye. It is available online a
 
 The documentation is built using the [sphinx](https://www.sphinx-doc.org/) framework.
 
-If you have python/pip, you can install sphinx using
+If you have python/pip, you can install the dependencies using the command below.
 ```
-pip install sphinx sphinx_rtd_theme
+pip3 install -r requirements.txt
 ``` 
 
 Build docs using
@@ -40,8 +40,8 @@ The rendered html can be found at `_build/html/index.html`
 
 ### Updating docs
 1. Edit or add files as needed.
-2. Build using `make html`
-3. Open `_build/html/index.html` in your favorite browser
+2. Build using `make livedocs`.
+3. Open `_build/html/index.html` in your favorite browser. The page should auto-update with your changes.
 4. Ensure the contents and links work correctly
 5. Submit a PR!
 

--- a/thirdeye/docs/getting_started.rst
+++ b/thirdeye/docs/getting_started.rst
@@ -1,0 +1,131 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
+.. _quick-start:
+
+****************************
+Getting Started
+****************************
+This document will help you set up ThirdEye(abbreviated as 'TE') with an external MySQL persistence layer.
+It will also demonstrate how to plugin your own datasets from custom datasources.
+
+Prerequisites
+######################
+
+You'll need Java 8+, Maven 3.6+, and NPM 3.10+
+
+
+Building ThirdEye from source
+##########################################
+Simply clone the repo and build using the set of commands below.
+
+.. code-block:: bash
+
+    git clone https://github.com/apache/incubator-pinot.git
+    cd incubator-pinot/thirdeye
+    chmod +x install.sh run-frontend.sh run-backend.sh reset.sh
+    ./install.sh
+
+.. note:: The build of thirdeye-frontend may take several minutes
+
+
+Configuration
+##########################################
+ThirdEye is extremely flexible in terms of storage and working with different persistence layers and
+data sources. In this document, we'll set it up using MySQL as the main persistence layer.
+
+By default, ThirdEye assumes ``./config`` as the main config directory relative to the current
+working dir. The configurations use the ``YAML`` file format.
+
+MySQL Persistence
+***********************
+
+.. note:: This section assumes that you have a running MySQL server available with admin privileges.
+
+Step 1. Create a Database for ThirdEye
+===========================================
+
+.. code-block:: sql
+
+  -- Create DB
+  CREATE DATABASE thirdeye_test
+    DEFAULT CHARACTER SET utf8mb4
+    DEFAULT COLLATE utf8mb4_unicode_ci;
+
+Step 2. Setup users with appropriate privileges.
+=======================================================
+
+This assumes that you have an admin user and an
+app user. The app user is more restrictive in terms of its privileges. You can also create
+a single user to do all operations.
+
+.. code-block:: sql
+
+  -- Create admin user
+  CREATE USER 'uthirdeyeadmin'@'%' IDENTIFIED BY 'pass';
+  GRANT ALL PRIVILEGES ON thirdeye_test.* TO 'uthirdeyeadmin'@'%' WITH GRANT OPTION;
+
+  -- Create app user
+  CREATE USER 'uthirdeye'@'%' IDENTIFIED BY 'pass';
+  GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON thirdeye_test.* TO 'uthirdeye'@'%';
+
+
+Step 3. Create the tables in the ThirdEye Database
+=======================================================
+
+Login to your MySQL database and run the script below.
+
+.. code-block:: bash
+
+  mysql -h localhost -u uthirdeye thirdeye_test -p < thirdeye-pinot/src/main/resources/schema/create-schema.sql
+
+
+Step 4. Update the persistence config file
+=======================================================
+ThirdEye stores it's persistence config in the file below.
+
+.. code-block:: bash
+
+    ./config/persistence.yml
+
+For demo purposes, TE uses an in memory H2 db by default. To use MySQL, change the file contents
+with the one shown below.
+
+.. code-block:: yaml
+
+  databaseConfiguration:
+    # Assuming a local MySQL server running on the default port 3306
+    url: jdbc:mysql://localhost/thirdeye_test?autoReconnect=true
+    user: uthirdeye
+    password: pass
+    driver: com.mysql.jdbc.Driver
+
+All set! ThirdEye is now configured to use MySQL as the persistence layer.
+
+Running ThirdEye
+##########################################
+
+You can use the command below to run ThirdEye assuming your working dir to be ``./thirdeye``
+
+.. code-block:: bash
+
+    ./run-frontend.sh
+
+.. note:: You can stop the ThirdEye dashboard server anytime by pressing **Ctrl+C** in the terminal
+

--- a/thirdeye/docs/getting_started.rst
+++ b/thirdeye/docs/getting_started.rst
@@ -30,6 +30,8 @@ Prerequisites
 
 You'll need Java 8+, Maven 3.6+, and NPM 3.10+
 
+.. warning:: On MacOS, Java 8 is the recommended version. Higher versions of JDK including Java 9 and Java 14 are known to have issues.
+
 
 Building ThirdEye from source
 ##########################################
@@ -129,3 +131,32 @@ You can use the command below to run ThirdEye assuming your working dir to be ``
 
 .. note:: You can stop the ThirdEye dashboard server anytime by pressing **Ctrl+C** in the terminal
 
+
+Creating an Application
+##########################################
+
+An application is a basic TE entity can serves as a container for metrics, alerts and other entities.
+
+In order to create an application, follow the steps below.
+
+1. Go to the ``thirdeye-admin`` page. http://localhost:1426/thirdeye-admin
+2. Click the ``Entity Editor`` tab
+3. Choose ``Application`` from ``Select config type``.
+4. In the ``Select Entity to Edit`` menu, select ``Create New``
+5. Copy paste the json block below into the textbox on the right and click ``load to editor``
+6. Click ``Submit`` on the bottom left to create an application.
+
+
+.. code-block:: json
+
+  {
+    "application": "myApp",
+    "recipients": ""
+  }
+
+We'll be using this application when creating alerts.
+
+Setting up Alerts
+##########################################
+
+You can set up alerts and do root cause analysis on this application. See more at :ref:`alert-setup`.

--- a/thirdeye/docs/introduction.rst
+++ b/thirdeye/docs/introduction.rst
@@ -25,3 +25,4 @@ Introduction
 
     intro
     quick_start
+    getting_started

--- a/thirdeye/docs/mysql.rst
+++ b/thirdeye/docs/mysql.rst
@@ -19,15 +19,21 @@
 
 .. _mysql:
 
+****************************
 MySQL
-=====
+****************************
 
-**0: Prerequisites**
+This doc will help you understand how to add data sources to ThirdEye.
+Please run through the **Quick Start** guide and shut down the frontend server process.
 
-Run through the **Quick Start** guide and shut down the frontend server process.
+Prerequisites
+######################
+
+An accessible MySQL server containing data.
 
 
-**1: Update the data sources configuration**
+Data sources configuration
+#####################################################
 
 Add your MySQL database URL and credentials in `thirdeye-pinot/config/datasources/data-sources-config.yml`. You will be able to add multiple databases with multiple credentials, as follows:
 
@@ -51,17 +57,36 @@ Add your MySQL database URL and credentials in `thirdeye-pinot/config/datasource
 Note: the `dbname` here is an arbitrary name that you want to name it. 
 In `dburl`, you still need to include the specific database you are using.
 
-**2: Run ThirdEye frontend**
+Here's an example below.
+
+.. code-block:: yaml
+
+  dataSourceConfigs:
+    - className: org.apache.pinot.thirdeye.datasource.sql.SqlThirdEyeDataSource
+      properties:
+        MySQL:
+          - db:
+              dataset_pageviews: jdbc:mysql://localhost/dataset
+            user: uthirdeye
+            password: pass
+
+
+Run ThirdEye frontend
+####################################
+
+Start the ThirdEye server.
 
 .. code-block:: bash
 
     ./run-frontend.sh
 
-**3: Import metric from MySQL**
+Import metric from MySQL
+####################################
 
-See :ref:`import-sql-metric`.
+The next step is to import metrics from your dataset into the ThirdEye system. Please see :ref:`import-sql-metric`.
 
-**4: Start an analysis**
+Start an analysis
+####################################
 
 Point your favorite browser to
 

--- a/thirdeye/docs/requirements.txt
+++ b/thirdeye/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx_rtd_theme
+sphinx-autobuild


### PR DESCRIPTION
Updated ThirdEye documentation:
- Added a Getting Started doc to setup TE with MySQL as the persistence layer
- Updated the MySQL doc with an example. +cosmetic refactor
- Added autoupdate target in makefile to facilitate live update of docs