### PR TITLE
[TE] Refactor Dashboard Server resources and dependencies

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/api/application/ApplicationResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/api/application/ApplicationResource.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.api.application;
 
+import com.google.inject.Inject;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import java.util.ArrayList;
@@ -58,9 +59,11 @@ public class ApplicationResource {
   private final DetectionConfigManager detectionDAO;
   private final DetectionAlertConfigManager detectionAlertDAO;
 
-
-  public ApplicationResource(ApplicationManager appDAO, MergedAnomalyResultManager anomalyDAO,
-      DetectionConfigManager detectionDAO, DetectionAlertConfigManager detectionAlertDAO) {
+  @Inject
+  public ApplicationResource(ApplicationManager appDAO,
+      MergedAnomalyResultManager anomalyDAO,
+      DetectionConfigManager detectionDAO,
+      DetectionAlertConfigManager detectionAlertDAO) {
     this.appDAO = appDAO;
     this.anomalyDAO = anomalyDAO;
     this.detectionDAO = detectionDAO;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/api/user/dashboard/UserDashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/api/user/dashboard/UserDashboardResource.java
@@ -21,6 +21,7 @@ package org.apache.pinot.thirdeye.api.user.dashboard;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
+import com.google.inject.Inject;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -76,9 +77,11 @@ public class UserDashboardResource {
   private final DetectionConfigManager detectionDAO;
   private final DetectionAlertConfigManager detectionAlertDAO;
 
-
-  public UserDashboardResource(MergedAnomalyResultManager anomalyDAO, MetricConfigManager metricDAO,
-      DatasetConfigManager datasetDAO, DetectionConfigManager detectionDAO,
+  @Inject
+  public UserDashboardResource(MergedAnomalyResultManager anomalyDAO,
+      MetricConfigManager metricDAO,
+      DatasetConfigManager datasetDAO,
+      DetectionConfigManager detectionDAO,
       DetectionAlertConfigManager detectionAlertDAO) {
     this.anomalyDAO = anomalyDAO;
     this.metricDAO = metricDAO;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/RootCauseResourceProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/RootCauseResourceProvider.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.pinot.thirdeye.dashboard;
+
+
+import com.google.inject.Provider;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseEntityFormatter;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseResource;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.DefaultEntityFormatter;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.FormatterLoader;
+import org.apache.pinot.thirdeye.rootcause.RCAFramework;
+import org.apache.pinot.thirdeye.rootcause.impl.RCAFrameworkLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RootCauseResourceProvider implements Provider<RootCauseResource> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RootCauseResourceProvider.class);
+  private final ThirdEyeDashboardConfiguration config;
+
+  public RootCauseResourceProvider(
+      final ThirdEyeDashboardConfiguration config) {
+    this.config = config;
+  }
+
+  private static File getRootCauseDefinitionsFile(ThirdEyeDashboardConfiguration config) {
+    if (config.getRootCause().getDefinitionsPath() == null) {
+      throw new IllegalArgumentException("definitionsPath must not be null");
+    }
+    File rcaConfigFile = new File(config.getRootCause().getDefinitionsPath());
+    if (!rcaConfigFile.isAbsolute()) {
+      return new File(config.getRootDir() + File.separator + rcaConfigFile);
+    }
+    return rcaConfigFile;
+  }
+
+  private static Map<String, RCAFramework> makeRootCauseFrameworks(RootCauseConfiguration config,
+      File definitionsFile) throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(config.getParallelism());
+    return RCAFrameworkLoader.getFrameworksFromConfig(definitionsFile, executor);
+  }
+
+  private static List<RootCauseEntityFormatter> makeRootCauseFormatters(
+      RootCauseConfiguration config) throws Exception {
+    List<RootCauseEntityFormatter> formatters = new ArrayList<>();
+    if (config.getFormatters() != null) {
+      for (String className : config.getFormatters()) {
+        try {
+          formatters.add(FormatterLoader.fromClassName(className));
+        } catch (ClassNotFoundException e) {
+          LOG.warn("Could not find formatter class '{}'. Skipping.", className, e);
+        }
+      }
+    }
+    formatters.add(new DefaultEntityFormatter());
+    return formatters;
+  }
+
+  private RootCauseResource makeRootCauseResource() throws Exception {
+    File definitionsFile = getRootCauseDefinitionsFile(config);
+    if (!definitionsFile.exists()) {
+      throw new IllegalArgumentException(
+          String.format("Could not find definitions file '%s'", definitionsFile));
+    }
+
+    RootCauseConfiguration rcConfig = config.getRootCause();
+    return new RootCauseResource(
+        makeRootCauseFrameworks(rcConfig, definitionsFile),
+        makeRootCauseFormatters(rcConfig));
+  }
+
+  @Override
+  public RootCauseResource get() {
+    try {
+      return makeRootCauseResource();
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -20,19 +20,30 @@
 package org.apache.pinot.thirdeye.dashboard;
 
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.google.common.cache.CacheBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.auth.AuthValueFactoryProvider;
-import io.dropwizard.auth.Authenticator;
+import io.dropwizard.bundles.redirect.PathRedirect;
+import io.dropwizard.bundles.redirect.RedirectBundle;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.views.ViewBundle;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
 import org.apache.pinot.thirdeye.api.application.ApplicationResource;
-import org.apache.pinot.thirdeye.auth.ThirdEyeCredentials;
-import org.apache.pinot.thirdeye.common.time.TimeGranularity;
+import org.apache.pinot.thirdeye.api.user.dashboard.UserDashboardResource;
 import org.apache.pinot.thirdeye.auth.ThirdEyeAuthFilter;
-import org.apache.pinot.thirdeye.auth.ThirdEyeAuthenticatorDisabled;
-import org.apache.pinot.thirdeye.auth.ThirdEyeLdapAuthenticator;
 import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
 import org.apache.pinot.thirdeye.common.BaseThirdEyeApplication;
 import org.apache.pinot.thirdeye.common.ThirdEyeSwaggerBundle;
-import org.apache.pinot.thirdeye.dashboard.configs.AuthConfiguration;
+import org.apache.pinot.thirdeye.common.time.TimeGranularity;
 import org.apache.pinot.thirdeye.dashboard.configs.ResourceConfiguration;
 import org.apache.pinot.thirdeye.dashboard.resources.AdminResource;
 import org.apache.pinot.thirdeye.dashboard.resources.AnomalyFlattenResource;
@@ -42,8 +53,6 @@ import org.apache.pinot.thirdeye.dashboard.resources.CacheResource;
 import org.apache.pinot.thirdeye.dashboard.resources.CustomizedEventResource;
 import org.apache.pinot.thirdeye.dashboard.resources.DashboardResource;
 import org.apache.pinot.thirdeye.dashboard.resources.DatasetConfigResource;
-import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseTemplateResource;
-import org.apache.pinot.thirdeye.dashboard.resources.v2.alerts.AlertResource;
 import org.apache.pinot.thirdeye.dashboard.resources.EntityManagerResource;
 import org.apache.pinot.thirdeye.dashboard.resources.EntityMappingResource;
 import org.apache.pinot.thirdeye.dashboard.resources.MetricConfigResource;
@@ -55,49 +64,19 @@ import org.apache.pinot.thirdeye.dashboard.resources.v2.AuthResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.ConfigResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.DataResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.DetectionAlertResource;
-import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseEntityFormatter;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseMetricResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseSessionResource;
-import org.apache.pinot.thirdeye.api.user.dashboard.UserDashboardResource;
-import org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.DefaultEntityFormatter;
-import org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.FormatterLoader;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseTemplateResource;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.alerts.AlertResource;
 import org.apache.pinot.thirdeye.dataset.DatasetAutoOnboardResource;
-import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.datasource.ThirdEyeCacheRegistry;
-import org.apache.pinot.thirdeye.datasource.loader.AggregationLoader;
-import org.apache.pinot.thirdeye.datasource.loader.DefaultAggregationLoader;
-import org.apache.pinot.thirdeye.datasource.loader.DefaultTimeSeriesLoader;
-import org.apache.pinot.thirdeye.datasource.loader.TimeSeriesLoader;
 import org.apache.pinot.thirdeye.datasource.sql.resources.SqlDataSourceResource;
-import org.apache.pinot.thirdeye.detection.DetectionResource;
 import org.apache.pinot.thirdeye.detection.DetectionConfigurationResource;
+import org.apache.pinot.thirdeye.detection.DetectionResource;
 import org.apache.pinot.thirdeye.detection.yaml.YamlResource;
-import org.apache.pinot.thirdeye.detector.email.filter.AlertFilterFactory;
-import org.apache.pinot.thirdeye.detector.function.AnomalyFunctionFactory;
 import org.apache.pinot.thirdeye.model.download.ModelDownloaderManager;
-import org.apache.pinot.thirdeye.rootcause.RCAFramework;
-import org.apache.pinot.thirdeye.rootcause.impl.RCAFrameworkLoader;
 import org.apache.pinot.thirdeye.tracking.RequestStatisticsLogger;
-import io.dropwizard.assets.AssetsBundle;
-import io.dropwizard.auth.CachingAuthenticator;
-import io.dropwizard.bundles.redirect.PathRedirect;
-import io.dropwizard.bundles.redirect.RedirectBundle;
-import io.dropwizard.lifecycle.Managed;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
-import io.dropwizard.views.ViewBundle;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import javax.servlet.DispatcherType;
-import javax.servlet.FilterRegistration;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,6 +91,7 @@ public class ThirdEyeDashboardApplication
 
   private RequestStatisticsLogger requestStatisticsLogger;
   private ModelDownloaderManager modelDownloaderManager;
+  private Injector injector;
 
   @Override
   public String getName() {
@@ -154,55 +134,42 @@ public class ThirdEyeDashboardApplication
       LOG.error("Exception while loading caches", e);
     }
 
-    AnomalyFunctionFactory anomalyFunctionFactory = new AnomalyFunctionFactory(config.getFunctionConfigPath());
-    AlertFilterFactory alertFilterFactory = new AlertFilterFactory(config.getAlertFilterConfigPath());
 
-    env.jersey().register(new DetectionConfigurationResource());
-    env.jersey().register(new DatasetAutoOnboardResource());
-    env.jersey().register(new DashboardResource());
-    env.jersey().register(new CacheResource());
-    env.jersey().register(new AnomalyResource(alertFilterFactory));
-    env.jersey().register(new EntityManagerResource(config));
-    env.jersey().register(new MetricConfigResource());
-    env.jersey().register(new DatasetConfigResource());
-    env.jersey().register(new AdminResource());
-    env.jersey().register(new SummaryResource());
-    env.jersey().register(new ThirdEyeResource());
-    env.jersey().register(new DataResource());
-    env.jersey().register(new AnomaliesResource(anomalyFunctionFactory));
-    env.jersey().register(new EntityMappingResource());
-    env.jersey().register(new OnboardDatasetMetricResource());
-    env.jersey().register(new AutoOnboardResource(config));
-    env.jersey().register(new ConfigResource(DAO_REGISTRY.getConfigDAO()));
-    env.jersey().register(new CustomizedEventResource(DAO_REGISTRY.getEventDAO()));
-    env.jersey().register(new AnomalyFlattenResource(DAO_REGISTRY.getMergedAnomalyResultDAO(),
-        DAO_REGISTRY.getDatasetConfigDAO(), DAO_REGISTRY.getMetricConfigDAO()));
-    env.jersey().register(new UserDashboardResource(
-        DAO_REGISTRY.getMergedAnomalyResultDAO(), DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO(),
-        DAO_REGISTRY.getDetectionConfigManager(), DAO_REGISTRY.getDetectionAlertConfigManager()));
-    env.jersey().register(new ApplicationResource(
-        DAO_REGISTRY.getApplicationDAO(), DAO_REGISTRY.getMergedAnomalyResultDAO(),
-        DAO_REGISTRY.getDetectionConfigManager(), DAO_REGISTRY.getDetectionAlertConfigManager()));
-    env.jersey().register(new DetectionResource());
-    env.jersey().register(new DetectionAlertResource(DAO_REGISTRY.getDetectionAlertConfigManager()));
-    env.jersey().register(new YamlResource(config.getAlerterConfiguration(), config.getDetectionPreviewConfig(),
-        config.getAlertOnboardingPermitPerSecond()));
-    env.jersey().register(new SqlDataSourceResource());
-    env.jersey().register(new AlertResource());
-    env.jersey().register(new RootCauseTemplateResource());
-
-    TimeSeriesLoader timeSeriesLoader = new DefaultTimeSeriesLoader(
-        DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO(),
-        ThirdEyeCacheRegistry.getInstance().getQueryCache(), ThirdEyeCacheRegistry.getInstance().getTimeSeriesCache());
-    AggregationLoader aggregationLoader = new DefaultAggregationLoader(
-        DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO(),
-        ThirdEyeCacheRegistry.getInstance().getQueryCache(), ThirdEyeCacheRegistry.getInstance().getDatasetMaxDataTimeCache());
-
-    env.jersey().register(new RootCauseSessionResource(
-        DAO_REGISTRY.getRootcauseSessionDAO(), new ObjectMapper()));
-    env.jersey().register(new RootCauseMetricResource(
-        Executors.newCachedThreadPool(), aggregationLoader, timeSeriesLoader,
-        DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO()));
+    final JerseyEnvironment jersey = env.jersey();
+    injector = Guice.createInjector(new ThirdEyeDashboardModule(config, env, DAO_REGISTRY));
+    Stream.of(
+        DetectionConfigurationResource.class,
+        DatasetAutoOnboardResource.class,
+        DashboardResource.class,
+        CacheResource.class,
+        AnomalyResource.class,
+        EntityManagerResource.class,
+        MetricConfigResource.class,
+        DatasetConfigResource.class,
+        AdminResource.class,
+        SummaryResource.class,
+        ThirdEyeResource.class,
+        DataResource.class,
+        AnomaliesResource.class,
+        EntityMappingResource.class,
+        OnboardDatasetMetricResource.class,
+        AutoOnboardResource.class,
+        ConfigResource.class,
+        CustomizedEventResource.class,
+        AnomalyFlattenResource.class,
+        UserDashboardResource.class,
+        ApplicationResource.class,
+        DetectionResource.class,
+        DetectionAlertResource.class,
+        YamlResource.class,
+        SqlDataSourceResource.class,
+        AlertResource.class,
+        RootCauseTemplateResource.class,
+        RootCauseSessionResource.class,
+        RootCauseMetricResource.class
+    )
+        .map(c -> injector.getInstance(c))
+        .forEach(jersey::register);
 
     env.getObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
     env.getObjectMapper().registerModule(makeMapperModule());
@@ -210,14 +177,14 @@ public class ThirdEyeDashboardApplication
     try {
       // root cause resource
       if (config.getRootCause() != null) {
-        env.jersey().register(makeRootCauseResource(config));
+        jersey.register(injector.getInstance(RootCauseResource.class));
       }
 
       // Load external resources
       if (config.getResourceConfig() != null) {
         List<ResourceConfiguration> resourceConfigurations = config.getResourceConfig();
         for (ResourceConfiguration resourceConfiguration : resourceConfigurations) {
-          env.jersey().register(Class.forName(resourceConfiguration.getClassName()));
+          jersey.register(Class.forName(resourceConfiguration.getClassName()));
           LOG.info("Registering resource [{}]", resourceConfiguration.getClassName());
         }
       }
@@ -227,37 +194,29 @@ public class ThirdEyeDashboardApplication
 
     // Authentication
     if (config.getAuthConfig() != null) {
-      final AuthConfiguration authConfig = config.getAuthConfig();
-
-      // default permissive authenticator
-      Authenticator<ThirdEyeCredentials, ThirdEyePrincipal> authenticator = new ThirdEyeAuthenticatorDisabled();
-
-      // ldap authenticator
-      if (authConfig.isAuthEnabled()) {
-        final ThirdEyeLdapAuthenticator
-            authenticatorLdap = new ThirdEyeLdapAuthenticator(authConfig.getDomainSuffix(), authConfig.getLdapUrl(), DAORegistry.getInstance().getSessionDAO());
-        authenticator = new CachingAuthenticator<>(env.metrics(), authenticatorLdap, CacheBuilder.newBuilder().expireAfterWrite(authConfig.getCacheTTL(), TimeUnit.SECONDS));
-      }
-
-      env.jersey().register(new ThirdEyeAuthFilter(authenticator, authConfig.getAllowedPaths(), authConfig.getAdminUsers(), DAORegistry.getInstance().getSessionDAO()));
-      env.jersey().register(new AuthValueFactoryProvider.Binder<>(ThirdEyePrincipal.class));
-      env.jersey().register(new AuthResource(authenticator, authConfig.getCookieTTL() * 1000));
+      jersey.register(injector.getInstance(ThirdEyeAuthFilter.class));
+      jersey.register(new AuthValueFactoryProvider.Binder<>(ThirdEyePrincipal.class));
+      jersey.register(injector.getInstance(AuthResource.class));
     }
 
     if (config.getModelDownloaderConfig() != null) {
-      modelDownloaderManager = new ModelDownloaderManager(config.getModelDownloaderConfig());
+      modelDownloaderManager = injector.getInstance(ModelDownloaderManager.class);
       modelDownloaderManager.start();
     }
 
-    env.lifecycle().manage(new Managed() {
+    env.lifecycle().manage(lifecycleManager());
+  }
+
+  private Managed lifecycleManager() {
+    return new Managed() {
       @Override
-      public void start() throws Exception {
+      public void start() {
         requestStatisticsLogger = new RequestStatisticsLogger(new TimeGranularity(1, TimeUnit.DAYS));
         requestStatisticsLogger.start();
       }
 
       @Override
-      public void stop() throws Exception {
+      public void stop() {
         if (requestStatisticsLogger != null) {
           requestStatisticsLogger.shutdown();
         }
@@ -265,48 +224,9 @@ public class ThirdEyeDashboardApplication
           modelDownloaderManager.shutdown();
         }
       }
-    });
+    };
   }
 
-  private static RootCauseResource makeRootCauseResource(ThirdEyeDashboardConfiguration config) throws Exception {
-    File definitionsFile = getRootCauseDefinitionsFile(config);
-    if(!definitionsFile.exists())
-      throw new IllegalArgumentException(String.format("Could not find definitions file '%s'", definitionsFile));
-
-    RootCauseConfiguration rcConfig = config.getRootCause();
-    return new RootCauseResource(
-        makeRootCauseFrameworks(rcConfig, definitionsFile),
-        makeRootCauseFormatters(rcConfig));
-  }
-
-  private static Map<String, RCAFramework> makeRootCauseFrameworks(RootCauseConfiguration config, File definitionsFile) throws Exception {
-    ExecutorService executor = Executors.newFixedThreadPool(config.getParallelism());
-    return RCAFrameworkLoader.getFrameworksFromConfig(definitionsFile, executor);
-  }
-
-  private static List<RootCauseEntityFormatter> makeRootCauseFormatters(RootCauseConfiguration config) throws Exception {
-    List<RootCauseEntityFormatter> formatters = new ArrayList<>();
-    if(config.getFormatters() != null) {
-      for(String className : config.getFormatters()) {
-        try {
-          formatters.add(FormatterLoader.fromClassName(className));
-        } catch(ClassNotFoundException e) {
-          LOG.warn("Could not find formatter class '{}'. Skipping.", className, e);
-        }
-      }
-    }
-    formatters.add(new DefaultEntityFormatter());
-    return formatters;
-  }
-
-  private static File getRootCauseDefinitionsFile(ThirdEyeDashboardConfiguration config) {
-    if(config.getRootCause().getDefinitionsPath() == null)
-      throw new IllegalArgumentException("definitionsPath must not be null");
-    File rcaConfigFile = new File(config.getRootCause().getDefinitionsPath());
-    if(!rcaConfigFile.isAbsolute())
-      return new File(config.getRootDir() + File.separator + rcaConfigFile);
-    return rcaConfigFile;
-  }
 
   /**
    * The entry point of application.

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardModule.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardModule.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.pinot.thirdeye.dashboard;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.cache.CacheBuilder;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.CachingAuthenticator;
+import io.dropwizard.setup.Environment;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.thirdeye.auth.ThirdEyeAuthFilter;
+import org.apache.pinot.thirdeye.auth.ThirdEyeAuthenticatorDisabled;
+import org.apache.pinot.thirdeye.auth.ThirdEyeCredentials;
+import org.apache.pinot.thirdeye.auth.ThirdEyeLdapAuthenticator;
+import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
+import org.apache.pinot.thirdeye.common.ThirdEyeConfiguration;
+import org.apache.pinot.thirdeye.dashboard.configs.AuthConfiguration;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.AuthResource;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseMetricResource;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseResource;
+import org.apache.pinot.thirdeye.datalayer.bao.ApplicationManager;
+import org.apache.pinot.thirdeye.datalayer.bao.ConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.DatasetConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionAlertConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.DetectionConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.EventManager;
+import org.apache.pinot.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import org.apache.pinot.thirdeye.datalayer.bao.MetricConfigManager;
+import org.apache.pinot.thirdeye.datalayer.bao.RootcauseSessionManager;
+import org.apache.pinot.thirdeye.datalayer.bao.SessionManager;
+import org.apache.pinot.thirdeye.datasource.DAORegistry;
+import org.apache.pinot.thirdeye.datasource.ThirdEyeCacheRegistry;
+import org.apache.pinot.thirdeye.datasource.cache.QueryCache;
+import org.apache.pinot.thirdeye.datasource.loader.AggregationLoader;
+import org.apache.pinot.thirdeye.datasource.loader.DefaultAggregationLoader;
+import org.apache.pinot.thirdeye.datasource.loader.DefaultTimeSeriesLoader;
+import org.apache.pinot.thirdeye.datasource.loader.TimeSeriesLoader;
+import org.apache.pinot.thirdeye.detection.cache.TimeSeriesCache;
+import org.apache.pinot.thirdeye.detection.yaml.YamlResource;
+import org.apache.pinot.thirdeye.detector.email.filter.AlertFilterFactory;
+import org.apache.pinot.thirdeye.detector.function.AnomalyFunctionFactory;
+import org.apache.pinot.thirdeye.model.download.ModelDownloaderManager;
+
+/**
+ * This is the main Guice module for ThirdEye Dashboard Server.
+ * All resources, dependencies are fed from bindings in this class.
+ */
+public class ThirdEyeDashboardModule extends AbstractModule {
+
+  private final ThirdEyeDashboardConfiguration config;
+  private final Environment environment;
+
+  // TODO spyne After refactoring bindinds, remove this dependency
+  private final DAORegistry DAO_REGISTRY;
+
+  public ThirdEyeDashboardModule(final ThirdEyeDashboardConfiguration config,
+      final Environment environment,
+      final DAORegistry DAO_REGISTRY) {
+    this.config = config;
+    this.environment = environment;
+    this.DAO_REGISTRY = DAO_REGISTRY;
+  }
+
+  @Override
+  protected void configure() {
+    /*
+     * Since the superclass is not abstract, this requires an explicit binding to the subclass
+     *      config class else Guice will create a new instance of config
+     */
+    bind(ThirdEyeConfiguration.class).to(ThirdEyeDashboardConfiguration.class);
+    bind(ThirdEyeDashboardConfiguration.class).toInstance(config);
+    bind(TimeSeriesLoader.class).to(DefaultTimeSeriesLoader.class);
+    bind(MetricRegistry.class).toInstance(environment.metrics());
+
+    /*
+     * TODO spyne Refactor DAO_REGISTRY bindings
+     *
+     * These bindings added here are a temporary hack. The goal is to leverage the DataSourceModule
+     * module directly to inject these classes. That way, all dependencies can be injected by Guice.
+     * This will be done in subsequent phases of refactoring.
+     */
+    bind(ConfigManager.class).toInstance(DAO_REGISTRY.getConfigDAO());
+    bind(EventManager.class).toInstance(DAO_REGISTRY.getEventDAO());
+    bind(MergedAnomalyResultManager.class).toInstance(DAO_REGISTRY.getMergedAnomalyResultDAO());
+    bind(DatasetConfigManager.class).toInstance(DAO_REGISTRY.getDatasetConfigDAO());
+    bind(MetricConfigManager.class).toInstance(DAO_REGISTRY.getMetricConfigDAO());
+    bind(DetectionConfigManager.class).toInstance(DAO_REGISTRY.getDetectionConfigManager());
+    bind(RootcauseSessionManager.class).toInstance(DAO_REGISTRY.getRootcauseSessionDAO());
+    bind(SessionManager.class).toInstance(DAO_REGISTRY.getSessionDAO());
+    bind(DetectionAlertConfigManager.class)
+        .toInstance(DAO_REGISTRY.getDetectionAlertConfigManager());
+    bind(ApplicationManager.class).toInstance(DAO_REGISTRY.getApplicationDAO());
+    bind(QueryCache.class).toInstance(ThirdEyeCacheRegistry.getInstance().getQueryCache());
+    bind(TimeSeriesCache.class)
+        .toInstance(ThirdEyeCacheRegistry.getInstance().getTimeSeriesCache());
+    bind(RootCauseResource.class)
+        .toProvider(new RootCauseResourceProvider(config))
+        .in(Scopes.SINGLETON);
+  }
+
+  @Singleton
+  @Provides
+  public AnomalyFunctionFactory getAnomalyFunctionFactory() {
+    return new AnomalyFunctionFactory(config.getFunctionConfigPath());
+  }
+
+  @Singleton
+  @Provides
+  public AlertFilterFactory getAlertFilterFactory() {
+    return new AlertFilterFactory(config.getAlertFilterConfigPath());
+  }
+
+  @Singleton
+  @Provides
+  public YamlResource getYamlResource() {
+    return new YamlResource(config.getAlerterConfiguration(),
+        config.getDetectionPreviewConfig(),
+        config.getAlertOnboardingPermitPerSecond());
+  }
+
+  @Singleton
+  @Provides
+  public ModelDownloaderManager getModelDownloaderManager() {
+    return new ModelDownloaderManager(config.getModelDownloaderConfig());
+  }
+
+  @Singleton
+  @Provides
+  public AggregationLoader getAggregationLoader(final QueryCache queryCache) {
+    return new DefaultAggregationLoader(DAO_REGISTRY.getMetricConfigDAO(),
+        DAO_REGISTRY.getDatasetConfigDAO(),
+        queryCache,
+        ThirdEyeCacheRegistry.getInstance().getDatasetMaxDataTimeCache());
+  }
+
+  @Singleton
+  @Provides
+  public RootCauseMetricResource getRootCauseMetricResource(
+      final AggregationLoader aggregationLoader,
+      final TimeSeriesLoader timeSeriesLoader,
+      final MetricConfigManager metricConfigManager,
+      final DatasetConfigManager datasetConfigManager) {
+    return new RootCauseMetricResource(Executors.newCachedThreadPool(),
+        aggregationLoader,
+        timeSeriesLoader,
+        metricConfigManager,
+        datasetConfigManager);
+  }
+
+  @Singleton
+  @Provides
+  public Authenticator<ThirdEyeCredentials, ThirdEyePrincipal> getAuthenticator(
+      final MetricRegistry metricRegistry,
+      final SessionManager sessionManager) {
+    final AuthConfiguration authConfig = config.getAuthConfig();
+
+    // default permissive authenticator
+    Authenticator<ThirdEyeCredentials, ThirdEyePrincipal> authenticator = new ThirdEyeAuthenticatorDisabled();
+
+    // ldap authenticator
+    if (authConfig.isAuthEnabled()) {
+      final ThirdEyeLdapAuthenticator
+          authenticatorLdap = new ThirdEyeLdapAuthenticator(
+          authConfig.getDomainSuffix(),
+          authConfig.getLdapUrl(),
+          sessionManager);
+      authenticator = new CachingAuthenticator<>(
+          metricRegistry,
+          authenticatorLdap,
+          CacheBuilder.newBuilder().expireAfterWrite(authConfig.getCacheTTL(), TimeUnit.SECONDS));
+    }
+    return authenticator;
+  }
+
+
+  @Singleton
+  @Provides
+  public ThirdEyeAuthFilter getThirdEyeAuthFilter(
+      final Authenticator<ThirdEyeCredentials, ThirdEyePrincipal> authenticator) {
+    final AuthConfiguration authConfig = config.getAuthConfig();
+    return new ThirdEyeAuthFilter(authenticator,
+        authConfig.getAllowedPaths(),
+        authConfig.getAdminUsers(),
+        DAORegistry.getInstance().getSessionDAO());
+  }
+
+  @Singleton
+  @Provides
+  public AuthResource getAuthResource(
+      final Authenticator<ThirdEyeCredentials, ThirdEyePrincipal> authenticator) {
+    final AuthConfiguration authConfig = config.getAuthConfig();
+    return new AuthResource(authenticator, authConfig.getCookieTTL() * 1000);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/AnomalyFlattenResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/AnomalyFlattenResource.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.thirdeye.dashboard.resources;
 
 import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -73,7 +74,9 @@ public class AnomalyFlattenResource {
   private static final int DEFAULT_THREAD_POOLS_SIZE = 5;
   private static final long DEFAULT_TIME_OUT_IN_MINUTES = 1;
 
-  public AnomalyFlattenResource(MergedAnomalyResultManager mergedAnomalyResultDAO, DatasetConfigManager datasetConfgDAO,
+  @Inject
+  public AnomalyFlattenResource(MergedAnomalyResultManager mergedAnomalyResultDAO,
+      DatasetConfigManager datasetConfgDAO,
       MetricConfigManager metricConfigDAO) {
     this.mergedAnomalyResultDAO = mergedAnomalyResultDAO;
     this.datasetConfgDAO = datasetConfgDAO;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/AnomalyResource.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.thirdeye.dashboard.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
 import org.apache.pinot.thirdeye.anomaly.alert.util.AlertFilterHelper;
 import org.apache.pinot.thirdeye.anomalydetection.context.AnomalyFeedback;
 import org.apache.pinot.thirdeye.api.Constants;
@@ -66,6 +67,7 @@ public class AnomalyResource {
 
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
+  @Inject
   public AnomalyResource(AlertFilterFactory alertFilterFactory) {
     this.anomalyMergedResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
     this.alertFilterFactory = alertFilterFactory;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/AutoOnboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/AutoOnboardResource.java
@@ -19,20 +19,13 @@
 
 package org.apache.pinot.thirdeye.dashboard.resources;
 
+import com.google.inject.Inject;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.apache.pinot.thirdeye.api.Constants;
 import org.apache.pinot.thirdeye.auto.onboard.AutoOnboard;
 import org.apache.pinot.thirdeye.auto.onboard.AutoOnboardUtility;
 import org.apache.pinot.thirdeye.common.ThirdEyeConfiguration;
-import org.apache.pinot.thirdeye.datasource.DataSourceConfig;
-import org.apache.pinot.thirdeye.datasource.DataSources;
-import org.apache.pinot.thirdeye.datasource.DataSourcesLoader;
-import org.apache.pinot.thirdeye.datasource.MetadataSourceConfig;
-import java.lang.reflect.Constructor;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.POST;
@@ -42,9 +35,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -57,6 +47,7 @@ public class AutoOnboardResource {
 
   private Map<String, List<AutoOnboard>> dataSourceToOnboardMap;
 
+  @Inject
   public AutoOnboardResource(ThirdEyeConfiguration thirdeyeConfig) {
     dataSourceToOnboardMap = AutoOnboardUtility.getDataSourceToAutoOnboardMap(thirdeyeConfig.getDataSourcesAsUrl());
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/CustomizedEventResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/CustomizedEventResource.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.dashboard.resources;
 
+import com.google.inject.Inject;
 import org.apache.pinot.thirdeye.anomaly.events.EventType;
 import org.apache.pinot.thirdeye.api.Constants;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.ResourceUtils;
@@ -50,6 +51,7 @@ public class CustomizedEventResource {
    *
    * @param eventDAO the event dao
    */
+  @Inject
   public CustomizedEventResource(EventManager eventDAO) {
     this.eventDAO = eventDAO;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/EntityManagerResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/EntityManagerResource.java
@@ -25,6 +25,7 @@ import static org.apache.pinot.thirdeye.dashboard.resources.ResourceUtils.ensure
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.google.inject.Inject;
 import org.apache.pinot.thirdeye.api.Constants;
 import org.apache.pinot.thirdeye.common.ThirdEyeConfiguration;
 import org.apache.pinot.thirdeye.datalayer.bao.AlertConfigManager;
@@ -98,6 +99,7 @@ public class EntityManagerResource {
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Logger LOG = LoggerFactory.getLogger(EntityManagerResource.class);
 
+  @Inject
   public EntityManagerResource(ThirdEyeConfiguration configuration) {
     this.anomalyFunctionManager = DAO_REGISTRY.getAnomalyFunctionDAO();
     this.metricConfigManager = DAO_REGISTRY.getMetricConfigDAO();

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -149,6 +150,7 @@ public class AnomaliesResource {
   private final DetectionPipelineLoader loader;
   private final DataProvider provider;
 
+  @Inject
   public AnomaliesResource(AnomalyFunctionFactory anomalyFunctionFactory) {
     this.metricConfigDAO = DAO_REGISTRY.getMetricConfigDAO();
     this.mergedAnomalyResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/ConfigResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/ConfigResource.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.dashboard.resources.v2;
 
+import com.google.inject.Inject;
 import org.apache.pinot.thirdeye.config.ConfigNamespace;
 import org.apache.pinot.thirdeye.datalayer.bao.ConfigManager;
 import java.io.IOException;
@@ -44,6 +45,7 @@ public class ConfigResource {
 
   private final ConfigManager configDAO;
 
+  @Inject
   public ConfigResource(ConfigManager configDAO) {
     this.configDAO = configDAO;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/DetectionAlertResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/DetectionAlertResource.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.dashboard.resources.v2;
 
+import com.google.inject.Inject;
 import org.apache.pinot.thirdeye.api.Constants;
 import org.apache.pinot.thirdeye.datalayer.bao.DetectionAlertConfigManager;
 import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
@@ -44,6 +45,7 @@ import javax.ws.rs.core.MediaType;
 public class DetectionAlertResource {
   private final DetectionAlertConfigManager detectionAlertDAO;
 
+  @Inject
   public DetectionAlertResource(DetectionAlertConfigManager detectionAlertDAO) {
     this.detectionAlertDAO = detectionAlertDAO;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/RootCauseSessionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/RootCauseSessionResource.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.dashboard.resources.v2;
 
+import com.google.inject.Inject;
 import org.apache.pinot.thirdeye.api.Constants;
 import org.apache.pinot.thirdeye.auth.ThirdEyeAuthFilter;
 import org.apache.pinot.thirdeye.datalayer.bao.RootcauseSessionManager;
@@ -53,6 +54,7 @@ public class RootCauseSessionResource {
   private final RootcauseSessionManager sessionDAO;
   private final ObjectMapper mapper;
 
+  @Inject
   public RootCauseSessionResource(RootcauseSessionManager sessionDAO, ObjectMapper mapper) {
     this.sessionDAO = sessionDAO;
     this.mapper = mapper;

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/DefaultTimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/loader/DefaultTimeSeriesLoader.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.thirdeye.datasource.loader;
 
+import com.google.inject.Inject;
 import org.apache.pinot.thirdeye.dataframe.DataFrame;
 import org.apache.pinot.thirdeye.dataframe.util.DataFrameUtils;
 import org.apache.pinot.thirdeye.dataframe.util.MetricSlice;
@@ -41,7 +42,11 @@ public class DefaultTimeSeriesLoader implements TimeSeriesLoader {
   private final QueryCache queryCache;
   private final TimeSeriesCache timeSeriesCache;
 
-  public DefaultTimeSeriesLoader(MetricConfigManager metricDAO, DatasetConfigManager datasetDAO, QueryCache queryCache, TimeSeriesCache cache) {
+  @Inject
+  public DefaultTimeSeriesLoader(MetricConfigManager metricDAO,
+      DatasetConfigManager datasetDAO,
+      QueryCache queryCache,
+      TimeSeriesCache cache) {
     this.metricDAO = metricDAO;
     this.datasetDAO = datasetDAO;
     this.queryCache = queryCache;


### PR DESCRIPTION
This refactor further extends the use of Guice beyond the datalayer by
wrapping all resource classes and dependencies with Guice.

Changes:
- replaces the top level object constructions in the Dashboard Server with Guice.
- All the dependencies have been moved to the Dashboard Server Module.
- Changes in the Resource files mostly involve adding @Inject annotation
- Make the metric registry easily accessible

Possible next steps:
- simplify the resource structure
- convert absolute resource paths to relative paths which make it much easier to manage resources
- refactor the Anomaly Server dependencies

There is no expected behavior change with this PR.