### PR TITLE
[TE] Added helm deployment for ThirdEye

### DIFF
--- a/kubernetes/helm/thirdeye/Chart.lock
+++ b/kubernetes/helm/thirdeye/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mysql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 1.6.6
+digest: sha256:6fa8d7b01e421ec3ca2ee257a4aedf58cb3a0e24b7683de7f9299b75bcb25825
+generated: "2020-09-01T11:59:46.921901-07:00"

--- a/kubernetes/helm/thirdeye/Chart.yaml
+++ b/kubernetes/helm/thirdeye/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+appVersion: 0.5.0-SNAPSHOT # Should be maintained automatically by a pipeline
+name: thirdeye
+description: One Stop Shop For Anomaly Detection. Built on Apache Pinot
+version: 0.1.0
+keywords:
+- olap
+- analytics
+- pinot
+- anomaly detection
+- rootcause analysis
+home: https://github.com/apache/incubator-pinot
+sources:
+- https://github.com/apache/incubator-pinot
+maintainers:
+- name: Alexander Pucher
+  email: alex@cortexdata.io
+- name: Suvodeep Pyne
+  email: pyne.suvodeep@gmail.com
+dependencies:
+- name: mysql
+  version: 1.6.6
+  repository: https://kubernetes-charts.storage.googleapis.com/
+

--- a/kubernetes/helm/thirdeye/README.md
+++ b/kubernetes/helm/thirdeye/README.md
@@ -1,0 +1,73 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# ThirdEye (Alpha)
+
+
+This helm chart installs ThirdEye with a Pinot Quickstart Cluster. 
+It sets up the following components.
+- MySQL 5.7 server
+- ThirdEye Frontend server
+- ThirdEye Backend server
+
+
+#### Prerequisites
+
+- kubectl (<https://kubernetes.io/docs/tasks/tools/install-kubectl>)
+- Helm (<https://helm.sh/docs/using_helm/#installing-helm>)
+- Configure kubectl to connect to the Kubernetes cluster.
+- An already Setup Pinot quickstart cluster.
+
+## Installing ThirdEye
+
+This installs thirdeye in the default namespace. 
+```bash
+./install.sh
+```
+
+All arguments passed to this script are forwarded to helm. So to install in namespace `te`, 
+you can simply pass on the helm arguments directly.  
+
+```bash
+./install.sh --namespace te
+```
+
+## Uninstalling ThirdEye
+
+Simply run one of the commands below depending on whether you are using a namespace or not.
+
+```bash
+helm uninstall thirdeye
+helm uninstall thirdeye --namespace te
+```
+
+
+## Configuration
+
+> Warning: The initdb.sql used for setting up the db may be out of date. Please note that this chart is currently a work in progress.  
+ 
+Please see `values.yaml` for configurable parameters. Specify parameters using `--set key=value[,key=value]` argument to `helm install`
+
+Alternatively a YAML file that specifies the values for the parameters can be provided like this:
+
+```bash
+./install.sh --name thirdeye -f values.yaml .
+```

--- a/kubernetes/helm/thirdeye/initdb.sql
+++ b/kubernetes/helm/thirdeye/initdb.sql
@@ -1,0 +1,448 @@
+create table if not exists generic_json_entity (
+    id bigint(20) primary key auto_increment,
+    json_val text,
+    beanClass varchar(200),
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index generic_json_entity_beanclass_idx on generic_json_entity(beanClass);
+
+create table if not exists anomaly_function_index (
+    function_name varchar(200) not null,
+    active boolean,
+    metric_id bigint(20) not null,
+    collection varchar(200),
+    metric varchar(200),
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10),
+    CONSTRAINT uc_functionName unique(function_name)
+) ENGINE=InnoDB;
+create index anomaly_function_name_idx on anomaly_function_index(function_name);
+create index anomaly_function_base_id_idx ON anomaly_function_index(base_id);
+
+create table if not exists job_index (
+    name varchar(200) not null,
+    status varchar(100) not null,
+    type varchar(100) not null,
+    config_id bigint(20),
+    schedule_start_time bigint(20) not null,
+    schedule_end_time bigint(20) not null,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index job_status_idx on job_index(status);
+create index job_type_idx on job_index(type);
+create index job_config_id_idx on job_index(config_id);
+create index job_base_id_idx ON job_index(base_id);
+
+create table if not exists task_index (
+    name varchar(200) not null,
+    status varchar(100) not null,
+    type varchar(100) not null,
+    start_time bigint(20) not null,
+    end_time bigint(20) not null,
+    job_id bigint(20),
+    worker_id bigint(20),
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index task_status_idx on task_index(status);
+create index task_type_idx on task_index(type);
+create index task_job_idx on task_index(job_id);
+create index task_base_id_idx ON task_index(base_id);
+create index task_name_idx ON task_index(name);
+create index task_start_time_idx on task_index(start_time);
+create index task_create_time_idx on task_index(create_time);
+create index task_status_start_time_idx on task_index(status, start_time);
+
+create table if not exists anomaly_feedback_index (
+    type varchar(100) not null,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index anomaly_feedback_base_id_idx ON anomaly_feedback_index(base_id);
+
+create table if not exists raw_anomaly_result_index (
+    function_id bigint(20),
+    job_id bigint(20),
+    anomaly_feedback_id bigint(20),
+    start_time bigint(20) not null,
+    end_time bigint(20) not null,
+    data_missing boolean default false not null,
+    merged boolean default false,
+    dimensions varchar(1023),
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index raw_anomaly_result_function_idx on raw_anomaly_result_index(function_id);
+create index raw_anomaly_result_feedback_idx on raw_anomaly_result_index(anomaly_feedback_id);
+create index raw_anomaly_result_job_idx on raw_anomaly_result_index(job_id);
+create index raw_anomaly_result_merged_idx on raw_anomaly_result_index(merged);
+create index raw_anomaly_result_data_missing_idx on raw_anomaly_result_index(data_missing);
+create index raw_anomaly_result_start_time_idx on raw_anomaly_result_index(start_time);
+create index raw_anomaly_result_base_id_idx on raw_anomaly_result_index(base_id);
+
+create table if not exists merged_anomaly_result_index (
+    function_id bigint(20),
+    detection_config_id bigint(20),
+    anomaly_feedback_id bigint(20),
+    metric_id bigint(20),
+    start_time bigint(20) not null,
+    end_time bigint(20) not null,
+    collection varchar(200),
+    metric varchar(200),
+    dimensions varchar(1023),
+    notified boolean default false,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    child boolean,
+    version int(10)
+) ENGINE=InnoDB;
+create index merged_anomaly_result_function_idx on merged_anomaly_result_index(function_id);
+create index merged_anomaly_result_feedback_idx on merged_anomaly_result_index(anomaly_feedback_id);
+create index merged_anomaly_result_metric_idx on merged_anomaly_result_index(metric_id);
+create index merged_anomaly_result_start_time_idx on merged_anomaly_result_index(start_time);
+create index merged_anomaly_result_base_id_idx on merged_anomaly_result_index(base_id);
+create index merged_anomaly_result_detection_config_id_idx on merged_anomaly_result_index(detection_config_id);
+
+create table if not exists dataset_config_index (
+    dataset varchar(200) not null,
+    display_name varchar(200),
+    active boolean,
+    requires_completeness_check boolean,
+    last_refresh_time bigint(20) default 0,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10),
+    CONSTRAINT uc_dataset unique(dataset)
+) ENGINE=InnoDB;
+create index dataset_config_dataset_idx on dataset_config_index(dataset);
+create index dataset_config_active_idx on dataset_config_index(active);
+create index dataset_config_requires_completeness_check_idx on dataset_config_index(requires_completeness_check);
+create index dataset_config_base_id_idx ON dataset_config_index(base_id);
+create index dataset_config_display_name_idx on dataset_config_index(display_name);
+create index dataset_config_last_refresh_time_idx on dataset_config_index(last_refresh_time);
+
+create table if not exists metric_config_index (
+    name varchar(200) not null,
+    dataset varchar(200) not null,
+    alias varchar(400) not null,
+    active boolean,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `metric_config_index` ADD UNIQUE `unique_metric_index`(`name`, `dataset`);
+create index metric_config_name_idx on metric_config_index(name);
+create index metric_config_dataset_idx on metric_config_index(dataset);
+create index metric_config_alias_idx on metric_config_index(alias);
+create index metric_config_active_idx on metric_config_index(active);
+create index metric_config_base_id_idx ON metric_config_index(base_id);
+
+create table if not exists override_config_index (
+    start_time bigint(20) NOT NULL,
+    end_time bigint(20) NOT NULL,
+    target_entity varchar(100) NOT NULL,
+    active boolean default false,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index override_config_target_entity_idx on override_config_index(target_entity);
+create index override_config_target_start_time_idx on override_config_index(start_time);
+create index override_config_base_id_idx ON override_config_index(base_id);
+
+create table if not exists alert_config_index (
+    active boolean,
+    name varchar(500) not null,
+    application VARCHAR(500) not null,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10),
+    CONSTRAINT uc_alert_name UNIQUE (name)
+) ENGINE=InnoDB;
+create index alert_config_application_idx on alert_config_index(application);
+create index alert_config_name_idx on alert_config_index(name);
+create index alert_config_base_id_idx ON alert_config_index(base_id);
+
+create table if not exists data_completeness_config_index (
+    dataset varchar(200) not null,
+    date_to_check_in_ms bigint(20) not null,
+    date_to_check_in_sdf varchar(20),
+    data_complete boolean,
+    percent_complete double,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `data_completeness_config_index` ADD UNIQUE `data_completeness_config_unique_index`(`dataset`, `date_to_check_in_ms`);
+create index data_completeness_config_dataset_idx on data_completeness_config_index(dataset);
+create index data_completeness_config_date_idx on data_completeness_config_index(date_to_check_in_ms);
+create index data_completeness_config_sdf_idx on data_completeness_config_index(date_to_check_in_sdf);
+create index data_completeness_config_complete_idx on data_completeness_config_index(data_complete);
+create index data_completeness_config_percent_idx on data_completeness_config_index(percent_complete);
+create index data_completeness_config_base_id_idx ON data_completeness_config_index(base_id);
+
+create table if not exists event_index (
+  name VARCHAR (100),
+  event_type VARCHAR (100),
+  start_time bigint(20) not null,
+  end_time bigint(20) not null,
+  metric_name VARCHAR(200),
+  service_name VARCHAR (200),
+  base_id bigint(20) not null,
+  create_time timestamp,
+  update_time timestamp default current_timestamp,
+  version int(10)
+) ENGINE=InnoDB;
+create index event_event_type_idx on event_index(event_type);
+create index event_start_time_idx on event_index(start_time);
+create index event_end_time_idx on event_index(end_time);
+create index event_base_id_idx ON event_index(base_id);
+
+create table if not exists detection_status_index (
+  function_id bigint(20),
+  dataset varchar(200) not null,
+  date_to_check_in_ms bigint(20) not null,
+  date_to_check_in_sdf varchar(20),
+  detection_run boolean,
+  base_id bigint(20) not null,
+  create_time timestamp,
+  update_time timestamp default current_timestamp,
+  version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `detection_status_index` ADD UNIQUE `detection_status_unique_index`(`function_id`, `date_to_check_in_sdf`);
+create index detection_status_dataset_idx on detection_status_index(dataset);
+create index detection_status_date_idx on detection_status_index(date_to_check_in_ms);
+create index detection_status_sdf_idx on detection_status_index(date_to_check_in_sdf);
+create index detection_status_run_idx on detection_status_index(detection_run);
+create index detection_status_function_idx on detection_status_index(function_id);
+create index detection_status_base_id_idx ON detection_status_index(base_id);
+
+create table if not exists autotune_config_index (
+    function_id bigint(20),
+    start_time bigint(20) not null,
+    end_time bigint(20) not null,
+    performance_evaluation_method varchar(200),
+    autotune_method varchar(200),
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index autotune_config_function_idx on autotune_config_index(function_id);
+create index autotune_config_autoTuneMethod_idx on autotune_config_index(autotune_method);
+create index autotune_config_performanceEval_idx on autotune_config_index(performance_evaluation_method);
+create index autotune_config_start_time_idx on autotune_config_index(start_time);
+create index autotune_config_base_id_idx ON autotune_config_index(base_id);
+
+create table if not exists classification_config_index (
+    name varchar(200) not null,
+    active boolean,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `classification_config_index` ADD UNIQUE `classification_config_unique_index`(`name`);
+create index classification_config_name_index on classification_config_index(name);
+create index classification_config_base_id_idx ON classification_config_index(base_id);
+
+create table if not exists entity_to_entity_mapping_index (
+    from_urn varchar(400) not null,
+    to_urn varchar(400) not null,
+    mapping_type varchar(500) not null,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `entity_to_entity_mapping_index` ADD UNIQUE `entity_mapping_unique_index`(`from_urn`, `to_urn`);
+create index entity_mapping_from_urn_idx on entity_to_entity_mapping_index(from_urn);
+create index entity_mapping_to_urn_idx on entity_to_entity_mapping_index(to_urn);
+create index entity_mapping_type_idx on entity_to_entity_mapping_index(mapping_type);
+create index entity_to_entity_mapping_base_id_idx ON entity_to_entity_mapping_index(base_id);
+
+create table if not exists grouped_anomaly_results_index (
+    alert_config_id bigint(20) not null,
+    dimensions varchar(1023),
+    end_time bigint(20) not null,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index grouped_anomaly_results_alert_config_id on grouped_anomaly_results_index(alert_config_id);
+create index grouped_anomaly_results_base_id_idx ON grouped_anomaly_results_index(base_id);
+
+create table if not exists onboard_dataset_metric_index (
+  dataset_name varchar(200) not null,
+  metric_name varchar(500),
+  data_source varchar(500) not null,
+  onboarded boolean,
+  base_id bigint(20) not null,
+  create_time timestamp,
+  update_time timestamp default current_timestamp,
+  version int(10)
+) ENGINE=InnoDB;
+create index onboard_dataset_idx on onboard_dataset_metric_index(dataset_name);
+create index onboard_metric_idx on onboard_dataset_metric_index(metric_name);
+create index onboard_datasource_idx on onboard_dataset_metric_index(data_source);
+create index onboard_onboarded_idx on onboard_dataset_metric_index(onboarded);
+create index onboard_dataset_metric_base_id_idx ON onboard_dataset_metric_index(base_id);
+
+create table if not exists config_index (
+    namespace varchar(64) not null,
+    name varchar(128) not null,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `config_index` ADD UNIQUE `config_unique_index`(`namespace`, `name`);
+create index config_namespace_idx on config_index(namespace);
+create index config_name_idx on config_index(name);
+create index config_base_id_idx ON config_index(base_id);
+
+create table application_index (
+  base_id bigint(20) not null,
+  create_time timestamp,
+  update_time timestamp default current_timestamp,
+  application VARCHAR (200) not null,
+  recipients VARCHAR(1000) NOT NULL
+);
+create index application_application_idx on application_index(application);
+
+create table if not exists alert_snapshot_index (
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index alert_snapshot_base_id_idx ON alert_snapshot_index(base_id);
+
+create table if not exists rootcause_session_index (
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    name varchar(256),
+    owner varchar(32),
+    previousId bigint(20),
+    anomalyId bigint(20),
+    anomaly_range_start bigint(8),
+    anomaly_range_end bigint(8),
+    created bigint(8),
+    updated bigint(8),
+    version int(10)
+) ENGINE=InnoDB;
+create index rootcause_session_name_idx on rootcause_session_index(name);
+create index rootcause_session_owner_idx on rootcause_session_index(owner);
+create index rootcause_session_previousId_idx on rootcause_session_index(previousId);
+create index rootcause_session_anomalyId_idx on rootcause_session_index(anomalyId);
+create index rootcause_session_anomaly_range_start_idx on rootcause_session_index(anomaly_range_start);
+create index rootcause_session_anomaly_range_end_idx on rootcause_session_index(anomaly_range_end);
+create index rootcause_session_created_idx on rootcause_session_index(created);
+create index rootcause_session_updated_idx on rootcause_session_index(updated);
+create index rootcause_session_base_id_idx ON rootcause_session_index(base_id);
+
+create table if not exists session_index (
+    base_id bigint(20) not null,
+    session_key CHAR(64) not null,
+    principal_type VARCHAR(32),
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `session_index` ADD UNIQUE `session_unique_index`(session_key);
+create index session_base_id_idx ON session_index(base_id);
+create index session_key_idx ON session_index(session_key);
+create index session_principal_type_idx ON session_index(principal_type);
+
+create table if not exists detection_config_index (
+    base_id bigint(20) not null,
+    `name` VARCHAR(256) not null,
+    active BOOLEAN,
+    created_by VARCHAR(256),
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `detection_config_index` ADD UNIQUE `detection_config_unique_index`(`name`);
+create index detection_config_base_id_idx ON detection_config_index(base_id);
+create index detection_config_name_idx ON detection_config_index(`name`);
+create index detection_config_active_idx ON detection_config_index(active);
+create index detection_config_created_by_index ON detection_config_index(created_by);
+
+create table if not exists detection_alert_config_index (
+    base_id bigint(20) not null,
+    application VARCHAR(128),
+    `name` VARCHAR(256) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `detection_alert_config_index` ADD UNIQUE `detection_alert_config_unique_index`(`name`);
+create index detection_alert_config_base_id_idx ON detection_alert_config_index(base_id);
+create index detection_alert_config_name_idx ON detection_alert_config_index(`name`);
+create index detection_alert_config_application_idx ON detection_alert_config_index(`application`);
+
+create table if not exists evaluation_index (
+    base_id bigint(20) not null,
+    detection_config_id bigint(20) not null,
+    start_time bigint(20) not null,
+    end_time bigint(20) not null,
+    detectorName VARCHAR(128),
+    mape double,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `evaluation_index` ADD UNIQUE `evaluation_index`(`detection_config_id`, `start_time`, `end_time`);
+create index evaluation_base_id_idx ON evaluation_index(base_id);
+create index evaluation_detection_config_id_idx ON evaluation_index(detection_config_id);
+create index evaluation_detection_start_time_idx on evaluation_index(start_time);
+
+create table if not exists rootcause_template_index (
+    base_id bigint(20) not null,
+    `name` VARCHAR(256) not null,
+    application VARCHAR(128),
+    owner varchar(32) not null,
+    metric_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `rootcause_template_index` ADD UNIQUE `rootcause_template_index`(`name`);
+create index rootcause_template_id_idx ON rootcause_template_index(base_id);
+create index rootcause_template_owner_idx ON rootcause_template_index(owner);
+create index rootcause_template_metric_idx on rootcause_template_index(metric_id);
+create index rootcause_template_config_application_idx ON rootcause_template_index(`application`);
+
+create table if not exists online_detection_data_index (
+    base_id bigint(20) not null,
+    dataset varchar(200),
+    metric varchar(200),
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+create index online_detection_data_id_idx ON online_detection_data_index(base_id);
+create index online_detection_data_dataset_idx ON online_detection_data_index(dataset);
+create index online_detection_data_metric_idx ON online_detection_data_index(metric);

--- a/kubernetes/helm/thirdeye/install.sh
+++ b/kubernetes/helm/thirdeye/install.sh
@@ -6,4 +6,4 @@ cd ${base_dir};
 # Note:
 # - initdb files must end with .sql
 # - When injecting yaml config via terminal, the period ('.') must be escaped and quoted
-helm install thirdeye . --set-file mysql.initializationFiles."initdb\.sql"="./initdb.sql"
+helm install thirdeye . --set-file mysql.initializationFiles."initdb\.sql"="./initdb.sql" --namespace te

--- a/kubernetes/helm/thirdeye/install.sh
+++ b/kubernetes/helm/thirdeye/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+base_dir=$(dirname "$0")
+cd ${base_dir};
+
+# Note:
+# - initdb files must end with .sql
+# - When injecting yaml config via terminal, the period ('.') must be escaped and quoted
+helm install thirdeye . --set-file mysql.initializationFiles."initdb\.sql"="./initdb.sql"

--- a/kubernetes/helm/thirdeye/install.sh
+++ b/kubernetes/helm/thirdeye/install.sh
@@ -6,4 +6,4 @@ cd ${base_dir};
 # Note:
 # - initdb files must end with .sql
 # - When injecting yaml config via terminal, the period ('.') must be escaped and quoted
-helm install thirdeye . --set-file mysql.initializationFiles."initdb\.sql"="./initdb.sql" --namespace te
+helm install thirdeye . --set-file mysql.initializationFiles."initdb\.sql"="./initdb.sql" $@

--- a/kubernetes/helm/thirdeye/templates/_helpers.tpl
+++ b/kubernetes/helm/thirdeye/templates/_helpers.tpl
@@ -1,0 +1,131 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "thirdeye.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "thirdeye.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "thirdeye.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified thirdeye frontend name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "thirdeye.frontend.fullname" -}}
+{{ template "thirdeye.fullname" . }}-{{ .Values.frontend.name }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified thirdeye backend name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "thirdeye.backend.fullname" -}}
+{{ template "thirdeye.fullname" . }}-{{ .Values.backend.name }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified thirdeye scheduler (backend with special detector.yml) name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "thirdeye.scheduler.fullname" -}}
+{{ template "thirdeye.fullname" . }}-{{ .Values.scheduler.name }}
+{{- end -}}
+
+{{/*
+The name of the thirdeye config.
+*/}}
+{{- define "thirdeye.config" -}}
+{{- printf "%s-config" (include "thirdeye.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the thirdeye scheduler (backend with special detector.yml) config.
+*/}}
+{{- define "thirdeye.scheduler.config" -}}
+{{- printf "%s-scheduler-config" (include "thirdeye.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the thirdeye frontend external service.
+*/}}
+{{- define "thirdeye.frontend.external" -}}
+{{- printf "%s-external" (include "thirdeye.frontend.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the thirdeye frontend headless service.
+*/}}
+{{- define "thirdeye.frontend.headless" -}}
+{{- printf "%s-headless" (include "thirdeye.frontend.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the thirdeye backend headless service.
+*/}}
+{{- define "thirdeye.backend.headless" -}}
+{{- printf "%s-headless" (include "thirdeye.backend.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the thirdeye scheduler (backend with special detector.yml) headless service.
+*/}}
+{{- define "thirdeye.scheduler.headless" -}}
+{{- printf "%s-headless" (include "thirdeye.scheduler.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+  Create a default fully qualified traefik name.
+  We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "thirdeye.traefik.fullname" -}}
+{{-   if .Values.traefik.fullnameOverride -}}
+{{-     .Values.traefik.fullnameOverride | trunc -63 | trimSuffix "-" -}}
+{{-   else -}}
+{{-     $name := default "traefik" .Values.traefik.nameOverride -}}
+{{-     printf "%s-%s" .Release.Name $name | trunc -63 | trimSuffix "-" -}}
+{{-    end -}}
+{{- end -}}
+

--- a/kubernetes/helm/thirdeye/templates/backend/deployment.yaml
+++ b/kubernetes/helm/thirdeye/templates/backend/deployment.yaml
@@ -67,23 +67,23 @@ spec:
           - containerPort: {{ .Values.backend.adminport }}
             protocol: TCP
         volumeMounts:
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/data-sources/data-sources-config.yml"
             subPath: "data-sources-config.yml"
             readOnly: true
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/data-sources/cache-config.yml"
             subPath: "cache-config.yml"
             readOnly: true
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/detector.yml"
             subPath: "detector.yml"
             readOnly: true
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/dashboard.yml"
             subPath: "dashboard.yml"
             readOnly: true
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/persistence.yml"
             subPath: "persistence.yml"
             readOnly: true
@@ -91,6 +91,6 @@ spec:
 {{ toYaml .Values.frontend.resources | indent 12 }}
       restartPolicy: Always
       volumes:
-        - name: thirdeye-pinot-quickstart-datasource-config
+        - name: thirdeye-config
           configMap:
-            name: thirdeye-pinot-quickstart-datasource-config
+            name: thirdeye-config

--- a/kubernetes/helm/thirdeye/templates/backend/deployment.yaml
+++ b/kubernetes/helm/thirdeye/templates/backend/deployment.yaml
@@ -1,0 +1,96 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "thirdeye.backend.fullname" . }}
+  labels:
+    app: {{ include "thirdeye.name" . }}
+    chart: {{ include "thirdeye.chart" . }}
+    component: {{ .Values.backend.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "thirdeye.name" . }}
+      release: {{ .Release.Name }}
+      component: {{ .Values.backend.name }}
+  replicas: {{ .Values.backend.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "thirdeye.name" . }}
+        release: {{ .Release.Name }}
+        component: {{ .Values.backend.name }}
+      annotations:
+{{ toYaml .Values.backend.podAnnotations | indent 8 }}
+    spec:
+      nodeSelector:
+{{ toYaml .Values.backend.nodeSelector | indent 8 }}
+      affinity:
+{{ toYaml .Values.backend.affinity | indent 8 }}
+      tolerations:
+{{ toYaml .Values.backend.tolerations | indent 8 }}
+      securityContext:
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsUser: 1000
+      containers:
+      - name: backend
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: [
+            "pinot-quickstart",
+            "backend"
+        ]
+        ports:
+          - containerPort: {{ .Values.backend.port }}
+            protocol: TCP
+          - containerPort: {{ .Values.backend.adminport }}
+            protocol: TCP
+        volumeMounts:
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/data-sources/data-sources-config.yml"
+            subPath: "data-sources-config.yml"
+            readOnly: true
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/data-sources/cache-config.yml"
+            subPath: "cache-config.yml"
+            readOnly: true
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/detector.yml"
+            subPath: "detector.yml"
+            readOnly: true
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/dashboard.yml"
+            subPath: "dashboard.yml"
+            readOnly: true
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/persistence.yml"
+            subPath: "persistence.yml"
+            readOnly: true
+        resources:
+{{ toYaml .Values.frontend.resources | indent 12 }}
+      restartPolicy: Always
+      volumes:
+        - name: thirdeye-pinot-quickstart-datasource-config
+          configMap:
+            name: thirdeye-pinot-quickstart-datasource-config

--- a/kubernetes/helm/thirdeye/templates/backend/service-headless.yaml
+++ b/kubernetes/helm/thirdeye/templates/backend/service-headless.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "thirdeye.backend.headless" . }}
+  labels:
+    app: {{ include "thirdeye.name" . }}
+    chart: {{ include "thirdeye.chart" . }}
+    component: {{ .Values.backend.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+    # [pod_name].[service_name].[namespace].svc.cluster.local
+    - port: {{ .Values.backend.port }}
+  selector:
+    app: {{ include "thirdeye.name" . }}
+    release: {{ .Release.Name }}
+    component: {{ .Values.backend.name }}

--- a/kubernetes/helm/thirdeye/templates/backend/service.yaml
+++ b/kubernetes/helm/thirdeye/templates/backend/service.yaml
@@ -20,19 +20,19 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "thirdeye.frontend.fullname" . }}
+  name: {{ include "thirdeye.backend.fullname" . }}
   labels:
     app: {{ include "thirdeye.name" . }}
     chart: {{ include "thirdeye.chart" . }}
-    component: {{ .Values.frontend.name }}
+    component: {{ .Values.backend.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.frontend.serviceType }}
+  type: {{ .Values.backend.serviceType }}
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
-    - port: {{ .Values.frontend.port }}
+    - port: {{ .Values.backend.port }}
   selector:
     app: {{ include "thirdeye.name" . }}
     release: {{ .Release.Name }}
-    component: {{ .Values.frontend.name }}
+    component: {{ .Values.backend.name }}

--- a/kubernetes/helm/thirdeye/templates/common/configmap.yaml
+++ b/kubernetes/helm/thirdeye/templates/common/configmap.yaml
@@ -1,0 +1,252 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thirdeye-pinot-quickstart-datasource-config
+data:
+  persistence.yml: |-
+    databaseConfiguration:
+      url: jdbc:mysql://{{ .Release.Name }}-mysql/thirdeye
+      user: {{ .Values.mysql.mysqlUser }}
+      password: {{ .Values.mysql.mysqlPassword }}
+      driver: com.mysql.jdbc.Driver
+  dashboard.yml: |-
+    authConfig:
+      authEnabled: false
+      authKey: ""
+      ldapUrl: ""
+      domainSuffix: []
+      cacheTTL: 3600
+      cookieTTL: 604800
+    resourceConfig: []
+    rootCause:
+      definitionsPath: rca.yml
+      parallelism: 5
+      formatters:
+        - org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.AnomalyEventFormatter
+        - org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.ThirdEyeEventFormatter
+        - org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.MetricEntityFormatter
+        - org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.DimensionEntityFormatter
+        - org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.ServiceEntityFormatter
+        - org.apache.pinot.thirdeye.dashboard.resources.v2.rootcause.DefaultEventEntityFormatter
+    dashboardHost: "http://localhost:1426"
+    failureFromAddress: thirdeye@localhost
+    failureToAddress: user@localhost
+    alerterConfiguration:
+      smtpConfiguration:
+        smtpHost: localhost
+        smtpPort: 25
+    logging:
+      level: INFO
+      loggers:
+        org.apache.pinot: INFO
+
+    server:
+      type: default
+      applicationConnectors:
+        - type: http
+          port: 1426
+      adminConnectors:
+        - type: http
+          port: 1427
+      requestLog:
+        type: external
+    whitelistDatasets: []
+    swagger:
+      resourcePackage: "org.apache.pinot.thirdeye.dashboard.resources,org.apache.pinot.thirdeye.dashboard.resources.v2,org.apache.pinot.thirdeye.anomaly.onboard,org.apache.pinot.thirdeye.detection,org.apache.pinot.thirdeye.detection.yaml"
+
+  detector.yml: |-
+    logging:
+      level: INFO
+      loggers:
+        org.hibernate.engine.internal: WARN
+    server:
+      type: default
+      rootPath: '/api/*'
+      applicationContextPath: /
+      adminContextPath: /admin
+      applicationConnectors:
+        - type: http
+          port: 1867
+      adminConnectors:
+        - type: http
+          port: 1868
+    alert: false
+    autoload: true
+    # autoOnboardConfiguration:
+    #   runFrequency: 10s
+
+    classifier: false
+    holidayEventsLoader: true
+    monitor: true
+    pinotProxy: false
+    scheduler: true
+    worker: true
+    detectionPipeline: true
+    detectionAlert: true
+    dashboardHost: "http://localhost:1426"
+    id: 0
+    alerterConfiguration:
+      smtpConfiguration:
+        smtpHost: "localhost"
+        smtpPort: 25
+    #  jiraConfiguration:
+    #    jiraUser: <REPLACE_ME>
+    #    jiraPassword: <REPLACE_ME>
+    #    jiraUrl: <REPLACE_ME>
+    #    jiraDefaultProject: <REPLACE_ME>
+    #    jiraIssueTypeId: 19
+    failureFromAddress: "thirdeye@localhost"
+    failureToAddress: "thirdeye@localhost"
+    phantomJsPath: "/usr/local/bin/jstf"
+    swagger:
+      resourcePackage: "org.apache.pinot.thirdeye.dashboard.resources,org.apache.pinot.thirdeye.dashboard.resources.v2,org.apache.pinot.thirdeye.anomaly.onboard"
+    holidayEventsLoaderConfiguration:
+      calendars:
+           - "en.australian#holiday@group.v.calendar.google.com"
+           - "en.austrian#holiday@group.v.calendar.google.com"
+           - "en.brazilian#holiday@group.v.calendar.google.com"
+           - "en.canadian#holiday@group.v.calendar.google.com"
+           - "en.china#holiday@group.v.calendar.google.com"
+           - "en.christian#holiday@group.v.calendar.google.com"
+           - "en.danish#holiday@group.v.calendar.google.com"
+           - "en.dutch#holiday@group.v.calendar.google.com"
+           - "en.finnish#holiday@group.v.calendar.google.com"
+           - "en.french#holiday@group.v.calendar.google.com"
+           - "en.german#holiday@group.v.calendar.google.com"
+           - "en.greek#holiday@group.v.calendar.google.com"
+           - "en.hong_kong#holiday@group.v.calendar.google.com"
+           - "en.indian#holiday@group.v.calendar.google.com"
+           - "en.indonesian#holiday@group.v.calendar.google.com"
+           - "en.irish#holiday@group.v.calendar.google.com"
+           - "en.islamic#holiday@group.v.calendar.google.com"
+           - "en.italian#holiday@group.v.calendar.google.com"
+           - "en.japanese#holiday@group.v.calendar.google.com"
+           - "en.jewish#holiday@group.v.calendar.google.com"
+           - "en.malaysia#holiday@group.v.calendar.google.com"
+           - "en.mexican#holiday@group.v.calendar.google.com"
+           - "en.new_zealand#holiday@group.v.calendar.google.com"
+           - "en.norwegian#holiday@group.v.calendar.google.com"
+           - "en.philippines#holiday@group.v.calendar.google.com"
+           - "en.polish#holiday@group.v.calendar.google.com"
+           - "en.portuguese#holiday@group.v.calendar.google.com"
+           - "en.russian#holiday@group.v.calendar.google.com"
+           - "en.singapore#holiday@group.v.calendar.google.com"
+           - "en.sa#holiday@group.v.calendar.google.com"
+           - "en.south_korea#holiday@group.v.calendar.google.com"
+           - "en.spain#holiday@group.v.calendar.google.com"
+           - "en.swedish#holiday@group.v.calendar.google.com"
+           - "en.taiwan#holiday@group.v.calendar.google.com"
+           - "en.uk#holiday@group.v.calendar.google.com"
+           - "en.usa#holiday@group.v.calendar.google.com"
+           - "en.vietnamese#holiday@group.v.calendar.google.com"
+      holidayLoadRange: 2592000000
+      runFrequency: 1
+    mockEventsLoader: true
+    mockEventsLoaderConfiguration:
+      generators:
+        - type: HOLIDAY
+          arrivalType: exponential
+          arrivalMean: 86400000
+          durationType: fixed
+          durationMean: 86400000
+          seed: 0
+          namePrefixes: [First, Second, Third, Last, Funky, Happy, Sad, Glorious, Jolly, Unity, Pinot's]
+          nameSuffixes: [day, day, days, celebration, rememberance, occurrence, moment]
+        - type: INFORMED
+          arrivalType: exponential
+          arrivalMean: 43200000
+          durationType: exponential
+          durationMean: 3600000
+          seed: 1
+          namePrefixes: [Login, Web, Search, Catalog, Integration, Network, Backup, Ingress, Proxy, Failure, Pinot, ThirdEye]
+          nameSuffixes: [backend, frontend, v1.1, v1.2, v1.3, v2.0, v3, v4, v5, storage, topic, container, database]
+        - type: CM
+          arrivalType: exponential
+          arrivalMean: 21600000
+          durationType: fixed
+          durationMean: 1800000
+          seed: 2
+          namePrefixes: [Database, Web, Search, Catalog, Integration, Network, Backup, Ingress, Proxy, Failure, Pinot, ThirdEye]
+        - type: CUSTOM
+          arrivalType: exponential
+          arrivalMean: 432000000
+          durationType: exponential
+          durationMean: 86400000
+          seed: 3
+          namePrefixes: [Marketing, Onboarding, Vaction, Outreach, InDay]
+          nameSuffixes: [integration, campaign, meeting]
+        - type: LIX
+          arrivalType: exponential
+          arrivalMean: 259200000
+          durationType: exponential
+          durationMean: 604800000
+          seed: 4
+          namePrefixes: [System, Model, Campaign, Welcome, Pinot, ThirdEye]
+
+  data-sources-config.yml: |-
+    # Please put the mock data source as the first in this configuration.
+    dataSourceConfigs:
+      - className: org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSource
+        properties:
+          zookeeperUrl: 'pinot-zookeeper:2181'
+          clusterName: 'pinot-quickstart'
+          controllerConnectionScheme: 'http'
+          controllerHost: 'pinot-controller'
+          controllerPort: 9000
+          cacheLoaderClassName: org.apache.pinot.thirdeye.datasource.pinot.PinotControllerResponseCacheLoader
+        metadataSourceConfigs:
+          - className: org.apache.pinot.thirdeye.auto.onboard.AutoOnboardPinotMetadataSource
+
+  cache-config.yml: |-
+    useInMemoryCache: true
+    useCentralizedCache: false
+
+    centralizedCacheSettings:
+      # TTL (time-to-live) for documents in seconds
+      ttl: 3600
+      # if inserting data points individually, max number of threads to spawn to parallel insert at a time
+      maxParallelInserts: 10
+      # which store to use
+      cacheDataStoreName: 'couchbase'
+      cacheDataSources:
+        couchbase:
+          className: org.apache.pinot.thirdeye.detection.cache.CouchbaseCacheDAO
+          config:
+            useCertificateBasedAuthentication: false
+            # at least 1 host needed
+            hosts:
+              - 'host1' # ex. http://localhost:8091
+              - 'host2' # ex. http://localhost:8092
+              - 'host3' # ex. http://localhost:8093
+              - 'host4' # and so on...
+            bucketName: 'your_bucket_name'
+            # if using certificate-based authentication, authUsername and authPassword values don't matter and won't be used
+            authUsername: 'your_bucket_user_username'
+            authPassword: 'your_bucket_user_password'
+            enableDnsSrv: false
+            # certificate based authentication is only available in Couchbase enterprise edition.
+            keyStoreFilePath: 'key/store/path/keystore_file' # e.g. '/var/identity.p12'
+            # if your keystore has a password, enter it here. by default, Java uses 'work_around_jdk-6879539' to enable empty passwords for certificates.
+            keyStorePassword: 'work_around_jdk-6879539'
+            trustStoreFilePath: 'trust/store/path/truststore_file' # e.g. '/etc/riddler/cacerts'
+            trustStorePassword: ''
+        # add your store of choice here

--- a/kubernetes/helm/thirdeye/templates/common/configmap.yaml
+++ b/kubernetes/helm/thirdeye/templates/common/configmap.yaml
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: thirdeye-pinot-quickstart-datasource-config
+  name: thirdeye-config
 data:
   persistence.yml: |-
     databaseConfiguration:

--- a/kubernetes/helm/thirdeye/templates/common/configmap.yaml
+++ b/kubernetes/helm/thirdeye/templates/common/configmap.yaml
@@ -89,12 +89,12 @@ data:
       adminConnectors:
         - type: http
           port: 1868
-    alert: false
+    alert: true
     autoload: true
     # autoOnboardConfiguration:
     #   runFrequency: 10s
 
-    classifier: false
+    classifier: true
     holidayEventsLoader: true
     monitor: true
     pinotProxy: false

--- a/kubernetes/helm/thirdeye/templates/frontend/deployment.yaml
+++ b/kubernetes/helm/thirdeye/templates/frontend/deployment.yaml
@@ -1,0 +1,96 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "thirdeye.frontend.fullname" . }}
+  labels:
+    app: {{ include "thirdeye.name" . }}
+    chart: {{ include "thirdeye.chart" . }}
+    component: {{ .Values.frontend.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "thirdeye.name" . }}
+      release: {{ .Release.Name }}
+      component: {{ .Values.frontend.name }}
+  replicas: {{ .Values.frontend.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "thirdeye.name" . }}
+        release: {{ .Release.Name }}
+        component: {{ .Values.frontend.name }}
+      annotations:
+{{ toYaml .Values.frontend.podAnnotations | indent 8 }}
+    spec:
+      nodeSelector:
+{{ toYaml .Values.frontend.nodeSelector | indent 8 }}
+      affinity:
+{{ toYaml .Values.frontend.affinity | indent 8 }}
+      tolerations:
+{{ toYaml .Values.frontend.tolerations | indent 8 }}
+      securityContext:
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsUser: 1000
+      containers:
+      - name: frontend
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: [
+            "pinot-quickstart",
+            "frontend"
+        ]
+        ports:
+          - containerPort: {{ .Values.frontend.port }}
+            protocol: TCP
+          - containerPort: {{ .Values.frontend.adminport }}
+            protocol: TCP
+        volumeMounts:
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/data-sources/data-sources-config.yml"
+            subPath: "data-sources-config.yml"
+            readOnly: true
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/data-sources/cache-config.yml"
+            subPath: "cache-config.yml"
+            readOnly: true
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/detector.yml"
+            subPath: "detector.yml"
+            readOnly: true
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/dashboard.yml"
+            subPath: "dashboard.yml"
+            readOnly: true
+          - name: thirdeye-pinot-quickstart-datasource-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/persistence.yml"
+            subPath: "persistence.yml"
+            readOnly: true
+        resources:
+{{ toYaml .Values.frontend.resources | indent 12 }}
+      restartPolicy: Always
+      volumes:
+        - name: thirdeye-pinot-quickstart-datasource-config
+          configMap:
+            name: thirdeye-pinot-quickstart-datasource-config

--- a/kubernetes/helm/thirdeye/templates/frontend/deployment.yaml
+++ b/kubernetes/helm/thirdeye/templates/frontend/deployment.yaml
@@ -67,23 +67,23 @@ spec:
           - containerPort: {{ .Values.frontend.adminport }}
             protocol: TCP
         volumeMounts:
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/data-sources/data-sources-config.yml"
             subPath: "data-sources-config.yml"
             readOnly: true
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/data-sources/cache-config.yml"
             subPath: "cache-config.yml"
             readOnly: true
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/detector.yml"
             subPath: "detector.yml"
             readOnly: true
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/dashboard.yml"
             subPath: "dashboard.yml"
             readOnly: true
-          - name: thirdeye-pinot-quickstart-datasource-config
+          - name: thirdeye-config
             mountPath: "/opt/thirdeye/config/pinot-quickstart/persistence.yml"
             subPath: "persistence.yml"
             readOnly: true
@@ -91,6 +91,6 @@ spec:
 {{ toYaml .Values.frontend.resources | indent 12 }}
       restartPolicy: Always
       volumes:
-        - name: thirdeye-pinot-quickstart-datasource-config
+        - name: thirdeye-config
           configMap:
-            name: thirdeye-pinot-quickstart-datasource-config
+            name: thirdeye-config

--- a/kubernetes/helm/thirdeye/templates/frontend/ingress.yaml
+++ b/kubernetes/helm/thirdeye/templates/frontend/ingress.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.traefik.enabled -}}
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ printf "%s-%s" (include "thirdeye.traefik.fullname" . ) "thirdeye" | trunc -63 }}
+spec:
+  rules:
+  - host: {{ .Release.Name }}.{{ .Release.Namespace }}.{{ required "domain is required." .Values.domain }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ include "thirdeye.frontend.headless" . }}
+          servicePort: {{ .Values.frontend.port }}
+{{- end }}

--- a/kubernetes/helm/thirdeye/templates/frontend/service-headless.yaml
+++ b/kubernetes/helm/thirdeye/templates/frontend/service-headless.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "thirdeye.frontend.headless" . }}
+  labels:
+    app: {{ include "thirdeye.name" . }}
+    chart: {{ include "thirdeye.chart" . }}
+    component: {{ .Values.frontend.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+    # [pod_name].[service_name].[namespace].svc.cluster.local
+    - port: {{ .Values.frontend.port }}
+  selector:
+    app: {{ include "thirdeye.name" . }}
+    release: {{ .Release.Name }}
+    component: {{ .Values.frontend.name }}

--- a/kubernetes/helm/thirdeye/templates/frontend/service.yaml
+++ b/kubernetes/helm/thirdeye/templates/frontend/service.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "thirdeye.frontend.fullname" . }}
+  labels:
+    app: {{ include "thirdeye.name" . }}
+    chart: {{ include "thirdeye.chart" . }}
+    component: {{ .Values.frontend.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: LoadBalancer
+  ports:
+    # [pod_name].[service_name].[namespace].svc.cluster.local
+    - port: {{ .Values.frontend.port }}
+  selector:
+    app: {{ include "thirdeye.name" . }}
+    release: {{ .Release.Name }}
+    component: {{ .Values.frontend.name }}

--- a/kubernetes/helm/thirdeye/values.yaml
+++ b/kubernetes/helm/thirdeye/values.yaml
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Default values for Presto image with built-in Pinot Connector.
+
+image:
+  repository: apachepinot/thirdeye
+  tag: latest
+  pullPolicy: IfNotPresent
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 4G
+  storageClass: ""
+
+
+frontend:
+  enabled: true
+  name: frontend
+  replicaCount: 1
+  port: 1426
+  adminport: 1427
+
+  resources: {}
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  podAnnotations: {}
+
+
+backend:
+  enabled: true
+  name: backend
+  replicaCount: 1
+  port: 1867
+  adminport: 1868
+
+  node:
+    environment: production
+    dataDir: /home/presto/data
+
+  resources: {}
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  podAnnotations: {}
+
+
+scheduler:
+  name: scheduler
+
+# MySQL:
+# ----------------------------
+# Note:  initializationFiles parameter needs to be injected via command line to
+# complete the DB setup.
+mysql:
+  mysqlRootPassword: password
+  mysqlUser: uthirdeye
+  mysqlPassword: pass
+  mysqlDatabase: thirdeye
+
+traefik:
+  enabled: false
+

--- a/kubernetes/helm/thirdeye/values.yaml
+++ b/kubernetes/helm/thirdeye/values.yaml
@@ -30,6 +30,7 @@ frontend:
   replicaCount: 1
   port: 1426
   adminport: 1427
+  serviceType: LoadBalancer
 
   resources: {}
   nodeSelector: {}
@@ -44,6 +45,7 @@ backend:
   replicaCount: 1
   port: 1867
   adminport: 1868
+  serviceType: LoadBalancer
 
   resources: {}
   nodeSelector: {}

--- a/kubernetes/helm/thirdeye/values.yaml
+++ b/kubernetes/helm/thirdeye/values.yaml
@@ -17,19 +17,12 @@
 # under the License.
 #
 
-# Default values for Presto image with built-in Pinot Connector.
+# Default values for ThirdEye Deployment
 
 image:
   repository: apachepinot/thirdeye
   tag: latest
   pullPolicy: IfNotPresent
-
-persistence:
-  enabled: true
-  accessMode: ReadWriteOnce
-  size: 4G
-  storageClass: ""
-
 
 frontend:
   enabled: true
@@ -39,13 +32,9 @@ frontend:
   adminport: 1427
 
   resources: {}
-
   nodeSelector: {}
-
   tolerations: []
-
   affinity: {}
-
   podAnnotations: {}
 
 
@@ -56,33 +45,28 @@ backend:
   port: 1867
   adminport: 1868
 
-  node:
-    environment: production
-    dataDir: /home/presto/data
-
   resources: {}
-
   nodeSelector: {}
-
   tolerations: []
-
   affinity: {}
-
   podAnnotations: {}
 
-
-scheduler:
-  name: scheduler
-
-# MySQL:
-# ----------------------------
-# Note:  initializationFiles parameter needs to be injected via command line to
-# complete the DB setup.
+# Persistence layer configuration
 mysql:
   mysqlRootPassword: password
   mysqlUser: uthirdeye
   mysqlPassword: pass
   mysqlDatabase: thirdeye
+
+  # Note:  initializationFiles parameter needs to be injected via command line to
+  # complete the DB setup.
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 4G
+  storageClass: ""
+
 
 traefik:
   enabled: false


### PR DESCRIPTION
## Description
Creating a helm application for ThirdEye to work with pinot quickstart
right off the box. The current change installs MySQL with the initial
set of tables. This creates thirdeye frontend and backend pods

#### Caveats
 - The initdb.sql needs to be updated regularly which is an overhead. To be refactored later.
 - Using the create-schema.sql is not possible at the moment since the script has errors with MySQL 5.7.

No backward incompatible changes.