### PR TITLE
[TE] Make data-sources configurable in ThirdEye Helm Chart

### DIFF
--- a/kubernetes/helm/thirdeye/config/data-sources/data-sources-config.yml
+++ b/kubernetes/helm/thirdeye/config/data-sources/data-sources-config.yml
@@ -1,0 +1,12 @@
+dataSourceConfigs:
+  # Default option is to run thirdeye with a pinot-quickstart cluster
+  - className: org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSource
+    properties:
+      zookeeperUrl: 'pinot-zookeeper:2181'
+      clusterName: 'pinot-quickstart'
+      controllerConnectionScheme: 'http'
+      controllerHost: 'pinot-controller'
+      controllerPort: 9000
+      cacheLoaderClassName: org.apache.pinot.thirdeye.datasource.pinot.PinotControllerResponseCacheLoader
+    metadataSourceConfigs:
+      - className: org.apache.pinot.thirdeye.auto.onboard.AutoOnboardPinotMetadataSource

--- a/kubernetes/helm/thirdeye/config/initdb.sql
+++ b/kubernetes/helm/thirdeye/config/initdb.sql
@@ -446,3 +446,15 @@ create table if not exists online_detection_data_index (
 create index online_detection_data_id_idx ON online_detection_data_index(base_id);
 create index online_detection_data_dataset_idx ON online_detection_data_index(dataset);
 create index online_detection_data_metric_idx ON online_detection_data_index(metric);
+
+create table if not exists anomaly_subscription_group_notification_index (
+    base_id bigint(20) not null,
+    anomaly_id bigint(20) not null,
+    detection_config_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `anomaly_subscription_group_notification_index` ADD UNIQUE `anomaly_subscription_group_notification_index`(anomaly_id);
+create index anomaly_subscription_group_anomaly_idx ON anomaly_subscription_group_notification_index(anomaly_id);
+create index anomaly_subscription_group_detection_config_idx ON anomaly_subscription_group_notification_index(anomaly_id)

--- a/kubernetes/helm/thirdeye/install.sh
+++ b/kubernetes/helm/thirdeye/install.sh
@@ -9,4 +9,7 @@ helm dependency update
 # Note:
 # - initdb files must end with .sql
 # - When injecting yaml config via terminal, the period ('.') must be escaped and quoted
-helm install thirdeye . --set-file mysql.initializationFiles."initdb\.sql"="./initdb.sql" $@
+helm install thirdeye . \
+  --set-file mysql.initializationFiles."initdb\.sql"="./config/initdb.sql" \
+  --set-file thirdeye.config.dataSources="./config/data-sources/data-sources-config.yml" \
+  $@

--- a/kubernetes/helm/thirdeye/templates/common/configmap.yaml
+++ b/kubernetes/helm/thirdeye/templates/common/configmap.yaml
@@ -204,19 +204,7 @@ data:
           seed: 4
           namePrefixes: [System, Model, Campaign, Welcome, Pinot, ThirdEye]
 
-  data-sources-config.yml: |-
-    # Please put the mock data source as the first in this configuration.
-    dataSourceConfigs:
-      - className: org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSource
-        properties:
-          zookeeperUrl: 'pinot-zookeeper:2181'
-          clusterName: 'pinot-quickstart'
-          controllerConnectionScheme: 'http'
-          controllerHost: 'pinot-controller'
-          controllerPort: 9000
-          cacheLoaderClassName: org.apache.pinot.thirdeye.datasource.pinot.PinotControllerResponseCacheLoader
-        metadataSourceConfigs:
-          - className: org.apache.pinot.thirdeye.auto.onboard.AutoOnboardPinotMetadataSource
+  data-sources-config.yml: {{ toYaml .Values.thirdeye.config.dataSources | indent 4 }}
 
   cache-config.yml: |-
     useInMemoryCache: true


### PR DESCRIPTION
Currently, the data-sources config file is hardcoded in the template.
This change allows user to replace the data-sources config in the config
directory thereby allowing the user to feed a custom configuration.

By default, TE expects the pinot-quickstart cluster to be the primary
data source.

No code changes.