### PR TITLE
add timeColumnName to tableConfig to enable TE auto-detection

### DIFF
--- a/pinot-tools/src/main/resources/generator/complexWebsite_config.json
+++ b/pinot-tools/src/main/resources/generator/complexWebsite_config.json
@@ -2,7 +2,8 @@
   "tableName": "complexWebsite",
   "segmentsConfig" : {
     "replication" : "1",
-    "schemaName" : "complexWebsite"
+    "schemaName" : "complexWebsite",
+    "timeColumnName": "hoursSinceEpoch"
   },
   "tableIndexConfig" : {
     "invertedIndexColumns" : [],

--- a/pinot-tools/src/main/resources/generator/simpleWebsite_config.json
+++ b/pinot-tools/src/main/resources/generator/simpleWebsite_config.json
@@ -2,7 +2,8 @@
   "tableName": "simpleWebsite",
   "segmentsConfig" : {
     "replication" : "1",
-    "schemaName" : "simpleWebsite"
+    "schemaName" : "simpleWebsite",
+    "timeColumnName": "hoursSinceEpoch"
   },
   "tableIndexConfig" : {
     "invertedIndexColumns" : [],


### PR DESCRIPTION
## Description
add timeColumnName to tableConfig for generated datasets to enable TE auto-detection of metrics

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes? Things to consider:
**No**
