### PR TITLE
Simplify compression logic for anomaly timelines view. 

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/views/CondensedAnomalyTimelinesView.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/views/CondensedAnomalyTimelinesView.java
@@ -234,7 +234,6 @@ public class CondensedAnomalyTimelinesView {
     long lastTimestampEnd = this.timeStamps.get(this.timeStamps.size() - 1) + this.bucketMillis;
 
     for (int i = 0; i < timeStamps.size(); i++) {
-      int count = 1;
       long timestamp = this.timeStamps.get(i);
       double observedValue = this.currentValues.get(i);
       double expectedValue = this.baselineValues.get(i);
@@ -243,15 +242,12 @@ public class CondensedAnomalyTimelinesView {
        */
       if ((lastTimestampEnd - timestamp) >= maxBucketMills) {
         while (i + 1 < this.timeStamps.size() && (this.timeStamps.get(i + 1) - timestamp) < maxBucketMills) {
-          observedValue += this.currentValues.get(i + 1);
-          expectedValue += this.baselineValues.get(i + 1);
           i++;
-          count++;
         }
       }
       aggregatedTimestamps.add(timestamp * DEFAULT_MIN_BUCKET_UNIT + timestampOffset);
-      aggregatedObservedValues.add(getRoundedDouble(observedValue/((double)count)));
-      aggregatedExpectedValues.add(getRoundedDouble(expectedValue/((double)count)));
+      aggregatedObservedValues.add(getRoundedDouble(observedValue));
+      aggregatedExpectedValues.add(getRoundedDouble(expectedValue));
     }
 
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/views/TestCondensedAnomalyTimelinesView.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/anomaly/views/TestCondensedAnomalyTimelinesView.java
@@ -110,8 +110,8 @@ public class TestCondensedAnomalyTimelinesView {
     for (int i = 0; i < compressedView.getTimeStamps().size(); i++) {
       Assert.assertEquals(compressedView.getTimeStamps().get(i).longValue(),
           (date.getMillis() - condensedView.timestampOffset)/minBucketMillis);
-      Assert.assertEquals(compressedView.getCurrentValues().get(i), i * 2 + 0.5);
-      Assert.assertEquals(compressedView.getBaselineValues().get(i), i * 2 + 0.83);
+      Assert.assertEquals(compressedView.getCurrentValues().get(i), i * 2 + 0d);
+      Assert.assertEquals(compressedView.getBaselineValues().get(i), i * 2 + 0.33);
       date = date.plusMinutes(10);
     }
 
@@ -121,8 +121,8 @@ public class TestCondensedAnomalyTimelinesView {
       TimeBucket timeBucket = decompressedView.getTimeBuckets().get(i);
       Assert.assertEquals(timeBucket.getCurrentStart(), date.getMillis());
       Assert.assertEquals(timeBucket.getCurrentEnd(), date.plusMinutes(10).getMillis());
-      Assert.assertEquals(decompressedView.getCurrentValues().get(i), i * 2 + 0.5);
-      Assert.assertEquals(decompressedView.getBaselineValues().get(i), i * 2 + 0.83);
+      Assert.assertEquals(decompressedView.getCurrentValues().get(i), i * 2 + 0d);
+      Assert.assertEquals(decompressedView.getBaselineValues().get(i), i * 2 + 0.33);
       date = date.plusMinutes(10);
     }
   }
@@ -142,8 +142,8 @@ public class TestCondensedAnomalyTimelinesView {
     for (int i = 0; i < compressedView.getTimeStamps().size(); i++) {
       Assert.assertEquals(compressedView.getTimeStamps().get(i).longValue(),
           (date.getMillis() - condensedView.timestampOffset)/minBucketMillis);
-      Assert.assertEquals(compressedView.getCurrentValues().get(i), i * 4 + 1.5);
-      Assert.assertEquals(compressedView.getBaselineValues().get(i), i * 4 + 1.83);
+      Assert.assertEquals(compressedView.getCurrentValues().get(i), i * 4 + 0d);
+      Assert.assertEquals(compressedView.getBaselineValues().get(i), i * 4 + 0.33);
       date = date.plusMinutes(20);
     }
 
@@ -153,8 +153,8 @@ public class TestCondensedAnomalyTimelinesView {
       TimeBucket timeBucket = decompressedView.getTimeBuckets().get(i);
       Assert.assertEquals(timeBucket.getCurrentStart(), date.getMillis());
       Assert.assertEquals(timeBucket.getCurrentEnd(), date.plusMinutes(20).getMillis());
-      Assert.assertEquals(decompressedView.getCurrentValues().get(i), i * 4 + 1.5);
-      Assert.assertEquals(decompressedView.getBaselineValues().get(i), i * 4 + 1.83);
+      Assert.assertEquals(decompressedView.getCurrentValues().get(i), i * 4 + 0d);
+      Assert.assertEquals(decompressedView.getBaselineValues().get(i), i * 4 + 0.33);
       date = date.plusMinutes(20);
     }
   }


### PR DESCRIPTION
Previously when compressing anomaly timelines view, we first take an average of the group of timestamps to be compressed, and put this average to the first timestamp. This naturally would shift the time series leftward, which makes it difficult for recovering the baseline when we want to do anomaly imputation. 
Now we only keep the values for the selected timestamps after compression, instead of taking an average that could cause value shifts.

