### PR TITLE
Optimize DistinctCount to store dictIds within segment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/BlockValSet.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.common;
 
+import javax.annotation.Nullable;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -36,6 +38,12 @@ public interface BlockValSet {
    * Returns {@code true} if the value set is for a single-value column, {@code false} otherwise.
    */
   boolean isSingleValue();
+
+  /**
+   * Returns the dictionary for the column, or {@code null} if the column is not dictionary-encoded.
+   */
+  @Nullable
+  Dictionary getDictionary();
 
   /**
    * SINGLE-VALUED COLUMN APIs

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
@@ -23,9 +23,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.EqualityUtils;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 
 
 /**
@@ -68,6 +68,15 @@ public class DataBlockCache {
     _columnDictIdLoaded.clear();
     _columnValueLoaded.clear();
     _columnNumValuesLoaded.clear();
+  }
+
+  /**
+   * Returns the number of documents within the current block.
+   *
+   * @return Number of documents within the current block
+   */
+  public int getNumDocs() {
+    return _length;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
@@ -18,13 +18,11 @@
  */
 package org.apache.pinot.core.operator;
 
-import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataBlockCache;
 import org.apache.pinot.core.common.DataFetcher;
 import org.apache.pinot.core.common.DataSource;
-import org.apache.pinot.core.common.DataSourceMetadata;
 import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 
@@ -33,17 +31,12 @@ public class ProjectionOperator extends BaseOperator<ProjectionBlock> {
   private static final String OPERATOR_NAME = "ProjectionOperator";
 
   private final Map<String, DataSource> _dataSourceMap;
-  private final Map<String, DataSourceMetadata> _dataSourceMetadataMap;
   private final BaseOperator<DocIdSetBlock> _docIdSetOperator;
   private final DataBlockCache _dataBlockCache;
 
   public ProjectionOperator(Map<String, DataSource> dataSourceMap,
       @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator) {
     _dataSourceMap = dataSourceMap;
-    _dataSourceMetadataMap = new HashMap<>(dataSourceMap.size());
-    for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
-      _dataSourceMetadataMap.put(entry.getKey(), entry.getValue().getDataSourceMetadata());
-    }
     _docIdSetOperator = docIdSetOperator;
     _dataBlockCache = new DataBlockCache(new DataFetcher(dataSourceMap));
   }
@@ -66,7 +59,7 @@ public class ProjectionOperator extends BaseOperator<ProjectionBlock> {
       return null;
     } else {
       _dataBlockCache.initNewBlock(docIdSetBlock.getDocIdSet(), docIdSetBlock.getSearchableLength());
-      return new ProjectionBlock(_dataSourceMetadataMap, _dataBlockCache, docIdSetBlock);
+      return new ProjectionBlock(_dataSourceMap, _dataBlockCache);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
@@ -25,9 +25,8 @@ import org.apache.pinot.core.common.BlockDocIdValueSet;
 import org.apache.pinot.core.common.BlockMetadata;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.DataBlockCache;
-import org.apache.pinot.core.common.DataSourceMetadata;
+import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.docvalsets.ProjectionBlockValSet;
-import org.apache.pinot.spi.data.FieldSpec;
 
 
 /**
@@ -35,14 +34,25 @@ import org.apache.pinot.spi.data.FieldSpec;
  * It provides DocIdSetBlock for a given column.
  */
 public class ProjectionBlock implements Block {
-  private final Map<String, DataSourceMetadata> _dataSourceMetadataMap;
-  private final DocIdSetBlock _docIdSetBlock;
+  private final Map<String, DataSource> _dataSourceMap;
   private final DataBlockCache _dataBlockCache;
 
-  public ProjectionBlock(Map<String, DataSourceMetadata> dataSourceMetadataMap, DataBlockCache dataBlockCache, DocIdSetBlock docIdSetBlock) {
-    _dataSourceMetadataMap = dataSourceMetadataMap;
-    _docIdSetBlock = docIdSetBlock;
+  public ProjectionBlock(Map<String, DataSource> dataSourceMap, DataBlockCache dataBlockCache) {
+    _dataSourceMap = dataSourceMap;
     _dataBlockCache = dataBlockCache;
+  }
+
+  public int getNumDocs() {
+    return _dataBlockCache.getNumDocs();
+  }
+
+  public BlockValSet getBlockValueSet(String column) {
+    return new ProjectionBlockValSet(_dataBlockCache, column, _dataSourceMap.get(column));
+  }
+
+  @Override
+  public BlockDocIdSet getBlockDocIdSet() {
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -56,26 +66,7 @@ public class ProjectionBlock implements Block {
   }
 
   @Override
-  public BlockDocIdSet getBlockDocIdSet() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public BlockMetadata getMetadata() {
     throw new UnsupportedOperationException();
-  }
-
-  public BlockValSet getBlockValueSet(String column) {
-    FieldSpec fieldSpec = _dataSourceMetadataMap.get(column).getFieldSpec();
-    return new ProjectionBlockValSet(_dataBlockCache, column, fieldSpec.getDataType(),
-        fieldSpec.isSingleValueField());
-  }
-
-  public DocIdSetBlock getDocIdSetBlock() {
-    return _docIdSetBlock;
-  }
-
-  public int getNumDocs() {
-    return _docIdSetBlock.getSearchableLength();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/TransformBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/TransformBlock.java
@@ -78,8 +78,4 @@ public class TransformBlock implements Block {
   public BlockMetadata getMetadata() {
     throw new UnsupportedOperationException();
   }
-
-  public DocIdSetBlock getDocIdSetBlock() {
-    return _projectionBlock.getDocIdSetBlock();
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pinot.core.operator.docvalsets;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.DataBlockCache;
+import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -32,32 +35,33 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class ProjectionBlockValSet implements BlockValSet {
   private final DataBlockCache _dataBlockCache;
   private final String _column;
-  private final DataType _dataType;
-  private final boolean _singleValue;
+  private final DataSource _dataSource;
 
   /**
    * Constructor for the class.
-   * The dataBlockCache argument is initialized in {@link ProjectionOperator},
-   * so that it can be reused across multiple calls to {@link ProjectionOperator#nextBlock()}.
-   *
-   * @param dataBlockCache data block cache
-   * @param column Projection column.
+   * The dataBlockCache is initialized in {@link ProjectionOperator} so that it can be reused across multiple calls to
+   * {@link ProjectionOperator#nextBlock()}.
    */
-  public ProjectionBlockValSet(DataBlockCache dataBlockCache, String column, DataType dataType, boolean singleValue) {
+  public ProjectionBlockValSet(DataBlockCache dataBlockCache, String column, DataSource dataSource) {
     _dataBlockCache = dataBlockCache;
     _column = column;
-    _dataType = dataType;
-    _singleValue = singleValue;
+    _dataSource = dataSource;
   }
 
   @Override
   public DataType getValueType() {
-    return _dataType;
+    return _dataSource.getDataSourceMetadata().getDataType();
   }
 
   @Override
   public boolean isSingleValue() {
-    return _singleValue;
+    return _dataSource.getDataSourceMetadata().isSingleValue();
+  }
+
+  @Nullable
+  @Override
+  public Dictionary getDictionary() {
+    return _dataSource.getDictionary();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/TransformBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/TransformBlockValSet.java
@@ -18,11 +18,13 @@
  */
 package org.apache.pinot.core.operator.docvalsets;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
@@ -50,6 +52,12 @@ public class TransformBlockValSet implements BlockValSet {
   @Override
   public boolean isSingleValue() {
     return _transformFunction.getResultMetadata().isSingleValue();
+  }
+
+  @Nullable
+  @Override
+  public Dictionary getDictionary() {
+    return _transformFunction.getDictionary();
   }
 
   @Override


### PR DESCRIPTION
## Description
For DistinctCount aggregation function, we can store dictIds within segment without fetching the values, and read the values from dictionary before returning the result for the segment.

Performance comparison:
With the data in `OfflineClusterIntegrationTest`, for query: `select distinctcountmv(DivAirports) from mytable`, latency dropped from 18ms to 6ms.