### PR TITLE
Fix race condition in MetricsHelper

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -376,6 +376,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    */
   public void initializeGlobalMeters() {
     M[] meters = getMeters();
+    LOGGER.info("Initializing global {} meters", meters.length);
 
     for (M meter : meters) {
       if (meter.isGlobal()) {
@@ -384,6 +385,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     }
 
     G[] gauges = getGauges();
+    LOGGER.info("Initializing global {} gauges", gauges.length);
     for (G gauge : gauges) {
       if (gauge.isGlobal()) {
         setValueOfGlobalGauge(gauge, 0);

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/JmxReporterMetricsRegistryRegistrationListener.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/JmxReporterMetricsRegistryRegistrationListener.java
@@ -20,6 +20,8 @@ package org.apache.pinot.common.metrics;
 
 import com.yammer.metrics.core.MetricsRegistry;
 import com.yammer.metrics.reporting.JmxReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -27,8 +29,12 @@ import com.yammer.metrics.reporting.JmxReporter;
  *
  */
 public class JmxReporterMetricsRegistryRegistrationListener implements MetricsRegistryRegistrationListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(JmxReporterMetricsRegistryRegistrationListener.class);
+
   @Override
   public void onMetricsRegistryRegistered(MetricsRegistry metricsRegistry) {
+    LOGGER.info("Registering JmxReporterMetricsRegistryRegistrationListener");
     new JmxReporter(metricsRegistry).start();
+    LOGGER.info("Number of metrics in metricsRegistry: {}", metricsRegistry.allMetrics().size());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <!-- hadoop-common, spark-core use commons-net -->
     <commons-net.version>3.1</commons-net.version>
     <!-- helix-core, spark-core use libraries from io.dropwizard.metrics -->
-    <dropwizard-metrics.version>3.2.3</dropwizard-metrics.version>
+    <dropwizard-metrics.version>4.1.2</dropwizard-metrics.version>
     <snappy-java.version>1.1.1.7</snappy-java.version>
     <log4j.version>2.11.2</log4j.version>
     <netty.version>4.1.42.Final</netty.version>


### PR DESCRIPTION
## Description
This PR:
* fixes a race condition in `MetricsHelper` class that `JmxReporterMetricsRegistryRegistrationListener` could be recycled by the time when the gc thread kicks in.
* bumps up dropwizard metrics version to 4.1.2.

The race condition can be reproduced whenever the memory pressure increases so that the gc gets triggered.