### PR TITLE
Change group key delimiter from '\t' to '\0'

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -201,7 +201,7 @@ public class GroupByCombineOperator extends BaseOperator<IntermediateResultsBloc
 
       // Trim the results map.
       AggregationGroupByTrimmingService aggregationGroupByTrimmingService =
-          new AggregationGroupByTrimmingService(aggregationFunctions, _queryContext.getLimit());
+          new AggregationGroupByTrimmingService(_queryContext);
       List<Map<String, Object>> trimmedResults =
           aggregationGroupByTrimmingService.trimIntermediateResultsMap(resultsMap);
       IntermediateResultsBlock mergedBlock = new IntermediateResultsBlock(aggregationFunctions, trimmedResults, true);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.groupby;
 
 import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 
 
@@ -26,7 +27,9 @@ import org.apache.pinot.core.operator.blocks.TransformBlock;
  * Interface for generating group keys.
  */
 public interface GroupKeyGenerator {
-  String DELIMITER = "\t";
+  // TODO: Remove LEGACY_DELIMITER after releasing 0.5.0
+  char LEGACY_DELIMITER = '\t';
+  char DELIMITER = '\0';
   int INVALID_ID = -1;
 
   /**
@@ -80,11 +83,14 @@ public interface GroupKeyGenerator {
     public String _stringKey;
 
     /**
-     * Returns the group key as an array
+     * Returns the group keys as a String array.
+     * NOTE: DO NOT use this method for single group-by expression, directly use _stringKey instead for performance
+     *       concern.
      */
     public String[] getKeys() {
-      // Set limit to -1 to prevent removing trailing empty strings
-      return _stringKey.split(GroupKeyGenerator.DELIMITER, -1);
+      assert _stringKey.indexOf(DELIMITER) != -1;
+      // Preserve all tokens to support empty strings
+      return StringUtils.splitPreserveAllTokens(_stringKey, GroupKeyGenerator.DELIMITER);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
@@ -126,7 +126,7 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 100000L, 0L, 700000L,
             100000L);
     QueriesTestUtils
-        .testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(), "w\t3818\t369", 1L,
+        .testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(), "w\0003818\000369", 1L,
             1095214422L, 1547156787, 528554902, 52058876L, 1L);
 
     // Test query with filter.
@@ -135,9 +135,8 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     QueriesTestUtils
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L, 275416L,
             109340L, 100000L);
-    QueriesTestUtils
-        .testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(), "L\t306633\t2147483647",
-            1L, 131154783L, 952002176, 674022574, 674022574L, 1L);
+    QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
+        "L\000306633\0002147483647", 1L, 131154783L, 952002176, 674022574, 674022574L, 1L);
   }
 
   @Test
@@ -151,7 +150,7 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 100000L, 0L, 700000L,
             100000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
-        "240129976\tL\t2147483647\t2147483647", 1L, 240129976L, 1649812746, 2077178039, 1952924139L, 1L);
+        "240129976\0L\0002147483647\0002147483647", 1L, 240129976L, 1649812746, 2077178039, 1952924139L, 1L);
 
     // Test query with filter.
     aggregationGroupByOperator = getOperatorForPqlQueryWithFilter(query);
@@ -160,7 +159,7 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L, 275416L,
             109340L, 100000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
-        "903461357\tL\t2147483647\t388", 2L, 1806922714L, 652024397, 674022574, 870535054L, 2L);
+        "903461357\0L\0002147483647\000388", 2L, 1806922714L, 652024397, 674022574, 870535054L, 2L);
   }
 
   @Test
@@ -174,8 +173,8 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 100000L, 0L, 700000L,
             100000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
-        "1118965780\t1848116124\t8599\t504\t1597666851\t675163196\t607034543", 1L, 1118965780L, 1848116124, 1597666851,
-        675163196L, 1L);
+        "1118965780\0001848116124\0008599\000504\0001597666851\000675163196\000607034543", 1L, 1118965780L, 1848116124,
+        1597666851, 675163196L, 1L);
 
     // Test query with filter.
     aggregationGroupByOperator = getOperatorForPqlQueryWithFilter(query);
@@ -184,7 +183,7 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 15620L, 275416L,
             109340L, 100000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
-        "949960647\t238753654\t2147483647\t2147483647\t674022574\t674022574\t674022574", 2L, 1899921294L, 238753654,
-        674022574, 1348045148L, 2L);
+        "949960647\000238753654\0002147483647\0002147483647\000674022574\000674022574\000674022574", 2L, 1899921294L,
+        238753654, 674022574, 1348045148L, 2L);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
@@ -104,7 +104,7 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 30000L, 0L, 210000L,
             30000L);
     QueriesTestUtils
-        .testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(), "1813102948\tP\tHEuxNvH",
+        .testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(), "1813102948\0P\0HEuxNvH",
             4L, 2062187196L, 1988589001, 394608493, 4782388964L, 4L);
 
     // Test query with filter.
@@ -114,7 +114,7 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 6129L, 84134L, 42903L,
             30000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
-        "1176631727\tP\tKrNxpdycSiwoRohEiTIlLqDHnx", 1L, 716185211L, 489993380, 371110078, 487714191L, 1L);
+        "1176631727\0P\0KrNxpdycSiwoRohEiTIlLqDHnx", 1L, 716185211L, 489993380, 371110078, 487714191L, 1L);
   }
 
   @Test
@@ -128,7 +128,8 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 30000L, 0L, 210000L,
             30000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
-        "484569489\t16200443\t1159557463\tP\tMaztCmmxxgguBUxPti", 2L, 969138978L, 995355481, 16200443, 2222394270L, 2L);
+        "484569489\00016200443\0001159557463\0P\0MaztCmmxxgguBUxPti", 2L, 969138978L, 995355481, 16200443, 2222394270L,
+        2L);
 
     // Test query with filter.
     aggregationGroupByOperator = getOperatorForPqlQueryWithFilter(query);
@@ -137,7 +138,7 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 6129L, 84134L, 42903L,
             30000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
-        "1318761745\t353175528\t1172307870\tP\tHEuxNvH", 2L, 2637523490L, 557154208, 353175528, 2427862396L, 2L);
+        "1318761745\000353175528\0001172307870\0P\0HEuxNvH", 2L, 2637523490L, 557154208, 353175528, 2427862396L, 2L);
   }
 
   @Test
@@ -151,8 +152,8 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 30000L, 0L, 270000L,
             30000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
-        "1784773968\t204243323\t628170461\t1985159279\t296467636\tP\tHEuxNvH\t402773817\t2047180536", 1L, 1784773968L,
-        204243323, 628170461, 1985159279L, 1L);
+        "1784773968\000204243323\000628170461\0001985159279\000296467636\0P\0HEuxNvH\000402773817\0002047180536", 1L,
+        1784773968L, 204243323, 628170461, 1985159279L, 1L);
 
     // Test query with filter.
     aggregationGroupByOperator = getOperatorForPqlQueryWithFilter(query);
@@ -161,8 +162,8 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
         .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), 6129L, 84134L, 55161L,
             30000L);
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
-        "1361199163\t178133991\t296467636\t788414092\t1719301234\tP\tMaztCmmxxgguBUxPti\t1284373442\t752388855", 1L,
-        1361199163L, 178133991, 296467636, 788414092L, 1L);
+        "1361199163\000178133991\000296467636\000788414092\0001719301234\0P\0MaztCmmxxgguBUxPti\0001284373442\000752388855",
+        1L, 1361199163L, 178133991, 296467636, 788414092L, 1L);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/GroupKeyTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/GroupKeyTest.java
@@ -28,37 +28,32 @@ public class GroupKeyTest {
   @Test
   public void testGetKeys() {
     GroupKeyGenerator.GroupKey groupKey = new GroupKeyGenerator.GroupKey();
-    groupKey._stringKey = "foo\tbar\t";
+    groupKey._stringKey = "foo\0bar\0";
     String[] keys = groupKey.getKeys();
     Assert.assertEquals(keys.length, 3);
     Assert.assertEquals(keys, new String[]{"foo", "bar", ""});
 
-    groupKey._stringKey = "foo\t\tbar";
+    groupKey._stringKey = "foo\0\0bar";
     keys = groupKey.getKeys();
     Assert.assertEquals(keys.length, 3);
     Assert.assertEquals(keys, new String[]{"foo", "", "bar"});
 
-    groupKey._stringKey = "\tfoo\tbar";
+    groupKey._stringKey = "\0foo\0bar";
     keys = groupKey.getKeys();
     Assert.assertEquals(keys.length, 3);
     Assert.assertEquals(keys, new String[]{"", "foo", "bar"});
 
-    groupKey._stringKey = "foo\t\t";
+    groupKey._stringKey = "foo\0\0";
     keys = groupKey.getKeys();
     Assert.assertEquals(keys.length, 3);
     Assert.assertEquals(keys, new String[]{"foo", "", ""});
 
-    groupKey._stringKey = "\t\t";
+    groupKey._stringKey = "\0\0";
     keys = groupKey.getKeys();
     Assert.assertEquals(keys.length, 3);
     Assert.assertEquals(keys, new String[]{"", "", ""});
 
-    groupKey._stringKey = "";
-    keys = groupKey.getKeys();
-    Assert.assertEquals(keys.length, 1);
-    Assert.assertEquals(keys, new String[]{""});
-
-    groupKey._stringKey = "\t";
+    groupKey._stringKey = "\0";
     keys = groupKey.getKeys();
     Assert.assertEquals(keys.length, 2);
     Assert.assertEquals(keys, new String[]{"", ""});

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
@@ -65,7 +65,6 @@ import org.openjdk.jmh.runner.options.TimeValue;
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgs = {"-server", "-Xmx8G", "-XX:MaxDirectMemorySize=16G"})
 public class BenchmarkCombineGroupBy {
-  private static final int TOP_N = 500;
   private static final int NUM_SEGMENTS = 4;
   private static final int NUM_RECORDS_PER_SEGMENT = 100_000;
   private static final int CARDINALITY_D1 = 500;
@@ -205,7 +204,7 @@ public class BenchmarkCombineGroupBy {
     }
 
     AggregationGroupByTrimmingService aggregationGroupByTrimmingService =
-        new AggregationGroupByTrimmingService(_aggregationFunctions, TOP_N);
+        new AggregationGroupByTrimmingService(_queryContext);
     List<Map<String, Object>> trimmedResults = aggregationGroupByTrimmingService.trimIntermediateResultsMap(resultsMap);
   }
 


### PR DESCRIPTION
## Description
Using '\t' as the group key delimiter will cause unexpected behavior when grouping on string value with '\t' inside. To solve it, we can use '\0' as the delimiter which is not allowed in the string values.

- Add code to handle both '\0' and '\t' as limiter on broker side for backward-compatibility
- Specialize case of grouping on single expression to save the redundant group key splits.

## Upgrade Notes
In order to achieve zero down-time upgrade, Brokers must be upgraded before Servers.