### PR TITLE
Fix extract method in AvroRecordExtractor class

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
@@ -47,12 +47,14 @@ public class AvroRecordExtractor implements RecordExtractor<GenericRecord> {
   public GenericRow extract(GenericRecord from, GenericRow to) {
     if (_extractAll) {
       List<Schema.Field> fields = from.getSchema().getFields();
-      fields.forEach(field -> {
+      for (Schema.Field field : fields) {
         String fieldName = field.name();
         to.putValue(fieldName, AvroUtils.convert(from.get(fieldName)));
-      });
+      }
     } else {
-      _fields.forEach(fieldName -> to.putValue(fieldName, AvroUtils.convert(from.get(fieldName))));
+      for (String fieldName : _fields) {
+        to.putValue(fieldName, AvroUtils.convert(from.get(fieldName)));
+      }
     }
     return to;
   }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
@@ -18,14 +18,14 @@
  */
 package org.apache.pinot.plugin.inputformat.avro;
 
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordExtractor;
 import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
-import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
@@ -46,14 +46,13 @@ public class AvroRecordExtractor implements RecordExtractor<GenericRecord> {
   @Override
   public GenericRow extract(GenericRecord from, GenericRow to) {
     if (_extractAll) {
-      Map<String, Object> jsonMap = JsonUtils.genericRecordToJson(from);
-      jsonMap.forEach((fieldName, value) -> to.putValue(fieldName, AvroUtils.convert(value)));
+      List<Schema.Field> fields = from.getSchema().getFields();
+      fields.forEach(field -> {
+        String fieldName = field.name();
+        to.putValue(fieldName, AvroUtils.convert(from.get(fieldName)));
+      });
     } else {
-      for (String fieldName : _fields) {
-        Object value = from.get(fieldName);
-        Object convertedValue = AvroUtils.convert(value);
-        to.putValue(fieldName, convertedValue);
-      }
+      _fields.forEach(fieldName -> to.putValue(fieldName, AvroUtils.convert(from.get(fieldName))));
     }
     return to;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -34,9 +34,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -193,17 +193,4 @@ public class JsonUtils {
         throw new IllegalArgumentException(String.format("Unsupported data type %s", dataType));
     }
   }
-
-  /**
-   * Converts from a GenericRecord to a json map
-   */
-  public static Map<String, Object> genericRecordToJson(GenericRecord genericRecord) {
-    try {
-      String jsonString = genericRecord.toString();
-      return DEFAULT_MAPPER.readValue(jsonString, new TypeReference<Map<String, Object>>() {
-      });
-    } catch (IOException e) {
-      throw new IllegalStateException("Caught exception when converting generic record " + genericRecord + " to JSON");
-    }
-  }
 }


### PR DESCRIPTION
## Description
This PR fixes the extract method in AvroRecordExtractor class.

When `_extractAll` is true, the generic record will be first converted to a json String and then parse to a json map, whereas json object has its precision limitation:
https://developers.google.com/discovery/v1/type-format

E.g. the column1 was originally of long type. But when it was converted to json string and then parse to a json map, the type would be changed to int. Thus, the actual value may be incorrect from the json map comparing to the actual value from generic record. Plus, since it changes the data type, it will have to trigger the `convert` method in DataTypeTransformer class, which will make confusion to detect schema mismatch.

This PR fixes it by fetching the actual value directly from the original generic record.
