### PR TITLE
Added set-diff operators and changed distinctCountThetaSketch syntax

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -463,7 +463,7 @@ public class BrokerRequestToQueryContextConverterTest {
     // DistinctCountThetaSketch (string literal and escape quote)
     {
       String query =
-          "SELECT DISTINCTCOUNTTHETASKETCH(foo, 'nominalEntries=1000', 'bar=''a''', 'bar=''b''', 'bar=''a'' AND bar=''b''') FROM testTable WHERE foobar IN ('a', 'b')";
+          "SELECT DISTINCTCOUNTTHETASKETCH(foo, 'nominalEntries=1000', 'bar=''a''', 'bar=''b''', 'SET_INTERSECT($1, $2)') FROM testTable WHERE bar IN ('a', 'b')";
       QueryContext[] queryContexts = getQueryContexts(query, query);
       for (QueryContext queryContext : queryContexts) {
         FunctionContext function = queryContext.getSelectExpressions().get(0).getFunction();
@@ -474,9 +474,9 @@ public class BrokerRequestToQueryContextConverterTest {
         assertEquals(arguments.get(1), ExpressionContext.forLiteral("nominalEntries=1000"));
         assertEquals(arguments.get(2), ExpressionContext.forLiteral("bar='a'"));
         assertEquals(arguments.get(3), ExpressionContext.forLiteral("bar='b'"));
-        assertEquals(arguments.get(4), ExpressionContext.forLiteral("bar='a' AND bar='b'"));
+        assertEquals(arguments.get(4), ExpressionContext.forLiteral("SET_INTERSECT($1, $2)"));
         assertEquals(QueryContextUtils.getAllColumns(queryContext),
-            new HashSet<>(Arrays.asList("foo", "bar", "foobar")));
+            new HashSet<>(Arrays.asList("foo", "bar")));
         assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ThetaSketchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ThetaSketchIntegrationTest.java
@@ -126,26 +126,26 @@ public class ThetaSketchIntegrationTest extends BaseClusterIntegrationTest {
 
     // gender = female
     String query = "select distinctCountThetaSketch(thetaSketchCol, '', "
-        + "'dimName = ''gender''', 'dimValue = ''Female''', 'dimName = ''gender'' AND dimValue = ''Female''') from "
+        + "'dimName = ''gender''', 'dimValue = ''Female''', 'SET_INTERSECT($1, $2)') from "
         + DEFAULT_TABLE_NAME + " where dimName = 'gender' AND dimValue = 'Female'";
     runAndAssert(query, 50 + 60 + 70 + 110 + 120 + 130);
 
     // gender = male
     query = "select distinctCountThetaSketch(thetaSketchCol, '', "
-        + "'dimName = ''gender''', 'dimValue = ''Male''', 'dimName = ''gender'' AND dimValue = ''Male''') from "
+        + "'dimName = ''gender''', 'dimValue = ''Male''', 'SET_INTERSECT($1, $2)') from "
         + DEFAULT_TABLE_NAME + " where dimName = 'gender' AND dimValue = 'Male'";
     runAndAssert(query, 80 + 90 + 100 + 140 + 150 + 160);
 
     // course = math
     query = "select distinctCountThetaSketch(thetaSketchCol, '', "
-        + "'dimName = ''course''', 'dimValue = ''Math''', 'dimName = ''course'' AND dimValue = ''Math''') from "
+        + "'dimName = ''course''', 'dimValue = ''Math''', 'SET_INTERSECT($1, $2)') from "
         + DEFAULT_TABLE_NAME + " where dimName = 'course' AND dimValue = 'Math'";
     runAndAssert(query, 50 + 80 + 110 + 140);
 
     // gender = female AND course = math
     query = "select distinctCountThetaSketch(thetaSketchCol, '', "
         + "'dimName = ''gender''', 'dimValue = ''Female''', 'dimName = ''course''', 'dimValue = ''Math''', "
-        + "'(dimName = ''gender'' AND dimValue = ''Female'') AND (dimName = ''course'' AND dimValue = ''Math'')') from "
+        + "'SET_INTERSECT(SET_INTERSECT($1, $2), SET_INTERSECT($3, $4))') from "
         + DEFAULT_TABLE_NAME
         + " where (dimName = 'gender' AND dimValue = 'Female') OR (dimName = 'course' AND dimValue = 'Math')";
     runAndAssert(query, 50 + 110);
@@ -153,13 +153,13 @@ public class ThetaSketchIntegrationTest extends BaseClusterIntegrationTest {
     // gender = male OR course = biology
     query = "select distinctCountThetaSketch(thetaSketchCol, '', "
         + "'dimName = ''gender''', 'dimValue = ''Male''', 'dimName = ''course''', 'dimValue = ''Biology''', "
-        + "'(dimName = ''gender'' AND dimValue = ''Male'') OR (dimName = ''course'' AND dimValue = ''Biology'')') from "
+        + "'SET_UNION(SET_INTERSECT($1, $2), SET_INTERSECT($3, $4))') from "
         + DEFAULT_TABLE_NAME
         + " where (dimName = 'gender' AND dimValue = 'Male') OR (dimName = 'course' AND dimValue = 'Biology')";
     runAndAssert(query, 70 + 80 + 90 + 100 + 130 + 140 + 150 + 160);
 
     // group by gender
-    query = "select dimValue, distinctCountThetaSketch(thetaSketchCol, '', 'dimName = ''gender''', 'dimName = ''gender''') from "
+    query = "select dimValue, distinctCountThetaSketch(thetaSketchCol, '', 'dimName = ''gender''', '$1') from "
         + DEFAULT_TABLE_NAME + " where dimName = 'gender' AND (dimValue = 'Female' OR dimValue = 'Male') "
         + "group by dimValue";
     runAndAssert(query,


### PR DESCRIPTION
#5377  Description

Currently, the DISTINCTCOUNTTHETASKETCH aggregation function does not support SET_DIFF operations. This pull-request addresses this gap.

However, this commit does introduce a backwards-incompatible change. We are suggesting to change the syntax a bit to the following:

```sql
SELECT DISTINCTCOUNTTHETASKETCH(col, 'nominalEntries=4096', 'predicate1', 'predicate2', 'SET_DIFF($1, $2)')
  FROM table
  WHERE predicate1 OR predicate2;
```

We are introducing 3 "merging functions" into the Pinot aggregation function:
1. SET_UNION
2. SET_INTERSECT
3. SET_DIFF

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [x] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)

## Release Notes
This patch introduces a new syntax to the recently introduced DISTINCTCOUNTTHETASKETCH aggregation function. The syntax will also introduce the new SET_DIFF functionality between 2 theta sketches. The syntax will be as follows:

```sql
SELECT DISTINCTCOUNTTHETASKETCH(col, 'nominalEntries=4096', 'predicate1', 'predicate2', 'SET_DIFF($1, $2)')
  FROM table
  WHERE predicate1 OR predicate2;
```

Please note that the `SET_DIFF` operation is **NOT** associative. The ordering of operation matters for this operation. `A NOT B` is not the same thing as `B NOT A`.

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
