### PR TITLE
Add ingestion descriptor in the header

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -292,6 +292,7 @@ public class CommonConstants {
     public static final String VERSION_HTTP_HEADER = "Pinot-Controller-Version";
     public static final String SEGMENT_NAME_HTTP_HEADER = "Pinot-Segment-Name";
     public static final String TABLE_NAME_HTTP_HEADER = "Pinot-Table-Name";
+    public static final String INGESTION_DESCRIPTOR = "Pinot-Ingestion-Descriptor";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "pinot.controller.crypter";
 
     public static final String CONFIG_OF_CONTROLLER_METRICS_PREFIX = "controller.metrics.prefix";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -186,9 +186,11 @@ public class PinotSegmentUploadDownloadRestletResource {
     String uploadTypeStr = null;
     String crypterClassNameInHeader = null;
     String downloadUri = null;
+    String ingestionDescriptor = null;
     if (headers != null) {
       extractHttpHeader(headers, CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER);
       extractHttpHeader(headers, CommonConstants.Controller.TABLE_NAME_HTTP_HEADER);
+      ingestionDescriptor = extractHttpHeader(headers, CommonConstants.Controller.INGESTION_DESCRIPTOR);
       uploadTypeStr = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE);
       crypterClassNameInHeader = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.CRYPTER);
       downloadUri = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI);
@@ -242,9 +244,8 @@ public class PinotSegmentUploadDownloadRestletResource {
 
       String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
       String clientAddress = InetAddress.getByName(request.getRemoteAddr()).getHostName();
-      LOGGER
-          .info("Processing upload request for segment: {} of table: {} from client: {}", segmentName, offlineTableName,
-              clientAddress);
+      LOGGER.info("Processing upload request for segment: {} of table: {} from client: {}, ingestion descriptor: {}",
+          segmentName, offlineTableName, clientAddress, ingestionDescriptor);
 
       // Validate segment
       new SegmentValidator(_pinotHelixResourceManager, _controllerConf, _executor, _connectionManager,


### PR DESCRIPTION
## Description
This PR adds ingestion descriptor in the header. This will be used to put the ingestion information from the flow, so that when there is something wrong with the data push, the Pinot administrator knows where/who to contact with.