### PR TITLE
[TE] Setup a rest client pipeline for comms between ThirdEye services; added RCA highlights API as an example

### DIFF
--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -193,11 +193,6 @@
       <artifactId>presto-jdbc</artifactId>
       <version>0.215</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.2.2</version>
-    </dependency>
 
     <!-- dataframe specific -->
     <dependency>

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -193,6 +193,11 @@
       <artifactId>presto-jdbc</artifactId>
       <version>0.215</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.2.2</version>
+    </dependency>
 
     <!-- dataframe specific -->
     <dependency>

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -27,10 +27,13 @@ import org.apache.pinot.thirdeye.anomaly.events.HolidayEventsLoader;
 import org.apache.pinot.thirdeye.anomaly.events.MockEventsLoader;
 import org.apache.pinot.thirdeye.anomaly.monitor.MonitorJobScheduler;
 import org.apache.pinot.thirdeye.anomaly.task.TaskDriver;
+import org.apache.pinot.thirdeye.common.restclient.ThirdEyeRestClientConfiguration;
 import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.auto.onboard.AutoOnboardService;
 import org.apache.pinot.thirdeye.common.BaseThirdEyeApplication;
 import org.apache.pinot.thirdeye.common.ThirdEyeSwaggerBundle;
+import org.apache.pinot.thirdeye.common.utils.SessionUtils;
+import org.apache.pinot.thirdeye.datalayer.dto.SessionDTO;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.datasource.ThirdEyeCacheRegistry;
 import org.apache.pinot.thirdeye.datasource.pinot.resources.PinotDataSourceResource;
@@ -164,6 +167,10 @@ public class ThirdEyeAnomalyApplication
           modelDownloaderManager = new ModelDownloaderManager(config.getModelDownloaderConfig());
           modelDownloaderManager.start();
         }
+        if (config.getThirdEyeRestClientConfiguration() != null) {
+          ThirdEyeRestClientConfiguration restClientConfig = config.getThirdEyeRestClientConfiguration();
+          updateAdminSession(restClientConfig.getAdminUser(), restClientConfig.getSessionKey());
+        }
       }
 
       @Override
@@ -194,5 +201,17 @@ public class ThirdEyeAnomalyApplication
         }
       }
     });
+  }
+
+  private void updateAdminSession(String adminUser, String sessionKey) {
+    SessionDTO savedSession = DAO_REGISTRY.getSessionDAO().findBySessionKey(sessionKey);
+    long expiryMillis = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365);
+    if (savedSession == null) {
+      SessionDTO sessionDTO = SessionUtils.buildServiceAccount(adminUser, sessionKey, expiryMillis);
+      DAO_REGISTRY.getSessionDAO().save(sessionDTO);
+    } else {
+      savedSession.setExpirationTime(expiryMillis);
+      DAO_REGISTRY.getSessionDAO().update(savedSession);
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.pinot.thirdeye.anomaly.task.TaskDriverConfiguration;
 import org.apache.pinot.thirdeye.auto.onboard.AutoOnboardConfiguration;
 import org.apache.pinot.thirdeye.common.ThirdEyeConfiguration;
 import java.util.List;
+import org.apache.pinot.thirdeye.common.restclient.ThirdEyeRestClientConfiguration;
 
 
 public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
@@ -51,11 +52,20 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
   private MonitorConfiguration monitorConfiguration = new MonitorConfiguration();
   private AutoOnboardConfiguration autoOnboardConfiguration = new AutoOnboardConfiguration();
   private TaskDriverConfiguration taskDriverConfiguration = new TaskDriverConfiguration();
+  private ThirdEyeRestClientConfiguration teRestConfig = new ThirdEyeRestClientConfiguration();
   private DataAvailabilitySchedulingConfiguration
       dataAvailabilitySchedulingConfiguration = new DataAvailabilitySchedulingConfiguration();
   private String failureFromAddress;
   private String failureToAddress;
   private List<String> holidayCountriesWhitelist;
+
+  public ThirdEyeRestClientConfiguration getThirdEyeRestClientConfiguration() {
+    return teRestConfig;
+  }
+
+  public void setThirdEyeRestClientConfiguration(ThirdEyeRestClientConfiguration teRestConfig) {
+    this.teRestConfig = teRestConfig;
+  }
 
   public HolidayEventsLoaderConfiguration getHolidayEventsLoaderConfiguration() {
     return holidayEventsLoaderConfiguration;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/constants/rca/MultiDimensionalSummaryConstants.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/constants/rca/MultiDimensionalSummaryConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.constants.rca;
+
+
+public class MultiDimensionalSummaryConstants {
+
+  // Cube algorithm parameters
+  public static final String CUBE_SUMMARY_SIZE = "summarySize";
+  public static final String CUBE_ONE_SIDE_ERROR = "oneSideError";
+  public static final String CUBE_DEPTH = "depth";
+  public static final String CUBE_DIM_HIERARCHIES = "hierarchies";
+  public static final String CUBE_ORDER_TYPE = "orderType";
+  public static final String CUBE_EXCLUDED_DIMENSIONS = "excludedDimensions";
+  public static final String CUBE_MANUAL_ORDER = "manualOrder";
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/constants/rca/RootCauseResourceConstants.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/constants/rca/RootCauseResourceConstants.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.constants.rca;
+
+public class RootCauseResourceConstants {
+  public static final String METRIC_URN = "metricUrn";
+  public static final String CURRENT_START = "currentStart";
+  public static final String CURRENT_END = "currentEnd";
+  public static final String BASELINE_START = "baselineStart";
+  public static final String BASELINE_END = "baselineEnd";
+  public static final String TIME_ZONE = "timeZone";
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
@@ -74,8 +74,6 @@ public abstract class AbstractRestClient {
     long startedMillis = System.currentTimeMillis();
 
     WebTarget webTarget = this.client.target(url);
-    //TODO: Compose url vs build using client? .path("employees");
-    // No handling of status codes?
 
     Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON).headers(headers);
     Response response = invocationBuilder.get();
@@ -100,8 +98,6 @@ public abstract class AbstractRestClient {
     long startedMillis = System.currentTimeMillis();
 
     WebTarget webTarget = this.client.target(url);
-    //TODO: Compose url vs build using client? .path("employees");
-    // No handling of status codes?
 
     Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON).headers(headers);
     Response response = invocationBuilder.post(Entity.entity(postContent, MediaType.APPLICATION_JSON));

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
@@ -19,21 +19,23 @@
 
 package org.apache.pinot.thirdeye.common.restclient;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import org.glassfish.jersey.client.ClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,63 +47,46 @@ public abstract class AbstractRestClient {
   private final Logger LOG = LoggerFactory.getLogger(this.getClass());
 
   protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  private final HttpURLConnectionFactory connectionFactory;
-
-  /**
-   * Using a URLFactory to create URLs allows unit tests to mock out server communication.
-   */
-  public class HttpURLConnectionFactory {
-    public HttpURLConnection openConnection(String url) throws MalformedURLException, IOException {
-      return (HttpURLConnection) new URL(url).openConnection();
-    }
-  }
+  private final Client client;
 
   /**
    * Set up the client with a default URLFactory that creates real HTTP connections.
    * For unit tests, we use the alternate constructor to pass a mock.
    */
   public AbstractRestClient() {
-    connectionFactory = new HttpURLConnectionFactory();
+    this.client = ClientBuilder.newClient(new ClientConfig());
   }
 
   /**
    * For testing only, create a client with an alternate URLFactory. This constructor allows
    * unit tests to mock server communication.
    */
-  public AbstractRestClient(HttpURLConnectionFactory connectionFactory) {
-    this.connectionFactory = connectionFactory;
-  }
-
-  /**
-   * Perform a GET request to the given URL, accepts a method that will parse the response as a parameter.
-   * A timeout of zero is interpreted as an infinite timeout.
-   * @param <T>  the type parameter defined as the return type of the response parser method
-   * @param url the http url
-   * @param host the host to connect to
-   * @param headers the headers for communication
-   */
-  public <T> T doGet(String url, String host, Map<String, String> headers,
-      ParseResponseFunction<InputStream, T> responseParserFunc) throws IOException {
-    return doGet(url, host, headers, 0, 0, responseParserFunc);
+  public AbstractRestClient(Client client) {
+    this.client = client;
   }
 
   /**
    * Perform a GET request to the given URL, accepts a method that will parse the response as a parameter.
    * @param <T>  the type parameter defined as the return type of the response parser method
    * @param url the http url
-   * @param host the host to connect to
-   * @param connectTimeout timeout in milliseconds
-   * @param readTimeout timeout in milliseconds
    */
-  public <T> T doGet(String url, String host, Map<String, String> reqHeaders, int connectTimeout, int readTimeout,
-      ParseResponseFunction<InputStream, T> responseParserFunc) throws IOException {
-    Map<String, String> headers = new HashMap<>(reqHeaders);
-    headers.put("User-Agent", getClass().getName());
-    headers.put("Host", host);
-    headers.put("Accept", "application/json");
+  public <T> T doGet(String url, MultivaluedMap<String, Object> headers, ParseResponseFunction<Response, T> responseParserFunc) throws IOException {
+    long startedMillis = System.currentTimeMillis();
 
-    return doRequest(url, "GET", new byte[0], null, connectTimeout, readTimeout, headers,
-        responseParserFunc);
+    WebTarget webTarget = this.client.target(url);
+    //TODO: Compose url vs build using client? .path("employees");
+    // No handling of status codes?
+
+    Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON).headers(headers);
+    Response response = invocationBuilder.get();
+
+    T result = responseParserFunc.parse(response);
+    long durationMillis = System.currentTimeMillis() - startedMillis;
+
+    LOG.info(String.format("GET '%s' succeeded in '%s'ms, response code '%s', response content '%s'.", url,
+        durationMillis, response.getStatus(), result));
+
+    return result;
   }
 
   /**
@@ -109,108 +94,25 @@ public abstract class AbstractRestClient {
    * If the payload is an object that will be serialized to JSON the isContentTypeJSON must be set to true
    * @param <T>  the type parameter defined as the return type of the response parser method
    * @param url the http url
-   * @param host the host to connect to
    * @param postContent the post content
-   * @param isContentTypeJson flag indicating if the content is json type or not
    */
-  public <T> T doPost(String url, String host, Map<String, String> reqHeaders, Object postContent,
-      boolean isContentTypeJson, ParseResponseFunction<InputStream, T> responseParserFunc) throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    OBJECT_MAPPER.writeValue(baos, postContent);
-    byte[] content = baos.toByteArray();
-    String contentType = isContentTypeJson ? "application/json" : null;
-
-    Map<String, String> headers = new HashMap<>(reqHeaders);
-    headers.put("User-Agent", getClass().getName());
-    headers.put("Host", host);
-    headers.put("Accept", "application/json");
-
-    return doRequest(url, "POST", content, contentType, 0, 0, headers,
-        responseParserFunc);
-  }
-
-  /**
-   * Send a request to the given URL with the given parameters.
-   * @param <T> the type parameter defined as the return type of the response parser method
-   * @param url server url.
-   * @param method HTTP method.
-   * @param content request content.
-   * @param contentType request content type.
-   * @param connectTimeoutMillis connection timeout.
-   * @param readTimeoutMillis read timeout.
-   * @param headers any additional request headers.
-   * @return T the result of the parser functions applied to the response content.
-   */
-  private <T> T doRequest(String url, String method, byte[] content, String contentType, int connectTimeoutMillis,
-      int readTimeoutMillis, Map<String, String> headers, ParseResponseFunction<InputStream, T> responseParserFunc)
-      throws IOException {
+  public <T> T doPost(String url, MultivaluedMap<String, Object> headers, Object postContent, ParseResponseFunction<Response, T> responseParserFunc) throws IOException {
     long startedMillis = System.currentTimeMillis();
 
-    HttpURLConnection conn = this.connectionFactory.openConnection(url);
-    conn.setRequestMethod(method);
-    conn.setRequestProperty("Content-Length", Integer.toString(content.length));
-    conn.setConnectTimeout(connectTimeoutMillis);
-    conn.setReadTimeout(readTimeoutMillis);
-    for (Map.Entry<String, String> header : headers.entrySet()) {
-      conn.setRequestProperty(header.getKey(), header.getValue());
-    }
-    if (content.length > 0) {
-      if (contentType != null) {
-        conn.setRequestProperty("Content-Type", contentType);
-      }
-      conn.setDoOutput(true);
-      OutputStream outs = conn.getOutputStream();
-      outs.write(content, 0, content.length);
-      outs.flush();
-      outs.close();
-    }
+    WebTarget webTarget = this.client.target(url);
+    //TODO: Compose url vs build using client? .path("employees");
+    // No handling of status codes?
 
-    // Read the InputStream
-    int code = conn.getResponseCode();
-    boolean success = code >= 200 && code <= 299;
-    InputStream in = success ? conn.getInputStream() : conn.getErrorStream();
-    try {
-      T result = responseParserFunc.parse(in);
-      long durationMillis = System.currentTimeMillis() - startedMillis;
+    Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON).headers(headers);
+    Response response = invocationBuilder.post(Entity.entity(postContent, MediaType.APPLICATION_JSON));
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(
-            String.format("'%s' '%s' succeeded in '%s'ms, response code '%s', response content '%s'.", method, url,
-                durationMillis, code, result));
-      }
+    T result = responseParserFunc.parse(response);
+    long durationMillis = System.currentTimeMillis() - startedMillis;
 
-      if (!success) {
-        throw new IOException(
-            String.format("'%s' '%s' failed in '%s'ms, response code '%s', response content '%s'.", method, url,
-                durationMillis, code, result));
-      }
+    LOG.info(String.format("POST '%s' succeeded in '%s'ms, response code '%s', response content '%s'.", url,
+            durationMillis, response.getStatus(), result));
 
-      return result;
-    } finally {
-      drainAndClose(in);
-    }
-  }
-
-  /**
-   * Completely drain the input stream. This is important so that HTTP keep-alive functions properly.
-   * See: http://docs.oracle.com/javase/6/docs/technotes/guides/net/http-keepalive.html
-   */
-  private void drainAndClose(InputStream stream) {
-    if (stream == null) {
-      return;
-    }
-
-    // Drain the stream completely
-    try {
-      while (stream.read() != -1) {
-        ;
-      }
-    } catch (Exception ignored) {}
-
-    // Close the stream
-    try {
-      stream.close();
-    } catch (Exception ignored) {}
+    return result;
   }
 
   /**
@@ -261,9 +163,9 @@ public abstract class AbstractRestClient {
    * Implementation for a single method class that can be used with doGet and doPost in order to parse a response stream
    * to a Map<String,Object>
    */
-  public class ResponseToMap implements ParseResponseFunction<InputStream, Map<String, Object>> {
-    public Map<String, Object> parse(InputStream inputStream) throws IOException {
-      return OBJECT_MAPPER.readValue(inputStream, new TypeReference<Map<String, Object>>() {});
+  public class ResponseToMap implements ParseResponseFunction<Response, Map<String, Object>> {
+    public Map<String, Object> parse(Response response) {
+      return response.readEntity(new GenericType<HashMap<String, Object>>() { });
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.restclient;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A generic API Rest Client to perform GET and POST
+ */
+public abstract class AbstractRestClient {
+  private final Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private final HttpURLConnectionFactory connectionFactory;
+
+  /**
+   * Using a URLFactory to create URLs allows unit tests to mock out server communication.
+   */
+  public class HttpURLConnectionFactory {
+    public HttpURLConnection openConnection(String url) throws MalformedURLException, IOException {
+      return (HttpURLConnection) new URL(url).openConnection();
+    }
+  }
+
+  /**
+   * Set up the client with a default URLFactory that creates real HTTP connections.
+   * For unit tests, we use the alternate constructor to pass a mock.
+   */
+  public AbstractRestClient() {
+    connectionFactory = new HttpURLConnectionFactory();
+  }
+
+  /**
+   * For testing only, create a client with an alternate URLFactory. This constructor allows
+   * unit tests to mock server communication.
+   */
+  public AbstractRestClient(HttpURLConnectionFactory connectionFactory) {
+    this.connectionFactory = connectionFactory;
+  }
+
+  /**
+   * Perform a GET request to the given URL, accepts a method that will parse the response as a parameter.
+   * A timeout of zero is interpreted as an infinite timeout.
+   * @param <T>  the type parameter defined as the return type of the response parser method
+   * @param url the http url
+   * @param host the host to connect to
+   * @param headers the headers for communication
+   */
+  public <T> T doGet(String url, String host, Map<String, String> headers,
+      ParseResponseFunction<InputStream, T> responseParserFunc) throws IOException {
+    return doGet(url, host, headers, 0, 0, responseParserFunc);
+  }
+
+  /**
+   * Perform a GET request to the given URL, accepts a method that will parse the response as a parameter.
+   * @param <T>  the type parameter defined as the return type of the response parser method
+   * @param url the http url
+   * @param host the host to connect to
+   * @param connectTimeout timeout in milliseconds
+   * @param readTimeout timeout in milliseconds
+   */
+  public <T> T doGet(String url, String host, Map<String, String> reqHeaders, int connectTimeout, int readTimeout,
+      ParseResponseFunction<InputStream, T> responseParserFunc) throws IOException {
+    Map<String, String> headers = new HashMap<>(reqHeaders);
+    headers.put("User-Agent", getClass().getName());
+    headers.put("Host", host);
+    headers.put("Accept", "application/json");
+
+    return doRequest(url, "GET", new byte[0], null, connectTimeout, readTimeout, headers,
+        responseParserFunc);
+  }
+
+  /**
+   * Perform a POST request to the given URL, with a JSON or raw string as content.
+   * If the payload is an object that will be serialized to JSON the isContentTypeJSON must be set to true
+   * @param <T>  the type parameter defined as the return type of the response parser method
+   * @param url the http url
+   * @param host the host to connect to
+   * @param postContent the post content
+   * @param isContentTypeJson flag indicating if the content is json type or not
+   */
+  public <T> T doPost(String url, String host, Map<String, String> reqHeaders, Object postContent,
+      boolean isContentTypeJson, ParseResponseFunction<InputStream, T> responseParserFunc) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    OBJECT_MAPPER.writeValue(baos, postContent);
+    byte[] content = baos.toByteArray();
+    String contentType = isContentTypeJson ? "application/json" : null;
+
+    Map<String, String> headers = new HashMap<>(reqHeaders);
+    headers.put("User-Agent", getClass().getName());
+    headers.put("Host", host);
+    headers.put("Accept", "application/json");
+
+    return doRequest(url, "POST", content, contentType, 0, 0, headers,
+        responseParserFunc);
+  }
+
+  /**
+   * Send a request to the given URL with the given parameters.
+   * @param <T> the type parameter defined as the return type of the response parser method
+   * @param url server url.
+   * @param method HTTP method.
+   * @param content request content.
+   * @param contentType request content type.
+   * @param connectTimeoutMillis connection timeout.
+   * @param readTimeoutMillis read timeout.
+   * @param headers any additional request headers.
+   * @return T the result of the parser functions applied to the response content.
+   */
+  private <T> T doRequest(String url, String method, byte[] content, String contentType, int connectTimeoutMillis,
+      int readTimeoutMillis, Map<String, String> headers, ParseResponseFunction<InputStream, T> responseParserFunc)
+      throws IOException {
+    long startedMillis = System.currentTimeMillis();
+
+    HttpURLConnection conn = this.connectionFactory.openConnection(url);
+    conn.setRequestMethod(method);
+    conn.setRequestProperty("Content-Length", Integer.toString(content.length));
+    conn.setConnectTimeout(connectTimeoutMillis);
+    conn.setReadTimeout(readTimeoutMillis);
+    for (Map.Entry<String, String> header : headers.entrySet()) {
+      conn.setRequestProperty(header.getKey(), header.getValue());
+    }
+    if (content.length > 0) {
+      if (contentType != null) {
+        conn.setRequestProperty("Content-Type", contentType);
+      }
+      conn.setDoOutput(true);
+      OutputStream outs = conn.getOutputStream();
+      outs.write(content, 0, content.length);
+      outs.flush();
+      outs.close();
+    }
+
+    // Read the InputStream
+    int code = conn.getResponseCode();
+    boolean success = code >= 200 && code <= 299;
+    InputStream in = success ? conn.getInputStream() : conn.getErrorStream();
+    try {
+      T result = responseParserFunc.parse(in);
+      long durationMillis = System.currentTimeMillis() - startedMillis;
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            String.format("'%s' '%s' succeeded in '%s'ms, response code '%s', response content '%s'.", method, url,
+                durationMillis, code, result));
+      }
+
+      if (!success) {
+        throw new IOException(
+            String.format("'%s' '%s' failed in '%s'ms, response code '%s', response content '%s'.", method, url,
+                durationMillis, code, result));
+      }
+
+      return result;
+    } finally {
+      drainAndClose(in);
+    }
+  }
+
+  /**
+   * Completely drain the input stream. This is important so that HTTP keep-alive functions properly.
+   * See: http://docs.oracle.com/javase/6/docs/technotes/guides/net/http-keepalive.html
+   */
+  private void drainAndClose(InputStream stream) {
+    if (stream == null) {
+      return;
+    }
+
+    // Drain the stream completely
+    try {
+      while (stream.read() != -1) {
+        ;
+      }
+    } catch (Exception ignored) {}
+
+    // Close the stream
+    try {
+      stream.close();
+    } catch (Exception ignored) {}
+  }
+
+  /**
+   * Composes a url from the host, api and queryParameters
+   */
+  protected String composeUrl(String host, String api, SortedMap<String, String> queryParameters) throws IOException {
+    return composeUrlGeneric(Protocol.HTTP, host, api, queryParameters);
+  }
+
+  /**
+   * Composes a url from the protocol, host, api and queryParameters
+   */
+  protected String composeUrlGeneric(Protocol protocol, String host, String api,
+      SortedMap<String, String> queryParameters) throws IOException {
+    StringBuilder url = new StringBuilder();
+    for (Protocol scheme : Protocol.values()) {
+      if (host.contains(scheme.val())) {
+        // protocol/scheme is already part of the host, do not append protocol
+        url.append(host);
+        break;
+      }
+    }
+    if (url.toString().isEmpty()) {
+      url.append(protocol.val()).append(host);
+    }
+    url.append(api);
+
+    if (queryParameters != null) {
+      try {
+        boolean firstQueryParam = true;
+        for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
+          url.append(firstQueryParam ? "?" : "&");
+          firstQueryParam = false;
+          url.append(entry.getKey()).append('=');
+          url.append(URLEncoder.encode(entry.getValue(), "UTF-8")
+              .replace("+", "%20")
+              .replace("%2F", "/"));
+        }
+      } catch (UnsupportedEncodingException ex) {
+        // Should never happen since UTF-8 is always supported.
+        throw new IOException("Failed to URLEncode query parameters.", ex);
+      }
+    }
+    return url.toString();
+  }
+
+  /**
+   * Implementation for a single method class that can be used with doGet and doPost in order to parse the response to
+   * a Map<String,Object>
+   */
+  public class ResponseToMap implements ParseResponseFunction<InputStream, Map<String, Object>> {
+    public Map<String, Object> parse(InputStream inputStream) throws IOException {
+      return OBJECT_MAPPER.readValue(inputStream, new TypeReference<Map<String, Object>>() {
+      });
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * A generic API Rest Client to perform short-lived http GET and POST
+ * A generic Jersey Client API to perform GET and POST
  */
 public abstract class AbstractRestClient {
   private final Logger LOG = LoggerFactory.getLogger(this.getClass());
@@ -50,7 +50,7 @@ public abstract class AbstractRestClient {
   private final Client client;
 
   /**
-   * Set up the client with a default URLFactory that creates real HTTP connections.
+   * Set up a default Jersey client.
    * For unit tests, we use the alternate constructor to pass a mock.
    */
   public AbstractRestClient() {
@@ -58,7 +58,7 @@ public abstract class AbstractRestClient {
   }
 
   /**
-   * For testing only, create a client with an alternate URLFactory. This constructor allows
+   * For testing only, create a client with an alternate client. This constructor allows
    * unit tests to mock server communication.
    */
   public AbstractRestClient(Client client) {
@@ -89,12 +89,11 @@ public abstract class AbstractRestClient {
 
   /**
    * Perform a POST request to the given URL, with a JSON or raw string as content.
-   * If the payload is an object that will be serialized to JSON the isContentTypeJSON must be set to true
-   * @param <T>  the type parameter defined as the return type of the response parser method
    * @param url the http url
    * @param postContent the post content
    */
-  public <T> T doPost(String url, MultivaluedMap<String, Object> headers, Object postContent, ParseResponseFunction<Response, T> responseParserFunc) throws IOException {
+  public <T> T doPost(String url, MultivaluedMap<String, Object> headers, Object postContent,
+      ParseResponseFunction<Response, T> responseParserFunc) throws IOException {
     long startedMillis = System.currentTimeMillis();
 
     WebTarget webTarget = this.client.target(url);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/AbstractRestClient.java
@@ -33,17 +33,18 @@ import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
+import javax.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 /**
- * A generic API Rest Client to perform GET and POST
+ * A generic API Rest Client to perform short-lived http GET and POST
  */
 public abstract class AbstractRestClient {
   private final Logger LOG = LoggerFactory.getLogger(this.getClass());
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private final HttpURLConnectionFactory connectionFactory;
 
   /**
@@ -257,13 +258,12 @@ public abstract class AbstractRestClient {
   }
 
   /**
-   * Implementation for a single method class that can be used with doGet and doPost in order to parse the response to
-   * a Map<String,Object>
+   * Implementation for a single method class that can be used with doGet and doPost in order to parse a response stream
+   * to a Map<String,Object>
    */
   public class ResponseToMap implements ParseResponseFunction<InputStream, Map<String, Object>> {
     public Map<String, Object> parse(InputStream inputStream) throws IOException {
-      return OBJECT_MAPPER.readValue(inputStream, new TypeReference<Map<String, Object>>() {
-      });
+      return OBJECT_MAPPER.readValue(inputStream, new TypeReference<Map<String, Object>>() {});
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/ParseResponseFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/ParseResponseFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.restclient;
+
+import java.io.IOException;
+
+
+/**
+ * A functional interface to allow passing a function to the rest client that would parse the response
+ *
+ * @param <T>  the type parameter
+ * @param <R>  the type parameter
+ */
+public interface ParseResponseFunction<T,R> {
+  /**
+   * Function that will take in a respnse and parse into an object
+   *
+   * @param t the t
+   * @return the r
+   * @throws IOException the io exception
+   */
+  R parse(T t) throws IOException;
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/Protocol.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/Protocol.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.restclient;
+
+public enum Protocol {
+  HTTP("http://"),
+  HTTPS("https://");
+
+  private String val;
+
+  Protocol(String val) {
+    this.val = val;
+  }
+
+  public String val() {
+    return this.val;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/ThirdEyeRcaRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/ThirdEyeRcaRestClient.java
@@ -20,10 +20,13 @@
 package org.apache.pinot.thirdeye.common.restclient;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.AuthResource;
@@ -55,9 +58,9 @@ public class ThirdEyeRcaRestClient extends AbstractRestClient {
     }
   }
 
-  /** For testing only, create a client with an alternate URLFactory. This constructor allows unit tests to mock server communication. */
-  /* package private */  ThirdEyeRcaRestClient(HttpURLConnectionFactory connectionFactory, ThirdEyePrincipal principal) {
-    super(connectionFactory);
+  /** For testing only, create a client with an alternate Client. This constructor allows unit tests to mock server communication. */
+  /* package private */  ThirdEyeRcaRestClient(Client client, ThirdEyePrincipal principal) {
+    super(client);
     this.principal = principal;
     this.thirdEyeHost = DEFAULT_THIRDEYE_RCA_SERVICE_HOST;
   }
@@ -69,12 +72,11 @@ public class ThirdEyeRcaRestClient extends AbstractRestClient {
     TreeMap<String, String> queryParameters = new TreeMap<String, String>();
     queryParameters.put("anomalyId", String.valueOf(anomalyId));
 
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Cookie", AuthResource.AUTH_TOKEN_NAME + "=" + principal.getSessionKey());
+    MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+    headers.put("Cookie", Arrays.asList(AuthResource.AUTH_TOKEN_NAME + "=" + principal.getSessionKey()));
 
     return doGet(
         composeUrl(this.thirdEyeHost, THIRDEYE_RCA_HIGHLIGHTS_URI, queryParameters),
-        this.thirdEyeHost,
         headers,
         new ResponseToMap());
   }
@@ -96,11 +98,11 @@ public class ThirdEyeRcaRestClient extends AbstractRestClient {
     queryParameters.put(CUBE_SUMMARY_SIZE, Long.toString(cubeSummarySize));
     queryParameters.put(CUBE_ORDER_TYPE, "auto");
 
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Cookie", AuthResource.AUTH_TOKEN_NAME + "=" + principal.getSessionKey());
+    MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+    headers.put("Cookie", Arrays.asList(AuthResource.AUTH_TOKEN_NAME + "=" + principal.getSessionKey()));
+
     return doGet(
         composeUrl(this.thirdEyeHost, THIRDEYE_RCA_CUBE_URI, queryParameters),
-        this.thirdEyeHost,
         headers,
         new ResponseToMap());
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/ThirdEyeRcaRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/ThirdEyeRcaRestClient.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.restclient;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.AuthResource;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
+
+import static org.apache.pinot.thirdeye.common.constants.rca.MultiDimensionalSummaryConstants.*;
+import static org.apache.pinot.thirdeye.common.constants.rca.RootCauseResourceConstants.*;
+
+
+/**
+ * ThirdEye API Client to communicate with ThirdEye RCA services
+ */
+public class ThirdEyeRcaRestClient extends AbstractRestClient {
+
+  private final String DEFAULT_THIRDEYE_RCA_SERVICE_HOST = "localhost:1426";
+  private final String THIRDEYE_RCA_CUBE_URI = "/dashboard/summary/autoDimensionOrder";
+  private final String THIRDEYE_RCA_HIGHLIGHTS_URI = "/rootcause/highlights";
+
+  private ThirdEyePrincipal principal;
+  private String thirdEyeHost;
+
+  public ThirdEyeRcaRestClient(ThirdEyePrincipal principal, String host) {
+    super();
+    this.principal = principal;
+
+    if (StringUtils.isEmpty(host)) {
+      this.thirdEyeHost = DEFAULT_THIRDEYE_RCA_SERVICE_HOST;
+    } else {
+      this.thirdEyeHost = host;
+    }
+  }
+
+  /** For testing only, create a client with an alternate URLFactory. This constructor allows unit tests to mock server communication. */
+  /* package private */  ThirdEyeRcaRestClient(HttpURLConnectionFactory connectionFactory, ThirdEyePrincipal principal) {
+    super(connectionFactory);
+    this.principal = principal;
+    this.thirdEyeHost = DEFAULT_THIRDEYE_RCA_SERVICE_HOST;
+  }
+
+  public Map<String, Object> getAllHighlights(long anomalyId) throws IOException {
+    TreeMap<String, String> queryParameters = new TreeMap<String, String>();
+    queryParameters.put("anomalyId", String.valueOf(anomalyId));
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put("Cookie", AuthResource.AUTH_TOKEN_NAME + "=" + principal.getSessionKey());
+    return doGet(
+        composeUrl(this.thirdEyeHost, THIRDEYE_RCA_HIGHLIGHTS_URI, queryParameters),
+        this.thirdEyeHost,
+        headers,
+        new ResponseToMap());
+  }
+
+  public Map<String, Object> getCubeHighlights(long anomalyId) throws IOException {
+    MergedAnomalyResultDTO anomalyDTO = DAORegistry.getInstance().getMergedAnomalyResultDAO().findById(anomalyId);
+
+    long startTime = anomalyDTO.getStartTime();
+    long endTime = anomalyDTO.getEndTime();
+    TreeMap<String, String> queryParameters = new TreeMap<String, String>();
+    queryParameters.put(METRIC_URN, anomalyDTO.getMetricUrn());
+    queryParameters.put(BASELINE_START, String.valueOf(startTime - TimeUnit.DAYS.toMillis(7)));
+    queryParameters.put(BASELINE_END, String.valueOf(endTime - TimeUnit.DAYS.toMillis(7)));
+    queryParameters.put(CURRENT_START, String.valueOf(startTime));
+    queryParameters.put(CURRENT_END, String.valueOf(endTime));
+
+    queryParameters.put(CUBE_DEPTH, "3");
+    queryParameters.put(CUBE_ONE_SIDE_ERROR, "false");
+    queryParameters.put(CUBE_ORDER_TYPE, "auto");
+    queryParameters.put(CUBE_SUMMARY_SIZE, "3");
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put("Cookie", AuthResource.AUTH_TOKEN_NAME + "=" + principal.getSessionKey());
+    return doGet(
+        composeUrl(this.thirdEyeHost, THIRDEYE_RCA_CUBE_URI, queryParameters),
+        this.thirdEyeHost,
+        headers,
+        new ResponseToMap());
+  }
+
+  public Map<String, Object> getRelatedEventHighlights(long anomalyId) throws IOException {
+    // TODO: placeholder
+    return new HashMap<>();
+  }
+
+  public Map<String, Object> getRelatedMetricHighlights(long anomalyId) throws IOException {
+    // TODO: placeholder
+    return new HashMap<>();
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/ThirdEyeRestClientConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/restclient/ThirdEyeRestClientConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.restclient;
+
+import java.util.Optional;
+
+
+public class ThirdEyeRestClientConfiguration {
+  private String adminUser;
+  private String sessionKey;
+  private static final String DEFAULT_THIRDEYE_SERVICE_NAME = "thirdeye";
+  private static final String DEFAULT_THIRDEYE_SERVICE_KEY = "thirdeyeServiceKey";
+
+  public String getAdminUser() {
+    return Optional.ofNullable(adminUser).orElse(DEFAULT_THIRDEYE_SERVICE_NAME);
+  }
+
+  public void setAdminUser(String adminUser) {
+    this.adminUser = adminUser;
+  }
+
+  public String getSessionKey() {
+    return Optional.ofNullable(sessionKey).orElse(DEFAULT_THIRDEYE_SERVICE_KEY);
+  }
+
+  public void setSessionKey(String sessionKey) {
+    this.sessionKey = sessionKey;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/utils/SessionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/utils/SessionUtils.java
@@ -1,0 +1,16 @@
+package org.apache.pinot.thirdeye.common.utils;
+
+import org.apache.pinot.thirdeye.datalayer.dto.SessionDTO;
+import org.apache.pinot.thirdeye.datalayer.pojo.SessionBean;
+
+
+public class SessionUtils {
+  public static SessionDTO buildServiceAccount(String user, String sessionKey, long expiryInMillis) {
+    SessionDTO sessionDTO = new SessionDTO();
+    sessionDTO.setPrincipal(user);
+    sessionDTO.setPrincipalType(SessionBean.PrincipalType.SERVICE);
+    sessionDTO.setSessionKey(sessionKey);
+    sessionDTO.setExpirationTime(expiryInMillis);
+    return sessionDTO;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -238,8 +238,8 @@ public class ThirdEyeDashboardApplication
       }
 
       env.jersey().register(new ThirdEyeAuthFilter(authenticator, authConfig.getAllowedPaths(), authConfig.getAdminUsers(), DAORegistry.getInstance().getSessionDAO()));
-      env.jersey().register(new AuthResource(authenticator, authConfig.getCookieTTL() * 1000));
       env.jersey().register(new AuthValueFactoryProvider.Binder<>(ThirdEyePrincipal.class));
+      env.jersey().register(new AuthResource(authenticator, authConfig.getCookieTTL() * 1000));
     }
 
     if (config.getModelDownloaderConfig() != null) {
@@ -273,6 +273,7 @@ public class ThirdEyeDashboardApplication
 
     RootCauseConfiguration rcConfig = config.getRootCause();
     return new RootCauseResource(
+        config.getDashboardHost(),
         makeRootCauseFrameworks(rcConfig, definitionsFile),
         makeRootCauseFormatters(rcConfig));
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -273,7 +273,6 @@ public class ThirdEyeDashboardApplication
 
     RootCauseConfiguration rcConfig = config.getRootCause();
     return new RootCauseResource(
-        config.getDashboardHost(),
         makeRootCauseFrameworks(rcConfig, definitionsFile),
         makeRootCauseFormatters(rcConfig));
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/SummaryResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/SummaryResource.java
@@ -69,11 +69,11 @@ public class SummaryResource {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
 
-  private static final String DEFAULT_TIMEZONE_ID = "UTC";
-  private static final String DEFAULT_DEPTH = "3";
-  private static final String DEFAULT_HIERARCHIES = "[]";
-  private static final String DEFAULT_ONE_SIDE_ERROR = "false";
-  private static final String DEFAULT_EXCLUDED_DIMENSIONS = "";
+  public static final String DEFAULT_TIMEZONE_ID = "UTC";
+  public static final String DEFAULT_DEPTH = "3";
+  public static final String DEFAULT_HIERARCHIES = "[]";
+  public static final String DEFAULT_ONE_SIDE_ERROR = "false";
+  public static final String DEFAULT_EXCLUDED_DIMENSIONS = "";
   private static final String JAVASCRIPT_NULL_STRING = "undefined";
   private static final String HTML_STRING_ENCODING = "UTF-8";
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/SummaryResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/SummaryResource.java
@@ -59,6 +59,9 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.pinot.thirdeye.common.constants.rca.MultiDimensionalSummaryConstants.*;
+import static org.apache.pinot.thirdeye.common.constants.rca.RootCauseResourceConstants.*;
+
 
 @Path(value = "/dashboard")
 public class SummaryResource {
@@ -96,21 +99,21 @@ public class SummaryResource {
   @Path(value = "/summary/autoDimensionOrder")
   @Produces(MediaType.APPLICATION_JSON)
   public String buildSummary(
-      @QueryParam("metricUrn") String metricUrn,
+      @QueryParam(METRIC_URN) String metricUrn,
       @QueryParam("dataset") String dataset,
       @QueryParam("metric") String metric,
-      @QueryParam("currentStart") long currentStartInclusive,
-      @QueryParam("currentEnd") long currentEndExclusive,
-      @QueryParam("baselineStart") long baselineStartInclusive,
-      @QueryParam("baselineEnd") long baselineEndExclusive,
+      @QueryParam(CURRENT_START) long currentStartInclusive,
+      @QueryParam(CURRENT_END) long currentEndExclusive,
+      @QueryParam(BASELINE_START) long baselineStartInclusive,
+      @QueryParam(BASELINE_END) long baselineEndExclusive,
       @QueryParam("dimensions") String groupByDimensions,
       @QueryParam("filters") String filterJsonPayload,
-      @QueryParam("summarySize") int summarySize,
-      @QueryParam("depth") @DefaultValue(DEFAULT_DEPTH) int depth,
-      @QueryParam("hierarchies") @DefaultValue(DEFAULT_HIERARCHIES) String hierarchiesPayload,
-      @QueryParam("oneSideError") @DefaultValue(DEFAULT_ONE_SIDE_ERROR) boolean doOneSideError,
-      @QueryParam("excludedDimensions") @DefaultValue(DEFAULT_EXCLUDED_DIMENSIONS) String excludedDimensions,
-      @QueryParam("timeZone") @DefaultValue(DEFAULT_TIMEZONE_ID) String timeZone) throws Exception {
+      @QueryParam(CUBE_SUMMARY_SIZE) int summarySize,
+      @QueryParam(CUBE_DEPTH) @DefaultValue(DEFAULT_DEPTH) int depth,
+      @QueryParam(CUBE_DIM_HIERARCHIES) @DefaultValue(DEFAULT_HIERARCHIES) String hierarchiesPayload,
+      @QueryParam(CUBE_ONE_SIDE_ERROR) @DefaultValue(DEFAULT_ONE_SIDE_ERROR) boolean doOneSideError,
+      @QueryParam(CUBE_EXCLUDED_DIMENSIONS) @DefaultValue(DEFAULT_EXCLUDED_DIMENSIONS) String excludedDimensions,
+      @QueryParam(TIME_ZONE) @DefaultValue(DEFAULT_TIMEZONE_ID) String timeZone) throws Exception {
     if (summarySize < 1) summarySize = 1;
 
     String metricName = metric;
@@ -176,18 +179,18 @@ public class SummaryResource {
   @Path(value = "/summary/manualDimensionOrder")
   @Produces(MediaType.APPLICATION_JSON)
   public String buildSummaryManualDimensionOrder(
-      @QueryParam("metricUrn") String metricUrn,
+      @QueryParam(METRIC_URN) String metricUrn,
       @QueryParam("dataset") String dataset,
       @QueryParam("metric") String metric,
-      @QueryParam("currentStart") long currentStartInclusive,
-      @QueryParam("currentEnd") long currentEndExclusive,
-      @QueryParam("baselineStart") long baselineStartInclusive,
-      @QueryParam("baselineEnd") long baselineEndExclusive,
+      @QueryParam(CURRENT_START) long currentStartInclusive,
+      @QueryParam(CURRENT_END) long currentEndExclusive,
+      @QueryParam(BASELINE_START) long baselineStartInclusive,
+      @QueryParam(BASELINE_END) long baselineEndExclusive,
       @QueryParam("dimensions") String groupByDimensions,
       @QueryParam("filters") String filterJsonPayload,
-      @QueryParam("summarySize") int summarySize,
-      @QueryParam("oneSideError") @DefaultValue(DEFAULT_ONE_SIDE_ERROR) boolean doOneSideError,
-      @QueryParam("timeZone") @DefaultValue(DEFAULT_TIMEZONE_ID) String timeZone) throws Exception {
+      @QueryParam(CUBE_SUMMARY_SIZE) int summarySize,
+      @QueryParam(CUBE_ONE_SIDE_ERROR) @DefaultValue(DEFAULT_ONE_SIDE_ERROR) boolean doOneSideError,
+      @QueryParam(TIME_ZONE) @DefaultValue(DEFAULT_TIMEZONE_ID) String timeZone) throws Exception {
     if (summarySize < 1) summarySize = 1;
 
     String metricName = metric;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/RootCauseResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/RootCauseResource.java
@@ -20,12 +20,10 @@
 package org.apache.pinot.thirdeye.dashboard.resources.v2;
 
 import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,17 +32,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import joptsimple.internal.Strings;
 import org.apache.pinot.thirdeye.api.Constants;
 import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
-import org.apache.pinot.thirdeye.common.restclient.ThirdEyeRcaRestClient;
 import org.apache.pinot.thirdeye.dashboard.resources.SummaryResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.pojo.RootCauseEntity;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
@@ -104,7 +99,7 @@ public class RootCauseResource {
         anomalyDTO.getEndTime() - TimeUnit.DAYS.toMillis(7), Strings.EMPTY, Strings.EMPTY,
         DEFAULT_HIGHLIGHT_CUBE_SUMMARY_SIZE, DEFAULT_HIGHLIGHT_CUBE_DEPTH, SummaryResource.DEFAULT_HIERARCHIES,
         false, DEFAULT_EXCLUDED_DIMENSIONS, SummaryResource.DEFAULT_TIMEZONE_ID);
-    responseMessage.put("cubeResults", new Gson().toJson(cubeHighlights));
+    responseMessage.put("cubeResults", cubeHighlights);
 
     return responseMessage;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionAlertScheme.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionAlertScheme.java
@@ -98,4 +98,8 @@ public abstract class DetectionAlertScheme {
           numOfAnomalies, this.subsConfig.getId(), e);
     }
   }
+
+  protected BaseNotificationContent getNotificationContent(Properties alertSchemeClientConfigs) {
+    return buildNotificationContent(alertSchemeClientConfigs);
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -148,7 +148,7 @@ public class DetectionEmailAlerter extends DetectionAlertScheme {
     blacklistRecipients(recipients);
     validateAlert(recipients, anomalies);
 
-    BaseNotificationContent content = buildNotificationContent(emailClientConfigs);
+    BaseNotificationContent content = getNotificationContent(emailClientConfigs);
     EmailEntity emailEntity = new EmailContentFormatter(emailClientConfigs, content, this.teConfig, subsConfig)
         .getEmailEntity(anomalies);
     if (Strings.isNullOrEmpty(this.subsConfig.getFrom())) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerter.java
@@ -21,7 +21,6 @@ package org.apache.pinot.thirdeye.detection.alert.scheme;
 
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.google.common.base.Preconditions;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -142,7 +141,7 @@ public class DetectionJiraAlerter extends DetectionAlertScheme {
     List<AnomalyResult> anomalyResultListOfGroup = new ArrayList<>(anomalies);
     anomalyResultListOfGroup.sort(COMPARATOR_DESC);
 
-    BaseNotificationContent content = super.buildNotificationContent(jiraClientConfig);
+    BaseNotificationContent content = getNotificationContent(jiraClientConfig);
 
     return new JiraContentFormatter(this.jiraAdminConfig, jiraClientConfig, content, this.teConfig, subsetSubsConfig)
         .getJiraEntity(notification.getDimensionFilters(), anomalyResultListOfGroup);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeJiraClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeJiraClient.java
@@ -108,7 +108,7 @@ public class ThirdEyeJiraClient {
     jiraQuery.append(" and ").append(buildQueryOnLabels(labels));
     jiraQuery.append(" and ").append(buildQueryOnCreatedBy(lookBackMillis));
 
-    Iterable<Issue> jiraIssuesIt = restClient.getSearchClient().searchJql(jiraQuery.toString()).claim().getIssues();Set up the client with a default URLFactory that creates real HTTP connections.
+    Iterable<Issue> jiraIssuesIt = restClient.getSearchClient().searchJql(jiraQuery.toString()).claim().getIssues();
     jiraIssuesIt.forEach(issues::add);
 
     LOG.info("Fetched {} Jira tickets using query - {}", issues.size(), jiraQuery.toString());

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeJiraClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeJiraClient.java
@@ -108,7 +108,7 @@ public class ThirdEyeJiraClient {
     jiraQuery.append(" and ").append(buildQueryOnLabels(labels));
     jiraQuery.append(" and ").append(buildQueryOnCreatedBy(lookBackMillis));
 
-    Iterable<Issue> jiraIssuesIt = restClient.getSearchClient().searchJql(jiraQuery.toString()).claim().getIssues();
+    Iterable<Issue> jiraIssuesIt = restClient.getSearchClient().searchJql(jiraQuery.toString()).claim().getIssues();Set up the client with a default URLFactory that creates real HTTP connections.
     jiraIssuesIt.forEach(issues::add);
 
     LOG.info("Fetched {} Jira tickets using query - {}", issues.size(), jiraQuery.toString());

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/BaseNotificationContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/BaseNotificationContent.java
@@ -525,11 +525,12 @@ public abstract class BaseNotificationContent implements NotificationContent {
     String entityName;
     String anomalyType;
     String properties;
+    String metricUrn;
 
     public AnomalyReportEntity(String anomalyId, String anomalyURL, String baselineVal, String currentVal, String lift,
         boolean positiveLift, Double swi, List<String> dimensions, String duration, String feedback, String function,
         String funcDescription, String metric, String startTime, String endTime, String timezone, String issueType,
-        String anomalyType, String properties) {
+        String anomalyType, String properties, String metricUrn) {
       this.anomalyId = anomalyId;
       this.anomalyURL = anomalyURL;
       this.baselineVal = baselineVal;
@@ -556,6 +557,7 @@ public abstract class BaseNotificationContent implements NotificationContent {
       this.issueType = issueType;
       this.anomalyType = anomalyType;
       this.properties = properties;
+      this.metricUrn = metricUrn;
     }
 
     public void setSeasonalValues(COMPARE_MODE compareMode, double seasonalValue, double current) {
@@ -871,6 +873,14 @@ public abstract class BaseNotificationContent implements NotificationContent {
 
     public void setWo4wLift(String wo4wLift) {
       this.wo4wLift = wo4wLift;
+    }
+
+    public String getMetricUrn() {
+      return metricUrn;
+    }
+
+    public void setMetricUrn(String metricUrn) {
+      this.metricUrn = metricUrn;
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/EntityGroupKeyContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/EntityGroupKeyContent.java
@@ -161,7 +161,7 @@ public class EntityGroupKeyContent extends BaseNotificationContent {
         detectionConfig.getName(), detectionConfig.getDescription(), anomaly.getMetric(),
         getDateString(anomaly.getStartTime(), dateTimeZone), getDateString(anomaly.getEndTime(), dateTimeZone),
         getTimezoneString(dateTimeZone), getIssueType(anomaly), anomaly.getType().getLabel(),
-        ThirdEyeStringUtils.encodeCompactedProperties(props));
+        ThirdEyeStringUtils.encodeCompactedProperties(props), anomaly.getMetricUrn());
 
     // Extract out the whitelisted metrics
     if (anomaly.getProperties() != null && anomaly.getProperties().containsKey(PROP_SUB_ENTITY_NAME)

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/HierarchicalAnomaliesContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/HierarchicalAnomaliesContent.java
@@ -169,8 +169,8 @@ public class HierarchicalAnomaliesContent extends BaseNotificationContent {
         getTimezoneString(dateTimeZone),
         getIssueType(anomaly),
         anomaly.getType().getLabel(),
-        ThirdEyeStringUtils.encodeCompactedProperties(props)
-
+        ThirdEyeStringUtils.encodeCompactedProperties(props),
+        anomaly.getMetricUrn()
     );
 
     List<String> affectedCountries = getMatchedFilterValues(anomaly, "country");

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/MetricAnomaliesContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/MetricAnomaliesContent.java
@@ -23,18 +23,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import java.util.Properties;
-import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
-import org.apache.pinot.thirdeye.datalayer.util.ThirdEyeStringUtils;
-import org.apache.pinot.thirdeye.datasource.DAORegistry;
-import org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
-import org.apache.pinot.thirdeye.anomaly.alert.util.AlertScreenshotHelper;
-import org.apache.pinot.thirdeye.anomalydetection.context.AnomalyFeedback;
-import org.apache.pinot.thirdeye.anomalydetection.context.AnomalyResult;
-import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
-import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
-import org.apache.pinot.thirdeye.datalayer.dto.EventDTO;
-import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,9 +31,21 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
+import org.apache.pinot.thirdeye.anomaly.alert.util.AlertScreenshotHelper;
+import org.apache.pinot.thirdeye.anomalydetection.context.AnomalyFeedback;
+import org.apache.pinot.thirdeye.anomalydetection.context.AnomalyResult;
+import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
+import org.apache.pinot.thirdeye.common.restclient.ThirdEyeRcaRestClient;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.EventDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.datalayer.util.ThirdEyeStringUtils;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
-import org.apache.pinot.thirdeye.rootcause.impl.MetricEntity;
-import org.apache.pinot.thirdeye.util.ThirdEyeUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,7 +149,8 @@ public class MetricAnomaliesContent extends BaseNotificationContent {
           getTimezoneString(dateTimeZone),
           getIssueType(anomaly),
           anomaly.getType().getLabel(),
-          ThirdEyeStringUtils.encodeCompactedProperties(props)
+          ThirdEyeStringUtils.encodeCompactedProperties(props),
+          anomaly.getMetricUrn()
       );
 
       // dimension filters / values
@@ -198,6 +200,25 @@ public class MetricAnomaliesContent extends BaseNotificationContent {
     templateData.put("detectionToAnomalyDetailsMap", functionAnomalyReports.asMap());
     templateData.put("metricToAnomalyDetailsMap", metricAnomalyReports.asMap());
     templateData.put("functionToId", functionToId);
+
+    // Display RCA highlights in email only if report contains anomalies belonging to a single metric.
+    // Note: Once we have a sophisticated rca highlight support and users start seeing value, we'll
+    // enable it for all the metrics.
+    if (metricAnomalyReports.keySet().size() == 1) {
+      String anomalyId = metricAnomalyReports.values().iterator().next().getAnomalyId();
+      Map<String, Object> rcaHighlights = new HashMap<>();
+      try {
+        ThirdEyePrincipal principal = new ThirdEyePrincipal();
+        principal.setName(this.thirdEyeAnomalyConfig.getThirdEyeRestClientConfiguration().getAdminUser());
+        principal.setSessionKey(this.thirdEyeAnomalyConfig.getThirdEyeRestClientConfiguration().getSessionKey());
+        rcaHighlights = new ThirdEyeRcaRestClient(principal, this.thirdEyeAnomalyConfig.getDashboardHost())
+            .getAllHighlights(Long.parseLong(anomalyId));
+      } catch (IOException e) {
+        LOG.error("Failed to retrieve the RCA Highlights for anomaly " + anomalyId, e);
+      }
+      LOG.info("Setting rootCauseHighlights in email template " + rcaHighlights);
+      templateData.put("rootCauseHighlights", rcaHighlights);
+    }
 
     return templateData;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/MetricAnomaliesContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/MetricAnomaliesContent.java
@@ -212,7 +212,7 @@ public class MetricAnomaliesContent extends BaseNotificationContent {
         principal.setName(this.thirdEyeAnomalyConfig.getThirdEyeRestClientConfiguration().getAdminUser());
         principal.setSessionKey(this.thirdEyeAnomalyConfig.getThirdEyeRestClientConfiguration().getSessionKey());
         rcaHighlights = new ThirdEyeRcaRestClient(principal, this.thirdEyeAnomalyConfig.getDashboardHost())
-            .getAllHighlights(Long.parseLong(anomalyId));
+            .getRootCauseHighlights(Long.parseLong(anomalyId));
       } catch (IOException e) {
         LOG.error("Failed to retrieve the RCA Highlights for anomaly " + anomalyId, e);
       }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/MockAbstractRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/MockAbstractRestClient.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.restclient;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.nio.charset.Charset;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.Assert;
+
+
+public class MockAbstractRestClient {
+  static AbstractRestClient.HttpURLConnectionFactory setupMock(final String expectedUrl, final String response,
+      HttpURLConnection mockConn) throws Exception {
+    return setupMock(expectedUrl, 200, response, mockConn);
+  }
+
+  static AbstractRestClient.HttpURLConnectionFactory setupMock(final String expectedUrl, final int responseCode,
+      final String response, HttpURLConnection mockConn) throws Exception {
+    AbstractRestClient.HttpURLConnectionFactory connectionFactory
+        = Mockito.mock(AbstractRestClient.HttpURLConnectionFactory.class);
+    final AtomicInteger callCount = new AtomicInteger(0);
+    Mockito.when(connectionFactory.openConnection(Mockito.anyString())).thenAnswer(new Answer<HttpURLConnection>() {
+      @Override
+      public HttpURLConnection answer(InvocationOnMock invocation) throws Throwable {
+        Assert.assertEquals(callCount.incrementAndGet(), 1,
+            "HTTP server called more than once.");
+        Assert.assertNotNull(invocation.getArguments(),
+            "Bad arguments to openConnection (getArguments() returned null)");
+        Assert.assertEquals(invocation.getArguments().length, 1,
+            "Bad arguments to openConnection. Expected exactly one argument.");
+        Assert.assertEquals(invocation.getArguments()[0], expectedUrl,
+            "Incorrect URL in the HTTP request.");
+        HttpURLConnection conn;
+
+        if(mockConn == null) {
+          conn = Mockito.mock(HttpURLConnection.class);
+          Mockito.when(conn.getOutputStream()).thenReturn(new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+              // This is a mock implementation. Write to nowhere.
+            }
+          });
+        }
+        else {
+          conn = mockConn;
+        }
+
+        Mockito.when(conn.getResponseCode()).thenReturn(responseCode);
+        if (responseCode >= 200 && responseCode <= 299) {
+          Mockito.when(conn.getInputStream())
+              .thenReturn(new ByteArrayInputStream(response.getBytes(Charset.forName("UTF-8"))));
+        } else {
+          Mockito.when(conn.getErrorStream())
+              .thenReturn(new ByteArrayInputStream(response.getBytes(Charset.forName("UTF-8"))));
+        }
+
+        return conn;
+      }
+    });
+
+    return connectionFactory;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/MockThirdEyeRcaRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/MockThirdEyeRcaRestClient.java
@@ -19,21 +19,22 @@
 
 package org.apache.pinot.thirdeye.common.restclient;
 
+import java.io.IOException;
 import java.util.Map;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 
-public class MockAbstractRestClient {
+public class MockThirdEyeRcaRestClient {
 
-  public static Client setupMockClient(final Map<String, Object> expectedResponse) {
+  public static ThirdEyeRcaRestClient setupMockClient(final Map<String, Object> expectedResponse) {
     Client client = mock(Client.class);
 
     WebTarget webTarget = mock(WebTarget.class);
@@ -47,6 +48,9 @@ public class MockAbstractRestClient {
     when(builder.get()).thenReturn(response);
     when(response.readEntity(any(GenericType.class))).thenReturn(expectedResponse);
 
-    return client;
+    ThirdEyePrincipal principal = new ThirdEyePrincipal();
+    principal.setSessionKey("dummy");
+
+    return new ThirdEyeRcaRestClient(client, principal);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestAbstractRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestAbstractRestClient.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.restclient;
+
+import java.io.IOException;
+import java.util.TreeMap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestAbstractRestClient extends AbstractRestClient {
+
+  /**
+   * Test compose url with null query parameters creates a valid url.
+   */
+  @Test
+  public void testComposeUrlNullQueryParameters() throws IOException {
+    String api = "/api/my/api";
+    String host = "host";
+
+    String actualUrl = composeUrl(host, api, null);
+    String expectedUrl = String.format("http://%s%s", host, api);
+
+    Assert.assertEquals(actualUrl,expectedUrl);
+  }
+
+  /**
+   * Test compose url parameter with space create a valid url
+   */
+  @Test
+  public void testComposeUrlGenericParameterWithSpaceAndSlash() throws IOException{
+    String api = "/api/my/api";
+    String host = "host";
+    String parameterName = "parameter";
+    String parameterValue = "param value";
+    TreeMap<String, String> queryParameters = new TreeMap<String, String>();
+    queryParameters.put(parameterName,parameterValue);
+
+    String actualUrl = composeUrlGeneric(Protocol.HTTPS, host, api, queryParameters);
+    String expectedUrl = "https://host/api/my/api?parameter=param%20value";
+
+    Assert.assertEquals(actualUrl,expectedUrl);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestThirdEyeRcaRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestThirdEyeRcaRestClient.java
@@ -19,7 +19,9 @@
 
 package org.apache.pinot.thirdeye.common.restclient;
 
+import java.util.HashMap;
 import java.util.Map;
+import javax.ws.rs.client.Client;
 import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
 import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
@@ -30,8 +32,6 @@ import org.testng.annotations.Test;
 
 
 public class TestThirdEyeRcaRestClient {
-
-  private static String SAMPLE_RESPONSE = "{\"cubeResults\": \"{}\"}";
 
   private DAOTestBase testDAOProvider;
   private long anomalyId;
@@ -46,17 +46,20 @@ public class TestThirdEyeRcaRestClient {
     anomaly.setMetric("metric");
     anomalyId = daoRegistry.getMergedAnomalyResultDAO().save(anomaly);
   }
+
   @Test
   public void testGetAllHighlights() throws Exception {
-    AbstractRestClient.HttpURLConnectionFactory factory = MockAbstractRestClient.setupMock(
-        "http://localhost:1426/rootcause/highlights?anomalyId=1",
-        SAMPLE_RESPONSE, null);
+    Map<String, Object> expectedResponse = new HashMap<>();
+    expectedResponse.put("cubeResults", "{}");
+
+    Client client = MockAbstractRestClient.setupMockClient(expectedResponse);
 
     ThirdEyePrincipal principal = new ThirdEyePrincipal();
     principal.setSessionKey("dummy");
-    ThirdEyeRcaRestClient client = new ThirdEyeRcaRestClient(factory, principal);
-    Map<String, Object> result = client.getRootCauseHighlights(anomalyId);
+    ThirdEyeRcaRestClient rcaClient = new ThirdEyeRcaRestClient(client, principal);
+    Map<String, Object> result = rcaClient.getRootCauseHighlights(anomalyId);
 
     Assert.assertTrue(result.containsKey("cubeResults"));
+    Assert.assertEquals(expectedResponse.get("cubeResults"), result.get("cubeResults"));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestThirdEyeRcaRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestThirdEyeRcaRestClient.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.common.restclient;
+
+import java.util.Map;
+import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
+import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TestThirdEyeRcaRestClient {
+
+  private static String SAMPLE_RESPONSE = "{ \"relatedMetrics\": \"{}\"," + " \"relatedEvents\": \"{}\"," + " \"cubeResults\": \"{}\"}";
+
+  private DAOTestBase testDAOProvider;
+  private long anomalyId;
+
+  @BeforeMethod
+  public void beforeMethod() throws Exception {
+    this.testDAOProvider = DAOTestBase.getInstance();
+    DAORegistry daoRegistry = DAORegistry.getInstance();
+
+    MergedAnomalyResultDTO anomaly = new MergedAnomalyResultDTO();
+    anomaly.setCollection("collection");
+    anomaly.setMetric("metric");
+    anomalyId = daoRegistry.getMergedAnomalyResultDAO().save(anomaly);
+  }
+  @Test
+  public void testGetAllHighlights() throws Exception {
+    AbstractRestClient.HttpURLConnectionFactory factory = MockAbstractRestClient.setupMock(
+        "http://localhost:1426/rootcause/highlights?anomalyId=1",
+        SAMPLE_RESPONSE, null);
+
+    ThirdEyePrincipal principal = new ThirdEyePrincipal();
+    principal.setSessionKey("dummy");
+    ThirdEyeRcaRestClient client = new ThirdEyeRcaRestClient(factory, principal);
+    Map<String, Object> result = client.getAllHighlights(anomalyId);
+
+    Assert.assertTrue(result.containsKey("relatedMetrics"));
+    Assert.assertTrue(result.containsKey("relatedEvents"));
+    Assert.assertTrue(result.containsKey("cubeResults"));
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestThirdEyeRcaRestClient.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestThirdEyeRcaRestClient.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 public class TestThirdEyeRcaRestClient {
 
-  private static String SAMPLE_RESPONSE = "{ \"relatedMetrics\": \"{}\"," + " \"relatedEvents\": \"{}\"," + " \"cubeResults\": \"{}\"}";
+  private static String SAMPLE_RESPONSE = "{\"cubeResults\": \"{}\"}";
 
   private DAOTestBase testDAOProvider;
   private long anomalyId;
@@ -55,10 +55,8 @@ public class TestThirdEyeRcaRestClient {
     ThirdEyePrincipal principal = new ThirdEyePrincipal();
     principal.setSessionKey("dummy");
     ThirdEyeRcaRestClient client = new ThirdEyeRcaRestClient(factory, principal);
-    Map<String, Object> result = client.getAllHighlights(anomalyId);
+    Map<String, Object> result = client.getRootCauseHighlights(anomalyId);
 
-    Assert.assertTrue(result.containsKey("relatedMetrics"));
-    Assert.assertTrue(result.containsKey("relatedEvents"));
     Assert.assertTrue(result.containsKey("cubeResults"));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionEmailAlerterTest.java
@@ -20,9 +20,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import org.apache.commons.mail.HtmlEmail;
 import org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
+import org.apache.pinot.thirdeye.common.restclient.MockThirdEyeRcaRestClient;
+import org.apache.pinot.thirdeye.common.restclient.ThirdEyeRcaRestClient;
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionAlertConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
@@ -36,6 +39,8 @@ import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotificatio
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
 import org.apache.pinot.thirdeye.detection.alert.filter.SubscriptionUtils;
 import org.apache.pinot.thirdeye.notification.commons.EmailEntity;
+import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
+import org.apache.pinot.thirdeye.notification.content.templates.MetricAnomaliesContent;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -148,10 +153,20 @@ public class DetectionEmailAlerterTest {
     final HtmlEmail htmlEmail = mock(HtmlEmail.class);
     when(htmlEmail.send()).thenReturn("sent");
 
+    Map<String, Object> expectedResponse = new HashMap<>();
+    expectedResponse.put("cubeResults", "{}");
+    ThirdEyeRcaRestClient rcaClient = MockThirdEyeRcaRestClient.setupMockClient(expectedResponse);
+    MetricAnomaliesContent metricAnomaliesContent = new MetricAnomaliesContent(rcaClient);
+
     DetectionEmailAlerter emailAlerter = new DetectionEmailAlerter(this.alertConfigDTO, this.thirdEyeConfig, notificationResults) {
       @Override
       protected HtmlEmail getHtmlContent(EmailEntity emailEntity) {
         return htmlEmail;
+      }
+
+      @Override
+      protected BaseNotificationContent getNotificationContent(Properties emailClientConfigs) {
+        return metricAnomaliesContent;
       }
     };
     // Executes successfully without errors

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionJiraAlerterTest.java
@@ -22,8 +22,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
+import org.apache.pinot.thirdeye.common.restclient.MockThirdEyeRcaRestClient;
+import org.apache.pinot.thirdeye.common.restclient.ThirdEyeRcaRestClient;
 import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionAlertConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
@@ -38,6 +41,8 @@ import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
 import org.apache.pinot.thirdeye.detection.alert.filter.SubscriptionUtils;
 import org.apache.pinot.thirdeye.notification.commons.JiraEntity;
 import org.apache.pinot.thirdeye.notification.commons.ThirdEyeJiraClient;
+import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
+import org.apache.pinot.thirdeye.notification.content.templates.MetricAnomaliesContent;
 import org.apache.pinot.thirdeye.notification.formatter.channels.TestJiraContentFormatter;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
@@ -140,7 +145,18 @@ public class DetectionJiraAlerterTest {
     doNothing().when(jiraClient).updateIssue(any(Issue.class), any(JiraEntity.class));
     doNothing().when(jiraClient).addComment(any(Issue.class), anyString());
 
-    DetectionJiraAlerter jiraAlerter = new DetectionJiraAlerter(this.alertConfigDTO, this.thirdEyeConfig, notificationResults, jiraClient);
+    Map<String, Object> expectedResponse = new HashMap<>();
+    expectedResponse.put("cubeResults", "{}");
+    ThirdEyeRcaRestClient rcaClient = MockThirdEyeRcaRestClient.setupMockClient(expectedResponse);
+    MetricAnomaliesContent metricAnomaliesContent = new MetricAnomaliesContent(rcaClient);
+
+    DetectionJiraAlerter jiraAlerter = new DetectionJiraAlerter(this.alertConfigDTO, this.thirdEyeConfig,
+        notificationResults, jiraClient) {
+      @Override
+      protected BaseNotificationContent getNotificationContent(Properties emailClientConfigs) {
+        return metricAnomaliesContent;
+      }
+    };
 
     // Executes successfully without errors
     jiraAlerter.run();

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/content/templates/TestMetricAnomaliesContent.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/content/templates/TestMetricAnomaliesContent.java
@@ -17,7 +17,12 @@
 package org.apache.pinot.thirdeye.notification.content.templates;
 
 import java.util.Properties;
+import javax.ws.rs.client.Client;
 import org.apache.pinot.thirdeye.anomaly.AnomalyType;
+import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
+import org.apache.pinot.thirdeye.common.restclient.MockAbstractRestClient;
+import org.apache.pinot.thirdeye.common.restclient.MockThirdEyeRcaRestClient;
+import org.apache.pinot.thirdeye.common.restclient.ThirdEyeRcaRestClient;
 import org.apache.pinot.thirdeye.constant.AnomalyResultSource;
 import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
@@ -66,6 +71,7 @@ import org.testng.annotations.Test;
 
 import static org.apache.pinot.thirdeye.datalayer.DaoTestUtils.*;
 import static org.apache.pinot.thirdeye.notification.commons.SmtpConfiguration.*;
+import static org.mockito.Mockito.*;
 
 
 public class TestMetricAnomaliesContent {
@@ -220,8 +226,12 @@ public class TestMetricAnomaliesContent {
     metric.setAlias(TEST + "::" + TEST);
     metricDAO.save(metric);
 
+    Map<String, Object> expectedResponse = new HashMap<>();
+    expectedResponse.put("cubeResults", "{}");
+    ThirdEyeRcaRestClient rcaClient = MockThirdEyeRcaRestClient.setupMockClient(expectedResponse);
+    MetricAnomaliesContent metricAnomaliesContent = new MetricAnomaliesContent(rcaClient);
     EmailContentFormatter
-        contentFormatter = new EmailContentFormatter(new Properties(), new MetricAnomaliesContent(),
+        contentFormatter = new EmailContentFormatter(new Properties(), metricAnomaliesContent,
         thirdeyeAnomalyConfig, DaoTestUtils.getTestNotificationConfig("Test Config"));
     EmailEntity emailEntity = contentFormatter.getEmailEntity(anomalies);
 


### PR DESCRIPTION
Given an anomaly, added an RCA highlights API which returns the cube results (and more). The PR also enables the notification pipeline to retrieve these results via a rest client. The results will be embedded into the alert email in a subsequent PR.

Changes:
* Created a generic API rest client (`AbstractRestClient`) for GET and POST requests and implemented an RCA rest client (`ThirdEyeRcaRestClient`) used for communicating with the RCA services.
* Packaged the rest client under the commons package so that it can be leveraged by all the modules.
* The Thirdeye rest client (admin service) account is configured in the `detector.yaml` configuration file.
Ex:
```
thirdeyeRestClient:
  adminUser: admin
  sessionKey: 1234
```
* Introduced a constants package under commons and moved some of the RCA constants there.
* Added unit tests for testing compose url and RCA rest client.
* Tested the entire pipeline by deploying locally.