### PR TITLE
[TE] Add ingress, traefik to helm chart

### DIFF
--- a/kubernetes/helm/thirdeye/templates/_helpers.tpl
+++ b/kubernetes/helm/thirdeye/templates/_helpers.tpl
@@ -115,3 +115,17 @@ The name of the thirdeye scheduler (backend with special detector.yml) headless 
 {{- define "thirdeye.scheduler.headless" -}}
 {{- printf "%s-headless" (include "thirdeye.scheduler.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+  Create a default fully qualified traefik name.
+  We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "thirdeye.traefik.fullname" -}}
+{{-   if .Values.traefik.fullnameOverride -}}
+{{-     .Values.traefik.fullnameOverride | trunc -63 | trimSuffix "-" -}}
+{{-   else -}}
+{{-     $name := default "traefik" .Values.traefik.nameOverride -}}
+{{-     printf "%s-%s" .Release.Name $name | trunc -63 | trimSuffix "-" -}}
+{{-    end -}}
+{{- end -}}
+

--- a/kubernetes/helm/thirdeye/templates/frontend/ingress.yaml
+++ b/kubernetes/helm/thirdeye/templates/frontend/ingress.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.traefik.enabled -}}
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ printf "%s-%s" (include "thirdeye.traefik.fullname" . ) "thirdeye" | trunc -63 }}
+spec:
+  rules:
+  - host: {{ .Release.Name }}.{{ .Release.Namespace }}.{{ required "domain is required." .Values.domain }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ include "thirdeye.frontend.headless" . }}
+          servicePort: {{ .Values.frontend.port }}
+{{- end }}

--- a/kubernetes/helm/thirdeye/values.yaml
+++ b/kubernetes/helm/thirdeye/values.yaml
@@ -68,3 +68,7 @@ persistence:
   accessMode: ReadWriteOnce
   size: 4G
   storageClass: ""
+
+# Optional: Enable for ingress
+traefik:
+  enabled: false


### PR DESCRIPTION
This change was previously reverted. However, turns out that this provides the user more flexibility in installation.

Changes
- Added an (conditional) ingress
- Added traefik switch
