### PR TITLE
Support post-aggregation in QueryContext

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.google.common.math.DoubleMath;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,9 +34,6 @@ import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
-import org.apache.pinot.core.query.request.context.FunctionContext;
-import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
-import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.parsers.CompilerConstants;
 
@@ -66,35 +62,6 @@ public class AggregationFunctionUtils {
       String column = aggregationInfo.getAggregationParams().get(CompilerConstants.COLUMN_KEY_IN_AGGREGATION_INFO);
       return Arrays.asList(column.split(CompilerConstants.AGGREGATION_FUNCTION_ARG_SEPARATOR));
     }
-  }
-
-  /**
-   * Creates a list of {@link AggregationFunction}s based on the given {@link QueryContext}.
-   */
-  public static List<AggregationFunction> getAggregationFunctions(QueryContext queryContext) {
-    List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
-    Set<FunctionContext> functions = new HashSet<>();
-    List<AggregationFunction> aggregationFunctions = new ArrayList<>();
-    for (ExpressionContext selectExpression : selectExpressions) {
-      FunctionContext function = selectExpression.getFunction();
-      if (function != null && function.getType() == FunctionContext.Type.AGGREGATION) {
-        // TODO: Deduplicate aggregation functions after deprecating the BrokerRequest. PQL relies on them to return the
-        //       correct columns.
-        functions.add(function);
-        aggregationFunctions.add(AggregationFunctionFactory.getAggregationFunction(function, queryContext));
-      }
-    }
-    // Add aggregation functions in the ORDER-BY clause but not in the SELECT clause
-    List<OrderByExpressionContext> orderByExpressions = queryContext.getOrderByExpressions();
-    if (orderByExpressions != null) {
-      for (OrderByExpressionContext orderByExpression : orderByExpressions) {
-        FunctionContext function = orderByExpression.getExpression().getFunction();
-        if (function != null && function.getType() == FunctionContext.Type.AGGREGATION && functions.add(function)) {
-          aggregationFunctions.add(AggregationFunctionFactory.getAggregationFunction(function, queryContext));
-        }
-      }
-    }
-    return aggregationFunctions;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.request.context.utils;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
@@ -34,6 +35,7 @@ public class QueryContextUtils {
   /**
    * Returns all the columns (IDENTIFIER expressions) in the given query.
    */
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public static Set<String> getAllColumns(QueryContext query) {
     Set<String> columns = new HashSet<>();
 
@@ -50,15 +52,28 @@ public class QueryContextUtils {
         expression.getColumns(columns);
       }
     }
+    FilterContext havingFilter = query.getHavingFilter();
+    if (havingFilter != null) {
+      havingFilter.getColumns(columns);
+    }
     List<OrderByExpressionContext> orderByExpressions = query.getOrderByExpressions();
     if (orderByExpressions != null) {
       for (OrderByExpressionContext orderByExpression : orderByExpressions) {
         orderByExpression.getColumns(columns);
       }
     }
-    FilterContext havingFilter = query.getHavingFilter();
-    if (havingFilter != null) {
-      havingFilter.getColumns(columns);
+
+    // NOTE: Also gather columns from the input expressions of the aggregation functions because for certain types of
+    //       aggregation (e.g. DistinctCountThetaSketch), some input expressions are compiled while constructing the
+    //       aggregation function.
+    AggregationFunction[] aggregationFunctions = query.getAggregationFunctions();
+    if (aggregationFunctions != null) {
+      for (AggregationFunction aggregationFunction : aggregationFunctions) {
+        List<ExpressionContext> inputExpressions = aggregationFunction.getInputExpressions();
+        for (ExpressionContext expression : inputExpressions) {
+          expression.getColumns(columns);
+        }
+      }
     }
 
     return columns;

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -28,12 +28,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.query.request.context.FunctionContext;
 import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.predicate.InPredicate;
+import org.apache.pinot.core.query.request.context.predicate.Predicate;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
 import org.apache.pinot.core.query.request.context.predicate.TextMatchPredicate;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
@@ -363,10 +365,105 @@ public class BrokerRequestToQueryContextConverterTest {
       assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
     }
 
+    // Post-aggregation (only supported in SQL format)
+    {
+      String sqlQuery =
+          "SELECT SUM(col1) * MAX(col2) FROM testTable GROUP BY col3 HAVING SUM(col1) > MIN(col2) AND SUM(col4) + col3 < MAX(col4) ORDER BY MAX(col1) + MAX(col2) - SUM(col4), col3 DESC";
+      QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(sqlQuery);
+
+      // SELECT clause
+      List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
+      assertEquals(selectExpressions.size(), 1);
+      FunctionContext function = selectExpressions.get(0).getFunction();
+      assertEquals(function.getType(), FunctionContext.Type.TRANSFORM);
+      assertEquals(function.getFunctionName(), "times");
+      List<ExpressionContext> arguments = function.getArguments();
+      assertEquals(arguments.size(), 2);
+      assertEquals(arguments.get(0), ExpressionContext.forFunction(
+          new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
+              Collections.singletonList(ExpressionContext.forIdentifier("col1")))));
+      assertEquals(arguments.get(1), ExpressionContext.forFunction(
+          new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
+              Collections.singletonList(ExpressionContext.forIdentifier("col2")))));
+
+      // HAVING clause
+      FilterContext havingFilter = queryContext.getHavingFilter();
+      assertNotNull(havingFilter);
+      assertEquals(havingFilter.getType(), FilterContext.Type.AND);
+      List<FilterContext> children = havingFilter.getChildren();
+      assertEquals(children.size(), 2);
+      FilterContext firstChild = children.get(0);
+      assertEquals(firstChild.getType(), FilterContext.Type.PREDICATE);
+      Predicate predicate = firstChild.getPredicate();
+      assertEquals(predicate.getType(), Predicate.Type.RANGE);
+      RangePredicate rangePredicate = (RangePredicate) predicate;
+      assertEquals(rangePredicate.getLowerBound(), "0");
+      assertFalse(rangePredicate.isLowerInclusive());
+      assertEquals(rangePredicate.getUpperBound(), RangePredicate.UNBOUNDED);
+      assertFalse(rangePredicate.isUpperInclusive());
+      function = rangePredicate.getLhs().getFunction();
+      assertEquals(function.getFunctionName(), "minus");
+      arguments = function.getArguments();
+      assertEquals(arguments.size(), 2);
+      assertEquals(arguments.get(0), ExpressionContext.forFunction(
+          new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
+              Collections.singletonList(ExpressionContext.forIdentifier("col1")))));
+      assertEquals(arguments.get(1), ExpressionContext.forFunction(
+          new FunctionContext(FunctionContext.Type.AGGREGATION, "min",
+              Collections.singletonList(ExpressionContext.forIdentifier("col2")))));
+      // Skip checking the second child of the AND filter
+
+      // ORDER-BY clause
+      List<OrderByExpressionContext> orderByExpressions = queryContext.getOrderByExpressions();
+      assertNotNull(orderByExpressions);
+      assertEquals(orderByExpressions.size(), 2);
+      OrderByExpressionContext firstOrderByExpression = orderByExpressions.get(0);
+      assertTrue(firstOrderByExpression.isAsc());
+      function = firstOrderByExpression.getExpression().getFunction();
+      assertEquals(function.getFunctionName(), "minus");
+      arguments = function.getArguments();
+      assertEquals(arguments.size(), 2);
+      assertEquals(arguments.get(0).getFunction().getFunctionName(), "plus");
+      assertEquals(arguments.get(1), ExpressionContext.forFunction(
+          new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
+              Collections.singletonList(ExpressionContext.forIdentifier("col4")))));
+
+      assertEquals(QueryContextUtils.getAllColumns(queryContext),
+          new HashSet<>(Arrays.asList("col1", "col2", "col3", "col4")));
+      assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
+
+      // Expected: SUM(col1), MAX(col2), MIN(col2), SUM(col4), MAX(col4), MAX(col1)
+      //noinspection rawtypes
+      AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
+      assertNotNull(aggregationFunctions);
+      assertEquals(aggregationFunctions.length, 6);
+      assertEquals(aggregationFunctions[0].getResultColumnName(), "sum(col1)");
+      assertEquals(aggregationFunctions[1].getResultColumnName(), "max(col2)");
+      assertEquals(aggregationFunctions[2].getResultColumnName(), "min(col2)");
+      assertEquals(aggregationFunctions[3].getResultColumnName(), "sum(col4)");
+      assertEquals(aggregationFunctions[4].getResultColumnName(), "max(col4)");
+      assertEquals(aggregationFunctions[5].getResultColumnName(), "max(col1)");
+      Map<FunctionContext, Integer> aggregationFunctionIndexMap = queryContext.getAggregationFunctionIndexMap();
+      assertNotNull(aggregationFunctionIndexMap);
+      assertEquals(aggregationFunctionIndexMap.size(), 6);
+      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
+          Collections.singletonList(ExpressionContext.forIdentifier("col1")))), 0);
+      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
+          Collections.singletonList(ExpressionContext.forIdentifier("col2")))), 1);
+      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "min",
+          Collections.singletonList(ExpressionContext.forIdentifier("col2")))), 2);
+      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
+          Collections.singletonList(ExpressionContext.forIdentifier("col4")))), 3);
+      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
+          Collections.singletonList(ExpressionContext.forIdentifier("col4")))), 4);
+      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
+          Collections.singletonList(ExpressionContext.forIdentifier("col1")))), 5);
+    }
+
     // DistinctCountThetaSketch (string literal and escape quote)
     {
       String query =
-          "SELECT DISTINCTCOUNTTHETASKETCH(foo, 'nominalEntries=1000', 'bar=''a''', 'bar=''b''', 'bar=''a'' AND bar=''b''') FROM testTable WHERE bar IN ('a', 'b')";
+          "SELECT DISTINCTCOUNTTHETASKETCH(foo, 'nominalEntries=1000', 'bar=''a''', 'bar=''b''', 'bar=''a'' AND bar=''b''') FROM testTable WHERE foobar IN ('a', 'b')";
       QueryContext[] queryContexts = getQueryContexts(query, query);
       for (QueryContext queryContext : queryContexts) {
         FunctionContext function = queryContext.getSelectExpressions().get(0).getFunction();
@@ -378,6 +475,9 @@ public class BrokerRequestToQueryContextConverterTest {
         assertEquals(arguments.get(2), ExpressionContext.forLiteral("bar='a'"));
         assertEquals(arguments.get(3), ExpressionContext.forLiteral("bar='b'"));
         assertEquals(arguments.get(4), ExpressionContext.forLiteral("bar='a' AND bar='b'"));
+        assertEquals(QueryContextUtils.getAllColumns(queryContext),
+            new HashSet<>(Arrays.asList("foo", "bar", "foobar")));
+        assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }
 


### PR DESCRIPTION
## Description
Support post-aggregation in QueryContext:
- Be able to extract aggregation functions within post-aggregation function (modeled as transform)
- Store a map from the AGGREGATION `FunctionContext` to the index of the corresponding `AggregationFunction` to help lookup the expressions

Other improvement:
- When extracting columns from `QueryContext`, include columns from the input expressions of the aggregation functions. For certain types of aggregation function (e.g. DistinctCountThetaSketch), some input expressions are compiled while constructing the aggregation function.