### PR TITLE
Expose response stats in the Pinot client's BrokerResponse.

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
@@ -29,6 +29,7 @@ class BrokerResponse {
   private JsonNode _selectionResults;
   private JsonNode _resultTable;
   private JsonNode _exceptions;
+  private ResponseStats _responseStats;
 
   private BrokerResponse() {
   }
@@ -38,6 +39,126 @@ class BrokerResponse {
     _exceptions = brokerResponse.get("exceptions");
     _selectionResults = brokerResponse.get("selectionResults");
     _resultTable = brokerResponse.get("resultTable");
+    _responseStats = ResponseStats.fromJson(brokerResponse);
+  }
+
+  public static class ResponseStats {
+    private final int _numServersQueried;
+    private final int _numServersResponded;
+    private final long _numDocsScanned;
+    private final long _numEntriesScannedInFilter;
+    private final long _numEntriesScannedPostFilter;
+    private final long _numSegmentsQueried;
+    private final long _numSegmentsProcessed;
+    private final long _numSegmentsMatched;
+    private final long _numConsumingSegmentsQueried;
+    private final long _minConsumingFreshnessTimeMs;
+    private final long _totalDocs;
+    private final boolean _numGroupsLimitReached;
+    private final long _timeUsedMs;
+
+    private ResponseStats(JsonNode brokerResponse) {
+      _numServersQueried = brokerResponse.has("numServersQueried") ?
+          brokerResponse.get("numServersQueried").asInt() : -1;
+      _numServersResponded = brokerResponse.has("numServersResponded") ?
+          brokerResponse.get("numServersResponded").asInt() : -1;
+      _numDocsScanned = brokerResponse.has("numDocsScanned") ?
+          brokerResponse.get("numDocsScanned").asLong() : -1L;
+      _numEntriesScannedInFilter = brokerResponse.has("numEntriesScannedInFilter") ?
+          brokerResponse.get("numEntriesScannedInFilter").asLong() : -1L;
+      _numEntriesScannedPostFilter = brokerResponse.has("numEntriesScannedPostFilter") ?
+          brokerResponse.get("numEntriesScannedPostFilter").asLong() : -1L;
+      _numSegmentsQueried = brokerResponse.has("numSegmentsQueried") ?
+          brokerResponse.get("numSegmentsQueried").asLong() : -1L;
+      _numSegmentsProcessed = brokerResponse.has("numSegmentsProcessed") ?
+          brokerResponse.get("numSegmentsProcessed").asLong() : -1L;
+      _numSegmentsMatched = brokerResponse.has("numSegmentsMatched") ?
+          brokerResponse.get("numSegmentsMatched").asLong() : -1L;
+      _numConsumingSegmentsQueried = brokerResponse.has("numConsumingSegmentsQueried") ?
+          brokerResponse.get("numConsumingSegmentsQueried").asLong() : -1L;
+      _minConsumingFreshnessTimeMs = brokerResponse.has("minConsumingFreshnessTimeMs") ?
+          brokerResponse.get("minConsumingFreshnessTimeMs").asLong() : -1L;
+      _totalDocs = brokerResponse.has("totalDocs") ?
+          brokerResponse.get("totalDocs").asLong() : -1L;
+      _numGroupsLimitReached = brokerResponse.has("numGroupsLimitReached")
+          && brokerResponse.get("numGroupsLimitReached").asBoolean();
+      _timeUsedMs = brokerResponse.has("timeUsedMs") ?
+          brokerResponse.get("timeUsedMs").asLong() : -1L;
+    }
+
+    static ResponseStats fromJson(JsonNode json) {
+      return new ResponseStats(json);
+    }
+
+    public int getNumServersQueried() {
+      return _numServersQueried;
+    }
+
+    public int getNumServersResponded() {
+      return _numServersResponded;
+    }
+
+    public long getNumDocsScanned() {
+      return _numDocsScanned;
+    }
+
+    public long getNumEntriesScannedInFilter() {
+      return _numEntriesScannedInFilter;
+    }
+
+    public long getNumEntriesScannedPostFilter() {
+      return _numEntriesScannedPostFilter;
+    }
+
+    public long getNumSegmentsQueried() {
+      return _numSegmentsQueried;
+    }
+
+    public long getNumSegmentsProcessed() {
+      return _numSegmentsProcessed;
+    }
+
+    public long getNumSegmentsMatched() {
+      return _numSegmentsMatched;
+    }
+
+    public long getNumConsumingSegmentsQueried() {
+      return _numConsumingSegmentsQueried;
+    }
+
+    public long getMinConsumingFreshnessTimeMs() {
+      return _minConsumingFreshnessTimeMs;
+    }
+
+    public long getTotalDocs() {
+      return _totalDocs;
+    }
+
+    public boolean isNumGroupsLimitReached() {
+      return _numGroupsLimitReached;
+    }
+
+    public long getTimeUsedMs() {
+      return _timeUsedMs;
+    }
+
+    @Override
+    public String toString() {
+      return "{numServersQueried: " + _numServersQueried +
+          ", numServersResponded: " + _numServersResponded +
+          ", numDocsScanned: " + _numDocsScanned +
+          ", numEntriesScannedInFilter: " + _numEntriesScannedInFilter +
+          ", numEntriesScannedPostFilter: " + _numEntriesScannedPostFilter +
+          ", numSegmentsQueried: " + _numSegmentsQueried +
+          ", numSegmentsProcessed: " + _numSegmentsProcessed +
+          ", numSegmentsMatched: " + _numSegmentsMatched +
+          ", numConsumingSegmentsQueried: " + _numConsumingSegmentsQueried +
+          ", minConsumingFreshnessTimeMs: " + _minConsumingFreshnessTimeMs +
+          "ms, totalDocs: " + _totalDocs +
+          ", numGroupsLimitReached: " + _numGroupsLimitReached +
+          ", timeUsedMs: " + _timeUsedMs +
+          "ms}";
+    }
   }
 
   boolean hasExceptions() {
@@ -66,6 +187,10 @@ class BrokerResponse {
     } else {
       return _aggregationResults.size();
     }
+  }
+
+  ResponseStats getResponseStats() {
+    return _responseStats;
   }
 
   static BrokerResponse fromJson(JsonNode json) {

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class Connection {
   private static final Logger LOGGER = LoggerFactory.getLogger(Connection.class);
   private final PinotClientTransport _transport;
-  private BrokerSelector _brokerSelector;
+  private final BrokerSelector _brokerSelector;
   private List<String> _brokerList;
 
   Connection(List<String> brokerList, PinotClientTransport transport) {
@@ -97,6 +97,18 @@ public class Connection {
   }
 
   /**
+   * Executes a Pinot Request and returns the Response.
+   *
+   * @param request The request to execute
+   * @return The BrokerResponse for the request.
+   * @throws PinotClientException If an exception occurs while processing the query
+   */
+  public BrokerResponse executeRequest(Request request)
+      throws PinotClientException {
+    return executeRequest(null, request);
+  }
+
+  /**
    * Executes a PQL query.
    *
    * Deprecated as we will soon be removing support for pql endpoint
@@ -132,6 +144,27 @@ public class Connection {
   }
 
   /**
+   * Executes a Pinot Request and returns the received BrokerResponse.
+   *
+   * @param request The request to execute
+   * @return Broker response received
+   * @throws PinotClientException If an exception occurs while processing the query
+   */
+  public BrokerResponse executeRequest(String tableName, Request request)
+      throws PinotClientException {
+    String brokerHostPort = _brokerSelector.selectBroker(tableName);
+    if (brokerHostPort == null) {
+      throw new PinotClientException(
+          "Could not find broker to query for table: " + (tableName == null ? "null" : tableName));
+    }
+    BrokerResponse response = _transport.executeQuery(brokerHostPort, request);
+    if (response.hasExceptions()) {
+      throw new PinotClientException("Query had processing exceptions: \n" + response.getExceptions());
+    }
+    return response;
+  }
+
+  /**
    * Executes a PQL query asynchronously.
    *
    * Deprecated as we will soon be removing support for pql endpoint
@@ -163,6 +196,24 @@ public class Connection {
     }
     final Future<BrokerResponse> responseFuture = _transport.executeQueryAsync(brokerHostPort, request);
     return new ResultSetGroupFuture(responseFuture);
+  }
+
+  /**
+   * Executes a Pinot Request asynchronously.
+   *
+   * @param request The request to execute
+   * @return A future containing the response of the query
+   * @throws PinotClientException If an exception occurs while processing the query
+   */
+  public Future<BrokerResponse> executeRequestAsync(Request request)
+      throws PinotClientException {
+    String brokerHostPort = _brokerSelector.selectBroker(null);
+    if (brokerHostPort == null) {
+      throw new PinotClientException(
+          "Could not find broker to query for statement: " + (request.getQuery() == null ? "null"
+              : request.getQuery()));
+    }
+    return _transport.executeQueryAsync(brokerHostPort, request);
   }
 
   /**

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/PreparedStatement.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/PreparedStatement.java
@@ -73,12 +73,30 @@ public class PreparedStatement {
   }
 
   /**
+   * Executes this prepared statement and returns the BrokerResponse.
+   *
+   * @return The BrokerResponse received.
+   */
+  public BrokerResponse executeRequest() {
+    return _connection.executeRequest(new Request(_queryFormat, fillStatementWithParameters()));
+  }
+
+  /**
    * Executes this prepared statement asynchronously.
    *
    * @return The query results
    */
   public Future<ResultSetGroup> executeAsync() {
     return _connection.executeAsync(new Request(_queryFormat, fillStatementWithParameters()));
+  }
+
+  /**
+   * Executes this prepared statement asynchronously.
+   *
+   * @return The query results
+   */
+  public Future<BrokerResponse> executeRequestAsync() {
+    return _connection.executeRequestAsync(new Request(_queryFormat, fillStatementWithParameters()));
   }
 
   /**

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultSetGroup.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ResultSetGroup.java
@@ -54,6 +54,10 @@ public class ResultSetGroup {
     }
   }
 
+  public static ResultSetGroup fromBrokerResponse(BrokerResponse response) {
+    return new ResultSetGroup(response);
+  }
+
   /**
    * Returns the number of result sets in this result set group, or 0 if there are no result sets; there is one result
    * set per aggregation function in the original query and one result set in the case of a selection query.

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/PreparedStatementTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/PreparedStatementTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
  *
  */
 public class PreparedStatementTest {
-  private DummyPinotClientTransport _dummyPinotClientTransport = new DummyPinotClientTransport();
+  private final DummyPinotClientTransport _dummyPinotClientTransport = new DummyPinotClientTransport();
   private PinotClientTransportFactory _previousTransportFactory = null;
 
   @Test
@@ -56,7 +56,7 @@ public class PreparedStatementTest {
     ConnectionFactory._transportFactory = _previousTransportFactory;
   }
 
-  class DummyPinotClientTransport implements PinotClientTransport {
+  static class DummyPinotClientTransport implements PinotClientTransport {
     private String _lastQuery;
 
     @Override


### PR DESCRIPTION
## Description
This would let the client application to observe and print response stats selectively
for queries and avoid reproducing slow queries.
Changes for the feature in https://github.com/apache/incubator-pinot/issues/5871

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
 * No

Does this PR fix a zero-downtime upgrade introduced earlier?
 * No

Does this PR otherwise need attention when creating release notes? Things to consider:
Yes. The Java client of Pinot now exposes BrokerResponse object, which has ResponseStats in the API.

## Release Notes
Pinot's Java client now exposes BrokerResponse and ResponseStats to the client application.