### PR TITLE
[TE] Cosmetic. Remove incessant DEBUG level logging from Data Layer classes

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/util/EntityMappingHolder.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/util/EntityMappingHolder.java
@@ -48,7 +48,6 @@ public class EntityMappingHolder {
   public void register(Connection connection, Class<? extends AbstractEntity> entityClass,
       String tableName) throws Exception {
     tableName = tableName.toLowerCase();
-    LOG.info("GENERATING MAPPING FOR TABLE: {}", tableName);
     DatabaseMetaData databaseMetaData = connection.getMetaData();
     String catalog = null;
     String schemaPattern = null;
@@ -92,7 +91,6 @@ public class EntityMappingHolder {
         if (success) {
           columnInfoMap.get(dbColumn).columnNameInEntity = entityColumn;
           columnInfoMap.get(dbColumn).field = field;
-          LOG.debug("Mapped {} to {}", dbColumn, entityColumn);
           columnMappingPerTable.get(tableName).put(dbColumn, entityColumn);
           break;
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/util/SqlQueryBuilder.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/util/SqlQueryBuilder.java
@@ -123,8 +123,6 @@ public class SqlQueryBuilder {
       if (columnInfo.field != null
           && !AUTO_UPDATE_COLUMN_SET.contains(columnInfo.columnNameInDB.toLowerCase())) {
         Object val = columnInfo.field.get(entity);
-        LOG.debug("Setting value: {} for:{} sqlType:{}", val, columnInfo.columnNameInDB,
-            columnInfo.sqlType);
         if (val != null) {
           if (columnInfo.sqlType == Types.CLOB) {
             Clob clob = conn.createClob();
@@ -244,7 +242,6 @@ public class SqlQueryBuilder {
       String dbFieldName = paramEntry.getKey();
       ColumnInfo info = columnInfoMap.get(dbFieldName);
       prepareStatement.setObject(parameterIndex++, paramEntry.getValue(), info.sqlType);
-      LOG.debug("Setting value:{} for {}", paramEntry.getValue(), dbFieldName);
 
     }
     return prepareStatement;


### PR DESCRIPTION
Removing a few debug level logging on a couple of classes which creates a lot of noise when running tests. These class instances go through a construct and destruct on every test and dumps the same logs over and over again.

No backward incompatible changes.