### PR TITLE
Message from exception in Schema add/validate

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -173,8 +173,8 @@ public class PinotSchemaRestletResource {
     try {
       SchemaUtils.validate(schema);
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, "Invalid schema: " + schema.getSchemaName(),
-          Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER,
+          "Invalid schema: " + schema.getSchemaName() + ". Reason: " + e.getMessage(), Response.Status.BAD_REQUEST, e);
     }
     return schema.toPrettyJsonString();
   }
@@ -190,8 +190,8 @@ public class PinotSchemaRestletResource {
     try {
       SchemaUtils.validate(schema);
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, "Invalid schema: " + schema.getSchemaName(),
-          Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER,
+          "Invalid schema: " + schema.getSchemaName() + ". Reason: " + e.getMessage(), Response.Status.BAD_REQUEST, e);
     }
     return schema.toPrettyJsonString();
   }
@@ -205,7 +205,8 @@ public class PinotSchemaRestletResource {
     try {
       SchemaUtils.validate(schema);
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, "Cannot add invalid schema: " + schema.getSchemaName(),
+      throw new ControllerApplicationException(LOGGER,
+          "Cannot add invalid schema: " + schema.getSchemaName() + ". Reason: " + e.getMessage(),
           Response.Status.BAD_REQUEST, e);
     }
 
@@ -235,7 +236,8 @@ public class PinotSchemaRestletResource {
     try {
       SchemaUtils.validate(schema);
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, "Cannot add invalid schema: " + schemaName,
+      throw new ControllerApplicationException(LOGGER,
+          "Cannot add invalid schema: " + schemaName + ". Reason: " + e.getMessage(),
           Response.Status.BAD_REQUEST, e);
     }
 


### PR DESCRIPTION
Including the message from exception in the final message returned from schema APIs. We've been receiving many complaints that schema add/validate fails with no actionable message. This is already being done correctly in TableConfig.

Request:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{ \ 
   "schemaName": "mySchema", \ 
   "dimensionFieldSpecs": [{ \ 
     "name": "dim1", \ 
     "dataType": "STRING", \ 
     "transformFunction": "Groovy(k-k)" \ 
   }] \ 
 }' 'http://localhost:9000/schemas?override=true'
```
Before change:
```
{
  "code": 400,
  "error": "Cannot add invalid schema: mySchema
}
```
After change:
```
{
  "code": 400,
  "error": "Cannot add invalid schema: mySchema. Reason: Exception in getting arguments for transform function 'Groovy(k-k)' for column 'dim1'"
}

```