### PR TITLE
Pradeep/s3 credential chain fix

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -430,18 +430,10 @@ public class S3PinotFS extends PinotFS {
       if (prefix.equals(DELIMITER)) {
         return true;
       }
-      try {
-        HeadObjectRequest headObjectRequest =
-            HeadObjectRequest.builder().bucket(uri.getHost()).key(prefix).build();
-        HeadObjectResponse s3ObjectMetadata = _s3Client.headObject(headObjectRequest);
 
-        return s3ObjectMetadata.sdkHttpResponse().isSuccessful();
-      } catch (NoSuchKeyException e) {
-        LOGGER.error("Could not get directory entry for {}", uri);
-      }
-
-      ListObjectsV2Request listObjectsV2Request =
-          ListObjectsV2Request.builder().bucket(uri.getHost()).prefix(prefix).build();
+      ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request
+              .builder().bucket(uri.getHost())
+              .prefix(prefix).maxKeys(2).build();
       ListObjectsV2Response listObjectsV2Response = _s3Client.listObjectsV2(listObjectsV2Request);
       return listObjectsV2Response.hasContents();
     } catch (NoSuchKeyException e) {

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -42,7 +42,10 @@ import com.google.common.collect.ImmutableList;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -90,8 +93,12 @@ public class S3PinotFS extends PinotFS {
         awsCredentialsProvider = StaticCredentialsProvider.create(awsBasicCredentials);
       } else {
         awsCredentialsProvider =
-            AwsCredentialsProviderChain.builder().addCredentialsProvider(SystemPropertyCredentialsProvider.create())
-                .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create()).build();
+            AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(SystemPropertyCredentialsProvider.create())
+                    .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                    .addCredentialsProvider(ProfileCredentialsProvider.create())
+                    .addCredentialsProvider(InstanceProfileCredentialsProvider.create())
+                    .build();
       }
 
       _s3Client = S3Client.builder().region(Region.of(region)).credentialsProvider(awsCredentialsProvider).build();

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -41,13 +41,8 @@ import com.google.common.collect.ImmutableList;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
-import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.regions.Region;
@@ -92,13 +87,7 @@ public class S3PinotFS extends PinotFS {
         AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
         awsCredentialsProvider = StaticCredentialsProvider.create(awsBasicCredentials);
       } else {
-        awsCredentialsProvider =
-            AwsCredentialsProviderChain.builder()
-                    .addCredentialsProvider(SystemPropertyCredentialsProvider.create())
-                    .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
-                    .addCredentialsProvider(ProfileCredentialsProvider.create())
-                    .addCredentialsProvider(InstanceProfileCredentialsProvider.create())
-                    .build();
+        awsCredentialsProvider = DefaultCredentialsProvider.create();
       }
 
       _s3Client = S3Client.builder().region(Region.of(region)).credentialsProvider(awsCredentialsProvider).build();
@@ -443,7 +432,7 @@ public class S3PinotFS extends PinotFS {
       }
       try {
         HeadObjectRequest headObjectRequest =
-            HeadObjectRequest.builder().bucket(uri.getHost()).key(uri.getPath()).build();
+            HeadObjectRequest.builder().bucket(uri.getHost()).key(prefix).build();
         HeadObjectResponse s3ObjectMetadata = _s3Client.headObject(headObjectRequest);
 
         return s3ObjectMetadata.sdkHttpResponse().isSuccessful();


### PR DESCRIPTION
## Description
For S3PinotFs

Use DefaultCredentialProvider which chains common ways to provider credentials
For example: Credentials provider file and Instance profile based credentials were missing. 
(https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html)

Fixig a Bug in isDirectory S3PinotFs HeadObjectRequst key contained a "/" as prefix which is causing it to fail.
Remove HeadObjectRequest infavor of ListObjectsV2 with a limit on number of keys retrieved to 2.
There's seems to a bug in S3Mock which was causing `testDeleteFile` to pass previously.