### PR TITLE
Make realtime threshold property names less ambiguous

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -56,7 +56,7 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
   public synchronized void updateFlushThreshold(PartitionLevelStreamConfig streamConfig,
       LLCRealtimeSegmentZKMetadata newSegmentZKMetadata, CommittingSegmentDescriptor committingSegmentDescriptor,
       @Nullable LLCRealtimeSegmentZKMetadata committingSegmentZKMetadata, int maxNumPartitionsPerInstance) {
-    final long desiredSegmentSizeBytes = streamConfig.getFlushSegmentDesiredSizeBytes();
+    final long desiredSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
     final long timeThresholdMillis = streamConfig.getFlushThresholdTimeMillis();
     final int autotuneInitialRows = streamConfig.getFlushAutotuneInitialRows();
     final long optimalSegmentSizeBytesMin = desiredSegmentSizeBytes / 2;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -24,7 +24,6 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
-import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.annotations.Test;
 
@@ -101,14 +100,14 @@ public class FlushThresholdUpdaterTest {
     PartitionLevelStreamConfig streamConfig = mock(PartitionLevelStreamConfig.class);
     when(streamConfig.getTableNameWithType()).thenReturn(REALTIME_TABLE_NAME);
     when(streamConfig.getFlushThresholdRows()).thenReturn(0);
-    when(streamConfig.getFlushSegmentDesiredSizeBytes()).thenReturn(flushSegmentDesiredSizeBytes);
+    when(streamConfig.getFlushThresholdSegmentSizeBytes()).thenReturn(flushSegmentDesiredSizeBytes);
     when(streamConfig.getFlushThresholdTimeMillis()).thenReturn(flushThresholdTimeMillis);
     when(streamConfig.getFlushAutotuneInitialRows()).thenReturn(flushAutotuneInitialRows);
     return streamConfig;
   }
 
   private PartitionLevelStreamConfig mockDefaultAutotuneStreamConfig() {
-    return mockAutotuneStreamConfig(StreamConfig.DEFAULT_FLUSH_SEGMENT_DESIRED_SIZE_BYTES,
+    return mockAutotuneStreamConfig(StreamConfig.DEFAULT_FLUSH_THRESHOLD_SEGMENT_SIZE_BYTES,
         StreamConfig.DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS, StreamConfig.DEFAULT_FLUSH_AUTOTUNE_INITIAL_ROWS);
   }
 
@@ -121,7 +120,7 @@ public class FlushThresholdUpdaterTest {
   @Test
   public void testSegmentSizeBasedFlushThreshold() {
     PartitionLevelStreamConfig streamConfig = mockDefaultAutotuneStreamConfig();
-    long desiredSegmentSizeBytes = streamConfig.getFlushSegmentDesiredSizeBytes();
+    long desiredSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
     long segmentSizeLowerLimit = (long) (desiredSegmentSizeBytes * 0.99);
     long segmentSizeHigherLimit = (long) (desiredSegmentSizeBytes * 1.01);
 
@@ -307,7 +306,7 @@ public class FlushThresholdUpdaterTest {
     SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
 
     // Use customized stream config
-    long flushSegmentDesiredSizeBytes = StreamConfig.DEFAULT_FLUSH_SEGMENT_DESIRED_SIZE_BYTES / 2;
+    long flushSegmentDesiredSizeBytes = StreamConfig.DEFAULT_FLUSH_THRESHOLD_SEGMENT_SIZE_BYTES / 2;
     long flushThresholdTimeMillis = StreamConfig.DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS / 2;
     int flushAutotuneInitialRows = StreamConfig.DEFAULT_FLUSH_AUTOTUNE_INITIAL_ROWS / 2;
     PartitionLevelStreamConfig streamConfig =

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelStreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelStreamConfig.java
@@ -39,7 +39,7 @@ public class PartitionLevelStreamConfig extends StreamConfig {
   @Override
   protected int extractFlushThresholdRows(Map<String, String> streamConfigMap) {
     String flushThresholdRowsKey =
-        StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS + StreamConfigProperties.LLC_SUFFIX;
+        StreamConfigProperties.DEPRECATED_SEGMENT_FLUSH_THRESHOLD_ROWS + StreamConfigProperties.LLC_SUFFIX;
     String flushThresholdRowsStr = streamConfigMap.get(flushThresholdRowsKey);
     if (flushThresholdRowsStr != null) {
       try {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -51,6 +51,8 @@ public class StreamConfigProperties {
   public static final String SEGMENT_FLUSH_THRESHOLD_TIME = "realtime.segment.flush.threshold.time";
 
   /**
+   * @deprecated because the property key is confusing (says size but is actually rows). Use {@link StreamConfigProperties#SEGMENT_FLUSH_THRESHOLD_ROWS}
+   *
    * Row count flush threshold for realtime segments. This behaves in a similar way for HLC and LLC. For HLC,
    * since there is only one consumer per server, this size is used as the size of the consumption buffer and
    * determines after how many rows we flush to disk. For example, if this threshold is set to two million rows,
@@ -69,9 +71,12 @@ public class StreamConfigProperties {
    * the size of the completed segment is the desired size (see REALTIME_DESIRED_SEGMENT_SIZE), unless
    * REALTIME_SEGMENT_FLUSH_TIME is reached first)
    */
-  public static final String SEGMENT_FLUSH_THRESHOLD_ROWS = "realtime.segment.flush.threshold.size";
+  public static final String DEPRECATED_SEGMENT_FLUSH_THRESHOLD_ROWS = "realtime.segment.flush.threshold.size";
+  public static final String SEGMENT_FLUSH_THRESHOLD_ROWS = "realtime.segment.flush.threshold.rows";
 
-  /*
+  /**
+   * @deprecated because the property key is confusing (desired size is not indicative of segment size). Use {@link StreamConfigProperties#SEGMENT_FLUSH_THRESHOLD_SEGMENT_SIZE}
+   *
    * The desired size of a completed realtime segment.
    * This config is used only if REALTIME_SEGMENT_FLUSH_SIZE is set
    * to 0. Default value of REALTIME_SEGMENT_FLUSH_SIZE is "200M". Values are parsed using DataSize class.
@@ -88,13 +93,13 @@ public class StreamConfigProperties {
    *
    * Not included here is any heap memory used (currently inverted index uses heap memory for consuming partitions).
    */
-  public static final String SEGMENT_FLUSH_DESIRED_SIZE = "realtime.segment.flush.desired.size";
+  public static final String DEPRECATED_SEGMENT_FLUSH_DESIRED_SIZE = "realtime.segment.flush.desired.size";
+  public static final String SEGMENT_FLUSH_THRESHOLD_SEGMENT_SIZE = "realtime.segment.flush.threshold.segment.size";
 
   /**
    * The initial num rows to use for segment size auto tuning. By default 100_000 is used.
    */
   public static final String SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS = "realtime.segment.flush.autotune.initialRows";
-
   // Time threshold that controller will wait for the segment to be built by the server
   public static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "realtime.segment.commit.timeoutSeconds";
 


### PR DESCRIPTION
## Description
The realtime threshold property names are confusing to users.
The property for "rows" reads as "realtime.segment.flush.threshold.size" and makes users put the segment size in there.
The property for segment size reads as "realtime.segment.flush.desired.size" and doesn't convey that it is a threshold and is expecting a segment size.

Introducing "realtime.segment.flush.threshold.rows" for rows threshold and "realtime.segment.flush.threshold.segment.size" for segment size threshold. The time property is fine "realtime.segment.flush.threshold.time".

The old properties are still present, for backward compatibility.

## Release Notes
New configurations introduced in stream configs "realtime.segment.flush.threshold.rows" and "realtime.segment.flush.threshold.segment.size".
Deprecated "realtime.segment.flush.threshold.size" and "realtime.segment.flush.desired.size"


## Documentation
https://docs.pinot.apache.org/configuration-reference/table#realtime-table-config
