### PR TITLE
Support BYTES type for DictinctCount aggregation function

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.query;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -63,21 +64,53 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
     for (AggregationFunction aggregationFunction : _aggregationFunctions) {
       String column = ((ExpressionContext) aggregationFunction.getInputExpressions().get(0)).getIdentifier();
       Dictionary dictionary = _dictionaryMap.get(column);
+      int dictionarySize = dictionary.length();
       switch (aggregationFunction.getType()) {
         case MAX:
-          aggregationResults.add(dictionary.getDoubleValue(dictionary.length() - 1));
+          aggregationResults.add(dictionary.getDoubleValue(dictionarySize - 1));
           break;
         case MIN:
           aggregationResults.add(dictionary.getDoubleValue(0));
           break;
         case MINMAXRANGE:
-          aggregationResults.add(
-              new MinMaxRangePair(dictionary.getDoubleValue(0), dictionary.getDoubleValue(dictionary.length() - 1)));
+          aggregationResults
+              .add(new MinMaxRangePair(dictionary.getDoubleValue(0), dictionary.getDoubleValue(dictionarySize - 1)));
           break;
         case DISTINCTCOUNT:
-          IntOpenHashSet set = new IntOpenHashSet(128);
-          for (int dictId = 0; dictId < dictionary.length(); dictId++) {
-            set.add(dictionary.get(dictId).hashCode());
+          IntOpenHashSet set = new IntOpenHashSet(dictionarySize);
+          switch (dictionary.getValueType()) {
+            case INT:
+              for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                set.add(dictionary.getIntValue(dictId));
+              }
+              break;
+            case LONG:
+              for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                set.add(Long.hashCode(dictionary.getLongValue(dictId)));
+              }
+              break;
+            case FLOAT:
+              for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                set.add(Float.hashCode(dictionary.getFloatValue(dictId)));
+              }
+              break;
+            case DOUBLE:
+              for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                set.add(Double.hashCode(dictionary.getDoubleValue(dictId)));
+              }
+              break;
+            case STRING:
+              for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                set.add(dictionary.getStringValue(dictId).hashCode());
+              }
+              break;
+            case BYTES:
+              for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                set.add(Arrays.hashCode(dictionary.getBytesValue(dictId)));
+              }
+              break;
+            default:
+              throw new IllegalStateException();
           }
           aggregationResults.add(set);
           break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.plan.AggregationGroupByOrderByPlanNode;
 import org.apache.pinot.core.plan.AggregationGroupByPlanNode;
@@ -165,7 +166,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     for (ExpressionContext expression : selectExpressions) {
       FunctionContext function = expression.getFunction();
       String functionName = function.getFunctionName();
-      if(!AggregationFunctionUtils.isFitForDictionaryBasedComputation(functionName)) {
+      if (!AggregationFunctionUtils.isFitForDictionaryBasedComputation(functionName)) {
         return false;
       }
 
@@ -175,7 +176,11 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
       }
       String column = argument.getIdentifier();
       Dictionary dictionary = indexSegment.getDataSource(column).getDictionary();
-      if (dictionary == null || !dictionary.isSorted()) {
+      if (dictionary == null) {
+        return false;
+      }
+      // NOTE: DISTINCTCOUNT does not require sorted dictionary
+      if (!dictionary.isSorted() && !functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNT.name())) {
         return false;
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.util.Arrays;
 import java.util.Map;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -95,6 +96,12 @@ public class DistinctCountAggregationFunction extends BaseSingleInputAggregation
           valueSet.add(stringValues[i].hashCode());
         }
         break;
+      case BYTES:
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          valueSet.add(Arrays.hashCode(bytesValues[i]));
+        }
+        break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT aggregation function: " + valueType);
     }
@@ -135,6 +142,12 @@ public class DistinctCountAggregationFunction extends BaseSingleInputAggregation
         String[] stringValues = blockValSet.getStringValuesSV();
         for (int i = 0; i < length; i++) {
           setValueForGroupKey(groupByResultHolder, groupKeyArray[i], stringValues[i].hashCode());
+        }
+        break;
+      case BYTES:
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          setValueForGroupKey(groupByResultHolder, groupKeyArray[i], Arrays.hashCode(bytesValues[i]));
         }
         break;
       default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import org.apache.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import org.apache.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 
@@ -130,6 +131,11 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
     Arrays.sort(sortedValues);
     return sortedValues;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.BYTES;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import java.util.Arrays;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 
@@ -110,6 +111,11 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.BYTES;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
@@ -170,6 +170,11 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.DOUBLE;
+  }
+
+  @Override
   public int indexOf(String stringValue) {
     return getDictId(Double.valueOf(stringValue), null);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/DoubleOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/DoubleOnHeapMutableDictionary.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import java.util.Arrays;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 @SuppressWarnings("Duplicates")
@@ -153,6 +154,11 @@ public class DoubleOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.DOUBLE;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
@@ -170,6 +170,11 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.FLOAT;
+  }
+
+  @Override
   public int indexOf(String stringValue) {
     return getDictId(Float.valueOf(stringValue), null);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import java.util.Arrays;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 @SuppressWarnings("Duplicates")
@@ -153,6 +154,11 @@ public class FloatOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.FLOAT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
@@ -170,6 +170,11 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.INT;
+  }
+
+  @Override
   public int indexOf(String stringValue) {
     return getDictId(Integer.valueOf(stringValue), null);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/IntOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/IntOnHeapMutableDictionary.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import java.util.Arrays;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 @SuppressWarnings("Duplicates")
@@ -153,6 +154,11 @@ public class IntOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.INT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
@@ -170,6 +170,11 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.LONG;
+  }
+
+  @Override
   public int indexOf(String stringValue) {
     return getDictId(Long.valueOf(stringValue), null);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/LongOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/LongOnHeapMutableDictionary.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import java.util.Arrays;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 @SuppressWarnings("Duplicates")
@@ -153,6 +154,11 @@ public class LongOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.LONG;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -27,6 +27,7 @@ import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import org.apache.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BytesUtils;
 
 
@@ -123,6 +124,11 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
     Arrays.sort(sortedValues);
     return sortedValues;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.STRING;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/StringOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/StringOnHeapMutableDictionary.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import java.util.Arrays;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BytesUtils;
 
 
@@ -111,6 +112,11 @@ public class StringOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.STRING;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/BytesDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/BytesDictionary.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
-import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BytesUtils;
 
 
 /**
@@ -34,6 +35,11 @@ public class BytesDictionary extends BaseImmutableDictionary {
   @Override
   public int insertionIndexOf(String stringValue) {
     return binarySearch(BytesUtils.toBytes(stringValue));
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.BYTES;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueBytesDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueBytesDictionary.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 
@@ -43,6 +44,11 @@ public class ConstantValueBytesDictionary extends BaseImmutableDictionary {
       return -2;
     }
     return 0;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.BYTES;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueDoubleDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueDoubleDictionary.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
 /**
  * Dictionary of a single double value.
  */
@@ -39,6 +42,11 @@ public class ConstantValueDoubleDictionary extends BaseImmutableDictionary {
       return -2;
     }
     return 0;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.DOUBLE;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueFloatDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueFloatDictionary.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
 /**
  * Dictionary of a single float value.
  */
@@ -39,6 +42,11 @@ public class ConstantValueFloatDictionary extends BaseImmutableDictionary {
       return -2;
     }
     return 0;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.FLOAT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueIntDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueIntDictionary.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
 /**
  * Dictionary of a single int value.
  */
@@ -39,6 +42,11 @@ public class ConstantValueIntDictionary extends BaseImmutableDictionary {
       return -2;
     }
     return 0;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.INT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueLongDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueLongDictionary.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
 /**
  * Dictionary of a single long value.
  */
@@ -39,6 +42,11 @@ public class ConstantValueLongDictionary extends BaseImmutableDictionary {
       return -2;
     }
     return 0;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.LONG;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueStringDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueStringDictionary.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BytesUtils;
 
 
@@ -42,6 +43,11 @@ public class ConstantValueStringDictionary extends BaseImmutableDictionary {
       return -2;
     }
     return 0;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.STRING;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/Dictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/Dictionary.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.core.segment.index.readers;
 
 import java.io.Closeable;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 /**
@@ -32,6 +34,11 @@ public interface Dictionary extends Closeable {
    * NOTE: Immutable dictionary is always sorted; mutable dictionary is always unsorted.
    */
   boolean isSorted();
+
+  /**
+   * Returns the data type of the values in the dictionary.
+   */
+  DataType getValueType();
 
   int length();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/DocIdDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/DocIdDictionary.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
 /**
  * DocId dictionary for the segment
  */
@@ -39,6 +42,11 @@ public class DocIdDictionary extends BaseImmutableDictionary {
     } else {
       return intValue;
     }
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.INT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/DoubleDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/DoubleDictionary.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.segment.index.readers;
 
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class DoubleDictionary extends BaseImmutableDictionary {
@@ -30,6 +31,11 @@ public class DoubleDictionary extends BaseImmutableDictionary {
   @Override
   public int insertionIndexOf(String stringValue) {
     return binarySearch(Double.parseDouble(stringValue));
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.DOUBLE;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/FloatDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/FloatDictionary.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.segment.index.readers;
 
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class FloatDictionary extends BaseImmutableDictionary {
@@ -30,6 +31,11 @@ public class FloatDictionary extends BaseImmutableDictionary {
   @Override
   public int insertionIndexOf(String stringValue) {
     return binarySearch(Float.parseFloat(stringValue));
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.FLOAT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/IntDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/IntDictionary.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.segment.index.readers;
 
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class IntDictionary extends BaseImmutableDictionary {
@@ -30,6 +31,11 @@ public class IntDictionary extends BaseImmutableDictionary {
   @Override
   public int insertionIndexOf(String stringValue) {
     return binarySearch(Integer.parseInt(stringValue));
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.INT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/LongDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/LongDictionary.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.segment.index.readers;
 
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class LongDictionary extends BaseImmutableDictionary {
@@ -30,6 +31,11 @@ public class LongDictionary extends BaseImmutableDictionary {
   @Override
   public int insertionIndexOf(String stringValue) {
     return binarySearch(Long.parseLong(stringValue));
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.LONG;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapDoubleDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapDoubleDictionary.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.segment.index.readers;
 import it.unimi.dsi.fastutil.doubles.Double2IntOpenHashMap;
 import java.util.Arrays;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 /**
@@ -62,6 +63,11 @@ public class OnHeapDoubleDictionary extends OnHeapDictionary {
     double doubleValue = Double.parseDouble(stringValue);
     int index = _valToDictId.get(doubleValue);
     return (index != NULL_VALUE_INDEX) ? index : Arrays.binarySearch(_dictIdToVal, doubleValue);
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.DOUBLE;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapFloatDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapFloatDictionary.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.segment.index.readers;
 import it.unimi.dsi.fastutil.floats.Float2IntOpenHashMap;
 import java.util.Arrays;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 /**
@@ -62,6 +63,11 @@ public class OnHeapFloatDictionary extends OnHeapDictionary {
     float floatValue = Float.parseFloat(stringValue);
     int index = _valToDictId.get(floatValue);
     return (index != NULL_VALUE_INDEX) ? index : Arrays.binarySearch(_dictIdToVal, floatValue);
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.FLOAT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapIntDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapIntDictionary.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.segment.index.readers;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import java.util.Arrays;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 /**
@@ -62,6 +63,11 @@ public class OnHeapIntDictionary extends OnHeapDictionary {
     int intValue = Integer.parseInt(stringValue);
     int index = _valToDictId.get(intValue);
     return (index != NULL_VALUE_INDEX) ? index : Arrays.binarySearch(_dictIdToVal, intValue);
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.INT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapLongDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapLongDictionary.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.segment.index.readers;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import java.util.Arrays;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 /**
@@ -62,6 +63,11 @@ public class OnHeapLongDictionary extends OnHeapDictionary {
     long longValue = Long.parseLong(stringValue);
     int index = _valToDictId.get(longValue);
     return (index != NULL_VALUE_INDEX) ? index : Arrays.binarySearch(_dictIdToVal, longValue);
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.LONG;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapStringDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/OnHeapStringDictionary.java
@@ -20,8 +20,9 @@ package org.apache.pinot.core.segment.index.readers;
 
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Arrays;
-import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BytesUtils;
 
 
 /**
@@ -80,6 +81,11 @@ public class OnHeapStringDictionary extends OnHeapDictionary {
       return _paddingByte == 0 ? Arrays.binarySearch(_unpaddedStrings, stringValue)
           : Arrays.binarySearch(_paddedStrings, padString(stringValue));
     }
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.STRING;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/StringDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/StringDictionary.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.core.segment.index.readers;
 
-import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BytesUtils;
 
 
 public class StringDictionary extends BaseImmutableDictionary {
@@ -31,6 +32,11 @@ public class StringDictionary extends BaseImmutableDictionary {
   @Override
   public int insertionIndexOf(String stringValue) {
     return binarySearch(stringValue);
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.STRING;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/FixedIntArrayOffHeapIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/FixedIntArrayOffHeapIdMap.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.apache.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import org.apache.pinot.core.io.readerwriter.impl.FixedByteSingleValueMultiColumnReaderWriter;
 import org.apache.pinot.core.realtime.impl.dictionary.BaseOffHeapMutableDictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 /**
@@ -125,6 +126,11 @@ public class FixedIntArrayOffHeapIdMap extends BaseOffHeapMutableDictionary impl
 
   @Override
   public Object getSortedValues() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DataType getValueType() {
     throw new UnsupportedOperationException();
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
@@ -1,0 +1,263 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.response.broker.AggregationResult;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.GroupByResult;
+import org.apache.pinot.common.segment.ReadMode;
+import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.common.utils.StringUtil;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
+import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
+import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
+import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Queries test for DISTINCT_COUNT queries.
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class DistinctCountQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "DistinctCountQueriesTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final Random RANDOM = new Random();
+
+  private static final int NUM_RECORDS = 2000;
+  private static final int MAX_VALUE = 1000;
+
+  private static final String INT_COLUMN = "intColumn";
+  private static final String LONG_COLUMN = "longColumn";
+  private static final String FLOAT_COLUMN = "floatColumn";
+  private static final String DOUBLE_COLUMN = "doubleColumn";
+  private static final String STRING_COLUMN = "stringColumn";
+  private static final String BYTES_COLUMN = "bytesColumn";
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, DataType.INT)
+      .addSingleValueDimension(LONG_COLUMN, DataType.LONG).addSingleValueDimension(FLOAT_COLUMN, DataType.FLOAT)
+      .addSingleValueDimension(DOUBLE_COLUMN, DataType.DOUBLE).addSingleValueDimension(STRING_COLUMN, DataType.STRING)
+      .addSingleValueDimension(BYTES_COLUMN, DataType.BYTES).build();
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+
+  private Set<Integer> _values;
+  private int[] _expectedResults;
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    // NOTE: Use a match all filter to switch between DictionaryBasedAggregationOperator and AggregationOperator
+    return " WHERE intColumn >= 0";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+
+    List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
+    int hashMapCapacity = HashUtil.getHashMapCapacity(MAX_VALUE);
+    _values = new HashSet<>(hashMapCapacity);
+    Set<Integer> longResultSet = new HashSet<>(hashMapCapacity);
+    Set<Integer> floatResultSet = new HashSet<>(hashMapCapacity);
+    Set<Integer> doubleResultSet = new HashSet<>(hashMapCapacity);
+    Set<Integer> stringResultSet = new HashSet<>(hashMapCapacity);
+    Set<Integer> bytesResultSet = new HashSet<>(hashMapCapacity);
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      int value = RANDOM.nextInt(MAX_VALUE);
+      GenericRow record = new GenericRow();
+      record.putValue(INT_COLUMN, value);
+      _values.add(Integer.hashCode(value));
+      record.putValue(LONG_COLUMN, (long) value);
+      longResultSet.add(Long.hashCode(value));
+      record.putValue(FLOAT_COLUMN, (float) value);
+      floatResultSet.add(Float.hashCode(value));
+      record.putValue(DOUBLE_COLUMN, (double) value);
+      doubleResultSet.add(Double.hashCode(value));
+      String stringValue = Integer.toString(value);
+      record.putValue(STRING_COLUMN, stringValue);
+      stringResultSet.add(stringValue.hashCode());
+      // NOTE: Create fixed-length bytes so that dictionary can be generated
+      byte[] bytesValue = StringUtil.encodeUtf8(StringUtils.leftPad(stringValue, 3, '0'));
+      record.putValue(BYTES_COLUMN, bytesValue);
+      bytesResultSet.add(Arrays.hashCode(bytesValue));
+      records.add(record);
+    }
+    _expectedResults =
+        new int[]{_values.size(), longResultSet.size(), floatResultSet.size(), doubleResultSet.size(), stringResultSet.size(), bytesResultSet.size()};
+
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
+
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @Test
+  public void testAggregationOnly() {
+    String query =
+        "SELECT DISTINCTCOUNT(intColumn), DISTINCTCOUNT(longColumn), DISTINCTCOUNT(floatColumn), DISTINCTCOUNT(doubleColumn), DISTINCTCOUNT(stringColumn), DISTINCTCOUNT(bytesColumn) FROM testTable";
+
+    // Inner segment
+    Operator operator = getOperatorForPqlQuery(query);
+    assertTrue(operator instanceof DictionaryBasedAggregationOperator);
+    IntermediateResultsBlock resultsBlock = ((DictionaryBasedAggregationOperator) operator).nextBlock();
+    QueriesTestUtils
+        .testInnerSegmentExecutionStatistics(operator.getExecutionStatistics(), NUM_RECORDS, 0, 0, NUM_RECORDS);
+    List<Object> aggregationResult = resultsBlock.getAggregationResult();
+
+    operator = getOperatorForPqlQueryWithFilter(query);
+    assertTrue(operator instanceof AggregationOperator);
+    IntermediateResultsBlock resultsBlockWithFilter = ((AggregationOperator) operator).nextBlock();
+    QueriesTestUtils
+        .testInnerSegmentExecutionStatistics(operator.getExecutionStatistics(), NUM_RECORDS, 0, 6 * NUM_RECORDS,
+            NUM_RECORDS);
+    List<Object> aggregationResultWithFilter = resultsBlockWithFilter.getAggregationResult();
+
+    assertNotNull(aggregationResult);
+    assertNotNull(aggregationResultWithFilter);
+    assertEquals(aggregationResult, aggregationResultWithFilter);
+    for (int i = 0; i < 6; i++) {
+      assertEquals(((Set<Integer>) aggregationResult.get(i)).size(), _expectedResults[i]);
+    }
+
+    // Inter segments
+    String[] expectedResults = new String[6];
+    for (int i = 0; i < 6; i++) {
+      expectedResults[i] = Integer.toString(_expectedResults[i]);
+    }
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
+    QueriesTestUtils
+        .testInterSegmentAggregationResult(brokerResponse, 4 * NUM_RECORDS, 0, 0, 4 * NUM_RECORDS, expectedResults);
+    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
+    QueriesTestUtils
+        .testInterSegmentAggregationResult(brokerResponse, 4 * NUM_RECORDS, 0, 4 * 6 * NUM_RECORDS, 4 * NUM_RECORDS,
+            expectedResults);
+  }
+
+  @Test
+  public void testAggregationGroupBy() {
+    String query =
+        "SELECT DISTINCTCOUNT(intColumn), DISTINCTCOUNT(longColumn), DISTINCTCOUNT(floatColumn), DISTINCTCOUNT(doubleColumn), DISTINCTCOUNT(stringColumn), DISTINCTCOUNT(bytesColumn) FROM testTable GROUP BY intColumn";
+
+    // Inner segment
+    Operator operator = getOperatorForPqlQuery(query);
+    assertTrue(operator instanceof AggregationGroupByOperator);
+    IntermediateResultsBlock resultsBlock = ((AggregationGroupByOperator) operator).nextBlock();
+    QueriesTestUtils
+        .testInnerSegmentExecutionStatistics(operator.getExecutionStatistics(), NUM_RECORDS, 0, 6 * NUM_RECORDS,
+            NUM_RECORDS);
+    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+    assertNotNull(aggregationGroupByResult);
+    int numGroups = 0;
+    Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
+    while (groupKeyIterator.hasNext()) {
+      numGroups++;
+      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+      assertTrue(_values.contains(Integer.parseInt(groupKey._stringKey)));
+      for (int i = 0; i < 6; i++) {
+        assertEquals(((Set<Integer>) aggregationGroupByResult.getResultForKey(groupKey, i)).size(), 1);
+      }
+    }
+    assertEquals(numGroups, _values.size());
+
+    // Inter segments
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
+    Assert.assertEquals(brokerResponse.getNumDocsScanned(), 4 * NUM_RECORDS);
+    Assert.assertEquals(brokerResponse.getNumEntriesScannedInFilter(), 0);
+    Assert.assertEquals(brokerResponse.getNumEntriesScannedPostFilter(), 4 * 6 * NUM_RECORDS);
+    Assert.assertEquals(brokerResponse.getTotalDocs(), 4 * NUM_RECORDS);
+    // size of this array will be equal to number of aggregation functions since
+    // we return each aggregation function separately
+    List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+    int numAggregationColumns = aggregationResults.size();
+    Assert.assertEquals(numAggregationColumns, 6);
+    for (AggregationResult aggregationResult : aggregationResults) {
+      Assert.assertNull(aggregationResult.getValue());
+      List<GroupByResult> groupByResults = aggregationResult.getGroupByResult();
+      numGroups = groupByResults.size();
+      for (int i = 0; i < numGroups; i++) {
+        GroupByResult groupByResult = groupByResults.get(i);
+        List<String> group = groupByResult.getGroup();
+        assertEquals(group.size(), 1);
+        assertTrue(_values.contains(Integer.parseInt(group.get(0))));
+        assertEquals(groupByResult.getValue(), Integer.toString(1));
+      }
+    }
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+    _indexSegment.destroy();
+  }
+}


### PR DESCRIPTION
## Description
Support BYTES type for DistinctCount aggregation function.

Changes:
- Add BYTES type support to `DistinctCountAggregationFunction`
- Correctly handle BYTES type in `DictionaryBasedAggregationOperator` for DistinctCount
- In order to correctly handle BYTES type in `DictionaryBasedAggregationOperator`, add `getValueType()` into the `Dictionary` interface
- Add DistinctCountQueriesTest to test DistinctCount queries on all data types