### PR TITLE
Bug fix: PinotSegmentToAvroConverter does not handle BYTES data type.

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentToAvroConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentToAvroConverter.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.tools.segment.converter;
 
 import java.io.File;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
@@ -60,6 +61,10 @@ public class PinotSegmentToAvroConverter implements PinotSegmentConverter {
             if (value instanceof Object[]) {
               record.put(field, Arrays.asList((Object[]) value));
             } else {
+              // PinotSegmentRecordReader returns byte[] instead of ByteBuffer.
+              if (value instanceof byte[]) {
+                value = ByteBuffer.wrap((byte[]) value);
+              }
               record.put(field, value);
             }
           }


### PR DESCRIPTION
* `PinotSegmentColumnReader.getValue()` returns `byte[]` for BYTES data type. However, GenericRecord
   expects a ByteBuffer, due to which the converter fails.

* There are only two callers for this api, one in `PinotSegmentToAvroConverter`, and another in Star Tree builder.

* While we could change the return type to ByteBuffer, it is unclear at this time what the future usage would be.
  Based on that, handiling it in `PinotSegmentToAvroConverter.

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
