### PR TITLE
TableCache Enhancement

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -18,17 +18,14 @@
  */
 package org.apache.pinot.broker.broker.helix;
 
+import com.google.common.collect.ImmutableList;
+import com.yammer.metrics.core.MetricsRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.Configuration;
-import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixConstants.ChangeType;
 import org.apache.helix.HelixDataAccessor;
@@ -61,14 +58,12 @@ import org.apache.pinot.common.utils.CommonConstants.Helix;
 import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.config.TagNameUtils;
+import org.apache.pinot.common.utils.helix.TableCache;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableList;
-import com.yammer.metrics.core.MetricsRegistry;
 
 
 @SuppressWarnings("unused")
@@ -106,7 +101,8 @@ public class HelixBrokerStarter implements ServiceStartable {
     this(brokerConf, clusterName, zkServer, null);
   }
 
-  public HelixBrokerStarter(PinotConfiguration brokerConf, String clusterName, String zkServer, @Nullable String brokerHost)
+  public HelixBrokerStarter(PinotConfiguration brokerConf, String clusterName, String zkServer,
+      @Nullable String brokerHost)
       throws Exception {
     _brokerConf = brokerConf;
     setupHelixSystemProperties();
@@ -190,17 +186,15 @@ public class HelixBrokerStarter implements ServiceStartable {
     _helixAdmin = _spectatorHelixManager.getClusterManagmentTool();
     _propertyStore = _spectatorHelixManager.getHelixPropertyStore();
     _helixDataAccessor = _spectatorHelixManager.getHelixDataAccessor();
+
     // Fetch cluster level config from ZK
-    ConfigAccessor configAccessor = _spectatorHelixManager.getConfigAccessor();
     HelixConfigScope helixConfigScope =
         new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(_clusterName).build();
-    Map<String, String> configMap = configAccessor.get(helixConfigScope, Arrays
+    Map<String, String> configMap = _helixAdmin.getConfig(helixConfigScope, Arrays
         .asList(Helix.ENABLE_CASE_INSENSITIVE_KEY, Helix.DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY,
             Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, Helix.DEFAULT_HYPERLOGLOG_LOG2M_KEY));
-    if (Boolean.parseBoolean(configMap.get(Helix.ENABLE_CASE_INSENSITIVE_KEY)) || Boolean
-        .parseBoolean(configMap.get(Helix.DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY))) {
-      _brokerConf.setProperty(Helix.ENABLE_CASE_INSENSITIVE_KEY, true);
-    }
+    boolean caseInsensitive = Boolean.parseBoolean(configMap.get(Helix.ENABLE_CASE_INSENSITIVE_KEY)) || Boolean
+        .parseBoolean(configMap.get(Helix.DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY));
     String log2mStr = configMap.get(Helix.DEFAULT_HYPERLOGLOG_LOG2M_KEY);
     if (log2mStr != null) {
       try {
@@ -233,9 +227,10 @@ public class HelixBrokerStarter implements ServiceStartable {
     queryQuotaManager.init(_spectatorHelixManager);
     // Initialize FunctionRegistry before starting the broker request handler
     FunctionRegistry.init();
+    TableCache tableCache = new TableCache(_propertyStore, caseInsensitive);
     _brokerRequestHandler =
         new SingleConnectionBrokerRequestHandler(_brokerConf, _routingManager, _accessControlFactory, queryQuotaManager,
-            _brokerMetrics, _propertyStore);
+            tableCache, _brokerMetrics);
 
     int brokerQueryPort = _brokerConf.getProperty(Helix.KEY_OF_BROKER_QUERY_PORT, Helix.DEFAULT_BROKER_QUERY_PORT);
     LOGGER.info("Starting broker admin application on port: {}", brokerQueryPort);
@@ -311,8 +306,9 @@ public class HelixBrokerStarter implements ServiceStartable {
       }
     }
 
-    double minResourcePercentForStartup = _brokerConf.getProperty(
-        Broker.CONFIG_OF_BROKER_MIN_RESOURCE_PERCENT_FOR_START, Broker.DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START);
+    double minResourcePercentForStartup = _brokerConf
+        .getProperty(Broker.CONFIG_OF_BROKER_MIN_RESOURCE_PERCENT_FOR_START,
+            Broker.DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START);
 
     LOGGER.info("Registering service status handler");
     ServiceStatus.setServiceStatusCallback(_brokerId, new ServiceStatus.MultipleCallbackServiceStatusCallback(
@@ -395,7 +391,8 @@ public class HelixBrokerStarter implements ServiceStartable {
     return _brokerRequestHandler;
   }
 
-  public static HelixBrokerStarter getDefault() throws Exception {
+  public static HelixBrokerStarter getDefault()
+      throws Exception {
     Map<String, Object> properties = new HashMap<>();
 
     properties.put(Helix.KEY_OF_BROKER_QUERY_PORT, 5001);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -21,12 +21,8 @@ package org.apache.pinot.broker.requesthandler;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-
-import org.apache.helix.ZNRecord;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.broker.api.RequestStatistics;
 import org.apache.pinot.broker.broker.AccessControlFactory;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
@@ -41,6 +37,7 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.common.utils.helix.TableCache;
 import org.apache.pinot.core.transport.AsyncQueryResponse;
 import org.apache.pinot.core.transport.QueryRouter;
 import org.apache.pinot.core.transport.ServerInstance;
@@ -59,9 +56,9 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
   private final QueryRouter _queryRouter;
 
   public SingleConnectionBrokerRequestHandler(PinotConfiguration config, RoutingManager routingManager,
-      AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, BrokerMetrics brokerMetrics,
-      ZkHelixPropertyStore<ZNRecord> propertyStore) {
-    super(config, routingManager, accessControlFactory, queryQuotaManager, brokerMetrics, propertyStore);
+      AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache,
+      BrokerMetrics brokerMetrics) {
+    super(config, routingManager, accessControlFactory, queryQuotaManager, tableCache, brokerMetrics);
     _queryRouter = new QueryRouter(_brokerId, brokerMetrics);
   }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.broker.requesthandler;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yammer.metrics.core.MetricsRegistry;
 import java.util.Random;
-
 import org.apache.pinot.broker.api.RequestStatistics;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -29,10 +31,6 @@ import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yammer.metrics.core.MetricsRegistry;
 
 
 public class LiteralOnlyBrokerRequestTest {
@@ -92,8 +90,8 @@ public class LiteralOnlyBrokerRequestTest {
   public void testBrokerRequestHandler()
       throws Exception {
     SingleConnectionBrokerRequestHandler requestHandler =
-        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, null, null,
-            new BrokerMetrics("", new MetricsRegistry(), false), null);
+        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, null, null, null,
+            new BrokerMetrics("", new MetricsRegistry(), false));
     long randNum = RANDOM.nextLong();
     byte[] randBytes = new byte[12];
     RANDOM.nextBytes(randBytes);
@@ -119,8 +117,8 @@ public class LiteralOnlyBrokerRequestTest {
   public void testBrokerRequestHandlerWithAsFunction()
       throws Exception {
     SingleConnectionBrokerRequestHandler requestHandler =
-        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, null, null,
-            new BrokerMetrics("", new MetricsRegistry(), false), null);
+        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, null, null, null,
+            new BrokerMetrics("", new MetricsRegistry(), false));
     long currentTsMin = System.currentTimeMillis();
     JsonNode request = new ObjectMapper().readTree(
         "{\"sql\":\"SELECT now() as currentTs, fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') as firstDayOf2020\"}");

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/TableCache.java
@@ -18,19 +18,23 @@
  */
 package org.apache.pinot.common.utils.helix;
 
-import java.util.Collection;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
 import org.I0Itec.zkclient.IZkChildListener;
 import org.I0Itec.zkclient.IZkDataListener;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.utils.SchemaUtils;
 import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -38,170 +42,284 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- *  Caches table config and schema of a table.
- *  At the start - loads all the table configs and schemas in map.
- *  sets up a zookeeper listener that watches for any change and updates the cache.
- *  TODO: optimize to load only changed table configs/schema on a callback.
- *  TODO: Table deletes are not handled as of now
- *  Goal is to eventually grow this into a PinotClusterDataAccessor
+ * The {@code TableCache} caches all the table configs and schemas within the cluster, and listens on ZK changes to keep
+ * them in sync. It also maintains the table name map and the column name map for case-insensitive queries.
  */
 public class TableCache {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableCache.class);
+  private static final String TABLE_CONFIG_PARENT_PATH = "/CONFIGS/TABLE";
+  private static final String TABLE_CONFIG_PATH_PREFIX = "/CONFIGS/TABLE/";
+  private static final String SCHEMA_PARENT_PATH = "/SCHEMAS";
+  private static final String SCHEMA_PATH_PREFIX = "/SCHEMAS/";
+  private static final String LOWER_CASE_OFFLINE_TABLE_SUFFIX = "_offline";
+  private static final String LOWER_CASE_REALTIME_TABLE_SUFFIX = "_realtime";
 
-  private static final String PROPERTYSTORE_SCHEMAS_PREFIX = "/SCHEMAS";
-  private static final String PROPERTYSTORE_TABLE_CONFIGS_PREFIX = "/CONFIGS/TABLE";
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final boolean _caseInsensitive;
+  // For case insensitive, key is lower case table name, value is actual table name
+  private final Map<String, String> _tableNameMap;
 
-  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
-  TableConfigChangeListener _tableConfigChangeListener;
-  SchemaChangeListener _schemaChangeListener;
+  // Key is table name with type suffix
+  private final TableConfigChangeListener _tableConfigChangeListener = new TableConfigChangeListener();
+  private final Map<String, TableConfig> _tableConfigMap = new ConcurrentHashMap<>();
+  // Key is raw table name
+  private final SchemaChangeListener _schemaChangeListener = new SchemaChangeListener();
+  private final Map<String, SchemaInfo> _schemaInfoMap = new ConcurrentHashMap<>();
 
-  public TableCache(ZkHelixPropertyStore<ZNRecord> propertyStore) {
+  public TableCache(ZkHelixPropertyStore<ZNRecord> propertyStore, boolean caseInsensitive) {
     _propertyStore = propertyStore;
-    _schemaChangeListener = new SchemaChangeListener();
-    _schemaChangeListener.refresh();
-    _tableConfigChangeListener = new TableConfigChangeListener();
-    _tableConfigChangeListener.refresh();
-  }
+    _caseInsensitive = caseInsensitive;
+    _tableNameMap = caseInsensitive ? new ConcurrentHashMap<>() : null;
 
-  public String getActualTableName(String tableName) {
-    return _tableConfigChangeListener._tableNameMap.getOrDefault(tableName.toLowerCase(), tableName);
-  }
+    synchronized (_tableConfigChangeListener) {
+      // Subscribe child changes before reading the data to avoid missing changes
+      _propertyStore.subscribeChildChanges(TABLE_CONFIG_PARENT_PATH, _tableConfigChangeListener);
 
-  public boolean containsTable(String tableName) {
-    return _tableConfigChangeListener._tableNameMap.containsKey(tableName.toLowerCase());
-  }
-
-  public String getActualColumnName(String tableName, String columnName) {
-    String schemaName = _tableConfigChangeListener._table2SchemaConfigMap.get(tableName.toLowerCase());
-    if (schemaName != null) {
-      String actualColumnName = _schemaChangeListener.getColumnName(schemaName, columnName);
-      // If actual column name doesn't exist in schema, then return the origin column name.
-      if (actualColumnName == null) {
-        return columnName;
-      }
-      return actualColumnName;
-    }
-    return columnName;
-  }
-
-  public TableConfig getTableConfig(String tableName) {
-    return _tableConfigChangeListener._tableConfigMap.get(tableName);
-  }
-
-  class TableConfigChangeListener implements IZkChildListener, IZkDataListener {
-
-    Map<String, TableConfig> _tableConfigMap = new ConcurrentHashMap<>();
-    Map<String, String> _tableNameMap = new ConcurrentHashMap<>();
-    Map<String, String> _table2SchemaConfigMap = new ConcurrentHashMap<>();
-
-    public synchronized void refresh() {
-      try {
-        //always subscribe first before reading, so that we dont miss any changes
-        _propertyStore.subscribeChildChanges(PROPERTYSTORE_TABLE_CONFIGS_PREFIX, _tableConfigChangeListener);
-        _propertyStore.subscribeDataChanges(PROPERTYSTORE_TABLE_CONFIGS_PREFIX, _tableConfigChangeListener);
-        List<ZNRecord> children =
-            _propertyStore.getChildren(PROPERTYSTORE_TABLE_CONFIGS_PREFIX, null, AccessOption.PERSISTENT);
-        if (children != null) {
-          for (ZNRecord znRecord : children) {
-            try {
-              TableConfig tableConfig = TableConfigUtils.fromZNRecord(znRecord);
-              String tableNameWithType = tableConfig.getTableName();
-              _tableConfigMap.put(tableNameWithType, tableConfig);
-              String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-              //create case insensitive mapping
-              _tableNameMap.put(tableNameWithType.toLowerCase(), tableNameWithType);
-              _tableNameMap.put(rawTableName.toLowerCase(), rawTableName);
-              //create case insensitive mapping between table name and schemaName
-              _table2SchemaConfigMap.put(tableNameWithType.toLowerCase(), rawTableName);
-              _table2SchemaConfigMap.put(rawTableName.toLowerCase(), rawTableName);
-            } catch (Exception e) {
-              LOGGER.warn("Exception loading table config for: {}: {}", znRecord.getId(), e.getMessage());
-              //ignore
-            }
-          }
+      List<String> tables = _propertyStore.getChildNames(TABLE_CONFIG_PARENT_PATH, AccessOption.PERSISTENT);
+      if (CollectionUtils.isNotEmpty(tables)) {
+        List<String> pathsToAdd = new ArrayList<>(tables.size());
+        for (String tableNameWithType : tables) {
+          pathsToAdd.add(TABLE_CONFIG_PATH_PREFIX + tableNameWithType);
         }
-      } catch (Exception e) {
-        LOGGER.warn("Exception subscribing/reading tableconfigs", e);
-        //ignore
+        addTableConfigs(pathsToAdd);
       }
     }
 
-    @Override
-    public void handleChildChange(String s, List<String> list)
-        throws Exception {
-      refresh();
+    synchronized (_schemaChangeListener) {
+      // Subscribe child changes before reading the data to avoid missing changes
+      _propertyStore.subscribeChildChanges(SCHEMA_PARENT_PATH, _schemaChangeListener);
+
+      List<String> tables = _propertyStore.getChildNames(SCHEMA_PARENT_PATH, AccessOption.PERSISTENT);
+      if (CollectionUtils.isNotEmpty(tables)) {
+        List<String> pathsToAdd = new ArrayList<>(tables.size());
+        for (String rawTableName : tables) {
+          pathsToAdd.add(SCHEMA_PATH_PREFIX + rawTableName);
+        }
+        addSchemas(pathsToAdd);
+      }
     }
 
-    @Override
-    public void handleDataChange(String s, Object o)
-        throws Exception {
-      refresh();
-    }
+    LOGGER.info("Initialized TableCache with caseInsensitive: {}", caseInsensitive);
+  }
 
-    @Override
-    public void handleDataDeleted(String s)
-        throws Exception {
-      refresh();
+  /**
+   * Returns {@code true} if the TableCache is case-insensitive, {@code false} otherwise.
+   */
+  public boolean isCaseInsensitive() {
+    return _caseInsensitive;
+  }
+
+  /**
+   * For case-insensitive only, returns the actual table name for the given case-insensitive table name (with or without
+   * type suffix), or {@code null} if the table does not exist.
+   */
+  @Nullable
+  public String getActualTableName(String caseInsensitiveTableName) {
+    Preconditions.checkState(_caseInsensitive, "TableCache is not case-insensitive");
+    return _tableNameMap.get(caseInsensitiveTableName.toLowerCase());
+  }
+
+  /**
+   * For case-insensitive only, returns a map from lower case column name to actual column name for the given table, or
+   * {@code null} if the table schema does not exist.
+   */
+  @Nullable
+  public Map<String, String> getColumnNameMap(String rawTableName) {
+    Preconditions.checkState(_caseInsensitive, "TableCache is not case-insensitive");
+    SchemaInfo schemaInfo = _schemaInfoMap.get(rawTableName);
+    return schemaInfo != null ? schemaInfo._columnNameMap : null;
+  }
+
+  /**
+   * Returns the table config for the given table, or {@code null} if it does not exist.
+   */
+  @Nullable
+  public TableConfig getTableConfig(String tableNameWithType) {
+    return _tableConfigMap.get(tableNameWithType);
+  }
+
+  /**
+   * Returns the schema for the given table, or {@code null} if it does not exist.
+   */
+  @Nullable
+  public Schema getSchema(String rawTableName) {
+    SchemaInfo schemaInfo = _schemaInfoMap.get(rawTableName);
+    return schemaInfo != null ? schemaInfo._schema : null;
+  }
+
+  private void addTableConfigs(List<String> paths) {
+    // Subscribe data changes before reading the data to avoid missing changes
+    for (String path : paths) {
+      _propertyStore.subscribeDataChanges(path, _tableConfigChangeListener);
+    }
+    List<ZNRecord> znRecords = _propertyStore.get(paths, null, AccessOption.PERSISTENT);
+    for (ZNRecord znRecord : znRecords) {
+      if (znRecord != null) {
+        try {
+          putTableConfig(znRecord);
+        } catch (Exception e) {
+          LOGGER.error("Caught exception while adding table config for ZNRecord: {}", znRecord.getId(), e);
+        }
+      }
     }
   }
 
-  class SchemaChangeListener implements IZkChildListener, IZkDataListener {
-    Map<String, Map<String, String>> _schemaColumnMap = new ConcurrentHashMap<>();
+  private void putTableConfig(ZNRecord znRecord)
+      throws IOException {
+    TableConfig tableConfig = TableConfigUtils.fromZNRecord(znRecord);
+    String tableNameWithType = tableConfig.getTableName();
+    _tableConfigMap.put(tableNameWithType, tableConfig);
+    if (_caseInsensitive) {
+      _tableNameMap.put(tableNameWithType.toLowerCase(), tableNameWithType);
+      String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+      _tableNameMap.put(rawTableName.toLowerCase(), rawTableName);
+    }
+  }
 
-    public synchronized void refresh() {
-      try {
-        //always subscribe first before reading, so that we dont miss any changes between reading and setting the watcher again
-        _propertyStore.subscribeChildChanges(PROPERTYSTORE_SCHEMAS_PREFIX, _schemaChangeListener);
-        _propertyStore.subscribeDataChanges(PROPERTYSTORE_SCHEMAS_PREFIX, _schemaChangeListener);
-        List<ZNRecord> children =
-            _propertyStore.getChildren(PROPERTYSTORE_SCHEMAS_PREFIX, null, AccessOption.PERSISTENT);
-        if (children != null) {
-          for (ZNRecord znRecord : children) {
-            try {
-              Schema schema = SchemaUtils.fromZNRecord(znRecord);
-              String schemaNameLowerCase = schema.getSchemaName().toLowerCase();
-              Collection<FieldSpec> allFieldSpecs = schema.getAllFieldSpecs();
-              ConcurrentHashMap<String, String> columnNameMap = new ConcurrentHashMap<>();
-              _schemaColumnMap.put(schemaNameLowerCase, columnNameMap);
-              for (FieldSpec fieldSpec : allFieldSpecs) {
-                columnNameMap.put(fieldSpec.getName().toLowerCase(), fieldSpec.getName());
-              }
-            } catch (Exception e) {
-              LOGGER.warn("Exception loading schema for: {}: {}", znRecord.getId(), e.getMessage());
-              //ignore
-            }
-          }
+  private void removeTableConfig(String path) {
+    _propertyStore.unsubscribeDataChanges(path, _tableConfigChangeListener);
+    String tableNameWithType = path.substring(TABLE_CONFIG_PATH_PREFIX.length());
+    _tableConfigMap.remove(tableNameWithType);
+    if (_caseInsensitive) {
+      _tableNameMap.remove(tableNameWithType.toLowerCase());
+      String lowerCaseRawTableName = TableNameBuilder.extractRawTableName(tableNameWithType).toLowerCase();
+      if (TableNameBuilder.isOfflineTableResource(tableNameWithType)) {
+        if (!_tableNameMap.containsKey(lowerCaseRawTableName + LOWER_CASE_REALTIME_TABLE_SUFFIX)) {
+          _tableNameMap.remove(lowerCaseRawTableName);
         }
-      } catch (Exception e) {
-        LOGGER.warn("Exception subscribing/reading schemas", e);
-        //ignore
+      } else {
+        if (!_tableNameMap.containsKey(lowerCaseRawTableName + LOWER_CASE_OFFLINE_TABLE_SUFFIX)) {
+          _tableNameMap.remove(lowerCaseRawTableName);
+        }
+      }
+    }
+  }
+
+  private void addSchemas(List<String> paths) {
+    // Subscribe data changes before reading the data to avoid missing changes
+    for (String path : paths) {
+      _propertyStore.subscribeDataChanges(path, _schemaChangeListener);
+    }
+    List<ZNRecord> znRecords = _propertyStore.get(paths, null, AccessOption.PERSISTENT);
+    for (ZNRecord znRecord : znRecords) {
+      if (znRecord != null) {
+        try {
+          putSchema(znRecord);
+        } catch (Exception e) {
+          LOGGER.error("Caught exception while adding schema for ZNRecord: {}", znRecord.getId(), e);
+        }
+      }
+    }
+  }
+
+  private void putSchema(ZNRecord znRecord)
+      throws IOException {
+    Schema schema = SchemaUtils.fromZNRecord(znRecord);
+    String rawTableName = schema.getSchemaName();
+    if (_caseInsensitive) {
+      Map<String, String> columnNameMap = new HashMap<>();
+      for (String columnName : schema.getColumnNames()) {
+        columnNameMap.put(columnName.toLowerCase(), columnName);
+      }
+      _schemaInfoMap.put(rawTableName, new SchemaInfo(schema, columnNameMap));
+    } else {
+      _schemaInfoMap.put(rawTableName, new SchemaInfo(schema, null));
+    }
+  }
+
+  private void removeSchema(String path) {
+    _propertyStore.unsubscribeDataChanges(path, _schemaChangeListener);
+    String rawTableName = path.substring(SCHEMA_PATH_PREFIX.length());
+    _schemaInfoMap.remove(rawTableName);
+  }
+
+  private class TableConfigChangeListener implements IZkChildListener, IZkDataListener {
+
+    @Override
+    public synchronized void handleChildChange(String path, List<String> tables) {
+      if (CollectionUtils.isEmpty(tables)) {
+        return;
+      }
+
+      // Only process new added table configs. Changed/removed table configs are handled by other callbacks.
+      List<String> pathsToAdd = new ArrayList<>();
+      for (String tableNameWithType : tables) {
+        if (!_tableConfigMap.containsKey(tableNameWithType)) {
+          pathsToAdd.add(TABLE_CONFIG_PATH_PREFIX + tableNameWithType);
+        }
+      }
+      if (!pathsToAdd.isEmpty()) {
+        addTableConfigs(pathsToAdd);
       }
     }
 
-    String getColumnName(String schemaName, String columnName) {
-      Map<String, String> columnNameMap = _schemaColumnMap.get(schemaName.toLowerCase());
-      if (columnNameMap != null) {
-        return columnNameMap.get(columnName.toLowerCase());
+    @Override
+    public synchronized void handleDataChange(String path, Object data) {
+      if (data != null) {
+        ZNRecord znRecord = (ZNRecord) data;
+        try {
+          putTableConfig(znRecord);
+        } catch (Exception e) {
+          LOGGER.error("Caught exception while refreshing table config for ZNRecord: {}", znRecord.getId(), e);
+        }
       }
-      return columnName;
     }
 
     @Override
-    public void handleChildChange(String s, List<String> list)
-        throws Exception {
-      refresh();
+    public synchronized void handleDataDeleted(String path) {
+      // NOTE: The path here is the absolute ZK path instead of the relative path to the property store.
+      String tableNameWithType = path.substring(path.lastIndexOf('/') + 1);
+      removeTableConfig(TABLE_CONFIG_PATH_PREFIX + tableNameWithType);
+    }
+  }
+
+  private class SchemaChangeListener implements IZkChildListener, IZkDataListener {
+
+    @Override
+    public synchronized void handleChildChange(String path, List<String> tables) {
+      if (CollectionUtils.isEmpty(tables)) {
+        return;
+      }
+
+      // Only process new added schemas. Changed/removed schemas are handled by other callbacks.
+      List<String> pathsToAdd = new ArrayList<>();
+      for (String rawTableName : tables) {
+        if (!_schemaInfoMap.containsKey(rawTableName)) {
+          pathsToAdd.add(SCHEMA_PATH_PREFIX + rawTableName);
+        }
+      }
+      if (!pathsToAdd.isEmpty()) {
+        addSchemas(pathsToAdd);
+      }
     }
 
     @Override
-    public void handleDataChange(String s, Object o)
-        throws Exception {
-      refresh();
+    public synchronized void handleDataChange(String path, Object data) {
+      if (data != null) {
+        ZNRecord znRecord = (ZNRecord) data;
+        try {
+          putSchema(znRecord);
+        } catch (Exception e) {
+          LOGGER.error("Caught exception while refreshing schema for ZNRecord: {}", znRecord.getId(), e);
+        }
+      }
     }
 
     @Override
-    public void handleDataDeleted(String s)
-        throws Exception {
-      refresh();
+    public synchronized void handleDataDeleted(String path) {
+      // NOTE: The path here is the absolute ZK path instead of the relative path to the property store.
+      String rawTableName = path.substring(path.lastIndexOf('/') + 1);
+      removeSchema(SCHEMA_PATH_PREFIX + rawTableName);
+    }
+  }
+
+  private static class SchemaInfo {
+    final Schema _schema;
+    final Map<String, String> _columnNameMap;
+
+    private SchemaInfo(Schema schema, Map<String, String> columnNameMap) {
+      _schema = schema;
+      _columnNameMap = columnNameMap;
     }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/TableCacheTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/TableCacheTest.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix;
+
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.common.utils.helix.TableCache;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class TableCacheTest extends ControllerTest {
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+    startController();
+    addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
+    addFakeServerInstancesToAutoJoinHelixCluster(1, true);
+  }
+
+  @Test
+  public void testTableCache()
+      throws Exception {
+    TableCache tableCache = new TableCache(_propertyStore, true);
+
+    assertNull(tableCache.getActualTableName("testTable"));
+    assertNull(tableCache.getColumnNameMap("testTable"));
+    assertNull(tableCache.getTableConfig("testTable_OFFLINE"));
+    assertNull(tableCache.getSchema("testTable"));
+
+    // Add a table config
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    _helixResourceManager.addTable(tableConfig);
+    // Wait for at most 10 seconds for the callback to add the table config to the cache
+    TestUtils.waitForCondition(aVoid -> tableCache.getTableConfig("testTable_OFFLINE") != null, 10_000L,
+        "Failed to add the table config to the cache");
+    assertEquals(tableCache.getActualTableName("TeStTaBlE"), "testTable");
+    assertEquals(tableCache.getActualTableName("TeStTaBlE_oFfLiNe"), "testTable_OFFLINE");
+    assertNull(tableCache.getActualTableName("testTable_REALTIME"));
+    assertEquals(tableCache.getTableConfig("testTable_OFFLINE"), tableConfig);
+    assertNull(tableCache.getColumnNameMap("testTable"));
+    assertNull(tableCache.getSchema("testTable"));
+
+    // Update the table config
+    tableConfig.getIndexingConfig().setCreateInvertedIndexDuringSegmentGeneration(true);
+    _helixResourceManager.updateTableConfig(tableConfig);
+    // Wait for at most 10 seconds for the callback to update the table config in the cache
+    // NOTE: Table config should never be null during the transitioning
+    TestUtils.waitForCondition(
+        aVoid -> Preconditions.checkNotNull(tableCache.getTableConfig("testTable_OFFLINE")).equals(tableConfig),
+        10_000L, "Failed to update the table config in the cache");
+    assertEquals(tableCache.getActualTableName("TeStTaBlE"), "testTable");
+    assertEquals(tableCache.getActualTableName("TeStTaBlE_oFfLiNe"), "testTable_OFFLINE");
+    assertNull(tableCache.getActualTableName("testTable_REALTIME"));
+    assertNull(tableCache.getColumnNameMap("testTable"));
+    assertNull(tableCache.getSchema("testTable"));
+
+    // Remove the table config
+    _helixResourceManager.deleteOfflineTable("testTable");
+    // Wait for at most 10 seconds for the callback to remove the table config from the cache
+    TestUtils.waitForCondition(aVoid -> tableCache.getTableConfig("testTable_OFFLINE") == null, 10_000L,
+        "Failed to remove the table config from the cache");
+    assertNull(tableCache.getActualTableName("testTable"));
+    assertNull(tableCache.getColumnNameMap("testTable"));
+    assertNull(tableCache.getSchema("testTable"));
+
+    // Add a schema
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName("testTable").addSingleValueDimension("testColumn", DataType.INT)
+            .build();
+    _helixResourceManager.addSchema(schema, false);
+    // Wait for at most 10 seconds for the callback to add the schema to the cache
+    TestUtils.waitForCondition(aVoid -> tableCache.getSchema("testTable") != null, 10_000L,
+        "Failed to add the schema to the cache");
+    assertEquals(tableCache.getColumnNameMap("testTable"), Collections.singletonMap("testcolumn", "testColumn"));
+    assertEquals(tableCache.getSchema("testTable"), schema);
+    // Case-insensitive table name are handled based on the table config instead of the schema
+    assertNull(tableCache.getActualTableName("testTable"));
+    assertNull(tableCache.getTableConfig("testTable_OFFLINE"));
+
+    // Update the schema
+    schema.addField(new DimensionFieldSpec("newColumn", DataType.LONG, true));
+    _helixResourceManager.updateSchema(schema, false);
+    // Wait for at most 10 seconds for the callback to update the schema in the cache
+    // NOTE: schema should never be null during the transitioning
+    TestUtils.waitForCondition(aVoid -> Preconditions.checkNotNull(tableCache.getSchema("testTable")).equals(schema),
+        10_000L, "Failed to update the schema in the cache");
+    Map<String, String> expectedColumnMap = new HashMap<>();
+    expectedColumnMap.put("testcolumn", "testColumn");
+    expectedColumnMap.put("newcolumn", "newColumn");
+    assertEquals(tableCache.getColumnNameMap("testTable"), expectedColumnMap);
+    // Case-insensitive table name are handled based on the table config instead of the schema
+    assertNull(tableCache.getActualTableName("testTable"));
+    assertNull(tableCache.getTableConfig("testTable_OFFLINE"));
+
+    // Remove the schema
+    _helixResourceManager.deleteSchema(schema);
+    // Wait for at most 10 seconds for the callback to remove the schema from the cache
+    TestUtils.waitForCondition(aVoid -> tableCache.getSchema("testTable") == null, 10_000L,
+        "Failed to remove the schema from the cache");
+    assertNull(tableCache.getActualTableName("testTable"));
+    assertNull(tableCache.getColumnNameMap("testTable"));
+    assertNull(tableCache.getSchema("testTable"));
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -92,6 +92,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -402,11 +402,11 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.5</version>
       </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
-    </dependency>
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.1</version>
+      </dependency>
       <dependency>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>


### PR DESCRIPTION
Refactor TableCache with the following enhancement:
- Support caching schema
- Correctly handle table config and schema change and remove
- Significantly reduce the ZK read (only need to read new added table config and schema)

Always create TableCache for broker so that we can access schema for query optimization