### PR TITLE
[TE] anomalies page - fix feedback is not populated if retrived by the method findByIds

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -31,8 +31,6 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   MergedAnomalyResultDTO findById(Long id);
 
-  List<MergedAnomalyResultDTO> findByIdList(List<Long> idList);
-
   List<MergedAnomalyResultDTO> findOverlappingByFunctionId(long functionId, long conflictWindowStart,
       long conflictWindowEnd);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -190,6 +190,11 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     }
   }
 
+  @Override
+  public List<MergedAnomalyResultDTO> findByIds(List<Long> ids) {
+    return this.findByIdList(ids);
+  }
+
   public List<MergedAnomalyResultDTO> findByIdList(List<Long> idList) {
     List<MergedAnomalyResultBean> mergedAnomalyResultBeanList =
         genericPojoDao.get(idList, MergedAnomalyResultBean.class);

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -191,11 +191,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findByIds(List<Long> ids) {
-    return this.findByIdList(ids);
-  }
-
-  public List<MergedAnomalyResultDTO> findByIdList(List<Long> idList) {
+  public List<MergedAnomalyResultDTO> findByIds(List<Long> idList) {
     List<MergedAnomalyResultBean> mergedAnomalyResultBeanList =
         genericPojoDao.get(idList, MergedAnomalyResultBean.class);
     if (CollectionUtils.isNotEmpty(mergedAnomalyResultBeanList)) {


### PR DESCRIPTION
Previously the anomaly feedback is not populated if retrieved by the method `findByIds`. This PR fixes the issue so that the feedbacks can be shown on the anomalies page.