### PR TITLE
upgrade to java 11

### DIFF
--- a/docker/images/pinot/Dockerfile
+++ b/docker/images/pinot/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM openjdk:8 AS pinot_build_env
+FROM openjdk:11 AS pinot_build_env
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
@@ -59,7 +59,7 @@ RUN git clone ${PINOT_GIT_URL} ${PINOT_BUILD_DIR} && \
     cp -r pinot-distribution/target/apache-pinot-*-bin/apache-pinot-*-bin/* ${PINOT_HOME}/. && \
     chmod +x ${PINOT_HOME}/bin/*.sh
 
-FROM openjdk:8-jdk-slim
+FROM openjdk:11-jdk-slim
 
 LABEL MAINTAINER=dev@pinot.apache.org
 

--- a/docker/images/pinot/Dockerfile
+++ b/docker/images/pinot/Dockerfile
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-FROM openjdk:11 AS pinot_build_env
+ARG JAVA_VERSION=8
+FROM openjdk:${JAVA_VERSION} AS pinot_build_env
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
@@ -59,7 +59,7 @@ RUN git clone ${PINOT_GIT_URL} ${PINOT_BUILD_DIR} && \
     cp -r pinot-distribution/target/apache-pinot-*-bin/apache-pinot-*-bin/* ${PINOT_HOME}/. && \
     chmod +x ${PINOT_HOME}/bin/*.sh
 
-FROM openjdk:11-jdk-slim
+FROM openjdk:${JAVA_VERSION}-jdk-slim
 
 LABEL MAINTAINER=dev@pinot.apache.org
 

--- a/docker/images/pinot/README.md
+++ b/docker/images/pinot/README.md
@@ -29,7 +29,7 @@ There is a docker build script which will build a given Git repo/branch and tag 
 Usage:
 
 ```SHELL
-./docker-build.sh [Docker Tag] [Git Branch] [Pinot Git URL]
+./docker-build.sh [Docker Tag] [Git Branch] [Pinot Git URL] [Kafka Version] [Java Version]
 ```
 
 This script will check out Pinot Repo `[Pinot Git URL]` on branch `[Git Branch]` and build the docker image for that.
@@ -41,6 +41,10 @@ The docker image is tagged as `[Docker Tag]`.
 `Git Branch`: The Pinot branch to build. Default is `master`.
 
 `Pinot Git URL`: The Pinot Git Repo to build, users can set it to their own fork. Please note that, the URL is `https://` based, not `git://`. Default is the Apache Repo: `https://github.com/apache/incubator-pinot.git`.
+
+`Kafka Version`: The Kafka Version to build pinot with. Default is `2.0`
+
+`Java Version`: The Java Version to build pinot with. Default is `8`
 
 * Example of building and tagging a snapshot on your own fork:
 ```SHELL

--- a/docker/images/pinot/docker-build.sh
+++ b/docker/images/pinot/docker-build.sh
@@ -49,6 +49,13 @@ else
   KAFKA_VERSION=2.0
 fi
 
-echo "Trying to build Pinot docker image from Git URL: [ ${PINOT_GIT_URL} ] on branch: [ ${PINOT_BRANCH} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]."
+if [[ "$#" -gt 4 ]]
+then
+  JAVA_VERSION=$4
+else
+  JAVA_VERSION=8
+fi
 
-docker build --no-cache -t ${DOCKER_TAG} --build-arg PINOT_BRANCH=${PINOT_BRANCH} --build-arg PINOT_GIT_URL=${PINOT_GIT_URL} --build-arg KAFKA_VERSION=${KAFKA_VERSION} -f Dockerfile .
+echo "Trying to build Pinot docker image from Git URL: [ ${PINOT_GIT_URL} ] on branch: [ ${PINOT_BRANCH} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]. Java Version: [ ${JAVA_VERSION} ]."
+
+docker build --no-cache -t ${DOCKER_TAG} --build-arg PINOT_BRANCH=${PINOT_BRANCH} --build-arg PINOT_GIT_URL=${PINOT_GIT_URL} --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg JAVA_VERSION=${JAVA_VERSION} -f Dockerfile .


### PR DESCRIPTION
## Description
Refers #5982 
Upgrades Pinot's default docker image from java 8 to 11
