### PR TITLE
Fix gcsFS copyToLocal to precreate local destination directory

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.slf4j.Logger;
@@ -325,6 +326,7 @@ public class GcsPinotFS  extends PinotFS {
   @Override
   public void copyToLocalFile(URI srcUri, File dstFile) throws Exception {
     LOGGER.info("Copy {} to local {}", srcUri, dstFile.getAbsolutePath());
+    FileUtils.forceMkdir(dstFile.getParentFile());
     Blob blob = getBlob(srcUri);
     checkState(existsBlob(blob), "File '%s' does not exists", srcUri);
     blob.downloadTo(dstFile.toPath());


### PR DESCRIPTION
## Description
Fix the error while downloading segment from GCS via controller.
https://github.com/apache/incubator-pinot/issues/5884

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes? Things to consider:
NA

## Release Notes
NA

## Documentation
NA