### PR TITLE
Move quickstart tests to use Java 14 release

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 1.8, 10, 11, 12, 13, 14-ea, 15-ea ]
+        java: [ 1.8, 10, 11, 12, 13, 14, 15-ea ]
     name: Pinot Quickstart on JDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Java 14 is patch 2 at this point, but we were using early access still.

## Upgrade Notes
N/A

## Release Notes
N/A

## Documentation
N/A