### PR TITLE
Retire travis from CI for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,35 +35,35 @@ stages:
 
 jobs:
   include:
-    - name: "Integration Tests - OracleJDK 8"
-      jdk: oraclejdk8
-      script:
-        - ./.travis/.travis_test.sh
-      env:
-        - RUN_INTEGRATION_TESTS=true
-    - name: "Unit Tests - OracleJDK 8"
-      jdk: oraclejdk8
-      script:
-        - ./.travis/.travis_test.sh
-      env:
-        - RUN_INTEGRATION_TESTS=false
-    - name: "QuickStart - Java 8 & OpenJDK 14-15"
-      jdk: oraclejdk8
-      script:
-        - ./.travis/.travis_quickstart.sh
-        - jdk_switcher use openjdk8
-        - ./.travis/.travis_install.sh
-        - ./.travis/.travis_quickstart.sh
-        - ./.travis/.travis_quickstart_openjdk.sh 14
-        - ./.travis/.travis_quickstart_openjdk.sh 15
-    - name: "QuickStart - OpenJDK 10-13"
-      jdk: openjdk10
-      script:
-        - java -version
-        - ./.travis/.travis_quickstart.sh
-        - ./.travis/.travis_quickstart_openjdk.sh 11
-        - ./.travis/.travis_quickstart_openjdk.sh 12
-        - ./.travis/.travis_quickstart_openjdk.sh 13
+#    - name: "Integration Tests - OracleJDK 8"
+#      jdk: oraclejdk8
+#      script:
+#        - ./.travis/.travis_test.sh
+#      env:
+#        - RUN_INTEGRATION_TESTS=true
+#    - name: "Unit Tests - OracleJDK 8"
+#      jdk: oraclejdk8
+#      script:
+#        - ./.travis/.travis_test.sh
+#      env:
+#        - RUN_INTEGRATION_TESTS=false
+#    - name: "QuickStart - Java 8 & OpenJDK 14-15"
+#      jdk: oraclejdk8
+#      script:
+#        - ./.travis/.travis_quickstart.sh
+#        - jdk_switcher use openjdk8
+#        - ./.travis/.travis_install.sh
+#        - ./.travis/.travis_quickstart.sh
+#        - ./.travis/.travis_quickstart_openjdk.sh 14
+#        - ./.travis/.travis_quickstart_openjdk.sh 15
+#    - name: "QuickStart - OpenJDK 10-13"
+#      jdk: openjdk10
+#      script:
+#        - java -version
+#        - ./.travis/.travis_quickstart.sh
+#        - ./.travis/.travis_quickstart_openjdk.sh 11
+#        - ./.travis/.travis_quickstart_openjdk.sh 12
+#        - ./.travis/.travis_quickstart_openjdk.sh 13
     - stage: deploy
       script:
         - travis_wait 40 ./.travis/.travis_nightly_build.sh


### PR DESCRIPTION
## Description
Based on recent dual CI phase running over Github Action and Travis, we found that Github Action is much faster and scalable than Travis. The turn around time for a PR to perform checks is about 40mins vs 1 hour+, and Travis will be even slower during rush hour. 

This PR will remove Travis from our CI pipeline for testing.

@jackjlli I still keep the deploy phase here.
