### PR TITLE
Support for exact distinct count for non int data types

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -192,9 +192,12 @@ public class HelixBrokerStarter implements ServiceStartable {
         new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(_clusterName).build();
     Map<String, String> configMap = _helixAdmin.getConfig(helixConfigScope, Arrays
         .asList(Helix.ENABLE_CASE_INSENSITIVE_KEY, Helix.DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY,
-            Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, Helix.DEFAULT_HYPERLOGLOG_LOG2M_KEY));
+            Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, Helix.DEFAULT_HYPERLOGLOG_LOG2M_KEY,
+            Helix.ENABLE_DISTINCT_COUNT_BITMAP_OVERRIDE_KEY));
+
     boolean caseInsensitive = Boolean.parseBoolean(configMap.get(Helix.ENABLE_CASE_INSENSITIVE_KEY)) || Boolean
         .parseBoolean(configMap.get(Helix.DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY));
+
     String log2mStr = configMap.get(Helix.DEFAULT_HYPERLOGLOG_LOG2M_KEY);
     if (log2mStr != null) {
       try {
@@ -204,8 +207,13 @@ public class HelixBrokerStarter implements ServiceStartable {
             Helix.DEFAULT_HYPERLOGLOG_LOG2M_KEY, log2mStr, CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M);
       }
     }
+
     if (Boolean.parseBoolean(configMap.get(Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE))) {
       _brokerConf.setProperty(Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, true);
+    }
+
+    if (Boolean.parseBoolean(configMap.get(Helix.ENABLE_DISTINCT_COUNT_BITMAP_OVERRIDE_KEY))) {
+      _brokerConf.setProperty(Helix.ENABLE_DISTINCT_COUNT_BITMAP_OVERRIDE_KEY, true);
     }
 
     LOGGER.info("Setting up broker request handler");

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -114,8 +114,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   private final RateLimiter _numDroppedLogRateLimiter;
   private final AtomicInteger _numDroppedLog;
 
-  private final boolean _enableQueryLimitOverride;
   private final int _defaultHllLog2m;
+  private final boolean _enableQueryLimitOverride;
+  private final boolean _enableDistinctCountBitmapOverride;
 
   public BaseBrokerRequestHandler(PinotConfiguration config, RoutingManager routingManager,
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache,
@@ -130,6 +131,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     _defaultHllLog2m = _config.getProperty(CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M_KEY,
         CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M);
     _enableQueryLimitOverride = _config.getProperty(Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, false);
+    _enableDistinctCountBitmapOverride =
+        _config.getProperty(CommonConstants.Helix.ENABLE_DISTINCT_COUNT_BITMAP_OVERRIDE_KEY, false);
 
     _brokerId = config.getProperty(Broker.CONFIG_OF_BROKER_ID, getDefaultBrokerId());
     _brokerTimeoutMs = config.getProperty(Broker.CONFIG_OF_BROKER_TIMEOUT_MS, Broker.DEFAULT_BROKER_TIMEOUT_MS);
@@ -204,6 +207,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
     if (_enableQueryLimitOverride) {
       handleQueryLimitOverride(brokerRequest, _queryResponseLimit);
+    }
+    if (_enableDistinctCountBitmapOverride) {
+      handleDistinctCountBitmapOverride(brokerRequest);
     }
     String tableName = brokerRequest.getQuerySource().getTableName();
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
@@ -564,6 +570,55 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         if (brokerRequest.getPinotQuery().getLimit() > queryLimit) {
           brokerRequest.getPinotQuery().setLimit(queryLimit);
         }
+      }
+    }
+  }
+
+  /**
+   * Helper method to rewrite 'DistinctCount' with 'DistinctCountBitmap' for the given broker request.
+   */
+  private static void handleDistinctCountBitmapOverride(BrokerRequest brokerRequest) {
+    List<AggregationInfo> aggregationsInfo = brokerRequest.getAggregationsInfo();
+    if (aggregationsInfo != null) {
+      for (AggregationInfo aggregationInfo : aggregationsInfo) {
+        if (StringUtils.remove(aggregationInfo.getAggregationType(), '_')
+            .equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNT.name())) {
+          aggregationInfo.setAggregationType(AggregationFunctionType.DISTINCTCOUNTBITMAP.name());
+        }
+      }
+    }
+    PinotQuery pinotQuery = brokerRequest.getPinotQuery();
+    if (pinotQuery != null) {
+      for (Expression expression : pinotQuery.getSelectList()) {
+        handleDistinctCountBitmapOverride(expression);
+      }
+      List<Expression> orderByExpressions = pinotQuery.getOrderByList();
+      if (orderByExpressions != null) {
+        for (Expression expression : orderByExpressions) {
+          handleDistinctCountBitmapOverride(expression);
+        }
+      }
+      Expression havingExpression = pinotQuery.getHavingExpression();
+      if (havingExpression != null) {
+        handleDistinctCountBitmapOverride(havingExpression);
+      }
+    }
+  }
+
+  /**
+   * Helper method to rewrite 'DistinctCount' with 'DistinctCountBitmap' for the given expression.
+   */
+  private static void handleDistinctCountBitmapOverride(Expression expression) {
+    Function function = expression.getFunctionCall();
+    if (function == null) {
+      return;
+    }
+    if (StringUtils.remove(function.getOperator(), '_')
+        .equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNT.name())) {
+      function.setOperator(AggregationFunctionType.DISTINCTCOUNTBITMAP.name());
+    } else {
+      for (Expression operand : function.getOperands()) {
+        handleDistinctCountBitmapOverride(operand);
       }
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -57,6 +57,9 @@ public class CommonConstants {
     public static final String DEFAULT_HYPERLOGLOG_LOG2M_KEY = "default.hyperloglog.log2m";
     public static final int DEFAULT_HYPERLOGLOG_LOG2M = 8;
 
+    // Whether to rewrite DistinctCount to DistinctCountBitmap
+    public static final String ENABLE_DISTINCT_COUNT_BITMAP_OVERRIDE_KEY = "enable.distinct.count.bitmap.override";
+
     // More information on why these numbers are set can be found in the following doc:
     // https://cwiki.apache.org/confluence/display/PINOT/Controller+Separation+between+Helix+and+Pinot
     public static final int NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE = 24;

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -23,9 +23,20 @@ import com.google.common.primitives.Longs;
 import com.tdunning.math.stats.MergingDigest;
 import com.tdunning.math.stats.TDigest;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.doubles.DoubleIterator;
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.doubles.DoubleSet;
+import it.unimi.dsi.fastutil.floats.FloatIterator;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatSet;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -33,6 +44,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.theta.Sketch;
 import org.apache.pinot.common.utils.StringUtil;
@@ -41,6 +53,8 @@ import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
 import org.apache.pinot.core.query.aggregation.function.customobject.DistinctTable;
 import org.apache.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
 import org.apache.pinot.core.query.aggregation.function.customobject.QuantileDigest;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.StringUtils;
 import org.locationtech.jts.geom.Geometry;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -48,6 +62,7 @@ import org.roaringbitmap.RoaringBitmap;
 /**
  * The {@code ObjectSerDeUtils} class provides the utility methods to serialize/de-serialize objects.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class ObjectSerDeUtils {
   private ObjectSerDeUtils() {
   }
@@ -68,7 +83,12 @@ public class ObjectSerDeUtils {
     DistinctTable(11),
     DataSketch(12),
     Geometry(13),
-    RoaringBitmap(14);
+    RoaringBitmap(14),
+    LongSet(15),
+    FloatSet(16),
+    DoubleSet(17),
+    StringSet(18),
+    BytesSet(19);
 
     private final int _value;
 
@@ -111,6 +131,19 @@ public class ObjectSerDeUtils {
         return ObjectType.Geometry;
       } else if (value instanceof RoaringBitmap) {
         return ObjectType.RoaringBitmap;
+      } else if (value instanceof LongSet) {
+        return ObjectType.LongSet;
+      } else if (value instanceof FloatSet) {
+        return ObjectType.FloatSet;
+      } else if (value instanceof DoubleSet) {
+        return ObjectType.DoubleSet;
+      } else if (value instanceof ObjectSet) {
+        ObjectSet objectSet = (ObjectSet) value;
+        if (objectSet.isEmpty() || objectSet.iterator().next() instanceof String) {
+          return ObjectType.StringSet;
+        } else {
+          return ObjectType.BytesSet;
+        }
       } else {
         throw new IllegalArgumentException("Unsupported type of value: " + value.getClass().getSimpleName());
       }
@@ -390,14 +423,14 @@ public class ObjectSerDeUtils {
     }
 
     @Override
-    public Map<Object, Object> deserialize(byte[] bytes) {
+    public HashMap<Object, Object> deserialize(byte[] bytes) {
       return deserialize(ByteBuffer.wrap(bytes));
     }
 
     @Override
-    public Map<Object, Object> deserialize(ByteBuffer byteBuffer) {
+    public HashMap<Object, Object> deserialize(ByteBuffer byteBuffer) {
       int size = byteBuffer.getInt();
-      Map<Object, Object> map = new HashMap<>(size);
+      HashMap<Object, Object> map = new HashMap<>(size);
       if (size == 0) {
         return map;
       }
@@ -437,18 +470,191 @@ public class ObjectSerDeUtils {
     }
 
     @Override
-    public IntSet deserialize(byte[] bytes) {
+    public IntOpenHashSet deserialize(byte[] bytes) {
       return deserialize(ByteBuffer.wrap(bytes));
     }
 
     @Override
-    public IntSet deserialize(ByteBuffer byteBuffer) {
+    public IntOpenHashSet deserialize(ByteBuffer byteBuffer) {
       int size = byteBuffer.getInt();
-      IntSet intSet = new IntOpenHashSet(size);
+      IntOpenHashSet intSet = new IntOpenHashSet(size);
       for (int i = 0; i < size; i++) {
         intSet.add(byteBuffer.getInt());
       }
       return intSet;
+    }
+  };
+
+  public static final ObjectSerDe<LongSet> LONG_SET_SER_DE = new ObjectSerDe<LongSet>() {
+
+    @Override
+    public byte[] serialize(LongSet longSet) {
+      int size = longSet.size();
+      byte[] bytes = new byte[Integer.BYTES + size * Long.BYTES];
+      ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+      byteBuffer.putInt(size);
+      LongIterator iterator = longSet.iterator();
+      while (iterator.hasNext()) {
+        byteBuffer.putLong(iterator.nextLong());
+      }
+      return bytes;
+    }
+
+    @Override
+    public LongOpenHashSet deserialize(byte[] bytes) {
+      return deserialize(ByteBuffer.wrap(bytes));
+    }
+
+    @Override
+    public LongOpenHashSet deserialize(ByteBuffer byteBuffer) {
+      int size = byteBuffer.getInt();
+      LongOpenHashSet longSet = new LongOpenHashSet(size);
+      for (int i = 0; i < size; i++) {
+        longSet.add(byteBuffer.getLong());
+      }
+      return longSet;
+    }
+  };
+
+  public static final ObjectSerDe<FloatSet> FLOAT_SET_SER_DE = new ObjectSerDe<FloatSet>() {
+
+    @Override
+    public byte[] serialize(FloatSet floatSet) {
+      int size = floatSet.size();
+      byte[] bytes = new byte[Integer.BYTES + size * Float.BYTES];
+      ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+      byteBuffer.putInt(size);
+      FloatIterator iterator = floatSet.iterator();
+      while (iterator.hasNext()) {
+        byteBuffer.putFloat(iterator.nextFloat());
+      }
+      return bytes;
+    }
+
+    @Override
+    public FloatOpenHashSet deserialize(byte[] bytes) {
+      return deserialize(ByteBuffer.wrap(bytes));
+    }
+
+    @Override
+    public FloatOpenHashSet deserialize(ByteBuffer byteBuffer) {
+      int size = byteBuffer.getInt();
+      FloatOpenHashSet floatSet = new FloatOpenHashSet(size);
+      for (int i = 0; i < size; i++) {
+        floatSet.add(byteBuffer.getFloat());
+      }
+      return floatSet;
+    }
+  };
+
+  public static final ObjectSerDe<DoubleSet> DOUBLE_SET_SER_DE = new ObjectSerDe<DoubleSet>() {
+
+    @Override
+    public byte[] serialize(DoubleSet doubleSet) {
+      int size = doubleSet.size();
+      byte[] bytes = new byte[Integer.BYTES + size * Double.BYTES];
+      ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+      byteBuffer.putInt(size);
+      DoubleIterator iterator = doubleSet.iterator();
+      while (iterator.hasNext()) {
+        byteBuffer.putDouble(iterator.nextDouble());
+      }
+      return bytes;
+    }
+
+    @Override
+    public DoubleOpenHashSet deserialize(byte[] bytes) {
+      return deserialize(ByteBuffer.wrap(bytes));
+    }
+
+    @Override
+    public DoubleOpenHashSet deserialize(ByteBuffer byteBuffer) {
+      int size = byteBuffer.getInt();
+      DoubleOpenHashSet doubleSet = new DoubleOpenHashSet(size);
+      for (int i = 0; i < size; i++) {
+        doubleSet.add(byteBuffer.getDouble());
+      }
+      return doubleSet;
+    }
+  };
+
+  public static final ObjectSerDe<Set<String>> STRING_SET_SER_DE = new ObjectSerDe<Set<String>>() {
+
+    @Override
+    public byte[] serialize(Set<String> stringSet) {
+      int size = stringSet.size();
+      // NOTE: No need to close the ByteArrayOutputStream.
+      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+      DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+      try {
+        dataOutputStream.writeInt(size);
+        for (String value : stringSet) {
+          byte[] bytes = StringUtils.encodeUtf8(value);
+          dataOutputStream.writeInt(bytes.length);
+          dataOutputStream.write(bytes);
+        }
+      } catch (IOException e) {
+        throw new RuntimeException("Caught exception while serializing Set<String>", e);
+      }
+      return byteArrayOutputStream.toByteArray();
+    }
+
+    @Override
+    public ObjectOpenHashSet<String> deserialize(byte[] bytes) {
+      return deserialize(ByteBuffer.wrap(bytes));
+    }
+
+    @Override
+    public ObjectOpenHashSet<String> deserialize(ByteBuffer byteBuffer) {
+      int size = byteBuffer.getInt();
+      ObjectOpenHashSet<String> stringSet = new ObjectOpenHashSet<>(size);
+      for (int i = 0; i < size; i++) {
+        int length = byteBuffer.getInt();
+        byte[] bytes = new byte[length];
+        byteBuffer.get(bytes);
+        stringSet.add(StringUtils.decodeUtf8(bytes));
+      }
+      return stringSet;
+    }
+  };
+
+  public static final ObjectSerDe<Set<ByteArray>> BYTES_SET_SER_DE = new ObjectSerDe<Set<ByteArray>>() {
+
+    @Override
+    public byte[] serialize(Set<ByteArray> bytesSet) {
+      int size = bytesSet.size();
+      // NOTE: No need to close the ByteArrayOutputStream.
+      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+      DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+      try {
+        dataOutputStream.writeInt(size);
+        for (ByteArray value : bytesSet) {
+          byte[] bytes = value.getBytes();
+          dataOutputStream.writeInt(bytes.length);
+          dataOutputStream.write(bytes);
+        }
+      } catch (IOException e) {
+        throw new RuntimeException("Caught exception while serializing Set<ByteArray>", e);
+      }
+      return byteArrayOutputStream.toByteArray();
+    }
+
+    @Override
+    public ObjectOpenHashSet<ByteArray> deserialize(byte[] bytes) {
+      return deserialize(ByteBuffer.wrap(bytes));
+    }
+
+    @Override
+    public ObjectOpenHashSet<ByteArray> deserialize(ByteBuffer byteBuffer) {
+      int size = byteBuffer.getInt();
+      ObjectOpenHashSet<ByteArray> bytesSet = new ObjectOpenHashSet<>(size);
+      for (int i = 0; i < size; i++) {
+        int length = byteBuffer.getInt();
+        byte[] bytes = new byte[length];
+        byteBuffer.get(bytes);
+        bytesSet.add(new ByteArray(bytes));
+      }
+      return bytesSet;
     }
   };
 
@@ -553,7 +759,12 @@ public class ObjectSerDeUtils {
       DISTINCT_TABLE_SER_DE,
       DATA_SKETCH_SER_DE,
       GEOMETRY_SER_DE,
-      ROARING_BITMAP_SER_DE
+      ROARING_BITMAP_SER_DE,
+      LONG_SET_SER_DE,
+      FLOAT_SET_SER_DE,
+      DOUBLE_SET_SER_DE,
+      STRING_SET_SER_DE,
+      BYTES_SET_SER_DE
   };
   //@formatter:on
 
@@ -565,7 +776,6 @@ public class ObjectSerDeUtils {
     return serialize(value, objectType._value);
   }
 
-  @SuppressWarnings("unchecked")
   public static byte[] serialize(Object value, int objectTypeValue) {
     return SER_DES[objectTypeValue].serialize(value);
   }
@@ -574,7 +784,6 @@ public class ObjectSerDeUtils {
     return deserialize(bytes, objectType._value);
   }
 
-  @SuppressWarnings("unchecked")
   public static <T> T deserialize(byte[] bytes, int objectTypeValue) {
     return (T) SER_DES[objectTypeValue].deserialize(bytes);
   }
@@ -583,7 +792,6 @@ public class ObjectSerDeUtils {
     return deserialize(byteBuffer, objectType._value);
   }
 
-  @SuppressWarnings("unchecked")
   public static <T> T deserialize(ByteBuffer byteBuffer, int objectTypeValue) {
     return (T) SER_DES[objectTypeValue].deserialize(byteBuffer);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pinot.core.operator.query;
 
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -30,6 +33,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
 /**
@@ -77,42 +81,52 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
               .add(new MinMaxRangePair(dictionary.getDoubleValue(0), dictionary.getDoubleValue(dictionarySize - 1)));
           break;
         case DISTINCTCOUNT:
-          IntOpenHashSet set = new IntOpenHashSet(dictionarySize);
           switch (dictionary.getValueType()) {
             case INT:
+              IntOpenHashSet intSet = new IntOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                set.add(dictionary.getIntValue(dictId));
+                intSet.add(dictionary.getIntValue(dictId));
               }
+              aggregationResults.add(intSet);
               break;
             case LONG:
+              LongOpenHashSet longSet = new LongOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                set.add(Long.hashCode(dictionary.getLongValue(dictId)));
+                longSet.add(dictionary.getLongValue(dictId));
               }
+              aggregationResults.add(longSet);
               break;
             case FLOAT:
+              FloatOpenHashSet floatSet = new FloatOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                set.add(Float.hashCode(dictionary.getFloatValue(dictId)));
+                floatSet.add(dictionary.getFloatValue(dictId));
               }
+              aggregationResults.add(floatSet);
               break;
             case DOUBLE:
+              DoubleOpenHashSet doubleSet = new DoubleOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                set.add(Double.hashCode(dictionary.getDoubleValue(dictId)));
+                doubleSet.add(dictionary.getDoubleValue(dictId));
               }
+              aggregationResults.add(doubleSet);
               break;
             case STRING:
+              ObjectOpenHashSet<String> stringSet = new ObjectOpenHashSet<>(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                set.add(dictionary.getStringValue(dictId).hashCode());
+                stringSet.add(dictionary.getStringValue(dictId));
               }
+              aggregationResults.add(stringSet);
               break;
             case BYTES:
+              ObjectOpenHashSet<ByteArray> bytesSet = new ObjectOpenHashSet<>(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                set.add(Arrays.hashCode(dictionary.getBytesValue(dictId)));
+                bytesSet.add(new ByteArray(dictionary.getBytesValue(dictId)));
               }
+              aggregationResults.add(bytesSet);
               break;
             default:
               throw new IllegalStateException();
           }
-          aggregationResults.add(set);
           break;
         case SEGMENTPARTITIONEDDISTINCTCOUNT:
           aggregationResults.add((long) dictionarySize);


### PR DESCRIPTION
## Description
Currently in `DistinctCount`, we use `IntOpenHashSet` to store distinct ids even for non int types. While this is efficient, the accuracy drops as the cardinality increase. This PR sets up the right `HashSet` based on column data type.

## Upgrade Notes
Brokers should be upgraded before servers in order to keep backward-compatible

## Release Notes
With this change, the `DistinctCount` aggregation function will always return the exact distinct count regardless of the column data type. It might bring performance overhead for data types other than `INT`.
For use cases that is performance sensitive and not require the exact distinct count, use `DistinctCountBitmap` which has the same behavior as the current `DistinctCount` and better performance.
Provide a new boolean Helix cluster config `enable.distinct.count.bitmap.override` to auto-rewrite `DistinctCount` to `DistinctCountBitmap` on broker.