### PR TITLE
Adding push job type of segment metadata only mode

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -214,6 +214,11 @@ public class FileUploadDownloadClient implements Closeable {
     return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(), SEGMENT_PATH);
   }
 
+  public static URI getUploadSegmentMetadataURI(URI controllerURI)
+      throws URISyntaxException {
+    return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(), SEGMENT_METADATA_PATH);
+  }
+
   private static HttpUriRequest getUploadFileRequest(String method, URI uri, ContentBody contentBody,
       @Nullable List<Header> headers, @Nullable List<NameValuePair> parameters, int socketTimeoutMs) {
     // Build the Http entity

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -87,7 +87,7 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   public enum FileUploadType {
-    URI, JSON, SEGMENT;
+    URI, JSON, SEGMENT, METADATA;
 
     public static FileUploadType getDefaultUploadType() {
       return SEGMENT;
@@ -103,7 +103,6 @@ public class FileUploadDownloadClient implements Closeable {
   private static final String SCHEMA_PATH = "/schemas";
   private static final String OLD_SEGMENT_PATH = "/segments";
   private static final String SEGMENT_PATH = "/v2/segments";
-  private static final String SEGMENT_METADATA_PATH = "/segmentmetadata";
   private static final String TABLES_PATH = "/tables";
   private static final String TYPE_DELIMITER = "?type=";
 
@@ -194,16 +193,6 @@ public class FileUploadDownloadClient implements Closeable {
     return getURI(HTTP, host, port, SEGMENT_PATH);
   }
 
-  public static URI getUploadSegmentMetadataHttpURI(String host, int port)
-      throws URISyntaxException {
-    return getURI(HTTP, host, port, SEGMENT_METADATA_PATH);
-  }
-
-  public static URI getUploadSegmentMetadataHttpsURI(String host, int port)
-      throws URISyntaxException {
-    return getURI(HTTPS, host, port, SEGMENT_METADATA_PATH);
-  }
-
   public static URI getUploadSegmentHttpsURI(String host, int port)
       throws URISyntaxException {
     return getURI(HTTPS, host, port, SEGMENT_PATH);
@@ -212,11 +201,6 @@ public class FileUploadDownloadClient implements Closeable {
   public static URI getUploadSegmentURI(URI controllerURI)
       throws URISyntaxException {
     return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(), SEGMENT_PATH);
-  }
-
-  public static URI getUploadSegmentMetadataURI(URI controllerURI)
-      throws URISyntaxException {
-    return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(), SEGMENT_METADATA_PATH);
   }
 
   private static HttpUriRequest getUploadFileRequest(String method, URI uri, ContentBody contentBody,

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
@@ -19,17 +19,28 @@
 package org.apache.pinot.plugin.ingestion.batch.common;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.TarGzCompressionUtils;
+import org.apache.pinot.core.segment.creator.impl.V1Constants;
+import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.ingestion.batch.spec.Constants;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
@@ -175,6 +186,114 @@ public class SegmentPushUtils implements Serializable {
           }
         });
       }
+    }
+  }
+
+  public static void sendSegmentUriToTarPathMap(SegmentGenerationJobSpec spec, PinotFS fileSystem, Map<String, String> segmentUriToTarPathMap)
+      throws Exception {
+    String tableName = spec.getTableSpec().getTableName();
+    LOGGER.info("Start pushing segments: {}... to locations: {} for table {}",
+        Arrays.toString(segmentUriToTarPathMap.entrySet().toArray()),
+        Arrays.toString(spec.getPinotClusterSpecs()), tableName);
+    for (String segmentUriPath : segmentUriToTarPathMap.keySet()) {
+      String tarFilePath = segmentUriToTarPathMap.get(segmentUriPath);
+      URI tarFileURI = URI.create(tarFilePath);
+      File segmentMetadataFile = getSegmentMetadataZipFile(fileSystem, tarFileURI);
+      File tarFile = new File(tarFilePath);
+      String fileName = tarFile.getName();
+      Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
+      String segmentName = fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length());
+      for (PinotClusterSpec pinotClusterSpec : spec.getPinotClusterSpecs()) {
+        URI controllerURI;
+        try {
+          controllerURI = new URI(pinotClusterSpec.getControllerURI());
+        } catch (URISyntaxException e) {
+          throw new RuntimeException("Got invalid controller uri - '" + pinotClusterSpec.getControllerURI() + "'");
+        }
+        LOGGER.info("Pushing segment: {} to location: {} for table {}", segmentName, controllerURI, tableName);
+        int attempts = 1;
+        if (spec.getPushJobSpec() != null && spec.getPushJobSpec().getPushAttempts() > 0) {
+          attempts = spec.getPushJobSpec().getPushAttempts();
+        }
+        long retryWaitMs = 1000L;
+        if (spec.getPushJobSpec() != null && spec.getPushJobSpec().getPushRetryIntervalMillis() > 0) {
+          retryWaitMs = spec.getPushJobSpec().getPushRetryIntervalMillis();
+        }
+        RetryPolicies.exponentialBackoffRetryPolicy(attempts, retryWaitMs, 5).attempt(() -> {
+          try {
+            List<Header> headers = ImmutableList
+                .of(new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentUriPath));
+            // Add table name as a request parameter
+            NameValuePair
+                tableNameValuePair = new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME,
+                tableName);
+            List<NameValuePair> parameters = Arrays.asList(tableNameValuePair);
+            SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT.uploadSegmentMetadata(
+                FileUploadDownloadClient.getUploadSegmentMetadataURI(controllerURI), segmentName, segmentMetadataFile, headers,
+                parameters, FILE_UPLOAD_DOWNLOAD_CLIENT.DEFAULT_SOCKET_TIMEOUT_MS);
+            LOGGER.info("Response for pushing table {} segment {} to location {} - {}: {}", tableName, segmentName,
+                controllerURI, response.getStatusCode(), response.getResponse());
+            return true;
+          } catch (HttpErrorStatusException e) {
+            int statusCode = e.getStatusCode();
+            if (statusCode >= 500) {
+              // Temporary exception
+              LOGGER.warn("Caught temporary exception while pushing table: {} segment: {} to {}, will retry", tableName,
+                  segmentName, controllerURI, e);
+              return false;
+            } else {
+              // Permanent exception
+              LOGGER
+                  .error("Caught permanent exception while pushing table: {} segment: {} to {}, won't retry", tableName,
+                      segmentName, controllerURI, e);
+              throw e;
+            }
+          }
+        });
+      }
+    }
+  }
+
+  public static Map<String, String> getSegmentUriToTarPathMap(URI outputDirURI, String uriPrefix, String uriSuffix, String[] files) {
+    Map<String, String> segmentUriToTarPathMap = new HashMap<>();
+    for (String file : files) {
+      URI uri = URI.create(file);
+      if (uri.getPath().endsWith(Constants.TAR_GZ_FILE_EXT)) {
+        URI updatedURI = SegmentPushUtils.generateSegmentTarURI(outputDirURI, uri, uriPrefix,uriSuffix);
+        segmentUriToTarPathMap.put(updatedURI.toString(), file);
+      }
+    }
+    return segmentUriToTarPathMap;
+  }
+
+  private static File getSegmentMetadataZipFile(PinotFS fileSystem, URI tarFileURI)
+      throws Exception {
+    long currentTime = System.nanoTime();
+    File tarFile = new File("segmentTar-" + currentTime + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION).getAbsoluteFile();
+    try {
+      fileSystem.copyToLocalFile(tarFileURI, tarFile);
+      File segmentMetadataDir = new File("segmentMetadataDir-" + currentTime).getAbsoluteFile();
+      if (segmentMetadataDir.exists()) {
+        FileUtils.forceDelete(segmentMetadataDir);
+      }
+      FileUtils.forceMkdir(segmentMetadataDir);
+
+      // Extract metadata.properties
+      LOGGER.info("Trying to untar Metadata file from: [{}] to [{}]", tarFile, segmentMetadataDir);
+      TarGzCompressionUtils.untarOneFile(tarFile, V1Constants.MetadataKeys.METADATA_FILE_NAME,
+          new File(segmentMetadataDir, V1Constants.MetadataKeys.METADATA_FILE_NAME));
+
+      // Extract creation.meta
+      LOGGER.info("Trying to untar CreationMeta file from: [{}] to [{}]", tarFile, segmentMetadataDir);
+      TarGzCompressionUtils.untarOneFile(tarFile, V1Constants.SEGMENT_CREATION_META,
+          new File(segmentMetadataDir, V1Constants.SEGMENT_CREATION_META));
+
+      File segmentMetadataFile = new File("segmentMetadataFile-" + currentTime + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+      LOGGER.info("Trying to tar segment metadata dir [{}] to [{}]", segmentMetadataDir, segmentMetadataFile);
+      TarGzCompressionUtils.createTarGzFile(segmentMetadataDir, segmentMetadataFile);
+      return segmentMetadataFile;
+    } finally {
+      FileUtils.deleteQuietly(tarFile);
     }
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentMetadataPushJobRunner.java
@@ -96,7 +96,7 @@ public class HadoopSegmentMetadataPushJobRunner implements IngestionJobRunner, S
           .getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec().getSegmentUriPrefix(),
               _spec.getPushJobSpec().getSegmentUriSuffix(), segmentsToPush.toArray(new String[0]));
       SegmentPushUtils
-          .sendSegmentUriToTarPathMap(_spec, PinotFSFactory.create(outputDirURI.getScheme()), segmentUriToTarPathMap);
+          .sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(outputDirURI.getScheme()), segmentUriToTarPathMap);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentMetadataPushJobRunner.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.ingestion.batch.hadoop;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.plugin.ingestion.batch.common.SegmentPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
+import org.apache.pinot.spi.ingestion.batch.spec.Constants;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+
+
+public class HadoopSegmentMetadataPushJobRunner implements IngestionJobRunner, Serializable {
+  private SegmentGenerationJobSpec _spec;
+
+  public HadoopSegmentMetadataPushJobRunner() {
+  }
+
+  public HadoopSegmentMetadataPushJobRunner(SegmentGenerationJobSpec spec) {
+    init(spec);
+  }
+
+  @Override
+  public void init(SegmentGenerationJobSpec spec) {
+    _spec = spec;
+  }
+
+  @Override
+  public void run() {
+    //init all file systems
+    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
+    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+    }
+
+    //Get outputFS for writing output pinot segments
+    URI outputDirURI;
+    try {
+      outputDirURI = new URI(_spec.getOutputDirURI());
+      if (outputDirURI.getScheme() == null) {
+        outputDirURI = new File(_spec.getOutputDirURI()).toURI();
+      }
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("outputDirURI is not valid - '" + _spec.getOutputDirURI() + "'");
+    }
+    PinotFS outputDirFS = PinotFSFactory.create(outputDirURI.getScheme());
+    //Get list of files to process
+    String[] files;
+    try {
+      files = outputDirFS.listFiles(outputDirURI, true);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to list all files under outputDirURI - '" + outputDirURI + "'");
+    }
+
+    List<String> segmentsToPush = new ArrayList<>();
+    for (String file : files) {
+      if (file.endsWith(Constants.TAR_GZ_FILE_EXT)) {
+        segmentsToPush.add(file);
+      }
+    }
+
+    int pushParallelism = _spec.getPushJobSpec().getPushParallelism();
+    if (pushParallelism < 1) {
+      pushParallelism = segmentsToPush.size();
+    }
+    // Push from driver
+
+    try {
+      Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
+          .getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec().getSegmentUriPrefix(),
+              _spec.getPushJobSpec().getSegmentUriSuffix(), segmentsToPush.toArray(new String[0]));
+      SegmentPushUtils
+          .sendSegmentUriToTarPathMap(_spec, PinotFSFactory.create(outputDirURI.getScheme()), segmentUriToTarPathMap);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentMetadataPushJobRunner.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.ingestion.batch.spark;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.plugin.ingestion.batch.common.SegmentPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
+import org.apache.pinot.spi.ingestion.batch.spec.Constants;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
+import org.apache.pinot.spi.utils.retry.RetriableOperationException;
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.VoidFunction;
+
+
+public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Serializable {
+  private SegmentGenerationJobSpec _spec;
+
+  public SparkSegmentMetadataPushJobRunner() {
+  }
+
+  public SparkSegmentMetadataPushJobRunner(SegmentGenerationJobSpec spec) {
+    init(spec);
+  }
+
+  @Override
+  public void init(SegmentGenerationJobSpec spec) {
+    _spec = spec;
+  }
+
+  @Override
+  public void run() {
+    //init all file systems
+    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
+    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+    }
+
+    //Get outputFS for writing output pinot segments
+    URI outputDirURI;
+    try {
+      outputDirURI = new URI(_spec.getOutputDirURI());
+      if (outputDirURI.getScheme() == null) {
+        outputDirURI = new File(_spec.getOutputDirURI()).toURI();
+      }
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("outputDirURI is not valid - '" + _spec.getOutputDirURI() + "'");
+    }
+    PinotFS outputDirFS = PinotFSFactory.create(outputDirURI.getScheme());
+    //Get list of files to process
+    String[] files;
+    try {
+      files = outputDirFS.listFiles(outputDirURI, true);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to list all files under outputDirURI - '" + outputDirURI + "'");
+    }
+
+    List<String> segmentsToPush = new ArrayList<>();
+    for (String file : files) {
+      if (file.endsWith(Constants.TAR_GZ_FILE_EXT)) {
+        segmentsToPush.add(file);
+      }
+    }
+
+    int pushParallelism = _spec.getPushJobSpec().getPushParallelism();
+    if (pushParallelism < 1) {
+      pushParallelism = segmentsToPush.size();
+    }
+    if (pushParallelism == 1) {
+      // Push from driver
+      try {
+        SegmentPushUtils.pushSegments(_spec, outputDirFS, segmentsToPush);
+      } catch (RetriableOperationException | AttemptsExceededException e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(SparkContext.getOrCreate());
+      JavaRDD<String> pathRDD = sparkContext.parallelize(segmentsToPush, pushParallelism);
+      URI finalOutputDirURI = outputDirURI;
+      // Prevent using lambda expression in Spark to avoid potential serialization exceptions, use inner function instead.
+      pathRDD.foreach(new VoidFunction<String>() {
+        @Override
+        public void call(String segmentTarPath)
+            throws Exception {
+          for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
+            PinotFSFactory
+                .register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+          }
+          try {
+            Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
+                .getSegmentUriToTarPathMap(finalOutputDirURI, _spec.getPushJobSpec().getSegmentUriPrefix(),
+                    _spec.getPushJobSpec().getSegmentUriSuffix(), new String[]{segmentTarPath});
+            SegmentPushUtils.sendSegmentUriToTarPathMap(_spec, PinotFSFactory.create(finalOutputDirURI.getScheme()),
+                segmentUriToTarPathMap);
+          } catch (RetriableOperationException | AttemptsExceededException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+    }
+  }
+}

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentMetadataPushJobRunner.java
@@ -119,7 +119,7 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
             Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
                 .getSegmentUriToTarPathMap(finalOutputDirURI, _spec.getPushJobSpec().getSegmentUriPrefix(),
                     _spec.getPushJobSpec().getSegmentUriSuffix(), new String[]{segmentTarPath});
-            SegmentPushUtils.sendSegmentUriToTarPathMap(_spec, PinotFSFactory.create(finalOutputDirURI.getScheme()),
+            SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(finalOutputDirURI.getScheme()),
                 segmentUriToTarPathMap);
           } catch (RetriableOperationException | AttemptsExceededException e) {
             throw new RuntimeException(e);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/resources/segmentCreationAndMetadataPushJobSpec.yaml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/resources/segmentCreationAndMetadataPushJobSpec.yaml
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+executionFrameworkSpec:
+  name: 'spark'
+  segmentGenerationJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentGenerationJobRunner'
+  segmentTarPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentTarPushJobRunner'
+  segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentUriPushJobRunner'
+  segmentMetadataPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentMetadataPushJobRunner'
+jobType: SegmentCreationAndMetadataPush
+inputDirURI: 'file:///path/to/input'
+includeFileNamePattern: 'glob:**/*.parquet'
+excludeFileNamePattern: 'glob:**/*.avro'
+outputDirURI: 'file:///path/to/output'
+overwriteOutput: true
+pinotFSSpecs:
+  - scheme: file
+    className: org.apache.pinot.spi.filesystem.LocalPinotFS
+recordReaderSpec:
+  dataFormat: 'parquet'
+  className: 'org.apache.pinot.parquet.data.readers.ParquetRecordReader'
+tableSpec:
+  tableName: 'myTable'
+  schemaURI: 'http://localhost:9000/tables/myTable/schema'
+  tableConfigURI: 'http://localhost:9000/tables/myTable'
+pinotClusterSpecs:
+  - controllerURI: 'localhost:9000'
+pushJobSpec:
+
+  # pushParallelism: push job parallelism, default is 1.
+  pushParallelism: 2
+
+  # pushAttempts: number of attempts for push job, default is 1, which means no retry.
+  pushAttempts: 2
+
+  # pushRetryIntervalMillis: retry wait Ms, default to 1 second.
+  pushRetryIntervalMillis: 1000

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
@@ -83,7 +83,7 @@ public class SegmentMetadataPushJobRunner implements IngestionJobRunner {
         .getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec().getSegmentUriPrefix(),
             _spec.getPushJobSpec().getSegmentUriSuffix(), files);
     try {
-      SegmentPushUtils.sendSegmentUriToTarPathMap(_spec, outputDirFS, segmentUriToTarPathMap);
+      SegmentPushUtils.sendSegmentUriAndMetadata(_spec, outputDirFS, segmentUriToTarPathMap);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.ingestion.batch.standalone;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.plugin.ingestion.batch.common.SegmentPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+
+
+public class SegmentMetadataPushJobRunner implements IngestionJobRunner {
+
+  private SegmentGenerationJobSpec _spec;
+
+  public SegmentMetadataPushJobRunner() {
+  }
+
+  public SegmentMetadataPushJobRunner(SegmentGenerationJobSpec spec) {
+    init(spec);
+  }
+
+  @Override
+  public void init(SegmentGenerationJobSpec spec) {
+    _spec = spec;
+    if (_spec.getPushJobSpec() == null) {
+      throw new RuntimeException("Missing PushJobSpec");
+    }
+  }
+
+  @Override
+  public void run() {
+    //init all file systems
+    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
+    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+    }
+
+    //Get outputFS for writing output Pinot segments
+    URI outputDirURI;
+    try {
+      outputDirURI = new URI(_spec.getOutputDirURI());
+      if (outputDirURI.getScheme() == null) {
+        outputDirURI = new File(_spec.getOutputDirURI()).toURI();
+      }
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("outputDirURI is not valid - '" + _spec.getOutputDirURI() + "'");
+    }
+    PinotFS outputDirFS = PinotFSFactory.create(outputDirURI.getScheme());
+
+    //Get list of files to process
+    String[] files;
+    try {
+      files = outputDirFS.listFiles(outputDirURI, true);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to list all files under outputDirURI - '" + outputDirURI + "'");
+    }
+    Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
+        .getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec().getSegmentUriPrefix(),
+            _spec.getPushJobSpec().getSegmentUriSuffix(), files);
+    try {
+      SegmentPushUtils.sendSegmentUriToTarPathMap(_spec, outputDirFS, segmentUriToTarPathMap);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
@@ -106,6 +106,9 @@ public class IngestionJobLauncher {
       case SegmentUriPush:
         kickoffIngestionJob(spec, executionFramework.getSegmentUriPushJobRunnerClassName());
         break;
+      case SegmentMetadataPush:
+        kickoffIngestionJob(spec, executionFramework.getSegmentMetadataPushJobRunnerClassName());
+        break;
       case SegmentCreationAndTarPush:
         kickoffIngestionJob(spec, executionFramework.getSegmentGenerationJobRunnerClassName());
         kickoffIngestionJob(spec, executionFramework.getSegmentTarPushJobRunnerClassName());
@@ -113,6 +116,10 @@ public class IngestionJobLauncher {
       case SegmentCreationAndUriPush:
         kickoffIngestionJob(spec, executionFramework.getSegmentGenerationJobRunnerClassName());
         kickoffIngestionJob(spec, executionFramework.getSegmentUriPushJobRunnerClassName());
+        break;
+      case SegmentCreationAndMetadataPush:
+        kickoffIngestionJob(spec, executionFramework.getSegmentGenerationJobRunnerClassName());
+        kickoffIngestionJob(spec, executionFramework.getSegmentMetadataPushJobRunnerClassName());
         break;
       default:
         LOGGER.error("Unsupported job type - {}. Support job types: {}", spec.getJobType(),
@@ -139,6 +146,6 @@ public class IngestionJobLauncher {
   }
 
   enum PinotIngestionJobType {
-    SegmentCreation, SegmentTarPush, SegmentUriPush, SegmentCreationAndTarPush, SegmentCreationAndUriPush,
+    SegmentCreation, SegmentTarPush, SegmentUriPush, SegmentMetadataPush, SegmentCreationAndTarPush, SegmentCreationAndUriPush, SegmentCreationAndMetadataPush,
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/runner/IngestionJobRunner.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/runner/IngestionJobRunner.java
@@ -28,6 +28,7 @@ import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
  *    SegmentGenerationJobRunner
  *    SegmentTarPushJobRunner
  *    SegmentUriPushJobRunner
+ *    SegmentMetadataPushJobRunner
  *
  */
 public interface IngestionJobRunner {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/ExecutionFrameworkSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/ExecutionFrameworkSpec.java
@@ -32,19 +32,24 @@ public class ExecutionFrameworkSpec implements Serializable {
   private String _name;
 
   /**
-   * The class implements org.apache.pinot.spi.batch.ingestion.runner.SegmentGenerationJobRunner interface.
+   * The class implements org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner interface.
    */
   private String _segmentGenerationJobRunnerClassName;
 
   /**
-   * The class implements org.apache.pinot.spi.batch.ingestion.runner.SegmentTarPushJobRunner interface.
+   * The class implements org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner interface.
    */
   private String _segmentTarPushJobRunnerClassName;
 
   /**
-   * The class implements org.apache.pinot.spi.batch.ingestion.runner.SegmentUriPushJobRunner interface.
+   * The class implements org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner interface.
    */
   private String _segmentUriPushJobRunnerClassName;
+
+  /**
+   * The class implements org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner interface.
+   */
+  private String _segmentMetadataPushJobRunnerClassName;
 
   /**
    * Extra configs for execution framework.
@@ -89,5 +94,13 @@ public class ExecutionFrameworkSpec implements Serializable {
 
   public void setExtraConfigs(Map<String, String> extraConfigs) {
     _extraConfigs = extraConfigs;
+  }
+
+  public String getSegmentMetadataPushJobRunnerClassName() {
+    return _segmentMetadataPushJobRunnerClassName;
+  }
+
+  public void setSegmentMetadataPushJobRunnerClassName(String segmentMetadataPushJobRunnerClassName) {
+    _segmentMetadataPushJobRunnerClassName = segmentMetadataPushJobRunnerClassName;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -38,8 +38,10 @@ public class SegmentGenerationJobSpec implements Serializable {
    *  'SegmentCreation'
    *  'SegmentTarPush'
    *  'SegmentUriPush'
+   *  'SegmentMetadataPush'
    *  'SegmentCreationAndTarPush'
    *  'SegmentCreationAndUriPush'
+   *  'SegmentCreationAndMetadataPush'
    */
   private String _jobType;
 


### PR DESCRIPTION
## Description
- Add new FileUploadType `METADATA`
- Add `/segments/metadata` endpoint to upload segment with METADATA only mode.
- Add new pinot push job types: SegmentMetadataPush and SegmentCreationAndMetadataPush
- This job will upload pinot segment metadata along with download URI to bypass controller downloading segment code path.
