### PR TITLE
Add RANGE FilterKind to support merging ranges for SQL

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
@@ -28,6 +28,7 @@ public enum FilterKind {
   LESS_THAN,
   LESS_THAN_OR_EQUAL,
   BETWEEN,
+  RANGE,
   IN,
   NOT_IN,
   REGEXP_LIKE,
@@ -41,7 +42,7 @@ public enum FilterKind {
    * @return True if the enum is of Range type, false otherwise.
    */
   public boolean isRange() {
-    return (this == GREATER_THAN || this == GREATER_THAN_OR_EQUAL || this == LESS_THAN || this == LESS_THAN_OR_EQUAL
-        || this == BETWEEN);
+    return this == GREATER_THAN || this == GREATER_THAN_OR_EQUAL || this == LESS_THAN || this == LESS_THAN_OR_EQUAL
+        || this == BETWEEN || this == RANGE;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/predicate/RangePredicate.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/predicate/RangePredicate.java
@@ -28,7 +28,9 @@ import org.apache.pinot.core.query.request.context.ExpressionContext;
  * <p>Pinot uses RANGE to represent '>', '>=', '<', '<=', BETWEEN so that intersection of multiple ranges can be merged.
  */
 public class RangePredicate implements Predicate {
-  public static final String DELIMITER = "\t\t";
+  public static final char DELIMITER = '\0';
+  // TODO: Remove the legacy delimiter after releasing 0.5.0
+  public static final String LEGACY_DELIMITER = "\t\t";
   public static final char LOWER_INCLUSIVE = '[';
   public static final char LOWER_EXCLUSIVE = '(';
   public static final char UPPER_INCLUSIVE = ']';
@@ -46,7 +48,7 @@ public class RangePredicate implements Predicate {
    * <ul>
    *   <li>Lower inclusive '[' or exclusive '('</li>
    *   <li>Lower bound ('*' for unbounded)</li>
-   *   <li>Delimiter ("\t\t")</li>
+   *   <li>Delimiter ('\0')</li>
    *   <li>Upper bound ('*' for unbounded)</li>
    *   <li>Upper inclusive ']' or exclusive ')'</li>
    * </ul>
@@ -54,6 +56,9 @@ public class RangePredicate implements Predicate {
   public RangePredicate(ExpressionContext lhs, String range) {
     _lhs = lhs;
     String[] split = StringUtils.split(range, DELIMITER);
+    if (split.length != 2) {
+      split = StringUtils.split(range, LEGACY_DELIMITER);
+    }
     String lower = split[0];
     String upper = split[1];
     _lowerInclusive = lower.charAt(0) == LOWER_INCLUSIVE;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
@@ -221,6 +221,9 @@ public class QueryContextConverterUtils {
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new RangePredicate(getExpression(operands.get(0)), true, getStringValue(operands.get(1)), true,
                 getStringValue(operands.get(2))));
+      case RANGE:
+        return new FilterContext(FilterContext.Type.PREDICATE, null,
+            new RangePredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
       case REGEXP_LIKE:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new RegexpLikePredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));

--- a/pinot-core/src/main/java/org/apache/pinot/core/requesthandler/RangeMergeOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/requesthandler/RangeMergeOptimizer.java
@@ -145,7 +145,8 @@ public class RangeMergeOptimizer extends FilterQueryTreeOptimizer {
       }
     }
 
-    stringBuilder.append(RangePredicate.DELIMITER);
+    // TODO: Switch to RangePredicate.DELIMITER after releasing 0.5.0
+    stringBuilder.append(RangePredicate.LEGACY_DELIMITER);
 
     String upperBound1 = predicate1.getUpperBound();
     String upperBound2 = predicate2.getUpperBound();


### PR DESCRIPTION
## Description
Currently we cannot replace `BrokerRequest` with `PinotQuery` completely because of the filter optimizer only works on `BrokerRequest`. One of the optimizations is to merge ranges joined by AND (very useful especially for hybrid table).
We cannot apply the same optimization to `PinotQuery` without a new `RANGE` FilterKind (e.g. no way to represent a > 10 AND a <= 20).
This PR introduces the new `RANGE` FilterKind so that Server knows how to process it.
After release `0.5.0`, we can add the optimizer for `PinotQuery` so that Broker can optimize `PinotQuery`, and Server already knows how to process the `RANGE` filter.

Also let Server support both `'\0'` and `"\t\t"` as the range delimiter so that it can work on string values with `'\t'` inside properly.