### PR TITLE
Bump up swagger-ui version and update related code

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -353,7 +353,7 @@ org.lz4:lz4-java:1.4.1
 org.roaringbitmap:RoaringBitmap:0.8.0
 org.roaringbitmap:shims:0.8.0
 org.scala-lang:scala-library:2.11.11
-org.webjars:swagger-ui:2.2.10-1
+org.webjars:swagger-ui:3.18.2
 org.xerial.java:xerial-core:2.1
 org.xerial.larray:larray:0.2.1
 org.xerial.larray:larray-buffer:0.2.1

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -81,7 +81,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
 
     URL swaggerDistLocation =
-        BrokerAdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.2.10-1/");
+        BrokerAdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/3.18.2/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }

--- a/pinot-common/src/main/resources/swagger-ui/index.html
+++ b/pinot-common/src/main/resources/swagger-ui/index.html
@@ -21,110 +21,67 @@
 
 <!-- This is directly copied from Swagger repository and modified to change url variable -->
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
-  <link rel="icon" type="image/png" href="../swaggerui-dist/images/favicon-32x32.png" sizes="32x32"/>
-  <link rel="icon" type="image/png" href="../swaggerui-dist/images/favicon-16x16.png" sizes="16x16"/>
-  <link href='../swaggerui-dist/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='../swaggerui-dist/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='../swaggerui-dist/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='../swaggerui-dist/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
-  <link href='../swaggerui-dist/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+  <link rel="stylesheet" type="text/css" href="swaggerui-dist/swagger-ui.css" >
+  <link rel="icon" type="image/png" href="swaggerui-dist/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="swaggerui-dist/favicon-16x16.png" sizes="16x16" />
+  <style>
+    html
+    {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
 
-  <script src='../swaggerui-dist/lib/object-assign-pollyfill.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/jquery.slideto.min.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/jquery.wiggle.min.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/handlebars-4.0.5.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/lodash.min.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/backbone-min.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/swagger-ui.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/jsoneditor.min.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/marked.js' type='text/javascript'></script>
-  <script src='../swaggerui-dist/lib/swagger-oauth.js' type='text/javascript'></script>
+    *,
+    *:before,
+    *:after
+    {
+      box-sizing: inherit;
+    }
 
-  <!-- Some basic translations -->
-  <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
-  <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
-  <!-- <script src='lang/en.js' type='text/javascript'></script> -->
-
-  <script type="text/javascript">
-    $(function () {
-      var url = window.location.search.match(/url=([^&]+)/);
-      if (url && url.length > 1) {
-        url = decodeURIComponent(url[1]);
-      } else {
-        url = "http://petstore.swagger.io/v2/swagger.json";
-      }
-
-      hljs.configure({
-        highlightSizeThreshold: 5000
-      });
-
-      // Pre load translate...
-      if (window.SwaggerTranslator) {
-        window.SwaggerTranslator.translate();
-      }
-      window.swaggerUi = new SwaggerUi({
-        url: url,
-        dom_id: "swagger-ui-container",
-        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
-        onComplete: function (swaggerApi, swaggerUi) {
-          if (typeof initOAuth == "function") {
-            initOAuth({
-              clientId: "your-client-id",
-              clientSecret: "your-client-secret-if-required",
-              realm: "your-realms",
-              appName: "your-app-name",
-              scopeSeparator: " ",
-              additionalQueryStringParams: {}
-            });
-          }
-
-          if (window.SwaggerTranslator) {
-            window.SwaggerTranslator.translate();
-          }
-        },
-        onFailure: function (data) {
-          log("Unable to Load SwaggerUI");
-        },
-        docExpansion: "none",
-        jsonEditor: true,
-        defaultModelRendering: 'schema',
-        showRequestHeaders: false
-      });
-
-      window.swaggerUi.load();
-
-      function log() {
-        if ('console' in window) {
-          console.log.apply(console, arguments);
-        }
-      }
-    });
-  </script>
+    body
+    {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
 </head>
 
-<body class="swagger-section">
-<div id='header'>
-  <div class="swagger-ui-wrap">
-    <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30"
-                                               src="../swaggerui-dist/images/logo_small.png"/><span class="logo__title">swagger</span></a>
-    <form id='api_selector'>
-      <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/>
-      </div>
-      <div id='auth_container'></div>
-      <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
-    </form>
-  </div>
-</div>
+<body>
+<div id="swagger-ui"></div>
 
-<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
-<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+<script src="swaggerui-dist/swagger-ui-bundle.js"> </script>
+<script src="swaggerui-dist/swagger-ui-standalone-preset.js"> </script>
+<script>
+  window.onload = function() {
+    var url = window.location.search.match(/url=([^&]+)/);
+    if (url && url.length > 1) {
+      url = decodeURIComponent(url[1]);
+    } else {
+      url = "/swagger.json";
+    }
+
+    // Build a system
+    const ui = SwaggerUIBundle({
+      url: url,
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      plugins: [
+        SwaggerUIBundle.plugins.DownloadUrl
+      ],
+      layout: "StandaloneLayout"
+    })
+
+    window.ui = ui
+  }
+</script>
 </body>
 </html>

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -19,9 +19,11 @@
 package org.apache.pinot.controller.api;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -149,6 +151,11 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     beanConfig.setBasePath("/");
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
+    try {
+      beanConfig.setHost(InetAddress.getLocalHost().getHostName());
+    } catch (UnknownHostException e) {
+      throw new RuntimeException("Cannot get localhost name");
+    }
 
     ClassLoader loader = this.getClass().getClassLoader();
     CLStaticHttpHandler apiStaticHttpHandler = new CLStaticHttpHandler(loader, "/api/");
@@ -156,7 +163,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/api/");
     httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/help/");
 
-    URL swaggerDistLocation = loader.getResource("META-INF/resources/webjars/swagger-ui/2.2.10-1/");
+    URL swaggerDistLocation = loader.getResource("META-INF/resources/webjars/swagger-ui/3.18.2/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }

--- a/pinot-controller/src/main/resources/api/index.html
+++ b/pinot-controller/src/main/resources/api/index.html
@@ -21,107 +21,67 @@
 
 <!-- This is directly copied from Swagger repository and modified to change url variable -->
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
-  <link rel="icon" type="image/png" href="swaggerui-dist/images/favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="swaggerui-dist/images/favicon-16x16.png" sizes="16x16" />
-  <link href='swaggerui-dist/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='swaggerui-dist/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='swaggerui-dist/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='swaggerui-dist/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
-  <link href='swaggerui-dist/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+  <link rel="stylesheet" type="text/css" href="swaggerui-dist/swagger-ui.css" >
+  <link rel="icon" type="image/png" href="swaggerui-dist/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="swaggerui-dist/favicon-16x16.png" sizes="16x16" />
+  <style>
+    html
+    {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
 
-  <script src='swaggerui-dist/lib/object-assign-pollyfill.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jquery.slideto.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jquery.wiggle.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/handlebars-4.0.5.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/lodash.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/backbone-min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/swagger-ui.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jsoneditor.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/marked.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/swagger-oauth.js' type='text/javascript'></script>
+    *,
+    *:before,
+    *:after
+    {
+      box-sizing: inherit;
+    }
 
-  <!-- Some basic translations -->
-  <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
-  <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
-  <!-- <script src='lang/en.js' type='text/javascript'></script> -->
-
-  <script type="text/javascript">
-    $(function () {
-      var url = window.location.search.match(/url=([^&]+)/);
-      if (url && url.length > 1) {
-        url = decodeURIComponent(url[1]);
-      } else {
-        url = "/swagger.json";
-      }
-
-      hljs.configure({
-        highlightSizeThreshold: 5000
-      });
-
-      // Pre load translate...
-      if(window.SwaggerTranslator) {
-        window.SwaggerTranslator.translate();
-      }
-      window.swaggerUi = new SwaggerUi({
-        url: url,
-        dom_id: "swagger-ui-container",
-        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
-        onComplete: function(swaggerApi, swaggerUi){
-          if(typeof initOAuth == "function") {
-            initOAuth({
-              clientId: "your-client-id",
-              clientSecret: "your-client-secret-if-required",
-              realm: "your-realms",
-              appName: "your-app-name",
-              scopeSeparator: " ",
-              additionalQueryStringParams: {}
-            });
-          }
-
-          if(window.SwaggerTranslator) {
-            window.SwaggerTranslator.translate();
-          }
-        },
-        onFailure: function(data) {
-          log("Unable to Load SwaggerUI");
-        },
-        docExpansion: "none",
-        jsonEditor: false,
-        defaultModelRendering: 'schema',
-        showRequestHeaders: false
-      });
-
-      window.swaggerUi.load();
-
-      function log() {
-        if ('console' in window) {
-          console.log.apply(console, arguments);
-        }
-      }
-    });
-  </script>
+    body
+    {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
 </head>
 
-<body class="swagger-section">
-<div id='header'>
-  <div class="swagger-ui-wrap">
-    <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="swaggerui-dist/images/logo_small.png" /><span class="logo__title">swagger</span></a>
-    <form id='api_selector'>
-      <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-      <div id='auth_container'></div>
-      <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
-    </form>
-  </div>
-</div>
+<body>
+<div id="swagger-ui"></div>
 
-<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
-<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+<script src="swaggerui-dist/swagger-ui-bundle.js"> </script>
+<script src="swaggerui-dist/swagger-ui-standalone-preset.js"> </script>
+<script>
+  window.onload = function() {
+    var url = window.location.search.match(/url=([^&]+)/);
+    if (url && url.length > 1) {
+      url = decodeURIComponent(url[1]);
+    } else {
+      url = "/swagger.json";
+    }
+
+    // Build a system
+    const ui = SwaggerUIBundle({
+      url: url,
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      plugins: [
+        SwaggerUIBundle.plugins.DownloadUrl
+      ],
+      layout: "StandaloneLayout"
+    })
+
+    window.ui = ui
+  }
+</script>
 </body>
+</html>

--- a/pinot-integration-tests/src/test/resources/index.html
+++ b/pinot-integration-tests/src/test/resources/index.html
@@ -1,106 +1,66 @@
 <!DOCTYPE html>
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
-  <link rel="icon" type="image/png" href="images/favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="images/favicon-16x16.png" sizes="16x16" />
-  <link href='css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='css/reset.css' media='print' rel='stylesheet' type='text/css'/>
-  <link href='css/print.css' media='print' rel='stylesheet' type='text/css'/>
+  <link rel="stylesheet" type="text/css" href="swaggerui-dist/swagger-ui.css" >
+  <link rel="icon" type="image/png" href="swaggerui-dist/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="swaggerui-dist/favicon-16x16.png" sizes="16x16" />
+  <style>
+    html
+    {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
 
-  <script src='lib/object-assign-pollyfill.js' type='text/javascript'></script>
-  <script src='lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-  <script src='lib/jquery.slideto.min.js' type='text/javascript'></script>
-  <script src='lib/jquery.wiggle.min.js' type='text/javascript'></script>
-  <script src='lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-  <script src='lib/handlebars-4.0.5.js' type='text/javascript'></script>
-  <script src='lib/lodash.min.js' type='text/javascript'></script>
-  <script src='lib/backbone-min.js' type='text/javascript'></script>
-  <script src='swagger-ui.js' type='text/javascript'></script>
-  <script src='lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
-  <script src='lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
-  <script src='lib/jsoneditor.min.js' type='text/javascript'></script>
-  <script src='lib/marked.js' type='text/javascript'></script>
-  <script src='lib/swagger-oauth.js' type='text/javascript'></script>
+    *,
+    *:before,
+    *:after
+    {
+      box-sizing: inherit;
+    }
 
-  <!-- Some basic translations -->
-  <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
-  <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
-  <!-- <script src='lang/en.js' type='text/javascript'></script> -->
-
-  <script type="text/javascript">
-    $(function () {
-      var url = window.location.search.match(/url=([^&]+)/);
-      if (url && url.length > 1) {
-        url = decodeURIComponent(url[1]);
-      } else {
-        url = "http://petstore.swagger.io/v2/swagger.json";
-      }
-
-      hljs.configure({
-        highlightSizeThreshold: 5000
-      });
-
-      // Pre load translate...
-      if(window.SwaggerTranslator) {
-        window.SwaggerTranslator.translate();
-      }
-      window.swaggerUi = new SwaggerUi({
-        url: url,
-        dom_id: "swagger-ui-container",
-        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
-        onComplete: function(swaggerApi, swaggerUi){
-          if(typeof initOAuth == "function") {
-            initOAuth({
-              clientId: "your-client-id",
-              clientSecret: "your-client-secret-if-required",
-              realm: "your-realms",
-              appName: "your-app-name",
-              scopeSeparator: " ",
-              additionalQueryStringParams: {}
-            });
-          }
-
-          if(window.SwaggerTranslator) {
-            window.SwaggerTranslator.translate();
-          }
-        },
-        onFailure: function(data) {
-          log("Unable to Load SwaggerUI");
-        },
-        docExpansion: "none",
-        jsonEditor: false,
-        defaultModelRendering: 'schema',
-        showRequestHeaders: false
-      });
-
-      window.swaggerUi.load();
-
-      function log() {
-        if ('console' in window) {
-          console.log.apply(console, arguments);
-        }
-      }
-  });
-  </script>
+    body
+    {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
 </head>
 
-<body class="swagger-section">
-<div id='header'>
-  <div class="swagger-ui-wrap">
-    <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">swagger</span></a>
-    <form id='api_selector'>
-      <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-      <div id='auth_container'></div>
-      <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
-    </form>
-  </div>
-</div>
+<body>
+<div id="swagger-ui"></div>
 
-<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
-<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+<script src="swaggerui-dist/swagger-ui-bundle.js"> </script>
+<script src="swaggerui-dist/swagger-ui-standalone-preset.js"> </script>
+<script>
+  window.onload = function() {
+    var url = window.location.search.match(/url=([^&]+)/);
+    if (url && url.length > 1) {
+      url = decodeURIComponent(url[1]);
+    } else {
+      url = "/swagger.json";
+    }
+
+    // Build a system
+    const ui = SwaggerUIBundle({
+      url: url,
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      plugins: [
+        SwaggerUIBundle.plugins.DownloadUrl
+      ],
+      layout: "StandaloneLayout"
+    })
+
+    window.ui = ui
+  }
+</script>
 </body>
 </html>

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
@@ -20,9 +20,11 @@ package org.apache.pinot.server.starter.helix;
 
 import io.swagger.jaxrs.config.BeanConfig;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.UnknownHostException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -102,6 +104,11 @@ public class AdminApiApplication extends ResourceConfig {
     beanConfig.setBasePath(baseUri.getPath());
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
+    try {
+      beanConfig.setHost(InetAddress.getLocalHost().getHostName());
+    } catch (UnknownHostException e) {
+      throw new RuntimeException("Cannot get localhost name");
+    }
 
     CLStaticHttpHandler staticHttpHandler =
         new CLStaticHttpHandler(AdminApiApplication.class.getClassLoader(), "/api/");
@@ -110,7 +117,7 @@ public class AdminApiApplication extends ResourceConfig {
     httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/help/");
 
     URL swaggerDistLocation =
-        AdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.2.10-1/");
+        AdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/3.18.2/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }

--- a/pinot-server/src/main/resources/api/index.html
+++ b/pinot-server/src/main/resources/api/index.html
@@ -21,107 +21,67 @@
 
 <!-- This is directly copied from Swagger repository and modified to change url variable -->
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
-  <link rel="icon" type="image/png" href="swaggerui-dist/images/favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="swaggerui-dist/images/favicon-16x16.png" sizes="16x16" />
-  <link href='swaggerui-dist/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='swaggerui-dist/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='swaggerui-dist/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='swaggerui-dist/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
-  <link href='swaggerui-dist/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+  <link rel="stylesheet" type="text/css" href="swaggerui-dist/swagger-ui.css" >
+  <link rel="icon" type="image/png" href="swaggerui-dist/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="swaggerui-dist/favicon-16x16.png" sizes="16x16" />
+  <style>
+    html
+    {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
 
-  <script src='swaggerui-dist/lib/object-assign-pollyfill.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jquery.slideto.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jquery.wiggle.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/handlebars-4.0.5.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/lodash.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/backbone-min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/swagger-ui.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/jsoneditor.min.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/marked.js' type='text/javascript'></script>
-  <script src='swaggerui-dist/lib/swagger-oauth.js' type='text/javascript'></script>
+    *,
+    *:before,
+    *:after
+    {
+      box-sizing: inherit;
+    }
 
-  <!-- Some basic translations -->
-  <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
-  <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
-  <!-- <script src='lang/en.js' type='text/javascript'></script> -->
-
-  <script type="text/javascript">
-    $(function () {
-      var url = window.location.search.match(/url=([^&]+)/);
-      if (url && url.length > 1) {
-        url = decodeURIComponent(url[1]);
-      } else {
-        url = "/swagger.json";
-      }
-
-      hljs.configure({
-        highlightSizeThreshold: 5000
-      });
-
-      // Pre load translate...
-      if(window.SwaggerTranslator) {
-        window.SwaggerTranslator.translate();
-      }
-      window.swaggerUi = new SwaggerUi({
-        url: url,
-        dom_id: "swagger-ui-container",
-        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
-        onComplete: function(swaggerApi, swaggerUi){
-          if(typeof initOAuth == "function") {
-            initOAuth({
-              clientId: "your-client-id",
-              clientSecret: "your-client-secret-if-required",
-              realm: "your-realms",
-              appName: "your-app-name",
-              scopeSeparator: " ",
-              additionalQueryStringParams: {}
-            });
-          }
-
-          if(window.SwaggerTranslator) {
-            window.SwaggerTranslator.translate();
-          }
-        },
-        onFailure: function(data) {
-          log("Unable to Load SwaggerUI");
-        },
-        docExpansion: "none",
-        jsonEditor: false,
-        defaultModelRendering: 'schema',
-        showRequestHeaders: false
-      });
-
-      window.swaggerUi.load();
-
-      function log() {
-        if ('console' in window) {
-          console.log.apply(console, arguments);
-        }
-      }
-    });
-  </script>
+    body
+    {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
 </head>
 
-<body class="swagger-section">
-<div id='header'>
-  <div class="swagger-ui-wrap">
-    <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="swaggerui-dist/images/logo_small.png" /><span class="logo__title">swagger</span></a>
-    <form id='api_selector'>
-      <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-      <div id='auth_container'></div>
-      <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
-    </form>
-  </div>
-</div>
+<body>
+<div id="swagger-ui"></div>
 
-<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
-<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+<script src="swaggerui-dist/swagger-ui-bundle.js"> </script>
+<script src="swaggerui-dist/swagger-ui-standalone-preset.js"> </script>
+<script>
+  window.onload = function() {
+    var url = window.location.search.match(/url=([^&]+)/);
+    if (url && url.length > 1) {
+      url = decodeURIComponent(url[1]);
+    } else {
+      url = "/swagger.json";
+    }
+
+    // Build a system
+    const ui = SwaggerUIBundle({
+      url: url,
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      plugins: [
+        SwaggerUIBundle.plugins.DownloadUrl
+      ],
+      layout: "StandaloneLayout"
+    })
+
+    window.ui = ui
+  }
+</script>
 </body>
+</html>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -77,7 +77,7 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
 
     URL swaggerDistLocation = PinotServiceManagerAdminApiApplication.class.getClassLoader()
-        .getResource("META-INF/resources/webjars/swagger-ui/2.2.10-1/");
+        .getResource("META-INF/resources/webjars/swagger-ui/3.18.2/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -897,7 +897,7 @@
       <dependency>
         <groupId>org.webjars</groupId>
         <artifactId>swagger-ui</artifactId>
-        <version>2.2.10-1</version>
+        <version>3.18.2</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
## Description
This PR bumps up swagger-ui version and updates related code.

vulnerability: Swagger-ui before 3.18.0 is vulnerable to Reverse Tabnabbing. Setting target="_blank" on anchor tags is unsafe unless used in conjunction with the rel="noopener" attribute. Opening a link via target blank attribute can change the original page, origin policy restrictions set by the browser can be bypassed.

The previous PR (https://github.com/apache/incubator-pinot/pull/5896) didn't make the related required code change in html files, and some frond-end files have already changed their locations in the newer swagger-ui version.

The below is the screenshot after making the code change:
![Screen Shot 2020-08-28 at 1 43 21 PM](https://user-images.githubusercontent.com/35080149/91613767-071b7580-e935-11ea-9628-c206138af9be.png)
