### PR TITLE
add user info in url to auth header in HTTP getDownloadFileRequest

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -327,8 +327,9 @@ public class FileUploadDownloadClient implements Closeable {
   private static HttpUriRequest getDownloadFileRequest(URI uri, int socketTimeoutMs) {
     RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
     setTimeout(requestBuilder, socketTimeoutMs);
-    if (uri.getUserInfo() != null) {
-      String encoded = Base64.encodeBase64String(StringUtil.encodeUtf8(uri.getUserInfo()));
+    String userInfo = uri.getUserInfo();
+    if (userInfo != null) {
+      String encoded = Base64.encodeBase64String(StringUtil.encodeUtf8(userInfo));
       String authHeader = "Basic " + encoded;
       requestBuilder.addHeader(HttpHeaders.AUTHORIZATION, authHeader);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
@@ -326,6 +327,11 @@ public class FileUploadDownloadClient implements Closeable {
   private static HttpUriRequest getDownloadFileRequest(URI uri, int socketTimeoutMs) {
     RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
     setTimeout(requestBuilder, socketTimeoutMs);
+    if (uri.getUserInfo() != null) {
+      String encoded = Base64.encodeBase64String(StringUtil.encodeUtf8(uri.getUserInfo()));
+      String authHeader = "Basic " + encoded;
+      requestBuilder.addHeader(HttpHeaders.AUTHORIZATION, authHeader);
+    }
     return requestBuilder.build();
   }
 


### PR DESCRIPTION
## Description
During Segment Uri Pull, while using HTTP Protocol the Username and Password Info can be passed through <code>userinfo</code> in <code>SegmentUriPrefix</code>. But when the HTTP request is redirected, the <code>userinfo</code> is discarded. Hence to retain the Basic Authentication during redirects, we can set the request Http header with the Basic Authentication Token.