### PR TITLE
[TE] enchance anomaly api to propagate feedback

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/AnomalyResource.java
@@ -156,11 +156,15 @@ public class AnomalyResource {
    *                        eg. payload
    *                        <p/>
    *                        { "feedbackType": "NOT_ANOMALY", "comment": "this is not an anomaly" }
+   * @param propagate       : a flag whether it should propagate the same feedback value to the parent of this anomaly
+   *                        and all its siblings if they exist
    */
   @POST
   @Path(value = "anomaly-merged-result/feedback/{anomaly_merged_result_id}")
   @ApiOperation("update anomaly merged result feedback")
-  public void updateAnomalyMergedResultFeedback(@PathParam("anomaly_merged_result_id") long anomalyResultId,
+  public void updateAnomalyMergedResultFeedback(
+      @PathParam("anomaly_merged_result_id") long anomalyResultId,
+      @QueryParam("propagate") @DefaultValue("true") boolean propagate,
       String payload) {
     try {
       MergedAnomalyResultDTO result = anomalyMergedResultDAO.findById(anomalyResultId);
@@ -168,18 +172,33 @@ public class AnomalyResource {
         throw new IllegalArgumentException("AnomalyResult not found with id " + anomalyResultId);
       }
       AnomalyFeedbackDTO feedbackRequest = OBJECT_MAPPER.readValue(payload, AnomalyFeedbackDTO.class);
-      AnomalyFeedback feedback = result.getFeedback();
-      if (feedback == null) {
-        feedback = new AnomalyFeedbackDTO();
-        result.setFeedback(feedback);
+      if (propagate && result.isChild()) {
+        // propagate the feedback to its parent and siblings
+        MergedAnomalyResultDTO parent = anomalyMergedResultDAO.findParent(result);
+        if (parent != null) {
+          updateAnomalyFeedback(parent, feedbackRequest);
+        } else {
+          LOG.warn("Cannot find parent for anomaly : {}, thus only updating the feedback of it", result.getId());
+          updateAnomalyFeedback(result, feedbackRequest);
+        }
+      } else {
+        updateAnomalyFeedback(result, feedbackRequest);
       }
-      feedback.setComment(feedbackRequest.getComment());
-      if (feedbackRequest.getFeedbackType() != null){
-        feedback.setFeedbackType(feedbackRequest.getFeedbackType());
-      }
-      anomalyMergedResultDAO.updateAnomalyFeedback(result);
     } catch (IOException e) {
       throw new IllegalArgumentException("Invalid payload " + payload, e);
     }
+  }
+
+  private void updateAnomalyFeedback(MergedAnomalyResultDTO anomaly, AnomalyFeedbackDTO newFeedback) {
+    AnomalyFeedback feedback = anomaly.getFeedback();
+    if (feedback == null) {
+      feedback = new AnomalyFeedbackDTO();
+      anomaly.setFeedback(feedback);
+    }
+    feedback.setComment(newFeedback.getComment());
+    if (newFeedback.getFeedbackType() != null) {
+      feedback.setFeedbackType(newFeedback.getFeedbackType());
+    }
+    anomalyMergedResultDAO.updateAnomalyFeedback(anomaly);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -78,6 +78,8 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   List<MergedAnomalyResultDTO> findAnomaliesByMetricIdAndTimeRange(Long metricId, long start, long end);
 
+  MergedAnomalyResultDTO findParent(MergedAnomalyResultDTO entity);
+
   void updateAnomalyFeedback(MergedAnomalyResultDTO entity);
 
   MergedAnomalyResultBean convertMergeAnomalyDTO2Bean(MergedAnomalyResultDTO entity);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -456,6 +456,24 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     return this.getAnomaliesForMetricBeanAndTimeRange(mbean, start, end);
   }
 
+  @Override
+  public MergedAnomalyResultDTO findParent(MergedAnomalyResultDTO entity) {
+    List<MergedAnomalyResultBean> candidates = genericPojoDao.get(Predicate.AND(
+        Predicate.EQ("detectionConfigId", entity.getDetectionConfigId()),
+        Predicate.LE("startTime", entity.getStartTime()),
+        Predicate.GE("endTime", entity.getEndTime())), MergedAnomalyResultBean.class);
+    for (MergedAnomalyResultBean candidate : candidates) {
+      if (candidate.getChildIds() != null && !candidate.getChildIds().isEmpty()) {
+        for (Long id : candidate.getChildIds()) {
+          if (entity.getId().equals(id)) {
+            return convertMergedAnomalyBean2DTO(candidate, new HashSet<>(Collections.singleton(candidate.getId())));
+          }
+        }
+      }
+    }
+    return null;
+  }
+
   private List<MergedAnomalyResultDTO> getAnomaliesForMetricBeanAndTimeRange(MetricConfigBean mbean, long start, long end) {
 
     LOG.info("Fetching anomalies for metric '{}' and dataset '{}'", mbean.getName(), mbean.getDataset());

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
@@ -262,6 +262,44 @@ public class TestMergedAnomalyResultManager{
     Assert.assertEquals(read.getChildren().iterator().next().getChildren().iterator().next().getChildren().iterator().next().getStartTime(), 1600);
   }
 
+  @Test
+  public void testFindParent() {
+    MergedAnomalyResultDTO top = new MergedAnomalyResultDTO();
+    top.setDetectionConfigId(1L);
+    top.setStartTime(1000);
+    top.setEndTime(3000);
+
+    MergedAnomalyResultDTO child1 = new MergedAnomalyResultDTO();
+    child1.setDetectionConfigId(1L);
+    child1.setStartTime(1000);
+    child1.setEndTime(2000);
+
+    MergedAnomalyResultDTO child2 = new MergedAnomalyResultDTO();
+    child2.setDetectionConfigId(1L);
+    child2.setStartTime(1200);
+    child2.setEndTime(1800);
+
+    MergedAnomalyResultDTO child3 = new MergedAnomalyResultDTO();
+    child3.setDetectionConfigId(1L);
+    child3.setStartTime(1500);
+    child3.setEndTime(3000);
+
+    child1.setChildren(new HashSet<>(Collections.singletonList(child2)));
+    top.setChildren(new HashSet<>(Arrays.asList(child1, child3)));
+
+    long topId = this.mergedAnomalyResultDAO.save(top);
+    MergedAnomalyResultDTO topNode = this.mergedAnomalyResultDAO.findById(topId);
+    MergedAnomalyResultDTO parent = null;
+    MergedAnomalyResultDTO leafNode = null;
+    for (MergedAnomalyResultDTO intermediate : topNode.getChildren()) {
+      if (!intermediate.getChildren().isEmpty()) {
+        parent = intermediate;
+        leafNode = intermediate.getChildren().iterator().next();
+      }
+    }
+    Assert.assertNotNull(parent);
+    Assert.assertEquals(parent, this.mergedAnomalyResultDAO.findParent(leafNode));
+  }
 
   public static DetectionConfigDTO mockDetectionConfig() {
     DetectionConfigDTO detectionConfig = new DetectionConfigDTO();


### PR DESCRIPTION
This PR is to enhance the anomaly feedback api so that it propagates the feedback to the parent of the specified anomaly and its siblings if the `propagate` flag is set. 