### PR TITLE
Enhance DataTypeTransformer to handle nested Map/List/Object[]

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/CompositeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/CompositeTransformer.java
@@ -39,21 +39,29 @@ public class CompositeTransformer implements RecordTransformer {
    * <p>NOTE: DO NOT CHANGE THE ORDER OF THE RECORD TRANSFORMERS
    * <ul>
    *   <li>
-   *     {@link ExpressionTransformer} before everyone else, so that we get the real columns for other transformers to work on
+   *     {@link ExpressionTransformer} before everyone else, so that we get the real columns for other transformers to
+   *     work on
    *   </li>
    *   <li>
    *     {@link FilterTransformer} after ExpressionTransformer, so that we have source as well as destination columns
    *   </li>
    *   <li>
-   *     We put {@link SanitizationTransformer} after {@link DataTypeTransformer} so that before sanitation, all values
-   *     follow the data types defined in the {@link Schema}.
+   *     {@link DataTypeTransformer} after FilterTransformer to convert values to comply with the schema
+   *   </li>
+   *   <li>
+   *     {@link NullValueTransformer} after {@link DataTypeTransformer} because empty Collection/Map/Object[] will be
+   *     replaced with null in DataTypeTransformer
+   *   </li>
+   *   <li>
+   *     {@link SanitizationTransformer} after {@link NullValueTransformer} so that before sanitation, all values are
+   *     non-null and follow the data types defined in the schema
    *   </li>
    * </ul>
    */
   public static CompositeTransformer getDefaultTransformer(TableConfig tableConfig, Schema schema) {
     return new CompositeTransformer(Arrays
-        .asList(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig), new NullValueTransformer(schema),
-            new DataTypeTransformer(schema), new SanitizationTransformer(schema)));
+        .asList(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig),
+            new DataTypeTransformer(schema), new NullValueTransformer(schema), new SanitizationTransformer(schema)));
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
@@ -18,9 +18,15 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -32,6 +38,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  * {@link NullValueTransformer} and {@link ExpressionTransformer}). After this, all values should be of the desired data
  * types.
  */
+@SuppressWarnings("rawtypes")
 public class DataTypeTransformer implements RecordTransformer {
   private static final Map<Class, PinotDataType> SINGLE_VALUE_TYPE_MAP = new HashMap<>();
   private static final Map<Class, PinotDataType> MULTI_VALUE_TYPE_MAP = new HashMap<>();
@@ -73,10 +80,15 @@ public class DataTypeTransformer implements RecordTransformer {
     for (Map.Entry<String, PinotDataType> entry : _dataTypes.entrySet()) {
       String column = entry.getKey();
       Object value = record.getValue(column);
-
-      // Convert List value to Object[]
-      if (value instanceof List) {
-        value = ((List) value).toArray();
+      if (value == null) {
+        continue;
+      }
+      PinotDataType dest = entry.getValue();
+      value = standardize(column, value, dest.isSingleValue());
+      // NOTE: The standardized value could be null for empty Collection/Map/Object[].
+      if (value == null) {
+        record.putValue(column, null);
+        continue;
       }
 
       // Convert data type if necessary
@@ -95,7 +107,6 @@ public class DataTypeTransformer implements RecordTransformer {
           source = PinotDataType.OBJECT;
         }
       }
-      PinotDataType dest = entry.getValue();
       if (source != dest) {
         value = dest.convert(value, source);
       }
@@ -103,5 +114,77 @@ public class DataTypeTransformer implements RecordTransformer {
       record.putValue(column, value);
     }
     return record;
+  }
+
+  /**
+   * Standardize the value into supported types.
+   */
+  @VisibleForTesting
+  @Nullable
+  static Object standardize(String column, @Nullable Object value, boolean isSingleValue) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Collection) {
+      return standardizeCollection(column, (Collection) value, isSingleValue);
+    }
+    if (value instanceof Map) {
+      return standardizeCollection(column, ((Map) value).values(), isSingleValue);
+    }
+    if (value instanceof Object[]) {
+      Object[] values = (Object[]) value;
+      int numValues = values.length;
+      if (numValues == 0) {
+        return null;
+      }
+      if (numValues == 1) {
+        return standardize(column, values[0], isSingleValue);
+      }
+      List<Object> standardizedValues = new ArrayList<>(numValues);
+      for (Object singleValue : values) {
+        Object standardizedValue = standardize(column, singleValue, true);
+        if (standardizedValue != null) {
+          standardizedValues.add(standardizedValue);
+        }
+      }
+      int numStandardizedValues = standardizedValues.size();
+      if (numStandardizedValues == 0) {
+        return null;
+      }
+      if (numStandardizedValues == 1) {
+        return standardizedValues.get(0);
+      }
+      Preconditions.checkState(!isSingleValue, "Cannot read single-value from Object[]: %s for column: %s",
+          Arrays.toString(values), column);
+      return standardizedValues.toArray();
+    }
+    return value;
+  }
+
+  private static Object standardizeCollection(String column, Collection collection, boolean isSingleValue) {
+    int numValues = collection.size();
+    if (numValues == 0) {
+      return null;
+    }
+    if (numValues == 1) {
+      return standardize(column, collection.iterator().next(), isSingleValue);
+    }
+    List<Object> standardizedValues = new ArrayList<>(numValues);
+    for (Object singleValue : collection) {
+      Object standardizedValue = standardize(column, singleValue, true);
+      if (standardizedValue != null) {
+        standardizedValues.add(standardizedValue);
+      }
+    }
+    int numStandardizedValues = standardizedValues.size();
+    if (numStandardizedValues == 0) {
+      return null;
+    }
+    if (numStandardizedValues == 1) {
+      return standardizedValues.get(0);
+    }
+    Preconditions
+        .checkState(!isSingleValue, "Cannot read single-value from collection: %s for column: %s", collection, column);
+    return standardizedValues.toArray();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
@@ -118,6 +118,11 @@ public class DataTypeTransformer implements RecordTransformer {
 
   /**
    * Standardize the value into supported types.
+   * <ul>
+   *   <li>Empty Collection/Map/Object[] will be standardized to null</li>
+   *   <li>Single-entry Collection/Map/Object[] will be standardized to single value (map key is ignored)</li>
+   *   <li>Multi-entries Collection/Map/Object[] will be standardized to Object[] (map key is ignored)</li>
+   * </ul>
    */
   @VisibleForTesting
   @Nullable
@@ -184,7 +189,7 @@ public class DataTypeTransformer implements RecordTransformer {
       return standardizedValues.get(0);
     }
     Preconditions
-        .checkState(!isSingleValue, "Cannot read single-value from collection: %s for column: %s", collection, column);
+        .checkState(!isSingleValue, "Cannot read single-value from Collection: %s for column: %s", collection, column);
     return standardizedValues.toArray();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/NullValueTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/NullValueTransformer.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.data.recordtransformer;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
@@ -49,8 +48,7 @@ public class NullValueTransformer implements RecordTransformer {
     for (Map.Entry<String, Object> entry : _defaultNullValues.entrySet()) {
       String fieldName = entry.getKey();
       Object value = record.getValue(fieldName);
-      if (value == null || (value instanceof Object[] && ((Object[]) value).length == 0) || (value instanceof List
-          && ((List) value).isEmpty())) {
+      if (value == null) {
         record.putDefaultNullValue(fieldName, entry.getValue());
       }
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.recordtransformer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsNoOrder;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
+
+
+public class DataTypeTransformerTest {
+  private static final String COLUMN = "testColumn";
+
+  @Test
+  public void testStandardize() {
+    // Tests for Map
+    Map<String, Object> map = Collections.emptyMap();
+    assertNull(DataTypeTransformer.standardize(COLUMN, map, true));
+    assertNull(DataTypeTransformer.standardize(COLUMN, map, false));
+    String expectedValue = "testValue";
+    map = Collections.singletonMap("testKey", expectedValue);
+    assertEquals(DataTypeTransformer.standardize(COLUMN, map, true), expectedValue);
+    assertEquals(DataTypeTransformer.standardize(COLUMN, map, false), expectedValue);
+    Object[] expectedValues = new Object[]{"testValue1", "testValue2"};
+    map = new HashMap<>();
+    map.put("testKey1", "testValue1");
+    map.put("testKey2", "testValue2");
+    try {
+      DataTypeTransformer.standardize(COLUMN, map, true);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+    assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, map, false), expectedValues);
+
+    // Tests for List
+    List<Object> list = Collections.emptyList();
+    assertNull(DataTypeTransformer.standardize(COLUMN, list, true));
+    assertNull(DataTypeTransformer.standardize(COLUMN, list, false));
+    list = Collections.singletonList(expectedValue);
+    assertEquals(DataTypeTransformer.standardize(COLUMN, list, true), expectedValue);
+    assertEquals(DataTypeTransformer.standardize(COLUMN, list, false), expectedValue);
+    list = Arrays.asList(expectedValues);
+    try {
+      DataTypeTransformer.standardize(COLUMN, list, true);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+    assertEquals((Object[]) DataTypeTransformer.standardize(COLUMN, list, false), expectedValues);
+
+    // Tests for Object[]
+    Object[] values = new Object[0];
+    assertNull(DataTypeTransformer.standardize(COLUMN, values, true));
+    assertNull(DataTypeTransformer.standardize(COLUMN, values, false));
+    values = new Object[]{expectedValue};
+    assertEquals(DataTypeTransformer.standardize(COLUMN, values, true), expectedValue);
+    assertEquals(DataTypeTransformer.standardize(COLUMN, values, false), expectedValue);
+    values = new Object[]{"testValue1", "testValue2"};
+    try {
+      DataTypeTransformer.standardize(COLUMN, values, true);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+    assertEquals((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
+
+    // Tests for nested Map/List/Object[]
+    map = Collections.singletonMap("testKey", Collections.emptyList());
+    assertNull(DataTypeTransformer.standardize(COLUMN, map, true));
+    assertNull(DataTypeTransformer.standardize(COLUMN, map, false));
+
+    map = Collections.singletonMap("testKey", Collections.singletonList(expectedValue));
+    assertEquals(DataTypeTransformer.standardize(COLUMN, map, true), expectedValue);
+    assertEquals(DataTypeTransformer.standardize(COLUMN, map, false), expectedValue);
+
+    map = new HashMap<>();
+    map.put("testKey1", Collections.emptyMap());
+    map.put("testKey2", Collections.singletonMap("testKey", expectedValue));
+    assertEquals(DataTypeTransformer.standardize(COLUMN, map, true), expectedValue);
+    assertEquals(DataTypeTransformer.standardize(COLUMN, map, false), expectedValue);
+
+    map = Collections.singletonMap("testKey", Arrays.asList(expectedValues));
+    try {
+      DataTypeTransformer.standardize(COLUMN, map, true);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+    assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, map, false), expectedValues);
+
+    map = new HashMap<>();
+    map.put("testKey1", Collections.emptyMap());
+    map.put("testKey2", Collections.singletonList("testValue1"));
+    map.put("testKey3", new Object[]{"testValue2"});
+    try {
+      DataTypeTransformer.standardize(COLUMN, map, true);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+    assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, map, false), expectedValues);
+
+    list = Arrays
+        .asList(Collections.singletonMap("testKey", "testValue1"), Collections.singletonMap("testKey", "testValue2"),
+            Collections.emptyMap());
+    try {
+      DataTypeTransformer.standardize(COLUMN, list, true);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+    assertEquals((Object[]) DataTypeTransformer.standardize(COLUMN, list, false), expectedValues);
+
+    values = new Object[]{new Object[0], Collections.singletonList(
+        Collections.singletonMap("testKey", "testValue1")), Collections.singletonMap("testKey",
+        Arrays.asList(new Object[]{"testValue2"}, Collections.emptyMap()))};
+    try {
+      DataTypeTransformer.standardize(COLUMN, values, true);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+    assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
@@ -36,19 +36,28 @@ public class DataTypeTransformerTest {
 
   @Test
   public void testStandardize() {
-    // Tests for Map
+    /**
+     * Tests for Map
+     */
+
+    // Empty Map
     Map<String, Object> map = Collections.emptyMap();
     assertNull(DataTypeTransformer.standardize(COLUMN, map, true));
     assertNull(DataTypeTransformer.standardize(COLUMN, map, false));
+
+    // Map with single entry
     String expectedValue = "testValue";
     map = Collections.singletonMap("testKey", expectedValue);
     assertEquals(DataTypeTransformer.standardize(COLUMN, map, true), expectedValue);
     assertEquals(DataTypeTransformer.standardize(COLUMN, map, false), expectedValue);
+
+    // Map with multiple entries
     Object[] expectedValues = new Object[]{"testValue1", "testValue2"};
     map = new HashMap<>();
     map.put("testKey1", "testValue1");
     map.put("testKey2", "testValue2");
     try {
+      // Should fail because Map with multiple entries cannot be standardized as single value
       DataTypeTransformer.standardize(COLUMN, map, true);
       fail();
     } catch (Exception e) {
@@ -56,15 +65,24 @@ public class DataTypeTransformerTest {
     }
     assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, map, false), expectedValues);
 
-    // Tests for List
+    /**
+     * Tests for List
+     */
+
+    // Empty List
     List<Object> list = Collections.emptyList();
     assertNull(DataTypeTransformer.standardize(COLUMN, list, true));
     assertNull(DataTypeTransformer.standardize(COLUMN, list, false));
+
+    // List with single entry
     list = Collections.singletonList(expectedValue);
     assertEquals(DataTypeTransformer.standardize(COLUMN, list, true), expectedValue);
     assertEquals(DataTypeTransformer.standardize(COLUMN, list, false), expectedValue);
+
+    // List with multiple entries
     list = Arrays.asList(expectedValues);
     try {
+      // Should fail because List with multiple entries cannot be standardized as single value
       DataTypeTransformer.standardize(COLUMN, list, true);
       fail();
     } catch (Exception e) {
@@ -72,15 +90,24 @@ public class DataTypeTransformerTest {
     }
     assertEquals((Object[]) DataTypeTransformer.standardize(COLUMN, list, false), expectedValues);
 
-    // Tests for Object[]
+    /**
+     * Tests for Object[]
+     */
+
+    // Empty Object[]
     Object[] values = new Object[0];
     assertNull(DataTypeTransformer.standardize(COLUMN, values, true));
     assertNull(DataTypeTransformer.standardize(COLUMN, values, false));
+
+    // Object[] with single entry
     values = new Object[]{expectedValue};
     assertEquals(DataTypeTransformer.standardize(COLUMN, values, true), expectedValue);
     assertEquals(DataTypeTransformer.standardize(COLUMN, values, false), expectedValue);
+
+    // Object[] with multiple entries
     values = new Object[]{"testValue1", "testValue2"};
     try {
+      // Should fail because Object[] with multiple entries cannot be standardized as single value
       DataTypeTransformer.standardize(COLUMN, values, true);
       fail();
     } catch (Exception e) {
@@ -88,23 +115,32 @@ public class DataTypeTransformerTest {
     }
     assertEquals((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
 
-    // Tests for nested Map/List/Object[]
+    /**
+     * Tests for nested Map/List/Object[]
+     */
+
+    // Map with empty List
     map = Collections.singletonMap("testKey", Collections.emptyList());
     assertNull(DataTypeTransformer.standardize(COLUMN, map, true));
     assertNull(DataTypeTransformer.standardize(COLUMN, map, false));
 
+    // Map with single-entry List
     map = Collections.singletonMap("testKey", Collections.singletonList(expectedValue));
     assertEquals(DataTypeTransformer.standardize(COLUMN, map, true), expectedValue);
     assertEquals(DataTypeTransformer.standardize(COLUMN, map, false), expectedValue);
 
+    // Map with one empty Map and one single-entry Map
     map = new HashMap<>();
     map.put("testKey1", Collections.emptyMap());
     map.put("testKey2", Collections.singletonMap("testKey", expectedValue));
+    // Can be standardized into single value because empty Map should be ignored
     assertEquals(DataTypeTransformer.standardize(COLUMN, map, true), expectedValue);
     assertEquals(DataTypeTransformer.standardize(COLUMN, map, false), expectedValue);
 
+    // Map with multi-entries List
     map = Collections.singletonMap("testKey", Arrays.asList(expectedValues));
     try {
+      // Should fail because Map with multiple entries cannot be standardized as single value
       DataTypeTransformer.standardize(COLUMN, map, true);
       fail();
     } catch (Exception e) {
@@ -112,11 +148,13 @@ public class DataTypeTransformerTest {
     }
     assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, map, false), expectedValues);
 
+    // Map with one empty Map, one single-entry List and one single-entry Object[]
     map = new HashMap<>();
     map.put("testKey1", Collections.emptyMap());
     map.put("testKey2", Collections.singletonList("testValue1"));
     map.put("testKey3", new Object[]{"testValue2"});
     try {
+      // Should fail because Map with multiple entries cannot be standardized as single value
       DataTypeTransformer.standardize(COLUMN, map, true);
       fail();
     } catch (Exception e) {
@@ -124,10 +162,12 @@ public class DataTypeTransformerTest {
     }
     assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, map, false), expectedValues);
 
+    // List with two single-entry Maps and one empty Map
     list = Arrays
         .asList(Collections.singletonMap("testKey", "testValue1"), Collections.singletonMap("testKey", "testValue2"),
             Collections.emptyMap());
     try {
+      // Should fail because List with multiple entries cannot be standardized as single value
       DataTypeTransformer.standardize(COLUMN, list, true);
       fail();
     } catch (Exception e) {
@@ -135,9 +175,11 @@ public class DataTypeTransformerTest {
     }
     assertEquals((Object[]) DataTypeTransformer.standardize(COLUMN, list, false), expectedValues);
 
+    // Object[] with two single-entry Maps
     values = new Object[]{Collections.singletonMap("testKey", "testValue1"), Collections.singletonMap("testKey",
         "testValue2")};
     try {
+      // Should fail because Object[] with multiple entries cannot be standardized as single value
       DataTypeTransformer.standardize(COLUMN, values, true);
       fail();
     } catch (Exception e) {
@@ -145,6 +187,7 @@ public class DataTypeTransformerTest {
     }
     assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
 
+    // Object[] with one empty Object[], one multi-entries List of nested Map/List/Object[]
     values = new Object[]{new Object[0], Collections.singletonList(
         Collections.singletonMap("testKey", "testValue1")), Collections.singletonMap("testKey",
         Arrays.asList(new Object[]{"testValue2"}, Collections.emptyMap()))};

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformerTest.java
@@ -135,6 +135,16 @@ public class DataTypeTransformerTest {
     }
     assertEquals((Object[]) DataTypeTransformer.standardize(COLUMN, list, false), expectedValues);
 
+    values = new Object[]{Collections.singletonMap("testKey", "testValue1"), Collections.singletonMap("testKey",
+        "testValue2")};
+    try {
+      DataTypeTransformer.standardize(COLUMN, values, true);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+    assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
+
     values = new Object[]{new Object[0], Collections.singletonList(
         Collections.singletonMap("testKey", "testValue1")), Collections.singletonMap("testKey",
         Arrays.asList(new Object[]{"testValue2"}, Collections.emptyMap()))};

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
@@ -110,7 +110,7 @@ public class ExpressionTransformerTest {
 
     Assert.assertEquals(genericRow.getValue("userId"), 1L);
     Assert.assertEquals(genericRow.getValue("fullName"), "John Denver");
-    Assert.assertEquals(((Integer[]) genericRow.getValue("bids")), new Integer[]{10, 20});
+    Assert.assertEquals(((Object[]) genericRow.getValue("bids")), new Integer[]{10, 20});
     Assert.assertEquals(genericRow.getValue("maxBid"), 20);
     // handle Map through transform functions
     Object[] map2Keys = (Object[]) genericRow.getValue("map2_keys");

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/RecordTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/RecordTransformerTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
-import java.util.Arrays;
 import java.util.Collections;
 import org.apache.pinot.spi.config.table.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -47,7 +46,8 @@ public class RecordTransformerTest {
       // For sanitation
       .addSingleValueDimension("svStringWithNullCharacters", DataType.STRING)
       .addSingleValueDimension("svStringWithLengthLimit", DataType.STRING).build();
-  private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
 
   static {
     SCHEMA.getFieldSpecFor("svStringWithLengthLimit").setMaxLength(2);
@@ -61,13 +61,13 @@ public class RecordTransformerTest {
     GenericRow record = new GenericRow();
     record.putValue("svInt", (byte) 123);
     record.putValue("svLong", (char) 123);
-    record.putValue("svFloat", Arrays.asList((short) 123, 456));
-    record.putValue("svDouble", new String[]{"123", "456"});
+    record.putValue("svFloat", Collections.singletonList((short) 123));
+    record.putValue("svDouble", new String[]{"123"});
     record.putValue("svBytes", "7b7b"/*new byte[]{123, 123}*/);
     record.putValue("mvInt", new Object[]{123L});
     record.putValue("mvLong", Collections.singletonList(123f));
     record.putValue("mvFloat", new Double[]{123d});
-    record.putValue("mvDouble", Collections.singletonList(123));
+    record.putValue("mvDouble", Collections.singletonMap("key", 123));
     record.putValue("svStringWithNullCharacters", "1\0002\0003");
     record.putValue("svStringWithLengthLimit", "123");
     return record;
@@ -93,7 +93,8 @@ public class RecordTransformerTest {
 
     // value not found
     genericRow = getRecord();
-    tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({notPresent == 123}, notPresent)"), null));
+    tableConfig
+        .setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({notPresent == 123}, notPresent)"), null));
     transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
     Assert.assertFalse(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
@@ -109,11 +110,11 @@ public class RecordTransformerTest {
 
     // multi value column
     genericRow = getRecord();
-    tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({svFloat.max() < 500}, svFloat)"), null));
+    tableConfig
+        .setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({svFloat.max() < 500}, svFloat)"), null));
     transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
     Assert.assertTrue(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
-
   }
 
   @Test
@@ -157,19 +158,6 @@ public class RecordTransformerTest {
   public void testNullValueTransformer() {
     RecordTransformer transformer = new NullValueTransformer(SCHEMA);
     GenericRow record = new GenericRow();
-    for (int i = 0; i < NUM_ROUNDS; i++) {
-      record = transformer.transform(record);
-      assertNotNull(record);
-      validateNullValueTransformerResult(record);
-    }
-
-    record.clear();
-    record.putValue("svInt", Collections.emptyList());
-    record.putValue("svLong", new String[0]);
-    record.putValue("svFloat", null);
-    record.putValue("mvInt", Collections.emptyList());
-    record.putValue("mvLong", new Object[0]);
-    record.putValue("mvFloat", null);
     for (int i = 0; i < NUM_ROUNDS; i++) {
       record = transformer.transform(record);
       assertNotNull(record);


### PR DESCRIPTION
## Description
Enhance DataTypeTransformer to handle nested Collection/Map/Object[]

- Empty `Collection/Map/Object[]` will be treated as `null`
- Single-entry `Collection/Map/Object[]` will be treated as single-value (map key is ignored)
- Multi-entry `Collection/Map/Object[]` will be treated as multi-value (map key is ignored)
- Move `NullValueTransformer` after `DataTypeTransformer` to handle the `null` from empty `Collection/Map/Object[]`

NOTE:
Multi-entry `Collection/Map/Object[]` will no longer be accepted for single-value column (instead of using the first value because that will cause data loss)