### PR TITLE
update data generator schema json with dataTimeSpec

### DIFF
--- a/pinot-tools/src/main/resources/generator/complexWebsite_schema.json
+++ b/pinot-tools/src/main/resources/generator/complexWebsite_schema.json
@@ -27,12 +27,13 @@
       "name": "platform"
     }
   ],
-  "timeFieldSpec": {
-    "incomingGranularitySpec": {
-      "timeType": "HOURS",
+  "dateTimeFieldSpecs": [
+    {
+      "name": "hoursSinceEpoch",
       "dataType": "LONG",
-      "name": "hoursSinceEpoch"
+      "format": "1:HOURS:EPOCH",
+      "granularity": "1:HOURS"
     }
-  },
+  ],
   "schemaName": "complexWebsite"
 }

--- a/pinot-tools/src/main/resources/generator/simpleWebsite_schema.json
+++ b/pinot-tools/src/main/resources/generator/simpleWebsite_schema.json
@@ -15,12 +15,13 @@
   ],
   "dimensionFieldSpecs": [
   ],
-  "timeFieldSpec": {
-    "incomingGranularitySpec": {
-      "timeType": "HOURS",
+  "dateTimeFieldSpecs": [
+    {
+      "name": "hoursSinceEpoch",
       "dataType": "LONG",
-      "name": "hoursSinceEpoch"
+      "format": "1:HOURS:EPOCH",
+      "granularity": "1:HOURS"
     }
-  },
+  ],
   "schemaName": "simpleWebsite"
 }


### PR DESCRIPTION
## Description
Update the data generator's default schema to use "dateTimeFieldSpecs"

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes? Things to consider:
**No**
