### PR TITLE
Set localhost as the base url in ControllerAdminApiApplication

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -152,15 +152,12 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     beanConfig.setBasePath("/");
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
-    try {
-      Collection<NetworkListener> listeners = httpServer.getListeners();
-      if (listeners.size() > 0) {
-        // fetch the port from the first listener which uses http
-        int port = listeners.iterator().next().getPort();
-        beanConfig.setHost(InetAddress.getLocalHost().getHostName() + ":" + port);
-      }
-    } catch (UnknownHostException e) {
-      throw new RuntimeException("Cannot get localhost name");
+
+    Collection<NetworkListener> listeners = httpServer.getListeners();
+    if (listeners.size() > 0) {
+      // fetch the port from the first listener which uses http
+      int port = listeners.iterator().next().getPort();
+      beanConfig.setHost("localhost:" + port);
     }
 
     ClassLoader loader = this.getClass().getClassLoader();


### PR DESCRIPTION
## Description
This PR sets localhost as the base url in ControllerAdminApiApplication. And localhost is the default base url in the previous swagger-ui version.
This base url will be used to send requests to the controller hosting this webpage.