### PR TITLE
Te bq connector

### DIFF
--- a/thirdeye/docs/bigquery.rst
+++ b/thirdeye/docs/bigquery.rst
@@ -1,0 +1,95 @@
+..
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+..
+
+.. _bigquery:
+
+****************************
+BigQuery
+****************************
+
+The BigQuery connectors uses the JDBC connector for BigQuery.
+See https://cloud.google.com/bigquery/providers/simba-drivers.
+The connector was tested with the JDBC driver `1.2.4`.
+
+WARNING: Using ThirdEye with BigQuery can incur some cost.
+TIPS:
+1. Use partitioned table, and use the _partitiontime as the time column in the ThirdEye metric.
+See https://cloud.google.com/bigquery/docs/partitioned-tables.
+2. Reserve slots to avoid on-demand query pricing.
+See https://cloud.google.com/bigquery/docs/reservations-intro.
+
+**0: Prerequisites**
+Rebuild ThirdEye with the specific resources for bigquery:
+
+.. code-block:: bash
+
+    ./install.sh bigquery
+
+
+**1: Update the data sources configuration**
+
+Add your BigQuery database URL and credentials in `thirdeye-pinot/config/datasources/data-sources-config.yml`. You will be able to add multiple databases with multiple credentials, as follows:
+
+.. code-block:: yaml
+
+    dataSourceConfigs:
+      - className: org.apache.pinot.thirdeye.datasource.sql.SqlThirdEyeDataSource
+        properties:
+          BigQuery:
+            - db:
+                dbname1: jdbc:bigquery://https://www.googleapis.com/bigquery/v2;ProjectId=PROJECT_ID1;OAuthType=1;
+                dbname2: jdbc:bigquery://https://www.googleapis.com/bigquery/v2;ProjectId=PROJECT_ID2;OAuthType=0;OAuthServiceAcctEmail=thirdeye-sa@project.iam.gserviceaccount.com;OAuthPvtKeyPath=/path/to/thirdeye-sa.json;
+              driver: com.simba.googlebigquery.jdbc42.Driver
+
+See how to build the BigQuery url here:
+https://www.simba.com/products/BigQuery/doc/JDBC_InstallGuide/content/jdbc/bq/using/connectionurl.htm
+You can use different authentication methods ``OAuthType``, see:
+https://www.simba.com/products/BigQuery/doc/JDBC_InstallGuide/content/jdbc/bq/options/oauthtype.htm
+
+Note: the `dbname` here is an arbitrary name. For BigQuery you will most likely use something that will recall the project running the BigQuery jobs.
+
+
+**2: Run ThirdEye frontend**
+
+.. code-block:: bash
+
+    ./run-frontend.sh
+
+**3: Import metric from BigQuery**
+
+See :ref:`import-sql-metric`.
+
+Specificities of BigQuery:
+``Table Name``: Use back tick, eg: ``\`project_id.dataset_id.table_name\```
+You can also unnest in the table name, eg: ``\`project_id.dataset_id.table_name\`,  unnest(repeated_field) as r``
+
+Example of time configuration:
+``Time column``:  ``UNIX_SECONDS(TIMESTAMP(DATETIME(_PARTITIONTIME)))``
+``Timezone``: ``UTC``
+``Time Format``: ``EPOCH``
+``Time Granularity``: ``1 SECONDS``
+
+
+**4: Start an analysis**
+
+Point your favorite browser to
+
+``http://localhost:1426/app/#/rootcause``
+
+and type any data set or metric name (fragment) in the search box. Auto-complete will now list the names of matching metrics. Select any metric to start an investigation.

--- a/thirdeye/docs/datasources.rst
+++ b/thirdeye/docs/datasources.rst
@@ -26,5 +26,6 @@ Data Sources Setup
     pinot
     mysql
     presto
+    bigquery
     import_sql_metric
     contribute_datasource

--- a/thirdeye/install.sh
+++ b/thirdeye/install.sh
@@ -5,8 +5,40 @@
 # mvn install -DskipTests -pl pinot-common,pinot-core,pinot-spi,pinot-java-client -am -Pbuild-shaded-jar || exit 1
 # cd thirdeye
 
+PROFILES_ARG=""
+
+if [ $# -ne 0 ]
+then
+PROFILES_ARG="-P "
+for var in "$@"
+do
+  echo "*******************************************************"
+  echo "Preparing build for custom datasource: $var"
+  echo "*******************************************************"
+  PROFILES_ARG=${PROFILES_ARG}${var},
+  case ${var} in
+  # [Optional] add your maven profile name and corresponding custom build here
+  bigquery)
+    # change driver version if need be. Default value is the recommended, tested version.
+    BQ_DRIVER_VERSION=${BQ_DRIVER_VERSION:="SimbaJDBCDriverforGoogleBigQuery42_1.2.4.1007"}
+    wget -N https://storage.googleapis.com/simba-bq-release/jdbc/${BQ_DRIVER_VERSION}.zip
+    unzip -o ${BQ_DRIVER_VERSION}.zip -d ./${BQ_DRIVER_VERSION}
+    # install bigQuery driver
+    mvn install:install-file -Dfile=./${BQ_DRIVER_VERSION}/GoogleBigQueryJDBC42.jar -DgroupId='com.simba.googlebigquery' -DartifactId='jdbc42' -Dversion='1.2.4' -Dpackaging='jar'
+    rm -r -d  -f ./${BQ_DRIVER_VERSION}
+    ;;
+  *)
+    echo "Unkown custom datasource argument ${var}. Aborting build."
+    exit 1
+    ;;
+  esac
+  PROFILES_ARG=${PROFILES_ARG%,}
+done
+fi
+
+
 echo "*******************************************************"
 echo "Building ThirdEye"
 echo "*******************************************************"
 
-mvn install -DskipTests || exit 1
+mvn install -DskipTests ${PROFILES_ARG}|| exit 1

--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -86,7 +86,7 @@
     <json.version>20170516</json.version>
     <log4j2.version>2.12.0</log4j2.version>
   </properties>
-  
+
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -544,6 +544,54 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <id>bigquery</id>
+      <properties>
+        <avro.version>1.9.0</avro.version>
+        <google-auth-library-oauth2-http.version>0.13.0</google-auth-library-oauth2-http.version>
+        <gax.version>1.42.0</gax.version>
+        <google-api-services-bigquery.version>v2-rev426-1.25.0</google-api-services-bigquery.version>
+        <jdbc42.version>1.2.4</jdbc42.version>
+      </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>com.google.auth</groupId>
+          <artifactId>google-auth-library-oauth2-http</artifactId>
+          <version>${google-auth-library-oauth2-http.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>com.google.api</groupId>
+          <artifactId>gax</artifactId>
+          <version>${gax.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>com.google.apis</groupId>
+          <artifactId>google-api-services-bigquery</artifactId>
+          <version>${google-api-services-bigquery.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+          <version>${avro.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>com.simba.googlebigquery</groupId>
+          <artifactId>jdbc42</artifactId>
+          <version>${jdbc42.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
+    </profile>
+  </profiles>
 
   <reporting>
     <plugins>

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -377,6 +377,40 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+  <profile>
+    <id>bigquery</id>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>com.google.apis</groupId>
+        <artifactId>google-api-services-bigquery</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>com.simba.googlebigquery</groupId>
+        <artifactId>jdbc42</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
@@ -88,6 +88,7 @@ public class SqlUtils {
   private static final String MYSQL = "MySQL";
   private static final String H2 = "H2";
   private static final String VERTICA = "Vertica";
+  private static final String BIGQUERY = "BigQuery";
 
   /**
    * Insert a table to SQL database, currently only used by H2, that can be read by ThirdEye
@@ -588,6 +589,26 @@ public class SqlUtils {
   }
 
   /**
+   * Convert java SimpleDateFormat to BigQuery StandardSQL's format
+   *
+   * @param timeFormat
+   * @return BigQuery Standard SQL time format
+   */
+  private static String timeFormatToBigQueryFormat(String timeFormat) {
+    switch (timeFormat) {
+      case "yyyyMMdd":
+        return "%Y%m%d";
+      case "yyyy-MM-dd hh:mm:ss":
+        return "%Y-%m-%d %H:%M:%S";
+      case "yyyy-MM-dd-HH":
+        return "%Y-%m-%d-%H";
+      default:
+        return "%Y-%m-%d %H:%M:%S";
+    }
+  }
+
+
+  /**
    * Return a SQL clause that cast any timeColumn as unix timestamp
    *
    * @param timeFormat format of time column
@@ -604,6 +625,8 @@ public class SqlUtils {
       return "TO_UNIXTIME(PARSEDATETIME(CAST(" + timeColumn + " AS VARCHAR), '" + timeFormat + "'))";
     } else if (sourceName.equals(VERTICA)) {
       return "EXTRACT(EPOCH FROM to_timestamp(to_char(" + timeColumn + "), '" + timeFormatToVerticaFormat(timeFormat) + "'))";
+    } else if (sourceName.equals(BIGQUERY)) {
+      return "UNIX_SECONDS(TIMESTAMP(PARSE_DATETIME(\"" + timeFormatToBigQueryFormat(timeFormat) + "\", " + timeColumn + ")))";
     }
     return "";
   }


### PR DESCRIPTION
## Description
Added support of BigQuery as a datasource for ThirdEye.
I followed https://thirdeye.readthedocs.io/en/latest/contribute_datasource.html. 

Design points: 
- The JDBC driver for BigQuery has to be downloaded and put into the maven project. Also, the driver requires specific version for some dependencies.

A normal build is unchanged: `mvn install -DskipTests` and a build with bigquery is  `mvn install -DskipTests -P bigquery`

Also, I've added the same principle for `install.sh`:
`./install.sh` has the same behavior as before, `./install.sh bigquery` downloads and  install the driver, and compile with the bigquery profile.

The install.sh loop can look a bit complex/over-engineered, but I am anticipating the fact that we will have other databases that require more ops or other profiles for specific dependencies. We already have another case for using CloudSQL on GCP, but it's not the purpose of this MR. To  give you an idea, the result is `./install.sh bigquery cloudsql`. 

I am not a Java  dev so I had no idea how to do this properly. Let me know if I you're thinking of a better way to do this.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes? Things to consider:
No

## Release Notes
Added support for BigQuery as a datasource in ThirdEye.

## Documentation
I've added a documentation page here `thirdeye/docs/bigquery.rst`, but I did not find how to build the doc so I'm not 100% sure it builds correctly.
