### PR TITLE
Support alias name to be same as selection

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -114,10 +114,9 @@ public class CalciteSqlParser {
     Set<String> aliasKeys = new HashSet<>();
     for (Identifier identifier : aliasMap.keySet()) {
       String aliasName = identifier.getName().toLowerCase();
-      if (aliasKeys.contains(aliasName)) {
+      if (!aliasKeys.add(aliasName)) {
         throw new SqlCompilationException("Duplicated alias name found.");
       }
-      aliasKeys.add(aliasName);
     }
     for (Expression selectExpr : pinotQuery.getSelectList()) {
       matchIdentifierInAliasMap(selectExpr, aliasKeys);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -113,7 +113,11 @@ public class CalciteSqlParser {
     // Sanity check on selection expression shouldn't use alias reference.
     Set<String> aliasKeys = new HashSet<>();
     for (Identifier identifier : aliasMap.keySet()) {
-      aliasKeys.add(identifier.getName().toLowerCase());
+      String aliasName = identifier.getName().toLowerCase();
+      if (aliasKeys.contains(aliasName)) {
+        throw new SqlCompilationException("Duplicated alias name found.");
+      }
+      aliasKeys.add(aliasName);
     }
     for (Expression selectExpr : pinotQuery.getSelectList()) {
       matchIdentifierInAliasMap(selectExpr, aliasKeys);
@@ -667,8 +671,7 @@ public class CalciteSqlParser {
         return RequestUtils.getLiteralExpression((SqlLiteral) node);
       case AS:
         SqlBasicCall asFuncSqlNode = (SqlBasicCall) node;
-        final Expression asFuncExpr = RequestUtils.getFunctionExpression(SqlKind.AS.toString());
-        asFuncExpr.getFunctionCall().addToOperands(toExpression(asFuncSqlNode.getOperands()[0]));
+        Expression leftExpr = toExpression(asFuncSqlNode.getOperands()[0]);
         SqlNode aliasSqlNode = asFuncSqlNode.getOperands()[1];
         String aliasName;
         switch (aliasSqlNode.getKind()) {
@@ -681,7 +684,16 @@ public class CalciteSqlParser {
           default:
             throw new SqlCompilationException("Unsupported Alias sql node - " + aliasSqlNode);
         }
-        asFuncExpr.getFunctionCall().addToOperands(RequestUtils.getIdentifierExpression(aliasName));
+        Expression rightExpr = RequestUtils.getIdentifierExpression(aliasName);
+        // Just return left identifier if both sides are the same identifier.
+        if (leftExpr.isSetIdentifier() && rightExpr.isSetIdentifier()) {
+          if (leftExpr.getIdentifier().getName().equals(rightExpr.getIdentifier().getName())) {
+            return leftExpr;
+          }
+        }
+        final Expression asFuncExpr = RequestUtils.getFunctionExpression(SqlKind.AS.toString());
+        asFuncExpr.getFunctionCall().addToOperands(leftExpr);
+        asFuncExpr.getFunctionCall().addToOperands(rightExpr);
         return asFuncExpr;
       case CASE:
         // CASE WHEN Statement is model as a function with variable length parameters.

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1246,6 +1246,17 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
+  public void testSameAliasInSelection() {
+    String sql;
+    PinotQuery pinotQuery;
+    sql = "SELECT C1 AS C1, C2 AS C2 FROM Foo";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    Assert.assertEquals(pinotQuery.getSelectListSize(), 2);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "C1");
+    Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "C2");
+  }
+
+  @Test
   public void testArithmeticOperator() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select a,b+2,c*5,(d+5)*2 from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 4);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -969,6 +969,22 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     testQuery(query, Collections.singletonList(query));
   }
 
+  @Test
+  public void testQueryWithSameAlias()
+      throws Exception {
+    //test repeated columns in selection query
+    String query = "SELECT ArrTime AS ArrTime, Carrier AS Carrier, DaysSinceEpoch AS DaysSinceEpoch FROM mytable ORDER BY DaysSinceEpoch DESC";
+    testQuery(query, Collections.singletonList(query));
+
+    //test repeated columns in selection query
+    query = "SELECT ArrTime AS ArrTime, DaysSinceEpoch AS DaysSinceEpoch, Carrier AS Carrier FROM mytable ORDER BY Carrier DESC";
+    testQuery(query, Collections.singletonList(query));
+
+    //test repeated columns in selection query
+    query = "SELECT ArrTime AS ArrTime, DaysSinceEpoch AS DaysSinceEpoch, Carrier AS Carrier FROM mytable ORDER BY Carrier DESC, ArrTime DESC";
+    testQuery(query, Collections.singletonList(query));
+  }
+
   @AfterClass
   public void tearDown()
       throws Exception {


### PR DESCRIPTION
## Description
A fix to support query like:
```
SELECT c1 AS c1 FROM myTable
```