### PR TITLE
Instance API to directly updateTags

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -35,6 +35,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.helix.model.InstanceConfig;
@@ -193,6 +194,27 @@ public class PinotInstanceRestletResource {
     if (!response.isSuccessful()) {
       throw new ControllerApplicationException(LOGGER, "Failure to update instance. Reason: " + response.getMessage(),
           Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    return new SuccessResponse("Instance successfully updated");
+  }
+
+  @PUT
+  @Path("/instances/{instanceName}/updateTags")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Update the tags of the specified instance", consumes = MediaType.APPLICATION_JSON, notes = "Update the tags of the specified instance")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal error")})
+  public SuccessResponse updateInstanceTags(
+      @ApiParam(value = "Instance name", required = true, example = "Server_a.b.com_20000 | Broker_my.broker.com_30000") @PathParam("instanceName") String instanceName,
+      @ApiParam(value = "Comma separated tags list", required = true) @QueryParam("tags") String tags) {
+    LOGGER.info("Instance update request received for instance: {}", instanceName);
+    if (tags == null) {
+      throw new ControllerApplicationException(LOGGER, "Must provide tags to update", Response.Status.BAD_REQUEST);
+    }
+    PinotResourceManagerResponse response = pinotHelixResourceManager.updateInstanceTags(instanceName, tags);
+    if (!response.isSuccessful()) {
+      throw new ControllerApplicationException(LOGGER,
+          "Failure to update instance tags. Reason: " + response.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
     }
     return new SuccessResponse("Instance successfully updated");
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -207,15 +207,16 @@ public class PinotInstanceRestletResource {
   public SuccessResponse updateInstanceTags(
       @ApiParam(value = "Instance name", required = true, example = "Server_a.b.com_20000 | Broker_my.broker.com_30000") @PathParam("instanceName") String instanceName,
       @ApiParam(value = "Comma separated tags list", required = true) @QueryParam("tags") String tags) {
-    LOGGER.info("Instance update request received for instance: {}", instanceName);
+    LOGGER.info("Instance update request received for instance: {} and tags: {}", instanceName, tags);
     if (tags == null) {
       throw new ControllerApplicationException(LOGGER, "Must provide tags to update", Response.Status.BAD_REQUEST);
     }
     PinotResourceManagerResponse response = pinotHelixResourceManager.updateInstanceTags(instanceName, tags);
     if (!response.isSuccessful()) {
       throw new ControllerApplicationException(LOGGER,
-          "Failure to update instance tags. Reason: " + response.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
+          "Failure to update instance: " + instanceName + " with tags: " + tags + ". Reason: " + response.getMessage(),
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
-    return new SuccessResponse("Instance successfully updated");
+    return new SuccessResponse("Successfully updated tags for instance: " + instanceName + " tags: " + tags);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -18,10 +18,9 @@
  */
 package org.apache.pinot.controller.helix;
 
-import com.google.common.base.Joiner;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
@@ -56,7 +55,7 @@ public class ControllerRequestURLBuilder {
   }
 
   public String forInstanceUpdateTags(String instanceName, List<String> tags) {
-    return StringUtil.join("/", _baseUrl, "instances", instanceName, "updateTags?tags=" + Joiner.on(",").join(tags));
+    return StringUtil.join("/", _baseUrl, "instances", instanceName, "updateTags?tags=" + StringUtils.join(tags, ","));
   }
 
   public String forInstanceList() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -53,6 +53,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "instances", instanceName);
   }
 
+  public String forInstanceUpdateTags(String instanceName, String tagsList) {
+    return StringUtil.join("/", _baseUrl, "instances", instanceName, "updateTags?tags=" + tagsList);
+  }
+
   public String forInstanceList() {
     return StringUtil.join("/", _baseUrl, "instances");
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.controller.helix;
 
+import com.google.common.base.Joiner;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.common.utils.StringUtil;
@@ -53,8 +55,8 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "instances", instanceName);
   }
 
-  public String forInstanceUpdateTags(String instanceName, String tagsList) {
-    return StringUtil.join("/", _baseUrl, "instances", instanceName, "updateTags?tags=" + tagsList);
+  public String forInstanceUpdateTags(String instanceName, List<String> tags) {
+    return StringUtil.join("/", _baseUrl, "instances", instanceName, "updateTags?tags=" + Joiner.on(",").join(tags));
   }
 
   public String forInstanceList() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.Criteria;
@@ -408,16 +409,11 @@ public class PinotHelixResourceManager {
     if (instanceConfig == null) {
       return PinotResourceManagerResponse.failure("Instance " + instanceIdToUpdate + " does not exists");
     }
-    String[] newTags = tags.split(",");
-    List<String> existingTags = Lists.newArrayList(instanceConfig.getTags());
-    for (String tag : existingTags) {
-      instanceConfig.removeTag(tag);
-    }
-    for (String tag : newTags) {
-      instanceConfig.addTag(tag);
-    }
+    List<String> tagList = Arrays.asList(StringUtils.split(tags, ','));
+    instanceConfig.getRecord().setListField(InstanceConfig.InstanceConfigProperty.TAG_LIST.name(), tagList);
     if (!_helixDataAccessor.setProperty(_keyBuilder.instanceConfig(instanceIdToUpdate), instanceConfig)) {
-      return PinotResourceManagerResponse.failure("Unable to update instance: " + instanceIdToUpdate);
+      return PinotResourceManagerResponse
+          .failure("Unable to update instance: " + instanceIdToUpdate + " to tags: " + tags);
     }
     return PinotResourceManagerResponse.SUCCESS;
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -135,6 +135,18 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
 
     checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{newBrokerTag}, null, null);
     checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345, new String[]{newServerTag}, null, null);
+
+    // Test Instance updateTags API
+    String brokerInstanceUpdateTagsUrl =
+        _controllerRequestURLBuilder.forInstanceUpdateTags(brokerInstanceId, "tag_BROKER,newTag_BROKER");
+    sendPutRequest(brokerInstanceUpdateTagsUrl);
+    String serverInstanceUpdateTagsUrl = _controllerRequestURLBuilder
+        .forInstanceUpdateTags(serverInstanceId, "tag_REALTIME,newTag_OFFLINE,newTag_REALTIME");
+    sendPutRequest(serverInstanceUpdateTagsUrl);
+    checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{"tag_BROKER", "newTag_BROKER"}, null,
+        null);
+    checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345,
+        new String[]{"tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"}, null, null);
   }
 
   private void checkInstanceInfo(String instanceName, String hostName, int port, String[] tags, String[] pools,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Function;
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -137,11 +138,11 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
     checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345, new String[]{newServerTag}, null, null);
 
     // Test Instance updateTags API
-    String brokerInstanceUpdateTagsUrl =
-        _controllerRequestURLBuilder.forInstanceUpdateTags(brokerInstanceId, "tag_BROKER,newTag_BROKER");
+    String brokerInstanceUpdateTagsUrl = _controllerRequestURLBuilder
+        .forInstanceUpdateTags(brokerInstanceId, Lists.newArrayList("tag_BROKER", "newTag_BROKER"));
     sendPutRequest(brokerInstanceUpdateTagsUrl);
-    String serverInstanceUpdateTagsUrl = _controllerRequestURLBuilder
-        .forInstanceUpdateTags(serverInstanceId, "tag_REALTIME,newTag_OFFLINE,newTag_REALTIME");
+    String serverInstanceUpdateTagsUrl = _controllerRequestURLBuilder.forInstanceUpdateTags(serverInstanceId,
+        Lists.newArrayList("tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"));
     sendPutRequest(serverInstanceUpdateTagsUrl);
     checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{"tag_BROKER", "newTag_BROKER"}, null,
         null);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -579,6 +579,14 @@ public abstract class ControllerTest {
     return constructResponse(httpConnection.getInputStream());
   }
 
+  public static String sendPutRequest(String urlString)
+      throws IOException {
+    HttpURLConnection httpConnection = (HttpURLConnection) new URL(urlString).openConnection();
+    httpConnection.setDoOutput(true);
+    httpConnection.setRequestMethod("PUT");
+    return constructResponse(httpConnection.getInputStream());
+  }
+
   public static String sendDeleteRequest(String urlString)
       throws IOException {
     HttpURLConnection httpConnection = (HttpURLConnection) new URL(urlString).openConnection();


### PR DESCRIPTION
## Description
New API for updating instance tags.
```
curl -i -X PUT "localhost:9000/instances/Server_10.20.30.40_8000/updateTags?tags=server_OFFLINE,server_REALTIME"
HTTP/1.1 200 OK
Pinot-Controller-Host: 10.20.30.40
Pinot-Controller-Version: Unknown
Access-Control-Allow-Origin: *
Content-Type: application/json
Content-Length: 42

{"status":"Instance successfully updated"}
```
## Release Notes
New API for updating instance tags directly