### PR TITLE
Allow serving of offline segments immediately/inclusively.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -26,8 +26,6 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.Configuration;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixConstants.ChangeType;
@@ -61,6 +59,7 @@ import org.apache.pinot.common.utils.CommonConstants.Helix;
 import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.config.TagNameUtils;
+import org.apache.pinot.common.utils.helix.TableCache;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
@@ -235,7 +234,7 @@ public class HelixBrokerStarter implements ServiceStartable {
     FunctionRegistry.init();
     _brokerRequestHandler =
         new SingleConnectionBrokerRequestHandler(_brokerConf, _routingManager, _accessControlFactory, queryQuotaManager,
-            _brokerMetrics, _propertyStore);
+            _brokerMetrics, new TableCache(_propertyStore));
 
     int brokerQueryPort = _brokerConf.getProperty(Helix.KEY_OF_BROKER_QUERY_PORT, Helix.DEFAULT_BROKER_QUERY_PORT);
     LOGGER.info("Starting broker admin application on port: {}", brokerQueryPort);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -41,6 +41,7 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.common.utils.helix.TableCache;
 import org.apache.pinot.core.transport.AsyncQueryResponse;
 import org.apache.pinot.core.transport.QueryRouter;
 import org.apache.pinot.core.transport.ServerInstance;
@@ -60,8 +61,8 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
   public SingleConnectionBrokerRequestHandler(PinotConfiguration config, RoutingManager routingManager,
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, BrokerMetrics brokerMetrics,
-      ZkHelixPropertyStore<ZNRecord> propertyStore) {
-    super(config, routingManager, accessControlFactory, queryQuotaManager, brokerMetrics, propertyStore);
+      TableCache tableCache) {
+    super(config, routingManager, accessControlFactory, queryQuotaManager, brokerMetrics, tableCache);
     _queryRouter = new QueryRouter(_brokerId, brokerMetrics);
   }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTests.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTests.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import com.yammer.metrics.core.MetricsRegistry;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.broker.api.RequestStatistics;
+import org.apache.pinot.broker.broker.AccessControlFactory;
+import org.apache.pinot.broker.broker.AllowAllAccessControlFactory;
+import org.apache.pinot.broker.queryquota.QueryQuotaManager;
+import org.apache.pinot.broker.routing.RoutingManager;
+import org.apache.pinot.broker.routing.RoutingTable;
+import org.apache.pinot.broker.routing.timeboundary.TimeBoundaryInfo;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.utils.helix.TableCache;
+import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.spi.config.table.QueryConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.common.utils.CommonConstants.Broker.Request.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.*;
+import static org.testng.Assert.*;
+
+
+public class BaseBrokerRequestHandlerTests {
+
+  private static final String TABLE = "tableName";
+  private static final String TIME_COLUMN = "daysSinceEpoch";
+
+  private PinotConfiguration _config;
+  @Mock private RoutingManager _routingManager;
+  private final AccessControlFactory _accessControlFactory = new AllowAllAccessControlFactory();
+  @Mock private QueryQuotaManager _queryQuotaManager;
+  private final BrokerMetrics _brokerMetrics = new BrokerMetrics(new MetricsRegistry());
+  @Mock private TableCache _tableCache;
+  private StubBrokerRequestHandler _handler;
+
+  @BeforeMethod
+  public void setUp() {
+    initMocks(this);
+    _config = new PinotConfiguration();
+    when(_routingManager.routingExists(any())).thenReturn(true);
+    when(_routingManager.getRoutingTable(any())).thenReturn(new RoutingTable(ImmutableMap.of(new ServerInstance(new InstanceConfig("Server_localhost_0000")), Collections.emptyList()), Collections.emptyList()));
+    when(_routingManager.getQueryTimeoutMs(any())).thenReturn(Long.MAX_VALUE);
+    when(_queryQuotaManager.acquire(any())).thenReturn(true);
+    when(_tableCache.getTableConfig(TableNameBuilder.OFFLINE.tableNameWithType(TABLE))).thenReturn(new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE).setQueryConfig(new QueryConfig(100L, false)).build());
+  }
+
+  @Test
+  public void testAttachesTimeBoundary() throws Exception {
+    String query = String.format("select * from %s", TABLE);
+    ObjectNode request = JsonUtils.newObjectNode();
+    request.put(PQL, query);
+
+    long daysSinceEpoch = LocalDate.of(2000, 1, 1).toEpochDay();
+    when(_routingManager.getTimeBoundaryInfo(TableNameBuilder.OFFLINE.tableNameWithType(TABLE))).thenReturn(new TimeBoundaryInfo(TIME_COLUMN, String.valueOf(daysSinceEpoch)));
+
+    _handler = new StubBrokerRequestHandler(_config, _routingManager, _accessControlFactory, _queryQuotaManager, _brokerMetrics, _tableCache);
+    _handler.handleRequest(request, null, new RequestStatistics());
+
+    BrokerRequest offlineBrokerRequest = _handler.getOfflineBrokerRequest();
+    assertEquals(offlineBrokerRequest.getFilterQuery().getColumn(), TIME_COLUMN);
+    assertEquals(offlineBrokerRequest.getFilterQuery().getValue().size(), 1);
+    assertEquals(offlineBrokerRequest.getFilterQuery().getValue().get(0), String.format("(*\t\t%d]", daysSinceEpoch));
+
+    BrokerRequest realtimeBrokerRequest = _handler.getRealtimeBrokerRequest();
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getColumn(), TIME_COLUMN);
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getValue().size(), 1);
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getValue().get(0), String.format("(%s\t\t*)", daysSinceEpoch));
+  }
+
+  @Test
+  public void testAttachesTimeBoundaryWithPreexistingTimeFilter() throws Exception {
+    long daysSinceEpoch = LocalDate.of(2000, 1, 1).toEpochDay();
+    long yesterday = daysSinceEpoch - 1;
+    long threeDaysAgo = daysSinceEpoch - 3;
+    String query = String.format("select * from %s where %s >= %d", TABLE, TIME_COLUMN, threeDaysAgo);
+    ObjectNode request = JsonUtils.newObjectNode();
+    request.put(PQL, query);
+
+    when(_routingManager.getTimeBoundaryInfo(TableNameBuilder.OFFLINE.tableNameWithType(TABLE))).thenReturn(new TimeBoundaryInfo(TIME_COLUMN, String.valueOf(yesterday)));
+
+    _handler = new StubBrokerRequestHandler(_config, _routingManager, _accessControlFactory, _queryQuotaManager, _brokerMetrics, _tableCache);
+    _handler.handleRequest(request, null, new RequestStatistics());
+
+    BrokerRequest offlineBrokerRequest = _handler.getOfflineBrokerRequest();
+    assertEquals(offlineBrokerRequest.getFilterQuery().getColumn(), TIME_COLUMN);
+    assertEquals(offlineBrokerRequest.getFilterQuery().getValue().size(), 1);
+    assertEquals(offlineBrokerRequest.getFilterQuery().getValue().get(0), String.format("[%d\t\t%d]", threeDaysAgo, yesterday));
+
+    BrokerRequest realtimeBrokerRequest = _handler.getRealtimeBrokerRequest();
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getColumn(), TIME_COLUMN);
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getValue().size(), 1);
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getValue().get(0), String.format("(%d\t\t*)", yesterday));
+  }
+
+  @Test
+  public void testAttachesTimeBoundaryWithConfigToServeOfflineImmediately() throws Exception {
+    when(_tableCache.getTableConfig(TableNameBuilder.OFFLINE.tableNameWithType(TABLE))).thenReturn(new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE).setQueryConfig(new QueryConfig(100L, true)).build());
+
+    String query = String.format("select * from %s", TABLE);
+    ObjectNode request = JsonUtils.newObjectNode();
+    request.put(PQL, query);
+
+    long daysSinceEpoch = LocalDate.of(2000, 1, 1).toEpochDay();
+    when(_routingManager.getTimeBoundaryInfo(TableNameBuilder.OFFLINE.tableNameWithType(TABLE))).thenReturn(new TimeBoundaryInfo(TIME_COLUMN, String.valueOf(daysSinceEpoch)));
+
+    _handler = new StubBrokerRequestHandler(_config, _routingManager, _accessControlFactory, _queryQuotaManager, _brokerMetrics, _tableCache);
+    _handler.handleRequest(request, null, new RequestStatistics());
+
+    BrokerRequest offlineBrokerRequest = _handler.getOfflineBrokerRequest();
+    assertEquals(offlineBrokerRequest.getFilterQuery().getColumn(), TIME_COLUMN);
+    assertEquals(offlineBrokerRequest.getFilterQuery().getValue().size(), 1);
+    assertEquals(offlineBrokerRequest.getFilterQuery().getValue().get(0), String.format("(*\t\t%d)", daysSinceEpoch));
+
+    BrokerRequest realtimeBrokerRequest = _handler.getRealtimeBrokerRequest();
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getColumn(), TIME_COLUMN);
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getValue().size(), 1);
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getValue().get(0), String.format("[%s\t\t*)", daysSinceEpoch));
+  }
+
+  @Test
+  public void testAttachesTimeBoundaryWithPreexistingTimeFilterAndConfigToServeOfflineImmediately() throws Exception {
+    when(_tableCache.getTableConfig(TableNameBuilder.OFFLINE.tableNameWithType(TABLE))).thenReturn(new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE).setQueryConfig(new QueryConfig(100L, true)).build());
+
+    long daysSinceEpoch = LocalDate.of(2000, 1, 1).toEpochDay();
+    long yesterday = daysSinceEpoch - 1;
+    long threeDaysAgo = daysSinceEpoch - 3;
+    String query = String.format("select * from %s where %s >= %d", TABLE, TIME_COLUMN, threeDaysAgo);
+    ObjectNode request = JsonUtils.newObjectNode();
+    request.put(PQL, query);
+
+    when(_routingManager.getTimeBoundaryInfo(TableNameBuilder.OFFLINE.tableNameWithType(TABLE))).thenReturn(new TimeBoundaryInfo(TIME_COLUMN, String.valueOf(yesterday)));
+
+    _handler = new StubBrokerRequestHandler(_config, _routingManager, _accessControlFactory, _queryQuotaManager, _brokerMetrics, _tableCache);
+    _handler.handleRequest(request, null, new RequestStatistics());
+
+    BrokerRequest offlineBrokerRequest = _handler.getOfflineBrokerRequest();
+    assertEquals(offlineBrokerRequest.getFilterQuery().getColumn(), TIME_COLUMN);
+    assertEquals(offlineBrokerRequest.getFilterQuery().getValue().size(), 1);
+    assertEquals(offlineBrokerRequest.getFilterQuery().getValue().get(0), String.format("[%d\t\t%d)", threeDaysAgo, yesterday));
+
+    BrokerRequest realtimeBrokerRequest = _handler.getRealtimeBrokerRequest();
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getColumn(), TIME_COLUMN);
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getValue().size(), 1);
+    assertEquals(realtimeBrokerRequest.getFilterQuery().getValue().get(0), String.format("[%d\t\t*)", yesterday));
+  }
+
+  private static class StubBrokerRequestHandler extends BaseBrokerRequestHandler {
+
+    private BrokerRequest _offlineBrokerRequest;
+    private BrokerRequest _realtimeBrokerRequest;
+
+    public StubBrokerRequestHandler(PinotConfiguration config, RoutingManager routingManager,
+        AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, BrokerMetrics brokerMetrics,
+        TableCache tableCache) {
+      super(config, routingManager, accessControlFactory, queryQuotaManager, brokerMetrics, tableCache);
+    }
+
+    @Override
+    protected BrokerResponse processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
+        @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
+        @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable,
+        long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics) {
+      _offlineBrokerRequest = offlineBrokerRequest;
+      _realtimeBrokerRequest = realtimeBrokerRequest;
+      return new BrokerResponseNative();
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void shutDown() {}
+
+    public BrokerRequest getOfflineBrokerRequest() {
+      return _offlineBrokerRequest;
+    }
+
+    public BrokerRequest getRealtimeBrokerRequest() {
+      return _realtimeBrokerRequest;
+    }
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -182,7 +182,7 @@ public class TableConfigSerDeTest {
     }
     {
       // With query config
-      QueryConfig queryConfig = new QueryConfig(1000L);
+      QueryConfig queryConfig = new QueryConfig(1000L, false);
       TableConfig tableConfig = tableConfigBuilder.setQueryConfig(queryConfig).build();
 
       checkQueryConfig(tableConfig);
@@ -363,6 +363,7 @@ public class TableConfigSerDeTest {
     QueryConfig queryConfig = tableConfig.getQueryConfig();
     assertNotNull(queryConfig);
     assertEquals(queryConfig.getTimeoutMs(), Long.valueOf(1000L));
+    assertFalse(queryConfig.getServeOfflineSegmentsImmediately());
   }
 
   private void checkIngestionConfig(TableConfig tableConfig) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -215,7 +215,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     // Set timeout as 5ms so that query will timeout
     TableConfig tableConfig = getOfflineTableConfig();
-    tableConfig.setQueryConfig(new QueryConfig(5L));
+    tableConfig.setQueryConfig(new QueryConfig(5L, false));
     updateTableConfig(tableConfig);
 
     // Wait for at most 1 minute for broker to receive and process the table config refresh message

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
@@ -38,14 +38,28 @@ public class QueryConfig extends BaseJsonConfig {
   // because by the time the server times out, the broker should already timed out and returned the response.
   private final Long _timeoutMs;
 
+  // By default, Pinot serves queries to Hybrid tables by applying a time filter based on data availability.
+  // For example, when the most recent offline segment is for 1/2/2000, and a query has no time filter, then the broker
+  // queries the offline table for * - 1/2/2000 (exclusive), and the realtime table with 1/2/2000 (inclusive) - *.
+  // This config tells the broker to immediately start serving offline segments once available; or in other words, to
+  // query the offline table with the most recent time value inclusively.
+  private final Boolean _serveOfflineSegmentsImmediately;
+
   @JsonCreator
-  public QueryConfig(@JsonProperty("timeoutMs") @Nullable Long timeoutMs) {
+  public QueryConfig(@JsonProperty("timeoutMs") @Nullable Long timeoutMs,
+      @JsonProperty("serveOfflineSegmentsImmediately") @Nullable Boolean serveOfflineSegmentsImmediately) {
     Preconditions.checkArgument(timeoutMs == null || timeoutMs > 0, "Invalid 'timeoutMs': %s", timeoutMs);
     _timeoutMs = timeoutMs;
+    _serveOfflineSegmentsImmediately = serveOfflineSegmentsImmediately;
   }
 
   @Nullable
   public Long getTimeoutMs() {
     return _timeoutMs;
+  }
+
+  @Nullable
+  public Boolean getServeOfflineSegmentsImmediately() {
+    return _serveOfflineSegmentsImmediately;
   }
 }


### PR DESCRIPTION
## Description

Today, Pinot serves queries to Hybrid tables by applying a time filter
based on data availability. For example, when the most recent offline
segment is for 1/2/2000, and a query has no time filter, then the broker
queries the offline table for * - 1/2/2000 (exclusive), and the realtime
table with 1/2/2000 (inclusive) - *.

This means that when you upload a new offline segment, it technically
doesn't begin to be served by the broker until another offline segment
pushes the watermark higher.

This change permits a new config which tells the broker to immediately
start serving offline segments once available; or in other words, to
query the offline table with the most recent time value inclusively.


## Upgrade Notes

New feature is entirely opt-in and should not require downtime to enable.