### PR TITLE
Add Range Indexing support for raw values

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
@@ -24,12 +24,11 @@ import org.apache.pinot.core.operator.dociditerators.ScanBasedDocIdIterator;
 import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
 import org.apache.pinot.core.operator.docidsets.FilterBlockDocIdSet;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
-import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory;
-import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.OfflineDictionaryBasedRangePredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.DoubleRawValueBasedRangePredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.FloatRawValueBasedRangePredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.IntRawValueBasedRangePredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.LongRawValueBasedRangePredicateEvaluator;
-import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.FloatRawValueBasedRangePredicateEvaluator;
-import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.DoubleRawValueBasedRangePredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.OfflineDictionaryBasedRangePredicateEvaluator;
 import org.apache.pinot.core.segment.index.readers.RangeIndexReader;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
@@ -44,8 +43,7 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
   private final DataSource _dataSource;
   private final int _numDocs;
 
-  public RangeIndexBasedFilterOperator(PredicateEvaluator rangePredicateEvaluator,
-      DataSource dataSource, int numDocs) {
+  public RangeIndexBasedFilterOperator(PredicateEvaluator rangePredicateEvaluator, DataSource dataSource, int numDocs) {
     _rangePredicateEvaluator = rangePredicateEvaluator;
     _dataSource = dataSource;
     _numDocs = numDocs;
@@ -59,34 +57,39 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
     int firstRangeId;
     int lastRangeId;
     if (_rangePredicateEvaluator instanceof OfflineDictionaryBasedRangePredicateEvaluator) {
-      firstRangeId = rangeIndexReader.findRangeId(((OfflineDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getStartDictId());
+      firstRangeId = rangeIndexReader
+          .findRangeId(((OfflineDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getStartDictId());
       // NOTE: End dictionary id is exclusive in OfflineDictionaryBasedRangePredicateEvaluator.
-      lastRangeId = rangeIndexReader.findRangeId(((OfflineDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getEndDictId() - 1);
+      lastRangeId = rangeIndexReader
+          .findRangeId(((OfflineDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getEndDictId() - 1);
     } else {
       switch (_rangePredicateEvaluator.getDataType()) {
-        case INT: {
-          firstRangeId = rangeIndexReader.findRangeId(((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
-          lastRangeId = rangeIndexReader.findRangeId(((RangePredicateEvaluatorFactory.IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+        case INT:
+          firstRangeId = rangeIndexReader
+              .findRangeId(((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
+          lastRangeId = rangeIndexReader
+              .findRangeId(((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
           break;
-        }
-        case LONG: {
-          firstRangeId = rangeIndexReader.findRangeId(((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
-          lastRangeId = rangeIndexReader.findRangeId(((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+        case LONG:
+          firstRangeId = rangeIndexReader
+              .findRangeId(((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
+          lastRangeId = rangeIndexReader
+              .findRangeId(((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
           break;
-        }
-        case FLOAT: {
-          firstRangeId = rangeIndexReader.findRangeId(((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
-          lastRangeId = rangeIndexReader.findRangeId(((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+        case FLOAT:
+          firstRangeId = rangeIndexReader
+              .findRangeId(((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
+          lastRangeId = rangeIndexReader
+              .findRangeId(((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
           break;
-        }
-        case DOUBLE: {
-          firstRangeId = rangeIndexReader.findRangeId(((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
-          lastRangeId = rangeIndexReader.findRangeId(((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+        case DOUBLE:
+          firstRangeId = rangeIndexReader
+              .findRangeId(((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
+          lastRangeId = rangeIndexReader
+              .findRangeId(((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
           break;
-        }
-        default: {
+        default:
           throw new IllegalStateException("String and Bytes data type not supported for Range Indexing");
-        }
       }
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
@@ -23,7 +23,13 @@ import org.apache.pinot.core.operator.blocks.FilterBlock;
 import org.apache.pinot.core.operator.dociditerators.ScanBasedDocIdIterator;
 import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
 import org.apache.pinot.core.operator.docidsets.FilterBlockDocIdSet;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory;
 import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.OfflineDictionaryBasedRangePredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.IntRawValueBasedRangePredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.LongRawValueBasedRangePredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.FloatRawValueBasedRangePredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.DoubleRawValueBasedRangePredicateEvaluator;
 import org.apache.pinot.core.segment.index.readers.RangeIndexReader;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
@@ -34,11 +40,11 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
 
   // NOTE: Range index can only apply to dictionary-encoded columns for now
   // TODO: Support raw index columns
-  private final OfflineDictionaryBasedRangePredicateEvaluator _rangePredicateEvaluator;
+  private final PredicateEvaluator _rangePredicateEvaluator;
   private final DataSource _dataSource;
   private final int _numDocs;
 
-  public RangeIndexBasedFilterOperator(OfflineDictionaryBasedRangePredicateEvaluator rangePredicateEvaluator,
+  public RangeIndexBasedFilterOperator(PredicateEvaluator rangePredicateEvaluator,
       DataSource dataSource, int numDocs) {
     _rangePredicateEvaluator = rangePredicateEvaluator;
     _dataSource = dataSource;
@@ -49,9 +55,40 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
   protected FilterBlock getNextBlock() {
     RangeIndexReader rangeIndexReader = (RangeIndexReader) _dataSource.getRangeIndex();
     assert rangeIndexReader != null;
-    int firstRangeId = rangeIndexReader.findRangeId(_rangePredicateEvaluator.getStartDictId());
-    // NOTE: End dictionary id is exclusive in OfflineDictionaryBasedRangePredicateEvaluator.
-    int lastRangeId = rangeIndexReader.findRangeId(_rangePredicateEvaluator.getEndDictId() - 1);
+
+    int firstRangeId;
+    int lastRangeId;
+    if (_rangePredicateEvaluator instanceof OfflineDictionaryBasedRangePredicateEvaluator) {
+      firstRangeId = rangeIndexReader.findRangeId(((OfflineDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getStartDictId());
+      // NOTE: End dictionary id is exclusive in OfflineDictionaryBasedRangePredicateEvaluator.
+      lastRangeId = rangeIndexReader.findRangeId(((OfflineDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getEndDictId() - 1);
+    } else {
+      switch (_rangePredicateEvaluator.getDataType()) {
+        case INT: {
+          firstRangeId = rangeIndexReader.findRangeId(((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
+          lastRangeId = rangeIndexReader.findRangeId(((RangePredicateEvaluatorFactory.IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          break;
+        }
+        case LONG: {
+          firstRangeId = rangeIndexReader.findRangeId(((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
+          lastRangeId = rangeIndexReader.findRangeId(((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          break;
+        }
+        case FLOAT: {
+          firstRangeId = rangeIndexReader.findRangeId(((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
+          lastRangeId = rangeIndexReader.findRangeId(((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          break;
+        }
+        case DOUBLE: {
+          firstRangeId = rangeIndexReader.findRangeId(((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
+          lastRangeId = rangeIndexReader.findRangeId(((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          break;
+        }
+        default: {
+          throw new IllegalStateException("String and Bytes data type not supported for Range Indexing");
+        }
+      }
+    }
 
     // Need to scan the first and last range as they might be partially matched
     // TODO: Detect fully matched first and last range

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -262,7 +262,7 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  private static final class IntRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  public static final class IntRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final int _lowerBound;
     final int _upperBound;
     final boolean _lowerInclusive;
@@ -278,6 +278,14 @@ public class RangePredicateEvaluatorFactory {
       _upperBound = upperUnbounded ? Integer.MAX_VALUE : Integer.parseInt(upperBound);
       _lowerInclusive = lowerUnbounded || rangePredicate.isLowerInclusive();
       _upperInclusive = upperUnbounded || rangePredicate.isUpperInclusive();
+    }
+
+    public int geLowerBound() {
+      return _lowerBound;
+    }
+
+    public int getUpperBound() {
+      return _upperBound;
     }
 
     @Override
@@ -307,7 +315,7 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  private static final class LongRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  public static final class LongRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final long _lowerBound;
     final long _upperBound;
     final boolean _lowerInclusive;
@@ -323,6 +331,14 @@ public class RangePredicateEvaluatorFactory {
       _upperBound = upperUnbounded ? Long.MAX_VALUE : Long.parseLong(upperBound);
       _lowerInclusive = lowerUnbounded || rangePredicate.isLowerInclusive();
       _upperInclusive = upperUnbounded || rangePredicate.isUpperInclusive();
+    }
+
+    public long geLowerBound() {
+      return _lowerBound;
+    }
+
+    public long getUpperBound() {
+      return _upperBound;
     }
 
     @Override
@@ -352,7 +368,7 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  private static final class FloatRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  public static final class FloatRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final float _lowerBound;
     final float _upperBound;
     final boolean _lowerInclusive;
@@ -368,6 +384,14 @@ public class RangePredicateEvaluatorFactory {
       _upperBound = upperUnbounded ? Float.POSITIVE_INFINITY : Float.parseFloat(upperBound);
       _lowerInclusive = lowerUnbounded || rangePredicate.isLowerInclusive();
       _upperInclusive = upperUnbounded || rangePredicate.isUpperInclusive();
+    }
+
+    public float geLowerBound() {
+      return _lowerBound;
+    }
+
+    public float getUpperBound() {
+      return _upperBound;
     }
 
     @Override
@@ -397,7 +421,7 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  private static final class DoubleRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  public static final class DoubleRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final double _lowerBound;
     final double _upperBound;
     final boolean _lowerInclusive;
@@ -413,6 +437,14 @@ public class RangePredicateEvaluatorFactory {
       _upperBound = upperUnbounded ? Double.POSITIVE_INFINITY : Double.parseDouble(upperBound);
       _lowerInclusive = lowerUnbounded || rangePredicate.isLowerInclusive();
       _upperInclusive = upperUnbounded || rangePredicate.isUpperInclusive();
+    }
+
+    public double geLowerBound() {
+      return _lowerBound;
+    }
+
+    public double getUpperBound() {
+      return _upperBound;
     }
 
     @Override
@@ -442,7 +474,7 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  private static final class StringRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  public static final class StringRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final String _lowerBound;
     final String _upperBound;
     final boolean _lowerInclusive;
@@ -488,7 +520,7 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  private static final class BytesRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  public static final class BytesRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final byte[] _lowerBound;
     final byte[] _upperBound;
     final boolean _lowerInclusive;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -474,7 +474,7 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  public static final class StringRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class StringRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final String _lowerBound;
     final String _upperBound;
     final boolean _lowerInclusive;
@@ -520,7 +520,7 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  public static final class BytesRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class BytesRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final byte[] _lowerBound;
     final byte[] _upperBound;
     final boolean _lowerInclusive;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
@@ -42,7 +42,7 @@ import java.io.IOException;
  *
  * <p>To create an inverted index:
  * <ul>
- *   <li>
+ *   <li>R
  *     Construct an instance of <code>InvertedIndexCreator</code>
  *   </li>
  *   <li>

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.segment.creator;
 
-import java.io.Closeable;
 import java.io.IOException;
 
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
@@ -56,7 +56,7 @@ import java.io.IOException;
  *
  * Support for Lucene based inverted index for text
  */
-public interface InvertedIndexCreator extends Closeable {
+public interface DictionaryBasedInvertedIndexCreator extends Closeable {
 
   /**
    * For single-valued column, adds the dictionary Id for the next document.

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
@@ -56,7 +56,7 @@ import java.io.IOException;
  *
  * Support for Lucene based inverted index for text
  */
-public interface DictionaryBasedInvertedIndexCreator extends Closeable {
+public interface DictionaryBasedInvertedIndexCreator extends InvertedIndexCreator {
 
   /**
    * For single-valued column, adds the dictionary Id for the next document.

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/DictionaryBasedInvertedIndexCreator.java
@@ -18,9 +18,6 @@
  */
 package org.apache.pinot.core.segment.creator;
 
-import java.io.IOException;
-
-
 /**
  * Support for RoaringBitmap inverted index:
  * <pre>
@@ -58,27 +55,17 @@ import java.io.IOException;
 public interface DictionaryBasedInvertedIndexCreator extends InvertedIndexCreator {
 
   /**
-   * For single-valued column, adds the dictionary Id for the next document.
+   * For single-value column, adds the dictionary id for the next document.
    */
   void add(int dictId);
 
   /**
-   * For multi-valued column, adds the dictionary Ids for the next document.
+   * For multi-value column, adds the dictionary ids for the next document.
    */
   void add(int[] dictIds, int length);
 
   /**
-   * Seals the index and flushes it to disk.
-   */
-  void seal()
-      throws IOException;
-
-  /**
-   * Add a row (represented by an object) with a given docId
-   * @param document document/object to add
-   * @param docId object's docId
-   *
-   * Currently this is
+   * For text column, adds the document of the given document id.
    */
   void addDoc(Object document, int docId);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/InvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/InvertedIndexCreator.java
@@ -19,11 +19,17 @@
 package org.apache.pinot.core.segment.creator;
 
 import java.io.Closeable;
+import java.io.IOException;
 
 
 /**
- * Marker interface for all inverted index creators
+ * Marker interface for all inverted index creators.
  */
 public interface InvertedIndexCreator extends Closeable {
 
+  /**
+   * Seals the index and flushes it to disk.
+   */
+  void seal()
+      throws IOException;
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/InvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/InvertedIndexCreator.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.segment.creator;
 
 import java.io.Closeable;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/InvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/InvertedIndexCreator.java
@@ -1,0 +1,11 @@
+package org.apache.pinot.core.segment.creator;
+
+import java.io.Closeable;
+
+
+/**
+ * Marker interface for all inverted index creators
+ */
+public interface InvertedIndexCreator extends Closeable {
+
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RawValueBasedInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RawValueBasedInvertedIndexCreator.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.segment.creator;
 
 import java.io.IOException;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RawValueBasedInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RawValueBasedInvertedIndexCreator.java
@@ -1,0 +1,53 @@
+package org.apache.pinot.core.segment.creator;
+
+import java.io.IOException;
+
+public interface RawValueBasedInvertedIndexCreator extends InvertedIndexCreator {
+    /**
+     * For single-valued column, adds the integer value for the next document.
+     */
+    void add(int value);
+
+    /**
+     * For multi-valued column, add the integer values for the next document.
+     */
+    void add(int[] values, int length);
+
+    /**
+     * For single-valued column, adds the long value for the next document.
+     */
+    void add(long value);
+
+    /**
+     * For multi-valued column, add the long values for the next document.
+     */
+    void add(long[] values, int length);
+
+    /**
+     * For single-valued column, adds the float value for the next document.
+     */
+    void add(float value);
+
+    /**
+     * For multi-valued column, add the float values for the next document.
+     */
+    void add(float[] values, int length);
+
+    /**
+     * For single-valued column, adds the double value for the next document.
+     */
+    void add(double value);
+
+    /**
+     * For multi-valued column, add the double values for the next document.
+     */
+    void add(double[] values, int length);
+
+    /**
+     * Seals the index and flushes it to disk.
+     */
+    void seal()
+            throws IOException;
+
+
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RawValueBasedInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/RawValueBasedInvertedIndexCreator.java
@@ -18,54 +18,45 @@
  */
 package org.apache.pinot.core.segment.creator;
 
-import java.io.IOException;
-
 public interface RawValueBasedInvertedIndexCreator extends InvertedIndexCreator {
-    /**
-     * For single-valued column, adds the integer value for the next document.
-     */
-    void add(int value);
 
-    /**
-     * For multi-valued column, add the integer values for the next document.
-     */
-    void add(int[] values, int length);
+  /**
+   * For single-value column, adds the int value for the next document.
+   */
+  void add(int value);
 
-    /**
-     * For single-valued column, adds the long value for the next document.
-     */
-    void add(long value);
+  /**
+   * For multi-value column, adds the int values for the next document.
+   */
+  void add(int[] values, int length);
 
-    /**
-     * For multi-valued column, add the long values for the next document.
-     */
-    void add(long[] values, int length);
+  /**
+   * For single-value column, adds the long value for the next document.
+   */
+  void add(long value);
 
-    /**
-     * For single-valued column, adds the float value for the next document.
-     */
-    void add(float value);
+  /**
+   * For multi-value column, adds the long values for the next document.
+   */
+  void add(long[] values, int length);
 
-    /**
-     * For multi-valued column, add the float values for the next document.
-     */
-    void add(float[] values, int length);
+  /**
+   * For single-value column, adds the float value for the next document.
+   */
+  void add(float value);
 
-    /**
-     * For single-valued column, adds the double value for the next document.
-     */
-    void add(double value);
+  /**
+   * For multi-value column, adds the float values for the next document.
+   */
+  void add(float[] values, int length);
 
-    /**
-     * For multi-valued column, add the double values for the next document.
-     */
-    void add(double[] values, int length);
+  /**
+   * For single-value column, adds the double value for the next document.
+   */
+  void add(double value);
 
-    /**
-     * Seals the index and flushes it to disk.
-     */
-    void seal()
-            throws IOException;
-
-
+  /**
+   * For multi-value column, adds the double values for the next document.
+   */
+  void add(double[] values, int length);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
@@ -27,14 +27,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.core.segment.creator.InvertedIndexCreator;
+import org.apache.pinot.core.segment.creator.DictionaryBasedInvertedIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 /**
- * Implementation of {@link InvertedIndexCreator} that uses off-heap memory.
+ * Implementation of {@link DictionaryBasedInvertedIndexCreator} that uses off-heap memory.
  * <p>We use 2 passes to create the inverted index.
  * <ul>
  *   <li>
@@ -52,7 +52,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  * </ul>
  * <p>Based on the number of values we need to store, we use direct memory or MMap file to allocate the buffer.
  */
-public final class OffHeapBitmapInvertedIndexCreator implements InvertedIndexCreator {
+public final class OffHeapBitmapInvertedIndexCreator implements DictionaryBasedInvertedIndexCreator {
   // Use MMapBuffer if the value buffer size is larger than 2G
   private static final int NUM_VALUES_THRESHOLD_FOR_MMAP_BUFFER = 500_000_000;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
@@ -26,10 +26,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.core.segment.creator.DictionaryBasedInvertedIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/OnHeapBitmapInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/OnHeapBitmapInvertedIndexCreator.java
@@ -25,15 +25,15 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.core.segment.creator.InvertedIndexCreator;
+import org.apache.pinot.core.segment.creator.DictionaryBasedInvertedIndexCreator;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 /**
- * Implementation of {@link InvertedIndexCreator} that uses on-heap memory.
+ * Implementation of {@link DictionaryBasedInvertedIndexCreator} that uses on-heap memory.
  */
-public final class OnHeapBitmapInvertedIndexCreator implements InvertedIndexCreator {
+public final class OnHeapBitmapInvertedIndexCreator implements DictionaryBasedInvertedIndexCreator {
   private final File _invertedIndexFile;
   private final MutableRoaringBitmap[] _bitmaps;
   private int _nextDocId;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/RangeIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/RangeIndexCreator.java
@@ -66,7 +66,7 @@ import static org.apache.pinot.core.segment.creator.impl.V1Constants.Indexes.BIT
  *   </li>
  * </ul>
  */
-public final class RangeIndexCreator implements RawValueBasedInvertedIndexCreator {
+public final class RangeIndexCreator implements RawValueBasedInvertedIndexCreator,DictionaryBasedInvertedIndexCreator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RangeIndexCreator.class);
 
@@ -176,6 +176,7 @@ public final class RangeIndexCreator implements RawValueBasedInvertedIndexCreato
     for (int i = 0; i < length; i++) {
       addValueToBuffer(values[i]);
       nextDoc();
+      _nextValueId = _nextValueId + 1;
     }
     nextDoc();
   }
@@ -223,6 +224,11 @@ public final class RangeIndexCreator implements RawValueBasedInvertedIndexCreato
       nextDoc();
     }
     nextDoc();
+  }
+
+  @Override
+  public void addDoc(Object document, int docIdCounter) {
+    throw new IllegalStateException("Range index creator does not support Object type currently");
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/RangeIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/RangeIndexCreator.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.core.query.utils.Pair;
-import org.apache.pinot.core.segment.creator.InvertedIndexCreator;
+import org.apache.pinot.core.segment.creator.DictionaryBasedInvertedIndexCreator;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
@@ -45,7 +45,7 @@ import static org.apache.pinot.core.segment.creator.impl.V1Constants.Indexes.BIT
 
 
 /**
- * Implementation of {@link InvertedIndexCreator} that uses off-heap memory.
+ * Implementation of {@link DictionaryBasedInvertedIndexCreator} that uses off-heap memory.
  * <p>We use 2 passes to create the range index.
  * <ul>
  *
@@ -65,7 +65,7 @@ import static org.apache.pinot.core.segment.creator.impl.V1Constants.Indexes.BIT
  *   </li>
  * </ul>
  */
-public final class RangeIndexCreator implements InvertedIndexCreator {
+public final class RangeIndexCreator implements DictionaryBasedInvertedIndexCreator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RangeIndexCreator.class);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/RangeIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/RangeIndexCreator.java
@@ -167,63 +167,70 @@ public final class RangeIndexCreator implements RawValueBasedInvertedIndexCreato
 
   @Override
   public void add(int value) {
-    addValueToBuffer(value);
-    nextDoc();
+    _numberValueBuffer.put(_nextDocId, value);
+    _docIdBuffer.put(_nextDocId, _nextDocId);
+    _nextDocId = _nextDocId + 1;
   }
 
   @Override
   public void add(int[] values, int length) {
     for (int i = 0; i < length; i++) {
-      addValueToBuffer(values[i]);
-      nextDoc();
+      _numberValueBuffer.put(_nextValueId, values[i]);
+      _docIdBuffer.put(_nextValueId, _nextDocId);
       _nextValueId = _nextValueId + 1;
     }
-    nextDoc();
+    _nextDocId = _nextDocId + 1;
   }
 
   @Override
   public void add(long value) {
-    addValueToBuffer(value);
-    nextDoc();
+    _numberValueBuffer.put(_nextDocId, value);
+    _docIdBuffer.put(_nextDocId, _nextDocId);
+    _nextDocId = _nextDocId + 1;
   }
 
   @Override
   public void add(long[] values, int length) {
     for (int i = 0; i < length; i++) {
-      addValueToBuffer(values[i]);
-      nextDoc();
+      _numberValueBuffer.put(_nextValueId, values[i]);
+      _docIdBuffer.put(_nextValueId, _nextDocId);
+      _nextValueId = _nextValueId + 1;
     }
-    nextDoc();
+    _nextDocId = _nextDocId + 1;
   }
 
   @Override
   public void add(float value) {
-    addValueToBuffer(value);
-    nextDoc();
+    _numberValueBuffer.put(_nextDocId, value);
+    _docIdBuffer.put(_nextDocId, _nextDocId);
+    _nextDocId = _nextDocId + 1;
   }
 
   @Override
   public void add(float[] values, int length) {
     for (int i = 0; i < length; i++) {
-      addValueToBuffer(values[i]);
-      nextDoc();
+      _numberValueBuffer.put(_nextValueId, values[i]);
+      _docIdBuffer.put(_nextValueId, _nextDocId);
+      _nextValueId = _nextValueId + 1;
     }
-    nextDoc();
+    _nextDocId = _nextDocId + 1;
   }
 
   @Override
   public void add(double value) {
-    addValueToBuffer(value);
-    nextDoc();
+    _numberValueBuffer.put(_nextDocId, value);
+    _docIdBuffer.put(_nextDocId, _nextDocId);
+    _nextDocId = _nextDocId + 1;
   }
 
   @Override
   public void add(double[] values, int length) {
     for (int i = 0; i < length; i++) {
-      addValueToBuffer(values[i]);
-      nextDoc();
+      _numberValueBuffer.put(_nextValueId, values[i]);
+      _docIdBuffer.put(_nextValueId, _nextDocId);
+      _nextValueId = _nextValueId + 1;
     }
-    nextDoc();
+    _nextDocId = _nextDocId + 1;
   }
 
   @Override
@@ -443,14 +450,6 @@ public final class RangeIndexCreator implements RawValueBasedInvertedIndexCreato
     }
   }
 
-  private void nextDoc() {
-    _nextDocId = _nextDocId + 1;
-  }
-
-  private void addValueToBuffer(Number value) {
-    _numberValueBuffer.put(_nextDocId, value);
-    _docIdBuffer.put(_nextDocId, _nextDocId);
-  }
 
   void dump() {
     StringBuilder docIdAsString = new StringBuilder("DocIdBuffer  [ ");

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/RangeIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/RangeIndexCreator.java
@@ -523,12 +523,12 @@ public final class RangeIndexCreator implements RawValueBasedInvertedIndexCreato
 
     @Override
     public void put(int position, Number value) {
-      _buffer.putInt(position << 3, value.intValue());
+      _buffer.putLong(position << 3, value.longValue());
     }
 
     @Override
     public Number get(int position) {
-      return _buffer.getInt(position << 3);
+      return _buffer.getLong(position << 3);
     }
 
     @Override
@@ -548,17 +548,17 @@ public final class RangeIndexCreator implements RawValueBasedInvertedIndexCreato
 
     @Override
     public void put(int position, Number value) {
-      _buffer.putInt(position << 2, value.intValue());
+      _buffer.putFloat(position << 2, value.intValue());
     }
 
     @Override
     public Number get(int position) {
-      return _buffer.getInt(position << 2);
+      return _buffer.getFloat(position << 2);
     }
 
     @Override
     public int compare(Number val1, Number val2) {
-      return Long.compare(val1.longValue(), val2.longValue());
+      return Float.compare(val1.floatValue(), val2.floatValue());
     }
   }
 
@@ -573,17 +573,17 @@ public final class RangeIndexCreator implements RawValueBasedInvertedIndexCreato
 
     @Override
     public void put(int position, Number value) {
-      _buffer.putInt(position << 3, value.intValue());
+      _buffer.putDouble(position << 3, value.doubleValue());
     }
 
     @Override
     public Number get(int position) {
-      return _buffer.getInt(position << 3);
+      return _buffer.getDouble(position << 3);
     }
 
     @Override
     public int compare(Number val1, Number val2) {
-      return Long.compare(val1.longValue(), val2.longValue());
+      return Double.compare(val1.doubleValue(), val2.doubleValue());
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
@@ -21,14 +21,9 @@ package org.apache.pinot.core.segment.creator.impl.inv.text;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
-import org.apache.lucene.analysis.Analyzer;
+
 import org.apache.lucene.analysis.CharArraySet;
-import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
-import org.apache.lucene.analysis.core.StopFilterFactory;
-import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StoredField;
@@ -37,7 +32,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
-import org.apache.pinot.core.segment.creator.InvertedIndexCreator;
+import org.apache.pinot.core.segment.creator.DictionaryBasedInvertedIndexCreator;
 import org.slf4j.LoggerFactory;
 
 
@@ -46,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * Used for both offline from {@link org.apache.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator}
  * and realtime from {@link org.apache.pinot.core.realtime.impl.invertedindex.RealtimeLuceneTextIndexReader}
  */
-public class LuceneTextIndexCreator implements InvertedIndexCreator {
+public class LuceneTextIndexCreator implements DictionaryBasedInvertedIndexCreator {
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexCreator.class);
   // TODO: make buffer size configurable choosing a default value based on the heap usage results in design doc
   private static final int LUCENE_INDEX_MAX_BUFFER_SIZE_MB = 500;
@@ -80,8 +75,8 @@ public class LuceneTextIndexCreator implements InvertedIndexCreator {
    *               Once {@link org.apache.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator}
    *               finishes indexing all documents/rows for the segment, we need to commit and close
    *               the Lucene index which will internally persist the index on disk, do the necessary
-   *               resource cleanup etc. We commit during {@link InvertedIndexCreator#seal()}
-   *               and close during {@link InvertedIndexCreator#close()}.
+   *               resource cleanup etc. We commit during {@link DictionaryBasedInvertedIndexCreator#seal()}
+   *               and close during {@link DictionaryBasedInvertedIndexCreator#close()}.
    *               This lucene index writer is used by both offline and realtime (both during
    *               indexing in-memory MutableSegment and later during conversion to offline).
    *               Since realtime segment conversion is again going to go through the offline

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/inv/text/LuceneTextIndexCreator.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.segment.creator.impl.inv.text;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -53,14 +52,10 @@ public class LuceneTextIndexCreator implements DictionaryBasedInvertedIndexCreat
   private final Directory _indexDirectory;
   private final IndexWriter _indexWriter;
 
-  public static final CharArraySet ENGLISH_STOP_WORDS_SET =
-      new CharArraySet(Arrays.asList(
-          "a", "an", "and", "are", "as", "at", "be", "but", "by",
-          "for", "if", "in", "into", "is", "it",
-          "no", "not", "of", "on", "or", "such",
-          "that", "the", "their", "then", "than", "there", "these",
-          "they", "this", "to", "was", "will", "with", "those"
-      ), true);
+  public static final CharArraySet ENGLISH_STOP_WORDS_SET = new CharArraySet(Arrays
+      .asList("a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it", "no",
+          "not", "of", "on", "or", "such", "that", "the", "their", "then", "than", "there", "these", "they", "this",
+          "to", "was", "will", "with", "those"), true);
 
   /**
    * Called by {@link org.apache.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator}
@@ -99,7 +94,8 @@ public class LuceneTextIndexCreator implements DictionaryBasedInvertedIndexCreat
       indexWriterConfig.setCommitOnClose(commit);
       _indexWriter = new IndexWriter(_indexDirectory, indexWriterConfig);
     } catch (Exception e) {
-      LOGGER.error("Failed to instantiate Lucene text index creator for column {}, exception {}", column, e.getMessage());
+      LOGGER
+          .error("Failed to instantiate Lucene text index creator for column {}, exception {}", column, e.getMessage());
       throw new RuntimeException(e);
     }
   }
@@ -117,7 +113,8 @@ public class LuceneTextIndexCreator implements DictionaryBasedInvertedIndexCreat
     try {
       _indexWriter.addDocument(docToIndex);
     } catch (Exception e) {
-      LOGGER.error("Failure while adding a new document to index for column {}, exception {}", _textColumn, e.getMessage());
+      LOGGER.error("Failure while adding a new document to index for column {}, exception {}", _textColumn,
+          e.getMessage());
       throw new RuntimeException(e);
     }
   }
@@ -148,7 +145,8 @@ public class LuceneTextIndexCreator implements DictionaryBasedInvertedIndexCreat
   }
 
   @Override
-  public void close() throws IOException {
+  public void close()
+      throws IOException {
     try {
       // based on the commit flag set in IndexWriterConfig, this will decide to commit or not
       _indexWriter.close();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/invertedindex/RangeIndexHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/invertedindex/RangeIndexHandler.java
@@ -206,7 +206,7 @@ public class RangeIndexHandler {
         return new FixedBitMVForwardIndexReader(buffer, numRows, columnMetadata.getTotalNumberOfEntries(),
                 numBitsPerValue);
       } else {
-        throw new RuntimeException("Range indexing is not supported for multi value non-dictionary columns");
+        throw new RuntimeException("Raw index on multi-value column is not supported");
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/invertedindex/RangeIndexHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/invertedindex/RangeIndexHandler.java
@@ -149,32 +149,38 @@ public class RangeIndexHandler {
           throws IOException {
     int numDocs = columnMetadata.getTotalDocs();
     try (RangeIndexCreator creator = new RangeIndexCreator(_indexDir, columnMetadata.getFieldSpec(),
-            FieldSpec.DataType.INT, -1, -1, numDocs, columnMetadata.getTotalNumberOfEntries())) {
+            columnMetadata.getDataType(), -1, -1, numDocs, columnMetadata.getTotalNumberOfEntries())) {
       try (ForwardIndexReader forwardIndexReader = getForwardIndexReader(columnMetadata, _segmentWriter);
            ForwardIndexReaderContext readerContext = forwardIndexReader.createContext()) {
         if (columnMetadata.isSingleValue()) {
           // Single-value column.
-          for (int i = 0; i < numDocs; i++) {
-            switch (columnMetadata.getDataType()) {
-              case INT: {
+          switch (columnMetadata.getDataType()) {
+            case INT: {
+              for (int i = 0; i < numDocs; i++) {
                 creator.add(forwardIndexReader.getInt(i, readerContext));
-                break;
               }
-              case LONG: {
-                creator.add(forwardIndexReader.getInt(i, readerContext));
-                break;
+              break;
+            }
+            case LONG: {
+              for (int i = 0; i < numDocs; i++) {
+                creator.add(forwardIndexReader.getLong(i, readerContext));
               }
-              case FLOAT: {
-                creator.add(forwardIndexReader.getInt(i, readerContext));
-                break;
+              break;
+            }
+            case FLOAT: {
+              for (int i = 0; i < numDocs; i++) {
+                creator.add(forwardIndexReader.getFloat(i, readerContext));
               }
-              case DOUBLE: {
-                creator.add(forwardIndexReader.getInt(i, readerContext));
-                break;
+              break;
+            }
+            case DOUBLE: {
+              for (int i = 0; i < numDocs; i++) {
+                creator.add(forwardIndexReader.getDouble(i, readerContext));
               }
-              default: {
-                throw new RuntimeException("Range indexing is not supported");
-              }
+              break;
+            }
+            default: {
+              throw new RuntimeException("Range indexing is not supported");
             }
           }
         }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,12 +19,14 @@
 package org.apache.pinot.core.segment.index.creator;
 
 import com.google.common.base.Preconditions;
+
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
+
 import org.apache.pinot.core.segment.creator.impl.inv.RangeIndexCreator;
 import org.apache.pinot.core.segment.index.readers.RangeIndexReader;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
@@ -42,120 +44,232 @@ import static org.apache.pinot.core.segment.creator.impl.V1Constants.Indexes.BIT
  */
 public class RangeIndexCreatorTest {
 
-  @Test
-  public void testInt()
-      throws Exception {
-    File indexDir = new File(System.getProperty("java.io.tmpdir") + "/testRangeIndex");
-    indexDir.mkdirs();
-    FieldSpec fieldSpec = new MetricFieldSpec();
-    fieldSpec.setDataType(FieldSpec.DataType.INT);
-    String columnName = "latency";
-    fieldSpec.setName(columnName);
-    int cardinality = 20;
-    int numDocs = 1000;
-    int numValues = 1000;
-    RangeIndexCreator creator =
-        new RangeIndexCreator(indexDir, fieldSpec, FieldSpec.DataType.INT, -1, -1, numDocs, numValues);
-    Random r = new Random();
-    Number[] values = new Number[numValues];
-    for (int i = 0; i < numDocs; i++) {
-      int val = r.nextInt(cardinality);
-      creator.add(val);
-      values[i] = val;
+    @Test
+    public void testInt()
+            throws Exception {
+        testDataType(FieldSpec.DataType.INT);
     }
-    creator.seal();
 
-    File rangeIndexFile = new File(indexDir, columnName + BITMAP_RANGE_INDEX_FILE_EXTENSION);
-    //TEST THE BUFFER FORMAT
-
-    testRangeIndexBufferFormat(values, rangeIndexFile);
-
-    //TEST USING THE READER
-    PinotDataBuffer pinotDataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile);
-    RangeIndexReader rangeIndexReader = new RangeIndexReader(pinotDataBuffer);
-    Number[] rangeStartArray = rangeIndexReader.getRangeStartArray();
-    for (int rangeId = 0; rangeId < rangeStartArray.length; rangeId++) {
-      ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
-      for (int docId : bitmap.toArray()) {
-        checkInt(rangeStartArray, rangeId, values, docId);
-      }
+    @Test
+    public void testLong()
+            throws Exception {
+        testDataType(FieldSpec.DataType.LONG);
     }
-  }
 
-  private void checkInt(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
-    if (rangeId != rangeStartArray.length - 1) {
-      Assert.assertTrue(
-          rangeStartArray[rangeId].intValue() <= values[docId].intValue() && values[docId].intValue() < rangeStartArray[
-              rangeId + 1].intValue(), "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
-    } else {
-      Assert.assertTrue(rangeStartArray[rangeId].intValue() <= values[docId].intValue(),
-          "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+    @Test
+    public void testFloat()
+            throws Exception {
+        testDataType(FieldSpec.DataType.FLOAT);
     }
-  }
 
-  private void testRangeIndexBufferFormat(Number[] values, File rangeIndexFile)
-      throws IOException {
-    DataInputStream dis = new DataInputStream(new FileInputStream(rangeIndexFile));
-    int version = dis.readInt();
-    int valueTypeBytesLength = dis.readInt();
+    @Test
+    public void testDouble()
+            throws Exception {
+        testDataType(FieldSpec.DataType.DOUBLE);
+    }
 
-    byte[] valueTypeBytes = new byte[valueTypeBytesLength];
-    dis.read(valueTypeBytes);
-    String name = new String(valueTypeBytes);
-    FieldSpec.DataType dataType = FieldSpec.DataType.valueOf(name);
 
-    int numRanges = dis.readInt();
+    private void testDataType(FieldSpec.DataType dataType)
+            throws IOException {
+        File indexDir = new File(System.getProperty("java.io.tmpdir") + "/testRangeIndex");
+        indexDir.mkdirs();
+        FieldSpec fieldSpec = new MetricFieldSpec();
+        fieldSpec.setDataType(dataType);
+        String columnName = "latency";
+        fieldSpec.setName(columnName);
+        int cardinality = 20;
+        int numDocs = 1000;
+        int numValues = 1000;
+        RangeIndexCreator creator =
+                new RangeIndexCreator(indexDir, fieldSpec, dataType, -1, -1, numDocs, numValues);
+        Random r = new Random();
+        Number[] values = new Number[numValues];
+        addDataToIndexer(dataType, cardinality, numDocs, creator, r, values);
 
-    Number[] rangeStart = new Number[numRanges];
-    Number rangeEnd;
 
-    switch (dataType) {
-      case INT:
-        for (int i = 0; i < numRanges; i++) {
-          rangeStart[i] = dis.readInt();
+        creator.seal();
+
+        File rangeIndexFile = new File(indexDir, columnName + BITMAP_RANGE_INDEX_FILE_EXTENSION);
+        //TEST THE BUFFER FORMAT
+
+        testRangeIndexBufferFormat(values, rangeIndexFile);
+
+        //TEST USING THE READER
+        PinotDataBuffer pinotDataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile);
+        RangeIndexReader rangeIndexReader = new RangeIndexReader(pinotDataBuffer);
+        Number[] rangeStartArray = rangeIndexReader.getRangeStartArray();
+        for (int rangeId = 0; rangeId < rangeStartArray.length; rangeId++) {
+            ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
+            for (int docId : bitmap.toArray()) {
+                switch (dataType) {
+                    case INT: {
+                        checkInt(rangeStartArray, rangeId, values, docId);
+                        break;
+                    }
+                    case LONG: {
+                        checkLong(rangeStartArray, rangeId, values, docId);
+                        break;
+                    }
+                    case FLOAT: {
+                        checkFloat(rangeStartArray, rangeId, values, docId);
+                        break;
+                    }
+                    case DOUBLE: {
+                        checkDouble(rangeStartArray, rangeId, values, docId);
+                        break;
+                    }
+                }
+            }
         }
-        rangeEnd = dis.readInt();
-        break;
-      case LONG:
-        for (int i = 0; i < numRanges; i++) {
-          rangeStart[i] = dis.readLong();
-        }
-        rangeEnd = dis.readLong();
-        break;
-      case FLOAT:
-        for (int i = 0; i < numRanges; i++) {
-          rangeStart[i] = dis.readFloat();
-        }
-        rangeEnd = dis.readFloat();
-        break;
-      case DOUBLE:
-        for (int i = 0; i < numRanges; i++) {
-          rangeStart[i] = dis.readDouble();
-        }
-        rangeEnd = dis.readDouble();
-        break;
     }
 
-    long[] rangeBitmapOffsets = new long[numRanges + 1];
-    for (int i = 0; i <= numRanges; i++) {
-      rangeBitmapOffsets[i] = dis.readLong();
+    private void addDataToIndexer(FieldSpec.DataType dataType, int cardinality, int numDocs, RangeIndexCreator creator, Random r, Number[] values) {
+        switch (dataType) {
+            case INT: {
+                for (int i = 0; i < numDocs; i++) {
+                    int val = r.nextInt(cardinality);
+                    creator.add(val);
+                    values[i] = val;
+                }
+                break;
+            }
+
+            case LONG: {
+                for (int i = 0; i < numDocs; i++) {
+                    long val = r.nextLong();
+                    creator.add(val);
+                    values[i] = val;
+                }
+                break;
+            }
+
+            case FLOAT: {
+                for (int i = 0; i < numDocs; i++) {
+                    float val = r.nextFloat();
+                    creator.add(val);
+                    values[i] = val;
+                }
+                break;
+            }
+
+            case DOUBLE: {
+                for (int i = 0; i < numDocs; i++) {
+                    double val = r.nextDouble();
+                    creator.add(val);
+                    values[i] = val;
+                }
+                break;
+            }
+        }
     }
-    ImmutableRoaringBitmap[] bitmaps = new ImmutableRoaringBitmap[numRanges];
-    for (int i = 0; i < numRanges; i++) {
-      long serializedBitmapLength;
-      serializedBitmapLength = rangeBitmapOffsets[i + 1] - rangeBitmapOffsets[i];
-      byte[] bytes = new byte[(int) serializedBitmapLength];
-      dis.read(bytes, 0, (int) serializedBitmapLength);
-      bitmaps[i] = new ImmutableRoaringBitmap(ByteBuffer.wrap(bytes));
-      for (int docId : bitmaps[i].toArray()) {
-        if (i != numRanges - 1) {
-          Assert.assertTrue(
-              rangeStart[i].intValue() <= values[docId].intValue() && values[docId].intValue() < rangeStart[i + 1]
-                  .intValue(), "rangestart:" + rangeStart[i] + " value:" + values[docId]);
+
+    private void checkInt(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
+        if (rangeId != rangeStartArray.length - 1) {
+            Assert.assertTrue(
+                    rangeStartArray[rangeId].intValue() <= values[docId].intValue() && values[docId].intValue() < rangeStartArray[
+                            rangeId + 1].intValue(), "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
         } else {
-          Assert.assertTrue(rangeStart[i].intValue() <= values[docId].intValue());
+            Assert.assertTrue(rangeStartArray[rangeId].intValue() <= values[docId].intValue(),
+                    "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
         }
-      }
     }
-  }
+
+    private void checkLong(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
+        if (rangeId != rangeStartArray.length - 1) {
+            Assert.assertTrue(
+                    rangeStartArray[rangeId].longValue() <= values[docId].longValue() && values[docId].longValue() < rangeStartArray[
+                            rangeId + 1].longValue(), "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+        } else {
+            Assert.assertTrue(rangeStartArray[rangeId].longValue() <= values[docId].longValue(),
+                    "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+        }
+    }
+
+    private void checkFloat(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
+        if (rangeId != rangeStartArray.length - 1) {
+            Assert.assertTrue(
+                    rangeStartArray[rangeId].floatValue() <= values[docId].floatValue() && values[docId].floatValue() < rangeStartArray[
+                            rangeId + 1].floatValue(), "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+        } else {
+            Assert.assertTrue(rangeStartArray[rangeId].floatValue() <= values[docId].floatValue(),
+                    "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+        }
+    }
+
+    private void checkDouble(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
+        if (rangeId != rangeStartArray.length - 1) {
+            Assert.assertTrue(
+                    rangeStartArray[rangeId].doubleValue() <= values[docId].doubleValue() && values[docId].doubleValue() < rangeStartArray[
+                            rangeId + 1].doubleValue(), "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+        } else {
+            Assert.assertTrue(rangeStartArray[rangeId].doubleValue() <= values[docId].doubleValue(),
+                    "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+        }
+    }
+
+    private void testRangeIndexBufferFormat(Number[] values, File rangeIndexFile)
+            throws IOException {
+        DataInputStream dis = new DataInputStream(new FileInputStream(rangeIndexFile));
+        int version = dis.readInt();
+        int valueTypeBytesLength = dis.readInt();
+
+        byte[] valueTypeBytes = new byte[valueTypeBytesLength];
+        dis.read(valueTypeBytes);
+        String name = new String(valueTypeBytes);
+        FieldSpec.DataType dataType = FieldSpec.DataType.valueOf(name);
+
+        int numRanges = dis.readInt();
+
+        Number[] rangeStart = new Number[numRanges];
+        Number rangeEnd;
+
+        switch (dataType) {
+            case INT:
+                for (int i = 0; i < numRanges; i++) {
+                    rangeStart[i] = dis.readInt();
+                }
+                rangeEnd = dis.readInt();
+                break;
+            case LONG:
+                for (int i = 0; i < numRanges; i++) {
+                    rangeStart[i] = dis.readLong();
+                }
+                rangeEnd = dis.readLong();
+                break;
+            case FLOAT:
+                for (int i = 0; i < numRanges; i++) {
+                    rangeStart[i] = dis.readFloat();
+                }
+                rangeEnd = dis.readFloat();
+                break;
+            case DOUBLE:
+                for (int i = 0; i < numRanges; i++) {
+                    rangeStart[i] = dis.readDouble();
+                }
+                rangeEnd = dis.readDouble();
+                break;
+        }
+
+        long[] rangeBitmapOffsets = new long[numRanges + 1];
+        for (int i = 0; i <= numRanges; i++) {
+            rangeBitmapOffsets[i] = dis.readLong();
+        }
+        ImmutableRoaringBitmap[] bitmaps = new ImmutableRoaringBitmap[numRanges];
+        for (int i = 0; i < numRanges; i++) {
+            long serializedBitmapLength;
+            serializedBitmapLength = rangeBitmapOffsets[i + 1] - rangeBitmapOffsets[i];
+            byte[] bytes = new byte[(int) serializedBitmapLength];
+            dis.read(bytes, 0, (int) serializedBitmapLength);
+            bitmaps[i] = new ImmutableRoaringBitmap(ByteBuffer.wrap(bytes));
+            for (int docId : bitmaps[i].toArray()) {
+                if (i != numRanges - 1) {
+                    Assert.assertTrue(
+                            rangeStart[i].intValue() <= values[docId].intValue() && values[docId].intValue() < rangeStart[i + 1]
+                                    .intValue(), "rangestart:" + rangeStart[i] + " value:" + values[docId]);
+                } else {
+                    Assert.assertTrue(rangeStart[i].intValue() <= values[docId].intValue());
+                }
+            }
+        }
+    }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
@@ -101,24 +101,28 @@ public class RangeIndexCreatorTest {
         for (int rangeId = 0; rangeId < rangeStartArray.length; rangeId++) {
             ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
             for (int docId : bitmap.toArray()) {
-                switch (dataType) {
-                    case INT: {
-                        checkInt(rangeStartArray, rangeId, values, docId);
-                        break;
-                    }
-                    case LONG: {
-                        checkLong(rangeStartArray, rangeId, values, docId);
-                        break;
-                    }
-                    case FLOAT: {
-                        checkFloat(rangeStartArray, rangeId, values, docId);
-                        break;
-                    }
-                    case DOUBLE: {
-                        checkDouble(rangeStartArray, rangeId, values, docId);
-                        break;
-                    }
-                }
+                checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId);
+            }
+        }
+    }
+
+    private void checkValueForDocId(FieldSpec.DataType dataType, Number[] values, Number[] rangeStartArray, int rangeId, int docId) {
+        switch (dataType) {
+            case INT: {
+                checkInt(rangeStartArray, rangeId, values, docId);
+                break;
+            }
+            case LONG: {
+                checkLong(rangeStartArray, rangeId, values, docId);
+                break;
+            }
+            case FLOAT: {
+                checkFloat(rangeStartArray, rangeId, values, docId);
+                break;
+            }
+            case DOUBLE: {
+                checkDouble(rangeStartArray, rangeId, values, docId);
+                break;
             }
         }
     }
@@ -262,13 +266,7 @@ public class RangeIndexCreatorTest {
             dis.read(bytes, 0, (int) serializedBitmapLength);
             bitmaps[i] = new ImmutableRoaringBitmap(ByteBuffer.wrap(bytes));
             for (int docId : bitmaps[i].toArray()) {
-                if (i != numRanges - 1) {
-                    Assert.assertTrue(
-                            rangeStart[i].intValue() <= values[docId].intValue() && values[docId].intValue() < rangeStart[i + 1]
-                                    .intValue(), "rangestart:" + rangeStart[i] + " value:" + values[docId]);
-                } else {
-                    Assert.assertTrue(rangeStart[i].intValue() <= values[docId].intValue());
-                }
+                checkValueForDocId(dataType, values, rangeStart, i, docId);
             }
         }
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
@@ -18,443 +18,366 @@
  */
 package org.apache.pinot.core.segment.index.creator;
 
-
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Random;
-
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.core.segment.creator.impl.inv.RangeIndexCreator;
 import org.apache.pinot.core.segment.index.readers.RangeIndexReader;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.MetricFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
-import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.core.segment.creator.impl.V1Constants.Indexes.BITMAP_RANGE_INDEX_FILE_EXTENSION;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
-/**
- * Class for testing Range index.
- */
 public class RangeIndexCreatorTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "RangeIndexCreatorTest");
+  private static final Random RANDOM = new Random();
+  private static final String COLUMN_NAME = "testColumn";
 
-    @Test
-    public void testInt()
-            throws Exception {
-        testDataType(FieldSpec.DataType.INT);
+  @BeforeClass
+  public void setUp()
+      throws IOException {
+    FileUtils.forceMkdir(INDEX_DIR);
+  }
+
+  @Test
+  public void testInt()
+      throws Exception {
+    testDataType(DataType.INT);
+  }
+
+  @Test
+  public void testLong()
+      throws Exception {
+    testDataType(DataType.LONG);
+  }
+
+  @Test
+  public void testFloat()
+      throws Exception {
+    testDataType(DataType.FLOAT);
+  }
+
+  @Test
+  public void testDouble()
+      throws Exception {
+    testDataType(DataType.DOUBLE);
+  }
+
+  @Test
+  public void testIntMV()
+      throws Exception {
+    testDataTypeMV(DataType.INT);
+  }
+
+  @Test
+  public void testLongMV()
+      throws Exception {
+    testDataTypeMV(DataType.LONG);
+  }
+
+  @Test
+  public void testFloatMV()
+      throws Exception {
+    testDataTypeMV(DataType.FLOAT);
+  }
+
+  @Test
+  public void testDoubleMV()
+      throws Exception {
+    testDataTypeMV(DataType.DOUBLE);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  private void testDataType(DataType dataType)
+      throws IOException {
+    FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, dataType, true);
+    int numDocs = 1000;
+    Number[] values = new Number[numDocs];
+
+    try (RangeIndexCreator creator = new RangeIndexCreator(INDEX_DIR, fieldSpec, dataType, -1, -1, numDocs, numDocs)) {
+      addDataToIndexer(dataType, numDocs, 1, creator, values);
+      creator.seal();
     }
 
-    @Test
-    public void testLong()
-            throws Exception {
-        testDataType(FieldSpec.DataType.LONG);
-    }
-
-    @Test
-    public void testFloat()
-            throws Exception {
-        testDataType(FieldSpec.DataType.FLOAT);
-    }
-
-    @Test
-    public void testDouble()
-            throws Exception {
-        testDataType(FieldSpec.DataType.DOUBLE);
-    }
-
-    @Test
-    public void testIntMV()
-            throws Exception {
-        testDataTypeMV(FieldSpec.DataType.INT);
-    }
-
-    @Test
-    public void testLongMV()
-            throws Exception {
-        testDataTypeMV(FieldSpec.DataType.LONG);
-    }
-
-    @Test
-    public void testFloatMV()
-            throws Exception {
-        testDataTypeMV(FieldSpec.DataType.FLOAT);
-    }
-
-    @Test
-    public void testDoubleMV()
-            throws Exception {
-        testDataTypeMV(FieldSpec.DataType.DOUBLE);
-    }
-
-    private void testDataType(FieldSpec.DataType dataType)
-            throws IOException {
-        File indexDir = new File(System.getProperty("java.io.tmpdir") + "/testRangeIndex");
-        indexDir.mkdirs();
-        FieldSpec fieldSpec = new MetricFieldSpec();
-        fieldSpec.setDataType(dataType);
-        String columnName = "latency";
-        fieldSpec.setName(columnName);
-        int cardinality = 20;
-        int numDocs = 1000;
-        int numValues = 1000;
-        RangeIndexCreator creator =
-                new RangeIndexCreator(indexDir, fieldSpec, dataType, -1, -1, numDocs, numValues);
-        Random r = new Random();
-        Number[] values = new Number[numValues];
-        addDataToIndexer(dataType, cardinality, numDocs, 1, creator, r, values);
-
-
-        creator.seal();
-
-        File rangeIndexFile = new File(indexDir, columnName + BITMAP_RANGE_INDEX_FILE_EXTENSION);
-        //TEST THE BUFFER FORMAT
-
-        testRangeIndexBufferFormat(values, rangeIndexFile);
-
-        //TEST USING THE READER
-        PinotDataBuffer pinotDataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile);
-        RangeIndexReader rangeIndexReader = new RangeIndexReader(pinotDataBuffer);
-        Number[] rangeStartArray = rangeIndexReader.getRangeStartArray();
-        for (int rangeId = 0; rangeId < rangeStartArray.length; rangeId++) {
-            ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
-            for (int docId : bitmap.toArray()) {
-                checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId, 1);
-            }
+    File rangeIndexFile = new File(INDEX_DIR, COLUMN_NAME + BITMAP_RANGE_INDEX_FILE_EXTENSION);
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile)) {
+      RangeIndexReader rangeIndexReader = new RangeIndexReader(dataBuffer);
+      Number[] rangeStartArray = rangeIndexReader.getRangeStartArray();
+      for (int rangeId = 0; rangeId < rangeStartArray.length; rangeId++) {
+        ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
+        for (int docId : bitmap.toArray()) {
+          checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId, 1);
         }
+      }
     }
 
-    private void testDataTypeMV(FieldSpec.DataType dataType)
-            throws IOException {
-        File indexDir = new File(System.getProperty("java.io.tmpdir") + "/testRangeIndex");
-        indexDir.mkdirs();
-        FieldSpec fieldSpec = new DimensionFieldSpec();
-        fieldSpec.setDataType(dataType);
-        String columnName = "latency";
-        fieldSpec.setName(columnName);
-        fieldSpec.setSingleValueField(false);
-        int cardinality = 20;
-        int numDocs = 1000;
-        int numValues = 1000;
-        int numValuesPerColumn = 10;
-        RangeIndexCreator creator =
-                new RangeIndexCreator(indexDir, fieldSpec, dataType, -1, -1, numDocs, numValues * numValuesPerColumn);
-        Random r = new Random();
-        Number[] values = new Number[numValues * numValuesPerColumn];
-        addDataToIndexer(dataType, cardinality, numDocs, numValuesPerColumn, creator, r, values);
+    FileUtils.forceDelete(rangeIndexFile);
+  }
 
+  private void testDataTypeMV(DataType dataType)
+      throws IOException {
+    FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, dataType, false);
+    int numDocs = 1000;
+    int numValuesPerMVEntry = 10;
+    int numValues = numDocs * numValuesPerMVEntry;
+    Number[] values = new Number[numValues];
 
-        creator.seal();
+    try (
+        RangeIndexCreator creator = new RangeIndexCreator(INDEX_DIR, fieldSpec, dataType, -1, -1, numDocs, numValues)) {
+      addDataToIndexer(dataType, numDocs, numValuesPerMVEntry, creator, values);
+      creator.seal();
+    }
 
-        File rangeIndexFile = new File(indexDir, columnName + BITMAP_RANGE_INDEX_FILE_EXTENSION);
-        //TEST THE BUFFER FORMAT
-
-        //testRangeIndexBufferFormat(values, rangeIndexFile);
-
-        //TEST USING THE READER
-        PinotDataBuffer pinotDataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile);
-        RangeIndexReader rangeIndexReader = new RangeIndexReader(pinotDataBuffer);
-        Number[] rangeStartArray = rangeIndexReader.getRangeStartArray();
-        for (int rangeId = 0; rangeId < rangeStartArray.length; rangeId++) {
-            ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
-            for (int docId : bitmap.toArray()) {
-                checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId, numValuesPerColumn);
-            }
+    File rangeIndexFile = new File(INDEX_DIR, COLUMN_NAME + BITMAP_RANGE_INDEX_FILE_EXTENSION);
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile)) {
+      RangeIndexReader rangeIndexReader = new RangeIndexReader(dataBuffer);
+      Number[] rangeStartArray = rangeIndexReader.getRangeStartArray();
+      int numRanges = rangeStartArray.length;
+      for (int rangeId = 0; rangeId < numRanges; rangeId++) {
+        ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
+        for (int docId : bitmap.toArray()) {
+          checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId, numValuesPerMVEntry);
         }
+      }
     }
 
-    private void checkValueForDocId(FieldSpec.DataType dataType, Number[] values, Number[] rangeStartArray, int rangeId, int docId, int numValuesPerColumn) {
-        switch (dataType) {
-            case INT: {
-                if (numValuesPerColumn > 1) {
-                    checkIntMV(rangeStartArray, rangeId, values, docId, numValuesPerColumn);
-                } else {
-                    checkInt(rangeStartArray, rangeId, values, docId);
-                }
-                break;
-            }
-            case LONG: {
-                if (numValuesPerColumn > 1) {
-                    checkLongMV(rangeStartArray, rangeId, values, docId, numValuesPerColumn);
-                } else {
-                    checkLong(rangeStartArray, rangeId, values, docId);
-                }
-                break;
-            }
-            case FLOAT: {
-                if (numValuesPerColumn > 1) {
-                    checkFloatMV(rangeStartArray, rangeId, values, docId, numValuesPerColumn);
-                } else {
-                    checkFloat(rangeStartArray, rangeId, values, docId);
-                }
-                break;
-            }
-            case DOUBLE: {
-                if (numValuesPerColumn > 1) {
-                    checkDoubleMV(rangeStartArray, rangeId, values, docId, numValuesPerColumn);
-                } else {
-                    checkDouble(rangeStartArray, rangeId, values, docId);
-                }
-                break;
-            }
-        }
-    }
+    FileUtils.forceDelete(rangeIndexFile);
+  }
 
-    private void addDataToIndexer(FieldSpec.DataType dataType, int cardinality, int numDocs, int numValuesPerColumn, RangeIndexCreator creator, Random r, Number[] values) {
-        switch (dataType) {
-            case INT: {
-                for (int i = 0; i < numDocs; i++) {
-
-                    if (numValuesPerColumn > 1) {
-                        int[] mvColumnArr = new int[numValuesPerColumn];
-                        for (int j = 0; j < numValuesPerColumn; j++) {
-                            int val = r.nextInt(cardinality);
-                            mvColumnArr[j] = val;
-                            values[numValuesPerColumn * i + j] = val;
-                        }
-                        creator.add(mvColumnArr, numValuesPerColumn);
-                    } else {
-                        int val = r.nextInt(cardinality);
-                        creator.add(val);
-                        values[i] = val;
-                    }
-                }
-                break;
-            }
-
-            case LONG: {
-                for (int i = 0; i < numDocs; i++) {
-                    if (numValuesPerColumn > 1) {
-                        long[] mvColumnArr = new long[numValuesPerColumn];
-                        for (int j = 0; j < numValuesPerColumn; j++) {
-                            long val = r.nextLong();
-                            mvColumnArr[j] = val;
-                            values[numValuesPerColumn * i + j] = val;
-                        }
-                        creator.add(mvColumnArr, numValuesPerColumn);
-                    } else {
-                        long val = r.nextLong();
-                        creator.add(val);
-                        values[i] = val;
-                    }
-                }
-                break;
-            }
-
-            case FLOAT: {
-                for (int i = 0; i < numDocs; i++) {
-                    if (numValuesPerColumn > 1) {
-                        float[] mvColumnArr = new float[numValuesPerColumn];
-                        for (int j = 0; j < numValuesPerColumn; j++) {
-                            float val = r.nextFloat();
-                            mvColumnArr[j] = val;
-                            values[numValuesPerColumn * i + j] = val;
-                        }
-                        creator.add(mvColumnArr, numValuesPerColumn);
-                    } else {
-                        float val = r.nextFloat();
-                        creator.add(val);
-                        values[i] = val;
-                    }
-                }
-                break;
-            }
-
-            case DOUBLE: {
-                for (int i = 0; i < numDocs; i++) {
-                    if (numValuesPerColumn > 1) {
-                        double[] mvColumnArr = new double[numValuesPerColumn];
-                        for (int j = 0; j < numValuesPerColumn; j++) {
-                            double val = r.nextDouble();
-                            mvColumnArr[j] = val;
-                            values[numValuesPerColumn * i + j] = val;
-                        }
-                        creator.add(mvColumnArr, numValuesPerColumn);
-                    } else {
-                        double val = r.nextDouble();
-                        creator.add(val);
-                        values[i] = val;
-                    }
-                }
-                break;
-            }
-        }
-    }
-
-    private void checkInt(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
-        if (rangeId != rangeStartArray.length - 1) {
-            Assert.assertTrue(
-                    rangeStartArray[rangeId].intValue() <= values[docId].intValue() && values[docId].intValue() < rangeStartArray[
-                            rangeId + 1].intValue(), "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+  private void addDataToIndexer(DataType dataType, int numDocs, int numValuesPerEntry, RangeIndexCreator creator,
+      Number[] values) {
+    switch (dataType) {
+      case INT:
+        if (numValuesPerEntry == 1) {
+          for (int i = 0; i < numDocs; i++) {
+            int value = RANDOM.nextInt();
+            values[i] = value;
+            creator.add(value);
+          }
         } else {
-            Assert.assertTrue(rangeStartArray[rangeId].intValue() <= values[docId].intValue(),
-                    "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
-        }
-    }
-
-    private void checkIntMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerColumn) {
-        boolean atleastOneInRange = false;
-
-        if (rangeId != rangeStartArray.length - 1) {
-            for (int i = 0; i < numValuesPerColumn; i++) {
-                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].intValue() <= values[numValuesPerColumn * docId + i].intValue() && values[numValuesPerColumn * docId + i].intValue() < rangeStartArray[
-                        rangeId + 1].intValue());
+          int[] intValues = new int[numValuesPerEntry];
+          for (int i = 0; i < numDocs; i++) {
+            for (int j = 0; j < numValuesPerEntry; j++) {
+              int value = RANDOM.nextInt();
+              intValues[j] = value;
+              values[i * numValuesPerEntry + j] = value;
             }
+            creator.add(intValues, numValuesPerEntry);
+          }
+        }
+        break;
+      case LONG:
+        if (numValuesPerEntry == 1) {
+          for (int i = 0; i < numDocs; i++) {
+            long value = RANDOM.nextLong();
+            values[i] = value;
+            creator.add(value);
+          }
         } else {
-            for (int i = 0; i < numValuesPerColumn; i++) {
-                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].intValue() <= values[numValuesPerColumn * docId + i].intValue());
+          long[] longValues = new long[numValuesPerEntry];
+          for (int i = 0; i < numDocs; i++) {
+            for (int j = 0; j < numValuesPerEntry; j++) {
+              long value = RANDOM.nextLong();
+              longValues[j] = value;
+              values[i * numValuesPerEntry + j] = value;
             }
+            creator.add(longValues, numValuesPerEntry);
+          }
         }
-
-        Assert.assertTrue(atleastOneInRange, "rangestart:" + rangeStartArray[rangeId]);
-    }
-
-    private void checkLong(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
-        if (rangeId != rangeStartArray.length - 1) {
-            Assert.assertTrue(
-                    rangeStartArray[rangeId].longValue() <= values[docId].longValue() && values[docId].longValue() < rangeStartArray[
-                            rangeId + 1].longValue(), "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+        break;
+      case FLOAT:
+        if (numValuesPerEntry == 1) {
+          for (int i = 0; i < numDocs; i++) {
+            float value = RANDOM.nextFloat();
+            values[i] = value;
+            creator.add(value);
+          }
         } else {
-            Assert.assertTrue(rangeStartArray[rangeId].longValue() <= values[docId].longValue(),
-                    "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
-        }
-    }
-
-    private void checkLongMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerColumn) {
-        boolean atleastOneInRange = false;
-
-        if (rangeId != rangeStartArray.length - 1) {
-            for (int i = 0; i < numValuesPerColumn; i++) {
-                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].longValue() <= values[numValuesPerColumn * docId + i].longValue() && values[numValuesPerColumn * docId + i].longValue() < rangeStartArray[
-                        rangeId + 1].longValue());
+          float[] floatValues = new float[numValuesPerEntry];
+          for (int i = 0; i < numDocs; i++) {
+            for (int j = 0; j < numValuesPerEntry; j++) {
+              float value = RANDOM.nextFloat();
+              floatValues[j] = value;
+              values[i * numValuesPerEntry + j] = value;
             }
+            creator.add(floatValues, numValuesPerEntry);
+          }
+        }
+        break;
+      case DOUBLE:
+        if (numValuesPerEntry == 1) {
+          for (int i = 0; i < numDocs; i++) {
+            double value = RANDOM.nextDouble();
+            values[i] = value;
+            creator.add(value);
+          }
         } else {
-            for (int i = 0; i < numValuesPerColumn; i++) {
-                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].longValue() <= values[numValuesPerColumn * docId + i].longValue());
+          double[] doubleValues = new double[numValuesPerEntry];
+          for (int i = 0; i < numDocs; i++) {
+            for (int j = 0; j < numValuesPerEntry; j++) {
+              double value = RANDOM.nextDouble();
+              doubleValues[j] = value;
+              values[i * numValuesPerEntry + j] = value;
             }
+            creator.add(doubleValues, numValuesPerEntry);
+          }
         }
-
-        Assert.assertTrue(atleastOneInRange, "rangestart:" + rangeStartArray[rangeId]);
+        break;
+      default:
+        throw new IllegalStateException();
     }
+  }
 
-    private void checkFloat(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
-        if (rangeId != rangeStartArray.length - 1) {
-            Assert.assertTrue(
-                    rangeStartArray[rangeId].floatValue() <= values[docId].floatValue() && values[docId].floatValue() < rangeStartArray[
-                            rangeId + 1].floatValue(), "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+  private void checkValueForDocId(DataType dataType, Number[] values, Number[] rangeStartArray, int rangeId, int docId,
+      int numValuesPerEntry) {
+    switch (dataType) {
+      case INT:
+        if (numValuesPerEntry == 1) {
+          checkInt(rangeStartArray, rangeId, values[docId].intValue());
         } else {
-            Assert.assertTrue(rangeStartArray[rangeId].floatValue() <= values[docId].floatValue(),
-                    "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+          checkIntMV(rangeStartArray, rangeId, values, docId, numValuesPerEntry);
         }
-    }
-
-    private void checkFloatMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerColumn) {
-        boolean atleastOneInRange = false;
-
-        if (rangeId != rangeStartArray.length - 1) {
-            for (int i = 0; i < numValuesPerColumn; i++) {
-                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].floatValue() <= values[numValuesPerColumn * docId + i].floatValue() && values[numValuesPerColumn * docId + i].floatValue() < rangeStartArray[
-                        rangeId + 1].floatValue());
-            }
+        break;
+      case LONG:
+        if (numValuesPerEntry == 1) {
+          checkLong(rangeStartArray, rangeId, values[docId].longValue());
         } else {
-            for (int i = 0; i < numValuesPerColumn; i++) {
-                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].floatValue() <= values[numValuesPerColumn * docId + i].floatValue());
-            }
+          checkLongMV(rangeStartArray, rangeId, values, docId, numValuesPerEntry);
         }
-
-        Assert.assertTrue(atleastOneInRange, "rangestart:" + rangeStartArray[rangeId]);
-    }
-
-    private void checkDouble(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
-        if (rangeId != rangeStartArray.length - 1) {
-            Assert.assertTrue(
-                    rangeStartArray[rangeId].doubleValue() <= values[docId].doubleValue() && values[docId].doubleValue() < rangeStartArray[
-                            rangeId + 1].doubleValue(), "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+        break;
+      case FLOAT:
+        if (numValuesPerEntry == 1) {
+          checkFloat(rangeStartArray, rangeId, values[docId].floatValue());
         } else {
-            Assert.assertTrue(rangeStartArray[rangeId].doubleValue() <= values[docId].doubleValue(),
-                    "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
+          checkFloatMV(rangeStartArray, rangeId, values, docId, numValuesPerEntry);
         }
-    }
-
-    private void checkDoubleMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerColumn) {
-        boolean atleastOneInRange = false;
-
-        if (rangeId != rangeStartArray.length - 1) {
-            for (int i = 0; i < numValuesPerColumn; i++) {
-                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].doubleValue() <= values[numValuesPerColumn * docId + i].doubleValue() && values[numValuesPerColumn * docId + i].doubleValue() < rangeStartArray[
-                        rangeId + 1].doubleValue());
-            }
+        break;
+      case DOUBLE:
+        if (numValuesPerEntry == 1) {
+          checkDouble(rangeStartArray, rangeId, values[docId].doubleValue());
         } else {
-            for (int i = 0; i < numValuesPerColumn; i++) {
-                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].doubleValue() <= values[numValuesPerColumn * docId + i].doubleValue());
-            }
+          checkDoubleMV(rangeStartArray, rangeId, values, docId, numValuesPerEntry);
         }
-
-        Assert.assertTrue(atleastOneInRange, "rangestart:" + rangeStartArray[rangeId]);
+        break;
+      default:
+        throw new IllegalStateException();
     }
+  }
 
-    private void testRangeIndexBufferFormat(Number[] values, File rangeIndexFile)
-            throws IOException {
-        DataInputStream dis = new DataInputStream(new FileInputStream(rangeIndexFile));
-        int version = dis.readInt();
-        int valueTypeBytesLength = dis.readInt();
-
-        byte[] valueTypeBytes = new byte[valueTypeBytesLength];
-        dis.read(valueTypeBytes);
-        String name = new String(valueTypeBytes);
-        FieldSpec.DataType dataType = FieldSpec.DataType.valueOf(name);
-
-        int numRanges = dis.readInt();
-
-        Number[] rangeStart = new Number[numRanges];
-        Number rangeEnd;
-
-        switch (dataType) {
-            case INT:
-                for (int i = 0; i < numRanges; i++) {
-                    rangeStart[i] = dis.readInt();
-                }
-                rangeEnd = dis.readInt();
-                break;
-            case LONG:
-                for (int i = 0; i < numRanges; i++) {
-                    rangeStart[i] = dis.readLong();
-                }
-                rangeEnd = dis.readLong();
-                break;
-            case FLOAT:
-                for (int i = 0; i < numRanges; i++) {
-                    rangeStart[i] = dis.readFloat();
-                }
-                rangeEnd = dis.readFloat();
-                break;
-            case DOUBLE:
-                for (int i = 0; i < numRanges; i++) {
-                    rangeStart[i] = dis.readDouble();
-                }
-                rangeEnd = dis.readDouble();
-                break;
-        }
-
-        long[] rangeBitmapOffsets = new long[numRanges + 1];
-        for (int i = 0; i <= numRanges; i++) {
-            rangeBitmapOffsets[i] = dis.readLong();
-        }
-        ImmutableRoaringBitmap[] bitmaps = new ImmutableRoaringBitmap[numRanges];
-        for (int i = 0; i < numRanges; i++) {
-            long serializedBitmapLength;
-            serializedBitmapLength = rangeBitmapOffsets[i + 1] - rangeBitmapOffsets[i];
-            byte[] bytes = new byte[(int) serializedBitmapLength];
-            dis.read(bytes, 0, (int) serializedBitmapLength);
-            bitmaps[i] = new ImmutableRoaringBitmap(ByteBuffer.wrap(bytes));
-            for (int docId : bitmaps[i].toArray()) {
-                checkValueForDocId(dataType, values, rangeStart, i, docId, 1);
-            }
-        }
+  private void checkInt(Number[] rangeStartArray, int rangeId, int value) {
+    assertTrue(rangeStartArray[rangeId].intValue() <= value);
+    if (rangeId != rangeStartArray.length - 1) {
+      assertTrue(value < rangeStartArray[rangeId + 1].intValue());
     }
+  }
+
+  private void checkIntMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerMVEntry) {
+    if (rangeId != rangeStartArray.length - 1) {
+      for (int i = 0; i < numValuesPerMVEntry; i++) {
+        if (rangeStartArray[rangeId].intValue() <= values[docId * numValuesPerMVEntry + i].intValue()
+            && values[docId * numValuesPerMVEntry + i].intValue() < rangeStartArray[rangeId + 1].intValue()) {
+          return;
+        }
+      }
+    } else {
+      for (int i = 0; i < numValuesPerMVEntry; i++) {
+        if (rangeStartArray[rangeId].intValue() <= values[docId * numValuesPerMVEntry + i].intValue()) {
+          return;
+        }
+      }
+    }
+    fail();
+  }
+
+  private void checkLong(Number[] rangeStartArray, int rangeId, long value) {
+    assertTrue(rangeStartArray[rangeId].longValue() <= value);
+    if (rangeId != rangeStartArray.length - 1) {
+      assertTrue(value < rangeStartArray[rangeId + 1].longValue());
+    }
+  }
+
+  private void checkLongMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerMVEntry) {
+    if (rangeId != rangeStartArray.length - 1) {
+      for (int i = 0; i < numValuesPerMVEntry; i++) {
+        if (rangeStartArray[rangeId].longValue() <= values[docId * numValuesPerMVEntry + i].longValue()
+            && values[docId * numValuesPerMVEntry + i].longValue() < rangeStartArray[rangeId + 1].longValue()) {
+          return;
+        }
+      }
+    } else {
+      for (int i = 0; i < numValuesPerMVEntry; i++) {
+        if (rangeStartArray[rangeId].longValue() <= values[docId * numValuesPerMVEntry + i].longValue()) {
+          return;
+        }
+      }
+    }
+    fail();
+  }
+
+  private void checkFloat(Number[] rangeStartArray, int rangeId, float value) {
+    assertTrue(rangeStartArray[rangeId].floatValue() <= value);
+    if (rangeId != rangeStartArray.length - 1) {
+      assertTrue(value < rangeStartArray[rangeId + 1].floatValue());
+    }
+  }
+
+  private void checkFloatMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId,
+      int numValuesPerMVEntry) {
+    if (rangeId != rangeStartArray.length - 1) {
+      for (int i = 0; i < numValuesPerMVEntry; i++) {
+        if (rangeStartArray[rangeId].floatValue() <= values[docId * numValuesPerMVEntry + i].floatValue()
+            && values[docId * numValuesPerMVEntry + i].floatValue() < rangeStartArray[rangeId + 1].floatValue()) {
+          return;
+        }
+      }
+    } else {
+      for (int i = 0; i < numValuesPerMVEntry; i++) {
+        if (rangeStartArray[rangeId].floatValue() <= values[docId * numValuesPerMVEntry + i].floatValue()) {
+          return;
+        }
+      }
+    }
+    fail();
+  }
+
+  private void checkDouble(Number[] rangeStartArray, int rangeId, double value) {
+    assertTrue(rangeStartArray[rangeId].doubleValue() <= value);
+    if (rangeId != rangeStartArray.length - 1) {
+      assertTrue(value < rangeStartArray[rangeId + 1].doubleValue());
+    }
+  }
+
+  private void checkDoubleMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId,
+      int numValuesPerMVEntry) {
+    if (rangeId != rangeStartArray.length - 1) {
+      for (int i = 0; i < numValuesPerMVEntry; i++) {
+        if (rangeStartArray[rangeId].doubleValue() <= values[docId * numValuesPerMVEntry + i].doubleValue()
+            && values[docId * numValuesPerMVEntry + i].doubleValue() < rangeStartArray[rangeId + 1].doubleValue()) {
+          return;
+        }
+      }
+    } else {
+      for (int i = 0; i < numValuesPerMVEntry; i++) {
+        if (rangeStartArray[rangeId].doubleValue() <= values[docId * numValuesPerMVEntry + i].doubleValue()) {
+          return;
+        }
+      }
+    }
+    fail();
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/RangeIndexCreatorTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.segment.index.creator;
 
-import com.google.common.base.Preconditions;
 
 import java.io.DataInputStream;
 import java.io.File;
@@ -30,6 +29,7 @@ import java.util.Random;
 import org.apache.pinot.core.segment.creator.impl.inv.RangeIndexCreator;
 import org.apache.pinot.core.segment.index.readers.RangeIndexReader;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -68,6 +68,29 @@ public class RangeIndexCreatorTest {
         testDataType(FieldSpec.DataType.DOUBLE);
     }
 
+    @Test
+    public void testIntMV()
+            throws Exception {
+        testDataTypeMV(FieldSpec.DataType.INT);
+    }
+
+    @Test
+    public void testLongMV()
+            throws Exception {
+        testDataTypeMV(FieldSpec.DataType.LONG);
+    }
+
+    @Test
+    public void testFloatMV()
+            throws Exception {
+        testDataTypeMV(FieldSpec.DataType.FLOAT);
+    }
+
+    @Test
+    public void testDoubleMV()
+            throws Exception {
+        testDataTypeMV(FieldSpec.DataType.DOUBLE);
+    }
 
     private void testDataType(FieldSpec.DataType dataType)
             throws IOException {
@@ -84,7 +107,7 @@ public class RangeIndexCreatorTest {
                 new RangeIndexCreator(indexDir, fieldSpec, dataType, -1, -1, numDocs, numValues);
         Random r = new Random();
         Number[] values = new Number[numValues];
-        addDataToIndexer(dataType, cardinality, numDocs, creator, r, values);
+        addDataToIndexer(dataType, cardinality, numDocs, 1, creator, r, values);
 
 
         creator.seal();
@@ -101,66 +124,162 @@ public class RangeIndexCreatorTest {
         for (int rangeId = 0; rangeId < rangeStartArray.length; rangeId++) {
             ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
             for (int docId : bitmap.toArray()) {
-                checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId);
+                checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId, 1);
             }
         }
     }
 
-    private void checkValueForDocId(FieldSpec.DataType dataType, Number[] values, Number[] rangeStartArray, int rangeId, int docId) {
+    private void testDataTypeMV(FieldSpec.DataType dataType)
+            throws IOException {
+        File indexDir = new File(System.getProperty("java.io.tmpdir") + "/testRangeIndex");
+        indexDir.mkdirs();
+        FieldSpec fieldSpec = new DimensionFieldSpec();
+        fieldSpec.setDataType(dataType);
+        String columnName = "latency";
+        fieldSpec.setName(columnName);
+        fieldSpec.setSingleValueField(false);
+        int cardinality = 20;
+        int numDocs = 1000;
+        int numValues = 1000;
+        int numValuesPerColumn = 10;
+        RangeIndexCreator creator =
+                new RangeIndexCreator(indexDir, fieldSpec, dataType, -1, -1, numDocs, numValues * numValuesPerColumn);
+        Random r = new Random();
+        Number[] values = new Number[numValues * numValuesPerColumn];
+        addDataToIndexer(dataType, cardinality, numDocs, numValuesPerColumn, creator, r, values);
+
+
+        creator.seal();
+
+        File rangeIndexFile = new File(indexDir, columnName + BITMAP_RANGE_INDEX_FILE_EXTENSION);
+        //TEST THE BUFFER FORMAT
+
+        //testRangeIndexBufferFormat(values, rangeIndexFile);
+
+        //TEST USING THE READER
+        PinotDataBuffer pinotDataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile);
+        RangeIndexReader rangeIndexReader = new RangeIndexReader(pinotDataBuffer);
+        Number[] rangeStartArray = rangeIndexReader.getRangeStartArray();
+        for (int rangeId = 0; rangeId < rangeStartArray.length; rangeId++) {
+            ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
+            for (int docId : bitmap.toArray()) {
+                checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId, numValuesPerColumn);
+            }
+        }
+    }
+
+    private void checkValueForDocId(FieldSpec.DataType dataType, Number[] values, Number[] rangeStartArray, int rangeId, int docId, int numValuesPerColumn) {
         switch (dataType) {
             case INT: {
-                checkInt(rangeStartArray, rangeId, values, docId);
+                if (numValuesPerColumn > 1) {
+                    checkIntMV(rangeStartArray, rangeId, values, docId, numValuesPerColumn);
+                } else {
+                    checkInt(rangeStartArray, rangeId, values, docId);
+                }
                 break;
             }
             case LONG: {
-                checkLong(rangeStartArray, rangeId, values, docId);
+                if (numValuesPerColumn > 1) {
+                    checkLongMV(rangeStartArray, rangeId, values, docId, numValuesPerColumn);
+                } else {
+                    checkLong(rangeStartArray, rangeId, values, docId);
+                }
                 break;
             }
             case FLOAT: {
-                checkFloat(rangeStartArray, rangeId, values, docId);
+                if (numValuesPerColumn > 1) {
+                    checkFloatMV(rangeStartArray, rangeId, values, docId, numValuesPerColumn);
+                } else {
+                    checkFloat(rangeStartArray, rangeId, values, docId);
+                }
                 break;
             }
             case DOUBLE: {
-                checkDouble(rangeStartArray, rangeId, values, docId);
+                if (numValuesPerColumn > 1) {
+                    checkDoubleMV(rangeStartArray, rangeId, values, docId, numValuesPerColumn);
+                } else {
+                    checkDouble(rangeStartArray, rangeId, values, docId);
+                }
                 break;
             }
         }
     }
 
-    private void addDataToIndexer(FieldSpec.DataType dataType, int cardinality, int numDocs, RangeIndexCreator creator, Random r, Number[] values) {
+    private void addDataToIndexer(FieldSpec.DataType dataType, int cardinality, int numDocs, int numValuesPerColumn, RangeIndexCreator creator, Random r, Number[] values) {
         switch (dataType) {
             case INT: {
                 for (int i = 0; i < numDocs; i++) {
-                    int val = r.nextInt(cardinality);
-                    creator.add(val);
-                    values[i] = val;
+
+                    if (numValuesPerColumn > 1) {
+                        int[] mvColumnArr = new int[numValuesPerColumn];
+                        for (int j = 0; j < numValuesPerColumn; j++) {
+                            int val = r.nextInt(cardinality);
+                            mvColumnArr[j] = val;
+                            values[numValuesPerColumn * i + j] = val;
+                        }
+                        creator.add(mvColumnArr, numValuesPerColumn);
+                    } else {
+                        int val = r.nextInt(cardinality);
+                        creator.add(val);
+                        values[i] = val;
+                    }
                 }
                 break;
             }
 
             case LONG: {
                 for (int i = 0; i < numDocs; i++) {
-                    long val = r.nextLong();
-                    creator.add(val);
-                    values[i] = val;
+                    if (numValuesPerColumn > 1) {
+                        long[] mvColumnArr = new long[numValuesPerColumn];
+                        for (int j = 0; j < numValuesPerColumn; j++) {
+                            long val = r.nextLong();
+                            mvColumnArr[j] = val;
+                            values[numValuesPerColumn * i + j] = val;
+                        }
+                        creator.add(mvColumnArr, numValuesPerColumn);
+                    } else {
+                        long val = r.nextLong();
+                        creator.add(val);
+                        values[i] = val;
+                    }
                 }
                 break;
             }
 
             case FLOAT: {
                 for (int i = 0; i < numDocs; i++) {
-                    float val = r.nextFloat();
-                    creator.add(val);
-                    values[i] = val;
+                    if (numValuesPerColumn > 1) {
+                        float[] mvColumnArr = new float[numValuesPerColumn];
+                        for (int j = 0; j < numValuesPerColumn; j++) {
+                            float val = r.nextFloat();
+                            mvColumnArr[j] = val;
+                            values[numValuesPerColumn * i + j] = val;
+                        }
+                        creator.add(mvColumnArr, numValuesPerColumn);
+                    } else {
+                        float val = r.nextFloat();
+                        creator.add(val);
+                        values[i] = val;
+                    }
                 }
                 break;
             }
 
             case DOUBLE: {
                 for (int i = 0; i < numDocs; i++) {
-                    double val = r.nextDouble();
-                    creator.add(val);
-                    values[i] = val;
+                    if (numValuesPerColumn > 1) {
+                        double[] mvColumnArr = new double[numValuesPerColumn];
+                        for (int j = 0; j < numValuesPerColumn; j++) {
+                            double val = r.nextDouble();
+                            mvColumnArr[j] = val;
+                            values[numValuesPerColumn * i + j] = val;
+                        }
+                        creator.add(mvColumnArr, numValuesPerColumn);
+                    } else {
+                        double val = r.nextDouble();
+                        creator.add(val);
+                        values[i] = val;
+                    }
                 }
                 break;
             }
@@ -178,6 +297,23 @@ public class RangeIndexCreatorTest {
         }
     }
 
+    private void checkIntMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerColumn) {
+        boolean atleastOneInRange = false;
+
+        if (rangeId != rangeStartArray.length - 1) {
+            for (int i = 0; i < numValuesPerColumn; i++) {
+                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].intValue() <= values[numValuesPerColumn * docId + i].intValue() && values[numValuesPerColumn * docId + i].intValue() < rangeStartArray[
+                        rangeId + 1].intValue());
+            }
+        } else {
+            for (int i = 0; i < numValuesPerColumn; i++) {
+                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].intValue() <= values[numValuesPerColumn * docId + i].intValue());
+            }
+        }
+
+        Assert.assertTrue(atleastOneInRange, "rangestart:" + rangeStartArray[rangeId]);
+    }
+
     private void checkLong(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
         if (rangeId != rangeStartArray.length - 1) {
             Assert.assertTrue(
@@ -187,6 +323,23 @@ public class RangeIndexCreatorTest {
             Assert.assertTrue(rangeStartArray[rangeId].longValue() <= values[docId].longValue(),
                     "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
         }
+    }
+
+    private void checkLongMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerColumn) {
+        boolean atleastOneInRange = false;
+
+        if (rangeId != rangeStartArray.length - 1) {
+            for (int i = 0; i < numValuesPerColumn; i++) {
+                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].longValue() <= values[numValuesPerColumn * docId + i].longValue() && values[numValuesPerColumn * docId + i].longValue() < rangeStartArray[
+                        rangeId + 1].longValue());
+            }
+        } else {
+            for (int i = 0; i < numValuesPerColumn; i++) {
+                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].longValue() <= values[numValuesPerColumn * docId + i].longValue());
+            }
+        }
+
+        Assert.assertTrue(atleastOneInRange, "rangestart:" + rangeStartArray[rangeId]);
     }
 
     private void checkFloat(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
@@ -200,6 +353,23 @@ public class RangeIndexCreatorTest {
         }
     }
 
+    private void checkFloatMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerColumn) {
+        boolean atleastOneInRange = false;
+
+        if (rangeId != rangeStartArray.length - 1) {
+            for (int i = 0; i < numValuesPerColumn; i++) {
+                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].floatValue() <= values[numValuesPerColumn * docId + i].floatValue() && values[numValuesPerColumn * docId + i].floatValue() < rangeStartArray[
+                        rangeId + 1].floatValue());
+            }
+        } else {
+            for (int i = 0; i < numValuesPerColumn; i++) {
+                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].floatValue() <= values[numValuesPerColumn * docId + i].floatValue());
+            }
+        }
+
+        Assert.assertTrue(atleastOneInRange, "rangestart:" + rangeStartArray[rangeId]);
+    }
+
     private void checkDouble(Number[] rangeStartArray, int rangeId, Number[] values, int docId) {
         if (rangeId != rangeStartArray.length - 1) {
             Assert.assertTrue(
@@ -209,6 +379,23 @@ public class RangeIndexCreatorTest {
             Assert.assertTrue(rangeStartArray[rangeId].doubleValue() <= values[docId].doubleValue(),
                     "rangestart:" + rangeStartArray[rangeId] + " value:" + values[docId]);
         }
+    }
+
+    private void checkDoubleMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerColumn) {
+        boolean atleastOneInRange = false;
+
+        if (rangeId != rangeStartArray.length - 1) {
+            for (int i = 0; i < numValuesPerColumn; i++) {
+                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].doubleValue() <= values[numValuesPerColumn * docId + i].doubleValue() && values[numValuesPerColumn * docId + i].doubleValue() < rangeStartArray[
+                        rangeId + 1].doubleValue());
+            }
+        } else {
+            for (int i = 0; i < numValuesPerColumn; i++) {
+                atleastOneInRange = atleastOneInRange || (rangeStartArray[rangeId].doubleValue() <= values[numValuesPerColumn * docId + i].doubleValue());
+            }
+        }
+
+        Assert.assertTrue(atleastOneInRange, "rangestart:" + rangeStartArray[rangeId]);
     }
 
     private void testRangeIndexBufferFormat(Number[] values, File rangeIndexFile)
@@ -266,7 +453,7 @@ public class RangeIndexCreatorTest {
             dis.read(bytes, 0, (int) serializedBitmapLength);
             bitmaps[i] = new ImmutableRoaringBitmap(ByteBuffer.wrap(bytes));
             for (int docId : bitmaps[i].toArray()) {
-                checkValueForDocId(dataType, values, rangeStart, i, docId);
+                checkValueForDocId(dataType, values, rangeStart, i, docId, 1);
             }
         }
     }


### PR DESCRIPTION
This PR implements #5703 
* Create new interface RawValueBasedRangeIndexCreator 
* Add support for raw value in existing Range indexer.

Following refactoring has been done in this PR
* create a marker interface InvertedIndexCreator
* rename the existing InvertedIndexCreator interface to DictionaryBasedInvertedIndexCreator
* create a new interface RawValueBasedInvertedIndexCreator which has add function for all data types instead of just int
* create a new RawValueBasedRangeIndexCreator which extends `RawValueBasedInvertedIndexCreator