### PR TITLE
Fixing the issue that transform UDFs are parsed as function name 'OTHER', not the real function names

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -767,6 +767,7 @@ public class CalciteSqlParser {
           functionName = AggregationFunctionType.COUNT.name();
         }
         break;
+      case OTHER:
       case OTHER_FUNCTION:
         functionName = functionNode.getOperator().getName().toUpperCase();
         break;

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -731,6 +731,19 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
+  public void testTimeTransformFunction() {
+    PinotQuery pinotQuery = CalciteSqlParser
+        .compileToPinotQuery("  select hour(ts), d1, sum(m1) from baseballStats group by hour(ts), d1");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "HOUR");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ts");
+    Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "d1");
+    Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "SUM");
+    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "HOUR");
+    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ts");
+    Assert.assertEquals(pinotQuery.getGroupByList().get(1).getIdentifier().getName(), "d1");
+  }
+
+  @Test
   public void testSqlDistinctQueryCompilation() {
     // test single column DISTINCT
     String sql = "SELECT DISTINCT c1 FROM foo";


### PR DESCRIPTION
## Description
This PR fixes the query like:
```
select Hour(event_time), group_city, sum(rsvp_count) from meetupRsvp group by Hour(event_time), group_city order by sum(rsvp_count) desc limit 10
```
which raises exceptions:
```
QueryExecutionError:
org.apache.pinot.core.query.exception.BadQueryRequestException: Unsupported function: other with 1 parameters
    at org.apache.pinot.core.operator.transform.function.TransformFunctionFactory.get(TransformFunctionFactory.java:181)
...
```

The reason is that `HOUR` is a pinot UDF which CalciteSQL parser doesn't recognize and marked the SQL_KIND as `OTHER` with the real function name inside the function info.
