### PR TITLE
Add an explicit RAT license check exclusion for github related templates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1671,6 +1671,9 @@
             <!-- Third eye (not part of the distribution) -->
             <exclude>thirdeye/**</exclude>
             <exclude>docker/images/pinot-thirdeye/**</exclude>
+
+            <!-- Github template files -->
+            <exclude>.github/*.md</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description
Add an explicit exclusion for github related templates. Currently the mvn build depends on .gitignore to exclude the file w/o license (see debug msg below). However, in cases like release, .gitignore will not be put into the src directory. That will cause license check failure.

> [INFO] Will parse SCM ignores for exclusions...
> [INFO] Parsing exclusions from /Users/tingchen/tmp/incubator-pinot/.gitignore


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
