### PR TITLE
[TE] Multiple changes to get TE running in a docker container

### DIFF
--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -53,14 +53,6 @@
           <groupId>org.glassfish.hk2.external</groupId>
           <artifactId>aopalliance-repackaged</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-access</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -70,12 +62,6 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-migrations</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -383,7 +383,6 @@ public class GenericPojoDao {
     genericJsonEntity.setId(pojo.getId());
     genericJsonEntity.setVersion(pojo.getVersion());
     PojoInfo pojoInfo = pojoInfoMap.get(pojo.getClass());
-    dumpTable(connection, pojoInfo.indexEntityClass);
     Set<String> fieldsToUpdate = Sets.newHashSet("jsonVal", "updateTime", "version");
     int affectedRows;
     try (PreparedStatement baseTableInsertStmt =
@@ -606,7 +605,6 @@ public class GenericPojoDao {
         @Override
         public List<E> handle(Connection connection) throws Exception {
           PojoInfo pojoInfo = pojoInfoMap.get(pojoClass);
-          dumpTable(connection, pojoInfo.indexEntityClass);
           List<? extends AbstractIndexEntity> indexEntities;
           try (PreparedStatement findMatchingIdsStatement = sqlQueryBuilder.createStatementFromSQL(
               connection, parameterizedSQL, parameterMap, pojoInfo.indexEntityClass)) {
@@ -726,7 +724,6 @@ public class GenericPojoDao {
               idsToReturn.add(entity.getBaseId());
             }
           }
-          dumpTable(connection, pojoInfo.indexEntityClass);
           return idsToReturn;
         }
       }, Collections.<Long>emptyList());
@@ -736,6 +733,15 @@ public class GenericPojoDao {
     }
   }
 
+  /**
+   * Dump all entities of type entityClass to logger
+   * This utility is useful to dump the entire table. However, it gets executed in code regularly in debug mode.
+   *
+   * @param connection SQL connection
+   * @param entityClass The entity class.
+   * @throws Exception exceptions encountered during row fetches
+   */
+  @SuppressWarnings("unused")
   private void dumpTable(Connection connection, Class<? extends AbstractEntity> entityClass)
       throws Exception {
     long tStart = System.nanoTime();

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/util/DaoProviderUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/util/DaoProviderUtil.java
@@ -103,8 +103,8 @@ public abstract class DaoProviderUtil {
       try {
         LOG.info("Creating database schema for default URL '{}'", DEFAULT_DATABASE_PATH);
         Connection conn = dataSource.getConnection();
-        ScriptRunner scriptRunner = new ScriptRunner(conn, false, false);
-        scriptRunner.setDelimiter(";", true);
+        final ScriptRunner scriptRunner = new ScriptRunner(conn, false);
+        scriptRunner.setDelimiter(";");
 
         InputStream createSchema = DaoProviderUtil.class.getResourceAsStream("/schema/create-schema.sql");
         scriptRunner.runScript(new InputStreamReader(createSchema));

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datalayer/bao/DAOTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datalayer/bao/DAOTestBase.java
@@ -93,8 +93,8 @@ public class DAOTestBase {
     Connection conn = ds.getConnection();
     // create schema
     URL createSchemaUrl = getClass().getResource("/schema/create-schema.sql");
-    ScriptRunner scriptRunner = new ScriptRunner(conn, false, false);
-    scriptRunner.setDelimiter(";", true);
+    ScriptRunner scriptRunner = new ScriptRunner(conn, true);
+    scriptRunner.setDelimiter(";");
     scriptRunner.setLogWriter(new PrintWriter(new NullWriter()));
     scriptRunner.runScript(new FileReader(createSchemaUrl.getFile()));
   }
@@ -103,7 +103,7 @@ public class DAOTestBase {
     System.out.println("Cleaning database: start");
     try (Connection conn = ds.getConnection()) {
       URL deleteSchemaUrl = getClass().getResource("/schema/drop-tables.sql");
-      ScriptRunner scriptRunner = new ScriptRunner(conn, false, false);
+      ScriptRunner scriptRunner = new ScriptRunner(conn, false);
       scriptRunner.setLogWriter(new PrintWriter(new NullWriter()));
       scriptRunner.runScript(new FileReader(deleteSchemaUrl.getFile()));
     }


### PR DESCRIPTION
## Changes
- Restored logback dependency which is crashing the frontend and backend server. This is turn uncovers other issues fixed below.
- Removed usage of dumpTable from code. Retaining the method for utility purpose. Dump table runs into errors because of an inconsistent state in `dimensionsMap` during the execution of multiple tests
- ScriptRunner to sanitize SQL commands for h2 db. The same script to setup MySQL is used by the test framework to setup the H2 db and it fails while parsing.
- Specifics like `Engine=InnoDB` is not recognized by h2 and throws error.
- The `ScriptRunner` class was refactored to remove some of the dead code.

### More Context
There are missing dependencies because of dependencies specifically excluded in the build script. This leads to ThirdEye failing to launch in a docker container. Removing the exclusions to fix the build.

Here is a stacktrace of the crash. This happens in both frontend and backend servers.

```
[2020-08-25 23:22:11] INFO  [main] o.e.j.u.log - Logging initialized @3811ms to org.eclipse.jetty.util.log.Slf4jLog 
java.lang.NoClassDefFoundError: ch/qos/logback/classic/spi/LoggerContextListener
	at java.lang.Class.getDeclaredFields0(Native Method)
	at java.lang.Class.privateGetDeclaredFields(Class.java:2583)
	at java.lang.Class.getDeclaredFields(Class.java:1916)
	at com.fasterxml.jackson.databind.util.ClassUtil.getDeclaredFields(ClassUtil.java:1113)
	at com.fasterxml.jackson.databind.introspect.AnnotatedFieldCollector._findFields(AnnotatedFieldCollector.java:66)
.. <truncated>.
com.fasterxml.jackson.module.afterburner.deser.SuperSonicBeanDeserializer.deserialize(SuperSonicBeanDeserializer.java:155)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4173)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2467)
	at io.dropwizard.configuration.BaseConfigurationFactory.build(BaseConfigurationFactory.java:127)
	at io.dropwizard.configuration.BaseConfigurationFactory.build(BaseConfigurationFactory.java:89)
	at io.dropwizard.cli.ConfiguredCommand.parseConfiguration(ConfiguredCommand.java:126)
	at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:74)
	at io.dropwizard.cli.Cli.run(Cli.java:78)
	at io.dropwizard.Application.run(Application.java:93)
	at org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyApplication.main(ThirdEyeAnomalyApplication.java:85)
Caused by: java.lang.ClassNotFoundException: ch.qos.logback.classic.spi.LoggerContextListener
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 42 more

```