### PR TITLE
GROOVY transform function UDF for queries

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -55,7 +55,7 @@ public enum TransformFunctionType {
   ARRAYLENGTH("arrayLength"),
   VALUEIN("valueIn"),
   MAPVALUE("mapValue"),
-
+  GROOVY("groovy"),
   // Special type for annotation based scalar functions
   SCALAR("scalar"),
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/function/GroovyFunctionEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/function/GroovyFunctionEvaluator.java
@@ -59,9 +59,9 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
   private final Binding _binding;
   private final Script _script;
 
-  public GroovyFunctionEvaluator(String transformExpression) {
-    Matcher matcher = GROOVY_FUNCTION_PATTERN.matcher(transformExpression);
-    Preconditions.checkState(matcher.matches(), "Invalid transform expression: %s", transformExpression);
+  public GroovyFunctionEvaluator(String closure) {
+    Matcher matcher = GROOVY_FUNCTION_PATTERN.matcher(closure);
+    Preconditions.checkState(matcher.matches(), "Invalid transform expression: %s", closure);
     String arguments = matcher.group(ARGUMENTS_GROUP_NAME);
     if (arguments != null) {
       _arguments = Splitter.on(ARGUMENTS_SEPARATOR).trimResults().splitToList(arguments);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/function/GroovyFunctionEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/function/GroovyFunctionEvaluator.java
@@ -55,6 +55,7 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
   private static final String ARGUMENTS_SEPARATOR = ",";
 
   private final List<String> _arguments;
+  private final int _numArguments;
   private final Binding _binding;
   private final Script _script;
 
@@ -67,6 +68,7 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
     } else {
       _arguments = Collections.emptyList();
     }
+    _numArguments = _arguments.size();
     _binding = new Binding();
     _script = new GroovyShell(_binding).parse(matcher.group(SCRIPT_GROUP_NAME));
   }
@@ -89,6 +91,17 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
         return null;
       }
       _binding.setVariable(argument, value);
+    }
+    return _script.run();
+  }
+
+  /**
+   * Evaluate the Groovy function with bindings provided as an array of Object
+   * The number of elements in the values must match the numArguments
+   */
+  public Object evaluate(Object[] values) {
+    for (int i = 0; i < _numArguments; i++) {
+      _binding.setVariable(_arguments.get(i), values[i]);
     }
     return _script.run();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunction.java
@@ -1,0 +1,438 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.data.function.GroovyFunctionEvaluator;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/**
+ * The GroovyTransformFunction executes groovy expressions
+ * first argument - groovy script (string) using arg0, arg1, arg2... as arguments e.g. 'arg0 + " " + arg1', 'arg0 + arg1.toList().max() + arg2' etc
+ * last argument - json string containing returnType and isSingleValue e.g. '{"returnType":"LONG", "isSingleValue":false}'
+ * remaining arguments 2 to n-1 - identifiers/functions to the groovy script
+ *
+ * Sample queries:
+ * SELECT GROOVY('arg0.findIndexValues{it==1}', products, '{"returnType":"LONG", "isSingleValue":false}') FROM myTable
+ * SELECT GROOVY('arg0 * arg1 * 10', arraylength(units), columnB, '{"returnType":"INT", "isSingleValue":true}') FROM bob
+ */
+public class GroovyTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "groovy";
+
+  private static final String RETURN_TYPE_KEY = "returnType";
+  private static final String IS_SINGLE_VALUE_KEY = "isSingleValue";
+  private static final String ARGUMENT_PREFIX = "arg";
+  private static final String GROOVY_TEMPLATE_WITH_ARGS = "Groovy({%s}, %s)";
+  private static final String GROOVY_TEMPLATE_WITHOUT_ARGS = "Groovy({%s})";
+  private static final String GROOVY_ARG_DELIMITER = ",";
+
+  private int[] _intResultSV;
+  private long[] _longResultSV;
+  private double[] _doubleResultSV;
+  private float[] _floatResultSV;
+  private String[] _stringResultSV;
+  private int[][] _intResultMV;
+  private long[][] _longResultMV;
+  private double[][] _doubleResultMV;
+  private float[][] _floatResultMV;
+  private String[][] _stringResultMV;
+  private TransformResultMetadata _resultMetadata;
+
+  private GroovyFunctionEvaluator _groovyFunctionEvaluator;
+  private int _numGroovyArgs;
+  private TransformFunction[] _groovyArguments;
+  private boolean[] _isSourceSingleValue;
+  private FieldSpec.DataType[] _sourceDataType;
+  private BiFunction<TransformFunction, ProjectionBlock, Object>[] _transformToValuesFunctions;
+  private BiFunction<Object, Integer, Object>[] _fetchElementFunctions;
+  private Object[] _sourceArrays;
+  private Object[] _bindingValues;
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    int numArgs = arguments.size();
+    if (numArgs < 2) {
+      throw new IllegalArgumentException("GROOVY transform function requires at least 2 arguments");
+    }
+
+    // first argument is groovy expression string
+    TransformFunction groovyTransformFunction = arguments.get(0);
+    Preconditions.checkState(groovyTransformFunction instanceof LiteralTransformFunction,
+        "First argument of GROOVY transform function must be a literal string, representing the groovy expression");
+
+    // last argument is a json string
+    TransformFunction returnValueMetadata = arguments.get(numArgs - 1);
+    Preconditions.checkState(returnValueMetadata instanceof LiteralTransformFunction,
+        "Last argument of GROOVY transform function must be a literal, representing a json string");
+    String returnValueMetadataStr = ((LiteralTransformFunction) returnValueMetadata).getLiteral();
+    try {
+      JsonNode returnValueMetadataJson = JsonUtils.stringToJsonNode(returnValueMetadataStr);
+      Preconditions.checkState(returnValueMetadataJson.hasNonNull(RETURN_TYPE_KEY),
+          "The json string in the last argument of GROOVY transform function must have non-null 'returnType'");
+      Preconditions.checkState(returnValueMetadataJson.hasNonNull(IS_SINGLE_VALUE_KEY),
+          "The json string in the last argument of GROOVY transform function must have non-null 'isSingleValue'");
+      String returnTypeStr = returnValueMetadataJson.get(RETURN_TYPE_KEY).asText();
+      Preconditions.checkState(EnumUtils.isValidEnum(FieldSpec.DataType.class, returnTypeStr),
+          "The 'returnType' in the json string which is the last argument of GROOVY transform function must be a valid FieldSpec.DataType enum value");
+      _resultMetadata = new TransformResultMetadata(FieldSpec.DataType.valueOf(returnTypeStr),
+          returnValueMetadataJson.get(IS_SINGLE_VALUE_KEY).asBoolean(true), false);
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Caught exception when converting json string '" + returnValueMetadataStr + "' to JsonNode", e);
+    }
+
+    // arguments 1 to n-1 are arguments to the groovy function
+    _numGroovyArgs = numArgs - 2;
+    if (_numGroovyArgs > 0) {
+      _groovyArguments = new TransformFunction[_numGroovyArgs];
+      _isSourceSingleValue = new boolean[_numGroovyArgs];
+      _sourceDataType = new FieldSpec.DataType[_numGroovyArgs];
+      int idx = 0;
+      for (int i = 1; i < numArgs - 1; i++) {
+        TransformFunction argument = arguments.get(i);
+        Preconditions.checkState(!(argument instanceof LiteralTransformFunction),
+            "Argument in positions 2 to n-1 must be a column or other transform functions");
+        _groovyArguments[idx] = argument;
+        TransformResultMetadata resultMetadata = argument.getResultMetadata();
+        _isSourceSingleValue[idx] = resultMetadata.isSingleValue();
+        _sourceDataType[idx++] = resultMetadata.getDataType();
+      }
+      // construct arguments string for GroovyFunctionEvaluator
+      String argumentsStr = IntStream.range(0, _numGroovyArgs).mapToObj(i -> ARGUMENT_PREFIX + i)
+          .collect(Collectors.joining(GROOVY_ARG_DELIMITER));
+      _groovyFunctionEvaluator = new GroovyFunctionEvaluator(String
+          .format(GROOVY_TEMPLATE_WITH_ARGS, ((LiteralTransformFunction) groovyTransformFunction).getLiteral(),
+              argumentsStr));
+
+      _transformToValuesFunctions = new BiFunction[_numGroovyArgs];
+      _fetchElementFunctions = new BiFunction[_numGroovyArgs];
+      initFunctions();
+    } else {
+      _groovyFunctionEvaluator = new GroovyFunctionEvaluator(String
+          .format(GROOVY_TEMPLATE_WITHOUT_ARGS, ((LiteralTransformFunction) groovyTransformFunction).getLiteral()));
+    }
+    _sourceArrays = new Object[_numGroovyArgs];
+    _bindingValues = new Object[_numGroovyArgs];
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return _resultMetadata;
+  }
+
+  private void initFunctions() {
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      BiFunction<Object, Integer, Object> getElementFunction;
+      BiFunction<TransformFunction, ProjectionBlock, Object> transformToValuesFunction;
+      if (_isSourceSingleValue[i]) {
+        switch (_sourceDataType[i]) {
+          case INT:
+            transformToValuesFunction = TransformFunction::transformToIntValuesSV;
+            getElementFunction = (sourceArray, position) -> ((int[]) sourceArray)[position];
+            break;
+          case LONG:
+            transformToValuesFunction = TransformFunction::transformToLongValuesSV;
+            getElementFunction = (sourceArray, position) -> ((long[]) sourceArray)[position];
+            break;
+          case FLOAT:
+            transformToValuesFunction = TransformFunction::transformToFloatValuesSV;
+            getElementFunction = (sourceArray, position) -> ((float[]) sourceArray)[position];
+            break;
+          case DOUBLE:
+            transformToValuesFunction = TransformFunction::transformToDoubleValuesSV;
+            getElementFunction = (sourceArray, position) -> ((double[]) sourceArray)[position];
+            break;
+          case STRING:
+            transformToValuesFunction = TransformFunction::transformToStringValuesSV;
+            getElementFunction = (sourceArray, position) -> ((String[]) sourceArray)[position];
+            break;
+          default:
+            throw new IllegalStateException(
+                "Unsupported data type '" + _sourceDataType[i] + "' for GROOVY transform function");
+        }
+      } else {
+        switch (_sourceDataType[i]) {
+          case INT:
+            transformToValuesFunction = TransformFunction::transformToIntValuesMV;
+            getElementFunction = (sourceArray, position) -> ((int[][]) sourceArray)[position];
+            break;
+          case LONG:
+            transformToValuesFunction = TransformFunction::transformToLongValuesMV;
+            getElementFunction = (sourceArray, position) -> ((long[][]) sourceArray)[position];
+            break;
+          case FLOAT:
+            transformToValuesFunction = TransformFunction::transformToFloatValuesMV;
+            getElementFunction = (sourceArray, position) -> ((float[][]) sourceArray)[position];
+            break;
+          case DOUBLE:
+            transformToValuesFunction = TransformFunction::transformToDoubleValuesMV;
+            getElementFunction = (sourceArray, position) -> ((double[][]) sourceArray)[position];
+            break;
+          case STRING:
+            transformToValuesFunction = TransformFunction::transformToStringValuesMV;
+            getElementFunction = (sourceArray, position) -> ((String[][]) sourceArray)[position];
+            break;
+          default:
+            throw new IllegalStateException(
+                "Unsupported data type '" + _sourceDataType[i] + "' for GROOVY transform function");
+        }
+      }
+      _transformToValuesFunctions[i] = transformToValuesFunction;
+      _fetchElementFunctions[i] = getElementFunction;
+    }
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    if (_intResultSV == null) {
+      _intResultSV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      _intResultSV[i] = (int) _groovyFunctionEvaluator.evaluate(_bindingValues);
+    }
+    return _intResultSV;
+  }
+
+  @Override
+  public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
+    if (_intResultMV == null) {
+      _intResultMV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      Object result = _groovyFunctionEvaluator.evaluate(_bindingValues);
+      if (result instanceof List) {
+        _intResultMV[i] = new IntArrayList((List<Integer>) result).toIntArray();
+      } else if (result instanceof int[]) {
+        _intResultMV[i] = (int[]) result;
+      } else {
+        throw new IllegalStateException("Unexpected result type '" + result.getClass() + "' for GROOVY function");
+      }
+    }
+    return _intResultMV;
+  }
+
+  @Override
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    if (_doubleResultSV == null) {
+      _doubleResultSV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      _doubleResultSV[i] = (double) _groovyFunctionEvaluator.evaluate(_bindingValues);
+    }
+    return _doubleResultSV;
+  }
+
+  @Override
+  public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
+    if (_doubleResultMV == null) {
+      _doubleResultMV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      Object result = _groovyFunctionEvaluator.evaluate(_bindingValues);
+      if (result instanceof List) {
+        _doubleResultMV[i] = new DoubleArrayList((List<Double>) result).toDoubleArray();
+      } else if (result instanceof double[]) {
+        _doubleResultMV[i] = (double[]) result;
+      } else {
+        throw new IllegalStateException("Unexpected result type '" + result.getClass() + "' for GROOVY function");
+      }
+    }
+    return _doubleResultMV;
+  }
+
+  @Override
+  public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
+    if (_longResultSV == null) {
+      _longResultSV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      _longResultSV[i] = (long) _groovyFunctionEvaluator.evaluate(_bindingValues);
+    }
+    return _longResultSV;
+  }
+
+  @Override
+  public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
+    if (_longResultMV == null) {
+      _longResultMV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      Object result = _groovyFunctionEvaluator.evaluate(_bindingValues);
+      if (result instanceof List) {
+        _longResultMV[i] = new LongArrayList((List<Long>) result).toLongArray();
+      } else if (result instanceof long[]) {
+        _longResultMV[i] = (long[]) result;
+      } else {
+        throw new IllegalStateException("Unexpected result type '" + result.getClass() + "' for GROOVY function");
+      }
+    }
+    return _longResultMV;
+  }
+
+  @Override
+  public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
+    if (_floatResultSV == null) {
+      _floatResultSV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      _floatResultSV[i] = (float) _groovyFunctionEvaluator.evaluate(_bindingValues);
+    }
+    return _floatResultSV;
+  }
+
+  @Override
+  public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
+    if (_floatResultMV == null) {
+      _floatResultMV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      Object result = _groovyFunctionEvaluator.evaluate(_bindingValues);
+      if (result instanceof List) {
+        _floatResultMV[i] = new FloatArrayList((List<Float>) result).toFloatArray();
+      } else if (result instanceof float[]) {
+        _floatResultMV[i] = (float[]) result;
+      } else {
+        throw new IllegalStateException("Unexpected result type '" + result.getClass() + "' for GROOVY function");
+      }
+    }
+    return _floatResultMV;
+  }
+
+  @Override
+  public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
+    if (_stringResultSV == null) {
+      _stringResultSV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      _stringResultSV[i] = (String) _groovyFunctionEvaluator.evaluate(_bindingValues);
+    }
+    return _stringResultSV;
+  }
+
+  @Override
+  public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
+    if (_stringResultMV == null) {
+      _stringResultMV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+    }
+    for (int i = 0; i < _numGroovyArgs; i++) {
+      _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], projectionBlock);
+    }
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numGroovyArgs; j++) {
+        _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
+      }
+      Object result = _groovyFunctionEvaluator.evaluate(_bindingValues);
+      if (result instanceof List) {
+        _stringResultMV[i] = ((List<String>) result).toArray(new String[0]);
+      } else if (result instanceof String[]) {
+        _stringResultMV[i] = (String[]) result;
+      } else {
+        throw new IllegalStateException("Unexpected result type '" + result.getClass() + "' for GROOVY function");
+      }
+    }
+    return _stringResultMV;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -90,6 +90,8 @@ public class TransformFunctionFactory {
           put(TransformFunctionType.ARRAYLENGTH.getName().toLowerCase(), ArrayLengthTransformFunction.class);
           put(TransformFunctionType.VALUEIN.getName().toLowerCase(), ValueInTransformFunction.class);
           put(TransformFunctionType.MAPVALUE.getName().toLowerCase(), MapValueTransformFunction.class);
+
+          put(TransformFunctionType.GROOVY.getName().toLowerCase(), GroovyTransformFunction.class);
           put(TransformFunctionType.CASE.getName().toLowerCase(), CaseTransformFunction.class);
 
           put(TransformFunctionType.EQUALS.getName().toLowerCase(), EqualsTransformFunction.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunctionTest.java
@@ -46,7 +46,9 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
 
     // max in array (returns SV INT)
     groovyTransformFunction = String
-        .format("groovy('arg0.toList().max()', %s, '{\"returnType\":\"INT\", \"isSingleValue\":true}')", INT_MV_COLUMN);
+        .format("groovy('{\"returnType\":\"INT\", \"isSingleValue\":true}', "
+            + "'arg0.toList().max()', "
+            + "%s)", INT_MV_COLUMN);
     int[] expectedResult1 = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedResult1[i] = Arrays.stream(_intMVValues[i]).max().getAsInt();
@@ -55,8 +57,9 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
 
     // simple addition (returns SV LONG)
     groovyTransformFunction = String
-        .format("groovy('arg0 + arg1', %s, %s, '{\"returnType\":\"LONG\", \"isSingleValue\":true}')", INT_SV_COLUMN,
-            LONG_SV_COLUMN);
+        .format("groovy('{\"returnType\":\"LONG\", \"isSingleValue\":true}', "
+                + "'arg0 + arg1', "
+                + "%s, %s)", INT_SV_COLUMN, LONG_SV_COLUMN);
     long[] expectedResult2 = new long[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedResult2[i] = _intSVValues[i] + _longSVValues[i];
@@ -65,8 +68,9 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
 
     // minimum of 2 numbers (returns SV DOUBLE)
     groovyTransformFunction = String
-        .format("groovy('Math.min(arg0, arg1)', %s, %s, '{\"returnType\":\"DOUBLE\", \"isSingleValue\":true}')",
-            DOUBLE_SV_COLUMN, INT_SV_COLUMN);
+        .format("groovy('{\"returnType\":\"DOUBLE\", \"isSingleValue\":true}', "
+                + "'Math.min(arg0, arg1)', "
+                + "%s, %s)", DOUBLE_SV_COLUMN, INT_SV_COLUMN);
     double[] expectedResult3 = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedResult3[i] = Math.min(_intSVValues[i], _doubleSVValues[i]);
@@ -75,8 +79,9 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
 
     // (returns SV FLOAT)
     groovyTransformFunction = String.format(
-        "groovy('def result; switch(arg0.length()) { case 10: result = 1.1; break; case 20: result = 1.2; break; default: result = 1.3;}; return result.floatValue()', %s, '{\"returnType\":\"FLOAT\", \"isSingleValue\":true}')",
-        STRING_ALPHANUM_SV_COLUMN);
+        "groovy('{\"returnType\":\"FLOAT\", \"isSingleValue\":true}', "
+            + "'def result; switch(arg0.length()) { case 10: result = 1.1; break; case 20: result = 1.2; break; default: result = 1.3;}; return result.floatValue()', "
+            + "%s)", STRING_ALPHANUM_SV_COLUMN);
     float[] expectedResult4 = new float[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedResult4[i] =
@@ -86,8 +91,9 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
 
     // string operations (returns SV STRING)
     groovyTransformFunction = String.format(
-        "groovy('[arg0, arg1, arg2].join(\"_\")', %s, %s, %s, '{\"returnType\":\"STRING\", \"isSingleValue\":true}')",
-        FLOAT_SV_COLUMN, STRING_SV_COLUMN, DOUBLE_SV_COLUMN);
+        "groovy('{\"returnType\":\"STRING\", \"isSingleValue\":true}', "
+            + "'[arg0, arg1, arg2].join(\"_\")', "
+            + "%s, %s, %s)", FLOAT_SV_COLUMN, STRING_SV_COLUMN, DOUBLE_SV_COLUMN);
     String[] expectedResult5 = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedResult5[i] = Joiner.on("_").join(_floatSVValues[i], _stringSVValues[i], _doubleSVValues[i]);
@@ -96,8 +102,9 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
 
     // find all in array that match (returns MV INT)
     groovyTransformFunction = String
-        .format("groovy('arg0.findAll{it < 5}', %s, '{\"returnType\":\"INT\", \"isSingleValue\":false}')",
-            INT_MV_COLUMN);
+        .format("groovy('{\"returnType\":\"INT\", \"isSingleValue\":false}', "
+                + "'arg0.findAll{it < 5}', "
+                + "%s)", INT_MV_COLUMN);
     int[][] expectedResult6 = new int[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedResult6[i] = Arrays.stream(_intMVValues[i]).filter(e -> e < 5).toArray();
@@ -106,8 +113,9 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
 
     // (returns MV LONG)
     groovyTransformFunction = String
-        .format("groovy('arg0.findIndexValues{it == 5}', %s, '{\"returnType\":\"LONG\", \"isSingleValue\":false}')",
-            INT_MV_COLUMN);
+        .format("groovy('{\"returnType\":\"LONG\", \"isSingleValue\":false}', "
+            + "'arg0.findIndexValues{it == 5}', "
+                + "%s)", INT_MV_COLUMN);
     long[][] expectedResult7 = new long[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
       int[] intMVValue = _intMVValues[i];
@@ -117,18 +125,18 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
     inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.LONG, false, expectedResult7});
 
     // no-args function (returns MV STRING)
-    groovyTransformFunction = "groovy('[\"foo\", \"bar\"]', '{\"returnType\":\"STRING\", \"isSingleValue\":false}')";
+    groovyTransformFunction = "groovy('{\"returnType\":\"STRING\", \"isSingleValue\":false}', '[\"foo\", \"bar\"]')";
     String[][] expectedResult8 = new String[NUM_ROWS][];
     Arrays.fill(expectedResult8, new String[]{"foo", "bar"});
     inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.STRING, false, expectedResult8});
 
     // nested groovy functions
     String groovy1 = String
-        .format("groovy('arg0.toList().max()', %s, '{\"returnType\":\"INT\", \"isSingleValue\":true}')", INT_MV_COLUMN);
+        .format("groovy('{\"returnType\":\"INT\", \"isSingleValue\":true}', 'arg0.toList().max()', %s)", INT_MV_COLUMN);
     String groovy2 = String
-        .format("groovy('arg0.toList().min()', %s, '{\"returnType\":\"INT\", \"isSingleValue\":true}')", INT_MV_COLUMN);
+        .format("groovy('{\"returnType\":\"INT\", \"isSingleValue\":true}', 'arg0.toList().min()', %s)", INT_MV_COLUMN);
     groovyTransformFunction = String
-        .format("groovy('[arg0, arg1, arg2.sum()]', %s, %s, %s, '{\"returnType\":\"INT\", \"isSingleValue\":false}')",
+        .format("groovy('{\"returnType\":\"INT\", \"isSingleValue\":false}', '[arg0, arg1, arg2.sum()]', %s, %s, %s)",
             groovy1, groovy2, INT_MV_COLUMN);
     int[][] expectedResult9 = new int[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -139,7 +147,7 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
 
     // nested with other functions
     groovyTransformFunction = String
-        .format("groovy('arg0 + arg1', %s, arraylength(%s), '{\"returnType\":\"INT\", \"isSingleValue\":true}')",
+        .format("groovy('{\"returnType\":\"INT\", \"isSingleValue\":true}', 'arg0 + arg1', %s, arraylength(%s))",
             INT_SV_COLUMN, INT_MV_COLUMN);
     int[] expectedResult10 = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -255,29 +263,29 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
     inputs.add(new Object[]{String.format("groovy(%s)", STRING_SV_COLUMN)});
     // first argument must be literal
     inputs.add(new Object[]{String.format("groovy(%s, %s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN)});
-    // last argument must be a literal
+    // second argument must be a literal
     inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s)", STRING_SV_COLUMN)});
-    // last argument must be a valid json
-    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, ']]')", STRING_SV_COLUMN)});
-    // last argument json must contain non-null key returnType
-    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"isSingleValue\":true}')", INT_SV_COLUMN)});
-    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"returnType\":null, \"isSingleValue\":true}')",
+    // first argument must be a valid json
+    inputs.add(new Object[]{String.format("groovy(']]', 'arg0 + 10', %s)", STRING_SV_COLUMN)});
+    // first argument json must contain non-null key returnType
+    inputs.add(new Object[]{String.format("groovy('{\"isSingleValue\":true}', 'arg0 + 10', %s)", INT_SV_COLUMN)});
+    inputs.add(new Object[]{String.format("groovy('{\"returnType\":null, \"isSingleValue\":true}', 'arg0 + 10', %s)",
         INT_SV_COLUMN)});
-    // last argument json must contain non-null key isSingleValue
-    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"returnType\":\"INT\"}')", INT_SV_COLUMN)});
-    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"returnType\":\"INT\", \"isSingleValue\":null}')",
+    // first argument json must contain non-null key isSingleValue
+    inputs.add(new Object[]{String.format("groovy('{\"returnType\":\"INT\"}', 'arg0 + 10', %s)", INT_SV_COLUMN)});
+    inputs.add(new Object[]{String.format("groovy('{\"returnType\":\"INT\", \"isSingleValue\":null}', 'arg0 + 10', %s)",
         INT_SV_COLUMN)});
     // return type must be valid DataType enum
-    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"returnType\":\"foo\", \"isSingleValue\":true}')",
+    inputs.add(new Object[]{String.format("groovy('{\"returnType\":\"foo\", \"isSingleValue\":true}', 'arg0 + 10', %s)",
         INT_SV_COLUMN)});
     // arguments must be columns/transform functions
-    inputs.add(new Object[]{"groovy('arg0 + 10', 'foo', '{\"returnType\":\"INT\", \"isSingleValue\":true}')"});
+    inputs.add(new Object[]{"groovy('{\"returnType\":\"INT\", \"isSingleValue\":true}', 'arg0 + 10', 'foo')"});
     inputs.add(new Object[]{String.format(
-        "groovy('arg0 + arg1 + 10', 'arraylength(colB)', %s, '{\"returnType\":\"INT\", \"isSingleValue\":true}')",
+        "groovy('{\"returnType\":\"INT\", \"isSingleValue\":true}', 'arg0 + arg1 + 10', 'arraylength(colB)', %s)",
         INT_SV_COLUMN)});
     // invalid groovy expression
-    inputs.add(new Object[]{"groovy('+-+', '{\"returnType\":\"INT\"}')"});
-    inputs.add(new Object[]{String.format("groovy('+-+arg0 arg1', %s, %s, '{\"returnType\":\"INT\"}')", INT_SV_COLUMN,
+    inputs.add(new Object[]{"groovy('{\"returnType\":\"INT\"}', '+-+')"});
+    inputs.add(new Object[]{String.format("groovy('{\"returnType\":\"INT\"}', '+-+arg0 arg1', %s, %s)", INT_SV_COLUMN,
         DOUBLE_SV_COLUMN)});
     return inputs.toArray(new Object[0][]);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunctionTest.java
@@ -1,0 +1,284 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import com.google.common.base.Joiner;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.IntSummaryStatistics;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests the GROOVY transform function
+ */
+public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
+
+  @DataProvider(name = "groovyFunctionDataProvider")
+  public Object[][] groovyFunctionDataProvider() {
+
+    String groovyTransformFunction;
+    List<Object[]> inputs = new ArrayList<>();
+
+    // max in array (returns SV INT)
+    groovyTransformFunction = String
+        .format("groovy('arg0.toList().max()', %s, '{\"returnType\":\"INT\", \"isSingleValue\":true}')", INT_MV_COLUMN);
+    int[] expectedResult1 = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResult1[i] = Arrays.stream(_intMVValues[i]).max().getAsInt();
+    }
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.INT, true, expectedResult1});
+
+    // simple addition (returns SV LONG)
+    groovyTransformFunction = String
+        .format("groovy('arg0 + arg1', %s, %s, '{\"returnType\":\"LONG\", \"isSingleValue\":true}')", INT_SV_COLUMN,
+            LONG_SV_COLUMN);
+    long[] expectedResult2 = new long[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResult2[i] = _intSVValues[i] + _longSVValues[i];
+    }
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.LONG, true, expectedResult2});
+
+    // minimum of 2 numbers (returns SV DOUBLE)
+    groovyTransformFunction = String
+        .format("groovy('Math.min(arg0, arg1)', %s, %s, '{\"returnType\":\"DOUBLE\", \"isSingleValue\":true}')",
+            DOUBLE_SV_COLUMN, INT_SV_COLUMN);
+    double[] expectedResult3 = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResult3[i] = Math.min(_intSVValues[i], _doubleSVValues[i]);
+    }
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.DOUBLE, true, expectedResult3});
+
+    // (returns SV FLOAT)
+    groovyTransformFunction = String.format(
+        "groovy('def result; switch(arg0.length()) { case 10: result = 1.1; break; case 20: result = 1.2; break; default: result = 1.3;}; return result.floatValue()', %s, '{\"returnType\":\"FLOAT\", \"isSingleValue\":true}')",
+        STRING_ALPHANUM_SV_COLUMN);
+    float[] expectedResult4 = new float[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResult4[i] =
+          _stringAlphaNumericSVValues.length == 10 ? 1.1f : (_stringAlphaNumericSVValues.length == 20 ? 1.2f : 1.3f);
+    }
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.FLOAT, true, expectedResult4});
+
+    // string operations (returns SV STRING)
+    groovyTransformFunction = String.format(
+        "groovy('[arg0, arg1, arg2].join(\"_\")', %s, %s, %s, '{\"returnType\":\"STRING\", \"isSingleValue\":true}')",
+        FLOAT_SV_COLUMN, STRING_SV_COLUMN, DOUBLE_SV_COLUMN);
+    String[] expectedResult5 = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResult5[i] = Joiner.on("_").join(_floatSVValues[i], _stringSVValues[i], _doubleSVValues[i]);
+    }
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.STRING, true, expectedResult5});
+
+    // find all in array that match (returns MV INT)
+    groovyTransformFunction = String
+        .format("groovy('arg0.findAll{it < 5}', %s, '{\"returnType\":\"INT\", \"isSingleValue\":false}')",
+            INT_MV_COLUMN);
+    int[][] expectedResult6 = new int[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResult6[i] = Arrays.stream(_intMVValues[i]).filter(e -> e < 5).toArray();
+    }
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.INT, false, expectedResult6});
+
+    // (returns MV LONG)
+    groovyTransformFunction = String
+        .format("groovy('arg0.findIndexValues{it == 5}', %s, '{\"returnType\":\"LONG\", \"isSingleValue\":false}')",
+            INT_MV_COLUMN);
+    long[][] expectedResult7 = new long[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      int[] intMVValue = _intMVValues[i];
+      expectedResult7[i] =
+          IntStream.range(0, intMVValue.length).filter(e -> intMVValue[e] == 5).mapToLong(e -> (long) e).toArray();
+    }
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.LONG, false, expectedResult7});
+
+    // no-args function (returns MV STRING)
+    groovyTransformFunction = "groovy('[\"foo\", \"bar\"]', '{\"returnType\":\"STRING\", \"isSingleValue\":false}')";
+    String[][] expectedResult8 = new String[NUM_ROWS][];
+    Arrays.fill(expectedResult8, new String[]{"foo", "bar"});
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.STRING, false, expectedResult8});
+
+    // nested groovy functions
+    String groovy1 = String
+        .format("groovy('arg0.toList().max()', %s, '{\"returnType\":\"INT\", \"isSingleValue\":true}')", INT_MV_COLUMN);
+    String groovy2 = String
+        .format("groovy('arg0.toList().min()', %s, '{\"returnType\":\"INT\", \"isSingleValue\":true}')", INT_MV_COLUMN);
+    groovyTransformFunction = String
+        .format("groovy('[arg0, arg1, arg2.sum()]', %s, %s, %s, '{\"returnType\":\"INT\", \"isSingleValue\":false}')",
+            groovy1, groovy2, INT_MV_COLUMN);
+    int[][] expectedResult9 = new int[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      IntSummaryStatistics stats = Arrays.stream(_intMVValues[i]).summaryStatistics();
+      expectedResult9[i] = new int[]{stats.getMax(), stats.getMin(), (int) stats.getSum()};
+    }
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.INT, false, expectedResult9});
+
+    // nested with other functions
+    groovyTransformFunction = String
+        .format("groovy('arg0 + arg1', %s, arraylength(%s), '{\"returnType\":\"INT\", \"isSingleValue\":true}')",
+            INT_SV_COLUMN, INT_MV_COLUMN);
+    int[] expectedResult10 = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResult10[i] = _intSVValues[i] + _intMVValues[i].length;
+    }
+    inputs.add(new Object[]{groovyTransformFunction, FieldSpec.DataType.INT, true, expectedResult10});
+
+    return inputs.toArray(new Object[0][]);
+  }
+
+  @Test(dataProvider = "groovyFunctionDataProvider")
+  public void testGroovyTransformFunctions(String expressionStr, FieldSpec.DataType resultType,
+      boolean isResultSingleValue, Object expectedResult) {
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof GroovyTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), GroovyTransformFunction.FUNCTION_NAME);
+    Assert.assertEquals(transformFunction.getResultMetadata().getDataType(), resultType);
+    Assert.assertEquals(transformFunction.getResultMetadata().isSingleValue(), isResultSingleValue);
+    Assert.assertFalse(transformFunction.getResultMetadata().hasDictionary());
+
+    if (isResultSingleValue) {
+      switch (resultType) {
+
+        case INT:
+          int[] intResults = transformFunction.transformToIntValuesSV(_projectionBlock);
+          int[] expectedInts = (int[]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(intResults[i], expectedInts[i]);
+          }
+          break;
+        case LONG:
+          long[] longResults = transformFunction.transformToLongValuesSV(_projectionBlock);
+          long[] expectedLongs = (long[]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(longResults[i], expectedLongs[i]);
+          }
+          break;
+        case FLOAT:
+          float[] floatResults = transformFunction.transformToFloatValuesSV(_projectionBlock);
+          float[] expectedFloats = (float[]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(floatResults[i], expectedFloats[i]);
+          }
+          break;
+        case DOUBLE:
+          double[] doubleResults = transformFunction.transformToDoubleValuesSV(_projectionBlock);
+          double[] expectedDoubles = (double[]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(doubleResults[i], expectedDoubles[i]);
+          }
+          break;
+        case STRING:
+          String[] stringResults = transformFunction.transformToStringValuesSV(_projectionBlock);
+          String[] expectedStrings = (String[]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(stringResults[i], expectedStrings[i]);
+          }
+          break;
+      }
+    } else {
+      switch (resultType) {
+
+        case INT:
+          int[][] intResults = transformFunction.transformToIntValuesMV(_projectionBlock);
+          int[][] expectedInts = (int[][]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(intResults[i], expectedInts[i]);
+          }
+          break;
+        case LONG:
+          long[][] longResults = transformFunction.transformToLongValuesMV(_projectionBlock);
+          long[][] expectedLongs = (long[][]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(longResults[i], expectedLongs[i]);
+          }
+          break;
+        case FLOAT:
+          float[][] floatResults = transformFunction.transformToFloatValuesMV(_projectionBlock);
+          float[][] expectedFloats = (float[][]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(floatResults[i], expectedFloats[i]);
+          }
+          break;
+        case DOUBLE:
+          double[][] doubleResults = transformFunction.transformToDoubleValuesMV(_projectionBlock);
+          double[][] expectedDoubles = (double[][]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(doubleResults[i], expectedDoubles[i]);
+          }
+          break;
+        case STRING:
+          String[][] stringResults = transformFunction.transformToStringValuesMV(_projectionBlock);
+          String[][] expectedStrings = (String[][]) expectedResult;
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(stringResults[i], expectedStrings[i]);
+          }
+          break;
+      }
+    }
+  }
+
+  @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
+  public void testIllegalArguments(String expressionStr) {
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(expressionStr);
+    TransformFunctionFactory.get(expression, _dataSourceMap);
+  }
+
+  @DataProvider(name = "testIllegalArguments")
+  public Object[][] testIllegalArguments() {
+    List<Object[]> inputs = new ArrayList<>();
+    // incorrect number of arguments
+    inputs.add(new Object[]{String.format("groovy(%s)", STRING_SV_COLUMN)});
+    // first argument must be literal
+    inputs.add(new Object[]{String.format("groovy(%s, %s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN)});
+    // last argument must be a literal
+    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s)", STRING_SV_COLUMN)});
+    // last argument must be a valid json
+    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, ']]')", STRING_SV_COLUMN)});
+    // last argument json must contain non-null key returnType
+    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"isSingleValue\":true}')", INT_SV_COLUMN)});
+    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"returnType\":null, \"isSingleValue\":true}')",
+        INT_SV_COLUMN)});
+    // last argument json must contain non-null key isSingleValue
+    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"returnType\":\"INT\"}')", INT_SV_COLUMN)});
+    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"returnType\":\"INT\", \"isSingleValue\":null}')",
+        INT_SV_COLUMN)});
+    // return type must be valid DataType enum
+    inputs.add(new Object[]{String.format("groovy('arg0 + 10', %s, '{\"returnType\":\"foo\", \"isSingleValue\":true}')",
+        INT_SV_COLUMN)});
+    // arguments must be columns/transform functions
+    inputs.add(new Object[]{"groovy('arg0 + 10', 'foo', '{\"returnType\":\"INT\", \"isSingleValue\":true}')"});
+    inputs.add(new Object[]{String.format(
+        "groovy('arg0 + arg1 + 10', 'arraylength(colB)', %s, '{\"returnType\":\"INT\", \"isSingleValue\":true}')",
+        INT_SV_COLUMN)});
+    // invalid groovy expression
+    inputs.add(new Object[]{"groovy('+-+', '{\"returnType\":\"INT\"}')"});
+    inputs.add(new Object[]{String.format("groovy('+-+arg0 arg1', %s, %s, '{\"returnType\":\"INT\"}')", INT_SV_COLUMN,
+        DOUBLE_SV_COLUMN)});
+    return inputs.toArray(new Object[0][]);
+  }
+}


### PR DESCRIPTION
## Description
GROOVY transform function for query time. 

Syntax:
```
groovy('<return value metadata json string>', '<groovy script>', argument0, argument1, argument2...)
```
- 1st argument is a json string representing all return value metadata. Example: `{"returnType":"INT","isSingleValue":true}`
- 2nd argument is the groovy expression. Use arg0, arg1 etc for referring to arguments.
- all remaining arguments (3rd to nth) are arguments to the function (identifiers/functions)

Examples:
- Single value result - 
```
groovy('{"returnType":"INT","isSingleValue":true}', 'arg0 + arg1', colA, colB)
```
- Single value result from array input - 
```
groovy('{"returnType":"INT","isSingleValue":true}', 'arg0.toList().max()', mvColumn)
```
- List result - 
```
groovy('{"returnType":"LONG","isSingleValue":false}', 'arg0.findIndexValues{ it > 5 }', mvColumn)
```
- Nested with other Pinot functions - 
```
groovy('{"returnType":"DOUBLE","isSingleValue":true}', 'arg0 * arg1', arraylength(mvColumn), colB)
```
- Multi line groovy script, with loops and conditions - 
```
groovy( '{"returnType":"DOUBLE","isSingleValue":true}', 
'def x = 0; arg0.eachWithIndex{item, idx-> if (item == "foo") {x = x + arg1[idx] }}; return x' , 
mvColumnA, mvColumnB)
```

Example in query:
```
SELECT 
GROOVY('{"returnType":"STRING","isSingleValue":true}', 'arg0+" "+arg1', firstName, lastName) AS fullName 
FROM myTable
```

Refer to `GroovyTransformFunctionTest` for more examples. **Detailed documentation coming soon.**


## Release Notes
GROOVY - New transform UDF which executes Groovy expressions in query.

## Documentation
TBD
