### PR TITLE
Removing node_modules from source tarball

### DIFF
--- a/pinot-distribution/pinot-source-assembly.xml
+++ b/pinot-distribution/pinot-source-assembly.xml
@@ -42,6 +42,9 @@
         <exclude>.gitignore</exclude>
         <exclude>contrib/**</exclude>
 
+        <!-- Do not inclue node_modules in pinot-controller -->
+        <exclude>pinot-controller/src/main/resources/node_modules/**</exclude>
+
         <!-- Do not include temp files created by maven-release-plugin -->
         <exclude>**/*.releaseBackup</exclude>
         <exclude>release.properties</exclude>


### PR DESCRIPTION
## Description
This PR removes the node_modules directory from the source tarball and reduces the source package size drastically.
