### PR TITLE
Cleanup the call to RealtimeSegmentConverter from HLCDataManager

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.yammer.metrics.core.Meter;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TimerTask;
@@ -286,9 +287,8 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           RealtimeSegmentConverter converter =
               new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), schema,
                   _tableNameWithType, tableConfig, realtimeSegmentZKMetadata.getSegmentName(), _sortedColumn,
-                  HLRealtimeSegmentDataManager.this._invertedIndexColumns, _noDictionaryColumns,
-                  _varLengthDictionaryColumns, null/*StarTreeIndexSpec*/,
-                  indexingConfig.isNullHandlingEnabled()); // Star tree not supported for HLC.
+                  _invertedIndexColumns, Collections.emptyList(), _noDictionaryColumns, _varLengthDictionaryColumns,
+                  indexingConfig.isNullHandlingEnabled());
 
           _segmentLogger.info("Trying to build segment");
           final long buildStartTime = System.nanoTime();

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.realtime.converter;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,21 +76,6 @@ public class RealtimeSegmentConverter {
     _varLengthDictionaryColumns = varLengthDictionaryColumns;
     _nullHandlingEnabled = nullHandlingEnabled;
     _textIndexColumns = textIndexColumns;
-  }
-
-  public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, String outputPath, Schema schema,
-      String tableName, TableConfig tableConfig, String segmentName, String sortedColumn,
-      List<String> invertedIndexColumns, List<String> noDictionaryColumns, List<String> varLengthDictionaryColumns,
-      boolean nullHandlingEnabled) {
-    this(realtimeSegment, outputPath, schema, tableName, tableConfig, segmentName, sortedColumn,
-        invertedIndexColumns, new ArrayList<>(), noDictionaryColumns, varLengthDictionaryColumns, nullHandlingEnabled);
-  }
-
-  // Used in RealtimeSegmentConverterTest
-  public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, String outputPath, Schema schema,
-      String tableName, TableConfig tableConfig, String segmentName, String sortedColumn) {
-    this(realtimeSegment, outputPath, schema, tableName, tableConfig, segmentName, sortedColumn, new ArrayList<>(),
-        new ArrayList<>(), new ArrayList<>(), null/*StarTreeIndexSpec*/, false/*nullHandlingEnabled*/);
   }
 
   public void build(@Nullable SegmentVersion segmentVersion, ServerMetrics serverMetrics)
@@ -153,7 +139,7 @@ public class RealtimeSegmentConverter {
    * Returns a new schema containing only physical columns
    */
   @VisibleForTesting
-  public Schema getUpdatedSchema(Schema original) {
+  public static Schema getUpdatedSchema(Schema original) {
     Schema newSchema = new Schema();
     for (String col : original.getPhysicalColumnNames()) {
       newSchema.addField(original.getFieldSpecFor(col));

--- a/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
@@ -41,16 +41,10 @@ public class RealtimeSegmentConverterTest {
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("col1", FieldSpec.DataType.STRING)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "col1"),
             new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "col2")).build();
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName("test").setTimeColumnName("col2").build();
     String segmentName = "segment1";
     VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSegmentSchema(schema, segmentName);
     Assert.assertEquals(schema.getColumnNames().size(), 5);
-
-    RealtimeSegmentConverter converter =
-        new RealtimeSegmentConverter(null, "", schema, "testTable", tableConfig, segmentName, "col1");
-
-    Schema newSchema = converter.getUpdatedSchema(schema);
+    Schema newSchema = RealtimeSegmentConverter.getUpdatedSchema(schema);
     Assert.assertEquals(newSchema.getColumnNames().size(), 2);
   }
 }


### PR DESCRIPTION
After the removal of old star tree spec, the calls to constructor were not correct. 