### PR TITLE
Enhance sql parser for having and post-aggregation

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.function.FunctionDefinitionRegistry;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.FilterOperator;
@@ -51,9 +52,12 @@ public class PinotQuery2BrokerRequestConverter {
     BrokerRequest brokerRequest = new BrokerRequest();
 
     //Query Source
-    QuerySource querySource = new QuerySource();
-    querySource.setTableName(pinotQuery.getDataSource().getTableName());
-    brokerRequest.setQuerySource(querySource);
+    DataSource dataSource = pinotQuery.getDataSource();
+    if (dataSource != null) {
+      QuerySource querySource = new QuerySource();
+      querySource.setTableName(dataSource.getTableName());
+      brokerRequest.setQuerySource(querySource);
+    }
 
     convertFilter(pinotQuery, brokerRequest);
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -74,6 +74,11 @@ public class CalciteSqlParser {
    * non-alphanumeric characters. */
   private static final Lex PINOT_LEX = Lex.MYSQL_ANSI;
 
+  // BABEL is a very liberal conformance value that allows anything supported by any dialect
+  private static final SqlParser.Config PARSER_CONFIG =
+      SqlParser.configBuilder().setLex(PINOT_LEX).setConformance(SqlConformanceEnum.BABEL)
+          .setParserFactory(SqlBabelParserImpl.FACTORY).build();
+
   // To Keep the backward compatibility with 'OPTION' Functionality in PQL, which is used to
   // provide more hints for query processing.
   //
@@ -215,7 +220,8 @@ public class CalciteSqlParser {
         identifiers.add(expression.getIdentifier().getName());
       } else if (expression.getFunctionCall() != null) {
         if (excludeAs && expression.getFunctionCall().getOperator().equalsIgnoreCase("AS")) {
-          identifiers.addAll(extractIdentifiers(Arrays.asList(expression.getFunctionCall().getOperands().get(0)), true));
+          identifiers
+              .addAll(extractIdentifiers(Arrays.asList(expression.getFunctionCall().getOperands().get(0)), true));
           continue;
         } else {
           identifiers.addAll(extractIdentifiers(expression.getFunctionCall().getOperands(), excludeAs));
@@ -235,7 +241,7 @@ public class CalciteSqlParser {
    */
   public static Expression compileToExpression(String expression)
       throws SqlParseException {
-    SqlParser sqlParser = getSqlParser(expression);
+    SqlParser sqlParser = SqlParser.create(expression, PARSER_CONFIG);
     SqlNode sqlNode = sqlParser.parseExpression();
     return toExpression(sqlNode);
   }
@@ -258,83 +264,78 @@ public class CalciteSqlParser {
   }
 
   private static PinotQuery compileCalciteSqlToPinotQuery(String sql) {
-    SqlParser sqlParser = getSqlParser(sql);
-    final SqlNode sqlNode;
+    SqlParser sqlParser = SqlParser.create(sql, PARSER_CONFIG);
+    SqlNode sqlNode;
     try {
       sqlNode = sqlParser.parseQuery();
     } catch (SqlParseException e) {
       throw new SqlCompilationException(e);
     }
 
-    PinotQuery pinotQuery = new PinotQuery();
-
-    SqlSelect selectSqlNode;
-    SqlOrderBy selectOrderBySqlNode = null;
-    switch (sqlNode.getKind()) {
-      case ORDER_BY:
-        selectOrderBySqlNode = (SqlOrderBy) sqlNode;
-        if (selectOrderBySqlNode.orderList != null) {
-          pinotQuery.setOrderByList(convertOrderByList(selectOrderBySqlNode.orderList));
-        }
-        if (selectOrderBySqlNode.fetch != null) {
-          pinotQuery.setLimit(Integer.valueOf(((SqlNumericLiteral) selectOrderBySqlNode.fetch).toValue()));
-        }
-        if (selectOrderBySqlNode.offset != null) {
-          pinotQuery.setOffset(Integer.valueOf(((SqlNumericLiteral) selectOrderBySqlNode.offset).toValue()));
-        }
-      case SELECT:
-        if (sqlNode instanceof SqlOrderBy) {
-          selectSqlNode = (SqlSelect) selectOrderBySqlNode.query;
-        } else {
-          selectSqlNode = (SqlSelect) sqlNode;
-        }
-
-        if (selectSqlNode.getFetch() != null) {
-          pinotQuery.setLimit(Integer.valueOf(((SqlNumericLiteral) selectSqlNode.getFetch()).toValue()));
-        }
-        if (selectSqlNode.getOffset() != null) {
-          pinotQuery.setOffset(Integer.valueOf(((SqlNumericLiteral) selectSqlNode.getOffset()).toValue()));
-        }
-        DataSource dataSource = new DataSource();
-        if (selectSqlNode.getFrom() != null) {
-          dataSource.setTableName(selectSqlNode.getFrom().toString());
-        }
-        pinotQuery.setDataSource(dataSource);
-        if (selectSqlNode.getModifierNode(SqlSelectKeyword.DISTINCT) != null) {
-          if (selectSqlNode.getGroup() != null) {
-            // TODO: explore support for GROUP BY with DISTINCT
-            throw new SqlCompilationException("DISTINCT with GROUP BY is not supported");
-          }
-          pinotQuery.setSelectList(convertDistinctSelectList(selectSqlNode.getSelectList()));
-        } else {
-          pinotQuery.setSelectList(convertSelectList(selectSqlNode.getSelectList()));
-        }
-
-        if (selectSqlNode.getWhere() != null) {
-          pinotQuery.setFilterExpression(toExpression(selectSqlNode.getWhere()));
-        }
-        if (selectSqlNode.getGroup() != null) {
-          pinotQuery.setGroupByList(convertSelectList(selectSqlNode.getGroup()));
-        }
-        break;
-      default:
-        throw new RuntimeException(
-            "Unable to convert SqlNode: " + sqlNode + " to PinotQuery. Unknown node type: " + sqlNode.getKind());
+    SqlSelect selectNode;
+    if (sqlNode instanceof SqlOrderBy) {
+      // Store order-by info into the select sql node
+      SqlOrderBy orderByNode = (SqlOrderBy) sqlNode;
+      selectNode = (SqlSelect) orderByNode.query;
+      selectNode.setOrderBy(orderByNode.orderList);
+      selectNode.setFetch(orderByNode.fetch);
+      selectNode.setOffset(orderByNode.offset);
+    } else {
+      selectNode = (SqlSelect) sqlNode;
     }
+
+    PinotQuery pinotQuery = new PinotQuery();
+    // SELECT
+    if (selectNode.getModifierNode(SqlSelectKeyword.DISTINCT) != null) {
+      // SELECT DISTINCT
+      if (selectNode.getGroup() != null) {
+        // TODO: explore support for GROUP BY with DISTINCT
+        throw new SqlCompilationException("DISTINCT with GROUP BY is not supported");
+      }
+      pinotQuery.setSelectList(convertDistinctSelectList(selectNode.getSelectList()));
+    } else {
+      pinotQuery.setSelectList(convertSelectList(selectNode.getSelectList()));
+    }
+    // FROM
+    SqlNode fromNode = selectNode.getFrom();
+    if (fromNode != null) {
+      DataSource dataSource = new DataSource();
+      dataSource.setTableName(fromNode.toString());
+      pinotQuery.setDataSource(dataSource);
+    }
+    // WHERE
+    SqlNode whereNode = selectNode.getWhere();
+    if (whereNode != null) {
+      pinotQuery.setFilterExpression(toExpression(whereNode));
+    }
+    // GROUP-BY
+    SqlNodeList groupByNodeList = selectNode.getGroup();
+    if (groupByNodeList != null) {
+      pinotQuery.setGroupByList(convertSelectList(groupByNodeList));
+    }
+    // HAVING
+    SqlNode havingNode = selectNode.getHaving();
+    if (havingNode != null) {
+      pinotQuery.setHavingExpression(toExpression(havingNode));
+    }
+    // ORDER-BY
+    SqlNodeList orderByNodeList = selectNode.getOrderList();
+    if (orderByNodeList != null) {
+      pinotQuery.setOrderByList(convertOrderByList(orderByNodeList));
+    }
+    // LIMIT
+    SqlNode limitNode = selectNode.getFetch();
+    if (limitNode != null) {
+      pinotQuery.setLimit(((SqlNumericLiteral) limitNode).intValue(false));
+    }
+    // OFFSET
+    SqlNode offsetNode = selectNode.getOffset();
+    if (offsetNode != null) {
+      pinotQuery.setOffset(((SqlNumericLiteral) offsetNode).intValue(false));
+    }
+
     queryRewrite(pinotQuery);
     return pinotQuery;
-  }
-
-  private static SqlParser getSqlParser(String sql) {
-    // TODO: Check if this can be converted to static or thread local.
-    SqlParser.ConfigBuilder parserBuilder = SqlParser.configBuilder();
-    parserBuilder.setLex(PINOT_LEX);
-
-    // BABEL is a very liberal conformance value that allows anything supported by any dialect
-    parserBuilder.setConformance(SqlConformanceEnum.BABEL);
-    parserBuilder.setParserFactory(SqlBabelParserImpl.FACTORY);
-
-    return SqlParser.create(sql, parserBuilder.build());
   }
 
   private static void queryRewrite(PinotQuery pinotQuery) {
@@ -342,10 +343,13 @@ public class CalciteSqlParser {
     invokeCompileTimeFunctions(pinotQuery);
 
     // Update Predicate Comparison
-    if (pinotQuery.isSetFilterExpression()) {
-      Expression filterExpression = pinotQuery.getFilterExpression();
-      Expression updatedFilterExpression = updateComparisonPredicate(filterExpression);
-      pinotQuery.setFilterExpression(updatedFilterExpression);
+    Expression filterExpression = pinotQuery.getFilterExpression();
+    if (filterExpression != null) {
+      pinotQuery.setFilterExpression(updateComparisonPredicate(filterExpression));
+    }
+    Expression havingExpression = pinotQuery.getHavingExpression();
+    if (havingExpression != null) {
+      pinotQuery.setHavingExpression(updateComparisonPredicate(havingExpression));
     }
 
     // Rewrite GroupBy to Distinct
@@ -354,6 +358,8 @@ public class CalciteSqlParser {
     // Update alias
     Map<Identifier, Expression> aliasMap = extractAlias(pinotQuery.getSelectList());
     applyAlias(aliasMap, pinotQuery);
+
+    // Validate
     validate(aliasMap, pinotQuery);
   }
 
@@ -397,7 +403,8 @@ public class CalciteSqlParser {
         pinotQuery.setGroupByList(Collections.emptyList());
       } else {
         selectIdentifiers.removeAll(groupByIdentifiers);
-        throw new SqlCompilationException(String.format("For non-aggregation group by query, all the identifiers in select clause should be in groupBys. Found identifier: %s",
+        throw new SqlCompilationException(String.format(
+            "For non-aggregation group by query, all the identifiers in select clause should be in groupBys. Found identifier: %s",
             Arrays.toString(selectIdentifiers.toArray(new String[0]))));
       }
     }
@@ -517,33 +524,38 @@ public class CalciteSqlParser {
   }
 
   private static void applyAlias(Map<Identifier, Expression> aliasMap, PinotQuery pinotQuery) {
-    if (pinotQuery.isSetFilterExpression()) {
-      applyAlias(aliasMap, pinotQuery.getFilterExpression());
+    Expression filterExpression = pinotQuery.getFilterExpression();
+    if (filterExpression != null) {
+      applyAlias(aliasMap, filterExpression);
     }
-    if (pinotQuery.isSetGroupByList()) {
-      for (Expression groupByExpr : pinotQuery.getGroupByList()) {
-        applyAlias(aliasMap, groupByExpr);
+    List<Expression> groupByList = pinotQuery.getGroupByList();
+    if (groupByList != null) {
+      for (Expression expression : groupByList) {
+        applyAlias(aliasMap, expression);
       }
     }
-    if (pinotQuery.isSetOrderByList()) {
-      for (Expression orderByExpr : pinotQuery.getOrderByList()) {
-        applyAlias(aliasMap, orderByExpr);
+    Expression havingExpression = pinotQuery.getHavingExpression();
+    if (havingExpression != null) {
+      applyAlias(aliasMap, havingExpression);
+    }
+    List<Expression> orderByList = pinotQuery.getOrderByList();
+    if (orderByList != null) {
+      for (Expression expression : orderByList) {
+        applyAlias(aliasMap, expression);
       }
     }
   }
 
   private static void applyAlias(Map<Identifier, Expression> aliasMap, Expression expression) {
-    if (expression == null) {
-      return;
-    }
     Identifier identifierKey = expression.getIdentifier();
-    if ((identifierKey != null) && (aliasMap.containsKey(identifierKey))) {
+    if (identifierKey != null && aliasMap.containsKey(identifierKey)) {
       Expression aliasExpression = aliasMap.get(identifierKey);
       expression.setType(aliasExpression.getType()).setIdentifier(aliasExpression.getIdentifier())
           .setFunctionCall(aliasExpression.getFunctionCall()).setLiteral(aliasExpression.getLiteral());
     }
-    if (expression.getFunctionCall() != null && expression.getFunctionCall().getOperandsSize() > 0) {
-      for (Expression operand : expression.getFunctionCall().getOperands()) {
+    Function function = expression.getFunctionCall();
+    if (function != null) {
+      for (Expression operand : function.getOperands()) {
         applyAlias(aliasMap, operand);
       }
     }
@@ -728,47 +740,89 @@ public class CalciteSqlParser {
         }
         caseFuncExpr.getFunctionCall().addToOperands(elseExpression);
         return caseFuncExpr;
-      case OTHER:
+      default:
         if (node instanceof SqlDataTypeSpec) {
           // This is to handle expression like: CAST(col AS INT)
           return RequestUtils.getLiteralExpression(((SqlDataTypeSpec) node).getTypeName().getSimple());
         } else {
-          // Move on to process default logic.
+          return compileFunctionExpression((SqlBasicCall) node);
         }
+    }
+  }
+
+  private static Expression compileFunctionExpression(SqlBasicCall functionNode) {
+    SqlKind functionKind = functionNode.getKind();
+    String functionName;
+    switch (functionKind) {
+      case AND:
+        return compileAndExpression(functionNode);
+      case OR:
+        return compileOrExpression(functionNode);
+      case COUNT:
+        SqlLiteral functionQuantifier = functionNode.getFunctionQuantifier();
+        if (functionQuantifier != null && functionQuantifier.toValue().equalsIgnoreCase("DISTINCT")) {
+          functionName = AggregationFunctionType.DISTINCTCOUNT.name();
+        } else {
+          functionName = AggregationFunctionType.COUNT.name();
+        }
+        break;
+      case OTHER_FUNCTION:
+        functionName = functionNode.getOperator().getName().toUpperCase();
+        break;
       default:
-        return compileFunctionExpression((SqlBasicCall) node);
+        functionName = functionKind.name();
     }
-  }
-
-  private static String extractFunctionName(SqlBasicCall funcSqlNode) {
-    String funcName = funcSqlNode.getOperator().getKind().name();
-    if (funcSqlNode.getOperator().getKind() == SqlKind.OTHER_FUNCTION) {
-      // in-built functions like REGEXP_LIKE, TEXT_MATCH, timeConvert etc that are not natively
-      // supported by Calcite grammar
-      funcName = funcSqlNode.getOperator().getName().toUpperCase();
-    }
-    if (funcName.equalsIgnoreCase(SqlKind.COUNT.toString()) && (funcSqlNode.getFunctionQuantifier() != null)
-        && funcSqlNode.getFunctionQuantifier().toValue().equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
-      funcName = AggregationFunctionType.DISTINCTCOUNT.getName();
-    }
-    return funcName;
-  }
-
-  private static Expression compileFunctionExpression(SqlBasicCall funcSqlNode) {
-    String funcName = extractFunctionName(funcSqlNode);
-    Expression funcExpr = RequestUtils.getFunctionExpression(funcName);
-    for (SqlNode child : funcSqlNode.getOperands()) {
-      if (child instanceof SqlNodeList) {
-        final Iterator<SqlNode> iterator = ((SqlNodeList) child).iterator();
-        while (iterator.hasNext()) {
-          final SqlNode next = iterator.next();
-          funcExpr.getFunctionCall().addToOperands(toExpression(next));
+    // When there is no argument, set an empty list as the operands
+    SqlNode[] childNodes = functionNode.getOperands();
+    List<Expression> operands = new ArrayList<>(childNodes.length);
+    for (SqlNode childNode : childNodes) {
+      if (childNode instanceof SqlNodeList) {
+        for (SqlNode node : (SqlNodeList) childNode) {
+          operands.add(toExpression(node));
         }
       } else {
-        funcExpr.getFunctionCall().addToOperands(toExpression(child));
+        operands.add(toExpression(childNode));
       }
     }
-    return funcExpr;
+    Expression functionExpression = RequestUtils.getFunctionExpression(functionName);
+    functionExpression.getFunctionCall().setOperands(operands);
+    return functionExpression;
+  }
+
+  /**
+   * Helper method to flatten the operands for the AND expression.
+   */
+  private static Expression compileAndExpression(SqlBasicCall andNode) {
+    List<Expression> operands = new ArrayList<>();
+    for (SqlNode childNode : andNode.getOperands()) {
+      if (childNode.getKind() == SqlKind.AND) {
+        Expression childAndExpression = compileAndExpression((SqlBasicCall) childNode);
+        operands.addAll(childAndExpression.getFunctionCall().getOperands());
+      } else {
+        operands.add(compileFunctionExpression((SqlBasicCall) childNode));
+      }
+    }
+    Expression andExpression = RequestUtils.getFunctionExpression(SqlKind.AND.name());
+    andExpression.getFunctionCall().setOperands(operands);
+    return andExpression;
+  }
+
+  /**
+   * Helper method to flatten the operands for the OR expression.
+   */
+  private static Expression compileOrExpression(SqlBasicCall orNode) {
+    List<Expression> operands = new ArrayList<>();
+    for (SqlNode childNode : orNode.getOperands()) {
+      if (childNode.getKind() == SqlKind.OR) {
+        Expression childAndExpression = compileOrExpression((SqlBasicCall) childNode);
+        operands.addAll(childAndExpression.getFunctionCall().getOperands());
+      } else {
+        operands.add(compileFunctionExpression((SqlBasicCall) childNode));
+      }
+    }
+    Expression andExpression = RequestUtils.getFunctionExpression(SqlKind.OR.name());
+    andExpression.getFunctionCall().setOperands(operands);
+    return andExpression;
   }
 
   protected static Expression invokeCompileTimeFunctionExpression(Expression funcExpr) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -18,9 +18,6 @@
  */
 package org.apache.pinot.sql.parsers;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -38,8 +35,9 @@ import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.request.FilterQueryTree;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.PinotQuery2BrokerRequestConverter;
-import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -48,6 +46,8 @@ import org.testng.annotations.Test;
  * Some tests for the SQL compiler.
  */
 public class CalciteSqlCompilerTest {
+  private static final PinotQuery2BrokerRequestConverter BROKER_REQUEST_CONVERTER =
+      new PinotQuery2BrokerRequestConverter();
 
   @Test
   public void testCaseWhenStatements() {
@@ -661,27 +661,6 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(groupbyList.get(1).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(groupbyList.get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "BAR");
     Assert.assertEquals(groupbyList.get(1).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "FOO");
-  }
-
-  @Test
-  public void testPqlAndSqlCompatible()
-      throws IOException {
-    try (BufferedReader sqlReader = new BufferedReader(
-        new InputStreamReader(CalciteSqlCompilerTest.class.getClassLoader().getResourceAsStream("sql_queries.list")));
-        BufferedReader pqlReader = new BufferedReader(new InputStreamReader(
-            CalciteSqlCompilerTest.class.getClassLoader().getResourceAsStream("pql_queries.list")))) {
-      PinotQuery2BrokerRequestConverter pinotQuery2BrokerRequestConverter = new PinotQuery2BrokerRequestConverter();
-      Pql2Compiler pqlCompiler = new Pql2Compiler();
-      String sql;
-      while ((sql = sqlReader.readLine()) != null) {
-        // Compilation should not throw exception
-        PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
-        BrokerRequest sqlBrokerRequest = pinotQuery2BrokerRequestConverter.convert(pinotQuery);
-
-        BrokerRequest pqlBrokerRequest = pqlCompiler.compileToBrokerRequest(pqlReader.readLine());
-        // TODO: compare SQL/PQL broker request
-      }
-    }
   }
 
   @Test
@@ -1520,21 +1499,21 @@ public class CalciteSqlCompilerTest {
     String query = "SELECT count(distinct bar) FROM foo";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctCount");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCTCOUNT");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar) FROM foo GROUP BY city";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctCount");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCTCOUNT");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar), distinctCount(bar) FROM foo GROUP BY city";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 2);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctCount");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCTCOUNT");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
@@ -1545,7 +1524,7 @@ public class CalciteSqlCompilerTest {
     query = "SELECT count(distinct bar), count(*), sum(a),min(a),max(b) FROM foo GROUP BY city";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctCount");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCTCOUNT");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
@@ -1555,7 +1534,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "AS");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "distinctCount");
+        "DISTINCTCOUNT");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "bar");
@@ -1665,11 +1644,14 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
-  public void testLiteralExpressionCheck() throws SqlParseException {
+  public void testLiteralExpressionCheck()
+      throws SqlParseException {
     Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("1123")));
     Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("'ab'")));
-    Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("AS('ab', randomStr)")));
-    Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("AS(123, randomTime)")));
+    Assert.assertTrue(
+        CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("AS('ab', randomStr)")));
+    Assert.assertTrue(
+        CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("AS(123, randomTime)")));
     Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("sum(abc)")));
     Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("count(*)")));
     Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("a+B")));
@@ -1707,7 +1689,9 @@ public class CalciteSqlCompilerTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NOT_NULL");
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
+    Assert
+        .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+            "col");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.IS_NOT_NULL);
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "col");
 
@@ -1715,7 +1699,9 @@ public class CalciteSqlCompilerTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NOT_NULL");
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
+    Assert
+        .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+            "col");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.IS_NOT_NULL);
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "col");
 
@@ -1723,7 +1709,9 @@ public class CalciteSqlCompilerTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NULL");
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
+    Assert
+        .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+            "col");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.IS_NULL);
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "col");
 
@@ -1731,7 +1719,9 @@ public class CalciteSqlCompilerTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NULL");
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
+    Assert
+        .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+            "col");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.IS_NULL);
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "col");
   }
@@ -1744,7 +1734,8 @@ public class CalciteSqlCompilerTest {
     BrokerRequest brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
 
     Assert.assertEquals(brokerRequest.getAggregationsInfo().size(), 1);
     Assert.assertEquals(brokerRequest.getAggregationsInfo().get(0).getAggregationType().toUpperCase(), "DISTINCT");
@@ -1755,8 +1746,10 @@ public class CalciteSqlCompilerTest {
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "col2");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "col2");
 
     Assert.assertEquals(brokerRequest.getAggregationsInfo().size(), 1);
     Assert.assertEquals(brokerRequest.getAggregationsInfo().get(0).getAggregationType().toUpperCase(), "DISTINCT");
@@ -1767,30 +1760,52 @@ public class CalciteSqlCompilerTest {
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "PLUS");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "TIMES");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col2");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5L);
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "PLUS");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
+            .getIdentifier().getName(), "col1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
+            .getFunctionCall().getOperator(), "TIMES");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
+            .getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col2");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
+            .getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5L);
 
     Assert.assertEquals(brokerRequest.getAggregationsInfo().size(), 1);
     Assert.assertEquals(brokerRequest.getAggregationsInfo().get(0).getAggregationType().toUpperCase(), "DISTINCT");
-    Assert.assertEquals(brokerRequest.getAggregationsInfo().get(0).getAggregationParams().get("column"), "plus(col1,times(col2,'5'))");
+    Assert.assertEquals(brokerRequest.getAggregationsInfo().get(0).getAggregationParams().get("column"),
+        "plus(col1,times(col2,'5'))");
 
     query = "SELECT col1+col2*5 AS col3 FROM foo GROUP BY col1, col2";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "PLUS");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "TIMES");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col2");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5L);
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "PLUS");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
+            .getIdentifier().getName(), "col1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
+            .getFunctionCall().getOperator(), "TIMES");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
+            .getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col2");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
+            .getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5L);
 
     Assert.assertEquals(brokerRequest.getAggregationsInfo().size(), 1);
     Assert.assertEquals(brokerRequest.getAggregationsInfo().get(0).getAggregationType().toUpperCase(), "DISTINCT");
-    Assert.assertEquals(brokerRequest.getAggregationsInfo().get(0).getAggregationParams().get("column"), "plus(col1,times(col2,'5'))");
+    Assert.assertEquals(brokerRequest.getAggregationsInfo().get(0).getAggregationParams().get("column"),
+        "plus(col1,times(col2,'5'))");
   }
 
   @Test(expectedExceptions = SqlCompilationException.class)
@@ -1802,6 +1817,211 @@ public class CalciteSqlCompilerTest {
       Assert.assertEquals(e.getMessage(),
           "For non-aggregation group by query, all the identifiers in select clause should be in groupBys. Found identifier: [col2]");
       throw e;
+    }
+  }
+
+  @Test
+  public void testFlattenAndOr() {
+    {
+      String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 > 0 AND col3 > 0) AND col4 > 0";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 4);
+      for (Expression operand : operands) {
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+      }
+
+      BrokerRequest brokerRequest = BROKER_REQUEST_CONVERTER.convert(pinotQuery);
+      FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+      Assert.assertEquals(filterQueryTree.getOperator(), FilterOperator.AND);
+      List<FilterQueryTree> children = filterQueryTree.getChildren();
+      Assert.assertEquals(children.size(), 4);
+      for (FilterQueryTree child : children) {
+        Assert.assertEquals(child.getOperator(), FilterOperator.RANGE);
+      }
+    }
+
+    {
+      String query = "SELECT * FROM foo WHERE col1 <= 0 OR col2 <= 0 OR (col3 <= 0 OR col4 <= 0)";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.OR.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 4);
+      for (Expression operand : operands) {
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
+      }
+
+      BrokerRequest brokerRequest = BROKER_REQUEST_CONVERTER.convert(pinotQuery);
+      FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+      Assert.assertEquals(filterQueryTree.getOperator(), FilterOperator.OR);
+      List<FilterQueryTree> children = filterQueryTree.getChildren();
+      Assert.assertEquals(children.size(), 4);
+      for (FilterQueryTree child : children) {
+        Assert.assertEquals(child.getOperator(), FilterOperator.RANGE);
+      }
+    }
+
+    {
+      String query =
+          "SELECT * FROM foo WHERE col1 > 0 AND ((col2 > 0 AND col3 > 0) AND (col1 <= 0 OR (col2 <= 0 OR (col3 <= 0 OR col4 <= 0) OR (col3 > 0 AND col4 > 0))))";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 4);
+      for (int i = 0; i < 3; i++) {
+        Assert.assertEquals(operands.get(i).getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+      }
+      functionCall = operands.get(3).getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.OR.name());
+      operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 5);
+      for (int i = 0; i < 4; i++) {
+        Assert.assertEquals(operands.get(i).getFunctionCall().getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
+      }
+      functionCall = operands.get(4).getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+      for (Expression operand : operands) {
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+      }
+
+      BrokerRequest brokerRequest = BROKER_REQUEST_CONVERTER.convert(pinotQuery);
+      FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+      Assert.assertEquals(filterQueryTree.getOperator(), FilterOperator.AND);
+      List<FilterQueryTree> children = filterQueryTree.getChildren();
+      Assert.assertEquals(children.size(), 4);
+      for (int i = 0; i < 3; i++) {
+        Assert.assertEquals(children.get(i).getOperator(), FilterOperator.RANGE);
+      }
+      filterQueryTree = children.get(3);
+      Assert.assertEquals(filterQueryTree.getOperator(), FilterOperator.OR);
+      children = filterQueryTree.getChildren();
+      Assert.assertEquals(children.size(), 5);
+      for (int i = 0; i < 4; i++) {
+        Assert.assertEquals(children.get(i).getOperator(), FilterOperator.RANGE);
+      }
+      filterQueryTree = children.get(4);
+      Assert.assertEquals(filterQueryTree.getOperator(), FilterOperator.AND);
+      children = filterQueryTree.getChildren();
+      Assert.assertEquals(children.size(), 2);
+      for (FilterQueryTree child : children) {
+        Assert.assertEquals(child.getOperator(), FilterOperator.RANGE);
+      }
+    }
+  }
+
+  @Test
+  public void testHavingClause() {
+    {
+      String query = "SELECT SUM(col1), col2 FROM foo WHERE true GROUP BY col2 HAVING SUM(col1) > 10";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      Function functionCall = pinotQuery.getHavingExpression().getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.GREATER_THAN.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), SqlKind.SUM.name());
+      Assert.assertEquals(operands.get(1).getLiteral().getFieldValue().toString(), "10");
+
+      // It should not throw exception when converting PinotQuery to BrokerRequest. Having clause won't be added to the
+      // BrokerRequest.
+      BrokerRequest brokerRequest = BROKER_REQUEST_CONVERTER.convert(pinotQuery);
+      Assert.assertNull(brokerRequest.getHavingFilterQuery());
+      Assert.assertNull(brokerRequest.getHavingFilterSubQueryMap());
+    }
+
+    {
+      String query =
+          "SELECT SUM(col1), col2 FROM foo WHERE true GROUP BY col2 HAVING SUM(col1) > 10 AND SUM(col3) > 5 AND SUM(col4) > 15";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      Function functionCall = pinotQuery.getHavingExpression().getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 3);
+      for (Expression operand : operands) {
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+      }
+
+      // It should not throw exception when converting PinotQuery to BrokerRequest. Having clause won't be added to the
+      // BrokerRequest.
+      BrokerRequest brokerRequest = BROKER_REQUEST_CONVERTER.convert(pinotQuery);
+      Assert.assertNull(brokerRequest.getHavingFilterQuery());
+      Assert.assertNull(brokerRequest.getHavingFilterSubQueryMap());
+    }
+  }
+
+  @Test
+  public void testPostAggregation() {
+    {
+      String query = "SELECT SUM(col1) * SUM(col2) FROM foo";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      List<Expression> selectList = pinotQuery.getSelectList();
+      Assert.assertEquals(selectList.size(), 1);
+      Function functionCall = selectList.get(0).getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.TIMES.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+      for (Expression operand : operands) {
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.SUM.name());
+      }
+
+      // It should not throw exception when converting PinotQuery to BrokerRequest. SELECT clause will be ignored when
+      // converting to QueryContext
+      BROKER_REQUEST_CONVERTER.convert(pinotQuery);
+    }
+
+    {
+      String query = "SELECT SUM(col1), col2 FROM foo GROUP BY col2 ORDER BY MAX(col1) - MAX(col3)";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      List<Expression> orderByList = pinotQuery.getOrderByList();
+      Assert.assertEquals(orderByList.size(), 1);
+      Function functionCall = orderByList.get(0).getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), "ASC");
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 1);
+      functionCall = operands.get(0).getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.MINUS.name());
+      operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+      for (Expression operand : operands) {
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.MAX.name());
+      }
+
+      // It should not throw exception when converting PinotQuery to BrokerRequest. ORDER-BY clause will be ignored when
+      // converting to QueryContext
+      BROKER_REQUEST_CONVERTER.convert(pinotQuery);
+    }
+
+    {
+      // Having will be rewritten to (SUM(col1) + SUM(col3)) - MAX(col4) > 0
+      String query = "SELECT SUM(col1), col2 FROM foo GROUP BY col2 HAVING SUM(col1) + SUM(col3) > MAX(col4)";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      Function functionCall = pinotQuery.getHavingExpression().getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.GREATER_THAN.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+      Assert.assertEquals(operands.get(1).getLiteral().getFieldValue().toString(), "0");
+      functionCall = operands.get(0).getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.MINUS.name());
+      operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), SqlKind.MAX.name());
+      functionCall = operands.get(0).getFunctionCall();
+      operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+      for (Expression operand : operands) {
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.SUM.name());
+      }
+
+      // It should not throw exception when converting PinotQuery to BrokerRequest. Having clause won't be added to the
+      // BrokerRequest.
+      BrokerRequest brokerRequest = BROKER_REQUEST_CONVERTER.convert(pinotQuery);
+      Assert.assertNull(brokerRequest.getHavingFilterQuery());
+      Assert.assertNull(brokerRequest.getHavingFilterSubQueryMap());
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -331,38 +331,37 @@ public class BrokerRequestToQueryContextConverterTest {
       assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
     }
 
-    // TODO: Uncomment the following part after CalciteSqlParser supports Having clause
     // Having (only supported in SQL format)
-//    {
-//      String sqlQuery = "SELECT SUM(foo), bar FROM testTable GROUP BY bar HAVING SUM(foo) IN (5, 10, 15)";
-//      QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(sqlQuery);
-//      List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
-//      assertEquals(selectExpressions.size(), 2);
-//      assertEquals(selectExpressions.get(0), ExpressionContext.forFunction(
-//          new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
-//              Collections.singletonList(ExpressionContext.forIdentifier("foo")))));
-//      assertEquals(selectExpressions.get(0).toString(), "sum(foo)");
-//      assertEquals(selectExpressions.get(1), ExpressionContext.forIdentifier("bar"));
-//      assertEquals(selectExpressions.get(1).toString(), "bar");
-//      assertTrue(queryContext.getAliasMap().isEmpty());
-//      assertNull(queryContext.getFilter());
-//      List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
-//      assertNotNull(groupByExpressions);
-//      assertEquals(groupByExpressions.size(), 1);
-//      assertEquals(groupByExpressions.get(0), ExpressionContext.forIdentifier("bar"));
-//      assertEquals(groupByExpressions.get(0).toString(), "bar");
-//      assertNull(queryContext.getOrderByExpressions());
-//      FilterContext havingFilter = queryContext.getHavingFilter();
-//      assertNotNull(havingFilter);
-//      assertEquals(havingFilter, new FilterContext(FilterContext.Type.PREDICATE, null, new InPredicate(ExpressionContext
-//          .forFunction(new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
-//              Collections.singletonList(ExpressionContext.forIdentifier("foo")))), Arrays.asList("5", "10", "15"))));
-//      assertEquals(havingFilter.toString(), "sum(foo) IN ('5','10','15')");
-//      assertEquals(queryContext.getLimit(), 10);
-//      assertEquals(queryContext.getOffset(), 0);
-//      assertEquals(QueryContextUtils.getAllColumns(queryContext), new HashSet<>(Arrays.asList("foo", "bar")));
-//      assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
-//    }
+    {
+      String sqlQuery = "SELECT SUM(foo), bar FROM testTable GROUP BY bar HAVING SUM(foo) IN (5, 10, 15)";
+      QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(sqlQuery);
+      List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
+      assertEquals(selectExpressions.size(), 2);
+      assertEquals(selectExpressions.get(0), ExpressionContext.forFunction(
+          new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
+              Collections.singletonList(ExpressionContext.forIdentifier("foo")))));
+      assertEquals(selectExpressions.get(0).toString(), "sum(foo)");
+      assertEquals(selectExpressions.get(1), ExpressionContext.forIdentifier("bar"));
+      assertEquals(selectExpressions.get(1).toString(), "bar");
+      assertTrue(queryContext.getAliasMap().isEmpty());
+      assertNull(queryContext.getFilter());
+      List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
+      assertNotNull(groupByExpressions);
+      assertEquals(groupByExpressions.size(), 1);
+      assertEquals(groupByExpressions.get(0), ExpressionContext.forIdentifier("bar"));
+      assertEquals(groupByExpressions.get(0).toString(), "bar");
+      assertNull(queryContext.getOrderByExpressions());
+      FilterContext havingFilter = queryContext.getHavingFilter();
+      assertNotNull(havingFilter);
+      assertEquals(havingFilter, new FilterContext(FilterContext.Type.PREDICATE, null, new InPredicate(ExpressionContext
+          .forFunction(new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
+              Collections.singletonList(ExpressionContext.forIdentifier("foo")))), Arrays.asList("5", "10", "15"))));
+      assertEquals(havingFilter.toString(), "sum(foo) IN ('5','10','15')");
+      assertEquals(queryContext.getLimit(), 10);
+      assertEquals(queryContext.getOffset(), 0);
+      assertEquals(QueryContextUtils.getAllColumns(queryContext), new HashSet<>(Arrays.asList("foo", "bar")));
+      assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
+    }
 
     // DistinctCountThetaSketch (string literal and escape quote)
     {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
@@ -37,9 +37,9 @@ import static org.testng.Assert.assertTrue;
 
 
 public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValueQueriesTest {
-  private static String SV_GROUP_BY = " group by column8";
-  private static String MV_GROUP_BY = " group by column7";
-  private static String ORDER_BY_ALIAS = " order by cnt_column6 DESC";
+  private static final String SV_GROUP_BY = " group by column8";
+  private static final String MV_GROUP_BY = " group by column7";
+  private static final String ORDER_BY_ALIAS = " order by cnt_column6 DESC";
 
   @Test
   public void testCountMV() {
@@ -157,7 +157,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), "cnt_column6");
 
     brokerResponse = getBrokerResponseForSqlQueryWithFilter(query);
-    QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 62480L, 874176L, 62480L, 400000L,
+    QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 62480L, 1101664L, 62480L, 400000L,
         Arrays.asList(new Long[][]{new Long[]{62480L}}), 1, expectedDataSchema);
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), "cnt_column6");
 


### PR DESCRIPTION
## Description
Enhance sql parser for having and post-aggregation

In `CalciteSqlParser`:
- Support parsing HAVING clause
- Flatten AND/OR expression
- Simplify `compileCalciteSqlToPinotQuery()` for better readability