### PR TITLE
Enable segment decryption for encrypted segments in Minion

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.pinot.spi.crypt.PinotCrypter;
+import org.apache.pinot.spi.crypt.PinotCrypterFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.annotations.Test;
 
@@ -54,16 +56,16 @@ public class SegmentFetcherFactoryTest {
     properties.put("protocols", Arrays.asList(HTTP_PROTOCOL, HTTPS_PROTOCOL, TEST_PROTOCOL, "foo"));
     properties.put("http.foo", "bar");
     properties.put(TEST_PROTOCOL + SegmentFetcherFactory.SEGMENT_FETCHER_CLASS_KEY_SUFFIX,
-        TestSegmentFetcher.class.getName());
+        FakeSegmentFetcher.class.getName());
     SegmentFetcherFactory.init(new PinotConfiguration(properties));
 
     assertEquals(SegmentFetcherFactory.getSegmentFetcher(HTTP_PROTOCOL).getClass(), HttpSegmentFetcher.class);
     assertEquals(SegmentFetcherFactory.getSegmentFetcher(HTTPS_PROTOCOL).getClass(), HttpsSegmentFetcher.class);
     assertEquals(SegmentFetcherFactory.getSegmentFetcher(FILE_PROTOCOL).getClass(), PinotFSSegmentFetcher.class);
     assertEquals(SegmentFetcherFactory.getSegmentFetcher("foo").getClass(), PinotFSSegmentFetcher.class);
-    assertEquals(SegmentFetcherFactory.getSegmentFetcher(TEST_PROTOCOL).getClass(), TestSegmentFetcher.class);
+    assertEquals(SegmentFetcherFactory.getSegmentFetcher(TEST_PROTOCOL).getClass(), FakeSegmentFetcher.class);
 
-    TestSegmentFetcher testFileFetcher = (TestSegmentFetcher) SegmentFetcherFactory.getSegmentFetcher(TEST_PROTOCOL);
+    FakeSegmentFetcher testFileFetcher = (FakeSegmentFetcher) SegmentFetcherFactory.getSegmentFetcher(TEST_PROTOCOL);
     assertEquals(testFileFetcher._initCalled, 1);
     assertEquals(testFileFetcher._fetchFileToLocalCalled, 0);
 
@@ -74,9 +76,28 @@ public class SegmentFetcherFactoryTest {
     SegmentFetcherFactory.fetchSegmentToLocal(TEST_URI, new File("foo/bar"));
     assertEquals(testFileFetcher._initCalled, 1);
     assertEquals(testFileFetcher._fetchFileToLocalCalled, 2);
+
+    // setup crypter
+    properties.put("class.fakePinotCrypter", FakePinotCrypter.class.getName());
+    PinotCrypterFactory.init(new PinotConfiguration(properties));
+    FakePinotCrypter fakeCrypter = (FakePinotCrypter) PinotCrypterFactory.create("fakePinotCrypter");
+
+    SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(TEST_URI, new File("foo/bar"), null);
+    assertEquals(testFileFetcher._initCalled, 1);
+    assertEquals(testFileFetcher._fetchFileToLocalCalled, 3);
+    assertEquals(fakeCrypter._initCalled, 1);
+    assertEquals(fakeCrypter._decryptCalled, 0);
+    assertEquals(fakeCrypter._encryptCalled, 0);
+
+    SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(TEST_URI, new File("foo/bar"), "fakePinotCrypter");
+    assertEquals(testFileFetcher._initCalled, 1);
+    assertEquals(testFileFetcher._fetchFileToLocalCalled, 4);
+    assertEquals(fakeCrypter._initCalled, 1);
+    assertEquals(fakeCrypter._decryptCalled, 1);
+    assertEquals(fakeCrypter._encryptCalled, 0);
   }
 
-  public static class TestSegmentFetcher implements SegmentFetcher {
+  public static class FakeSegmentFetcher implements SegmentFetcher {
     private int _initCalled = 0;
     private int _fetchFileToLocalCalled = 0;
 
@@ -96,6 +117,28 @@ public class SegmentFetcherFactoryTest {
     public void fetchSegmentToLocal(List<URI> uri, File dest)
         throws Exception {
       throw new UnsupportedOperationException();
+    }
+  }
+
+  public static class FakePinotCrypter implements PinotCrypter {
+
+    private int _initCalled = 0;
+    private int _encryptCalled = 0;
+    private int _decryptCalled = 0;
+
+    @Override
+    public void init(PinotConfiguration config) {
+      _initCalled++;
+    }
+
+    @Override
+    public void encrypt(File decryptedFile, File encryptedFile) {
+      _encryptCalled++;
+    }
+
+    @Override
+    public void decrypt(File encryptedFile, File decryptedFile) {
+      _decryptCalled++;
     }
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
@@ -80,6 +80,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
 
     File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + UUID.randomUUID());
     Preconditions.checkState(tempDataDir.mkdirs());
+    String crypterName = getTableConfig(tableNameWithType).getValidationConfig().getCrypterClassName();
 
     try {
       List<File> inputSegmentFiles = new ArrayList<>();
@@ -87,7 +88,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         // Download the segment file
         File tarredSegmentFile = new File(tempDataDir, "tarredSegmentFile_" + i);
         LOGGER.info("Downloading segment from {} to {}", downloadURLs[i], tarredSegmentFile.getAbsolutePath());
-        SegmentFetcherFactory.fetchSegmentToLocal(downloadURLs[i], tarredSegmentFile);
+        SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(downloadURLs[i], tarredSegmentFile, crypterName);
 
         // Un-tar the segment file
         File segmentDir = new File(tempDataDir, "segmentDir_" + i);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseSingleSegmentConversionExecutor.java
@@ -78,11 +78,13 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
 
     File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + UUID.randomUUID());
     Preconditions.checkState(tempDataDir.mkdirs(), "Failed to create temporary directory: %s", tempDataDir);
+    String crypterName = getTableConfig(tableNameWithType).getValidationConfig().getCrypterClassName();
+
     try {
       // Download the tarred segment file
       File tarredSegmentFile = new File(tempDataDir, "tarredSegment");
       LOGGER.info("Downloading segment from {} to {}", downloadURL, tarredSegmentFile.getAbsolutePath());
-      SegmentFetcherFactory.fetchSegmentToLocal(downloadURL, tarredSegmentFile);
+      SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(downloadURL, tarredSegmentFile, crypterName);
 
       // Un-tar the segment file
       File segmentDir = new File(tempDataDir, "segmentDir");

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseTaskExecutor.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pinot.minion.executor;
 
+import com.google.common.base.Preconditions;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.spi.config.table.TableConfig;
 
 
 public abstract class BaseTaskExecutor implements PinotTaskExecutor {
@@ -29,5 +32,12 @@ public abstract class BaseTaskExecutor implements PinotTaskExecutor {
   @Override
   public void cancel() {
     _cancelled = true;
+  }
+
+  protected TableConfig getTableConfig(String tableNameWithType) {
+    TableConfig tableConfig =
+        ZKMetadataProvider.getTableConfig(MINION_CONTEXT.getHelixPropertyStore(), tableNameWithType);
+    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", tableNameWithType);
+    return tableConfig;
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/MergeRollupTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/MergeRollupTaskExecutor.java
@@ -60,8 +60,7 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     String mergedSegmentName = configs.get(MinionConstants.MergeRollupTask.MERGED_SEGMENT_NAME_KEY);
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
 
-    TableConfig tableConfig =
-        ZKMetadataProvider.getTableConfig(MINION_CONTEXT.getHelixPropertyStore(), tableNameWithType);
+    TableConfig tableConfig = getTableConfig(tableNameWithType);
 
     MergeRollupSegmentConverter rollupSegmentConverter =
         new MergeRollupSegmentConverter.Builder().setMergeType(mergeType).setTableName(tableNameWithType)

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PurgeTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PurgeTaskExecutor.java
@@ -18,11 +18,9 @@
  */
 package org.apache.pinot.minion.executor;
 
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.Collections;
 import java.util.Map;
-import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
@@ -44,9 +42,7 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
 
-    TableConfig tableConfig =
-        ZKMetadataProvider.getTableConfig(MINION_CONTEXT.getHelixPropertyStore(), tableNameWithType);
-    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", tableNameWithType);
+    TableConfig tableConfig = getTableConfig(tableNameWithType);
     SegmentPurger.RecordPurgerFactory recordPurgerFactory = MINION_CONTEXT.getRecordPurgerFactory();
     SegmentPurger.RecordPurger recordPurger =
         recordPurgerFactory != null ? recordPurgerFactory.getRecordPurger(rawTableName) : null;


### PR DESCRIPTION
Minion downloads segments locally and purges (or modifies) records of the segments. If segments are encrypted, Minion needs to decrypt them before applying any purge (or modification). Decryption has to be performed by the same crypter that is used for encryption. Crypter is specified in TableConfig.
Please note that Minion doesn't need to encrypt the segment after purge/modification. When un-encrypted segments get uploaded to Controller through upload api, they get encrypted automatically (this happens if the crypter config is available in table config).