### PR TITLE
[TE] Adding Holiday Events in helm chart

### DIFF
--- a/kubernetes/helm/thirdeye/README.md
+++ b/kubernetes/helm/thirdeye/README.md
@@ -71,3 +71,12 @@ Alternatively a YAML file that specifies the values for the parameters can be pr
 ```bash
 ./install.sh --name thirdeye -f values.yaml .
 ```
+
+## Holiday Events
+
+ThirdEye allows you to display events from external Google Calendars. To enable this feature, 
+simply provide a JSON key. Check https://docs.simplecalendar.io/google-api-key/
+
+```bash
+./install.sh  --set-file backend.holidayLoaderKey="/path/to/holiday-loader-key.json"
+```

--- a/kubernetes/helm/thirdeye/templates/backend/deployment.yaml
+++ b/kubernetes/helm/thirdeye/templates/backend/deployment.yaml
@@ -87,6 +87,12 @@ spec:
             mountPath: "/opt/thirdeye/config/pinot-quickstart/persistence.yml"
             subPath: "persistence.yml"
             readOnly: true
+          {{- if .Values.backend.holidayLoaderKey }}
+          - name: thirdeye-config
+            mountPath: "/opt/thirdeye/config/pinot-quickstart/holiday-loader-key.json"
+            subPath: "holiday-loader-key.json"
+            readOnly: true
+          {{- end }}
         resources:
 {{ toYaml .Values.frontend.resources | indent 12 }}
       restartPolicy: Always

--- a/kubernetes/helm/thirdeye/templates/common/configmap.yaml
+++ b/kubernetes/helm/thirdeye/templates/common/configmap.yaml
@@ -95,7 +95,7 @@ data:
     #   runFrequency: 10s
 
     classifier: true
-    holidayEventsLoader: true
+    holidayEventsLoader: {{ not .Values.backend.holidayLoaderKey | ternary "false" "true" }}
     monitor: true
     pinotProxy: false
     scheduler: true
@@ -163,6 +163,7 @@ data:
     mockEventsLoader: true
     mockEventsLoaderConfiguration:
       generators:
+        {{- if not .Values.backend.holidayLoaderKey }}
         - type: HOLIDAY
           arrivalType: exponential
           arrivalMean: 86400000
@@ -171,6 +172,7 @@ data:
           seed: 0
           namePrefixes: [First, Second, Third, Last, Funky, Happy, Sad, Glorious, Jolly, Unity, Pinot's]
           nameSuffixes: [day, day, days, celebration, rememberance, occurrence, moment]
+        {{- end }}
         - type: INFORMED
           arrivalType: exponential
           arrivalMean: 43200000
@@ -250,3 +252,7 @@ data:
             trustStoreFilePath: 'trust/store/path/truststore_file' # e.g. '/etc/riddler/cacerts'
             trustStorePassword: ''
         # add your store of choice here
+
+  {{- if .Values.backend.holidayLoaderKey }}
+  holiday-loader-key.json: {{ .Values.backend.holidayLoaderKey | toPrettyJson }}
+  {{- end }}


### PR DESCRIPTION
ThirdEye allows you to display events from external Google Calendars. To enable this feature,
simply provide a JSON key. Check https://docs.simplecalendar.io/google-api-key/

Exposed a command line parameter at installation to add holiday events.

```bash
./install.sh  --set-file backend.holidayLoaderKey="/path/to/holiday-loader-key.json"
```