### PR TITLE
Allow Pinot to accept query with FROM clause in the format of [database].[table]

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -466,8 +466,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (TableNameBuilder.isTableResource(tableName)) {
       if (_routingManager.routingExists(tableNameSplits[1]) && !_routingManager.routingExists(tableName)) {
         brokerRequest.getQuerySource().setTableName(tableNameSplits[1]);
-        return;
       }
+      return;
     }
     if (_routingManager.routingExists(TableNameBuilder.REALTIME.tableNameWithType(tableNameSplits[1]))
         && !_routingManager.routingExists(TableNameBuilder.REALTIME.tableNameWithType(tableName))) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
@@ -67,6 +67,10 @@ public class TableCache {
     return _tableConfigChangeListener._tableNameMap.getOrDefault(tableName.toLowerCase(), tableName);
   }
 
+  public boolean existTableName(String tableName) {
+    return _tableConfigChangeListener._tableNameMap.containsKey(tableName.toLowerCase());
+  }
+
   public String getActualColumnName(String tableName, String columnName) {
     String schemaName = _tableConfigChangeListener._table2SchemaConfigMap.get(tableName.toLowerCase());
     if (schemaName != null) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
@@ -67,7 +67,7 @@ public class TableCache {
     return _tableConfigChangeListener._tableNameMap.getOrDefault(tableName.toLowerCase(), tableName);
   }
 
-  public boolean existTableName(String tableName) {
+  public boolean containsTable(String tableName) {
     return _tableConfigChangeListener._tableNameMap.containsKey(tableName.toLowerCase());
   }
 


### PR DESCRIPTION
## Description
Allow Pinot to accept query with FROM clause in the format of [database].[table].
Will update TableName to `[table]` in BrokerRequest, when `[database].[table]` doesn't exist but `[table]` exists.

For case sensitive mode (default), use RoutingManager to check table existence.
For case insensitive mode, use TableCache to check table existence.

Some thoughts here:
We should try to prevent user creating table with dot in the table name.

## Release Notes
Allow Pinot to accept query with FROM clause in the format of [database].[table].