### PR TITLE
Add error message to broker response in case of broker send error

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -49,8 +49,6 @@ import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
-import static org.apache.pinot.common.exception.QueryException.BROKER_REQUEST_SEND_ERROR_CODE;
-
 
 /**
  * The <code>SingleConnectionBrokerRequestHandler</code> class is a thread-safe broker request handler using a single
@@ -118,9 +116,11 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
     brokerResponse.setNumServersQueried(numServersQueried);
     brokerResponse.setNumServersResponded(numServersResponded);
 
-    if (asyncQueryResponse.getBrokerRequestSendException() != null) {
-      String errorMsg = QueryException.getTruncatedStackTrace(asyncQueryResponse.getBrokerRequestSendException());
-      brokerResponse.addToExceptions(new QueryProcessingException(BROKER_REQUEST_SEND_ERROR_CODE, errorMsg));
+    Exception brokerRequestSendException = asyncQueryResponse.getBrokerRequestSendException();
+    if (brokerRequestSendException != null) {
+      String errorMsg = QueryException.getTruncatedStackTrace(brokerRequestSendException);
+      brokerResponse
+          .addToExceptions(new QueryProcessingException(QueryException.BROKER_REQUEST_SEND_ERROR_CODE, errorMsg));
     }
     if (brokerResponse.getExceptionsSize() > 0) {
       _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.BROKER_RESPONSES_WITH_PROCESSING_EXCEPTIONS, 1);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -31,12 +31,14 @@ import org.apache.pinot.broker.api.RequestStatistics;
 import org.apache.pinot.broker.broker.AccessControlFactory;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
 import org.apache.pinot.broker.routing.RoutingManager;
+import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.BrokerQueryPhase;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.transport.AsyncQueryResponse;
@@ -46,6 +48,8 @@ import org.apache.pinot.core.transport.ServerResponse;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+
+import static org.apache.pinot.common.exception.QueryException.BROKER_REQUEST_SEND_ERROR_CODE;
 
 
 /**
@@ -114,6 +118,10 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
     brokerResponse.setNumServersQueried(numServersQueried);
     brokerResponse.setNumServersResponded(numServersResponded);
 
+    if (asyncQueryResponse.getBrokerRequestSendException() != null) {
+      String errorMsg = QueryException.getTruncatedStackTrace(asyncQueryResponse.getBrokerRequestSendException());
+      brokerResponse.addToExceptions(new QueryProcessingException(BROKER_REQUEST_SEND_ERROR_CODE, errorMsg));
+    }
     if (brokerResponse.getExceptionsSize() > 0) {
       _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.BROKER_RESPONSES_WITH_PROCESSING_EXCEPTIONS, 1);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -53,6 +53,7 @@ public class QueryException {
   public static final int BROKER_TIMEOUT_ERROR_CODE = 400;
   public static final int BROKER_RESOURCE_MISSING_ERROR_CODE = 410;
   public static final int BROKER_INSTANCE_MISSING_ERROR_CODE = 420;
+  public static final int BROKER_REQUEST_SEND_ERROR_CODE = 425;
   public static final int TOO_MANY_REQUESTS_ERROR_CODE = 429;
   public static final int INTERNAL_ERROR_CODE = 450;
   public static final int MERGE_RESPONSE_ERROR_CODE = 500;
@@ -125,8 +126,17 @@ public class QueryException {
   }
 
   public static ProcessingException getException(ProcessingException processingException, Exception exception) {
+    return getException(processingException, getTruncatedStackTrace(exception));
+  }
+
+  public static ProcessingException getException(ProcessingException processingException, String errorMessage) {
     String errorType = processingException.getMessage();
     ProcessingException copiedProcessingException = processingException.deepCopy();
+    copiedProcessingException.setMessage(errorType + ":\n" + errorMessage);
+    return copiedProcessingException;
+  }
+
+  public static String getTruncatedStackTrace(Exception exception) {
     StringWriter stringWriter = new StringWriter();
     exception.printStackTrace(new PrintWriter(stringWriter));
     String fullStackTrace = stringWriter.toString();
@@ -136,15 +146,7 @@ public class QueryException {
     for (int i = 0; i < numLinesOfStackTrace; i++) {
       lengthOfStackTrace += lines[i].length();
     }
-    copiedProcessingException.setMessage(errorType + ":\n" + fullStackTrace.substring(0, lengthOfStackTrace));
-    return copiedProcessingException;
-  }
-
-  public static ProcessingException getException(ProcessingException processingException, String errorMessage) {
-    String errorType = processingException.getMessage();
-    ProcessingException copiedProcessingException = processingException.deepCopy();
-    copiedProcessingException.setMessage(errorType + ":\n" + errorMessage);
-    return copiedProcessingException;
+    return fullStackTrace.substring(0, lengthOfStackTrace);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -39,6 +39,8 @@ public class AsyncQueryResponse {
   private final CountDownLatch _countDownLatch;
   private final long _maxEndTimeMs;
 
+  private Exception _brokerRequestSendException;
+
   public AsyncQueryResponse(QueryRouter queryRouter, long requestId, Set<ServerRoutingInstance> serversQueried,
       long startTimeMs, long timeoutMs) {
     _queryRouter = queryRouter;
@@ -104,5 +106,13 @@ public class AsyncQueryResponse {
     if (serverResponse != null && serverResponse.getDataTable() == null) {
       markQueryFailed();
     }
+  }
+
+  public Exception getBrokerRequestSendException() {
+    return _brokerRequestSendException;
+  }
+
+  public void setBrokerRequestSendException(Exception brokerRequestSendException) {
+    _brokerRequestSendException = brokerRequestSendException;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -39,7 +39,7 @@ public class AsyncQueryResponse {
   private final CountDownLatch _countDownLatch;
   private final long _maxEndTimeMs;
 
-  private Exception _brokerRequestSendException;
+  private volatile Exception _brokerRequestSendException;
 
   public AsyncQueryResponse(QueryRouter queryRouter, long requestId, Set<ServerRoutingInstance> serversQueried,
       long startTimeMs, long timeoutMs) {
@@ -112,7 +112,7 @@ public class AsyncQueryResponse {
     return _brokerRequestSendException;
   }
 
-  public void setBrokerRequestSendException(Exception brokerRequestSendException) {
+  void setBrokerRequestSendException(Exception brokerRequestSendException) {
     _brokerRequestSendException = brokerRequestSendException;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -92,6 +92,7 @@ public class QueryRouter {
         LOGGER.error("Caught exception while sending request {} to server: {}, marking query failed", requestId,
             serverRoutingInstance, e);
         _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.REQUEST_SEND_EXCEPTIONS, 1);
+        asyncQueryResponse.setBrokerRequestSendException(e);
         asyncQueryResponse.markQueryFailed();
         break;
       }


### PR DESCRIPTION
On Pinot Broker, the incoming request gets written into socket channels of the target Servers. This happens on `QueryRouter.submitQuery(...)` function. If any exception occurs during  submitQuery for any reason like connection refused to one of the servers, sending requests to the remaining servers are abandoned and the partial responses from already successful sent requests are returned in BrokerResponse with no indication of the exception.
Although partial response is acceptable, there should be an indication of such problem in broker response to make life easier for ppl debugging this issue. Recently there was an incident where, for a specific use case, broker response was empty (no partial response) and there was no exception returned, while data was available on Pinot Servers. After good amount of time going through logs, this issue was discovered with exception being connection refused by only one faulty server.
This PR adds the exception to BrokerReponse for easier debugging.