### PR TITLE
New endpoint to get routing table for sql query

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -20,7 +20,7 @@ package org.apache.pinot.integration.tests;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.ArrayList;
+import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
 
@@ -182,6 +182,19 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
     Assert.assertNotNull(getDebugInfo("debug/routingTable/" + tableName));
     Assert.assertNotNull(getDebugInfo("debug/routingTable/" + TableNameBuilder.OFFLINE.tableNameWithType(tableName)));
     Assert.assertNotNull(getDebugInfo("debug/routingTable/" + TableNameBuilder.REALTIME.tableNameWithType(tableName)));
+  }
+
+  @Test
+  public void testBrokerDebugRoutingTableSQL()
+          throws Exception {
+    String tableName = getTableName();
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    String encodedSQL;
+    encodedSQL = URLEncoder.encode("select * from " + realtimeTableName, "UTF-8");
+    Assert.assertNotNull(getDebugInfo("debug/routingTable/sql?query=" + encodedSQL));
+    encodedSQL = URLEncoder.encode("select * from " + offlineTableName, "UTF-8");
+    Assert.assertNotNull(getDebugInfo("debug/routingTable/sql?query=" + encodedSQL));
   }
 
   @Test


### PR DESCRIPTION
`PinotBrokerDebug` API contains endpoint that get routing table for PQL query. This new endpoint gets routing table for SQL query. 

What is the required for? 

- Pinot is moving from PQL to the SQL, and would be good to get routing table for SQL query. 
- In one use case, this was needed. In `spark-pinot-connector` (PR: [5787](https://github.com/apache/incubator-pinot/pull/5787)), connector receives routing table by sql query. Thus we needs this endpoint. 