### PR TITLE
Disallow table creation with dot in the table name

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -112,7 +112,11 @@ public class PinotTableRestletResource {
     TableConfig tableConfig;
     try {
       tableConfig = JsonUtils.stringToObject(tableConfigStr, TableConfig.class);
+      // TableConfigUtils.validate(...) is used across table create/update.
       TableConfigUtils.validate(tableConfig);
+      // TableConfigUtils.validateTableName(...) checks table name rules.
+      // So it won't effect already created tables.
+      TableConfigUtils.validateTableName(tableConfig);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -96,6 +96,17 @@ public class PinotTableRestletResourceTest extends ControllerTest {
       Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 400"));
     }
 
+    offlineTableConfig = _offlineBuilder.build();
+    offlineTableConfigJson = (ObjectNode) offlineTableConfig.toJsonNode();
+    offlineTableConfigJson.put(TableConfig.TABLE_NAME_KEY, "bad.table.with.dot");
+    try {
+      sendPostRequest(_createTableUrl, offlineTableConfigJson.toString());
+      Assert.fail("Creation of an OFFLINE table with dot in the table name does not fail");
+    } catch (IOException e) {
+      // Expected 400 Bad Request
+      Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 400"));
+    }
+
     // Create an OFFLINE table with a valid name which should succeed
     offlineTableConfig = _offlineBuilder.setTableName("valid_table_name").build();
     String offlineTableConfigString = offlineTableConfig.toJsonString();

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -56,6 +56,20 @@ public final class TableConfigUtils {
     validateIngestionConfig(tableConfig.getIngestionConfig());
   }
 
+  /**
+   * Validates the table name with the following rules:
+   * <ul>
+   *   <li>Table name shouldn't contain dot in it</li>
+   * </ul>
+   */
+  public static void validateTableName(TableConfig tableConfig) {
+    String tableName = tableConfig.getTableName();
+    if (tableName.contains(".")) {
+      throw new IllegalStateException(
+          "Table name: '" + tableName + "' containing '.' is not allowed");
+    }
+  }
+
   private static void validateValidationConfig(TableConfig tableConfig) {
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
     if (validationConfig != null) {


### PR DESCRIPTION
## Description
Disallow dot in table name during table creation.

## Release Notes
Disallow dot in table name during table creation.

Backward compatibility:
- No impact on existing tables, but no longer allow new table creation with dot in table name.