### PR TITLE
Null check for invalid column name

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -23,9 +23,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+
+import com.google.common.base.Preconditions;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
 import org.apache.pinot.core.segment.index.datasource.ImmutableDataSource;
+import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.core.segment.index.readers.ForwardIndexReader;
@@ -91,7 +94,10 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
 
   @Override
   public DataSource getDataSource(String column) {
-    return new ImmutableDataSource(_segmentMetadata.getColumnMetadataFor(column), _indexContainerMap.get(column));
+    ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
+    Preconditions.checkNotNull(columnMetadata,
+        "ColumnMetadata for " + column + " should not be null. " + "Potentially invalid column name specified.");
+    return new ImmutableDataSource(columnMetadata, _indexContainerMap.get(column));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -639,7 +639,8 @@ public class MutableSegmentImpl implements MutableSegment {
       if (fieldSpec == null) {
         // If the column was added during ingestion, we will construct the column provider based on its fieldSpec to provide values
         fieldSpec = _newlyAddedColumnsFieldMap.get(column);
-        Preconditions.checkNotNull(fieldSpec, "FieldSpec for " + column + " should not be null");
+        Preconditions.checkNotNull(fieldSpec,
+            "FieldSpec for " + column + " should not be null. " + "Potentially invalid column name specified.");
       }
       // TODO: Refactor virtual column provider to directly generate data source
       VirtualColumnContext virtualColumnContext = new VirtualColumnContext(fieldSpec, _numDocsIndexed);


### PR DESCRIPTION
Adding a null check inside getDataSource method for potentially invalid column name (#5899)

## Description
This PR improves the readability of the error message (instead of just throwing a NullPointerException).

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [x] No

Does this PR fix a zero-downtime upgrade introduced earlier?
* [x] No

Does this PR otherwise need attention when creating release notes? Things to consider:
* [x] No