### PR TITLE
Avoid redundant creation & merging of empty sketches.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -384,7 +385,11 @@ public class DistinctCountThetaSketchAggregationFunction implements AggregationF
 
   @Override
   public Map<String, Sketch> extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
-    Map<Predicate, Union> unionMap = getUnionMap(aggregationResultHolder);
+    Map<Predicate, Union> unionMap = aggregationResultHolder.getResult();
+    if (unionMap == null || unionMap.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
     Map<String, Sketch> result = new HashMap<>();
     for (PredicateInfo predicateInfo : _predicateInfoMap.values()) {
       result.put(predicateInfo.getStringPredicate(), unionMap.get(predicateInfo.getPredicate()).getResult());
@@ -394,7 +399,11 @@ public class DistinctCountThetaSketchAggregationFunction implements AggregationF
 
   @Override
   public Map<String, Sketch> extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
-    Map<Predicate, Union> unionMap = getUnionMap(groupByResultHolder, groupKey);
+    Map<Predicate, Union> unionMap = groupByResultHolder.getResult(groupKey);
+    if (unionMap == null || unionMap.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
     Map<String, Sketch> result = new HashMap<>();
     for (PredicateInfo predicateInfo : _predicateInfoMap.values()) {
       result.put(predicateInfo.getStringPredicate(), unionMap.get(predicateInfo.getPredicate()).getResult());
@@ -404,9 +413,9 @@ public class DistinctCountThetaSketchAggregationFunction implements AggregationF
 
   @Override
   public Map<String, Sketch> merge(Map<String, Sketch> intermediateResult1, Map<String, Sketch> intermediateResult2) {
-    if (intermediateResult1 == null) {
+    if (intermediateResult1 == null || intermediateResult1.isEmpty()) {
       return intermediateResult2;
-    } else if (intermediateResult2 == null) {
+    } else if (intermediateResult2 == null || intermediateResult2.isEmpty()) {
       return intermediateResult1;
     }
 


### PR DESCRIPTION
For segments where no rows are selected, the intermediate and the final merge steps
still create empty Union objects and merge them. This can cause huge latency degradation
in cases there is a large number of segments, and large value of nominal entriesf

This PR avoids creation/merging of empty sketches. Doing so, we are seeing a latency
improvement from 8s to < 500ms for 167 segments, and nominal entries of `1048576`.

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
