### PR TITLE
Add missing null check before closing reader context.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -273,35 +273,36 @@ public class DataFetcher {
     }
 
     void readIntValues(int[] docIds, int length, int[] valueBuffer) {
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
-        _reader.readDictIds(docIds, length, dictIdBuffer, getReaderContext());
+        _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readIntValues(dictIdBuffer, length, valueBuffer);
       } else {
         switch (_reader.getValueType()) {
           case INT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getInt(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getInt(docIds[i], readerContext);
             }
             break;
           case LONG:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (int) _reader.getLong(docIds[i], getReaderContext());
+              valueBuffer[i] = (int) _reader.getLong(docIds[i], readerContext);
             }
             break;
           case FLOAT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (int) _reader.getFloat(docIds[i], getReaderContext());
+              valueBuffer[i] = (int) _reader.getFloat(docIds[i], readerContext);
             }
             break;
           case DOUBLE:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (int) _reader.getDouble(docIds[i], getReaderContext());
+              valueBuffer[i] = (int) _reader.getDouble(docIds[i], readerContext);
             }
             break;
           case STRING:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Integer.parseInt(_reader.getString(docIds[i], getReaderContext()));
+              valueBuffer[i] = Integer.parseInt(_reader.getString(docIds[i], readerContext));
             }
             break;
           default:
@@ -311,35 +312,36 @@ public class DataFetcher {
     }
 
     void readLongValues(int[] docIds, int length, long[] valueBuffer) {
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
-        _reader.readDictIds(docIds, length, dictIdBuffer, getReaderContext());
+        _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readLongValues(dictIdBuffer, length, valueBuffer);
       } else {
         switch (_reader.getValueType()) {
           case INT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getInt(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getInt(docIds[i], readerContext);
             }
             break;
           case LONG:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getLong(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getLong(docIds[i], readerContext);
             }
             break;
           case FLOAT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (long) _reader.getFloat(docIds[i], getReaderContext());
+              valueBuffer[i] = (long) _reader.getFloat(docIds[i], readerContext);
             }
             break;
           case DOUBLE:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (long) _reader.getDouble(docIds[i], getReaderContext());
+              valueBuffer[i] = (long) _reader.getDouble(docIds[i], readerContext);
             }
             break;
           case STRING:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Long.parseLong(_reader.getString(docIds[i], getReaderContext()));
+              valueBuffer[i] = Long.parseLong(_reader.getString(docIds[i], readerContext));
             }
             break;
           default:
@@ -349,35 +351,36 @@ public class DataFetcher {
     }
 
     void readFloatValues(int[] docIds, int length, float[] valueBuffer) {
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
-        _reader.readDictIds(docIds, length, dictIdBuffer, getReaderContext());
+        _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readFloatValues(dictIdBuffer, length, valueBuffer);
       } else {
         switch (_reader.getValueType()) {
           case INT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getInt(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getInt(docIds[i], readerContext);
             }
             break;
           case LONG:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getLong(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getLong(docIds[i], readerContext);
             }
             break;
           case FLOAT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getFloat(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getFloat(docIds[i], readerContext);
             }
             break;
           case DOUBLE:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (float) _reader.getDouble(docIds[i], getReaderContext());
+              valueBuffer[i] = (float) _reader.getDouble(docIds[i], readerContext);
             }
             break;
           case STRING:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Float.parseFloat(_reader.getString(docIds[i], getReaderContext()));
+              valueBuffer[i] = Float.parseFloat(_reader.getString(docIds[i], readerContext));
             }
             break;
           default:
@@ -387,35 +390,36 @@ public class DataFetcher {
     }
 
     void readDoubleValues(int[] docIds, int length, double[] valueBuffer) {
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
-        _reader.readDictIds(docIds, length, dictIdBuffer, getReaderContext());
+        _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readDoubleValues(dictIdBuffer, length, valueBuffer);
       } else {
         switch (_reader.getValueType()) {
           case INT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getInt(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getInt(docIds[i], readerContext);
             }
             break;
           case LONG:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getLong(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getLong(docIds[i], readerContext);
             }
             break;
           case FLOAT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getFloat(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getFloat(docIds[i], readerContext);
             }
             break;
           case DOUBLE:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getDouble(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getDouble(docIds[i], readerContext);
             }
             break;
           case STRING:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Double.parseDouble(_reader.getString(docIds[i], getReaderContext()));
+              valueBuffer[i] = Double.parseDouble(_reader.getString(docIds[i], readerContext));
             }
             break;
           default:
@@ -425,40 +429,41 @@ public class DataFetcher {
     }
 
     void readStringValues(int[] docIds, int length, String[] valueBuffer) {
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
-        _reader.readDictIds(docIds, length, dictIdBuffer, getReaderContext());
+        _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readStringValues(dictIdBuffer, length, valueBuffer);
       } else {
         switch (_reader.getValueType()) {
           case INT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Integer.toString(_reader.getInt(docIds[i], getReaderContext()));
+              valueBuffer[i] = Integer.toString(_reader.getInt(docIds[i], readerContext));
             }
             break;
           case LONG:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Long.toString(_reader.getLong(docIds[i], getReaderContext()));
+              valueBuffer[i] = Long.toString(_reader.getLong(docIds[i], readerContext));
             }
             break;
           case FLOAT:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Float.toString(_reader.getFloat(docIds[i], getReaderContext()));
+              valueBuffer[i] = Float.toString(_reader.getFloat(docIds[i], readerContext));
             }
             break;
           case DOUBLE:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Double.toString(_reader.getDouble(docIds[i], getReaderContext()));
+              valueBuffer[i] = Double.toString(_reader.getDouble(docIds[i], readerContext));
             }
             break;
           case STRING:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getString(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getString(docIds[i], readerContext);
             }
             break;
           case BYTES:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = BytesUtils.toHexString(_reader.getBytes(docIds[i], getReaderContext()));
+              valueBuffer[i] = BytesUtils.toHexString(_reader.getBytes(docIds[i], readerContext));
             }
             break;
           default:
@@ -468,20 +473,21 @@ public class DataFetcher {
     }
 
     void readBytesValues(int[] docIds, int length, byte[][] valueBuffer) {
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
-        _reader.readDictIds(docIds, length, dictIdBuffer, getReaderContext());
+        _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readBytesValues(dictIdBuffer, length, valueBuffer);
       } else {
         switch (_reader.getValueType()) {
           case STRING:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = BytesUtils.toBytes(_reader.getString(docIds[i], getReaderContext()));
+              valueBuffer[i] = BytesUtils.toBytes(_reader.getString(docIds[i], readerContext));
             }
             break;
           case BYTES:
             for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getBytes(docIds[i], getReaderContext());
+              valueBuffer[i] = _reader.getBytes(docIds[i], readerContext);
             }
             break;
           default:
@@ -551,7 +557,9 @@ public class DataFetcher {
     @Override
     public void close()
         throws IOException {
-      _readerContext.close();
+      if (_readerContext != null) {
+        _readerContext.close();
+      }
     }
   }
 }


### PR DESCRIPTION
With lazy initialization, the ForwardIndexReaderContext can be null. The close()
method is not called today, but if/when it will be, this could lead to NPE.

- Adding NULL check to fix this potential problem.
- Also, assigned getContext() to local variable for readability.