### PR TITLE
Introduce IdSet and add IdSetAggregationFunction

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/AggregationFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/AggregationFunctionType.java
@@ -43,6 +43,7 @@ public enum AggregationFunctionType {
   PERCENTILE("percentile"),
   PERCENTILEEST("percentileEst"),
   PERCENTILETDIGEST("percentileTDigest"),
+  IDSET("idSet"),
 
   // Geo aggregation functions
   STUNION("STUnion"),

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -53,6 +53,8 @@ import org.apache.pinot.core.query.aggregation.function.customobject.AvgPair;
 import org.apache.pinot.core.query.aggregation.function.customobject.DistinctTable;
 import org.apache.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
 import org.apache.pinot.core.query.aggregation.function.customobject.QuantileDigest;
+import org.apache.pinot.core.query.utils.idset.IdSet;
+import org.apache.pinot.core.query.utils.idset.IdSets;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.StringUtils;
 import org.locationtech.jts.geom.Geometry;
@@ -88,7 +90,8 @@ public class ObjectSerDeUtils {
     FloatSet(16),
     DoubleSet(17),
     StringSet(18),
-    BytesSet(19);
+    BytesSet(19),
+    IdSet(20);
 
     private final int _value;
 
@@ -144,6 +147,8 @@ public class ObjectSerDeUtils {
         } else {
           return ObjectType.BytesSet;
         }
+      } else if (value instanceof IdSet) {
+        return ObjectType.IdSet;
       } else {
         throw new IllegalArgumentException("Unsupported type of value: " + value.getClass().getSimpleName());
       }
@@ -742,6 +747,35 @@ public class ObjectSerDeUtils {
     }
   };
 
+  public static final ObjectSerDe<IdSet> ID_SET_SER_DE = new ObjectSerDe<IdSet>() {
+    @Override
+    public byte[] serialize(IdSet idSet) {
+      try {
+        return idSet.toBytes();
+      } catch (IOException e) {
+        throw new RuntimeException("Caught exception while serializing IdSet", e);
+      }
+    }
+
+    @Override
+    public IdSet deserialize(byte[] bytes) {
+      try {
+        return IdSets.fromBytes(bytes);
+      } catch (IOException e) {
+        throw new RuntimeException("Caught exception while deserializing IdSet", e);
+      }
+    }
+
+    @Override
+    public IdSet deserialize(ByteBuffer byteBuffer) {
+      try {
+        return IdSets.fromByteBuffer(byteBuffer);
+      } catch (IOException e) {
+        throw new RuntimeException("Caught exception while deserializing IdSet", e);
+      }
+    }
+  };
+
   // NOTE: DO NOT change the order, it has to be the same order as the ObjectType
   //@formatter:off
   private static final ObjectSerDe[] SER_DES = {
@@ -764,7 +798,8 @@ public class ObjectSerDeUtils {
       FLOAT_SET_SER_DE,
       DOUBLE_SET_SER_DE,
       STRING_SET_SER_DE,
-      BYTES_SET_SER_DE
+      BYTES_SET_SER_DE,
+      ID_SET_SER_DE
   };
   //@formatter:on
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -137,6 +137,8 @@ public class AggregationFunctionFactory {
             return new DistinctCountThetaSketchAggregationFunction(arguments);
           case DISTINCTCOUNTRAWTHETASKETCH:
             return new DistinctCountRawThetaSketchAggregationFunction(arguments);
+          case IDSET:
+            return new IdSetAggregationFunction(arguments);
           case COUNTMV:
             return new CountMVAggregationFunction(firstArgument);
           case MINMV:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
@@ -1,0 +1,352 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.function.AggregationFunctionType;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.utils.idset.IdSet;
+import org.apache.pinot.core.query.utils.idset.IdSets;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/**
+ * The {@code IdSetAggregationFunction} collects the values for a given single-value expression into an IdSet, which can
+ * be used in the second query to optimize the query with huge IN clause generated from another query.
+ * <p>The generated IdSet can be backed by RoaringBitmap, Roaring64NavigableMap or BloomFilter based on type of the ids
+ * and the function parameters.
+ * <p>The function takes an optional second argument as the parameters for the function. There are 3 parameters for the
+ * function:
+ * <ul>
+ *   <li>
+ *     sizeThresholdInBytes: When the size of the IdSet exceeds this threshold, convert the IdSet to BloomFilterIdSet to
+ *     reduce the size of the IdSet. Directly create BloomFilterIdSet if it is smaller or equal to 0. (Default 8MB)
+ *   </li>
+ *   <li>
+ *     expectedInsertions: Number of expected insertions for the BloomFilter, must be positive. (Default 5M)
+ *   </li>
+ *   <li>
+ *     fpp: Desired false positive probability for the BloomFilter, must be positive and less than 1.0. (Default 0.03)
+ *   </li>
+ * </ul>
+ * <p>Example: IDSET(col, 'sizeThresholdInBytes=1000;expectedInsertions=10000;fpp=0.03')
+ */
+public class IdSetAggregationFunction extends BaseSingleInputAggregationFunction<IdSet, String> {
+  private static final char PARAMETER_DELIMITER = ';';
+  private static final char PARAMETER_KEY_VALUE_SEPARATOR = '=';
+  private static final String UPPER_CASE_SIZE_THRESHOLD_IN_BYTES = "SIZETHRESHOLDINBYTES";
+  private static final String UPPER_CASE_EXPECTED_INSERTIONS = "EXPECTEDINSERTIONS";
+  private static final String UPPER_CASE_FPP = "FPP";
+
+  private final int _sizeThresholdInBytes;
+  private final int _expectedInsertions;
+  private final double _fpp;
+
+  public IdSetAggregationFunction(List<ExpressionContext> arguments) {
+    super(arguments.get(0));
+    if (arguments.size() == 1) {
+      _sizeThresholdInBytes = IdSets.DEFAULT_SIZE_THRESHOLD_IN_BYTES;
+      _expectedInsertions = IdSets.DEFAULT_EXPECTED_INSERTIONS;
+      _fpp = IdSets.DEFAULT_FPP;
+    } else {
+      ExpressionContext parametersExpression = arguments.get(1);
+      Preconditions.checkArgument(parametersExpression.getType() == ExpressionContext.Type.LITERAL,
+          "Second argument of IdSet must be literal (parameters)");
+
+      int sizeThresholdInBytes = IdSets.DEFAULT_SIZE_THRESHOLD_IN_BYTES;
+      int expectedInsertions = IdSets.DEFAULT_EXPECTED_INSERTIONS;
+      double fpp = IdSets.DEFAULT_FPP;
+      String parametersString = parametersExpression.getLiteral();
+      StringUtils.deleteWhitespace(parametersString);
+      String[] keyValuePairs = StringUtils.split(parametersString, PARAMETER_DELIMITER);
+      for (String keyValuePair : keyValuePairs) {
+        String[] keyAndValue = StringUtils.split(keyValuePair, PARAMETER_KEY_VALUE_SEPARATOR);
+        Preconditions.checkArgument(keyAndValue.length == 2, "Invalid parameter: %s", keyValuePair);
+        String key = keyAndValue[0];
+        String value = keyAndValue[1];
+        switch (key.toUpperCase()) {
+          case UPPER_CASE_SIZE_THRESHOLD_IN_BYTES:
+            sizeThresholdInBytes = Integer.parseInt(value);
+            break;
+          case UPPER_CASE_EXPECTED_INSERTIONS:
+            expectedInsertions = Integer.parseInt(value);
+            break;
+          case UPPER_CASE_FPP:
+            fpp = Double.parseDouble(value);
+            break;
+          default:
+            throw new IllegalArgumentException("Invalid parameter key: " + key);
+        }
+      }
+      _sizeThresholdInBytes = sizeThresholdInBytes;
+      _expectedInsertions = expectedInsertions;
+      _fpp = fpp;
+    }
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.IDSET;
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    return new ObjectAggregationResultHolder();
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    DataType valueType = blockValSet.getValueType();
+    IdSet idSet = getIdSet(aggregationResultHolder, valueType);
+    switch (valueType) {
+      case INT:
+        int[] intValues = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length; i++) {
+          idSet.add(intValues[i]);
+        }
+        break;
+      case LONG:
+        long[] longValues = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length; i++) {
+          idSet.add(longValues[i]);
+        }
+        break;
+      case FLOAT:
+        float[] floatValues = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length; i++) {
+          idSet.add(floatValues[i]);
+        }
+        break;
+      case DOUBLE:
+        double[] doubleValues = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          idSet.add(doubleValues[i]);
+        }
+        break;
+      case STRING:
+        String[] stringValues = blockValSet.getStringValuesSV();
+        for (int i = 0; i < length; i++) {
+          idSet.add(stringValues[i]);
+        }
+        break;
+      case BYTES:
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          idSet.add(bytesValues[i]);
+        }
+        break;
+      default:
+        throw new IllegalStateException("Illegal data type for ID_SET aggregation function: " + valueType);
+    }
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    DataType valueType = blockValSet.getValueType();
+    switch (valueType) {
+      case INT:
+        int[] intValues = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length; i++) {
+          getIdSet(groupByResultHolder, groupKeyArray[i], DataType.INT).add(intValues[i]);
+        }
+        break;
+      case LONG:
+        long[] longValues = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length; i++) {
+          getIdSet(groupByResultHolder, groupKeyArray[i], DataType.LONG).add(longValues[i]);
+        }
+        break;
+      case FLOAT:
+        float[] floatValues = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length; i++) {
+          getIdSet(groupByResultHolder, groupKeyArray[i], DataType.FLOAT).add(floatValues[i]);
+        }
+        break;
+      case DOUBLE:
+        double[] doubleValues = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          getIdSet(groupByResultHolder, groupKeyArray[i], DataType.DOUBLE).add(doubleValues[i]);
+        }
+        break;
+      case STRING:
+        String[] stringValues = blockValSet.getStringValuesSV();
+        for (int i = 0; i < length; i++) {
+          getIdSet(groupByResultHolder, groupKeyArray[i], DataType.STRING).add(stringValues[i]);
+        }
+        break;
+      case BYTES:
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          getIdSet(groupByResultHolder, groupKeyArray[i], DataType.BYTES).add(bytesValues[i]);
+        }
+        break;
+      default:
+        throw new IllegalStateException("Illegal data type for ID_SET aggregation function: " + valueType);
+    }
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    DataType valueType = blockValSet.getValueType();
+    switch (valueType) {
+      case INT:
+        int[] intValues = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length; i++) {
+          int intValue = intValues[i];
+          for (int groupKey : groupKeysArray[i]) {
+            getIdSet(groupByResultHolder, groupKey, DataType.INT).add(intValue);
+          }
+        }
+        break;
+      case LONG:
+        long[] longValues = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length; i++) {
+          long longValue = longValues[i];
+          for (int groupKey : groupKeysArray[i]) {
+            getIdSet(groupByResultHolder, groupKey, DataType.LONG).add(longValue);
+          }
+        }
+        break;
+      case FLOAT:
+        float[] floatValues = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length; i++) {
+          float floatValue = floatValues[i];
+          for (int groupKey : groupKeysArray[i]) {
+            getIdSet(groupByResultHolder, groupKey, DataType.FLOAT).add(floatValue);
+          }
+        }
+        break;
+      case DOUBLE:
+        double[] doubleValues = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          double doubleValue = doubleValues[i];
+          for (int groupKey : groupKeysArray[i]) {
+            getIdSet(groupByResultHolder, groupKey, DataType.DOUBLE).add(doubleValue);
+          }
+        }
+        break;
+      case STRING:
+        String[] stringValues = blockValSet.getStringValuesSV();
+        for (int i = 0; i < length; i++) {
+          String stringValue = stringValues[i];
+          for (int groupKey : groupKeysArray[i]) {
+            getIdSet(groupByResultHolder, groupKey, DataType.STRING).add(stringValue);
+          }
+        }
+        break;
+      case BYTES:
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          byte[] bytesValue = bytesValues[i];
+          for (int groupKey : groupKeysArray[i]) {
+            getIdSet(groupByResultHolder, groupKey, DataType.BYTES).add(bytesValue);
+          }
+        }
+        break;
+      default:
+        throw new IllegalStateException("Illegal data type for ID_SET aggregation function: " + valueType);
+    }
+  }
+
+  @Override
+  public IdSet extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    IdSet idSet = aggregationResultHolder.getResult();
+    return idSet != null ? idSet : IdSets.emptyIdSet();
+  }
+
+  @Override
+  public IdSet extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+    IdSet idSet = groupByResultHolder.getResult(groupKey);
+    return idSet != null ? idSet : IdSets.emptyIdSet();
+  }
+
+  @Override
+  public IdSet merge(IdSet intermediateResult1, IdSet intermediateResult2) {
+    return IdSets.merge(intermediateResult1, intermediateResult2, _sizeThresholdInBytes, _expectedInsertions, _fpp);
+  }
+
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return false;
+  }
+
+  @Override
+  public ColumnDataType getIntermediateResultColumnType() {
+    return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.STRING;
+  }
+
+  @Override
+  public String extractFinalResult(IdSet intermediateResult) {
+    try {
+      return intermediateResult.toBase64String();
+    } catch (IOException e) {
+      throw new RuntimeException("Caught exception while serializing IdSet", e);
+    }
+  }
+
+  /**
+   * Returns the IdSet from the result holder or creates a new one if it does not exist.
+   */
+  private IdSet getIdSet(AggregationResultHolder aggregationResultHolder, DataType valueType) {
+    IdSet idSet = aggregationResultHolder.getResult();
+    if (idSet == null) {
+      idSet = IdSets.create(valueType, _sizeThresholdInBytes, _expectedInsertions, _fpp);
+      aggregationResultHolder.setValue(idSet);
+    }
+    return idSet;
+  }
+
+  /**
+   * Returns the IdSet for the given group key or creates a new one if it does not exist.
+   */
+  private IdSet getIdSet(GroupByResultHolder groupByResultHolder, int groupKey, DataType valueType) {
+    IdSet idSet = groupByResultHolder.getResult(groupKey);
+    if (idSet == null) {
+      idSet = IdSets.create(valueType, _sizeThresholdInBytes, _expectedInsertions, _fpp);
+      groupByResultHolder.setValueForKey(groupKey, idSet);
+    }
+    return idSet;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
@@ -119,10 +119,11 @@ public class BrokerRequestToQueryContextConverter {
           int numArguments = stringExpressions.size();
           List<ExpressionContext> arguments = new ArrayList<>(numArguments);
           if (functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNTTHETASKETCH.getName()) || functionName
-              .equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNTRAWTHETASKETCH.getName())) {
-            // NOTE: For DistinctCountThetaSketch and DistinctCountRawThetaSketch, because of the legacy behavior of PQL
-            //       compiler treating string literal as identifier in aggregation, here we treat all expressions except
-            //       for the first one as string literal.
+              .equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNTRAWTHETASKETCH.getName()) || functionName
+              .equalsIgnoreCase(AggregationFunctionType.IDSET.getName())) {
+            // NOTE: For DistinctCountThetaSketch, DistinctCountRawThetaSketch and IdSet, because of the legacy behavior
+            //       of PQL compiler treating string literal as identifier in aggregation, here we treat all expressions
+            //       except for the first one as string literal.
             arguments.add(QueryContextConverterUtils.getExpression(stringExpressions.get(0)));
             for (int i = 1; i < numArguments; i++) {
               arguments.add(ExpressionContext.forLiteral(stringExpressions.get(i)));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/BloomFilterIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/BloomFilterIdSet.java
@@ -1,0 +1,235 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.utils.idset;
+
+import com.google.common.base.Preconditions;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnel;
+import com.google.common.hash.Funnels;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/**
+ * The {@code BloomFilterIdSet} is an IdSet backed by the {@link BloomFilter}, and can be used to store all types of
+ * ids.
+ */
+@SuppressWarnings({"rawtypes", "unchecked", "UnstableApiUsage"})
+public class BloomFilterIdSet implements IdSet {
+
+  private enum FunnelType {
+    // DO NOT change the ids as the ser/de relies on them
+    INT((byte) 0), LONG((byte) 1), STRING((byte) 2), BYTES((byte) 3);
+
+    private final byte _id;
+
+    FunnelType(byte id) {
+      _id = id;
+    }
+
+    public byte getId() {
+      return _id;
+    }
+  }
+
+  private final FunnelType _funnelType;
+  private final BloomFilter _bloomFilter;
+  private final int _serializedSizeInBytes;
+
+  BloomFilterIdSet(DataType dataType, int expectedInsertions, double fpp) {
+    switch (dataType) {
+      case INT:
+      case FLOAT:
+        _funnelType = FunnelType.INT;
+        _bloomFilter = BloomFilter.create(Funnels.integerFunnel(), expectedInsertions, fpp);
+        break;
+      case LONG:
+      case DOUBLE:
+        _funnelType = FunnelType.LONG;
+        _bloomFilter = BloomFilter.create(Funnels.longFunnel(), expectedInsertions, fpp);
+        break;
+      case STRING:
+        _funnelType = FunnelType.STRING;
+        _bloomFilter = BloomFilter.create(Funnels.unencodedCharsFunnel(), expectedInsertions, fpp);
+        break;
+      case BYTES:
+        _funnelType = FunnelType.BYTES;
+        _bloomFilter = BloomFilter.create(Funnels.byteArrayFunnel(), expectedInsertions, fpp);
+        break;
+      default:
+        throw new IllegalStateException("Unsupported data type: " + dataType);
+    }
+    // NOTE: 1 byte for IdSet type, 1 byte for FunnelType, (2 bytes, 1 int, N longs) for BloomFilter.
+    //       See BloomFilter.writeTo(OutputStream out) for details.
+    long numBitsInBloomFilter = (long) (-expectedInsertions * Math.log(fpp) / (Math.log(2) * Math.log(2)));
+    _serializedSizeInBytes =
+        4 + Integer.BYTES + ((int) ((numBitsInBloomFilter + Long.SIZE - 1) / Long.SIZE) * Long.BYTES);
+  }
+
+  private BloomFilterIdSet(FunnelType funnelType, BloomFilter bloomFilter, int serializedSizeInBytes) {
+    _funnelType = funnelType;
+    _bloomFilter = bloomFilter;
+    _serializedSizeInBytes = serializedSizeInBytes;
+  }
+
+  BloomFilter getBloomFilter() {
+    return _bloomFilter;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.BLOOM_FILTER;
+  }
+
+  @Override
+  public void add(int id) {
+    _bloomFilter.put(id);
+  }
+
+  @Override
+  public void add(long id) {
+    _bloomFilter.put(id);
+  }
+
+  @Override
+  public void add(float id) {
+    _bloomFilter.put(Float.floatToRawIntBits(id));
+  }
+
+  @Override
+  public void add(double id) {
+    _bloomFilter.put(Double.doubleToRawLongBits(id));
+  }
+
+  @Override
+  public void add(String id) {
+    _bloomFilter.put(id);
+  }
+
+  @Override
+  public void add(byte[] id) {
+    _bloomFilter.put(id);
+  }
+
+  @Override
+  public boolean contains(int id) {
+    return _bloomFilter.mightContain(id);
+  }
+
+  @Override
+  public boolean contains(long id) {
+    return _bloomFilter.mightContain(id);
+  }
+
+  @Override
+  public boolean contains(float id) {
+    return _bloomFilter.mightContain(Float.floatToRawIntBits(id));
+  }
+
+  @Override
+  public boolean contains(double id) {
+    return _bloomFilter.mightContain(Double.doubleToRawLongBits(id));
+  }
+
+  @Override
+  public boolean contains(String id) {
+    return _bloomFilter.mightContain(id);
+  }
+
+  @Override
+  public boolean contains(byte[] id) {
+    return _bloomFilter.mightContain(id);
+  }
+
+  @Override
+  public int getSerializedSizeInBytes() {
+    return _serializedSizeInBytes;
+  }
+
+  @Override
+  public byte[] toBytes()
+      throws IOException {
+    // NOTE: No need to close the stream.
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(_serializedSizeInBytes);
+    byteArrayOutputStream.write(Type.BLOOM_FILTER.getId());
+    byteArrayOutputStream.write(_funnelType.getId());
+    _bloomFilter.writeTo(byteArrayOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
+
+  /**
+   * Deserializes the BloomFilterIdSet from a ByteBuffer.
+   * <p>NOTE: The ByteBuffer does not include the IdSet.Type byte.
+   */
+  static BloomFilterIdSet fromByteBuffer(ByteBuffer byteBuffer)
+      throws IOException {
+    Preconditions.checkArgument(byteBuffer.hasArray(),
+        "Cannot deserialize BloomFilter from ByteBuffer not backed by an accessible byte array");
+    // Count the IdSet.Type byte
+    int serializedSizeInBytes = 1 + byteBuffer.remaining();
+    byte funnelTypeId = byteBuffer.get();
+    FunnelType funnelType;
+    Funnel funnel;
+    switch (funnelTypeId) {
+      case 0:
+        funnelType = FunnelType.INT;
+        funnel = Funnels.integerFunnel();
+        break;
+      case 1:
+        funnelType = FunnelType.LONG;
+        funnel = Funnels.longFunnel();
+        break;
+      case 2:
+        funnelType = FunnelType.STRING;
+        funnel = Funnels.unencodedCharsFunnel();
+        break;
+      case 3:
+        funnelType = FunnelType.BYTES;
+        funnel = Funnels.byteArrayFunnel();
+        break;
+      default:
+        throw new IllegalStateException();
+    }
+    // NOTE: No need to close the stream.
+    BloomFilter bloomFilter = BloomFilter.readFrom(
+        new ByteArrayInputStream(byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(),
+            byteBuffer.remaining()), funnel);
+    return new BloomFilterIdSet(funnelType, bloomFilter, serializedSizeInBytes);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * _funnelType.hashCode() + _bloomFilter.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BloomFilterIdSet)) {
+      return false;
+    }
+    BloomFilterIdSet that = (BloomFilterIdSet) o;
+    return _funnelType == that._funnelType && _bloomFilter.equals(that._bloomFilter);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/EmptyIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/EmptyIdSet.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.utils.idset;
+
+/**
+ * The {@code EmptyIdSet} represents an empty IdSet.
+ */
+public class EmptyIdSet implements IdSet {
+  private EmptyIdSet() {
+  }
+
+  static final EmptyIdSet INSTANCE = new EmptyIdSet();
+
+  @Override
+  public Type getType() {
+    return Type.EMPTY;
+  }
+
+  @Override
+  public boolean contains(int id) {
+    return false;
+  }
+
+  @Override
+  public boolean contains(long id) {
+    return false;
+  }
+
+  @Override
+  public boolean contains(float id) {
+    return false;
+  }
+
+  @Override
+  public boolean contains(double id) {
+    return false;
+  }
+
+  @Override
+  public boolean contains(String id) {
+    return false;
+  }
+
+  @Override
+  public boolean contains(byte[] id) {
+    return false;
+  }
+
+  @Override
+  public int getSerializedSizeInBytes() {
+    return 1;
+  }
+
+  @Override
+  public byte[] toBytes() {
+    // Single byte of IdSet.Type.EMPTY (0)
+    return new byte[1];
+  }
+
+  @Override
+  public int hashCode() {
+    return 0;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/IdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/IdSet.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.utils.idset;
+
+import java.io.IOException;
+import java.util.Base64;
+
+
+/**
+ * The {@code IdSet} represents a collection of ids. It can be used to optimize the query with huge IN clause.
+ */
+public interface IdSet {
+
+  enum Type {
+    // DO NOT change the ids as the ser/de relies on them
+    EMPTY((byte) 0), ROARING_BITMAP((byte) 1), ROARING_64_NAVIGABLE_MAP((byte) 2), BLOOM_FILTER((byte) 3);
+
+    private final byte _id;
+
+    Type(byte id) {
+      _id = id;
+    }
+
+    public byte getId() {
+      return _id;
+    }
+  }
+
+  /**
+   * Returns the type of the IdSet.
+   */
+  Type getType();
+
+  /**
+   * Adds an INT id into the IdSet.
+   */
+  default void add(int id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Adds a LONG id into the IdSet.
+   */
+  default void add(long id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Adds a FLOAT id into the IdSet.
+   */
+  default void add(float id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Adds a DOUBLE id into the IdSet.
+   */
+  default void add(double id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Adds a STRING id into the IdSet.
+   */
+  default void add(String id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Adds a BYTES id into the IdSet.
+   */
+  default void add(byte[] id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns {@code true} if the IdSet contains the given INT id, {@code false} otherwise.
+   */
+  default boolean contains(int id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns {@code true} if the IdSet contains the given LONG id, {@code false} otherwise.
+   */
+  default boolean contains(long id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns {@code true} if the IdSet contains the given FLOAT id, {@code false} otherwise.
+   */
+  default boolean contains(float id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns {@code true} if the IdSet contains the given DOUBLE id, {@code false} otherwise.
+   */
+  default boolean contains(double id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns {@code true} if the IdSet contains the given STRING id, {@code false} otherwise.
+   */
+  default boolean contains(String id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns {@code true} if the IdSet contains the given BYTES id, {@code false} otherwise.
+   */
+  default boolean contains(byte[] id) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns the number of bytes required to serialize the IdSet.
+   */
+  int getSerializedSizeInBytes();
+
+  /**
+   * Serializes the IdSet into a byte array.
+   */
+  byte[] toBytes()
+      throws IOException;
+
+  /**
+   * Serializes the IdSet into a Base64 string.
+   * <p>Use Base64 instead of Hex encoding for better compression.
+   */
+  default String toBase64String()
+      throws IOException {
+    return Base64.getEncoder().encodeToString(toBytes());
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/IdSets.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/IdSets.java
@@ -1,0 +1,236 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.utils.idset;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.PeekableIntIterator;
+import org.roaringbitmap.longlong.LongIterator;
+
+
+/**
+ * The class {@code IdSets} contains the utility methods for the {@link IdSet}.
+ */
+@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+public class IdSets {
+  private IdSets() {
+  }
+
+  // Use 8MB as the default threshold to convert to BloomFilter
+  public static final int DEFAULT_SIZE_THRESHOLD_IN_BYTES = 8 * 1024 * 1024;
+  // NOTE: With default expectedInsertions and fpp, the BloomFilter will be around 4.35MB.
+  public static final int DEFAULT_EXPECTED_INSERTIONS = 5_000_000;
+  public static final double DEFAULT_FPP = 0.03;
+
+  /**
+   * Creates an IdSet.
+   *
+   * @param dataType Data type of the ids
+   * @return Created IdSet
+   * */
+  public static IdSet create(DataType dataType) {
+    return create(dataType, DEFAULT_SIZE_THRESHOLD_IN_BYTES, DEFAULT_EXPECTED_INSERTIONS, DEFAULT_FPP);
+  }
+
+  /**
+   * Creates an IdSet.
+   *
+   * @param dataType Data type of the ids
+   * @param sizeThresholdInBytes Size threshold in bytes to convert to BloomFilterIdSet. Directly create
+   *                             BloomFilterIdSet if it is smaller or equal to 0
+   * @param expectedInsertions Number of expected insertions for the BloomFilter, must be positive
+   * @param fpp Desired false positive probability for the BloomFilter, must be positive and less than 1.0
+   * @return Created IdSet
+   */
+  public static IdSet create(DataType dataType, int sizeThresholdInBytes, int expectedInsertions, double fpp) {
+    if (sizeThresholdInBytes <= 0) {
+      return new BloomFilterIdSet(dataType, expectedInsertions, fpp);
+    }
+    switch (dataType) {
+      case INT:
+        return new RoaringBitmapIdSet();
+      case LONG:
+        return new Roaring64NavigableMapIdSet();
+      case FLOAT:
+      case DOUBLE:
+      case STRING:
+      case BYTES:
+        return new BloomFilterIdSet(dataType, expectedInsertions, fpp);
+      default:
+        throw new IllegalStateException("Unsupported data type: " + dataType);
+    }
+  }
+
+  /**
+   * Returns an EmptyIdSet.
+   */
+  public static EmptyIdSet emptyIdSet() {
+    return EmptyIdSet.INSTANCE;
+  }
+
+  /**
+   * Merges 2 IdSets, converts to BloomFilterIdSet if the size exceeds the size threshold.
+   *
+   * @param idSet1 First IdSet to merge
+   * @param idSet2 Second IdSet to merge
+   * @return Merged IdSet
+   */
+  public static IdSet merge(IdSet idSet1, IdSet idSet2) {
+    return merge(idSet1, idSet2, DEFAULT_SIZE_THRESHOLD_IN_BYTES, DEFAULT_EXPECTED_INSERTIONS, DEFAULT_FPP);
+  }
+
+  /**
+   * Merges 2 IdSets, converts to BloomFilterIdSet if the size exceeds the size threshold.
+   *
+   * @param idSet1 First IdSet to merge
+   * @param idSet2 Second IdSet to merge
+   * @param sizeThresholdInBytes Size threshold in bytes to convert to BloomFilterIdSet. Directly create
+   *                             BloomFilterIdSet if it is smaller or equal to 0
+   * @param expectedInsertions Number of expected insertions for the BloomFilter, must be positive
+   * @param fpp Desired false positive probability for the BloomFilter, must be positive and less than 1.0
+   * @return Merged IdSet
+   */
+  public static IdSet merge(IdSet idSet1, IdSet idSet2, int sizeThresholdInBytes, int expectedInsertions, double fpp) {
+    IdSet.Type idSet1Type = idSet1.getType();
+    if (idSet1Type == IdSet.Type.EMPTY) {
+      return idSet2;
+    }
+    IdSet.Type idSet2Type = idSet2.getType();
+    if (idSet2Type == IdSet.Type.EMPTY) {
+      return idSet1;
+    }
+    if (idSet1Type == idSet2Type) {
+      switch (idSet1Type) {
+        case ROARING_BITMAP:
+          RoaringBitmapIdSet roaringBitmapIdSet = (RoaringBitmapIdSet) idSet1;
+          roaringBitmapIdSet.getBitmap().or(((RoaringBitmapIdSet) idSet2).getBitmap());
+          return convertToBloomFilterIdSetIfNeeded(roaringBitmapIdSet, sizeThresholdInBytes, expectedInsertions, fpp);
+        case ROARING_64_NAVIGABLE_MAP:
+          Roaring64NavigableMapIdSet roaring64NavigableMapIdSet = (Roaring64NavigableMapIdSet) idSet1;
+          roaring64NavigableMapIdSet.getBitmap().or(((Roaring64NavigableMapIdSet) idSet2).getBitmap());
+          return convertToBloomFilterIdSetIfNeeded(roaring64NavigableMapIdSet, sizeThresholdInBytes, expectedInsertions,
+              fpp);
+        case BLOOM_FILTER:
+          BloomFilterIdSet bloomFilterIdSet = (BloomFilterIdSet) idSet1;
+          bloomFilterIdSet.getBloomFilter().putAll(((BloomFilterIdSet) idSet2).getBloomFilter());
+          return bloomFilterIdSet;
+        default:
+          throw new IllegalStateException();
+      }
+    }
+    // One of the IdSet is BloomFilterIdSet, the other one is not
+    BloomFilterIdSet bloomFilterIdSet;
+    IdSet nonBloomFilterIdSet;
+    IdSet.Type nonBloomFilterIdSetType;
+    if (idSet1Type == IdSet.Type.BLOOM_FILTER) {
+      bloomFilterIdSet = (BloomFilterIdSet) idSet1;
+      nonBloomFilterIdSet = idSet2;
+      nonBloomFilterIdSetType = idSet2Type;
+    } else {
+      assert idSet2Type == IdSet.Type.BLOOM_FILTER;
+      bloomFilterIdSet = (BloomFilterIdSet) idSet2;
+      nonBloomFilterIdSet = idSet1;
+      nonBloomFilterIdSetType = idSet1Type;
+    }
+    if (nonBloomFilterIdSetType == IdSet.Type.ROARING_BITMAP) {
+      PeekableIntIterator intIterator = ((RoaringBitmapIdSet) nonBloomFilterIdSet).getBitmap().getIntIterator();
+      while (intIterator.hasNext()) {
+        bloomFilterIdSet.add(intIterator.next());
+      }
+    } else {
+      assert nonBloomFilterIdSetType == IdSet.Type.ROARING_64_NAVIGABLE_MAP;
+      LongIterator longIterator = ((Roaring64NavigableMapIdSet) nonBloomFilterIdSet).getBitmap().getLongIterator();
+      while (longIterator.hasNext()) {
+        bloomFilterIdSet.add(longIterator.next());
+      }
+    }
+    return bloomFilterIdSet;
+  }
+
+  /**
+   * Helper method to convert the RoaringBitmapIdSet to BloomFilterIdSet if it exceeds the size threshold.
+   */
+  private static IdSet convertToBloomFilterIdSetIfNeeded(RoaringBitmapIdSet roaringBitmapIdSet, int sizeThreshold,
+      int expectedInsertions, double fpp) {
+    if (roaringBitmapIdSet.getSerializedSizeInBytes() <= sizeThreshold) {
+      return roaringBitmapIdSet;
+    }
+    BloomFilterIdSet bloomFilterIdSet = new BloomFilterIdSet(DataType.INT, expectedInsertions, fpp);
+    PeekableIntIterator intIterator = roaringBitmapIdSet.getBitmap().getIntIterator();
+    while (intIterator.hasNext()) {
+      bloomFilterIdSet.add(intIterator.next());
+    }
+    return bloomFilterIdSet;
+  }
+
+  /**
+   * Helper method to convert the Roaring64NavigableMapIdSet to BloomFilterIdSet if it exceeds the size threshold.
+   */
+  private static IdSet convertToBloomFilterIdSetIfNeeded(Roaring64NavigableMapIdSet roaring64NavigableMapIdSet,
+      int sizeThreshold, int expectedInsertions, double fpp) {
+    if (roaring64NavigableMapIdSet.getSerializedSizeInBytes() <= sizeThreshold) {
+      return roaring64NavigableMapIdSet;
+    }
+    BloomFilterIdSet bloomFilterIdSet = new BloomFilterIdSet(DataType.LONG, expectedInsertions, fpp);
+    LongIterator longIterator = roaring64NavigableMapIdSet.getBitmap().getLongIterator();
+    while (longIterator.hasNext()) {
+      bloomFilterIdSet.add(longIterator.next());
+    }
+    return bloomFilterIdSet;
+  }
+
+  /**
+   * Deserializes the IdSet from a byte array.
+   */
+  public static IdSet fromBytes(byte[] bytes)
+      throws IOException {
+    return fromByteBuffer(ByteBuffer.wrap(bytes));
+  }
+
+  /**
+   * Deserializes the IdSet from a ByteBuffer.
+   */
+  public static IdSet fromByteBuffer(ByteBuffer byteBuffer)
+      throws IOException {
+    byte typeId = byteBuffer.get();
+    switch (typeId) {
+      case 0:
+        return EmptyIdSet.INSTANCE;
+      case 1:
+        return RoaringBitmapIdSet.fromByteBuffer(byteBuffer);
+      case 2:
+        return Roaring64NavigableMapIdSet.fromByteBuffer(byteBuffer);
+      case 3:
+        return BloomFilterIdSet.fromByteBuffer(byteBuffer);
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  /**
+   * Deserializes the IdSet from a Base64 string.
+   * <p>Use Base64 instead of Hex encoding for better compression.
+   */
+  public static IdSet fromBase64String(String base64String)
+      throws IOException {
+    return fromBytes(Base64.getDecoder().decode(base64String));
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/Roaring64NavigableMapIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/Roaring64NavigableMapIdSet.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.utils.idset;
+
+import com.google.common.base.Preconditions;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+
+/**
+ * The {@code Roaring64NavigableMapIdSet} is an IdSet backed by the {@link Roaring64NavigableMap}, and can be used to
+ * store LONG ids.
+ */
+public class Roaring64NavigableMapIdSet implements IdSet {
+  private final Roaring64NavigableMap _bitmap;
+
+  Roaring64NavigableMapIdSet() {
+    _bitmap = new Roaring64NavigableMap();
+  }
+
+  private Roaring64NavigableMapIdSet(Roaring64NavigableMap bitmap) {
+    _bitmap = bitmap;
+  }
+
+  Roaring64NavigableMap getBitmap() {
+    return _bitmap;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.ROARING_64_NAVIGABLE_MAP;
+  }
+
+  @Override
+  public void add(long id) {
+    _bitmap.addLong(id);
+  }
+
+  @Override
+  public boolean contains(long id) {
+    return _bitmap.contains(id);
+  }
+
+  @Override
+  public int getSerializedSizeInBytes() {
+    return 1 + (int) _bitmap.serializedSizeInBytes();
+  }
+
+  @Override
+  public byte[] toBytes()
+      throws IOException {
+    int numBytes = 1 + (int) _bitmap.serializedSizeInBytes();
+    // NOTE: No need to close these streams.
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(numBytes);
+    DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+    dataOutputStream.write(Type.ROARING_64_NAVIGABLE_MAP.getId());
+    _bitmap.serialize(dataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
+
+  /**
+   * Deserializes the Roaring64NavigableMapIdSet from a ByteBuffer.
+   * <p>NOTE: The ByteBuffer does not include the IdSet.Type byte.
+   */
+  static Roaring64NavigableMapIdSet fromByteBuffer(ByteBuffer byteBuffer)
+      throws IOException {
+    Preconditions.checkArgument(byteBuffer.hasArray(),
+        "Cannot deserialize Roaring64NavigableMap from ByteBuffer not backed by an accessible byte array");
+    Roaring64NavigableMap roaring64NavigableMap = new Roaring64NavigableMap();
+    // NOTE: No need to close these streams.
+    roaring64NavigableMap.deserialize(new DataInputStream(
+        new ByteArrayInputStream(byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(),
+            byteBuffer.remaining())));
+    return new Roaring64NavigableMapIdSet(roaring64NavigableMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return _bitmap.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Roaring64NavigableMapIdSet)) {
+      return false;
+    }
+    Roaring64NavigableMapIdSet that = (Roaring64NavigableMapIdSet) o;
+    return _bitmap.equals(that._bitmap);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/RoaringBitmapIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/idset/RoaringBitmapIdSet.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.utils.idset;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.roaringbitmap.RoaringBitmap;
+
+
+/**
+ * The {@code RoaringBitmapIdSet} is an IdSet backed by the {@link RoaringBitmap}, and can be used to store INT ids.
+ */
+public class RoaringBitmapIdSet implements IdSet {
+  private final RoaringBitmap _bitmap;
+
+  RoaringBitmapIdSet() {
+    _bitmap = new RoaringBitmap();
+  }
+
+  private RoaringBitmapIdSet(RoaringBitmap bitmap) {
+    _bitmap = bitmap;
+  }
+
+  RoaringBitmap getBitmap() {
+    return _bitmap;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.ROARING_BITMAP;
+  }
+
+  @Override
+  public void add(int id) {
+    _bitmap.add(id);
+  }
+
+  @Override
+  public boolean contains(int id) {
+    return _bitmap.contains(id);
+  }
+
+  @Override
+  public int getSerializedSizeInBytes() {
+    return 1 + _bitmap.serializedSizeInBytes();
+  }
+
+  @Override
+  public byte[] toBytes() {
+    int numBytes = 1 + _bitmap.serializedSizeInBytes();
+    byte[] bytes = new byte[numBytes];
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    byteBuffer.put(Type.ROARING_BITMAP.getId());
+    _bitmap.serialize(byteBuffer);
+    return bytes;
+  }
+
+  /**
+   * Deserializes the RoaringBitmapIdSet from a ByteBuffer.
+   * <p>NOTE: The ByteBuffer does not include the IdSet.Type byte.
+   */
+  static RoaringBitmapIdSet fromByteBuffer(ByteBuffer byteBuffer)
+      throws IOException {
+    RoaringBitmap roaringBitmap = new RoaringBitmap();
+    roaringBitmap.deserialize(byteBuffer);
+    return new RoaringBitmapIdSet(roaringBitmap);
+  }
+
+  @Override
+  public int hashCode() {
+    return _bitmap.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RoaringBitmapIdSet)) {
+      return false;
+    }
+    RoaringBitmapIdSet that = (RoaringBitmapIdSet) o;
+    return _bitmap.equals(that._bitmap);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/utils/idset/IdSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/utils/idset/IdSetTest.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.utils.idset;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.io.IOException;
+import java.util.Random;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+public class IdSetTest {
+  private static final int NUM_VALUES = 10000;
+  private static final int MAX_VALUE = 20000;
+  private static final Random RANDOM = new Random();
+
+  private final IntOpenHashSet _intSet = new IntOpenHashSet();
+  private final LongOpenHashSet _longSet = new LongOpenHashSet();
+  private final IdSet _intIdSet =
+      IdSets.create(DataType.INT, IdSets.DEFAULT_SIZE_THRESHOLD_IN_BYTES, NUM_VALUES, IdSets.DEFAULT_FPP);
+  private final IdSet _longIdSet =
+      IdSets.create(DataType.LONG, IdSets.DEFAULT_SIZE_THRESHOLD_IN_BYTES, NUM_VALUES, IdSets.DEFAULT_FPP);
+  private final IdSet _intBloomFilterIdSet = IdSets.create(DataType.INT, 0, NUM_VALUES, IdSets.DEFAULT_FPP);
+  private final IdSet _longBloomFilterIdSet = IdSets.create(DataType.LONG, 0, NUM_VALUES, IdSets.DEFAULT_FPP);
+
+  @BeforeClass
+  public void setUp() {
+    for (int i = 0; i < NUM_VALUES; i++) {
+      int intId = RANDOM.nextInt(MAX_VALUE);
+      long longId = intId + (long) Integer.MAX_VALUE;
+      _intSet.add(intId);
+      _longSet.add(longId);
+      _intIdSet.add(intId);
+      _longIdSet.add(longId);
+      _intBloomFilterIdSet.add(intId);
+      _longBloomFilterIdSet.add(longId);
+    }
+  }
+
+  @Test
+  public void testIdSet() {
+    testEmptyIdSet(IdSets.emptyIdSet());
+    assertEquals(_intIdSet.getType(), IdSet.Type.ROARING_BITMAP);
+    testIntIdSet(_intIdSet);
+    assertEquals(_longIdSet.getType(), IdSet.Type.ROARING_64_NAVIGABLE_MAP);
+    testLongIdSet(_longIdSet);
+    assertEquals(_intBloomFilterIdSet.getType(), IdSet.Type.BLOOM_FILTER);
+    testIntIdSet(_intBloomFilterIdSet);
+    assertEquals(_longBloomFilterIdSet.getType(), IdSet.Type.BLOOM_FILTER);
+    testLongIdSet(_longBloomFilterIdSet);
+  }
+
+  private void testEmptyIdSet(IdSet emptyIdSet) {
+    assertEquals(emptyIdSet.getType(), IdSet.Type.EMPTY);
+  }
+
+  private void testIntIdSet(IdSet intIdSet) {
+    if (intIdSet.getType() == IdSet.Type.ROARING_BITMAP) {
+      for (int i = 0; i < NUM_VALUES; i++) {
+        int intId = RANDOM.nextInt(MAX_VALUE);
+        assertEquals(intIdSet.contains(intId), _intSet.contains(intId));
+      }
+    } else {
+      assertEquals(intIdSet.getType(), IdSet.Type.BLOOM_FILTER);
+      for (int i = 0; i < NUM_VALUES; i++) {
+        int intId = RANDOM.nextInt(MAX_VALUE);
+        if (_intIdSet.contains(intId)) {
+          assertTrue(intIdSet.contains(intId));
+        }
+      }
+    }
+  }
+
+  private void testLongIdSet(IdSet longIdSet) {
+    if (longIdSet.getType() == IdSet.Type.ROARING_64_NAVIGABLE_MAP) {
+      for (int i = 0; i < NUM_VALUES; i++) {
+        long longId = RANDOM.nextInt(MAX_VALUE) + (long) Integer.MAX_VALUE;
+        assertEquals(longIdSet.contains(longId), _longSet.contains(longId));
+      }
+    } else {
+      assertEquals(longIdSet.getType(), IdSet.Type.BLOOM_FILTER);
+      for (int i = 0; i < NUM_VALUES; i++) {
+        long longId = RANDOM.nextInt(MAX_VALUE) + (long) Integer.MAX_VALUE;
+        if (_longSet.contains(longId)) {
+          assertTrue(longIdSet.contains(longId));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testSerDe()
+      throws IOException {
+    assertEquals(IdSets.fromBytes(IdSets.emptyIdSet().toBytes()), IdSets.emptyIdSet());
+    assertEquals(IdSets.fromBase64String(IdSets.emptyIdSet().toBase64String()), IdSets.emptyIdSet());
+
+    assertEquals(IdSets.fromBytes(_intIdSet.toBytes()), _intIdSet);
+    assertEquals(IdSets.fromBase64String(_intIdSet.toBase64String()), _intIdSet);
+
+    assertEquals(IdSets.fromBytes(_longIdSet.toBytes()), _longIdSet);
+    assertEquals(IdSets.fromBase64String(_longIdSet.toBase64String()), _longIdSet);
+
+    assertEquals(IdSets.fromBytes(_intBloomFilterIdSet.toBytes()), _intBloomFilterIdSet);
+    assertEquals(IdSets.fromBase64String(_intBloomFilterIdSet.toBase64String()), _intBloomFilterIdSet);
+
+    assertEquals(IdSets.fromBytes(_longBloomFilterIdSet.toBytes()), _longBloomFilterIdSet);
+    assertEquals(IdSets.fromBase64String(_longBloomFilterIdSet.toBase64String()), _longBloomFilterIdSet);
+  }
+
+  @Test
+  public void testMerge()
+      throws IOException {
+    // Merge with empty IdSet
+    assertSame(IdSets.merge(IdSets.emptyIdSet(), IdSets.emptyIdSet()), IdSets.emptyIdSet());
+    assertSame(IdSets.merge(_intIdSet, IdSets.emptyIdSet()), _intIdSet);
+    assertSame(IdSets.merge(IdSets.emptyIdSet(), _intIdSet), _intIdSet);
+    assertSame(IdSets.merge(_longIdSet, IdSets.emptyIdSet()), _longIdSet);
+    assertSame(IdSets.merge(IdSets.emptyIdSet(), _longIdSet), _longIdSet);
+    assertSame(IdSets.merge(_intBloomFilterIdSet, IdSets.emptyIdSet()), _intBloomFilterIdSet);
+    assertSame(IdSets.merge(IdSets.emptyIdSet(), _intBloomFilterIdSet), _intBloomFilterIdSet);
+    assertSame(IdSets.merge(_longBloomFilterIdSet, IdSets.emptyIdSet()), _longBloomFilterIdSet);
+    assertSame(IdSets.merge(IdSets.emptyIdSet(), _longBloomFilterIdSet), _longBloomFilterIdSet);
+
+    // Merge 2 IdSets of the same type
+    {
+      IdSet mergedIdSet = IdSets.merge(IdSets.fromBytes(_intIdSet.toBytes()), IdSets.fromBytes(_intIdSet.toBytes()));
+      assertEquals(mergedIdSet, _intIdSet);
+    }
+    {
+      IdSet mergedIdSet = IdSets.merge(IdSets.fromBytes(_longIdSet.toBytes()), IdSets.fromBytes(_longIdSet.toBytes()));
+      assertEquals(mergedIdSet, _longIdSet);
+    }
+    {
+      IdSet mergedIdSet = IdSets
+          .merge(IdSets.fromBytes(_intBloomFilterIdSet.toBytes()), IdSets.fromBytes(_intBloomFilterIdSet.toBytes()));
+      assertEquals(mergedIdSet, _intBloomFilterIdSet);
+    }
+    {
+      IdSet mergedIdSet = IdSets
+          .merge(IdSets.fromBytes(_longBloomFilterIdSet.toBytes()), IdSets.fromBytes(_longBloomFilterIdSet.toBytes()));
+      assertEquals(mergedIdSet, _longBloomFilterIdSet);
+    }
+
+    // Merge with BloomFilterIdSet
+    {
+      IdSet mergedIdSet =
+          IdSets.merge(IdSets.fromBytes(_intIdSet.toBytes()), IdSets.fromBytes(_intBloomFilterIdSet.toBytes()));
+      assertEquals(mergedIdSet, _intBloomFilterIdSet);
+    }
+    {
+      IdSet mergedIdSet =
+          IdSets.merge(IdSets.fromBytes(_intBloomFilterIdSet.toBytes()), IdSets.fromBytes(_intIdSet.toBytes()));
+      assertEquals(mergedIdSet, _intBloomFilterIdSet);
+    }
+    {
+      IdSet mergedIdSet =
+          IdSets.merge(IdSets.fromBytes(_longIdSet.toBytes()), IdSets.fromBytes(_longBloomFilterIdSet.toBytes()));
+      assertEquals(mergedIdSet, _longBloomFilterIdSet);
+    }
+    {
+      IdSet mergedIdSet =
+          IdSets.merge(IdSets.fromBytes(_longBloomFilterIdSet.toBytes()), IdSets.fromBytes(_longIdSet.toBytes()));
+      assertEquals(mergedIdSet, _longBloomFilterIdSet);
+    }
+
+    // Convert to BloomFilterIdSet
+    {
+      IdSet mergedIdSet = IdSets
+          .merge(IdSets.fromBytes(_intIdSet.toBytes()), IdSets.fromBytes(_intIdSet.toBytes()), 1, NUM_VALUES,
+              IdSets.DEFAULT_FPP);
+      assertEquals(mergedIdSet, _intBloomFilterIdSet);
+    }
+    {
+      IdSet mergedIdSet = IdSets
+          .merge(IdSets.fromBytes(_longIdSet.toBytes()), IdSets.fromBytes(_longIdSet.toBytes()), 1, NUM_VALUES,
+              IdSets.DEFAULT_FPP);
+      assertEquals(mergedIdSet, _longBloomFilterIdSet);
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/IdSetQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/IdSetQueriesTest.java
@@ -1,0 +1,401 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.AggregationResult;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.GroupByResult;
+import org.apache.pinot.common.segment.ReadMode;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
+import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
+import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.core.query.utils.idset.BloomFilterIdSet;
+import org.apache.pinot.core.query.utils.idset.EmptyIdSet;
+import org.apache.pinot.core.query.utils.idset.IdSets;
+import org.apache.pinot.core.query.utils.idset.Roaring64NavigableMapIdSet;
+import org.apache.pinot.core.query.utils.idset.RoaringBitmapIdSet;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Queries test for ID_SET queries.
+ */
+public class IdSetQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "IdSetQueriesTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final Random RANDOM = new Random();
+
+  private static final int NUM_RECORDS = 1000;
+  private static final int MAX_VALUE = 2000;
+
+  private static final String INT_COLUMN = "intColumn";
+  private static final String LONG_COLUMN = "longColumn";
+  private static final String FLOAT_COLUMN = "floatColumn";
+  private static final String DOUBLE_COLUMN = "doubleColumn";
+  private static final String STRING_COLUMN = "stringColumn";
+  private static final String BYTES_COLUMN = "bytesColumn";
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, DataType.INT)
+      .addSingleValueDimension(LONG_COLUMN, DataType.LONG).addSingleValueDimension(FLOAT_COLUMN, DataType.FLOAT)
+      .addSingleValueDimension(DOUBLE_COLUMN, DataType.DOUBLE).addSingleValueDimension(STRING_COLUMN, DataType.STRING)
+      .addSingleValueDimension(BYTES_COLUMN, DataType.BYTES).build();
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+
+  private final int[] _values = new int[NUM_RECORDS];
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    // NOTE: Use a filter that does not match any record to test the empty IdSet.
+    return " WHERE intColumn > 2000";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+
+    List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      int intValue = RANDOM.nextInt(MAX_VALUE);
+      _values[i] = intValue;
+      long longValue = intValue + (long) Integer.MAX_VALUE;
+      float floatValue = intValue + 0.5f;
+      double doubleValue = intValue + 0.25;
+      String stringValue = Integer.toString(intValue);
+      byte[] bytesValue = stringValue.getBytes();
+      GenericRow record = new GenericRow();
+      record.putValue(INT_COLUMN, intValue);
+      record.putValue(LONG_COLUMN, longValue);
+      record.putValue(FLOAT_COLUMN, floatValue);
+      record.putValue(DOUBLE_COLUMN, doubleValue);
+      record.putValue(STRING_COLUMN, stringValue);
+      record.putValue(BYTES_COLUMN, bytesValue);
+      records.add(record);
+    }
+
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
+
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @Test
+  public void testAggregationOnly()
+      throws IOException {
+    String query =
+        "SELECT IDSET(intColumn), IDSET(longColumn), IDSET(floatColumn), IDSET(doubleColumn), IDSET(stringColumn), IDSET(bytesColumn) FROM testTable";
+
+    // Inner segment
+    {
+      // Without filter
+      AggregationOperator aggregationOperator = getOperatorForPqlQuery(query);
+      IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
+      QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), NUM_RECORDS, 0,
+          6 * NUM_RECORDS, NUM_RECORDS);
+      List<Object> aggregationResult = resultsBlock.getAggregationResult();
+      assertNotNull(aggregationResult);
+      assertEquals(aggregationResult.size(), 6);
+      RoaringBitmapIdSet intIdSet = (RoaringBitmapIdSet) aggregationResult.get(0);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(intIdSet.contains(_values[i]));
+      }
+      Roaring64NavigableMapIdSet longIdSet = (Roaring64NavigableMapIdSet) aggregationResult.get(1);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(longIdSet.contains(_values[i] + (long) Integer.MAX_VALUE));
+      }
+      BloomFilterIdSet floatIdSet = (BloomFilterIdSet) aggregationResult.get(2);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(floatIdSet.contains(_values[i] + 0.5f));
+      }
+      BloomFilterIdSet doubleIdSet = (BloomFilterIdSet) aggregationResult.get(3);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(doubleIdSet.contains(_values[i] + 0.25));
+      }
+      BloomFilterIdSet stringIdSet = (BloomFilterIdSet) aggregationResult.get(4);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(stringIdSet.contains(Integer.toString(_values[i])));
+      }
+      BloomFilterIdSet bytesIdSet = (BloomFilterIdSet) aggregationResult.get(5);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(bytesIdSet.contains(Integer.toString(_values[i]).getBytes()));
+      }
+    }
+    {
+      // With filter
+      AggregationOperator aggregationOperator = getOperatorForPqlQueryWithFilter(query);
+      IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
+      QueriesTestUtils
+          .testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 0, 0, 0, NUM_RECORDS);
+      List<Object> aggregationResult = resultsBlock.getAggregationResult();
+      assertNotNull(aggregationResult);
+      assertEquals(aggregationResult.size(), 6);
+      for (int i = 0; i < 6; i++) {
+        assertTrue(aggregationResult.get(i) instanceof EmptyIdSet);
+      }
+    }
+
+    // Inter segments
+    {
+      // Without filter (expect 4 * inner segment result)
+      BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
+      Assert.assertEquals(brokerResponse.getNumDocsScanned(), 4 * NUM_RECORDS);
+      Assert.assertEquals(brokerResponse.getNumEntriesScannedInFilter(), 0);
+      Assert.assertEquals(brokerResponse.getNumEntriesScannedPostFilter(), 4 * 6 * NUM_RECORDS);
+      Assert.assertEquals(brokerResponse.getTotalDocs(), 4 * NUM_RECORDS);
+      List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+      Assert.assertEquals(aggregationResults.size(), 6);
+      RoaringBitmapIdSet intIdSet =
+          (RoaringBitmapIdSet) IdSets.fromBase64String((String) aggregationResults.get(0).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(intIdSet.contains(_values[i]));
+      }
+      Roaring64NavigableMapIdSet longIdSet =
+          (Roaring64NavigableMapIdSet) IdSets.fromBase64String((String) aggregationResults.get(1).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(longIdSet.contains(_values[i] + (long) Integer.MAX_VALUE));
+      }
+      BloomFilterIdSet floatIdSet =
+          (BloomFilterIdSet) IdSets.fromBase64String((String) aggregationResults.get(2).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(floatIdSet.contains(_values[i] + 0.5f));
+      }
+      BloomFilterIdSet doubleIdSet =
+          (BloomFilterIdSet) IdSets.fromBase64String((String) aggregationResults.get(3).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(doubleIdSet.contains(_values[i] + 0.25));
+      }
+      BloomFilterIdSet stringIdSet =
+          (BloomFilterIdSet) IdSets.fromBase64String((String) aggregationResults.get(4).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(stringIdSet.contains(Integer.toString(_values[i])));
+      }
+      BloomFilterIdSet bytesIdSet =
+          (BloomFilterIdSet) IdSets.fromBase64String((String) aggregationResults.get(5).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(bytesIdSet.contains(Integer.toString(_values[i]).getBytes()));
+      }
+    }
+    {
+      // With filter
+      BrokerResponseNative brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
+      Assert.assertEquals(brokerResponse.getNumDocsScanned(), 0);
+      Assert.assertEquals(brokerResponse.getNumEntriesScannedInFilter(), 0);
+      Assert.assertEquals(brokerResponse.getNumEntriesScannedPostFilter(), 0);
+      Assert.assertEquals(brokerResponse.getTotalDocs(), 4 * NUM_RECORDS);
+      List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+      Assert.assertEquals(aggregationResults.size(), 6);
+      for (int i = 0; i < 6; i++) {
+        assertTrue(IdSets.fromBase64String((String) aggregationResults.get(i).getValue()) instanceof EmptyIdSet);
+      }
+    }
+  }
+
+  @Test
+  public void testAggregationGroupBy()
+      throws IOException {
+    String query =
+        "SELECT IDSET(intColumn), IDSET(longColumn), IDSET(floatColumn), IDSET(doubleColumn), IDSET(stringColumn), IDSET(bytesColumn) FROM testTable GROUP BY 1";
+
+    // Inner segment
+    {
+      AggregationGroupByOperator aggregationGroupByOperator = getOperatorForPqlQuery(query);
+      IntermediateResultsBlock resultsBlock = aggregationGroupByOperator.nextBlock();
+      QueriesTestUtils
+          .testInnerSegmentExecutionStatistics(aggregationGroupByOperator.getExecutionStatistics(), NUM_RECORDS, 0,
+              6 * NUM_RECORDS, NUM_RECORDS);
+      AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+      assertNotNull(aggregationGroupByResult);
+      Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
+      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+      RoaringBitmapIdSet intIdSet = (RoaringBitmapIdSet) aggregationGroupByResult.getResultForKey(groupKey, 0);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(intIdSet.contains(_values[i]));
+      }
+      Roaring64NavigableMapIdSet longIdSet =
+          (Roaring64NavigableMapIdSet) aggregationGroupByResult.getResultForKey(groupKey, 1);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(longIdSet.contains(_values[i] + (long) Integer.MAX_VALUE));
+      }
+      BloomFilterIdSet floatIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForKey(groupKey, 2);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(floatIdSet.contains(_values[i] + 0.5f));
+      }
+      BloomFilterIdSet doubleIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForKey(groupKey, 3);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(doubleIdSet.contains(_values[i] + 0.25));
+      }
+      BloomFilterIdSet stringIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForKey(groupKey, 4);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(stringIdSet.contains(Integer.toString(_values[i])));
+      }
+      BloomFilterIdSet bytesIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForKey(groupKey, 5);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(bytesIdSet.contains(Integer.toString(_values[i]).getBytes()));
+      }
+      assertFalse(groupKeyIterator.hasNext());
+    }
+
+    // Inter segments (expect 4 * inner segment result)
+    {
+      BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
+      Assert.assertEquals(brokerResponse.getNumDocsScanned(), 4 * NUM_RECORDS);
+      Assert.assertEquals(brokerResponse.getNumEntriesScannedInFilter(), 0);
+      Assert.assertEquals(brokerResponse.getNumEntriesScannedPostFilter(), 4 * 6 * NUM_RECORDS);
+      Assert.assertEquals(brokerResponse.getTotalDocs(), 4 * NUM_RECORDS);
+      List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+      Assert.assertEquals(aggregationResults.size(), 6);
+      for (AggregationResult aggregationResult : aggregationResults) {
+        Assert.assertNull(aggregationResult.getValue());
+        List<GroupByResult> groupByResults = aggregationResult.getGroupByResult();
+        assertEquals(groupByResults.size(), 1);
+      }
+      RoaringBitmapIdSet intIdSet = (RoaringBitmapIdSet) IdSets
+          .fromBase64String((String) aggregationResults.get(0).getGroupByResult().get(0).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(intIdSet.contains(_values[i]));
+      }
+      Roaring64NavigableMapIdSet longIdSet = (Roaring64NavigableMapIdSet) IdSets
+          .fromBase64String((String) aggregationResults.get(1).getGroupByResult().get(0).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(longIdSet.contains(_values[i] + (long) Integer.MAX_VALUE));
+      }
+      BloomFilterIdSet floatIdSet = (BloomFilterIdSet) IdSets
+          .fromBase64String((String) aggregationResults.get(2).getGroupByResult().get(0).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(floatIdSet.contains(_values[i] + 0.5f));
+      }
+      BloomFilterIdSet doubleIdSet = (BloomFilterIdSet) IdSets
+          .fromBase64String((String) aggregationResults.get(3).getGroupByResult().get(0).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(doubleIdSet.contains(_values[i] + 0.25));
+      }
+      BloomFilterIdSet stringIdSet = (BloomFilterIdSet) IdSets
+          .fromBase64String((String) aggregationResults.get(4).getGroupByResult().get(0).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(stringIdSet.contains(Integer.toString(_values[i])));
+      }
+      BloomFilterIdSet bytesIdSet = (BloomFilterIdSet) IdSets
+          .fromBase64String((String) aggregationResults.get(5).getGroupByResult().get(0).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(bytesIdSet.contains(Integer.toString(_values[i]).getBytes()));
+      }
+    }
+  }
+
+  @Test
+  public void testQueryWithParameters()
+      throws IOException {
+    String query = "SELECT IDSET(intColumn, 'sizeThresholdInBytes=0;expectedInsertions=1000') FROM testTable";
+
+    // Inner segment
+    {
+      AggregationOperator aggregationOperator = getOperatorForPqlQuery(query);
+      IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
+      QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), NUM_RECORDS, 0,
+          NUM_RECORDS, NUM_RECORDS);
+      List<Object> aggregationResult = resultsBlock.getAggregationResult();
+      assertNotNull(aggregationResult);
+      assertEquals(aggregationResult.size(), 1);
+      // Should directly create BloomFilterIdSet
+      BloomFilterIdSet intIdSet = (BloomFilterIdSet) aggregationResult.get(0);
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(intIdSet.contains(_values[i]));
+      }
+      // Should be much smaller than the default BloomFilterIdSet (4.35MB)
+      assertEquals(intIdSet.getSerializedSizeInBytes(), 928);
+    }
+
+    // Inter segments (expect 4 * inner segment result)
+    {
+      BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
+      Assert.assertEquals(brokerResponse.getNumDocsScanned(), 4 * NUM_RECORDS);
+      Assert.assertEquals(brokerResponse.getNumEntriesScannedInFilter(), 0);
+      Assert.assertEquals(brokerResponse.getNumEntriesScannedPostFilter(), 4 * NUM_RECORDS);
+      Assert.assertEquals(brokerResponse.getTotalDocs(), 4 * NUM_RECORDS);
+      List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+      Assert.assertEquals(aggregationResults.size(), 1);
+      // Should directly create BloomFilterIdSet
+      BloomFilterIdSet intIdSet =
+          (BloomFilterIdSet) IdSets.fromBase64String((String) aggregationResults.get(0).getValue());
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        assertTrue(intIdSet.contains(_values[i]));
+      }
+      // Should be much smaller than the default BloomFilterIdSet (4.35MB)
+      assertEquals(intIdSet.getSerializedSizeInBytes(), 928);
+    }
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _indexSegment.destroy();
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.8.0</version>
+        <version>0.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.101tec</groupId>


### PR DESCRIPTION
## Description
For issue #5925 

Introduce `IdSet` which represents a collection of ids and can be used to replace the large IN clause to optimize the query.
4 types of `IdSet` are introduced:
- `EmptyIdSet`: Used as a place holder for empty id set
- `RoaringBitmapIdSet`: Based on `RoaringBitmap` and can be used to store INT ids
- `Roaring64NavigableMapIdSet`: Based on `Roaring64NavigableMap` and can be used to store LONG ids
- `BloomFilterIdSet`: Based on `BloomFilter` and can be used to store any type of ids (contains won't be 100% accurate because of the nature of `BloomFilter`)

Add `IdSetAggregationFunction` to create `IdSet` for a column.
3 configurable parameters for the function:
- `sizeThresholdInBytes`: Once the size of the `IdSet` reaches this threshold, convert it to `BloomFilterIdSet` to save space
- `expectedInsertions`: Number of expected insertions for the BloomFilter, must be positive
- `fpp`: Desired false positive probability for the BloomFilter, must be positive and less than 1.0

The parameters can be passed to the function as the second argument, e.g.:
`SELECT IDSET(intColumn, 'sizeThresholdInBytes=1000;expectedInsertions=1000;fpp=0.03') FROM testTable`

Bump up the version of `RoaringBitmap` to `0.9.0` to include some bug fixes for `Roaring64NavigableMap`.