### PR TITLE
Incorporating embedded exception while trying to fetch stream offset

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -610,7 +610,7 @@ public class PinotLLCRealtimeSegmentManager {
     } catch (Exception e) {
       throw new IllegalStateException(String
           .format("Failed to fetch the offset for topic: %s, partition: %s with criteria: %s",
-              streamConfig.getTopicName(), partitionId, offsetCriteria));
+              streamConfig.getTopicName(), partitionId, offsetCriteria), e);
     }
   }
 


### PR DESCRIPTION
Related to #5955 
Currently, 'getPartitionOffset' method (PinotLLCRealtimeSegmentManager) is swallowing the underlying exception, while trying to fetch stream offset. This small PR is to report this underlying exception