### PR TITLE
[TE] Added DataSource.getMinDateTime() API implementation for PinotDataSource

### DIFF
--- a/thirdeye/.gitignore
+++ b/thirdeye/.gitignore
@@ -4,6 +4,7 @@ tmp
 dependency-reduced-pom.xml
 .project
 .classpath
+venv/
 .settings/
 test-output/
 *.iml

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/ThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/ThirdEyeDataSource.java
@@ -40,6 +40,16 @@ public interface ThirdEyeDataSource {
 
   /**
    * Returns max dateTime in millis for the dataset
+   * @param dataset name of the dataset
+   * @return the time corresponding to the earliest available data point.
+   * @throws Exception
+   */
+  default long getMinDataTime(String dataset) throws Exception {
+    return -1L;
+  }
+
+  /**
+   * Returns max dateTime in millis for the dataset
    * @param dataset
    * @return
    * @throws Exception

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotDataSourceTimeQuery.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotDataSourceTimeQuery.java
@@ -26,8 +26,6 @@ import org.apache.pinot.thirdeye.datalayer.dto.DatasetConfigDTO;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.datasource.pinot.resultset.ThirdEyeResultSetGroup;
 import org.apache.pinot.thirdeye.util.ThirdEyeUtils;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
@@ -42,16 +40,15 @@ import org.slf4j.LoggerFactory;
 /**
  * This class contains methods to return max date time for datasets in pinot
  */
-public class PinotDataSourceMaxTime {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PinotDataSourceMaxTime.class);
+public class PinotDataSourceTimeQuery {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotDataSourceTimeQuery.class);
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
-  private final static String COLLECTION_MAX_TIME_QUERY_TEMPLATE = "SELECT max(%s) FROM %s WHERE %s";
+  private final static String TIME_QUERY_TEMPLATE = "SELECT %s(%s) FROM %s WHERE %s";
 
-  private final Map<String, Long> collectionToPrevMaxDataTimeMap = new ConcurrentHashMap<String, Long>();
   private final PinotThirdEyeDataSource pinotThirdEyeDataSource;
 
-  public PinotDataSourceMaxTime(PinotThirdEyeDataSource pinotThirdEyeDataSource) {
+  public PinotDataSourceTimeQuery(PinotThirdEyeDataSource pinotThirdEyeDataSource) {
     this.pinotThirdEyeDataSource = pinotThirdEyeDataSource;
   }
 
@@ -61,7 +58,23 @@ public class PinotDataSourceMaxTime {
    * @return max date time in millis
    */
   public long getMaxDateTime(String dataset) {
-    LOGGER.debug("Loading maxDataTime cache {}", dataset);
+    long maxTime = queryTimeSpecFromPinot(dataset, "max");
+    if (maxTime <= 0) {
+      maxTime = System.currentTimeMillis();
+    }
+    return maxTime;
+  }
+
+  /**
+   * Returns the earliest time in millis for a dataset in pinot
+   * @param dataset name of the dataset
+   * @return min (earliest) date time in millis. Returns 0 if dataset is not found
+   */
+  public long getMinDateTime(String dataset) {
+    return queryTimeSpecFromPinot(dataset, "min");
+  }
+
+  private long queryTimeSpecFromPinot(final String dataset, final String functionName) {
     long maxTime = 0;
     try {
       DatasetConfigDTO datasetConfig = DAO_REGISTRY.getDatasetConfigDAO().findByDataset(dataset);
@@ -69,9 +82,10 @@ public class PinotDataSourceMaxTime {
       TimeSpec timeSpec = ThirdEyeUtils.getTimestampTimeSpecFromDatasetConfig(datasetConfig);
 
       long cutoffTime = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);
-      String timeClause = PqlUtils.getBetweenClause(new DateTime(0, DateTimeZone.UTC), new DateTime(cutoffTime, DateTimeZone.UTC), timeSpec, dataset);
+      String timeClause = PqlUtils
+          .getBetweenClause(new DateTime(0, DateTimeZone.UTC), new DateTime(cutoffTime, DateTimeZone.UTC), timeSpec, dataset);
 
-      String maxTimePql = String.format(COLLECTION_MAX_TIME_QUERY_TEMPLATE, timeSpec.getColumnName(), dataset, timeClause);
+      String maxTimePql = String.format(TIME_QUERY_TEMPLATE, functionName, timeSpec.getColumnName(), dataset, timeClause);
       PinotQuery maxTimePinotQuery = new PinotQuery(maxTimePql, dataset);
 
       ThirdEyeResultSetGroup resultSetGroup;
@@ -79,7 +93,8 @@ public class PinotDataSourceMaxTime {
       try {
         pinotThirdEyeDataSource.refreshPQL(maxTimePinotQuery);
         resultSetGroup = pinotThirdEyeDataSource.executePQL(maxTimePinotQuery);
-        ThirdeyeMetricsUtil.getRequestLog().success(this.pinotThirdEyeDataSource.getName(), dataset, timeSpec.getColumnName(), tStart, System.nanoTime());
+        ThirdeyeMetricsUtil
+            .getRequestLog().success(this.pinotThirdEyeDataSource.getName(), dataset, timeSpec.getColumnName(), tStart, System.nanoTime());
       } catch (ExecutionException e) {
         ThirdeyeMetricsUtil.getRequestLog().failure(this.pinotThirdEyeDataSource.getName(), dataset, timeSpec.getColumnName(), tStart, System.nanoTime(), e);
         throw e;
@@ -87,12 +102,10 @@ public class PinotDataSourceMaxTime {
 
       if (resultSetGroup.size() == 0 || resultSetGroup.get(0).getRowCount() == 0) {
         LOGGER.error("Failed to get latest max time for dataset {} with PQL: {}", dataset, maxTimePinotQuery.getQuery());
-        this.collectionToPrevMaxDataTimeMap.remove(dataset);
       } else {
         DateTimeZone timeZone = Utils.getDataTimeZone(dataset);
 
         long endTime = new Double(resultSetGroup.get(0).getDouble(0)).longValue();
-        this.collectionToPrevMaxDataTimeMap.put(dataset, endTime);
         // endTime + 1 to make sure we cover the time range of that time value.
         String timeFormat = timeSpec.getFormat();
         if (StringUtils.isBlank(timeFormat) || TimeSpec.SINCE_EPOCH_FORMAT.equals(timeFormat)) {
@@ -107,10 +120,6 @@ public class PinotDataSourceMaxTime {
       }
     } catch (Exception e) {
       LOGGER.warn("Exception getting maxTime from collection: {}", dataset, e);
-      this.collectionToPrevMaxDataTimeMap.remove(dataset);
-    }
-    if (maxTime <= 0) {
-      maxTime = System.currentTimeMillis();
     }
     return maxTime;
   }


### PR DESCRIPTION
## Description
The min datetime API is required to fetch the earliest available timestamp
for a given dataset in Pinot.
- By default the API returns -1L for other datasources apart Pinot.
- If the dataset is not present in Pinot, it returns 0
- Else it queries pinot for the timestamp
- `PinotDataSourceMaxTime` has been renamed to `PinotDataSourceTimeQuery`
- The `collectionToPrevMaxDataTimeMap` map has been removed since it was being updated but never queried.

There are NO backward incompatible changes.