### PR TITLE
Adding Test coverage to NoOpPinotCrypt class

### DIFF
--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -140,5 +140,10 @@
       <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/crypt/NoOpPinotCryptTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/crypt/NoOpPinotCryptTest.java
@@ -1,0 +1,37 @@
+package org.apache.pinot.spi.crypt;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class NoOpPinotCryptTest {
+
+  PinotCrypter pinotCrypter;
+  File srcFile;
+  File destinationFile;
+  @BeforeTest
+  public void init() throws IOException {
+    pinotCrypter = new NoOpPinotCrypter();
+    srcFile = File.createTempFile("srcFile","txt");
+    srcFile.deleteOnExit();
+    destinationFile = File.createTempFile("destFile","txt");
+    destinationFile.deleteOnExit();
+    FileUtils.write(srcFile,"testData");
+  }
+
+  @Test
+  public void testEncryption() throws IOException {
+    pinotCrypter.encrypt(srcFile,destinationFile);
+    Assert.assertTrue(FileUtils.contentEquals(srcFile,destinationFile));
+  }
+
+  @Test
+  public void testDecryption() throws IOException {
+    pinotCrypter.decrypt(destinationFile,srcFile);
+    Assert.assertTrue(FileUtils.contentEquals(srcFile,destinationFile));
+  }
+
+}


### PR DESCRIPTION
## Description

This class did not have any code coverage. Adding a simple test to improve test coverage. 
Adding test as part of this issue: https://github.com/apache/incubator-pinot/issues/5699

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] No 
Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] No
Does this PR otherwise need attention when creating release notes? No

