### PR TITLE
Do not apply shade plugin on parent modules

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/pom.xml
@@ -35,5 +35,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>none</phase.prop>
   </properties>
 </project>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
@@ -36,6 +36,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <hadoop.version>2.7.0</hadoop.version>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
@@ -35,6 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
@@ -35,6 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
@@ -33,6 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <profiles>
     <profile>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/pom.xml
@@ -35,6 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/pom.xml
@@ -36,6 +36,7 @@
     <spark.version>2.2.0</spark.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>2.11.11</scala.version>
+    <phase.prop>package</phase.prop>
   </properties>
   <profiles>
     <profile>

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -33,6 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
@@ -35,6 +35,7 @@
   <url>https://pinot.apache.org</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
@@ -33,6 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -42,6 +42,7 @@
     <reactivestream.version>1.0.3</reactivestream.version>
     <s3mock.version>2.1.19</s3mock.version>
     <javax.version>3.1.0</javax.version>
+    <phase.prop>package</phase.prop>
   </properties>
 
   <dependencyManagement>

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
@@ -34,6 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
@@ -34,6 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
@@ -36,6 +36,7 @@
     <pinot.root>${basedir}/../../..</pinot.root>
     <kafka.lib.version>2.0.0</kafka.lib.version>
     <confluent.version>5.3.1</confluent.version>
+    <phase.prop>package</phase.prop>
   </properties>
   <repositories>
     <repository>

--- a/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
@@ -34,6 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-json/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-json/pom.xml
@@ -34,6 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -35,6 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -34,6 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -36,6 +36,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <proto.version>3.11.4</proto.version>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
@@ -34,6 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/pom.xml
@@ -37,6 +37,7 @@
     <pinot.root>${basedir}/../../..</pinot.root>
     <kafka.lib.version>0.9.0.1</kafka.lib.version>
     <kafka.scala.version>2.10</kafka.scala.version>
+    <phase.prop>package</phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
@@ -36,6 +36,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <kafka.lib.version>2.0.0</kafka.lib.version>
+    <phase.prop>package</phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
@@ -35,6 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -109,21 +109,6 @@
             </executions>
           </plugin>
           <plugin>
-            <artifactId>maven-clean-plugin</artifactId>
-            <version>3.1.0</version>
-            <configuration>
-              <filesets>
-                <fileset>
-                  <directory>${pinot.root}/pinot-plugins/target/plugins/</directory>
-                  <includes>
-                    <include>**/*.pom</include>
-                  </includes>
-                  <followSymlinks>false</followSymlinks>
-                </fileset>
-              </filesets>
-            </configuration>
-          </plugin>
-          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
           </plugin>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -36,6 +36,7 @@
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
     <plugin.type />
+    <phase.prop>none</phase.prop>
   </properties>
 
   <modules>
@@ -74,7 +75,7 @@
             <version>3.2.1</version>
             <executions>
               <execution>
-                <phase>package</phase>
+                <phase>${phase.prop}</phase>
                 <goals>
                   <goal>shade</goal>
                 </goals>


### PR DESCRIPTION
## Description
Address issue https://github.com/apache/incubator-pinot/issues/5022
The `*shaded.pom` files were generated because of the application of shade plugin on the parent modules.

Remove them by parametrizing the plugin phase element, and setting it to `none` phase in parem pom to skip the execution.


