### PR TITLE
Thirdeye docker log crash fix

### DIFF
--- a/docker/images/pinot-thirdeye/bin/start-thirdeye.sh
+++ b/docker/images/pinot-thirdeye/bin/start-thirdeye.sh
@@ -39,11 +39,11 @@ fi
 
 echo "Running thirdeye backend config: ${CONFIG_DIR}"
 [ -f "${CONFIG_DIR}/data-sources/data-sources-config-backend.yml" ] && cp "${CONFIG_DIR}/data-sources/data-sources-config-backend.yml" "${CONFIG_DIR}/data-sources/data-sources-config.yml"
-java -cp "./bin/thirdeye-pinot.jar" org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyApplication "${CONFIG_DIR}" &
+java -Dlog4j.configurationFile=log4j2.xml -cp "./bin/thirdeye-pinot.jar" org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyApplication "${CONFIG_DIR}" &
 sleep 10
 
 echo "Running thirdeye frontend config: ${CONFIG_DIR}"
 [ -f "${CONFIG_DIR}/data-sources/data-sources-config-frontend.yml" ] && cp "${CONFIG_DIR}/data-sources/data-sources-config-frontend.yml" "${CONFIG_DIR}/data-sources/data-sources-config.yml"
-java -cp "./bin/thirdeye-pinot.jar" org.apache.pinot.thirdeye.dashboard.ThirdEyeDashboardApplication "${CONFIG_DIR}" &
+java -Dlog4j.configurationFile=log4j2.xml -cp "./bin/thirdeye-pinot.jar" org.apache.pinot.thirdeye.dashboard.ThirdEyeDashboardApplication "${CONFIG_DIR}" &
 
 wait

--- a/docker/images/pinot-thirdeye/config/ephemeral/dashboard.yml
+++ b/docker/images/pinot-thirdeye/config/ephemeral/dashboard.yml
@@ -1,3 +1,5 @@
+logging:
+  type: external
 authConfig:
   authEnabled: false
   authKey: ""

--- a/docker/images/pinot-thirdeye/config/ephemeral/dashboard.yml
+++ b/docker/images/pinot-thirdeye/config/ephemeral/dashboard.yml
@@ -26,6 +26,8 @@ alerterConfiguration:
     smtpHost: localhost
     smtpPort: 25
 server:
+  requestLog:
+    type: external
   type: default
   applicationConnectors:
     - type: http

--- a/docker/images/pinot-thirdeye/config/ephemeral/detector.yml
+++ b/docker/images/pinot-thirdeye/config/ephemeral/detector.yml
@@ -1,7 +1,5 @@
 logging:
-  level: INFO
-  loggers:
-    org.hibernate.engine.internal: WARN
+  type: external
 server:
   type: default
   rootPath: '/api/*'

--- a/docker/images/pinot-thirdeye/config/ephemeral/detector.yml
+++ b/docker/images/pinot-thirdeye/config/ephemeral/detector.yml
@@ -1,6 +1,8 @@
 logging:
   type: external
 server:
+  requestLog:
+    type: external
   type: default
   rootPath: '/api/*'
   applicationContextPath: /

--- a/docker/images/pinot-thirdeye/config/pinot-quickstart/dashboard.yml
+++ b/docker/images/pinot-thirdeye/config/pinot-quickstart/dashboard.yml
@@ -1,3 +1,5 @@
+logging:
+  type: external
 authConfig:
   authEnabled: false
   authKey: ""

--- a/docker/images/pinot-thirdeye/config/pinot-quickstart/dashboard.yml
+++ b/docker/images/pinot-thirdeye/config/pinot-quickstart/dashboard.yml
@@ -26,6 +26,8 @@ alerterConfiguration:
     smtpHost: localhost
     smtpPort: 25
 server:
+  requestLog:
+    type: external
   type: default
   applicationConnectors:
     - type: http

--- a/docker/images/pinot-thirdeye/config/pinot-quickstart/detector.yml
+++ b/docker/images/pinot-thirdeye/config/pinot-quickstart/detector.yml
@@ -1,7 +1,5 @@
 logging:
-  level: INFO
-  loggers:
-    org.hibernate.engine.internal: WARN
+  type: external
 server:
   type: default
   rootPath: '/api/*'

--- a/docker/images/pinot-thirdeye/config/pinot-quickstart/detector.yml
+++ b/docker/images/pinot-thirdeye/config/pinot-quickstart/detector.yml
@@ -1,6 +1,8 @@
 logging:
   type: external
 server:
+  requestLog:
+    type: external
   type: default
   rootPath: '/api/*'
   applicationContextPath: /


### PR DESCRIPTION
## Description
Recent changes to ThirdEye logging aren't reflected in the config files shipped with the docker image and break the launch of apachepinot/thirdeye. This PR modifies the configuration to launch the container successfully.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes? Things to consider:
**No**
