### PR TITLE
Support IN_ID_SET predicate

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InIdSetPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InIdSetPredicateEvaluatorFactory.java
@@ -1,0 +1,239 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate;
+
+import org.apache.pinot.core.query.request.context.predicate.InIdSetPredicate;
+import org.apache.pinot.core.query.request.context.predicate.Predicate;
+import org.apache.pinot.core.query.utils.idset.IdSet;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/**
+ * Factory for IN_ID_SET predicate evaluators.
+ */
+public class InIdSetPredicateEvaluatorFactory {
+  private InIdSetPredicateEvaluatorFactory() {
+  }
+
+  public static BaseDictionaryBasedPredicateEvaluator newDictionaryBasedEvaluator(InIdSetPredicate inIdSetPredicate,
+      Dictionary dictionary) {
+    return new DictionaryBasedInIdSetPredicateEvaluator(inIdSetPredicate, dictionary);
+  }
+
+  public static BaseRawValueBasedPredicateEvaluator newRawValueBasedEvaluator(InIdSetPredicate inIdSetPredicate,
+      DataType dataType) {
+    switch (dataType) {
+      case INT:
+        return new IntRawValueBasedInIdSetPredicateEvaluator(inIdSetPredicate);
+      case LONG:
+        return new LongRawValueBasedInIdSetPredicateEvaluator(inIdSetPredicate);
+      case FLOAT:
+        return new FloatRawValueBasedInIdSetPredicateEvaluator(inIdSetPredicate);
+      case DOUBLE:
+        return new DoubleRawValueBasedInIdSetPredicateEvaluator(inIdSetPredicate);
+      case STRING:
+        return new StringRawValueBasedInIdSetPredicateEvaluator(inIdSetPredicate);
+      case BYTES:
+        return new BytesRawValueBasedInIdSetPredicateEvaluator(inIdSetPredicate);
+      default:
+        throw new UnsupportedOperationException("Unsupported data type: " + dataType);
+    }
+  }
+
+  private static final class DictionaryBasedInIdSetPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
+    final IdSet _idSet;
+    final Dictionary _dictionary;
+    final DataType _valueType;
+
+    DictionaryBasedInIdSetPredicateEvaluator(InIdSetPredicate inIdSetPredicate, Dictionary dictionary) {
+      _idSet = inIdSetPredicate.getIdSet();
+      _dictionary = dictionary;
+      _valueType = dictionary.getValueType();
+    }
+
+    @Override
+    public Predicate.Type getPredicateType() {
+      return Predicate.Type.IN_ID_SET;
+    }
+
+    @Override
+    public boolean applySV(int dictId) {
+      switch (_valueType) {
+        case INT:
+          return _idSet.contains(_dictionary.getIntValue(dictId));
+        case LONG:
+          return _idSet.contains(_dictionary.getLongValue(dictId));
+        case FLOAT:
+          return _idSet.contains(_dictionary.getFloatValue(dictId));
+        case DOUBLE:
+          return _idSet.contains(_dictionary.getDoubleValue(dictId));
+        case STRING:
+          return _idSet.contains(_dictionary.getStringValue(dictId));
+        case BYTES:
+          return _idSet.contains(_dictionary.getBytesValue(dictId));
+        default:
+          throw new IllegalStateException();
+      }
+    }
+
+    @Override
+    public int[] getMatchingDictIds() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static final class IntRawValueBasedInIdSetPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+    final IdSet _idSet;
+
+    IntRawValueBasedInIdSetPredicateEvaluator(InIdSetPredicate inIdSetPredicate) {
+      _idSet = inIdSetPredicate.getIdSet();
+    }
+
+    @Override
+    public Predicate.Type getPredicateType() {
+      return Predicate.Type.IN_ID_SET;
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.INT;
+    }
+
+    @Override
+    public boolean applySV(int value) {
+      return _idSet.contains(value);
+    }
+  }
+
+  private static final class LongRawValueBasedInIdSetPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+    final IdSet _idSet;
+
+    LongRawValueBasedInIdSetPredicateEvaluator(InIdSetPredicate inIdSetPredicate) {
+      _idSet = inIdSetPredicate.getIdSet();
+    }
+
+    @Override
+    public Predicate.Type getPredicateType() {
+      return Predicate.Type.IN_ID_SET;
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.INT;
+    }
+
+    @Override
+    public boolean applySV(long value) {
+      return _idSet.contains(value);
+    }
+  }
+
+  private static final class FloatRawValueBasedInIdSetPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+    final IdSet _idSet;
+
+    FloatRawValueBasedInIdSetPredicateEvaluator(InIdSetPredicate inIdSetPredicate) {
+      _idSet = inIdSetPredicate.getIdSet();
+    }
+
+    @Override
+    public Predicate.Type getPredicateType() {
+      return Predicate.Type.IN_ID_SET;
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.INT;
+    }
+
+    @Override
+    public boolean applySV(float value) {
+      return _idSet.contains(value);
+    }
+  }
+
+  private static final class DoubleRawValueBasedInIdSetPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+    final IdSet _idSet;
+
+    DoubleRawValueBasedInIdSetPredicateEvaluator(InIdSetPredicate inIdSetPredicate) {
+      _idSet = inIdSetPredicate.getIdSet();
+    }
+
+    @Override
+    public Predicate.Type getPredicateType() {
+      return Predicate.Type.IN_ID_SET;
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.INT;
+    }
+
+    @Override
+    public boolean applySV(double value) {
+      return _idSet.contains(value);
+    }
+  }
+
+  private static final class StringRawValueBasedInIdSetPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+    final IdSet _idSet;
+
+    StringRawValueBasedInIdSetPredicateEvaluator(InIdSetPredicate inIdSetPredicate) {
+      _idSet = inIdSetPredicate.getIdSet();
+    }
+
+    @Override
+    public Predicate.Type getPredicateType() {
+      return Predicate.Type.IN_ID_SET;
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.INT;
+    }
+
+    @Override
+    public boolean applySV(String value) {
+      return _idSet.contains(value);
+    }
+  }
+
+  private static final class BytesRawValueBasedInIdSetPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+    final IdSet _idSet;
+
+    BytesRawValueBasedInIdSetPredicateEvaluator(InIdSetPredicate inIdSetPredicate) {
+      _idSet = inIdSetPredicate.getIdSet();
+    }
+
+    @Override
+    public Predicate.Type getPredicateType() {
+      return Predicate.Type.IN_ID_SET;
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.INT;
+    }
+
+    @Override
+    public boolean applySV(byte[] value) {
+      return _idSet.contains(value);
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.filter.predicate;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
 import org.apache.pinot.core.query.request.context.predicate.EqPredicate;
+import org.apache.pinot.core.query.request.context.predicate.InIdSetPredicate;
 import org.apache.pinot.core.query.request.context.predicate.InPredicate;
 import org.apache.pinot.core.query.request.context.predicate.NotEqPredicate;
 import org.apache.pinot.core.query.request.context.predicate.NotInPredicate;
@@ -56,6 +57,9 @@ public class PredicateEvaluatorProvider {
           case REGEXP_LIKE:
             return RegexpLikePredicateEvaluatorFactory
                 .newDictionaryBasedEvaluator((RegexpLikePredicate) predicate, dictionary);
+          case IN_ID_SET:
+            return InIdSetPredicateEvaluatorFactory
+                .newDictionaryBasedEvaluator((InIdSetPredicate) predicate, dictionary);
           default:
             throw new UnsupportedOperationException("Unsupported predicate type: " + predicate.getType());
         }
@@ -75,6 +79,8 @@ public class PredicateEvaluatorProvider {
           case REGEXP_LIKE:
             return RegexpLikePredicateEvaluatorFactory
                 .newRawValueBasedEvaluator((RegexpLikePredicate) predicate, dataType);
+          case IN_ID_SET:
+            return InIdSetPredicateEvaluatorFactory.newRawValueBasedEvaluator((InIdSetPredicate) predicate, dataType);
           default:
             throw new UnsupportedOperationException("Unsupported predicate type: " + predicate.getType());
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/predicate/InIdSetPredicate.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/predicate/InIdSetPredicate.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.request.context.predicate;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.utils.idset.IdSet;
+
+
+/**
+ * Predicate for IN_ID_SET.
+ */
+public class InIdSetPredicate implements Predicate {
+  public static final String ID_SET_INDICATOR = "__IDSET__";
+
+  private final ExpressionContext _lhs;
+  private final IdSet _idSet;
+
+  public InIdSetPredicate(ExpressionContext lhs, IdSet idSet) {
+    _lhs = lhs;
+    _idSet = idSet;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.IN_ID_SET;
+  }
+
+  @Override
+  public ExpressionContext getLhs() {
+    return _lhs;
+  }
+
+  public IdSet getIdSet() {
+    return _idSet;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof InIdSetPredicate)) {
+      return false;
+    }
+    InIdSetPredicate that = (InIdSetPredicate) o;
+    return Objects.equals(_lhs, that._lhs) && Objects.equals(_idSet, that._idSet);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_lhs, _idSet);
+  }
+
+  @Override
+  public String toString() {
+    try {
+      return _lhs + " IN ('__IDSET__','" + _idSet.toBase64String() + "')";
+    } catch (IOException e) {
+      throw new RuntimeException("Caught exception while serializing the IdSet", e);
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/predicate/Predicate.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/predicate/Predicate.java
@@ -28,7 +28,7 @@ import org.apache.pinot.core.query.request.context.ExpressionContext;
  */
 public interface Predicate {
   enum Type {
-    EQ, NOT_EQ, IN, NOT_IN, RANGE, REGEXP_LIKE, TEXT_MATCH, IS_NULL, IS_NOT_NULL;
+    EQ, NOT_EQ, IN, NOT_IN, RANGE, REGEXP_LIKE, TEXT_MATCH, IS_NULL, IS_NOT_NULL, IN_ID_SET;
 
     public boolean isExclusive() {
       return this == NOT_EQ || this == NOT_IN || this == IS_NOT_NULL;

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -102,12 +102,13 @@ public class StarTreeUtils {
         }
         switch (predicate.getType()) {
           // NOTE: Do not use star-tree for the following predicates because:
-          //       - REGEXP_LIKE: Need to scan the whole dictionary to gather the matching dictionary ids
+          //       - REGEXP_LIKE/IN_ID_SET: Need to scan the whole dictionary to gather the matching dictionary ids
           //       - TEXT_MATCH/IS_NULL/IS_NOT_NULL: No way to gather the matching dictionary ids
           case REGEXP_LIKE:
           case TEXT_MATCH:
           case IS_NULL:
           case IS_NOT_NULL:
+          case IN_ID_SET:
             return false;
         }
         return starTreeDimensions.contains(lhs.getIdentifier());

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/predicate/PredicateTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/predicate/PredicateTest.java
@@ -71,6 +71,9 @@ public class PredicateTest {
     // IsNotNullPredicate
     assertEquals(testSerDe("foo\tIS not\tNulL"), "foo IS NOT NULL");
 
+    // InIdSetPredicate
+    assertEquals(testSerDe("foo In (\t'__iDsEt__',\t'ATowAAAAAAAA')"), "foo IN ('__IDSET__','ATowAAAAAAAA')");
+
     // Non-standard RangePredicate (merged ranges)
     RangePredicate rangePredicate =
         new RangePredicate(ExpressionContext.forIdentifier("foo"), true, "123", false, "456");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -33,6 +33,8 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.client.ResultSet;
 import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.core.query.utils.idset.IdSet;
+import org.apache.pinot.core.query.utils.idset.IdSets;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
@@ -251,6 +253,18 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     query =
         "SELECT DaysSinceEpoch, MAX(ArrDelay) - MAX(AirTime) AS Diff FROM mytable GROUP BY DaysSinceEpoch HAVING (Diff >= 300 AND Diff < 500) OR Diff < -500 ORDER BY Diff DESC";
     testSqlQuery(query, Collections.singletonList(query));
+
+    // IN_ID_SET
+    IdSet idSet = IdSets.create(FieldSpec.DataType.LONG);
+    idSet.add(19690L);
+    idSet.add(20355L);
+    idSet.add(21171L);
+    // Also include a non-existing id
+    idSet.add(0L);
+    String inIdSetQuery =
+        "SELECT COUNT(*) FROM mytable WHERE AirlineID IN ('__IDSET__', '" + idSet.toBase64String() + "')";
+    String inQuery = "SELECT COUNT(*) FROM mytable WHERE AirlineID IN (19690, 20355, 21171, 0)";
+    testSqlQuery(inIdSetQuery, Collections.singletonList(inQuery));
   }
 
   /**


### PR DESCRIPTION
## Description
Support `IN_ID_SET` predicate for filtering on serialized `IdSet`
In order to filter on a serialized `IdSet`, put a special indicator: `__IDSET__` as the first argument of the `IN` clause.

Example query:
`SELECT COUNT(*) FROM mytable WHERE AirlineID IN ('__IDSET__', 'AgAAAAABAAAAADowAAABAAAAAAADABAAAAAAAOpMg0+zUg==')`
(`AgAAAAABAAAAADowAAABAAAAAAADABAAAAAAAOpMg0+zUg==` is the base64 encoded `IdSet`)
