### PR TITLE
Add null check while fetching the schema

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -274,14 +274,20 @@ public class ZKMetadataProvider {
     if (tableType == null || tableType == TableType.REALTIME) {
       TableConfig realtimeTableConfig = getRealtimeTableConfig(propertyStore, tableName);
       if (realtimeTableConfig != null) {
-        schema = getSchema(propertyStore, realtimeTableConfig.getValidationConfig().getSchemaName());
+        String realtimeSchemaNameFromValidationConfig = realtimeTableConfig.getValidationConfig().getSchemaName();
+        if (realtimeSchemaNameFromValidationConfig != null) {
+          schema = getSchema(propertyStore, realtimeSchemaNameFromValidationConfig);
+        }
       }
     }
     // Try to fetch offline schema if realtime schema does not exist
     if (schema == null && (tableType == null || tableType == TableType.OFFLINE)) {
       TableConfig offlineTableConfig = getOfflineTableConfig(propertyStore, tableName);
       if (offlineTableConfig != null) {
-        schema = getSchema(propertyStore, offlineTableConfig.getValidationConfig().getSchemaName());
+        String offlineSchemaNameFromValidationConfig = offlineTableConfig.getValidationConfig().getSchemaName();
+        if (offlineSchemaNameFromValidationConfig != null) {
+          schema = getSchema(propertyStore, offlineSchemaNameFromValidationConfig);
+        }
       }
     }
     if (schema != null) {


### PR DESCRIPTION
When call ZKMetadataProvider:getSchema(), input parameter schemaName
is declared as `Nonnull`; however, it's possible that we pass null value.
This pr adds the null check to avoid the such case.