### PR TITLE
[TE] Error handling refactor of EntityManagerResource

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/BadRequestWebException.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/BadRequestWebException.java
@@ -1,3 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 package org.apache.pinot.thirdeye.dashboard.resources;
 
 import javax.ws.rs.WebApplicationException;
@@ -5,6 +25,12 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+/**
+ * This exception is thrown when the user makes an error in the request. This in turn fires a
+ * {@link WebApplicationException} with BAD_REQUEST(400) status code.
+ *
+ * Please check the utilites in the {@link ResourceUtils} class to easily use this class.
+ */
 public class BadRequestWebException extends WebApplicationException {
 
   public BadRequestWebException() {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/BadRequestWebException.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/BadRequestWebException.java
@@ -1,0 +1,29 @@
+package org.apache.pinot.thirdeye.dashboard.resources;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+public class BadRequestWebException extends WebApplicationException {
+
+  public BadRequestWebException() {
+    this("Bad or Malformed Request");
+  }
+
+  public BadRequestWebException(Exception e) {
+    super(Response
+        .status(Status.BAD_REQUEST)
+        .entity(e.getMessage())
+        .type(MediaType.TEXT_PLAIN)
+        .build());
+  }
+
+  public BadRequestWebException(String message) {
+    super(Response
+        .status(Status.BAD_REQUEST)
+        .entity(message)
+        .type(MediaType.TEXT_PLAIN)
+        .build());
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/ResourceUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/ResourceUtils.java
@@ -1,0 +1,19 @@
+package org.apache.pinot.thirdeye.dashboard.resources;
+
+public class ResourceUtils {
+
+  public static void ensure(boolean condition, String message) {
+    if (!condition) {
+      throw new BadRequestWebException(message);
+    }
+  }
+
+  public static <T> T ensureExists(T o, String message) {
+    ensure(o != null, message);
+    return o;
+  }
+
+  public static BadRequestWebException badRequest(String errorMsg) {
+    return new BadRequestWebException(errorMsg);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/ResourceUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/ResourceUtils.java
@@ -42,6 +42,7 @@ public class ResourceUtils {
    *
    * @param o ensure this object is not null
    * @param message message sent in the 400 response to the user in plain text
+   * @return o (same object) if exists
    */
   public static <T> T ensureExists(T o, String message) {
     ensure(o != null, message);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/ResourceUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/ResourceUtils.java
@@ -1,18 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 package org.apache.pinot.thirdeye.dashboard.resources;
 
+/**
+ * This class is expected to house static utilities that help responding to resource requests.
+ */
 public class ResourceUtils {
 
+  /**
+   * ensure a condition is true and respond with bad request otherwise
+   *
+   * @param condition ensure this condition is true
+   * @param message message sent in the 400 response to the user in plain text
+   */
   public static void ensure(boolean condition, String message) {
     if (!condition) {
       throw new BadRequestWebException(message);
     }
   }
 
+  /**
+   * ensure the object exists and respond with bad request otherwise
+   *
+   * @param o ensure this object is not null
+   * @param message message sent in the 400 response to the user in plain text
+   */
   public static <T> T ensureExists(T o, String message) {
     ensure(o != null, message);
     return o;
   }
 
+  /**
+   * Utility method to throw badRequest
+   * @param errorMsg msg to be sent to user
+   * @return instance of BadRequestWebException
+   */
   public static BadRequestWebException badRequest(String errorMsg) {
     return new BadRequestWebException(errorMsg);
   }


### PR DESCRIPTION
## Description
- Throw 400 instead of 500 for invalid query params
- Added a placeholder for resource utility methods: ResourceUtils
- Added BadRequestWebException to better handle invalid requests

The long term goal is to have a suite of utilities to make the Resource code
simple by easing out validations and error handling