### PR TITLE
Avoid variable substitution in metadata

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/ColumnMetadata.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/ColumnMetadata.java
@@ -122,9 +122,12 @@ public class ColumnMetadata {
       builder.setDateTimeGranularity(dateTimeGranularity);
     }
 
-    // Set min/max value if available.
-    String minString = config.getString(getKeyFor(column, MIN_VALUE), null);
-    String maxString = config.getString(getKeyFor(column, MAX_VALUE), null);
+    // Set min/max value if available
+    // NOTE: Use getProperty() instead of getString() to avoid variable substitution ('${anotherKey}'), which can cause
+    //       problem for special values such as '$${' where the first '$' is identified as escape character.
+    // TODO: Use getProperty() for other properties as well to avoid the overhead of variable substitution
+    String minString = (String) config.getProperty(getKeyFor(column, MIN_VALUE));
+    String maxString = (String) config.getProperty(getKeyFor(column, MAX_VALUE));
     if (minString != null && maxString != null) {
       switch (dataType) {
         case INT:

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
@@ -69,6 +69,14 @@ public class SegmentColumnarIndexCreatorTest {
     assertTrue(SegmentColumnarIndexCreator.isValidPropertyValue(""));
     testPropertyValueWithSpecialCharacters("");
 
+    // Variable substitution (should be disabled)
+    assertTrue(SegmentColumnarIndexCreator.isValidPropertyValue("$${testKey}"));
+    testPropertyValueWithSpecialCharacters("$${testKey}");
+
+    // Escape character for variable substitution
+    assertTrue(SegmentColumnarIndexCreator.isValidPropertyValue("$${"));
+    testPropertyValueWithSpecialCharacters("$${");
+
     for (int i = 0; i < NUM_ROUNDS; i++) {
       testPropertyValueWithSpecialCharacters(RandomStringUtils.randomAscii(5));
       testPropertyValueWithSpecialCharacters(RandomStringUtils.random(5));
@@ -80,11 +88,11 @@ public class SegmentColumnarIndexCreatorTest {
     if (SegmentColumnarIndexCreator.isValidPropertyValue(value)) {
       PropertiesConfiguration configuration = new PropertiesConfiguration(CONFIG_FILE);
       configuration.setProperty(PROPERTY_KEY, value);
-      assertEquals(configuration.getString(PROPERTY_KEY), value);
+      assertEquals(configuration.getProperty(PROPERTY_KEY), value);
       configuration.save();
 
       configuration = new PropertiesConfiguration(CONFIG_FILE);
-      assertEquals(configuration.getString(PROPERTY_KEY), value);
+      assertEquals(configuration.getProperty(PROPERTY_KEY), value);
     }
   }
 


### PR DESCRIPTION
## Description
In the segment metadata and column metadata, we always store the actual value in the property file and never use variable substitution (`${anotherKey}`). Using variable substitution can cause problem for special values such as `$${` where the first `$` is identified as escape character and removed.
Replace `getString()` with `getProperty()` for column min/max value to avoid variable substitution.