### PR TITLE
Configurable segment generation job parallelism for Hadoop and Spark

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
@@ -230,7 +230,11 @@ public class HadoopSegmentGenerationJobRunner extends Configured implements Inge
       if (hadoopTokenFileLocation != null) {
         jobConf.set("mapreduce.job.credentials.binary", hadoopTokenFileLocation);
       }
-      jobConf.setInt(JobContext.NUM_MAPS, numDataFiles);
+      int jobParallelism = _spec.getSegmentCreationJobParallelism();
+      if (jobParallelism <= 0 || jobParallelism > numDataFiles) {
+        jobParallelism = numDataFiles;
+      }
+      jobConf.setInt(JobContext.NUM_MAPS, jobParallelism);
 
       // Pinot plugins are necessary to launch Pinot ingestion job from every mapper.
       // In order to ensure pinot plugins would be loaded to each worker, this method

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/resources/segmentCreationAndTarPushJobSpec.yaml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/resources/segmentCreationAndTarPushJobSpec.yaml
@@ -28,6 +28,7 @@ includeFileNamePattern: 'glob:**/*.parquet'
 excludeFileNamePattern: 'glob:**/*.avro'
 outputDirURI: 'file:///path/to/output'
 overwriteOutput: true
+parallelism: 10000
 pinotFSSpecs:
   - scheme: file
     className: org.apache.pinot.spi.filesystem.LocalPinotFS

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -70,6 +70,11 @@ public class SegmentGenerationJobSpec implements Serializable {
   private String _outputDirURI;
 
   /**
+   * Segment creation job parallelism.
+   */
+  private int _segmentCreationJobParallelism;
+
+  /**
    * Should overwrite output segments if existed.
    */
   private boolean _overwriteOutput;
@@ -231,6 +236,14 @@ public class SegmentGenerationJobSpec implements Serializable {
 
   public void setPushJobSpec(PushJobSpec pushJobSpec) {
     _pushJobSpec = pushJobSpec;
+  }
+
+  public int getSegmentCreationJobParallelism() {
+    return _segmentCreationJobParallelism;
+  }
+
+  public void setSegmentCreationJobParallelism(int segmentCreationJobParallelism) {
+    _segmentCreationJobParallelism = segmentCreationJobParallelism;
   }
 }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncherTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncherTest.java
@@ -60,6 +60,7 @@ public class IngestionJobLauncherTest {
         GroovyTemplateUtils.class.getClassLoader().getResource("job.config").getFile(), context);
     Assert.assertEquals(spec.getInputDirURI(), "file:///path/to/input/2020/06/07");
     Assert.assertEquals(spec.getOutputDirURI(), "file:///path/to/output/2020/06/07");
+    Assert.assertEquals(spec.getSegmentCreationJobParallelism(), 100);
   }
 
   @Test
@@ -70,5 +71,6 @@ public class IngestionJobLauncherTest {
         GroovyTemplateUtils.class.getClassLoader().getResource("job_json.config").getFile(), null);
     Assert.assertEquals(spec.getInputDirURI(), "file:///path/to/input/2020/07/22");
     Assert.assertEquals(spec.getOutputDirURI(), "file:///path/to/output/2020/07/22");
+    Assert.assertEquals(spec.getSegmentCreationJobParallelism(), 0);
   }
 }

--- a/pinot-spi/src/test/resources/ingestion_job_spec_template.yaml
+++ b/pinot-spi/src/test/resources/ingestion_job_spec_template.yaml
@@ -28,6 +28,7 @@ includeFileNamePattern: 'glob:**/*.parquet'
 excludeFileNamePattern: 'glob:**/*.avro'
 outputDirURI: 'file:///path/to/output/${year}/${month}/${day}'
 overwriteOutput: true
+segmentCreationJobParallelism: 100
 pinotFSSpecs:
   - scheme: file
     className: org.apache.pinot.spi.filesystem.LocalPinotFS


### PR DESCRIPTION
## Description
Adding field 'segmentCreationJobParallelism' to allow users to set segment generation job parallelism, default to the number of input files.  This can avoid issues of hadoop/spark job submission timeout.

Sample error logs/stacktraces of Spark job submission:
```
20/09/12 20:13:02 {} INFO org.apache.pinot.plugin.filesystem.S3PinotFS: Listed 40000 files from URI: s3://my-s3-bucket/, is recursive: true
20/09/12 20:14:31 {} ERROR org.apache.spark.deploy.yarn.ApplicationMaster: Uncaught exception: 
java.util.concurrent.TimeoutException: Futures timed out after [100000 milliseconds]
	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:259) ~[scala-library-2.12.10.jar:?]
	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:263) ~[scala-library-2.12.10.jar:?]
	at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:220) ~[org_apache_spark_spark_shaded_distro_2_12.jar:?]
	at org.apache.spark.deploy.yarn.ApplicationMaster.runDriver(ApplicationMaster.scala:469) ~[org_apache_spark_spark_shaded_distro_2_12.jar:?]
	at org.apache.spark.deploy.yarn.ApplicationMaster.runImpl(ApplicationMaster.scala:305) ~[org_apache_spark_spark_shaded_distro_2_12.jar:?]
	at org.apache.spark.deploy.yarn.ApplicationMaster.$anonfun$run$1(ApplicationMaster.scala:245) ~[org_apache_spark_spark_shaded_distro_2_12.jar:?]
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) [scala-library-2.12.10.jar:?]
	at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$3.run(ApplicationMaster.scala:779) [org_apache_spark_spark_shaded_distro_2_12.jar:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_265]
	at javax.security.auth.Subject.doAs(Subject.java:422) [?:1.8.0_265]
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1730) [hadoop-common-3.2.1.jar:?]
	at org.apache.spark.deploy.yarn.ApplicationMaster.doAsUser(ApplicationMaster.scala:778) [org_apache_spark_spark_shaded_distro_2_12.jar:?]
	at org.apache.spark.deploy.yarn.ApplicationMaster.run(ApplicationMaster.scala:245) [org_apache_spark_spark_shaded_distro_2_12.jar:?]
	at org.apache.spark.deploy.yarn.ApplicationMaster$.main(ApplicationMaster.scala:803) [org_apache_spark_spark_shaded_distro_2_12.jar:?]
	at org.apache.spark.deploy.yarn.ApplicationMaster.main(ApplicationMaster.scala) [org_apache_spark_spark_shaded_distro_2_12.jar:?]
20/09/12 20:14:31 {} INFO org.apache.spark.deploy.yarn.ApplicationMaster: Final app status: FAILED, exitCode: 13, (reason: Uncaught exception: java.util.concurrent.TimeoutException: Futures timed out after [100000 milliseconds]
	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:259)
	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:263)
	at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:220)
	at org.apache.spark.deploy.yarn.ApplicationMaster.runDriver(ApplicationMaster.scala:469)
	at org.apache.spark.deploy.yarn.ApplicationMaster.runImpl(ApplicationMaster.scala:305)
	at org.apache.spark.deploy.yarn.ApplicationMaster.$anonfun$run$1(ApplicationMaster.scala:245)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$3.run(ApplicationMaster.scala:779)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1730)
	at org.apache.spark.deploy.yarn.ApplicationMaster.doAsUser(ApplicationMaster.scala:778)
	at org.apache.spark.deploy.yarn.ApplicationMaster.run(ApplicationMaster.scala:245)
	at org.apache.spark.deploy.yarn.ApplicationMaster$.main(ApplicationMaster.scala:803)
	at org.apache.spark.deploy.yarn.ApplicationMaster.main(ApplicationMaster.scala)
)
20/09/12 20:14:31 {} INFO org.apache.spark.deploy.yarn.ApplicationMaster: Deleting staging directory hdfs://hadoop/user/user1/.sparkStaging/application_1596183113611_11111
```