### PR TITLE
Transform and extract map values to array

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/PinotDataType.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/PinotDataType.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
+import java.util.Iterator;
+import java.util.Map;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
 
@@ -470,7 +472,112 @@ public enum PinotDataType {
     }
   },
 
-  OBJECT_ARRAY;
+  OBJECT_ARRAY {
+    @Override
+    public Integer[] toIntegerArray(Object value) {
+      Object[] valueArray = (Object[]) value;
+      int length = valueArray.length;
+      Integer[] integerArray = new Integer[length];
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType  = getPrimitiveDataTypeFromMap((Map) valueArray[0]);
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            integerArray[i] = singleValueType.toInteger(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          integerArray[i] = singleValueType.toInteger(valueArray[i]);
+        }
+      }
+      return integerArray;
+    }
+
+    @Override
+    public Long[] toLongArray(Object value) {
+      Object[] valueArray = (Object[]) value;
+      int length = valueArray.length;
+      Long[] longArray = new Long[length];
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType  = getPrimitiveDataTypeFromMap((Map) valueArray[0]);
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            longArray[i] = singleValueType.toLong(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          longArray[i] = singleValueType.toLong(valueArray[i]);
+        }
+      }
+      return longArray;
+    }
+
+    @Override
+    public Float[] toFloatArray(Object value) {
+      Object[] valueArray = (Object[]) value;
+      int length = valueArray.length;
+      Float[] floatArray = new Float[length];
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType  = getPrimitiveDataTypeFromMap((Map) valueArray[0]);
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            floatArray[i] = singleValueType.toFloat(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          floatArray[i] = singleValueType.toFloat(valueArray[i]);
+        }
+      }
+      return floatArray;
+    }
+
+    @Override
+    public Double[] toDoubleArray(Object value) {
+      Object[] valueArray = (Object[]) value;
+      int length = valueArray.length;
+      Double[] doubleArray = new Double[length];
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType  = getPrimitiveDataTypeFromMap((Map) valueArray[0]);
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            doubleArray[i] = singleValueType.toDouble(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          doubleArray[i] = singleValueType.toDouble(valueArray[i]);
+        }
+      }
+      return doubleArray;
+    }
+
+    @Override
+    public String[] toStringArray(Object value) {
+      Object[] valueArray = (Object[]) value;
+      int length = valueArray.length;
+      String[] stringArray = new String[length];
+      if (valueArray[0] instanceof Map) {
+        PinotDataType singleValueType  = getPrimitiveDataTypeFromMap((Map) valueArray[0]);
+        for (int i = 0; i < length; i++) {
+          for (Object obj : ((Map<Object, Object>) valueArray[i]).values()) {
+            stringArray[i] = singleValueType.toString(obj);
+          }
+        }
+      } else {
+        PinotDataType singleValueType = getSingleValueType();
+        for (int i = 0; i < length; i++) {
+          stringArray[i] = singleValueType.toString(valueArray[i]);
+        }
+      }
+      return stringArray;
+    }
+  };
 
   /**
    * NOTE: override toInteger(), toLong(), toFloat(), toDouble(), toString() and toBytes() for single-value types.
@@ -630,6 +737,24 @@ public enum PinotDataType {
       default:
         throw new UnsupportedOperationException(
             "Unsupported data type: " + dataType + " in field: " + fieldSpec.getName());
+    }
+  }
+
+  public static PinotDataType getPrimitiveDataTypeFromMap(Map<Object, Object> map) {
+    Iterator<Object> iterator = map.values().iterator();
+    Object obj = iterator.next();
+    if (obj instanceof Integer) {
+      return PinotDataType.INTEGER;
+    } else if (obj instanceof Long) {
+      return PinotDataType.LONG;
+    } else if (obj instanceof Float) {
+      return PinotDataType.FLOAT;
+    } else if (obj instanceof Double) {
+      return PinotDataType.DOUBLE;
+    } else if (obj instanceof String) {
+      return PinotDataType.STRING;
+    } else {
+      throw new IllegalStateException(String.format("'%s' isn't supported in the map.", obj.getClass()));
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/PinotDataTypeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/PinotDataTypeTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.core.data.recordtransformer.PinotDataType.*;
@@ -101,6 +103,20 @@ public class PinotDataTypeTest {
     assertEquals(OBJECT.toInteger(new NumberObject("123")).intValue(), 123);
     assertEquals(OBJECT.toString(new NumberObject("123")), "123");
     assertEquals(OBJECT_ARRAY.getSingleValueType(), OBJECT);
+  }
+
+  @Test
+  public void testMap() {
+    Map<String, String> map1 = new HashMap<>();
+    map1.put("item", "10");
+    Map<String, String> map2 = new HashMap<>();
+    map2.put("item", "20");
+    Object[] objectArray = new Object[] {map1, map2};
+    assertEquals(STRING_ARRAY.convert(objectArray, OBJECT_ARRAY), new String[] {"10", "20"});
+    assertEquals(INTEGER_ARRAY.convert(objectArray, OBJECT_ARRAY), new Integer[]{10, 20});
+    assertEquals(LONG_ARRAY.convert(objectArray, OBJECT_ARRAY), new Long[]{10L, 20L});
+    assertEquals(FLOAT_ARRAY.convert(objectArray, OBJECT_ARRAY), new Float[]{10.0f, 20f});
+    assertEquals(DOUBLE_ARRAY.convert(objectArray, OBJECT_ARRAY), new Double[]{10.0d, 20d});
   }
 
   @Test


### PR DESCRIPTION
## Description
This PR fixes the issue introduced from this PR: #5238

The returned type from the GenericRow could be map, whereas there is no logic to handle map type in DataTypeTransformer class.

The workaround here is to fetch the values from the map to the dedicated array.