### PR TITLE
update Swagger (OpenAPI) configuration for HTTP+HTTPS

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -424,7 +424,7 @@ org.scala-lang:scala-library:2.11.11
 org.scala-lang:scala-reflect:2.11.11
 org.scala-lang:scalap:2.11.0
 org.testng:testng:6.11
-org.webjars:swagger-ui:2.2.2
+org.webjars:swagger-ui:2.2.10-1
 org.xerial.java:xerial-core:2.1
 org.xerial.larray:larray:0.2.1
 org.xerial.larray:larray-buffer:0.2.1

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -71,7 +71,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot broker information");
     beanConfig.setContact("https://github.com/apache/incubator-pinot");
     beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL});
+    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     beanConfig.setBasePath(_baseUri.getPath());
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
@@ -81,7 +81,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
 
     URL swaggerDistLocation =
-        BrokerAdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");
+        BrokerAdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.2.10-1/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -52,7 +52,6 @@ public class ControllerConf extends PinotConfiguration {
   public static final String HELIX_CLUSTER_NAME = "controller.helix.cluster.name";
   public static final String CLUSTER_TENANT_ISOLATION_ENABLE = "cluster.tenant.isolation.enable";
   public static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
-  public static final String CONSOLE_WEBAPP_USE_HTTPS = "controller.query.console.useHttps";
   public static final String EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT = "controller.upload.onlineToOfflineTimeout";
   public static final String CONTROLLER_MODE = "controller.mode";
   public static final String LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY = "controller.resource.rebalance.strategy";
@@ -201,14 +200,6 @@ public class ControllerConf extends PinotConfiguration {
     return Optional.ofNullable(getProperty(CONSOLE_WEBAPP_ROOT_PATH))
 
         .orElseGet(() -> ControllerConf.class.getClassLoader().getResource("webapp").toExternalForm());
-  }
-
-  public void setQueryConsoleUseHttps(boolean useHttps) {
-    setProperty(CONSOLE_WEBAPP_USE_HTTPS, useHttps);
-  }
-
-  public boolean getQueryConsoleUseHttps() {
-    return getProperty(CONSOLE_WEBAPP_USE_HTTPS, false);
   }
 
   public void setJerseyAdminPrimary(String jerseyAdminPrimary) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -416,7 +416,7 @@ public class ControllerStarter implements ServiceStartable {
       }
     });
 
-    _adminApp.start(_listenerConfigs, ListenerConfigUtil.shouldAdvertiseAsHttps(_listenerConfigs, _config));
+    _adminApp.start(_listenerConfigs);
 
     _listenerConfigs.stream().forEach(listenerConfig -> LOGGER.info("Controller services available at {}://{}:{}/",
         listenerConfig.getProtocol(), listenerConfig.getHost(), listenerConfig.getPort()));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -104,7 +104,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     httpServer.addListener(listener);
   }
 
-  public void start(List<ListenerConfig> listenerConfigs, boolean advertiseHttps) {
+  public void start(List<ListenerConfig> listenerConfigs) {
     // ideally greater than reserved port but then port 80 is also valid
     Preconditions.checkNotNull(listenerConfigs);
 
@@ -122,7 +122,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
       throw new RuntimeException("Failed to start Http Server", e);
     }
 
-    setupSwagger(_httpServer, advertiseHttps);
+    setupSwagger(_httpServer);
 
     ClassLoader classLoader = ControllerAdminApiApplication.class.getClassLoader();
 
@@ -139,17 +139,13 @@ public class ControllerAdminApiApplication extends ResourceConfig {
         .map(port -> port.toString()).collect(Collectors.joining(",")));
   }
 
-  private void setupSwagger(HttpServer httpServer, boolean advertiseHttps) {
+  private void setupSwagger(HttpServer httpServer) {
     BeanConfig beanConfig = new BeanConfig();
     beanConfig.setTitle("Pinot Controller API");
     beanConfig.setDescription("APIs for accessing Pinot Controller information");
     beanConfig.setContact("https://github.com/apache/incubator-pinot");
     beanConfig.setVersion("1.0");
-    if (advertiseHttps) {
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
-    } else {
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL});
-    }
+    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     beanConfig.setBasePath("/");
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
@@ -160,7 +156,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/api/");
     httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/help/");
 
-    URL swaggerDistLocation = loader.getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");
+    URL swaggerDistLocation = loader.getResource("META-INF/resources/webjars/swagger-ui/2.2.10-1/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ListenerConfigUtil.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ListenerConfigUtil.java
@@ -59,23 +59,6 @@ public abstract class ListenerConfigUtil {
     return listenerConfigs;
   }
 
-  /**
-   * Will determine if the query console should be advertised as http or https.
-   * 
-   * The query console can be advertised as secured with 
-   * {@link ControllerConf#getQueryConsoleUseHttps()} for cases for only http 
-   * listeners are defined by the query console is served by a secured reverse 
-   * proxy.
-   * 
-   * @param listenerConfigs generated listener configs from {@link ListenerConfigUtil#buildListenerConfigs(ControllerConf)}
-   * @param controllerConf property holders for controller configuration
-   * @return whether the query console should be advertised as http or https.
-   */
-  public static boolean shouldAdvertiseAsHttps(List<ListenerConfig> listenerConfigs, ControllerConf controllerConf) {
-    return controllerConf.getQueryConsoleUseHttps() || !listenerConfigs.stream().map(ListenerConfig::getProtocol)
-        .filter(protocol -> protocol.equals("http")).findAny().isPresent();
-  }
-
   private static Optional<TlsConfiguration> buildTlsConfiguration(String protocol, ControllerConf controllerConf) {
     return Optional.ofNullable(controllerConf.getControllerAccessProtocolProperty(protocol, "tls.keystore.path"))
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
@@ -45,8 +45,6 @@ public class ListenerConfigUtilTest {
     Assert.assertEquals(listenerConfigs.size(), 1);
 
     assertLegacyListener(listenerConfigs.get(0));
-
-    Assert.assertTrue(ListenerConfigUtil.shouldAdvertiseAsHttps(listenerConfigs, controllerConf));
   }
 
   /**
@@ -70,8 +68,6 @@ public class ListenerConfigUtilTest {
 
     assertLegacyListener(legacyListener);
     assertHttpsListener(httpsListener, "10.0.0.10", 9443);
-
-    Assert.assertFalse(ListenerConfigUtil.shouldAdvertiseAsHttps(listenerConfigs, controllerConf));
   }
 
   /**
@@ -116,8 +112,6 @@ public class ListenerConfigUtilTest {
     Assert.assertEquals(listenerConfigs.size(), 1);
 
     assertHttpsListener(listenerConfigs.get(0), "0.0.0.0", 9443);
-
-    Assert.assertTrue(ListenerConfigUtil.shouldAdvertiseAsHttps(listenerConfigs, controllerConf));
   }
 
   /**

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
@@ -98,7 +98,7 @@ public class AdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot server information");
     beanConfig.setContact("https://github.com/apache/incubator-pinot");
     beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL});
+    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     beanConfig.setBasePath(baseUri.getPath());
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
@@ -110,7 +110,7 @@ public class AdminApiApplication extends ResourceConfig {
     httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/help/");
 
     URL swaggerDistLocation =
-        AdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");
+        AdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.2.10-1/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -66,7 +66,7 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot Starter information");
     beanConfig.setContact("https://github.com/apache/incubator-pinot");
     beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL});
+    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     beanConfig.setBasePath(_baseUri.getPath());
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
@@ -77,7 +77,7 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
 
     URL swaggerDistLocation = PinotServiceManagerAdminApiApplication.class.getClassLoader()
-        .getResource("META-INF/resources/webjars/swagger-ui/2.2.2/");
+        .getResource("META-INF/resources/webjars/swagger-ui/2.2.10-1/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -896,7 +896,7 @@
       <dependency>
         <groupId>org.webjars</groupId>
         <artifactId>swagger-ui</artifactId>
-        <version>2.2.2</version>
+        <version>2.2.10-1</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
## Description
Before, the Swagger initialization was only permitting HTTP schema for
most applications and optionally the HTTPS schema which had to be
configured.

Now, Swagger will always list both schemas. By default, it picks the
first schema (which will be HTTP) on the client. When a Swagger page is
opened the swagger JS client will prefer the protcol the page is on, if
it is listed as supported. This means the Swagger browser pages for
Pinot will now work out-of-the-box for HTTPS-only setups.

For this to work though, Swagger UI needs to be updated because the
current version does not correctly select the scheme, which was addessed
in https://github.com/swagger-api/swagger-js/pull/857.

I've tested the Swagger pages with my own environment where Pinot is hosted and only reachable via HTTPS. It wasn't obvious that the query console actually used any of this, and appears to be working fine.

I also took a quick look at the release notes between `2.2.2` and `2.2.10`, and it was nothing but minor bug fixes. `2.2.10-1` is just a minor change to the `webjar`.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
Removes the configuration option `controller.query.console.useHttps`. Support for HTTPS on Swagger pages is now automatic. Fixes #5814.

## Documentation
N/A