### PR TITLE
Fix code to correctly extract value of multi-value column from avro file

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
@@ -56,7 +56,6 @@ public class DataTypeTransformer implements RecordTransformer {
     MULTI_VALUE_TYPE_MAP.put(Float.class, PinotDataType.FLOAT_ARRAY);
     MULTI_VALUE_TYPE_MAP.put(Double.class, PinotDataType.DOUBLE_ARRAY);
     MULTI_VALUE_TYPE_MAP.put(String.class, PinotDataType.STRING_ARRAY);
-    MULTI_VALUE_TYPE_MAP.put(HashMap.class, PinotDataType.MAP);
   }
 
   private final Map<String, PinotDataType> _dataTypes = new HashMap<>();
@@ -87,9 +86,11 @@ public class DataTypeTransformer implements RecordTransformer {
         Object[] values = (Object[]) value;
         source = MULTI_VALUE_TYPE_MAP.get(values[0].getClass());
         if (source == null) {
-          source = PinotDataType.OBJECT_ARRAY;
-        } else if (source == PinotDataType.MAP) {
-          source = PinotDataType.getSpecificMapDataTypeFromMap((Map<Object, Object>) values[0]);
+          if (values[0] instanceof Map) {
+            source = PinotDataType.getSpecificMapDataTypeFromMap((Map<Object, Object>) values[0]);
+          } else {
+            source = PinotDataType.OBJECT_ARRAY;
+          }
         }
       } else {
         // Single-value column
@@ -100,7 +101,6 @@ public class DataTypeTransformer implements RecordTransformer {
       }
       PinotDataType dest = entry.getValue();
       if (source != dest) {
-
         value = dest.convert(value, source);
       }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
@@ -56,14 +56,12 @@ public class DataTypeTransformer implements RecordTransformer {
     MULTI_VALUE_TYPE_MAP.put(Float.class, PinotDataType.FLOAT_ARRAY);
     MULTI_VALUE_TYPE_MAP.put(Double.class, PinotDataType.DOUBLE_ARRAY);
     MULTI_VALUE_TYPE_MAP.put(String.class, PinotDataType.STRING_ARRAY);
-    MULTI_VALUE_TYPE_MAP.put(HashMap.class, PinotDataType.HASHMAP);
+    MULTI_VALUE_TYPE_MAP.put(HashMap.class, PinotDataType.MAP);
   }
 
   private final Map<String, PinotDataType> _dataTypes = new HashMap<>();
-  private final Schema _schema;
 
   public DataTypeTransformer(Schema schema) {
-    _schema = schema;
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
       if (!fieldSpec.isVirtualColumn()) {
         _dataTypes.put(fieldSpec.getName(), PinotDataType.getPinotDataType(fieldSpec));
@@ -90,8 +88,8 @@ public class DataTypeTransformer implements RecordTransformer {
         source = MULTI_VALUE_TYPE_MAP.get(values[0].getClass());
         if (source == null) {
           source = PinotDataType.OBJECT_ARRAY;
-        } else if (source == PinotDataType.HASHMAP) {
-          source = PinotDataType.getPinotDataTypeFromHashMap((Map<Object, Object>) values[0]);
+        } else if (source == PinotDataType.MAP) {
+          source = PinotDataType.getSpecificMapDataTypeFromMap((Map<Object, Object>) values[0]);
         }
       } else {
         // Single-value column

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
@@ -56,11 +56,14 @@ public class DataTypeTransformer implements RecordTransformer {
     MULTI_VALUE_TYPE_MAP.put(Float.class, PinotDataType.FLOAT_ARRAY);
     MULTI_VALUE_TYPE_MAP.put(Double.class, PinotDataType.DOUBLE_ARRAY);
     MULTI_VALUE_TYPE_MAP.put(String.class, PinotDataType.STRING_ARRAY);
+    MULTI_VALUE_TYPE_MAP.put(HashMap.class, PinotDataType.HASHMAP);
   }
 
   private final Map<String, PinotDataType> _dataTypes = new HashMap<>();
+  private final Schema _schema;
 
   public DataTypeTransformer(Schema schema) {
+    _schema = schema;
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
       if (!fieldSpec.isVirtualColumn()) {
         _dataTypes.put(fieldSpec.getName(), PinotDataType.getPinotDataType(fieldSpec));
@@ -87,6 +90,8 @@ public class DataTypeTransformer implements RecordTransformer {
         source = MULTI_VALUE_TYPE_MAP.get(values[0].getClass());
         if (source == null) {
           source = PinotDataType.OBJECT_ARRAY;
+        } else if (source == PinotDataType.HASHMAP) {
+          source = PinotDataType.getPinotDataTypeFromHashMap((Map<Object, Object>) values[0]);
         }
       } else {
         // Single-value column
@@ -97,6 +102,7 @@ public class DataTypeTransformer implements RecordTransformer {
       }
       PinotDataType dest = entry.getValue();
       if (source != dest) {
+
         value = dest.convert(value, source);
       }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/PinotDataType.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/PinotDataType.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -474,37 +472,37 @@ public enum PinotDataType {
     }
   },
 
-  HASHMAP,
+  MAP,
 
-  INTEGER_HASHMAP {
+  INTEGER_MAP {
     @Override
     public Integer[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toIntegerArray(value);
     }
   },
 
-  LONG_HASHMAP {
+  LONG_MAP {
     @Override
     public Long[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toLongArray(value);
     }
   },
 
-  FLOAT_HASHMAP {
+  FLOAT_MAP {
     @Override
     public Float[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toFloatArray(value);
     }
   },
 
-  DOUBLE_HASHMAP {
+  DOUBLE_MAP {
     @Override
     public Double[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toDoubleArray(value);
     }
   },
 
-  STRING_HASHMAP {
+  STRING_MAP {
     @Override
     public String[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toStringArray(value);
@@ -548,10 +546,11 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       Integer[] integerArray = new Integer[length];
-      if (valueArray[0] instanceof HashMap) {
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType = getSingleValueType();
         for (int i = 0; i < length; i++) {
-          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
-            integerArray[i] = PinotDataType.INTEGER.toInteger(obj);
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            integerArray[i] = singleValueType.toInteger(obj);
           }
         }
       } else {
@@ -571,10 +570,11 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       Long[] longArray = new Long[length];
-      if (valueArray[0] instanceof HashMap) {
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType = getSingleValueType();
         for (int i = 0; i < length; i++) {
-          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
-            longArray[i] = PinotDataType.LONG.toLong(obj);
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            longArray[i] = singleValueType.toLong(obj);
           }
         }
       } else {
@@ -594,10 +594,11 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       Float[] floatArray = new Float[length];
-      if (valueArray[0] instanceof HashMap) {
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType = getSingleValueType();
         for (int i = 0; i < length; i++) {
-          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
-            floatArray[i] = PinotDataType.FLOAT.toFloat(obj);
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            floatArray[i] = singleValueType.toFloat(obj);
           }
         }
       } else {
@@ -617,10 +618,11 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       Double[] doubleArray = new Double[length];
-      if (valueArray[0] instanceof HashMap) {
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType = getSingleValueType();
         for (int i = 0; i < length; i++) {
-          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
-            doubleArray[i] = PinotDataType.DOUBLE.toDouble(obj);
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            doubleArray[i] = singleValueType.toDouble(obj);
           }
         }
       } else {
@@ -640,10 +642,11 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       String[] stringArray = new String[length];
-      if (valueArray[0] instanceof HashMap) {
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType = getSingleValueType();
         for (int i = 0; i < length; i++) {
-          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
-            stringArray[i] = PinotDataType.STRING.toString(obj);
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            stringArray[i] = singleValueType.toString(obj);
           }
         }
       } else {
@@ -673,14 +676,19 @@ public enum PinotDataType {
       case SHORT_ARRAY:
         return SHORT;
       case INTEGER_ARRAY:
+      case INTEGER_MAP:
         return INTEGER;
       case LONG_ARRAY:
+      case LONG_MAP:
         return LONG;
       case FLOAT_ARRAY:
+      case FLOAT_MAP:
         return FLOAT;
       case DOUBLE_ARRAY:
+      case DOUBLE_MAP:
         return DOUBLE;
       case STRING_ARRAY:
+      case STRING_MAP:
         return STRING;
       case OBJECT_ARRAY:
         return OBJECT;
@@ -714,19 +722,19 @@ public enum PinotDataType {
     }
   }
 
-  public static PinotDataType getPinotDataTypeFromHashMap(Map<Object, Object> map) {
+  public static PinotDataType getSpecificMapDataTypeFromMap(Map<Object, Object> map) {
     Iterator<Object> iterator = map.values().iterator();
     Object obj = iterator.next();
     if (obj instanceof Integer) {
-      return PinotDataType.INTEGER_HASHMAP;
+      return PinotDataType.INTEGER_MAP;
     } else if (obj instanceof Long) {
-      return PinotDataType.LONG_HASHMAP;
+      return PinotDataType.LONG_MAP;
     } else if (obj instanceof Float) {
-      return PinotDataType.FLOAT_HASHMAP;
+      return PinotDataType.FLOAT_MAP;
     } else if (obj instanceof Double) {
-      return PinotDataType.DOUBLE_HASHMAP;
+      return PinotDataType.DOUBLE_MAP;
     } else if (obj instanceof String) {
-      return PinotDataType.STRING_HASHMAP;
+      return PinotDataType.STRING_MAP;
     } else {
       throw new IllegalStateException(String.format("'%s' isn't supported in the hash map.", obj.getClass()));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/PinotDataType.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/PinotDataType.java
@@ -472,37 +472,35 @@ public enum PinotDataType {
     }
   },
 
-  MAP,
-
-  INTEGER_MAP {
+  INTEGER_VALUE_MAP {
     @Override
     public Integer[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toIntegerArray(value);
     }
   },
 
-  LONG_MAP {
+  LONG_VALUE_MAP {
     @Override
     public Long[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toLongArray(value);
     }
   },
 
-  FLOAT_MAP {
+  FLOAT_VALUE_MAP {
     @Override
     public Float[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toFloatArray(value);
     }
   },
 
-  DOUBLE_MAP {
+  DOUBLE_VALUE_MAP {
     @Override
     public Double[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toDoubleArray(value);
     }
   },
 
-  STRING_MAP {
+  STRING_VALUE_MAP {
     @Override
     public String[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toStringArray(value);
@@ -676,19 +674,19 @@ public enum PinotDataType {
       case SHORT_ARRAY:
         return SHORT;
       case INTEGER_ARRAY:
-      case INTEGER_MAP:
+      case INTEGER_VALUE_MAP:
         return INTEGER;
       case LONG_ARRAY:
-      case LONG_MAP:
+      case LONG_VALUE_MAP:
         return LONG;
       case FLOAT_ARRAY:
-      case FLOAT_MAP:
+      case FLOAT_VALUE_MAP:
         return FLOAT;
       case DOUBLE_ARRAY:
-      case DOUBLE_MAP:
+      case DOUBLE_VALUE_MAP:
         return DOUBLE;
       case STRING_ARRAY:
-      case STRING_MAP:
+      case STRING_VALUE_MAP:
         return STRING;
       case OBJECT_ARRAY:
         return OBJECT;
@@ -726,16 +724,17 @@ public enum PinotDataType {
     Iterator<Object> iterator = map.values().iterator();
     Object obj = iterator.next();
     if (obj instanceof Integer) {
-      return PinotDataType.INTEGER_MAP;
+      return PinotDataType.INTEGER_VALUE_MAP;
     } else if (obj instanceof Long) {
-      return PinotDataType.LONG_MAP;
+      return PinotDataType.LONG_VALUE_MAP;
     } else if (obj instanceof Float) {
-      return PinotDataType.FLOAT_MAP;
+      return PinotDataType.FLOAT_VALUE_MAP;
     } else if (obj instanceof Double) {
-      return PinotDataType.DOUBLE_MAP;
+      return PinotDataType.DOUBLE_VALUE_MAP;
     } else if (obj instanceof String) {
-      return PinotDataType.STRING_MAP;
+      return PinotDataType.STRING_VALUE_MAP;
     } else {
+      // TODO: Support more complex map types like nested map, single-entry map with multiple values (Object[]).
       throw new IllegalStateException(String.format("'%s' isn't supported in the hash map.", obj.getClass()));
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/PinotDataType.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/PinotDataType.java
@@ -18,6 +18,10 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
 
@@ -470,6 +474,43 @@ public enum PinotDataType {
     }
   },
 
+  HASHMAP,
+
+  INTEGER_HASHMAP {
+    @Override
+    public Integer[] convert(Object value, PinotDataType sourceType) {
+      return sourceType.toIntegerArray(value);
+    }
+  },
+
+  LONG_HASHMAP {
+    @Override
+    public Long[] convert(Object value, PinotDataType sourceType) {
+      return sourceType.toLongArray(value);
+    }
+  },
+
+  FLOAT_HASHMAP {
+    @Override
+    public Float[] convert(Object value, PinotDataType sourceType) {
+      return sourceType.toFloatArray(value);
+    }
+  },
+
+  DOUBLE_HASHMAP {
+    @Override
+    public Double[] convert(Object value, PinotDataType sourceType) {
+      return sourceType.toDoubleArray(value);
+    }
+  },
+
+  STRING_HASHMAP {
+    @Override
+    public String[] convert(Object value, PinotDataType sourceType) {
+      return sourceType.toStringArray(value);
+    }
+  },
+
   OBJECT_ARRAY;
 
   /**
@@ -507,9 +548,17 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       Integer[] integerArray = new Integer[length];
-      PinotDataType singleValueType = getSingleValueType();
-      for (int i = 0; i < length; i++) {
-        integerArray[i] = singleValueType.toInteger(valueArray[i]);
+      if (valueArray[0] instanceof HashMap) {
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
+            integerArray[i] = PinotDataType.INTEGER.toInteger(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          integerArray[i] = singleValueType.toInteger(valueArray[i]);
+        }
       }
       return integerArray;
     }
@@ -522,9 +571,17 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       Long[] longArray = new Long[length];
-      PinotDataType singleValueType = getSingleValueType();
-      for (int i = 0; i < length; i++) {
-        longArray[i] = singleValueType.toLong(valueArray[i]);
+      if (valueArray[0] instanceof HashMap) {
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
+            longArray[i] = PinotDataType.LONG.toLong(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          longArray[i] = singleValueType.toLong(valueArray[i]);
+        }
       }
       return longArray;
     }
@@ -537,9 +594,17 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       Float[] floatArray = new Float[length];
-      PinotDataType singleValueType = getSingleValueType();
-      for (int i = 0; i < length; i++) {
-        floatArray[i] = singleValueType.toFloat(valueArray[i]);
+      if (valueArray[0] instanceof HashMap) {
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
+            floatArray[i] = PinotDataType.FLOAT.toFloat(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          floatArray[i] = singleValueType.toFloat(valueArray[i]);
+        }
       }
       return floatArray;
     }
@@ -552,9 +617,17 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       Double[] doubleArray = new Double[length];
-      PinotDataType singleValueType = getSingleValueType();
-      for (int i = 0; i < length; i++) {
-        doubleArray[i] = singleValueType.toDouble(valueArray[i]);
+      if (valueArray[0] instanceof HashMap) {
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
+            doubleArray[i] = PinotDataType.DOUBLE.toDouble(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          doubleArray[i] = singleValueType.toDouble(valueArray[i]);
+        }
       }
       return doubleArray;
     }
@@ -567,9 +640,17 @@ public enum PinotDataType {
       Object[] valueArray = (Object[]) value;
       int length = valueArray.length;
       String[] stringArray = new String[length];
-      PinotDataType singleValueType = getSingleValueType();
-      for (int i = 0; i < length; i++) {
-        stringArray[i] = singleValueType.toString(valueArray[i]);
+      if (valueArray[0] instanceof HashMap) {
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((HashMap<Object, Object>) valueArray[i]).values()) {
+            stringArray[i] = PinotDataType.STRING.toString(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          stringArray[i] = singleValueType.toString(valueArray[i]);
+        }
       }
       return stringArray;
     }
@@ -630,6 +711,24 @@ public enum PinotDataType {
       default:
         throw new UnsupportedOperationException(
             "Unsupported data type: " + dataType + " in field: " + fieldSpec.getName());
+    }
+  }
+
+  public static PinotDataType getPinotDataTypeFromHashMap(Map<Object, Object> map) {
+    Iterator<Object> iterator = map.values().iterator();
+    Object obj = iterator.next();
+    if (obj instanceof Integer) {
+      return PinotDataType.INTEGER_HASHMAP;
+    } else if (obj instanceof Long) {
+      return PinotDataType.LONG_HASHMAP;
+    } else if (obj instanceof Float) {
+      return PinotDataType.FLOAT_HASHMAP;
+    } else if (obj instanceof Double) {
+      return PinotDataType.DOUBLE_HASHMAP;
+    } else if (obj instanceof String) {
+      return PinotDataType.STRING_HASHMAP;
+    } else {
+      throw new IllegalStateException(String.format("'%s' isn't supported in the hash map.", obj.getClass()));
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
@@ -1,0 +1,50 @@
+package org.apache.pinot.core.data.recordtransformer;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class DataTypeTransformerTest {
+
+  @Test
+  public void testDataTypeTransformer() {
+    Schema pinotSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("SV1", FieldSpec.DataType.INT)
+        .addMultiValueDimension("MV1", FieldSpec.DataType.INT)
+        .addMultiValueDimension("MV2", FieldSpec.DataType.STRING)
+        .addMultiValueDimension("MV3", FieldSpec.DataType.LONG)
+        .addMultiValueDimension("MV4", FieldSpec.DataType.FLOAT)
+        .addMultiValueDimension("MV5", FieldSpec.DataType.DOUBLE)
+        .build();
+
+    // generate test data
+    Map<String, String> map1 = new HashMap<>();
+    map1.put("item", "10");
+    Map<String, String> map2 = new HashMap<>();
+    map2.put("item", "20");
+    Object[] objectArray = new Object[]{map1, map2};
+    GenericRow genericRow = new GenericRow();
+    genericRow.putValue("SV1", 1.1);
+    genericRow.putDefaultNullValue("MV1", objectArray);
+    genericRow.putDefaultNullValue("MV2", objectArray);
+    genericRow.putDefaultNullValue("MV3", objectArray);
+    genericRow.putDefaultNullValue("MV4", objectArray);
+    genericRow.putDefaultNullValue("MV5", objectArray);
+
+    DataTypeTransformer dataTypeTransformer = new DataTypeTransformer(pinotSchema);
+    dataTypeTransformer.transform(genericRow);
+
+    assertEquals(genericRow.getValue("SV1"), 1);
+    assertEquals(genericRow.getValue("MV1"), new Integer[]{10, 20});
+    assertEquals(genericRow.getValue("MV2"), new String[]{"10", "20"});
+    assertEquals(genericRow.getValue("MV3"), new Long[]{10L, 20L});
+    assertEquals(genericRow.getValue("MV4"), new Float[]{10f, 20f});
+    assertEquals(genericRow.getValue("MV5"), new Double[]{10d, 20d});
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.data.recordtransformer;
 
 import java.util.HashMap;

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
@@ -353,16 +353,6 @@ public class AvroUtils {
    * Handles the conversion of every field of the GenericRecord
    */
   private static Object handleGenericRecord(GenericData.Record record) {
-    List<Field> fields = record.getSchema().getFields();
-    if (fields.isEmpty()) {
-      return null;
-    }
-
-    Map<Object, Object> convertedMap = new HashMap<>();
-    for (Field field : fields) {
-      String fieldName = field.name();
-      convertedMap.put(fieldName, convert(record.get(fieldName)));
-    }
-    return convertedMap;
+    return record.get(0);
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
@@ -353,6 +353,16 @@ public class AvroUtils {
    * Handles the conversion of every field of the GenericRecord
    */
   private static Object handleGenericRecord(GenericData.Record record) {
-    return record.get(0);
+    List<Field> fields = record.getSchema().getFields();
+    if (fields.isEmpty()) {
+      return null;
+    }
+
+    Map<Object, Object> convertedMap = new HashMap<>();
+    for (Field field : fields) {
+      String fieldName = field.name();
+      convertedMap.put(fieldName, convert(record.get(fieldName)));
+    }
+    return convertedMap;
   }
 }


### PR DESCRIPTION
## Description
This PR fixed the issue introduced from this PR: https://github.com/apache/incubator-pinot/pull/5238

Basically the value of the multi-value column should be at the 1st level instead of digging into the deepest level. The issue is causing the segment creation fail to extract the correct value from the avro file.

## Tests Done
Before the change:
```
java.lang.ClassCastException: java.util.HashMap cannot be cast to java.lang.Number
	at org.apache.pinot.core.data.recordtransformer.PinotDataType$11.toInteger(PinotDataType.java:392) ~[classes/:?]
	at org.apache.pinot.core.data.recordtransformer.PinotDataType.toIntegerArray(PinotDataType.java:512) ~[classes/:?]
	at org.apache.pinot.core.data.recordtransformer.PinotDataType$13.convert(PinotDataType.java:441) ~[classes/:?]
	at org.apache.pinot.core.data.recordtransformer.PinotDataType$13.convert(PinotDataType.java:438) ~[classes/:?]
	at org.apache.pinot.core.data.recordtransformer.DataTypeTransformer.transform(DataTypeTransformer.java:100) ~[classes/:?]
	at org.apache.pinot.core.data.recordtransformer.CompositeTransformer.transform(CompositeTransformer.java:74) ~[classes/:?]
	at org.apache.pinot.core.segment.creator.RecordReaderSegmentCreationDataSource.gatherStats(RecordReaderSegmentCreationDataSource.java:70) ~[classes/:?]
	at org.apache.pinot.core.segment.creator.RecordReaderSegmentCreationDataSource.gatherStats(RecordReaderSegmentCreationDataSource.java:38) ~[classes/:?]
	at org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl.init(SegmentIndexCreationDriverImpl.java:146) ~[classes/:?]
	at org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl.init(SegmentIndexCreationDriverImpl.java:131) ~[classes/:?]
	at org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl.init(SegmentIndexCreationDriverImpl.java:93) ~[classes/:?]
	at org.apache.pinot.tools.admin.command.CreateSegmentCommand.lambda$execute$0(CreateSegmentCommand.java:238) ~[classes/:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_172]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_172]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_172]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_172]
```

After the change:
```
2020/07/23 17:02:15.195 INFO [CreateSegmentCommand] [pool-2-thread-1] Successfully created segment: segmentName_20200722_20200722_0 at directory: ~/sampleData/output/segmentName_20200722_20200722_0
2020/07/23 17:02:15.196 INFO [CreateSegmentCommand] [main] Successfully created 1 segments from data files: [~/sampleData/input/test.avro]
```
