### PR TITLE
Include branch name when publishing pinot release to bintray

### DIFF
--- a/.travis/.travis_nightly_build.sh
+++ b/.travis/.travis_nightly_build.sh
@@ -20,6 +20,7 @@
 
 if [ -n "${DEPLOY_BUILD_OPTS}" ]; then
   echo "Deploying to bintray"
+  echo "Current branch name: ${TRAVIS_BRANCH}"
 
   BUILD_VERSION=$(grep -E "<version>(.*)-SNAPSHOT</version>" pom.xml | cut -d'>' -f2 | cut -d'<' -f1 | cut -d'-' -f1)
   echo "Current build version: $BUILD_VERSION${DEV_VERSION}"
@@ -27,5 +28,5 @@ if [ -n "${DEPLOY_BUILD_OPTS}" ]; then
   mvn versions:commit -q -B
 
   # Deploy to bintray
-  mvn deploy -s .travis/.ci.settings.xml -DskipTests -q -DretryFailedDeploymentCount=5 -DaltDeploymentRepository=bintray-linkedin-maven::default::'https://api.bintray.com/maven/linkedin/maven/pinot/;publish=1;override=1'
+  mvn deploy -s .travis/.ci.settings.xml -DscmBranch="${TRAVIS_BRANCH}" -DskipTests -q -DretryFailedDeploymentCount=5 -DaltDeploymentRepository=bintray-linkedin-maven::default::'https://api.bintray.com/maven/linkedin/maven/pinot/;publish=1;override=1'
 fi


### PR DESCRIPTION
## Description
This PR includes branch name in the manifest when publishing pinot release to bintray.

As someone mentioned in https://github.com/mojohaus/buildnumber-maven-plugin/issues/53:
> If you are using Jenkins or some automated CI tool, Its most likely that the commit was checked out in a detached state. In detached state, HEAD won't have the branch information

That's why the value of branch name in previous releases are shown as `UNKNOWN`.

Sample info after this change from https://travis-ci.org/github/apache/incubator-pinot/builds/727461249:
```
Manifest-Version: 1.0
Archiver-Version: Plexus Archiver
Created-By: Apache Maven
Built-By: travis
Build-Jdk: 1.8.0_151
Specification-Title: Pinot Controller
Specification-Version: 0.5.0-dev-18752
Specification-Vendor: Apache Software Foundation
Build-Time: 2020-09-15T18:31:31Z
Implementation-Branch: check-branch-name
Implementation-Title: pinot-controller
Implementation-Vendor: Apache Software Foundation
Implementation-Vendor-Id: org.apache.pinot
Implementation-Version: 0.5.0-dev-18752-c5905be15f839add19c746cb23e209
 5d10fd0d1f
```
