### PR TITLE
Fetch Brokers From Controller in JDBC

### DIFF
--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -63,7 +63,6 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-java-client</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnectionMetaData.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnectionMetaData.java
@@ -20,13 +20,10 @@ package org.apache.pinot.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
-import java.sql.RowIdLifetime;
 import java.sql.SQLException;
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
@@ -39,6 +39,7 @@ public class PinotDriver implements Driver {
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(PinotDriver.class);
   private final String SCHEME = "pinot";
   public static final String TENANT = "tenant";
+  public static final String DEFAULT_TENANT = "DefaultTenant";
 
   @Override
   public Connection connect(String url, Properties info)
@@ -47,8 +48,7 @@ public class PinotDriver implements Driver {
       LOGGER.info("Initiating connection to database for url: " + url);
       PinotClientTransport pinotClientTransport = new JsonAsyncHttpPinotClientTransportFactory().buildTransport();
       String controllerUrl = DriverUtils.getControllerFromURL(url);
-      Preconditions.checkArgument(info.containsKey(TENANT), "Pinot tenant missing in the properties");
-      String tenant = info.getProperty(TENANT);
+      String tenant = info.getProperty(TENANT, DEFAULT_TENANT);
       return new PinotConnection(controllerUrl, pinotClientTransport, tenant);
     } catch (Exception e) {
       throw new SQLException(String.format("Failed to connect to url : %s", url), e);

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
@@ -85,7 +85,7 @@ public class PinotControllerTransport {
 
   public ControllerTenantBrokerResponse getBrokersFromController(String controllerAddress, String tenant) {
     try {
-      String url = "http://" + controllerAddress + "/brokers/tenants/" + tenant;
+      String url = "http://" + controllerAddress + "/v2/brokers/tenants/" + tenant;
       AsyncHttpClient.BoundRequestBuilder requestBuilder = _httpClient.prepareGet(url);
       if (_headers != null) {
         _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
@@ -20,22 +20,21 @@ package org.apache.pinot.client.controller;
 
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.Response;
-import java.util.HashMap;
-import java.util.List;
+
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+
 import org.apache.pinot.client.PinotClientException;
+import org.apache.pinot.client.controller.response.ControllerTenantBrokerResponse;
 import org.apache.pinot.client.controller.response.SchemaResponse;
-import org.apache.pinot.client.controller.response.SchemaResponse.SchemaResponseFuture;
 import org.apache.pinot.client.controller.response.TableResponse;
-import org.apache.pinot.client.controller.response.TableResponse.TableResponseFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 public class PinotControllerTransport {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotControllerTransport.class);
 
   AsyncHttpClient _httpClient = new AsyncHttpClient();
@@ -59,7 +58,7 @@ public class PinotControllerTransport {
       final Future<Response> response =
           requestBuilder.addHeader("Content-Type", "application/json; charset=utf-8").execute();
 
-      TableResponseFuture tableResponseFuture = new TableResponseFuture(response, url);
+      TableResponse.TableResponseFuture tableResponseFuture = new TableResponse.TableResponseFuture(response, url);
       return tableResponseFuture.get();
     } catch (ExecutionException e) {
       throw new PinotClientException(e);
@@ -77,8 +76,26 @@ public class PinotControllerTransport {
       final Future<Response> response =
           requestBuilder.addHeader("Content-Type", "application/json; charset=utf-8").execute();
 
-      SchemaResponseFuture schemaResponseFuture = new SchemaResponseFuture(response, url);
+      SchemaResponse.SchemaResponseFuture schemaResponseFuture = new SchemaResponse.SchemaResponseFuture(response, url);
       return schemaResponseFuture.get();
+    } catch (ExecutionException e) {
+      throw new PinotClientException(e);
+    }
+  }
+
+  public ControllerTenantBrokerResponse getBrokersFromController(String controllerAddress, String tenant) {
+    try {
+      String url = "http://" + controllerAddress + "/brokers/tenants/" + tenant;
+      AsyncHttpClient.BoundRequestBuilder requestBuilder = _httpClient.prepareGet(url);
+      if (_headers != null) {
+        _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));
+      }
+
+      final Future<Response> response =
+              requestBuilder.addHeader("Content-Type", "application/json; charset=utf-8").execute();
+
+      ControllerTenantBrokerResponse.ControllerTenantBrokerResponseFuture controllerTableBrokerResponseFuture = new ControllerTenantBrokerResponse.ControllerTenantBrokerResponseFuture(response, url);
+      return controllerTableBrokerResponseFuture.get();
     } catch (ExecutionException e) {
       throw new PinotClientException(e);
     }

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
@@ -56,9 +56,13 @@ public class ControllerTenantBrokerResponse {
     for (JsonNode broker : _brokers) {
       String hostName = broker.get("host").textValue();
       Integer port = broker.get("port").intValue();
-
-      String brokerHostPort = String.format("%s:%d", hostName, port);
-      brokerList.add(brokerHostPort);
+      String brokerIP = hostName;
+      if(hostName.contains("_")) {
+        String[] hostNamePart = hostName.split("_");
+        brokerIP = hostNamePart[hostNamePart.length - 1];
+      }
+      String brokerIPPort = String.format("%s:%d", brokerIP, port);
+      brokerList.add(brokerIPPort);
     }
 
     return brokerList;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.client.controller.response;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
@@ -54,11 +54,10 @@ public class ControllerTenantBrokerResponse {
     List<String> brokerList = new ArrayList<>();
 
     for (JsonNode broker : _brokers) {
-      String[] brokerPath = broker.textValue().split("_");
-      if(brokerPath.length < 3){
-        throw new RuntimeException("Invalid Broker Name found in controller: " + broker.textValue());
-      }
-      String brokerHostPort = String.format("%s:%s", brokerPath[1], brokerPath[2]);
+      String hostName = broker.get("host").textValue();
+      Integer port = broker.get("port").intValue();
+
+      String brokerHostPort = String.format("%s:%d", hostName, port);
       brokerList.add(brokerHostPort);
     }
 

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -70,14 +70,8 @@ public class DriverUtils {
       url = url.substring(5);
     }
     URI uri = URI.create(url);
-    String[] params = uri.getRawQuery().split(QUERY_SEPERATOR);
-    for (String param : params) {
-      String[] query = param.split(PARAM_SEPERATOR);
-      if (query[0].toLowerCase().contentEquals(CONTROLLER)) {
-        return query[1];
-      }
-    }
-    return null;
+    String controllerUrl = String.format("%s:%d", uri.getHost(), uri.getPort());
+    return controllerUrl;
   }
 
   public static Integer getSQLDataType(String columnDataType) {

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/DummyPinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/DummyPinotControllerTransport.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.client;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/DummyPinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/DummyPinotControllerTransport.java
@@ -29,7 +29,7 @@ public class DummyPinotControllerTransport extends PinotControllerTransport {
   @Override
   public ControllerTenantBrokerResponse getBrokersFromController(String controllerAddress, String tenant) {
     try {
-      String jsonString = "[\"dummy\"]";
+      String jsonString = "[{\"instanceName\": \"dummy\", \"host\" : \"dummy\", \"port\" : 8000}]";
       ObjectMapper objectMapper = new ObjectMapper();
       JsonNode dummyBrokerJsonResponse = objectMapper.readTree(jsonString);
       return ControllerTenantBrokerResponse.fromJson(dummyBrokerJsonResponse);

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/DummyPinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/DummyPinotControllerTransport.java
@@ -1,0 +1,23 @@
+package org.apache.pinot.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.pinot.client.controller.PinotControllerTransport;
+import org.apache.pinot.client.controller.response.ControllerTenantBrokerResponse;
+
+
+public class DummyPinotControllerTransport extends PinotControllerTransport {
+
+  @Override
+  public ControllerTenantBrokerResponse getBrokersFromController(String controllerAddress, String tenant) {
+    try {
+      String jsonString = "[\"dummy\"]";
+      ObjectMapper objectMapper = new ObjectMapper();
+      JsonNode dummyBrokerJsonResponse = objectMapper.readTree(jsonString);
+      return ControllerTenantBrokerResponse.fromJson(dummyBrokerJsonResponse);
+    } catch (Exception e) {
+
+    }
+    return ControllerTenantBrokerResponse.empty();
+  }
+}

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotConnectionTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotConnectionTest.java
@@ -29,11 +29,13 @@ import org.testng.annotations.Test;
 public class PinotConnectionTest {
   private DummyPinotClientTransport
       _dummyPinotClientTransport = new DummyPinotClientTransport();
+
+  private DummyPinotControllerTransport _dummyPinotControllerTransport = new DummyPinotControllerTransport();
   private PinotClientTransportFactory _previousTransportFactory = null;
 
   @Test
   public void createStatementTest() throws Exception {
-    PinotConnection pinotConnection  = new PinotConnection(Collections.singletonList("dummy"), _dummyPinotClientTransport);
+    PinotConnection pinotConnection  = new PinotConnection("dummy", _dummyPinotClientTransport, "dummy" ,_dummyPinotControllerTransport);
     Statement statement = pinotConnection.createStatement();
     Assert.assertNotNull(statement);
   }

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
@@ -38,12 +38,13 @@ public class PinotPreparedStatementTest {
   public static final String DATE_QUERY = "SELECT * FROM dummy WHERE date = ? and updated_at = ? and created_at = ?";
   public static final String SINGLE_STRING_QUERY = "SELECT * FROM dummy WHERE value = ?";
   private DummyPinotClientTransport _dummyPinotClientTransport = new DummyPinotClientTransport();
+  private DummyPinotControllerTransport _dummyPinotControllerTransport = new DummyPinotControllerTransport();
   private PinotClientTransportFactory _previousTransportFactory = null;
 
   @Test
   public void testSetAndClearValues()
       throws Exception {
-    PinotConnection connection = new PinotConnection(Collections.singletonList("dummy"), _dummyPinotClientTransport);
+    PinotConnection connection = new PinotConnection("dummy", _dummyPinotClientTransport, "dummy" ,_dummyPinotControllerTransport);
     PreparedStatement preparedStatement = connection.prepareStatement(QUERY);
 
     preparedStatement.setString(1, "foo");
@@ -73,7 +74,7 @@ public class PinotPreparedStatementTest {
   @Test
   public void testSetDateTime()
       throws Exception {
-    PinotConnection connection = new PinotConnection(Collections.singletonList("dummy"), _dummyPinotClientTransport);
+    PinotConnection connection = new PinotConnection("dummy", _dummyPinotClientTransport, "dummy" ,_dummyPinotControllerTransport);
     PreparedStatement preparedStatement = connection.prepareStatement(DATE_QUERY);
 
     Long currentTimestamp = System.currentTimeMillis();
@@ -93,7 +94,7 @@ public class PinotPreparedStatementTest {
   @Test
   public void testSetAdditionalDataTypes()
       throws Exception {
-    PinotConnection connection = new PinotConnection(Collections.singletonList("dummy"), _dummyPinotClientTransport);
+    PinotConnection connection = new PinotConnection("dummy", _dummyPinotClientTransport, "dummy" ,_dummyPinotControllerTransport);
     PreparedStatement preparedStatement = connection.prepareStatement(SINGLE_STRING_QUERY);
 
     String value = "1234567891011121314151617181920";

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotStatementTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotStatementTest.java
@@ -30,13 +30,15 @@ import org.testng.annotations.Test;
 
 public class PinotStatementTest {
   private DummyPinotClientTransport _dummyPinotClientTransport = new DummyPinotClientTransport();
+  private DummyPinotControllerTransport _dummyPinotControllerTransport = new DummyPinotControllerTransport();
+
   private PinotClientTransportFactory _previousTransportFactory = null;
 
   @Test
   public void testExecuteQuery() throws Exception {
-    PinotConnection connection = new PinotConnection(Collections.singletonList("dummy"), _dummyPinotClientTransport);
+    PinotConnection connection = new PinotConnection("dummy", _dummyPinotClientTransport, "dummy" ,_dummyPinotControllerTransport);
     Statement statement = new PinotStatement(connection);
-    ResultSet resultSet = statement.executeQuery("dummy");
+    ResultSet resultSet = statement.executeQuery("select * from dummy");
     Assert.assertNotNull(resultSet);
     Assert.assertEquals(statement.getConnection(), connection);
   }


### PR DESCRIPTION
Currently, there is no mechanism in JDBC connector to use the correct broker to execute a query.
The PR fixes the issue by getting Tenant as property in the JDBC connector and fetching brokers from the controller.