### PR TITLE
Starts Broker and Server in parallel when using ServiceManager

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -157,7 +157,7 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
       throws Exception {
     try {
       LOGGER.info("Executing command: " + toString());
-      startPinotService("ServiceManager", this::startServiceManager);
+      startPinotService("SERVICE_MANAGER", this::startServiceManager);
 
       if (_bootstrapConfigPaths != null) {
         for (String configPath : _bootstrapConfigPaths) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -254,9 +254,9 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   }
 
   private boolean clusterExists(String instanceId) {
-    HelixManager spectatorHelixManager =
-        HelixManagerFactory.getZKHelixManager(_clusterName, instanceId, InstanceType.SPECTATOR, _zkAddress);
     try {
+      HelixManager spectatorHelixManager =
+          HelixManagerFactory.getZKHelixManager(_clusterName, instanceId, InstanceType.SPECTATOR, _zkAddress);
       spectatorHelixManager.connect();
       spectatorHelixManager.disconnect();
       return true;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -192,7 +192,20 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   }
 
   private void startPinotService(Map<String, Object> properties) {
-    startPinotService(ServiceRole.valueOf(properties.get(PINOT_SERVICE_ROLE).toString()), properties);
+    ServiceRole role = ServiceRole.valueOf(properties.get(PINOT_SERVICE_ROLE).toString());
+    switch (role) {
+      // Broker and Server can be started in parallel always
+      case BROKER:
+      case SERVER:
+        new Thread("Starting " + role) {
+          @Override public void run() {
+            startPinotService(role, properties);
+          }
+        }.start();
+        break;
+      default:
+        startPinotService(role, properties);
+    }
   }
 
   public boolean startPinotService(ServiceRole role, Map<String, Object> properties) {


### PR DESCRIPTION
## Description
This makes PinotServiceManager start services in the following order end ensures the process exit code is 1 on failure.

1. PinotServiceManager
2. Bootstrap services in role ServiceRole.CONTROLLER
3. All remaining bootstrap services in parallel

Fixes #5876

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? No

Does this PR fix a zero-downtime upgrade introduced earlier? No

Does this PR otherwise need attention when creating release notes? Yes

## Release Notes
PinotServiceManager now services in the following order end ensures the process exit code is 1 on failure.

1. PinotServiceManager
2. Bootstrap services in role ServiceRole.CONTROLLER
3. All remaining bootstrap services in parallel

## Documentation
N/A
