### PR TITLE
[Post-aggregation] Support type conversion for all scalar functions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInfo.java
@@ -22,14 +22,13 @@ import java.lang.reflect.Method;
 
 
 public class FunctionInfo {
-
   private final Method _method;
   private final Class<?> _clazz;
 
   public FunctionInfo(Method method, Class<?> clazz) {
-    super();
-    this._method = method;
-    this._clazz = clazz;
+    method.setAccessible(true);
+    _method = method;
+    _clazz = clazz;
   }
 
   public Method getMethod() {
@@ -38,42 +37,5 @@ public class FunctionInfo {
 
   public Class<?> getClazz() {
     return _clazz;
-  }
-
-  /**
-   * Check if the Function is applicable to the argumentTypes.
-   * We can only know the types at runtime, so we can validate if the return type is Object.
-   * For e.g funcA( funcB('3.14'), columnA)
-   * We can only know return type of funcB and 3.14 (String.class) but
-   * we cannot know the type of columnA in advance without knowing the source schema
-   * @param argumentTypes
-   * @return
-   */
-  public boolean isApplicable(Class<?>[] argumentTypes) {
-
-    Class<?>[] parameterTypes = _method.getParameterTypes();
-
-    if (parameterTypes.length != argumentTypes.length) {
-      return false;
-    }
-
-    for (int i = 0; i < parameterTypes.length; i++) {
-      Class<?> type = parameterTypes[i];
-      //
-      if (!type.isAssignableFrom(argumentTypes[i]) && argumentTypes[i] != Object.class) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Eventually we will need to convert the input datatypes before invoking the actual method. For now, there is no conversion
-   *
-   * @param args
-   * @return
-   */
-  public Object[] convertTypes(Object[] args) {
-    return args;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.annotations.ScalarFunction;
 import org.reflections.Reflections;
 import org.reflections.scanners.MethodAnnotationsScanner;
@@ -104,6 +105,6 @@ public class FunctionRegistry {
   }
 
   private static String canonicalize(String functionName) {
-    return functionName.toLowerCase();
+    return StringUtils.remove(functionName, '_').toLowerCase();
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.PinotDataType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+public class FunctionUtils {
+  private FunctionUtils() {
+  }
+
+  // Types allowed as the function parameter (in the function signature) for type conversion
+  private static final Map<Class<?>, PinotDataType> PARAMETER_TYPE_MAP = new HashMap<Class<?>, PinotDataType>() {{
+    put(int.class, PinotDataType.INTEGER);
+    put(Integer.class, PinotDataType.INTEGER);
+    put(long.class, PinotDataType.LONG);
+    put(Long.class, PinotDataType.LONG);
+    put(float.class, PinotDataType.FLOAT);
+    put(Float.class, PinotDataType.FLOAT);
+    put(double.class, PinotDataType.DOUBLE);
+    put(Double.class, PinotDataType.DOUBLE);
+    put(String.class, PinotDataType.STRING);
+    put(byte[].class, PinotDataType.BYTES);
+  }};
+
+  // Types allowed as the function argument (actual value passed into the function) for type conversion
+  private static final Map<Class<?>, PinotDataType> ARGUMENT_TYPE_MAP = new HashMap<Class<?>, PinotDataType>() {{
+    put(Byte.class, PinotDataType.BYTE);
+    put(Boolean.class, PinotDataType.BOOLEAN);
+    put(Character.class, PinotDataType.CHARACTER);
+    put(Short.class, PinotDataType.SHORT);
+    put(Integer.class, PinotDataType.INTEGER);
+    put(Long.class, PinotDataType.LONG);
+    put(Float.class, PinotDataType.FLOAT);
+    put(Double.class, PinotDataType.DOUBLE);
+    put(String.class, PinotDataType.STRING);
+    put(byte[].class, PinotDataType.BYTES);
+  }};
+
+  private static final Map<Class<?>, DataType> DATA_TYPE_MAP = new HashMap<Class<?>, DataType>() {{
+    put(int.class, DataType.INT);
+    put(Integer.class, DataType.INT);
+    put(long.class, DataType.LONG);
+    put(Long.class, DataType.LONG);
+    put(float.class, DataType.FLOAT);
+    put(Float.class, DataType.FLOAT);
+    put(double.class, DataType.DOUBLE);
+    put(Double.class, DataType.DOUBLE);
+    put(String.class, DataType.STRING);
+    put(byte[].class, DataType.BYTES);
+  }};
+
+  private static final Map<Class<?>, ColumnDataType> COLUMN_DATA_TYPE_MAP = new HashMap<Class<?>, ColumnDataType>() {{
+    put(int.class, ColumnDataType.INT);
+    put(Integer.class, ColumnDataType.INT);
+    put(long.class, ColumnDataType.LONG);
+    put(Long.class, ColumnDataType.LONG);
+    put(float.class, ColumnDataType.FLOAT);
+    put(Float.class, ColumnDataType.FLOAT);
+    put(double.class, ColumnDataType.DOUBLE);
+    put(Double.class, ColumnDataType.DOUBLE);
+    put(String.class, ColumnDataType.STRING);
+    put(byte[].class, ColumnDataType.BYTES);
+  }};
+
+  /**
+   * Returns the corresponding PinotDataType for the given parameter class, or {@code null} if there is no one matching.
+   */
+  @Nullable
+  public static PinotDataType getParameterType(Class<?> clazz) {
+    return PARAMETER_TYPE_MAP.get(clazz);
+  }
+
+  /**
+   * Returns the corresponding PinotDataType for the given argument class, or {@code null} if there is no one matching.
+   */
+  @Nullable
+  public static PinotDataType getArgumentType(Class<?> clazz) {
+    return ARGUMENT_TYPE_MAP.get(clazz);
+  }
+
+  /**
+   * Returns the corresponding DataType for the given class, or {@code null} if there is no one matching.
+   */
+  @Nullable
+  public static DataType getDataType(Class<?> clazz) {
+    return DATA_TYPE_MAP.get(clazz);
+  }
+
+  /**
+   * Returns the corresponding ColumnDataType for the given class, or {@code null} if there is no one matching.
+   */
+  @Nullable
+  public static ColumnDataType getColumnDataType(Class<?> clazz) {
+    return COLUMN_DATA_TYPE_MAP.get(clazz);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/annotations/ScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/annotations/ScalarFunction.java
@@ -25,13 +25,26 @@ import java.lang.annotation.Target;
 
 
 /**
- * Annotation Class for Scalar Functions
- * Methods annotated using the interface are registered in the FunctionsRegistry
- * and can be used as UDFs during Querying
+ * Annotation Class for Scalar Functions.
+ *
+ * Methods annotated using the interface are registered in the FunctionsRegistry, and can be used for transform and
+ * filtering during record ingestion, and transform and post-aggregation during query execution.
+ *
+ * NOTE:
+ *   1. The annotated method must be under the package of name 'org.apache.pinot.*.function.*' to be auto-registered.
+ *   2. The following parameter types are supported for auto type conversion:
+ *     - int/Integer
+ *     - long/Long
+ *     - float/Float
+ *     - double/Double
+ *     - String
+ *     - byte[]
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface ScalarFunction {
-    boolean enabled() default true;
-    String name() default "";
+
+  boolean enabled() default true;
+
+  String name() default "";
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar;
+
+import org.apache.pinot.common.function.annotations.ScalarFunction;
+
+
+/**
+ * Arithmetic scalar functions.
+ */
+public class ArithmeticFunctions {
+  private ArithmeticFunctions() {
+  }
+
+  @ScalarFunction
+  public static double plus(double a, double b) {
+    return a + b;
+  }
+
+  @ScalarFunction
+  public static double minus(double a, double b) {
+    return a - b;
+  }
+
+  @ScalarFunction
+  public static double times(double a, double b) {
+    return a * b;
+  }
+
+  @ScalarFunction
+  public static double divide(double a, double b) {
+    return a / b;
+  }
+
+  @ScalarFunction
+  public static double mod(double a, double b) {
+    return a % b;
+  }
+
+  @ScalarFunction
+  public static double min(double a, double b) {
+    return Double.min(a, b);
+  }
+
+  @ScalarFunction
+  public static double max(double a, double b) {
+    return Double.max(a, b);
+  }
+
+  @ScalarFunction
+  public static double abs(double a) {
+    return Math.abs(a);
+  }
+
+  @ScalarFunction
+  public static double ceil(double a) {
+    return Math.ceil(a);
+  }
+
+  @ScalarFunction
+  public static double floor(double a) {
+    return Math.floor(a);
+  }
+
+  @ScalarFunction
+  public static double exp(double a) {
+    return Math.exp(a);
+  }
+
+  @ScalarFunction
+  public static double ln(double a) {
+    return Math.log(a);
+  }
+
+  @ScalarFunction
+  public static double sqrt(double a) {
+    return Math.sqrt(a);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.function;
+package org.apache.pinot.common.function.scalar;
 
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.function.DateTimePatternHandler;
 import org.apache.pinot.common.function.annotations.ScalarFunction;
-import org.joda.time.format.DateTimeFormat;
 
 
 /**
@@ -65,11 +65,14 @@ import org.joda.time.format.DateTimeFormat;
  *   </code>
  */
 public class DateTimeFunctions {
+  private DateTimeFunctions() {
+  }
+
   /**
    * Convert epoch millis to epoch seconds
    */
   @ScalarFunction
-  static Long toEpochSeconds(Long millis) {
+  public static long toEpochSeconds(long millis) {
     return TimeUnit.MILLISECONDS.toSeconds(millis);
   }
 
@@ -77,7 +80,7 @@ public class DateTimeFunctions {
    * Convert epoch millis to epoch minutes
    */
   @ScalarFunction
-  static Long toEpochMinutes(Long millis) {
+  public static long toEpochMinutes(long millis) {
     return TimeUnit.MILLISECONDS.toMinutes(millis);
   }
 
@@ -85,7 +88,7 @@ public class DateTimeFunctions {
    * Convert epoch millis to epoch hours
    */
   @ScalarFunction
-  static Long toEpochHours(Long millis) {
+  public static long toEpochHours(long millis) {
     return TimeUnit.MILLISECONDS.toHours(millis);
   }
 
@@ -93,7 +96,7 @@ public class DateTimeFunctions {
    * Convert epoch millis to epoch days
    */
   @ScalarFunction
-  static Long toEpochDays(Long millis) {
+  public static long toEpochDays(long millis) {
     return TimeUnit.MILLISECONDS.toDays(millis);
   }
 
@@ -101,71 +104,71 @@ public class DateTimeFunctions {
    * Convert epoch millis to epoch seconds, round to nearest rounding bucket
    */
   @ScalarFunction
-  static Long toEpochSecondsRounded(Long millis, Number roundToNearest) {
-    return (TimeUnit.MILLISECONDS.toSeconds(millis) / roundToNearest.intValue()) * roundToNearest.intValue();
+  public static long toEpochSecondsRounded(long millis, long roundToNearest) {
+    return (TimeUnit.MILLISECONDS.toSeconds(millis) / roundToNearest) * roundToNearest;
   }
 
   /**
    * Convert epoch millis to epoch minutes, round to nearest rounding bucket
    */
   @ScalarFunction
-  static Long toEpochMinutesRounded(Long millis, Number roundToNearest) {
-    return (TimeUnit.MILLISECONDS.toMinutes(millis) / roundToNearest.intValue()) * roundToNearest.intValue();
+  public static long toEpochMinutesRounded(long millis, long roundToNearest) {
+    return (TimeUnit.MILLISECONDS.toMinutes(millis) / roundToNearest) * roundToNearest;
   }
 
   /**
    * Convert epoch millis to epoch hours, round to nearest rounding bucket
    */
   @ScalarFunction
-  static Long toEpochHoursRounded(Long millis, Number roundToNearest) {
-    return (TimeUnit.MILLISECONDS.toHours(millis) / roundToNearest.intValue()) * roundToNearest.intValue();
+  public static long toEpochHoursRounded(long millis, long roundToNearest) {
+    return (TimeUnit.MILLISECONDS.toHours(millis) / roundToNearest) * roundToNearest;
   }
 
   /**
    * Convert epoch millis to epoch days, round to nearest rounding bucket
    */
   @ScalarFunction
-  static Long toEpochDaysRounded(Long millis, Number roundToNearest) {
-    return (TimeUnit.MILLISECONDS.toDays(millis) / roundToNearest.intValue()) * roundToNearest.intValue();
+  public static long toEpochDaysRounded(long millis, long roundToNearest) {
+    return (TimeUnit.MILLISECONDS.toDays(millis) / roundToNearest) * roundToNearest;
   }
 
   /**
    * Convert epoch millis to epoch seconds, divided by given bucket, to get nSecondsSinceEpoch
    */
   @ScalarFunction
-  static Long toEpochSecondsBucket(Long millis, Number bucket) {
-    return TimeUnit.MILLISECONDS.toSeconds(millis) / bucket.intValue();
+  public static long toEpochSecondsBucket(long millis, long bucket) {
+    return TimeUnit.MILLISECONDS.toSeconds(millis) / bucket;
   }
 
   /**
    * Convert epoch millis to epoch minutes, divided by given bucket, to get nMinutesSinceEpoch
    */
   @ScalarFunction
-  static Long toEpochMinutesBucket(Long millis, Number bucket) {
-    return TimeUnit.MILLISECONDS.toMinutes(millis) / bucket.intValue();
+  public static long toEpochMinutesBucket(long millis, long bucket) {
+    return TimeUnit.MILLISECONDS.toMinutes(millis) / bucket;
   }
 
   /**
    * Convert epoch millis to epoch hours, divided by given bucket, to get nHoursSinceEpoch
    */
   @ScalarFunction
-  static Long toEpochHoursBucket(Long millis, Number bucket) {
-    return TimeUnit.MILLISECONDS.toHours(millis) / bucket.intValue();
+  public static long toEpochHoursBucket(long millis, long bucket) {
+    return TimeUnit.MILLISECONDS.toHours(millis) / bucket;
   }
 
   /**
    * Convert epoch millis to epoch days, divided by given bucket, to get nDaysSinceEpoch
    */
   @ScalarFunction
-  static Long toEpochDaysBucket(Long millis, Number bucket) {
-    return TimeUnit.MILLISECONDS.toDays(millis) / bucket.intValue();
+  public static long toEpochDaysBucket(long millis, long bucket) {
+    return TimeUnit.MILLISECONDS.toDays(millis) / bucket;
   }
 
   /**
    * Converts epoch seconds to epoch millis
    */
   @ScalarFunction
-  static Long fromEpochSeconds(Long seconds) {
+  public static long fromEpochSeconds(long seconds) {
     return TimeUnit.SECONDS.toMillis(seconds);
   }
 
@@ -173,63 +176,63 @@ public class DateTimeFunctions {
    * Converts epoch minutes to epoch millis
    */
   @ScalarFunction
-  static Long fromEpochMinutes(Number minutes) {
-    return TimeUnit.MINUTES.toMillis(minutes.longValue());
+  public static long fromEpochMinutes(long minutes) {
+    return TimeUnit.MINUTES.toMillis(minutes);
   }
 
   /**
    * Converts epoch hours to epoch millis
    */
   @ScalarFunction
-  static Long fromEpochHours(Number hours) {
-    return TimeUnit.HOURS.toMillis(hours.longValue());
+  public static long fromEpochHours(long hours) {
+    return TimeUnit.HOURS.toMillis(hours);
   }
 
   /**
    * Converts epoch days to epoch millis
    */
   @ScalarFunction
-  static Long fromEpochDays(Number daysSinceEpoch) {
-    return TimeUnit.DAYS.toMillis(daysSinceEpoch.longValue());
+  public static long fromEpochDays(long days) {
+    return TimeUnit.DAYS.toMillis(days);
   }
 
   /**
    * Converts nSecondsSinceEpoch (seconds that have been divided by a bucket), to epoch millis
    */
   @ScalarFunction
-  static Long fromEpochSecondsBucket(Long seconds, Number bucket) {
-    return TimeUnit.SECONDS.toMillis(seconds * bucket.intValue());
+  public static long fromEpochSecondsBucket(long seconds, long bucket) {
+    return TimeUnit.SECONDS.toMillis(seconds * bucket);
   }
 
   /**
    * Converts nMinutesSinceEpoch (minutes that have been divided by a bucket), to epoch millis
    */
   @ScalarFunction
-  static Long fromEpochMinutesBucket(Number minutes, Number bucket) {
-    return TimeUnit.MINUTES.toMillis(minutes.longValue() * bucket.intValue());
+  public static long fromEpochMinutesBucket(long minutes, long bucket) {
+    return TimeUnit.MINUTES.toMillis(minutes * bucket);
   }
 
   /**
    * Converts nHoursSinceEpoch (hours that have been divided by a bucket), to epoch millis
    */
   @ScalarFunction
-  static Long fromEpochHoursBucket(Number hours, Number bucket) {
-    return TimeUnit.HOURS.toMillis(hours.longValue() * bucket.intValue());
+  public static long fromEpochHoursBucket(long hours, long bucket) {
+    return TimeUnit.HOURS.toMillis(hours * bucket);
   }
 
   /**
    * Converts nDaysSinceEpoch (days that have been divided by a bucket), to epoch millis
    */
   @ScalarFunction
-  static Long fromEpochDaysBucket(Number daysSinceEpoch, Number bucket) {
-    return TimeUnit.DAYS.toMillis(daysSinceEpoch.longValue() * bucket.intValue());
+  public static long fromEpochDaysBucket(long days, long bucket) {
+    return TimeUnit.DAYS.toMillis(days * bucket);
   }
 
   /**
    * Converts epoch millis to DateTime string represented by pattern
    */
   @ScalarFunction
-  static String toDateTime(Long millis, String pattern) {
+  public static String toDateTime(long millis, String pattern) {
     return DateTimePatternHandler.parseEpochMillisToDateTimeString(millis, pattern);
   }
 
@@ -237,26 +240,24 @@ public class DateTimeFunctions {
    * Converts DateTime string represented by pattern to epoch millis
    */
   @ScalarFunction
-  static Long fromDateTime(String dateTimeString, String pattern) {
+  public static long fromDateTime(String dateTimeString, String pattern) {
     return DateTimePatternHandler.parseDateTimeStringToEpochMillis(dateTimeString, pattern);
   }
-
 
   /**
    * Round the given time value to nearest multiple
    * @return the original value but rounded to the nearest multiple of @param roundToNearest
    */
   @ScalarFunction
-  static Long round(Long timeValue, Number roundToNearest) {
-    long roundingValue = roundToNearest.longValue();
-    return (timeValue / roundingValue) * roundingValue;
+  public static long round(long timeValue, long roundToNearest) {
+    return (timeValue / roundToNearest) * roundToNearest;
   }
 
   /**
    * Return current time as epoch millis
    */
   @ScalarFunction
-  static Long now() {
+  public static long now() {
     return System.currentTimeMillis();
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.function;
+package org.apache.pinot.common.function.scalar;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Map;
@@ -36,12 +36,14 @@ import org.apache.pinot.spi.utils.JsonUtils;
  *   </code>
  */
 public class JsonFunctions {
+  private JsonFunctions() {
+  }
 
   /**
    * Convert Map to Json String
    */
   @ScalarFunction
-  static String toJsonMapStr(Map map)
+  public static String toJsonMapStr(Map map)
       throws JsonProcessingException {
     return JsonUtils.objectToString(map);
   }
@@ -50,9 +52,8 @@ public class JsonFunctions {
    * Convert object to Json String
    */
   @ScalarFunction
-  static String json_format(Object object)
+  public static String jsonFormat(Object object)
       throws JsonProcessingException {
     return JsonUtils.objectToString(object);
   }
-
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.function;
-
+package org.apache.pinot.common.function.scalar;
 
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
@@ -33,6 +32,9 @@ import org.apache.pinot.common.function.annotations.ScalarFunction;
  * <code> SELECT UPPER(playerName) FROM baseballStats LIMIT 10 </code>
  */
 public class StringFunctions {
+  private StringFunctions() {
+  }
+
   private final static Pattern LTRIM = Pattern.compile("^\\s+");
   private final static Pattern RTRIM = Pattern.compile("\\s+$");
 
@@ -42,7 +44,7 @@ public class StringFunctions {
    * @return reversed input in from end to start
    */
   @ScalarFunction
-  static String reverse(String input) {
+  public static String reverse(String input) {
     return StringUtils.reverse(input);
   }
 
@@ -52,7 +54,7 @@ public class StringFunctions {
    * @return string in lower case format
    */
   @ScalarFunction
-  static String lower(String input) {
+  public static String lower(String input) {
     return input.toLowerCase();
   }
 
@@ -62,7 +64,7 @@ public class StringFunctions {
    * @return string in upper case format
    */
   @ScalarFunction
-  static String upper(String input) {
+  public static String upper(String input) {
     return input.toUpperCase();
   }
 
@@ -73,7 +75,7 @@ public class StringFunctions {
    * @return substring from beginIndex to end of the parent string
    */
   @ScalarFunction
-  static String substr(String input, Integer beginIndex) {
+  public static String substr(String input, int beginIndex) {
     return input.substring(beginIndex);
   }
 
@@ -88,7 +90,7 @@ public class StringFunctions {
    * @return substring from beginIndex to endIndex
    */
   @ScalarFunction
-  static String substr(String input, Integer beginIndex, Integer endIndex) {
+  public static String substr(String input, int beginIndex, int endIndex) {
     if (endIndex == -1) {
       return substr(input, beginIndex);
     }
@@ -103,7 +105,7 @@ public class StringFunctions {
    * @return The two input strings joined by the seperator
    */
   @ScalarFunction
-  static String concat(String input1, String input2, String seperator) {
+  public static String concat(String input1, String input2, String seperator) {
     String result = input1;
     result = result + seperator + input2;
     return result;
@@ -115,7 +117,7 @@ public class StringFunctions {
    * @return trim spaces from both ends of the string
    */
   @ScalarFunction
-  static String trim(String input) {
+  public static String trim(String input) {
     return input.trim();
   }
 
@@ -124,7 +126,7 @@ public class StringFunctions {
    * @return trim spaces from left side of the string
    */
   @ScalarFunction
-  static String ltrim(String input) {
+  public static String ltrim(String input) {
     return LTRIM.matcher(input).replaceAll("");
   }
 
@@ -133,7 +135,7 @@ public class StringFunctions {
    * @return trim spaces from right side of the string
    */
   @ScalarFunction
-  static String rtrim(String input) {
+  public static String rtrim(String input) {
     return RTRIM.matcher(input).replaceAll("");
   }
 
@@ -143,7 +145,7 @@ public class StringFunctions {
    * @return length of the string
    */
   @ScalarFunction
-  static Integer length(String input) {
+  public static int length(String input) {
     return input.length();
   }
 
@@ -156,7 +158,7 @@ public class StringFunctions {
    * @return start index of the Nth instance of subtring in main string
    */
   @ScalarFunction
-  static Integer strpos(String input, String find, Integer instance) {
+  public static int strpos(String input, String find, int instance) {
     return StringUtils.ordinalIndexOf(input, find, instance);
   }
 
@@ -167,7 +169,7 @@ public class StringFunctions {
    * @return true if string starts with prefix, false o.w.
    */
   @ScalarFunction
-  static Boolean startsWith(String input, String prefix) {
+  public static boolean startsWith(String input, String prefix) {
     return input.startsWith(prefix);
   }
 
@@ -178,7 +180,7 @@ public class StringFunctions {
    * @param substitute new substring to be replaced with target
    */
   @ScalarFunction
-  static String replace(String input, String find, String substitute) {
+  public static String replace(String input, String find, String substitute) {
     return input.replaceAll(find, substitute);
   }
 
@@ -190,7 +192,7 @@ public class StringFunctions {
    * @return string padded from the right side with pad to reach final size
    */
   @ScalarFunction
-  static String rpad(String input, Integer size, String pad) {
+  public static String rpad(String input, int size, String pad) {
     return StringUtils.rightPad(input, size, pad);
   }
 
@@ -202,7 +204,7 @@ public class StringFunctions {
    * @return string padded from the left side with pad to reach final size
    */
   @ScalarFunction
-  static String lpad(String input, Integer size, String pad) {
+  public static String lpad(String input, int size, String pad) {
     return StringUtils.leftPad(input, size, pad);
   }
 
@@ -212,7 +214,7 @@ public class StringFunctions {
    * @return the Unicode codepoint of the first character of the string
    */
   @ScalarFunction
-  static Integer codepoint(String input) {
+  public static int codepoint(String input) {
     return input.codePointAt(0);
   }
 
@@ -222,7 +224,7 @@ public class StringFunctions {
    * @return the character corresponding to the Unicode codepoint
    */
   @ScalarFunction
-  static String chr(Integer codepoint) {
+  public static String chr(int codepoint) {
     char[] result = Character.toChars(codepoint);
     return new String(result);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.data.recordtransformer;
+package org.apache.pinot.common.utils;
 
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
 
@@ -630,6 +631,35 @@ public enum PinotDataType {
       default:
         throw new UnsupportedOperationException(
             "Unsupported data type: " + dataType + " in field: " + fieldSpec.getName());
+    }
+  }
+
+  public static PinotDataType getPinotDataType(ColumnDataType columnDataType) {
+    switch (columnDataType) {
+      case INT:
+        return INTEGER;
+      case LONG:
+        return LONG;
+      case FLOAT:
+        return FLOAT;
+      case DOUBLE:
+        return DOUBLE;
+      case STRING:
+        return STRING;
+      case BYTES:
+        return BYTES;
+      case INT_ARRAY:
+        return INTEGER_ARRAY;
+      case LONG_ARRAY:
+        return LONG_ARRAY;
+      case FLOAT_ARRAY:
+        return FLOAT_ARRAY;
+      case DOUBLE_ARRAY:
+        return DOUBLE_ARRAY;
+      case STRING_ARRAY:
+        return STRING_ARRAY;
+      default:
+        throw new IllegalStateException("Cannot convert ColumnDataType: " + columnDataType + " to PinotDataType");
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -849,7 +849,8 @@ public class CalciteSqlParser {
         }
         try {
           FunctionInvoker invoker = new FunctionInvoker(functionInfo);
-          Object result = invoker.process(arguments);
+          invoker.convertTypes(arguments);
+          Object result = invoker.invoke(arguments);
           return RequestUtils.getLiteralExpression(result);
         } catch (Exception e) {
           throw new SqlCompilationException(new IllegalArgumentException("Unsupported function - " + funcName, e));

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.data.recordtransformer;
+package org.apache.pinot.common.utils;
 
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.core.data.recordtransformer.PinotDataType.*;
+import static org.apache.pinot.common.utils.PinotDataType.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/function/FunctionEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/function/FunctionEvaluatorFactory.java
@@ -87,18 +87,11 @@ public class FunctionEvaluatorFactory {
   }
 
   public static FunctionEvaluator getExpressionEvaluator(String transformExpression) {
-    FunctionEvaluator functionEvaluator;
-    try {
-      if (transformExpression.startsWith(GroovyFunctionEvaluator.getGroovyExpressionPrefix())) {
-        functionEvaluator = new GroovyFunctionEvaluator(transformExpression);
-      } else {
-        functionEvaluator = new InbuiltFunctionEvaluator(transformExpression);
-      }
-    } catch (Exception e) {
-      throw new IllegalStateException(
-          "Could not construct FunctionEvaluator for transformFunction: " + transformExpression, e);
+    if (transformExpression.startsWith(GroovyFunctionEvaluator.getGroovyExpressionPrefix())) {
+      return new GroovyFunctionEvaluator(transformExpression);
+    } else {
+      return new InbuiltFunctionEvaluator(transformExpression);
     }
-    return functionEvaluator;
   }
 
   private static String getDefaultMapKeysTransformExpression(String mapColumnName) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.PinotDataType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -27,15 +27,15 @@ import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.core.common.DataSource;
-import org.apache.pinot.core.geospatial.transform.function.StContainsFunction;
-import org.apache.pinot.core.geospatial.transform.function.StDistanceFunction;
 import org.apache.pinot.core.geospatial.transform.function.StAreaFunction;
 import org.apache.pinot.core.geospatial.transform.function.StAsBinaryFunction;
+import org.apache.pinot.core.geospatial.transform.function.StAsTextFunction;
+import org.apache.pinot.core.geospatial.transform.function.StContainsFunction;
+import org.apache.pinot.core.geospatial.transform.function.StDistanceFunction;
 import org.apache.pinot.core.geospatial.transform.function.StEqualsFunction;
 import org.apache.pinot.core.geospatial.transform.function.StGeogFromTextFunction;
 import org.apache.pinot.core.geospatial.transform.function.StGeogFromWKBFunction;
 import org.apache.pinot.core.geospatial.transform.function.StGeomFromTextFunction;
-import org.apache.pinot.core.geospatial.transform.function.StAsTextFunction;
 import org.apache.pinot.core.geospatial.transform.function.StGeomFromWKBFunction;
 import org.apache.pinot.core.geospatial.transform.function.StGeometryTypeFunction;
 import org.apache.pinot.core.geospatial.transform.function.StPointFunction;
@@ -176,12 +176,7 @@ public class TransformFunctionFactory {
           if (functionInfo == null) {
             throw new BadQueryRequestException("Unsupported transform function: " + functionName);
           }
-          try {
-            transformFunction = new ScalarTransformFunctionWrapper(functionName, functionInfo);
-          } catch (Exception e) {
-            throw new RuntimeException("Caught exception while constructing scalar transform function: " + functionName,
-                e);
-          }
+          transformFunction = new ScalarTransformFunctionWrapper(functionInfo);
         }
         List<ExpressionContext> arguments = function.getArguments();
         List<TransformFunction> transformFunctionArguments = new ArrayList<>(arguments.size());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.postaggregation;
+
+import com.google.common.base.Preconditions;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.FunctionInvoker;
+import org.apache.pinot.common.function.FunctionRegistry;
+import org.apache.pinot.common.function.FunctionUtils;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.PinotDataType;
+
+
+/**
+ * Post-aggregation function on the annotated scalar function.
+ */
+public class PostAggregationFunction {
+  private final FunctionInvoker _functionInvoker;
+  private final PinotDataType[] _argumentTypes;
+  private final ColumnDataType _resultType;
+
+  public PostAggregationFunction(String functionName, ColumnDataType[] argumentTypes) {
+    FunctionInfo functionInfo = FunctionRegistry.getFunctionByName(functionName);
+    Preconditions.checkArgument(functionInfo != null, "Unsupported function: %s", functionName);
+    _functionInvoker = new FunctionInvoker(functionInfo);
+    PinotDataType[] parameterTypes = _functionInvoker.getParameterTypes();
+    int numArguments = argumentTypes.length;
+    Preconditions.checkArgument(numArguments == parameterTypes.length,
+        "Wrong number of arguments for method: %s, expected: %s, actual: %s", functionInfo.getMethod(),
+        parameterTypes.length, numArguments);
+    _argumentTypes = new PinotDataType[numArguments];
+    for (int i = 0; i < numArguments; i++) {
+      _argumentTypes[i] = PinotDataType.getPinotDataType(argumentTypes[i]);
+    }
+    ColumnDataType resultType = FunctionUtils.getColumnDataType(_functionInvoker.getResultClass());
+    // Handle unrecognized result class with STRING
+    _resultType = resultType != null ? resultType : ColumnDataType.STRING;
+  }
+
+  /**
+   * Returns the ColumnDataType of the result.
+   */
+  public ColumnDataType getResultType() {
+    return _resultType;
+  }
+
+  /**
+   * Invoke the function with the given arguments.
+   * NOTE: The passed in arguments could be modified during the type conversion.
+   */
+  public Object invoke(Object[] arguments) {
+    int numArguments = arguments.length;
+    PinotDataType[] parameterTypes = _functionInvoker.getParameterTypes();
+    for (int i = 0; i < numArguments; i++) {
+      PinotDataType parameterType = parameterTypes[i];
+      PinotDataType argumentType = _argumentTypes[i];
+      if (parameterType != argumentType) {
+        arguments[i] = parameterType.convert(arguments[i], argumentType);
+      }
+    }
+    Object result = _functionInvoker.invoke(arguments);
+    return _resultType == ColumnDataType.STRING ? result.toString() : result;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
@@ -35,41 +35,45 @@ import org.testng.annotations.Test;
  */
 public class InbuiltFunctionsTest {
 
-  @Test(dataProvider = "dateTimeFunctionsTestDataProvider")
-  public void testDateTimeTransformFunctions(String transformFunction, List<String> arguments, GenericRow row,
-      Object result)
-      throws Exception {
-    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(transformFunction);
-    Assert.assertEquals(evaluator.getArguments(), arguments);
-    Assert.assertEquals(evaluator.evaluate(row), result);
+  private void testFunction(String functionExpression, List<String> expectedArguments, GenericRow row,
+      Object expectedResult) {
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression);
+    Assert.assertEquals(evaluator.getArguments(), expectedArguments);
+    Assert.assertEquals(evaluator.evaluate(row), expectedResult);
   }
 
-  @DataProvider(name = "dateTimeFunctionsTestDataProvider")
+  @Test(dataProvider = "dateTimeFunctionsDataProvider")
+  public void testDateTimeFunctions(String functionExpression, List<String> expectedArguments, GenericRow row,
+      Object expectedResult) {
+    testFunction(functionExpression, expectedArguments, row, expectedResult);
+  }
+
+  @DataProvider(name = "dateTimeFunctionsDataProvider")
   public Object[][] dateTimeFunctionsDataProvider() {
     List<Object[]> inputs = new ArrayList<>();
+
     // round epoch millis to nearest 15 minutes
     GenericRow row0_0 = new GenericRow();
     row0_0.putValue("timestamp", 1578685189000L);
     // round to 15 minutes, but keep in milliseconds: Fri Jan 10 2020 19:39:49 becomes Fri Jan 10 2020 19:30:00
-    inputs.add(new Object[]{"round(timestamp, 900000)", Lists.newArrayList(
-        "timestamp"), row0_0, 1578684600000L});
+    inputs.add(new Object[]{"round(timestamp, 900000)", Lists.newArrayList("timestamp"), row0_0, 1578684600000L});
 
-    // toEpochSeconds
+    // toEpochSeconds (with type conversion)
     GenericRow row1_0 = new GenericRow();
-    row1_0.putValue("timestamp", 1578685189000L);
+    row1_0.putValue("timestamp", 1578685189000.0);
     inputs.add(new Object[]{"toEpochSeconds(timestamp)", Lists.newArrayList("timestamp"), row1_0, 1578685189L});
 
-    // toEpochSeconds w/ rounding
+    // toEpochSeconds w/ rounding (with type conversion)
     GenericRow row1_1 = new GenericRow();
-    row1_1.putValue("timestamp", 1578685189000L);
+    row1_1.putValue("timestamp", "1578685189000");
     inputs.add(
         new Object[]{"toEpochSecondsRounded(timestamp, 10)", Lists.newArrayList("timestamp"), row1_1, 1578685180L});
 
-    // toEpochSeconds w/ bucketing
+    // toEpochSeconds w/ bucketing (with underscore in function name)
     GenericRow row1_2 = new GenericRow();
     row1_2.putValue("timestamp", 1578685189000L);
-    inputs
-        .add(new Object[]{"toEpochSecondsBucket(timestamp, 10)", Lists.newArrayList("timestamp"), row1_2, 157868518L});
+    inputs.add(
+        new Object[]{"to_epoch_seconds_bucket(timestamp, 10)", Lists.newArrayList("timestamp"), row1_2, 157868518L});
 
     // toEpochMinutes
     GenericRow row2_0 = new GenericRow();
@@ -215,15 +219,13 @@ public class InbuiltFunctionsTest {
     return inputs.toArray(new Object[0][]);
   }
 
-  @Test(dataProvider = "jsonFunctionDataProvider")
-  public void testJsonFunctions(String transformFunction, List<String> arguments, GenericRow row, Object result)
-      throws Exception {
-    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(transformFunction);
-    Assert.assertEquals(evaluator.getArguments(), arguments);
-    Assert.assertEquals(evaluator.evaluate(row), result);
+  @Test(dataProvider = "jsonFunctionsDataProvider")
+  public void testJsonFunctions(String functionExpression, List<String> expectedArguments, GenericRow row,
+      Object expectedResult) {
+    testFunction(functionExpression, expectedArguments, row, expectedResult);
   }
 
-  @DataProvider(name = "jsonFunctionDataProvider")
+  @DataProvider(name = "jsonFunctionsDataProvider")
   public Object[][] jsonFunctionsDataProvider()
       throws IOException {
     List<Object[]> inputs = new ArrayList<>();
@@ -259,6 +261,39 @@ public class InbuiltFunctionsTest {
         "[{\"one\":1,\"two\":{\"sub1\":1.1,\"sub2\":1.2},\"three\":[\"a\",\"b\"]},{\"one\":11,\"two\":{\"sub1\":11.1,\"sub2\":11.2},\"three\":[\"aa\",\"bb\"]}]";
     row5.putValue("jsonMap", JsonUtils.stringToObject(jsonStr, List.class));
     inputs.add(new Object[]{"json_format(jsonMap)", Lists.newArrayList("jsonMap"), row5, jsonStr});
+
+    return inputs.toArray(new Object[0][]);
+  }
+
+  @Test(dataProvider = "arithmeticFunctionsDataProvider")
+  public void testArithmeticFunctions(String functionExpression, List<String> expectedArguments, GenericRow row,
+      Object expectedResult) {
+    testFunction(functionExpression, expectedArguments, row, expectedResult);
+  }
+
+  @DataProvider(name = "arithmeticFunctionsDataProvider")
+  public Object[][] arithmeticFunctionsDataProvider() {
+    List<Object[]> inputs = new ArrayList<>();
+
+    GenericRow row0 = new GenericRow();
+    row0.putValue("a", (byte) 1);
+    row0.putValue("b", (char) 2);
+    inputs.add(new Object[]{"plus(a, b)", Lists.newArrayList("a", "b"), row0, 3.0});
+
+    GenericRow row1 = new GenericRow();
+    row1.putValue("a", (short) 3);
+    row1.putValue("b", 4);
+    inputs.add(new Object[]{"minus(a, b)", Lists.newArrayList("a", "b"), row1, -1.0});
+
+    GenericRow row2 = new GenericRow();
+    row2.putValue("a", 5L);
+    row2.putValue("b", 6f);
+    inputs.add(new Object[]{"times(a, b)", Lists.newArrayList("a", "b"), row2, 30.0});
+
+    GenericRow row3 = new GenericRow();
+    row3.putValue("a", 7.0);
+    row3.putValue("b", "8");
+    inputs.add(new Object[]{"divide(a, b)", Lists.newArrayList("a", "b"), row3, 0.875});
 
     return inputs.toArray(new Object[0][]);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -44,7 +44,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringUpperTransformFunction() {
     ExpressionContext expression =
-        QueryContextConverterUtils.getExpression(String.format("upper(%s)", STRING_ALPHANUM_SV_COLUMN));
+        QueryContextConverterUtils.getExpression(String.format("UPPER(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "upper");
@@ -58,7 +58,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringReverseTransformFunction() {
     ExpressionContext expression =
-        QueryContextConverterUtils.getExpression(String.format("reverse(%s)", STRING_ALPHANUM_SV_COLUMN));
+        QueryContextConverterUtils.getExpression(String.format("rEvErSe(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "reverse");
@@ -72,7 +72,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringSubStrTransformFunction() {
     ExpressionContext expression =
-        QueryContextConverterUtils.getExpression(String.format("substr(%s, 0, 2)", STRING_ALPHANUM_SV_COLUMN));
+        QueryContextConverterUtils.getExpression(String.format("sub_str(%s, 0, 2)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "substr");
@@ -83,7 +83,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        QueryContextConverterUtils.getExpression(String.format("substr(%s, 2, -1)", STRING_ALPHANUM_SV_COLUMN));
+        QueryContextConverterUtils.getExpression(String.format("substr(%s, '2', '-1')", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "substr");

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.postaggregation;
+
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.geospatial.GeometryUtils;
+import org.apache.pinot.core.geospatial.serde.GeometrySerializer;
+import org.locationtech.jts.geom.Coordinate;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class PostAggregationFunctionTest {
+
+  @Test
+  public void testPostAggregationFunction() {
+    // Plus
+    PostAggregationFunction function =
+        new PostAggregationFunction("plus", new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.LONG});
+    assertEquals(function.getResultType(), ColumnDataType.DOUBLE);
+    assertEquals(function.invoke(new Object[]{1, 2L}), 3.0);
+
+    // Minus
+    function = new PostAggregationFunction("MINUS", new ColumnDataType[]{ColumnDataType.FLOAT, ColumnDataType.DOUBLE});
+    assertEquals(function.getResultType(), ColumnDataType.DOUBLE);
+    assertEquals(function.invoke(new Object[]{3f, 4.0}), -1.0);
+
+    // Times
+    function = new PostAggregationFunction("tImEs", new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT});
+    assertEquals(function.getResultType(), ColumnDataType.DOUBLE);
+    assertEquals(function.invoke(new Object[]{"5", 6}), 30.0);
+
+    // Reverse
+    function = new PostAggregationFunction("reverse", new ColumnDataType[]{ColumnDataType.LONG});
+    assertEquals(function.getResultType(), ColumnDataType.STRING);
+    assertEquals(function.invoke(new Object[]{"1234567890"}), "0987654321");
+
+    // ST_AsText
+    function = new PostAggregationFunction("ST_AsText", new ColumnDataType[]{ColumnDataType.BYTES});
+    assertEquals(function.getResultType(), ColumnDataType.STRING);
+    assertEquals(function.invoke(
+        new Object[]{GeometrySerializer.serialize(GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(10, 20)))}),
+        "POINT (10 20)");
+  }
+}


### PR DESCRIPTION
## Description
Support type conversion for all scalar functions.
Parameter classes supported for type conversion using `PinotDataType`:
- int/Integer
- long/Long
- float/Float
- double/Double
- String
- byte[]

Also handle function name with underscore in `FunctionRegistry`.

Support type conversion for all features using the scalar function:
- Compile time function in `CalciteSqlParser`
- Record transform/filter during ingestion in `InbuiltFunctionEvaluator`
- Transform during query execution in `ScalarTransformFunctionWrapper`

Add `PostAggregationFunction` to handle post-aggregation calculation using the scalar function.
Add `ArithmeticFunctions` for all the arithmetic scalar functions:
- plus
- minus
- times
- divide
- mod
- min
- max
- abs
- ceil
- floor
- exp
- ln
- sqrt