### PR TITLE
[TE] The endpoint for searching anomalies and pagination

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -69,6 +69,7 @@ import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseSessionResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseTemplateResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.alerts.AlertResource;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.anomalies.AnomalySearchResource;
 import org.apache.pinot.thirdeye.dataset.DatasetAutoOnboardResource;
 import org.apache.pinot.thirdeye.datasource.ThirdEyeCacheRegistry;
 import org.apache.pinot.thirdeye.datasource.sql.resources.SqlDataSourceResource;
@@ -166,7 +167,8 @@ public class ThirdEyeDashboardApplication
         AlertResource.class,
         RootCauseTemplateResource.class,
         RootCauseSessionResource.class,
-        RootCauseMetricResource.class
+        RootCauseMetricResource.class,
+        AnomalySearchResource.class
     )
         .map(c -> injector.getInstance(c))
         .forEach(jersey::register);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/ResourceUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/ResourceUtils.java
@@ -369,4 +369,21 @@ public class ResourceUtils {
 
     throw new IllegalStateException(String.format("Could not classify feedback status of anomaly id %d", anomaly.getId()));
   }
+
+  /**
+   * For a list of objects, return the paginated results
+   * @param list the list of objects
+   * @param offset the start pos
+   * @param limit the maximum number of objects returned
+   * @param <T> the type for the objects
+   * @return the sublist for the paginated result
+   */
+  public static <T> List<T> paginateResults(List<T> list, int offset, int limit) {
+    if (offset >= list.size()) {
+      // requested page is out of bound
+      return Collections.emptyList();
+    }
+    return list.subList(offset, Math.min(offset + limit, list.size()));
+  }
+
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearchFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearchFilter.java
@@ -1,3 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 package org.apache.pinot.thirdeye.dashboard.resources.v2.anomalies;
 
 import java.util.Collections;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearchFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearchFilter.java
@@ -1,0 +1,132 @@
+package org.apache.pinot.thirdeye.dashboard.resources.v2.anomalies;
+
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * The type Anomaly search filter.
+ */
+public class AnomalySearchFilter {
+  private final List<String> feedbacks;
+  private final List<String> subscriptionGroups;
+  private final List<String> detectionNames;
+  private final List<String> metrics;
+  private final List<String> datasets;
+  private final List<Long> anomalyIds;
+  private final Long startTime;
+  private final Long endTime;
+
+  /**
+   * Instantiates a new Anomaly search filter.
+   *
+   * @param startTime the start time
+   * @param endTime the end time
+   */
+  public AnomalySearchFilter(Long startTime, Long endTime) {
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.feedbacks = Collections.emptyList();
+    this.subscriptionGroups = Collections.emptyList();
+    this.detectionNames = Collections.emptyList();
+    this.metrics = Collections.emptyList();
+    this.datasets = Collections.emptyList();
+    this.anomalyIds = Collections.emptyList();
+  }
+
+  /**
+   * Instantiates a new Anomaly search filter.
+   *
+   * @param startTime the start time
+   * @param endTime the end time
+   * @param feedbacks the feedbacks
+   * @param subscriptionGroups the subscription groups
+   * @param detectionNames the detection names
+   * @param metrics the metrics
+   * @param datasets the datasets
+   * @param anomalyIds the anomaly ids
+   */
+  public AnomalySearchFilter(Long startTime, Long endTime, List<String> feedbacks, List<String> subscriptionGroups, List<String> detectionNames,
+      List<String> metrics, List<String> datasets, List<Long> anomalyIds) {
+    this.feedbacks = feedbacks;
+    this.subscriptionGroups = subscriptionGroups;
+    this.detectionNames = detectionNames;
+    this.metrics = metrics;
+    this.datasets = datasets;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.anomalyIds = anomalyIds;
+  }
+
+  /**
+   * Gets start time.
+   *
+   * @return the start time
+   */
+  public Long getStartTime() {
+    return startTime;
+  }
+
+  /**
+   * Gets end time.
+   *
+   * @return the end time
+   */
+  public Long getEndTime() {
+    return endTime;
+  }
+
+  /**
+   * Gets feedbacks.
+   *
+   * @return the feedbacks
+   */
+  public List<String> getFeedbacks() {
+    return feedbacks;
+  }
+
+  /**
+   * Gets subscription groups.
+   *
+   * @return the subscription groups
+   */
+  public List<String> getSubscriptionGroups() {
+    return subscriptionGroups;
+  }
+
+  /**
+   * Gets detection names.
+   *
+   * @return the detection names
+   */
+  public List<String> getDetectionNames() {
+    return detectionNames;
+  }
+
+  /**
+   * Gets metrics.
+   *
+   * @return the metrics
+   */
+  public List<String> getMetrics() {
+    return metrics;
+  }
+
+  /**
+   * Gets datasets.
+   *
+   * @return the datasets
+   */
+  public List<String> getDatasets() {
+    return datasets;
+  }
+
+  /**
+   * Gets anomaly ids.
+   *
+   * @return the anomaly ids
+   */
+  public List<Long> getAnomalyIds() {
+    return anomalyIds;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearchResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearchResource.java
@@ -1,3 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 package org.apache.pinot.thirdeye.dashboard.resources.v2.anomalies;
 
 import io.swagger.annotations.Api;
@@ -33,16 +53,16 @@ public class AnomalySearchResource {
   /**
    * Search and paginate the anomalies according to the parameters.
    *
-   * @param limit the limit
-   * @param offset the offset
-   * @param startTime the start time
-   * @param endTime the end time
+   * @param limit the limit of the the number of anomalies returned
+   * @param offset the offset for the start position
+   * @param startTime the start time for the anomaly range
+   * @param endTime the end time for the anomaly range
    * @param feedbacks the feedback types, e.g. ANOMALY, NOT_ANOMALY
    * @param subscriptionGroups the subscription groups
    * @param detectionNames the detection names
-   * @param metrics the metrics
-   * @param datasets the datasets
-   * @param anomalyIds the anomaly ids
+   * @param metrics the metrics for the anomalies
+   * @param datasets the datasets for the anomalies
+   * @param anomalyIds the anomaly ids for the anomalies
    * @return the response
    */
   @GET

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearchResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearchResource.java
@@ -1,0 +1,61 @@
+package org.apache.pinot.thirdeye.dashboard.resources.v2.anomalies;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import java.util.List;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.thirdeye.api.Constants;
+
+
+/**
+ * The type Anomaly search resource.
+ */
+@Path(value = "/anomaly-search")
+@Produces(MediaType.APPLICATION_JSON)
+@Api(tags = {Constants.DETECTION_TAG})
+public class AnomalySearchResource {
+
+  private final AnomalySearcher anomalySearcher;
+
+  /**
+   * Instantiates a new Anomaly search resource.
+   */
+  public AnomalySearchResource() {
+    this.anomalySearcher = new AnomalySearcher();
+  }
+
+  /**
+   * Search and paginate the anomalies according to the parameters.
+   *
+   * @param limit the limit
+   * @param offset the offset
+   * @param startTime the start time
+   * @param endTime the end time
+   * @param feedbacks the feedback types, e.g. ANOMALY, NOT_ANOMALY
+   * @param subscriptionGroups the subscription groups
+   * @param detectionNames the detection names
+   * @param metrics the metrics
+   * @param datasets the datasets
+   * @param anomalyIds the anomaly ids
+   * @return the response
+   */
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation("Search and paginate anomalies according to the parameters")
+  public Response findAlerts(@QueryParam("limit") @DefaultValue("10") int limit,
+      @QueryParam("offset") @DefaultValue("0") int offset, @QueryParam("startTime") Long startTime,
+      @QueryParam("endTime") Long endTime, @QueryParam("feedbackStatus") List<String> feedbacks,
+      @QueryParam("subscriptionGroup") List<String> subscriptionGroups,
+      @QueryParam("detectionName") List<String> detectionNames, @QueryParam("metric") List<String> metrics,
+      @QueryParam("dataset") List<String> datasets, @QueryParam("anomalyId") List<Long> anomalyIds) {
+    AnomalySearchFilter searchFilter =
+        new AnomalySearchFilter(startTime, endTime, feedbacks, subscriptionGroups, detectionNames, metrics, datasets, anomalyIds);
+    return Response.ok().entity(this.anomalySearcher.search(searchFilter, limit, offset)).build();
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearcher.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearcher.java
@@ -1,3 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 package org.apache.pinot.thirdeye.dashboard.resources.v2.anomalies;
 
 import com.google.common.collect.ImmutableMap;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearcher.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearcher.java
@@ -1,0 +1,136 @@
+package org.apache.pinot.thirdeye.dashboard.resources.v2.anomalies;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.pinot.thirdeye.constant.AnomalyFeedbackType;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.ResourceUtils;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionAlertConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import org.apache.pinot.thirdeye.datalayer.dto.AbstractDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.datalayer.pojo.DetectionConfigBean;
+import org.apache.pinot.thirdeye.datalayer.util.Predicate;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
+
+import static org.apache.pinot.thirdeye.constant.AnomalyFeedbackType.*;
+
+
+/**
+ * The type Anomaly searcher.
+ */
+public class AnomalySearcher {
+  private final MergedAnomalyResultManager anomalyDAO;
+  private final DetectionConfigManager detectionConfigDAO;
+  private final DetectionAlertConfigManager detectionAlertConfigDAO;
+
+  /**
+   * Instantiates a new Anomaly searcher.
+   */
+  public AnomalySearcher() {
+    this.anomalyDAO = DAORegistry.getInstance().getMergedAnomalyResultDAO();
+    this.detectionConfigDAO = DAORegistry.getInstance().getDetectionConfigManager();
+    this.detectionAlertConfigDAO = DAORegistry.getInstance().getDetectionAlertConfigManager();
+  }
+
+  /**
+   * Search and retrieve all the anomalies matching to the search filter and limits.
+   *
+   * @param searchFilter the search filter
+   * @param limit the limit
+   * @param offset the offset
+   * @return the result
+   */
+  public Map<String, Object> search(AnomalySearchFilter searchFilter, int limit, int offset) {
+    Predicate predicate = Predicate.EQ("child", false);
+    if (searchFilter.getStartTime() != null) {
+      predicate = Predicate.AND(predicate, Predicate.LT("startTime", searchFilter.getEndTime()));
+    }
+    if (searchFilter.getEndTime() != null) {
+      predicate = Predicate.AND(predicate, Predicate.GT("endTime", searchFilter.getStartTime()));
+    }
+    // search by detections or subscription groups
+    Set<Long> detectionConfigIds = new HashSet<>();
+    Set<Long> subscribedDetectionConfigIds = new HashSet<>();
+    if (!searchFilter.getDetectionNames().isEmpty()) {
+      detectionConfigIds =
+          this.detectionConfigDAO.findByPredicate(Predicate.IN("name", searchFilter.getDetectionNames().toArray()))
+              .stream()
+              .map(DetectionConfigBean::getId)
+              .collect(Collectors.toSet());
+    }
+    if (!searchFilter.getSubscriptionGroups().isEmpty()) {
+      subscribedDetectionConfigIds = this.detectionAlertConfigDAO.findByPredicate(
+          Predicate.IN("name", searchFilter.getSubscriptionGroups().toArray()))
+          .stream()
+          .map(detectionAlertConfigDTO -> detectionAlertConfigDTO.getVectorClocks().keySet())
+          .flatMap(Collection::stream)
+          .collect(Collectors.toSet());
+    }
+    if (!searchFilter.getDetectionNames().isEmpty() && !searchFilter.getSubscriptionGroups().isEmpty()) {
+      // intersect the detection config ids if searching by both
+      detectionConfigIds.retainAll(subscribedDetectionConfigIds);
+    } else {
+      detectionConfigIds.addAll(subscribedDetectionConfigIds);
+    }
+    if (!searchFilter.getDetectionNames().isEmpty() || !searchFilter.getSubscriptionGroups().isEmpty()) {
+      // add the predicate using detection config id
+      if (detectionConfigIds.isEmpty()) {
+        // if detection not found, return empty result
+        return ImmutableMap.of("count", 0, "limit", limit, "offset", offset, "elements", Collections.emptyList());
+      }
+      predicate = Predicate.AND(predicate, Predicate.IN("detectionConfigId", detectionConfigIds.toArray()));
+    }
+
+    // search by datasets
+    if (!searchFilter.getDatasets().isEmpty()) {
+      List<Predicate> datasetPredicates = new ArrayList<>();
+      for (String dataset : searchFilter.getDatasets()) {
+        datasetPredicates.add(Predicate.LIKE("collection", "%" + dataset + "%"));
+      }
+      predicate = Predicate.AND(predicate, Predicate.OR(datasetPredicates.toArray(new Predicate[0])));
+    }
+    // search by metrics
+    if (!searchFilter.getMetrics().isEmpty()) {
+      predicate = Predicate.AND(predicate, Predicate.IN("metric", searchFilter.getMetrics().toArray()));
+    }
+    // search by ids
+    if (!searchFilter.getAnomalyIds().isEmpty()) {
+      predicate = Predicate.AND(predicate, Predicate.IN("baseId", searchFilter.getAnomalyIds().toArray()));
+    }
+
+    long count;
+    List<MergedAnomalyResultDTO> results;
+    if (searchFilter.getFeedbacks().isEmpty()) {
+      List<Long> anomalyIds = this.anomalyDAO.findIdsByPredicate(predicate)
+          .stream()
+          .sorted(Comparator.reverseOrder())
+          .collect(Collectors.toList());
+      count = anomalyIds.size();
+      results = anomalyIds.isEmpty() ? Collections.emptyList()
+          : this.anomalyDAO.findByIds(ResourceUtils.paginateResults(anomalyIds, offset, limit));
+    } else {
+      // filter by feedback types if requested
+      List<MergedAnomalyResultDTO> anomalies = this.anomalyDAO.findByPredicate(predicate);
+      Set<AnomalyFeedbackType> feedbackFilters =
+          searchFilter.getFeedbacks().stream().map(AnomalyFeedbackType::valueOf).collect(Collectors.toSet());
+      results = anomalies.stream()
+          .filter(anomaly -> (anomaly.getFeedback() == null && feedbackFilters.contains(NO_FEEDBACK)) || (
+              anomaly.getFeedback() != null && feedbackFilters.contains(anomaly.getFeedback().getFeedbackType())))
+          .sorted(Comparator.comparingLong(AbstractDTO::getId).reversed())
+          .collect(Collectors.toList());
+      count = results.size();
+      results = ResourceUtils.paginateResults(results, offset, limit);
+    }
+    return ImmutableMap.of("count", count, "limit", limit, "offset", offset, "elements", results);
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/entity/MergedAnomalyResultIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/entity/MergedAnomalyResultIndex.java
@@ -35,6 +35,7 @@ public class MergedAnomalyResultIndex extends AbstractIndexEntity {
   String metric;
   DimensionMap dimensions;
   boolean notified;
+  boolean child;
 
   public long getDetectionConfigId() {
     return detectionConfigId;
@@ -114,5 +115,13 @@ public class MergedAnomalyResultIndex extends AbstractIndexEntity {
 
   public void setNotified(boolean notified) {
     this.notified = notified;
+  }
+
+  public boolean isChild() {
+    return child;
+  }
+
+  public void setChild(boolean child) {
+    this.child = child;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/main/resources/schema/create-schema.sql
@@ -110,6 +110,7 @@ create table if not exists merged_anomaly_result_index (
     base_id bigint(20) not null,
     create_time timestamp,
     update_time timestamp default current_timestamp,
+    child boolean,
     version int(10)
 ) ENGINE=InnoDB;
 create index merged_anomaly_result_function_idx on merged_anomaly_result_index(function_id);

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearcherTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearcherTest.java
@@ -1,3 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 package org.apache.pinot.thirdeye.dashboard.resources.v2.anomalies;
 
 import java.util.Arrays;

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearcherTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/dashboard/resources/v2/anomalies/AnomalySearcherTest.java
@@ -1,0 +1,68 @@
+package org.apache.pinot.thirdeye.dashboard.resources.v2.anomalies;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.thirdeye.datalayer.bao.DAOTestBase;
+import org.apache.pinot.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
+import org.apache.pinot.thirdeye.detection.ConfigUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class AnomalySearcherTest {
+  private DAOTestBase testDAOProvider;
+  private MergedAnomalyResultManager anomalyDAO;
+
+  @BeforeClass
+  public void beforeClass() {
+    testDAOProvider = DAOTestBase.getInstance();
+    anomalyDAO = DAORegistry.getInstance().getMergedAnomalyResultDAO();
+    MergedAnomalyResultDTO anomaly1 = new MergedAnomalyResultDTO();
+    MergedAnomalyResultDTO anomaly2 = new MergedAnomalyResultDTO();
+    MergedAnomalyResultDTO anomaly3 = new MergedAnomalyResultDTO();
+
+    anomaly1.setStartTime(1L);
+    anomaly1.setEndTime(2L);
+    anomaly1.setCollection("test_dataset_1");
+    anomaly2.setStartTime(2L);
+    anomaly2.setEndTime(3L);
+    anomaly2.setCollection("test_dataset_2");
+    anomaly3.setStartTime(5L);
+    anomaly3.setEndTime(6L);
+    anomalyDAO.save(anomaly1);
+    anomalyDAO.save(anomaly2);
+    anomalyDAO.save(anomaly3);
+  }
+
+  @Test
+  public void testSearch() {
+    AnomalySearcher anomalySearcher = new AnomalySearcher();
+    Map<String, Object> result = anomalySearcher.search(new AnomalySearchFilter(1L, 3L), 10, 0);
+    Assert.assertEquals(result.get("count"), 2L);
+    Assert.assertEquals(result.get("limit"), 10);
+    Assert.assertEquals(result.get("offset"), 0);
+    List<MergedAnomalyResultDTO> anomalies = ConfigUtils.getList(result.get("elements"));
+    Assert.assertEquals(anomalies.size(), 2);
+    Assert.assertEquals(anomalies.get(0), anomalyDAO.findById(1L));
+    Assert.assertEquals(anomalies.get(1), anomalyDAO.findById(2L));
+  }
+
+  @Test
+  public void testSearchWithFilters() {
+    AnomalySearcher anomalySearcher = new AnomalySearcher();
+    Map<String, Object> result = anomalySearcher.search(
+        new AnomalySearchFilter(1L, 3L, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), Arrays.asList("test_dataset_1"), Collections.emptyList()), 10, 0);
+    Assert.assertEquals(result.get("count"), 1L);
+    Assert.assertEquals(result.get("limit"), 10);
+    Assert.assertEquals(result.get("offset"), 0);
+    List<MergedAnomalyResultDTO> anomalies = ConfigUtils.getList(result.get("elements"));
+    Assert.assertEquals(anomalies.size(), 1);
+    Assert.assertEquals(anomalies.get(0), anomalyDAO.findById(1L));
+  }
+}


### PR DESCRIPTION
This PR creates the endpoints for searching and paginate the anomalies. The endpoint is built for the anomaly page v3. It brings the response time from ~30s to around 300ms. We should see a ~100x speedup of the page load time.

The current Anomaly list page is loading slowly because of calling legacy endpoints. Although the old endpoint works ok when the scale is small, it responses very slowly when handling anomalies on a large scale. (above 100k+ anomalies)

This endpoint pushes the filtering and pagination of the anomalies into backend and database servers instead of doing it in the UI. 