### PR TITLE
Adding controller healthcheck endpoint: /health

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -26,6 +26,8 @@ import org.apache.pinot.common.Utils;
  */
 public enum ControllerMeter implements AbstractMetrics.Meter {
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),
+  HEALTHCHECK_OK_CALLS("healthcheck", true),
+  HEALTHCHECK_BAD_CALLS("healthcheck", true),
   CONTROLLER_INSTANCE_POST_ERROR("InstancePostError", true),
   CONTROLLER_INSTANCE_DELETE_ERROR("InstanceDeleteError", true),
   CONTROLLER_SEGMENT_UPLOAD_ERROR("SegmentUploadError", true),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerHealthCheck.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerHealthCheck.java
@@ -43,6 +43,18 @@ public class PinotControllerHealthCheck {
   @ApiOperation(value = "Check controller health")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Good")})
   @Produces(MediaType.TEXT_PLAIN)
+  public String checkHealthLegacy() {
+    if (StringUtils.isNotBlank(controllerConf.generateVipUrl())) {
+      return "GOOD";
+    }
+    return "";
+  }
+
+  @GET
+  @Path("health")
+  @ApiOperation(value = "Check controller health")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Good")})
+  @Produces(MediaType.TEXT_PLAIN)
   public String checkHealth() {
     if (StringUtils.isNotBlank(controllerConf.generateVipUrl())) {
       return "GOOD";


### PR DESCRIPTION
## Description
Adding controller health check endpoint: /health to be on par with other pinot components.

Existing check: `/pinot-controller/admin` is still available without any change of the behavior.

## Release Notes
Adding controller health check endpoint: `/health`
