### PR TITLE
[TE] deprecate the yaml/list endpoint

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
@@ -1059,10 +1059,13 @@ public class YamlResource {
    * Query all detection yaml configurations and optionally filter, then format as JSON and enhance with
    * detection config id, isActive, and createdBy information
    *
+   * NOTE: it is limited to list and filter the most recent 100 alerts only due to possible OOM issues.
+   *
    * @param dataset The dataset param passed by the client in the REST API call.
    * @param metric The metric param passed by the client in the REST API call.
    * @return the yaml configuration converted in to JSON, with enhanced information from detection config DTO.
    */
+  @Deprecated
   private List<Map<String, Object>> queryDetectionConfigurations(String dataset, String metric) {
     List<Map<String, Object>> yamls;
     if (dataset == null && metric == null) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/yaml/YamlResource.java
@@ -1067,14 +1067,14 @@ public class YamlResource {
     List<Map<String, Object>> yamls;
     if (dataset == null && metric == null) {
       yamls = this.detectionConfigDAO
-          .findAll()
+          .list(100, 0)
           .parallelStream()
           .map(config -> formatConfigOrNull(config))
           .filter(c -> c!= null)
           .collect(Collectors.toList());
     } else {
       yamls = this.detectionConfigDAO
-          .findAll()
+          .list(100, 0)
           .parallelStream()
           .map(config -> formatConfigOrNull(config))
           .filter(c -> c!= null)
@@ -1096,8 +1096,12 @@ public class YamlResource {
    */
   @GET
   @Path("/list")
-  @ApiOperation("Get the list of all detection YAML configurations as JSON enhanced with additional information, optionally filtered.")
+  @ApiOperation(
+      "Get the list of all detection YAML configurations as JSON enhanced with additional information, optionally filtered."
+          + "IMPORTANT NOTE: This endpoint is deprecated because it is not scalable. Please use the /alerts endpoint instead. "
+          + "For now, it is limited to list and filter the most recent 100 alerts only. ")
   @Produces(MediaType.APPLICATION_JSON)
+  @Deprecated
   public Response listYamls(
       @ApiParam("Dataset the detection configurations should be filtered by") @QueryParam("dataset") String dataset,
       @ApiParam("Metric the detection configurations should be filtered by") @QueryParam("metric") String metric){


### PR DESCRIPTION
This PR marks the "yaml/list" endpoint as deprecated because it is not scalable. The new endpoint '/alerts' has been built to search the alerts more efficiently. Also, this PR limits the query to 100 alerts at most to avoid possible out of memory issues.