### PR TITLE
Bump up swagger ui version to 3.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -897,7 +897,7 @@
       <dependency>
         <groupId>org.webjars</groupId>
         <artifactId>swagger-ui</artifactId>
-        <version>2.2.10-1</version>
+        <version>3.18.2</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
## Description
vulnerability: Swagger-ui before 3.18.0 is vulnerable to Reverse Tabnabbing. Setting target="_blank" on anchor tags is unsafe unless used in conjunction with the rel="noopener" attribute. Opening a link via target blank attribute can change the original page, origin policy restrictions set by the browser can be bypassed.