### PR TITLE
DataGenerator should tolerate DATE_TIME and COMPLEX fields

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
@@ -205,6 +205,11 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
           timeUnits.put(col, tfs.getIncomingGranularitySpec().getTimeType());
           break;
 
+        // forward compatibility with pattern generator
+        case DATE_TIME:
+        case COMPLEX:
+          break;
+
         default:
           throw new RuntimeException("Invalid field type.");
       }


### PR DESCRIPTION
## Description
Fixes a forward compatibility issue with DATE_TIME fields in the data generator

## Upgrade Notes
Does this PR prevent a zero down-time upgrade?
**no**

Does this PR fix a zero-downtime upgrade introduced earlier?
**no**

Does this PR otherwise need attention when creating release notes? Things to consider:
**no**

