### PR TITLE
Introduce IndexContainer in MutableSegmentImpl to reduce map lookups

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.indexsegment.mutable;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntArrays;
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -49,7 +50,7 @@ import org.apache.pinot.core.realtime.impl.invertedindex.RealtimeInvertedIndexRe
 import org.apache.pinot.core.realtime.impl.invertedindex.RealtimeLuceneIndexRefreshState;
 import org.apache.pinot.core.realtime.impl.invertedindex.RealtimeLuceneIndexRefreshState.RealtimeLuceneReaders;
 import org.apache.pinot.core.realtime.impl.invertedindex.RealtimeLuceneTextIndexReader;
-import org.apache.pinot.core.realtime.impl.nullvalue.RealtimeNullValueVectorReaderWriter;
+import org.apache.pinot.core.realtime.impl.nullvalue.MutableNullValueVector;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.index.datasource.ImmutableDataSource;
 import org.apache.pinot.core.segment.index.datasource.MutableDataSource;
@@ -58,7 +59,6 @@ import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.index.readers.BloomFilterReader;
 import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
 import org.apache.pinot.core.segment.index.readers.MutableForwardIndex;
-import org.apache.pinot.core.segment.index.readers.NullValueVectorReader;
 import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnContext;
 import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProvider;
 import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory;
@@ -75,11 +75,13 @@ import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.RowMetadata;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.IntIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class MutableSegmentImpl implements MutableSegment {
   // For multi-valued column, forward-index.
   // Maximum number of multi-values per row. We assert on this.
@@ -108,19 +110,8 @@ public class MutableSegmentImpl implements MutableSegment {
   private final int _partitionId;
   private final boolean _nullHandlingEnabled;
 
-  // TODO: Keep one map to store all these info
-  private final Map<String, NumValuesInfo> _numValuesInfoMap = new HashMap<>();
-  private final Map<String, BaseMutableDictionary> _dictionaryMap = new HashMap<>();
-  private final Map<String, MutableForwardIndex> _forwardIndexMap = new HashMap<>();
-  private final Map<String, InvertedIndexReader> _invertedIndexMap = new HashMap<>();
-  private final Map<String, InvertedIndexReader> _rangeIndexMap = new HashMap<>();
-  private final Map<String, InvertedIndexReader> _textIndexMap = new HashMap<>();
-  private final Map<String, BloomFilterReader> _bloomFilterMap = new HashMap<>();
-  // Only store min/max for non-dictionary fields
-  private final Map<String, Comparable> _minValueMap = new HashMap<>();
-  private final Map<String, Comparable> _maxValueMap = new HashMap<>();
+  private final Map<String, IndexContainer> _indexContainerMap = new HashMap<>();
 
-  private final Map<String, RealtimeNullValueVectorReaderWriter> _nullValueVectorMap = new HashMap<>();
   private final IdMap<FixedIntArray> _recordIdMap;
   private boolean _aggregateMetrics;
 
@@ -211,22 +202,32 @@ public class MutableSegmentImpl implements MutableSegment {
     // Initialize for each column
     for (FieldSpec fieldSpec : _physicalFieldSpecs) {
       String column = fieldSpec.getName();
-      _numValuesInfoMap.put(column, new NumValuesInfo());
+
+      // Partition info
+      PartitionFunction partitionFunction = null;
+      int partitionId = 0;
+      if (column.equals(_partitionColumn)) {
+        partitionFunction = _partitionFunction;
+        partitionId = _partitionId;
+      }
 
       // Check whether to generate raw index for the column while consuming
       // Only support generating raw index on single-value columns that do not have inverted index while
       // consuming. After consumption completes and the segment is built, all single-value columns can have raw index
       DataType dataType = fieldSpec.getDataType();
       boolean isFixedWidthColumn = dataType.isFixedWidth();
+      MutableForwardIndex forwardIndex;
+      BaseMutableDictionary dictionary;
       if (isNoDictionaryColumn(noDictionaryColumns, invertedIndexColumns, fieldSpec, column)) {
         // No dictionary column (always single-valued)
         assert fieldSpec.isSingleValueField();
 
+        dictionary = null;
         String allocationContext =
             buildAllocationContext(_segmentName, column, V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
         if (isFixedWidthColumn) {
-          _forwardIndexMap.put(column,
-              new FixedByteSVMutableForwardIndex(false, dataType, _capacity, _memoryManager, allocationContext));
+          forwardIndex =
+              new FixedByteSVMutableForwardIndex(false, dataType, _capacity, _memoryManager, allocationContext);
         } else {
           // RealtimeSegmentStatsHistory does not have the stats for no-dictionary columns from previous consuming
           // segments
@@ -235,13 +236,9 @@ public class MutableSegmentImpl implements MutableSegment {
           // TODO: Use the stats to get estimated average length
           // Use a smaller capacity as opposed to segment flush size
           int initialCapacity = Math.min(_capacity, NODICT_VARIABLE_WIDTH_ESTIMATED_NUMBER_OF_VALUES_DEFAULT);
-          _forwardIndexMap.put(column,
-              new VarByteSVMutableForwardIndex(dataType, _memoryManager, allocationContext, initialCapacity,
-                  NODICT_VARIABLE_WIDTH_ESTIMATED_AVERAGE_VALUE_LENGTH_DEFAULT));
+          forwardIndex = new VarByteSVMutableForwardIndex(dataType, _memoryManager, allocationContext, initialCapacity,
+              NODICT_VARIABLE_WIDTH_ESTIMATED_AVERAGE_VALUE_LENGTH_DEFAULT);
         }
-        // Init min/max value map to avoid potential thread safety issue (expanding hashMap while reading).
-        _minValueMap.put(column, null);
-        _maxValueMap.put(column, null);
       } else {
         // Dictionary-encoded column
 
@@ -255,47 +252,53 @@ public class MutableSegmentImpl implements MutableSegment {
         int estimatedCardinality = (int) (_statsHistory.getEstimatedCardinality(column) * 1.1);
         String dictionaryAllocationContext =
             buildAllocationContext(_segmentName, column, V1Constants.Dict.FILE_EXTENSION);
-        _dictionaryMap.put(column, MutableDictionaryFactory
+        dictionary = MutableDictionaryFactory
             .getMutableDictionary(dataType, _offHeap, _memoryManager, dictionaryColumnSize,
-                Math.min(estimatedCardinality, _capacity), dictionaryAllocationContext));
+                Math.min(estimatedCardinality, _capacity), dictionaryAllocationContext);
 
         if (fieldSpec.isSingleValueField()) {
           // Single-value dictionary-encoded forward index
           String allocationContext = buildAllocationContext(_segmentName, column,
               V1Constants.Indexes.UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION);
-          _forwardIndexMap.put(column,
-              new FixedByteSVMutableForwardIndex(true, DataType.INT, _capacity, _memoryManager, allocationContext));
+          forwardIndex =
+              new FixedByteSVMutableForwardIndex(true, DataType.INT, _capacity, _memoryManager, allocationContext);
         } else {
           // Multi-value dictionary-encoded forward index
           String allocationContext = buildAllocationContext(_segmentName, column,
               V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION);
           // TODO: Start with a smaller capacity on FixedByteMVForwardIndexReaderWriter and let it expand
-          _forwardIndexMap.put(column,
+          forwardIndex =
               new FixedByteMVMutableForwardIndex(MAX_MULTI_VALUES_PER_ROW, avgNumMultiValues, _capacity, Integer.BYTES,
-                  _memoryManager, allocationContext));
+                  _memoryManager, allocationContext);
         }
 
         // Even though the column is defined as 'no-dictionary' in the config, we did create dictionary for consuming segment.
         noDictionaryColumns.remove(column);
       }
 
-      if (invertedIndexColumns.contains(column)) {
-        _invertedIndexMap.put(column, new RealtimeInvertedIndexReader());
-      }
+      // Inverted index
+      RealtimeInvertedIndexReader invertedIndexReader =
+          invertedIndexColumns.contains(column) ? new RealtimeInvertedIndexReader() : null;
 
-      if (_nullHandlingEnabled) {
-        _nullValueVectorMap.put(column, new RealtimeNullValueVectorReaderWriter());
-      }
-
+      // Text index
+      RealtimeLuceneTextIndexReader textIndex;
       if (textIndexColumns.contains(column)) {
-        RealtimeLuceneTextIndexReader realtimeLuceneIndexReader =
-            new RealtimeLuceneTextIndexReader(column, new File(config.getConsumerDir()), _segmentName);
-        _textIndexMap.put(column, realtimeLuceneIndexReader);
+        textIndex = new RealtimeLuceneTextIndexReader(column, new File(config.getConsumerDir()), _segmentName);
         if (_realtimeLuceneReaders == null) {
           _realtimeLuceneReaders = new RealtimeLuceneReaders(_segmentName);
         }
-        _realtimeLuceneReaders.addReader(realtimeLuceneIndexReader);
+        _realtimeLuceneReaders.addReader(textIndex);
+      } else {
+        textIndex = null;
       }
+
+      // Null value vector
+      MutableNullValueVector nullValueVector = _nullHandlingEnabled ? new MutableNullValueVector() : null;
+
+      // TODO: Support range index and bloom filter for mutable segment
+      _indexContainerMap.put(column,
+          new IndexContainer(fieldSpec, partitionFunction, partitionId, new NumValuesInfo(), forwardIndex, dictionary,
+              invertedIndexReader, null, textIndex, null, nullValueVector));
     }
 
     if (_realtimeLuceneReaders != null) {
@@ -360,7 +363,7 @@ public class MutableSegmentImpl implements MutableSegment {
    */
   @Deprecated
   public long getMinTime() {
-    Long minTime = extractTimeValue(getMinVal(_timeColumnName));
+    Long minTime = extractTimeValue(_indexContainerMap.get(_timeColumnName)._minValue);
     if (minTime != null) {
       return minTime;
     }
@@ -372,7 +375,7 @@ public class MutableSegmentImpl implements MutableSegment {
    */
   @Deprecated
   public long getMaxTime() {
-    Long maxTime = extractTimeValue(getMaxVal(_timeColumnName));
+    Long maxTime = extractTimeValue(_indexContainerMap.get(_timeColumnName)._maxValue);
     if (maxTime != null) {
       return maxTime;
     }
@@ -393,32 +396,6 @@ public class MutableSegmentImpl implements MutableSegment {
     return null;
   }
 
-  /**
-   * Get min value of a column in the segment.
-   * @param column
-   * @return min value
-   */
-  public Comparable getMinVal(String column) {
-    BaseMutableDictionary dictionary = _dictionaryMap.get(column);
-    if (dictionary != null) {
-      return dictionary.getMinVal();
-    }
-    return _minValueMap.get(column);
-  }
-
-  /**
-   * Get max value of a column in the segment.
-   * @param column
-   * @return max value
-   */
-  public Comparable getMaxVal(String column) {
-    BaseMutableDictionary dictionary = _dictionaryMap.get(column);
-    if (dictionary != null) {
-      return dictionary.getMaxVal();
-    }
-    return _maxValueMap.get(column);
-  }
-
   public void addExtraColumns(Schema newSchema) {
     for (String columnName : newSchema.getColumnNames()) {
       if (!_schema.getColumnNames().contains(columnName)) {
@@ -432,202 +409,194 @@ public class MutableSegmentImpl implements MutableSegment {
     _logger.info("Newly added columns: " + _newlyAddedColumnsFieldMap.toString());
   }
 
+  // NOTE: Okay for single-writer
+  @SuppressWarnings("NonAtomicOperationOnVolatileField")
   @Override
   public boolean index(GenericRow row, @Nullable RowMetadata rowMetadata) {
-    boolean canTakeMore;
     // Update dictionary first
-    Map<String, Object> dictIdMap = updateDictionary(row);
-
-    int numDocs = _numDocsIndexed;
+    updateDictionary(row);
 
     // If metrics aggregation is enabled and if the dimension values were already seen, this will return existing docId,
     // else this will return a new docId.
-    int docId = getOrCreateDocId(dictIdMap);
+    int docId = getOrCreateDocId();
 
-    // docId == numDocs implies new docId.
-    if (docId == numDocs) {
-      // Add forward and inverted indices for new document.
-      addForwardIndex(row, docId, dictIdMap);
-      addInvertedIndex(row, docId, dictIdMap);
-      if (_nullHandlingEnabled) {
-        handleNullValues(row, docId);
-      }
-
-      // Update number of document indexed at last to make the latest record queryable
+    boolean canTakeMore;
+    if (docId == _numDocsIndexed) {
+      // New row
+      addNewRow(row);
+      // Update number of documents indexed at last to make the latest row queryable
       canTakeMore = _numDocsIndexed++ < _capacity;
     } else {
-      Preconditions
-          .checkState(_aggregateMetrics, "Invalid document-id during indexing: " + docId + " expected: " + numDocs);
-      // Update metrics for existing document.
-      canTakeMore = aggregateMetrics(row, docId);
+      // Aggregate metrics for an existing row
+      assert _aggregateMetrics;
+      aggregateMetrics(row, docId);
+      canTakeMore = true;
     }
 
+    // Update last indexed time and latest ingestion time
     _lastIndexedTimeMs = System.currentTimeMillis();
-
-    if (rowMetadata != null && rowMetadata.getIngestionTimeMs() != Long.MIN_VALUE) {
+    if (rowMetadata != null) {
       _latestIngestionTimeMs = Math.max(_latestIngestionTimeMs, rowMetadata.getIngestionTimeMs());
     }
+
     return canTakeMore;
   }
 
-  private Map<String, Object> updateDictionary(GenericRow row) {
-    Map<String, Object> dictIdMap = new HashMap<>();
-    for (FieldSpec fieldSpec : _physicalFieldSpecs) {
-      String column = fieldSpec.getName();
+  private void updateDictionary(GenericRow row) {
+    for (Map.Entry<String, IndexContainer> entry : _indexContainerMap.entrySet()) {
+      String column = entry.getKey();
+      IndexContainer indexContainer = entry.getValue();
       Object value = row.getValue(column);
-
-      BaseMutableDictionary dictionary = _dictionaryMap.get(column);
+      BaseMutableDictionary dictionary = indexContainer._dictionary;
       if (dictionary != null) {
-        if (fieldSpec.isSingleValueField()) {
-          dictIdMap.put(column, dictionary.index(value));
+        if (indexContainer._fieldSpec.isSingleValueField()) {
+          indexContainer._dictId = dictionary.index(value);
         } else {
-          int[] dictIds = dictionary.index((Object[]) value);
-          dictIdMap.put(column, dictIds);
-
-          // No need to update min/max time value as time column cannot be multi-valued
-          continue;
+          indexContainer._dictIds = dictionary.index((Object[]) value);
         }
+
+        // Update min/max value from dictionary
+        indexContainer._minValue = dictionary.getMinVal();
+        indexContainer._maxValue = dictionary.getMaxVal();
       }
     }
-    return dictIdMap;
   }
 
-  private void addForwardIndex(GenericRow row, int docId, Map<String, Object> dictIdMap) {
-    // Store dictionary Id(s) for columns with dictionary
-    for (FieldSpec fieldSpec : _physicalFieldSpecs) {
-      String column = fieldSpec.getName();
+  private void addNewRow(GenericRow row) {
+    int docId = _numDocsIndexed;
+    for (Map.Entry<String, IndexContainer> entry : _indexContainerMap.entrySet()) {
+      String column = entry.getKey();
+      IndexContainer indexContainer = entry.getValue();
       Object value = row.getValue(column);
-      NumValuesInfo numValuesInfo = _numValuesInfoMap.get(column);
+      FieldSpec fieldSpec = indexContainer._fieldSpec;
       if (fieldSpec.isSingleValueField()) {
-        // SV column
-        MutableForwardIndex mutableForwardIndex = _forwardIndexMap.get(column);
-        Integer dictId = (Integer) dictIdMap.get(column);
-        if (dictId != null) {
-          // SV Column with dictionary
-          mutableForwardIndex.setDictId(docId, dictId);
+        // Single-value column
+
+        // Update numValues info
+        indexContainer._numValuesInfo.updateSVEntry();
+
+        // Update indexes
+        MutableForwardIndex forwardIndex = indexContainer._forwardIndex;
+        int dictId = indexContainer._dictId;
+        if (dictId >= 0) {
+          // Dictionary-encoded single-value column
+
+          // Update forward index
+          forwardIndex.setDictId(docId, dictId);
+
+          // Update inverted index
+          RealtimeInvertedIndexReader invertedIndex = indexContainer._invertedIndex;
+          if (invertedIndex != null) {
+            invertedIndex.add(dictId, docId);
+          }
         } else {
-          // No-dictionary SV column
+          // Single-value column with raw index
+
+          // Update forward index
           DataType dataType = fieldSpec.getDataType();
           switch (dataType) {
             case INT:
-              mutableForwardIndex.setInt(docId, (Integer) value);
+              forwardIndex.setInt(docId, (Integer) value);
               break;
             case LONG:
-              mutableForwardIndex.setLong(docId, (Long) value);
+              forwardIndex.setLong(docId, (Long) value);
               break;
             case FLOAT:
-              mutableForwardIndex.setFloat(docId, (Float) value);
+              forwardIndex.setFloat(docId, (Float) value);
               break;
             case DOUBLE:
-              mutableForwardIndex.setDouble(docId, (Double) value);
+              forwardIndex.setDouble(docId, (Double) value);
               break;
             case STRING:
-              mutableForwardIndex.setString(docId, (String) value);
+              forwardIndex.setString(docId, (String) value);
               break;
             case BYTES:
-              mutableForwardIndex.setBytes(docId, (byte[]) value);
+              forwardIndex.setBytes(docId, (byte[]) value);
               break;
             default:
               throw new UnsupportedOperationException(
                   "Unsupported data type: " + dataType + " for no-dictionary column: " + column);
           }
-        }
 
-        numValuesInfo.updateSVEntry();
-      } else {
-        // MV column: always dictionary encoded
-        int[] dictIds = (int[]) dictIdMap.get(column);
-        _forwardIndexMap.get(column).setDictIdMV(docId, dictIds);
-
-        numValuesInfo.updateMVEntry(dictIds.length);
-      }
-
-      // Update min/max value for no dictionary columns
-      if ((_dictionaryMap.get(column) != null) || !(value instanceof Comparable)) {
-        continue;
-      }
-      Comparable comparableValue = (Comparable) value;
-      Comparable currentMinValue = _minValueMap.get(column);
-      if (currentMinValue == null) {
-        _minValueMap.put(column, comparableValue);
-        _maxValueMap.put(column, comparableValue);
-        continue;
-      }
-      if (comparableValue.compareTo(currentMinValue) < 0) {
-        _minValueMap.put(column, comparableValue);
-      }
-      if (comparableValue.compareTo(_maxValueMap.get(column)) > 0) {
-        _maxValueMap.put(column, comparableValue);
-      }
-    }
-  }
-
-  private void addInvertedIndex(GenericRow row, int docId, Map<String, Object> dictIdMap) {
-    // Update inverted index at last
-    // NOTE: inverted index have to be updated at last because once it gets updated, the latest record will become
-    // queryable
-    for (FieldSpec fieldSpec : _physicalFieldSpecs) {
-      String column = fieldSpec.getName();
-      InvertedIndexReader invertedIndex = _invertedIndexMap.get(column);
-      if (invertedIndex != null) {
-        if (invertedIndex instanceof RealtimeLuceneTextIndexReader) {
-          ((RealtimeLuceneTextIndexReader) invertedIndex).addDoc(row.getValue(column), docId);
-        } else {
-          RealtimeInvertedIndexReader realtimeInvertedIndexReader = (RealtimeInvertedIndexReader) invertedIndex;
-          if (fieldSpec.isSingleValueField()) {
-            realtimeInvertedIndexReader.add(((Integer) dictIdMap.get(column)), docId);
-          } else {
-            int[] dictIds = (int[]) dictIdMap.get(column);
-            for (int dictId : dictIds) {
-              realtimeInvertedIndexReader.add(dictId, docId);
+          // Update min/max value from raw value
+          // NOTE: Skip updating min/max value for aggregated metrics because the value will change over time.
+          if (!_aggregateMetrics || fieldSpec.getFieldType() != FieldSpec.FieldType.METRIC) {
+            Comparable comparable;
+            if (dataType == DataType.BYTES) {
+              comparable = new ByteArray((byte[]) value);
+            } else {
+              comparable = (Comparable) value;
+            }
+            if (indexContainer._minValue == null) {
+              indexContainer._minValue = comparable;
+              indexContainer._maxValue = comparable;
+            } else {
+              if (comparable.compareTo(indexContainer._minValue) < 0) {
+                indexContainer._minValue = comparable;
+              }
+              if (comparable.compareTo(indexContainer._maxValue) > 0) {
+                indexContainer._maxValue = comparable;
+              }
             }
           }
         }
+
+        // Update text index
+        RealtimeLuceneTextIndexReader textIndex = indexContainer._textIndex;
+        if (textIndex != null) {
+          textIndex.addDoc(value, docId);
+        }
+      } else {
+        // Multi-value column (always dictionary-encoded)
+
+        int[] dictIds = indexContainer._dictIds;
+
+        // Update numValues info
+        indexContainer._numValuesInfo.updateMVEntry(dictIds.length);
+
+        // Update forward index
+        indexContainer._forwardIndex.setDictIdMV(docId, dictIds);
+
+        // Update inverted index
+        RealtimeInvertedIndexReader invertedIndex = indexContainer._invertedIndex;
+        if (invertedIndex != null) {
+          for (int dictId : dictIds) {
+            invertedIndex.add(dictId, docId);
+          }
+        }
+      }
+
+      // Update null value vector
+      if (_nullHandlingEnabled && row.isNullValue(column)) {
+        indexContainer._nullValueVector.setNull(docId);
       }
     }
   }
 
-  /**
-   * Check if the row has any null fields and update the
-   * column null value vectors accordingly
-   * @param row specifies row being ingested
-   * @param docId specified docId for this row
-   */
-  private void handleNullValues(GenericRow row, int docId) {
-    if (!row.hasNullValues()) {
-      return;
-    }
-
-    for (String columnName : row.getNullValueFields()) {
-      _nullValueVectorMap.get(columnName).setNull(docId);
-    }
-  }
-
-  private boolean aggregateMetrics(GenericRow row, int docId) {
+  private void aggregateMetrics(GenericRow row, int docId) {
     for (MetricFieldSpec metricFieldSpec : _physicalMetricFieldSpecs) {
       String column = metricFieldSpec.getName();
       Object value = row.getValue(column);
-      MutableForwardIndex mutableForwardIndex = _forwardIndexMap.get(column);
+      MutableForwardIndex forwardIndex = _indexContainerMap.get(column)._forwardIndex;
       DataType dataType = metricFieldSpec.getDataType();
       switch (dataType) {
         case INT:
-          mutableForwardIndex.setInt(docId, (Integer) value + mutableForwardIndex.getInt(docId));
+          forwardIndex.setInt(docId, (Integer) value + forwardIndex.getInt(docId));
           break;
         case LONG:
-          mutableForwardIndex.setLong(docId, (Long) value + mutableForwardIndex.getLong(docId));
+          forwardIndex.setLong(docId, (Long) value + forwardIndex.getLong(docId));
           break;
         case FLOAT:
-          mutableForwardIndex.setFloat(docId, (Float) value + mutableForwardIndex.getFloat(docId));
+          forwardIndex.setFloat(docId, (Float) value + forwardIndex.getFloat(docId));
           break;
         case DOUBLE:
-          mutableForwardIndex.setDouble(docId, (Double) value + mutableForwardIndex.getDouble(docId));
+          forwardIndex.setDouble(docId, (Double) value + forwardIndex.getDouble(docId));
           break;
         default:
           throw new UnsupportedOperationException(
-              "Unsupported data type: " + dataType + " for no-dictionary column: " + column);
+              "Unsupported data type: " + dataType + " for aggregate metric column: " + column);
       }
     }
-    return true;
   }
 
   @Override
@@ -678,25 +647,7 @@ public class MutableSegmentImpl implements MutableSegment {
       return new ImmutableDataSource(virtualColumnProvider.buildMetadata(virtualColumnContext),
           virtualColumnProvider.buildColumnIndexContainer(virtualColumnContext));
     } else {
-      PartitionFunction partitionFunction = null;
-      int partitionId = 0;
-      if (column.equals(_partitionColumn)) {
-        partitionFunction = _partitionFunction;
-        partitionId = _partitionId;
-      }
-      NumValuesInfo numValuesInfo = _numValuesInfoMap.get(column);
-      MutableForwardIndex forwardIndex = _forwardIndexMap.get(column);
-      BaseMutableDictionary dictionary = _dictionaryMap.get(column);
-      InvertedIndexReader invertedIndex = _invertedIndexMap.get(column);
-      InvertedIndexReader rangeIndex = _rangeIndexMap.get(column);
-      InvertedIndexReader textIndex = _textIndexMap.get(column);
-      BloomFilterReader bloomFilter = _bloomFilterMap.get(column);
-      Comparable minValue = getMinVal(column);
-      Comparable maxValue = getMaxVal(column);
-      RealtimeNullValueVectorReaderWriter nullValueVector = _nullValueVectorMap.get(column);
-      return new MutableDataSource(fieldSpec, _numDocsIndexed, numValuesInfo.getNumValues(),
-          numValuesInfo.getMaxNumValuesPerMVEntry(), partitionFunction, partitionId, minValue, maxValue, forwardIndex,
-          dictionary, invertedIndex, textIndex, rangeIndex, bloomFilter, nullValueVector);
+      return _indexContainerMap.get(column).toDataSource();
     }
   }
 
@@ -712,18 +663,15 @@ public class MutableSegmentImpl implements MutableSegment {
    * @return Generic row with physical columns of the specified row.
    */
   public GenericRow getRecord(int docId, GenericRow reuse) {
-    for (FieldSpec fieldSpec : _physicalFieldSpecs) {
-      String column = fieldSpec.getName();
-      Object value = getValue(docId, _forwardIndexMap.get(column), _dictionaryMap.get(column),
-          _numValuesInfoMap.get(column).getMaxNumValuesPerMVEntry());
-      reuse.putValue(column, value);
-
-      if (_nullHandlingEnabled) {
-        NullValueVectorReader reader = _nullValueVectorMap.get(column);
-        // If column has null value for this docId, set that accordingly in GenericRow
-        if (reader.isNull(docId)) {
-          reuse.putDefaultNullValue(column, value);
-        }
+    for (Map.Entry<String, IndexContainer> entry : _indexContainerMap.entrySet()) {
+      String column = entry.getKey();
+      IndexContainer indexContainer = entry.getValue();
+      Object value = getValue(docId, indexContainer._forwardIndex, indexContainer._dictionary,
+          indexContainer._numValuesInfo._maxNumValuesPerMVEntry);
+      if (_nullHandlingEnabled && indexContainer._nullValueVector.isNull(docId)) {
+        reuse.putDefaultNullValue(column, value);
+      } else {
+        reuse.putValue(column, value);
       }
     }
     return reuse;
@@ -782,13 +730,15 @@ public class MutableSegmentImpl implements MutableSegment {
                 numSeconds);
 
         RealtimeSegmentStatsHistory.SegmentStats segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
-        for (Map.Entry<String, BaseMutableDictionary> entry : _dictionaryMap.entrySet()) {
-          String columnName = entry.getKey();
-          BaseOffHeapMutableDictionary dictionary = (BaseOffHeapMutableDictionary) entry.getValue();
-          RealtimeSegmentStatsHistory.ColumnStats columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
-          columnStats.setCardinality(dictionary.length());
-          columnStats.setAvgColumnSize(dictionary.getAvgValueSize());
-          segmentStats.setColumnStats(columnName, columnStats);
+        for (Map.Entry<String, IndexContainer> entry : _indexContainerMap.entrySet()) {
+          String column = entry.getKey();
+          BaseOffHeapMutableDictionary dictionary = (BaseOffHeapMutableDictionary) entry.getValue()._dictionary;
+          if (dictionary != null) {
+            RealtimeSegmentStatsHistory.ColumnStats columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
+            columnStats.setCardinality(dictionary.length());
+            columnStats.setAvgColumnSize(dictionary.getAvgValueSize());
+            segmentStats.setColumnStats(column, columnStats);
+          }
         }
         segmentStats.setNumRowsConsumed(_numDocsIndexed);
         segmentStats.setNumRowsIndexed(_numDocsIndexed);
@@ -798,47 +748,22 @@ public class MutableSegmentImpl implements MutableSegment {
       }
     }
 
-    for (MutableForwardIndex mutableForwardIndex : _forwardIndexMap.values()) {
-      try {
-        mutableForwardIndex.close();
-      } catch (IOException e) {
-        _logger.error("Failed to close index. Service will continue with potential memory leak, error: ", e);
-        // fall through to close other segments
-      }
-    }
-    // clear map now that index is closed to prevent accidental usage
-    _forwardIndexMap.clear();
-
-    for (InvertedIndexReader index : _invertedIndexMap.values()) {
-      if (index instanceof RealtimeInvertedIndexReader) {
-        ((RealtimeInvertedIndexReader) index).close();
-      }
-    }
-    _invertedIndexMap.clear();
-
+    // Stop the text index refresh before closing the indexes
     if (_realtimeLuceneReaders != null) {
       // set this to true as a way of signalling the refresh task thread to
       // not attempt refresh on this segment here onwards
       _realtimeLuceneReaders.getLock().lock();
-      _realtimeLuceneReaders.setSegmentDestroyed();
       try {
-        for (RealtimeLuceneTextIndexReader realtimeLuceneReader : _realtimeLuceneReaders.getRealtimeLuceneReaders()) {
-          // close each realtime lucene reader for this segment
-          realtimeLuceneReader.close();
-        }
-        // clear the list.
+        _realtimeLuceneReaders.setSegmentDestroyed();
         _realtimeLuceneReaders.clearRealtimeReaderList();
       } finally {
         _realtimeLuceneReaders.getLock().unlock();
       }
     }
 
-    for (Map.Entry<String, BaseMutableDictionary> entry : _dictionaryMap.entrySet()) {
-      try {
-        entry.getValue().close();
-      } catch (IOException e) {
-        _logger.error("Failed to close the dictionary for column: {}. Continuing with error.", entry.getKey(), e);
-      }
+    // Close the indexes
+    for (IndexContainer indexContainer : _indexContainerMap.values()) {
+      indexContainer.close();
     }
 
     if (_recordIdMap != null) {
@@ -867,16 +792,19 @@ public class MutableSegmentImpl implements MutableSegment {
    * @return The docIds to use for iteration
    */
   public int[] getSortedDocIdIterationOrderWithSortedColumn(String column) {
-    BaseMutableDictionary dictionary = _dictionaryMap.get(column);
-    int numValues = dictionary.length();
+    IndexContainer indexContainer = _indexContainerMap.get(column);
+    BaseMutableDictionary dictionary = indexContainer._dictionary;
 
+    // Sort all values in the dictionary
+    int numValues = dictionary.length();
     int[] dictIds = new int[numValues];
     for (int i = 0; i < numValues; i++) {
       dictIds[i] = i;
     }
+    IntArrays.quickSort(dictIds, dictionary::compare);
 
-    IntArrays.quickSort(dictIds, (dictId1, dictId2) -> dictionary.compare(dictId1, dictId2));
-    RealtimeInvertedIndexReader invertedIndex = (RealtimeInvertedIndexReader) _invertedIndexMap.get(column);
+    // Re-order documents using the inverted index
+    RealtimeInvertedIndexReader invertedIndex = indexContainer._invertedIndex;
     int[] docIds = new int[_numDocsIndexed];
     int docIdIndex = 0;
     for (int dictId : dictIds) {
@@ -906,7 +834,7 @@ public class MutableSegmentImpl implements MutableSegment {
     return segmentName + ":" + columnName + indexType;
   }
 
-  private int getOrCreateDocId(Map<String, Object> dictIdMap) {
+  private int getOrCreateDocId() {
     if (!_aggregateMetrics) {
       return _numDocsIndexed;
     }
@@ -916,10 +844,10 @@ public class MutableSegmentImpl implements MutableSegment {
 
     // FIXME: this for loop breaks for multi value dimensions. https://github.com/apache/incubator-pinot/issues/3867
     for (FieldSpec fieldSpec : _physicalDimensionFieldSpecs) {
-      dictIds[i++] = (Integer) dictIdMap.get(fieldSpec.getName());
+      dictIds[i++] = _indexContainerMap.get(fieldSpec.getName())._dictId;
     }
     for (String timeColumnName : _physicalTimeColumnNames) {
-      dictIds[i++] = (Integer) dictIdMap.get(timeColumnName);
+      dictIds[i++] = _indexContainerMap.get(timeColumnName)._dictId;
     }
     return _recordIdMap.put(new FixedIntArray(dictIds));
   }
@@ -1033,13 +961,89 @@ public class MutableSegmentImpl implements MutableSegment {
       _numValues += numValuesInMVEntry;
       _maxNumValuesPerMVEntry = Math.max(_maxNumValuesPerMVEntry, numValuesInMVEntry);
     }
+  }
 
-    int getNumValues() {
-      return _numValues;
+  private class IndexContainer implements Closeable {
+    final FieldSpec _fieldSpec;
+    final PartitionFunction _partitionFunction;
+    final int _partitionId;
+    final NumValuesInfo _numValuesInfo;
+    final MutableForwardIndex _forwardIndex;
+    final BaseMutableDictionary _dictionary;
+    final RealtimeInvertedIndexReader _invertedIndex;
+    final InvertedIndexReader _rangeIndex;
+    final RealtimeLuceneTextIndexReader _textIndex;
+    final BloomFilterReader _bloomFilter;
+    final MutableNullValueVector _nullValueVector;
+
+    volatile Comparable _minValue;
+    volatile Comparable _maxValue;
+
+    // Hold the dictionary id for the latest record
+    int _dictId = Integer.MIN_VALUE;
+    int[] _dictIds;
+
+    IndexContainer(FieldSpec fieldSpec, @Nullable PartitionFunction partitionFunction, int partitionId,
+        NumValuesInfo numValuesInfo, MutableForwardIndex forwardIndex, @Nullable BaseMutableDictionary dictionary,
+        @Nullable RealtimeInvertedIndexReader invertedIndex, @Nullable InvertedIndexReader rangeIndex,
+        @Nullable RealtimeLuceneTextIndexReader textIndex, @Nullable BloomFilterReader bloomFilter,
+        @Nullable MutableNullValueVector nullValueVector) {
+      _fieldSpec = fieldSpec;
+      _partitionFunction = partitionFunction;
+      _partitionId = partitionId;
+      _numValuesInfo = numValuesInfo;
+      _forwardIndex = forwardIndex;
+      _dictionary = dictionary;
+      _invertedIndex = invertedIndex;
+      _rangeIndex = rangeIndex;
+      _textIndex = textIndex;
+      _bloomFilter = bloomFilter;
+      _nullValueVector = nullValueVector;
     }
 
-    int getMaxNumValuesPerMVEntry() {
-      return _maxNumValuesPerMVEntry;
+    DataSource toDataSource() {
+      return new MutableDataSource(_fieldSpec, _numDocsIndexed, _numValuesInfo._numValues,
+          _numValuesInfo._maxNumValuesPerMVEntry, _partitionFunction, _partitionId, _minValue, _maxValue, _forwardIndex,
+          _dictionary, _invertedIndex, _rangeIndex, _textIndex, _bloomFilter, _nullValueVector);
+    }
+
+    @Override
+    public void close() {
+      String column = _fieldSpec.getName();
+      try {
+        _forwardIndex.close();
+      } catch (Exception e) {
+        _logger.error("Caught exception while closing forward index for column: {}, continuing with error", column, e);
+      }
+      if (_dictionary != null) {
+        try {
+          _dictionary.close();
+        } catch (Exception e) {
+          _logger.error("Caught exception while closing dictionary for column: {}, continuing with error", column, e);
+        }
+      }
+      if (_invertedIndex != null) {
+        try {
+          _invertedIndex.close();
+        } catch (Exception e) {
+          _logger
+              .error("Caught exception while closing inverted index for column: {}, continuing with error", column, e);
+        }
+      }
+      if (_rangeIndex != null) {
+        try {
+          _rangeIndex.close();
+        } catch (Exception e) {
+          _logger.error("Caught exception while closing range index for column: {}, continuing with error", column, e);
+        }
+      }
+      if (_textIndex != null) {
+        try {
+          _textIndex.close();
+        } catch (Exception e) {
+          _logger.error("Caught exception while closing text index for column: {}, continuing with error", column, e);
+        }
+      }
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/nullvalue/MutableNullValueVector.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/nullvalue/MutableNullValueVector.java
@@ -21,16 +21,15 @@ package org.apache.pinot.core.realtime.impl.nullvalue;
 import org.apache.pinot.core.realtime.impl.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.core.segment.index.readers.NullValueVectorReader;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 /**
- * Defines a real-time null value vector to be used in realtime ingestion.
+ * Mutable null value vector (for CONSUMING segment).
  */
-public class RealtimeNullValueVectorReaderWriter implements NullValueVectorReader {
+public class MutableNullValueVector implements NullValueVectorReader {
   private final ThreadSafeMutableRoaringBitmap _nullBitmap;
 
-  public RealtimeNullValueVectorReaderWriter() {
+  public MutableNullValueVector() {
     _nullBitmap = new ThreadSafeMutableRoaringBitmap();
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/nullvalue/MutableNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/nullvalue/MutableNullValueVectorTest.java
@@ -18,34 +18,28 @@
  */
 package org.apache.pinot.core.realtime.impl.nullvalue;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
-public class RealtimeNullValueVectorReaderWriterTest {
-  private static RealtimeNullValueVectorReaderWriter readerWriter = null;
-  private static final Random random = new Random(System.currentTimeMillis());
+public class MutableNullValueVectorTest {
+  private static final Random RANDOM = new Random();
+  private static final int NUM_DOCS = 100;
   private static final int MAX_DOC_ID = 10000;
 
-  @BeforeClass
-  public void setup() {
-    readerWriter = new RealtimeNullValueVectorReaderWriter();
-  }
+  private final MutableNullValueVector _nullValueVector = new MutableNullValueVector();
 
   @Test
-  public void testRealtimeNullValueVectorReaderWriter() {
-    List<Integer> randomdocIds = new ArrayList<>();
-    for (int i = 0; i < 100; i++) {
-      int randomDocId = random.nextInt(MAX_DOC_ID);
-      readerWriter.setNull(randomDocId);
-      randomdocIds.add(randomDocId);
+  public void testMutableNullValueVector() {
+    int[] docIds = new int[NUM_DOCS];
+    for (int i = 0; i < NUM_DOCS; i++) {
+      int docId = RANDOM.nextInt(MAX_DOC_ID);
+      _nullValueVector.setNull(docId);
+      docIds[i] = docId;
     }
-    for (int i = 0; i < 100; i++) {
-      Assert.assertTrue(readerWriter.isNull(randomdocIds.get(i)));
+    for (int i = 0; i < NUM_DOCS; i++) {
+      Assert.assertTrue(_nullValueVector.isNull(docIds[i]));
     }
   }
 }


### PR DESCRIPTION
## Description
Motivation:
Currently within `MutableSegmentImpl` we maintain 10 maps from column to different type of index or column stats, which is very inefficient and requires a lot of redundant map lookups to access or update indexes. Also, it is quite hard to manage 10 maps, and the number of maps will keep growing as we add more types of indexes.

Changes:
- Introduce `IndexContainer` class inside MutableSegmentImpl to wrap all the index and stats for a column
- Add helper method in `IndexContainer` to directly get `DataSource` and close all indexes for a column
- Simplify the min/max value handling, add min/max value support for `BYTES` column
- Store `dictId` for the latest ingested records in `IndexContainer` to avoid the per-record map from column to dictId

Bug fixes:
- Do not store min/max value for aggregated metrics
- Add document into text index properly
