### PR TITLE
Fix encrypted file path in Segment Fetcher

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -129,7 +129,7 @@ public class SegmentFetcherFactory {
       fetchSegmentToLocal(uri, dest);
     } else {
       // download
-      File tempDownloadedFile = new File(dest, ENCODED_SUFFIX);
+      File tempDownloadedFile = new File(dest.getPath() + ENCODED_SUFFIX);
       fetchSegmentToLocal(uri, tempDownloadedFile);
 
       // decrypt

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
@@ -95,6 +95,8 @@ public class SegmentFetcherFactoryTest {
     assertEquals(fakeCrypter._initCalled, 1);
     assertEquals(fakeCrypter._decryptCalled, 1);
     assertEquals(fakeCrypter._encryptCalled, 0);
+    assertEquals(fakeCrypter._originalPath, "foo/bar.enc");
+    assertEquals(fakeCrypter._decryptedPath, "foo/bar");
   }
 
   public static class FakeSegmentFetcher implements SegmentFetcher {
@@ -125,6 +127,8 @@ public class SegmentFetcherFactoryTest {
     private int _initCalled = 0;
     private int _encryptCalled = 0;
     private int _decryptCalled = 0;
+    private String _originalPath;
+    private String _decryptedPath;
 
     @Override
     public void init(PinotConfiguration config) {
@@ -132,13 +136,15 @@ public class SegmentFetcherFactoryTest {
     }
 
     @Override
-    public void encrypt(File decryptedFile, File encryptedFile) {
+    public void encrypt(File origFile, File encFile) {
       _encryptCalled++;
     }
 
     @Override
-    public void decrypt(File encryptedFile, File decryptedFile) {
+    public void decrypt(File origFile, File decFile) {
       _decryptCalled++;
+      _originalPath = origFile.getPath();
+      _decryptedPath = decFile.getPath();
     }
   }
 }


### PR DESCRIPTION
## Description
The encoded suffix `.enc` needs to be added to the destination path to make a separate temporary file. For example, for destination file `foo/bar`, currently the temp file is mistakenly created as `foo/bar/.enc` instead of the correct one `foo/bar.enc`.

## Testing Done
- unit test
- also ran minion locally along with controller, server, and broker and verified the expected behavior
