### PR TITLE
List of partitioners in SegmentProcessorFramework

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperConfig.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.processing.framework;
 
+import java.util.List;
 import org.apache.pinot.core.segment.processing.filter.RecordFilterConfig;
 import org.apache.pinot.core.segment.processing.partitioner.PartitionerConfig;
 import org.apache.pinot.core.segment.processing.transformer.RecordTransformerConfig;
@@ -32,14 +33,14 @@ public class SegmentMapperConfig {
   private final Schema _pinotSchema;
   private final RecordTransformerConfig _recordTransformerConfig;
   private final RecordFilterConfig _recordFilterConfig;
-  private final PartitionerConfig _partitionerConfig;
+  private final List<PartitionerConfig> _partitionerConfigs;
 
   public SegmentMapperConfig(Schema pinotSchema, RecordTransformerConfig recordTransformerConfig,
-      RecordFilterConfig recordFilterConfig, PartitionerConfig partitionerConfig) {
+      RecordFilterConfig recordFilterConfig, List<PartitionerConfig> partitionerConfigs) {
     _pinotSchema = pinotSchema;
     _recordTransformerConfig = recordTransformerConfig;
     _recordFilterConfig = recordFilterConfig;
-    _partitionerConfig = partitionerConfig;
+    _partitionerConfigs = partitionerConfigs;
   }
 
   /**
@@ -66,7 +67,7 @@ public class SegmentMapperConfig {
   /**
    * The PartitioningConfig for the mapper
    */
-  public PartitionerConfig getPartitionerConfig() {
-    return _partitionerConfig;
+  public List<PartitionerConfig> getPartitionerConfigs() {
+    return _partitionerConfigs;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
@@ -19,10 +19,17 @@
 package org.apache.pinot.core.segment.processing.framework;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.core.segment.processing.collector.CollectorConfig;
 import org.apache.pinot.core.segment.processing.filter.RecordFilterConfig;
 import org.apache.pinot.core.segment.processing.partitioner.PartitionerConfig;
+import org.apache.pinot.core.segment.processing.partitioner.PartitionerFactory;
 import org.apache.pinot.core.segment.processing.transformer.RecordTransformerConfig;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 
@@ -36,18 +43,18 @@ public class SegmentProcessorConfig {
   private final Schema _schema;
   private final RecordTransformerConfig _recordTransformerConfig;
   private final RecordFilterConfig _recordFilterConfig;
-  private final PartitionerConfig _partitionerConfig;
+  private final List<PartitionerConfig> _partitionerConfigs;
   private final CollectorConfig _collectorConfig;
   private final SegmentConfig _segmentConfig;
 
   private SegmentProcessorConfig(TableConfig tableConfig, Schema schema,
       RecordTransformerConfig recordTransformerConfig, RecordFilterConfig recordFilterConfig,
-      PartitionerConfig partitionerConfig, CollectorConfig collectorConfig, SegmentConfig segmentConfig) {
+      List<PartitionerConfig> partitionerConfigs, CollectorConfig collectorConfig, SegmentConfig segmentConfig) {
     _tableConfig = tableConfig;
     _schema = schema;
     _recordTransformerConfig = recordTransformerConfig;
     _recordFilterConfig = recordFilterConfig;
-    _partitionerConfig = partitionerConfig;
+    _partitionerConfigs = partitionerConfigs;
     _collectorConfig = collectorConfig;
     _segmentConfig = segmentConfig;
   }
@@ -83,8 +90,8 @@ public class SegmentProcessorConfig {
   /**
    * The PartitioningConfig for the SegmentProcessorFramework's map phase
    */
-  public PartitionerConfig getPartitionerConfig() {
-    return _partitionerConfig;
+  public List<PartitionerConfig> getPartitionerConfigs() {
+    return _partitionerConfigs;
   }
 
   /**
@@ -109,7 +116,7 @@ public class SegmentProcessorConfig {
     private Schema _schema;
     private RecordTransformerConfig _recordTransformerConfig;
     private RecordFilterConfig _recordFilterConfig;
-    private PartitionerConfig _partitionerConfig;
+    private List<PartitionerConfig> _partitionerConfigs;
     private CollectorConfig _collectorConfig;
     private SegmentConfig _segmentConfig;
 
@@ -133,8 +140,8 @@ public class SegmentProcessorConfig {
       return this;
     }
 
-    public Builder setPartitionerConfig(PartitionerConfig partitionerConfig) {
-      _partitionerConfig = partitionerConfig;
+    public Builder setPartitionerConfigs(List<PartitionerConfig> partitionerConfigs) {
+      _partitionerConfigs = partitionerConfigs;
       return this;
     }
 
@@ -151,14 +158,15 @@ public class SegmentProcessorConfig {
     public SegmentProcessorConfig build() {
       Preconditions.checkState(_tableConfig != null, "Must provide table config in SegmentProcessorConfig");
       Preconditions.checkState(_schema != null, "Must provide schema in SegmentProcessorConfig");
+
       if (_recordTransformerConfig == null) {
         _recordTransformerConfig = new RecordTransformerConfig.Builder().build();
       }
       if (_recordFilterConfig == null) {
         _recordFilterConfig = new RecordFilterConfig.Builder().build();
       }
-      if (_partitionerConfig == null) {
-        _partitionerConfig = new PartitionerConfig.Builder().build();
+      if (CollectionUtils.isEmpty(_partitionerConfigs)) {
+        _partitionerConfigs = Lists.newArrayList(new PartitionerConfig.Builder().build());
       }
       if (_collectorConfig == null) {
         _collectorConfig = new CollectorConfig.Builder().build();
@@ -167,7 +175,7 @@ public class SegmentProcessorConfig {
         _segmentConfig = new SegmentConfig.Builder().build();
       }
       return new SegmentProcessorConfig(_tableConfig, _schema, _recordTransformerConfig, _recordFilterConfig,
-          _partitionerConfig, _collectorConfig, _segmentConfig);
+          _partitionerConfigs, _collectorConfig, _segmentConfig);
     }
   }
 
@@ -175,7 +183,7 @@ public class SegmentProcessorConfig {
   public String toString() {
     return "SegmentProcessorConfig{" + "\n_tableConfig=" + _tableConfig + ", \n_schema=" + _schema
         .toSingleLineJsonString() + ", \n_recordFilterConfig=" + _recordFilterConfig + ", \n_recordTransformerConfig="
-        + _recordTransformerConfig + ", \n_partitioningConfig=" + _partitionerConfig + ", \n_collectorConfig="
+        + _recordTransformerConfig + ", \n_partitionerConfigs=" + _partitionerConfigs + ", \n_collectorConfig="
         + _collectorConfig + ", \n_segmentsConfig=" + _segmentConfig + "\n}";
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -132,7 +132,7 @@ public class SegmentProcessorFramework {
       // Set mapperId as the name of the segment
       SegmentMapperConfig mapperConfig =
           new SegmentMapperConfig(_pinotSchema, _segmentProcessorConfig.getRecordTransformerConfig(),
-              _segmentProcessorConfig.getRecordFilterConfig(), _segmentProcessorConfig.getPartitionerConfig());
+              _segmentProcessorConfig.getRecordFilterConfig(), _segmentProcessorConfig.getPartitionerConfigs());
       SegmentMapper mapper = new SegmentMapper(mapperInput.getName(), mapperInput, mapperConfig, _mapperOutputDir);
       mapper.map();
       mapper.cleanup();

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.data.partition.PartitionFunction;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -36,6 +37,7 @@ import org.apache.pinot.core.segment.processing.partitioner.PartitionerFactory;
 import org.apache.pinot.core.segment.processing.partitioner.PartitionerConfig;
 import org.apache.pinot.core.segment.processing.transformer.RecordTransformerConfig;
 import org.apache.pinot.plugin.inputformat.avro.AvroRecordReader;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -161,54 +163,70 @@ public class SegmentMapperTest {
 
     // default configs
     SegmentMapperConfig config1 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(), new PartitionerConfig.Builder().build());
+        new RecordFilterConfig.Builder().build(), Lists.newArrayList(new PartitionerConfig.Builder().build()));
     Map<String, List<Object[]>> expectedRecords1 = new HashMap<>();
     expectedRecords1.put("0", outputData);
     inputs.add(new Object[]{mapperId, config1, expectedRecords1});
 
     // round robin partitioner
     SegmentMapperConfig config12 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(), new PartitionerConfig.Builder().setPartitionerType(
-        PartitionerFactory.PartitionerType.ROUND_ROBIN).setNumPartitions(3).build());
+        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
+        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.ROUND_ROBIN)
+            .setNumPartitions(3).build()));
     Map<String, List<Object[]>> expectedRecords12 = new HashMap<>();
     IntStream.range(0, 3).forEach(i -> expectedRecords12.put(String.valueOf(i), new ArrayList<>()));
     for (int i = 0; i < outputData.size(); i++) {
-      expectedRecords12.get(String.valueOf(i%3)).add(outputData.get(i));
+      expectedRecords12.get(String.valueOf(i % 3)).add(outputData.get(i));
     }
     inputs.add(new Object[]{mapperId, config12, expectedRecords12});
 
     // partition by timeValue
     SegmentMapperConfig config2 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(),
+        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-            .setColumnName("timeValue").build());
+            .setColumnName("timeValue").build()));
     Map<String, List<Object[]>> expectedRecords2 =
         outputData.stream().collect(Collectors.groupingBy(r -> String.valueOf(r[2]), Collectors.toList()));
     inputs.add(new Object[]{mapperId, config2, expectedRecords2});
 
     // partition by campaign
     SegmentMapperConfig config3 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(),
+        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-            .setColumnName("campaign").build());
+            .setColumnName("campaign").build()));
     Map<String, List<Object[]>> expectedRecords3 =
         outputData.stream().collect(Collectors.groupingBy(r -> String.valueOf(r[0]), Collectors.toList()));
     inputs.add(new Object[]{mapperId, config3, expectedRecords3});
 
     // transform function partition
     SegmentMapperConfig config4 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(),
+        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TRANSFORM_FUNCTION)
-            .setTransformFunction("toEpochDays(timeValue)").build());
+            .setTransformFunction("toEpochDays(timeValue)").build()));
     Map<String, List<Object[]>> expectedRecords4 = outputData.stream()
         .collect(Collectors.groupingBy(r -> String.valueOf(((long) r[2]) / 86400000), Collectors.toList()));
     inputs.add(new Object[]{mapperId, config4, expectedRecords4});
+
+    // partition by column and then table column partition config
+    SegmentMapperConfig config41 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
+        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
+        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
+            .setColumnName("campaign").build(),
+        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TABLE_PARTITION_CONFIG)
+            .setColumnName("clicks").setColumnPartitionConfig(new ColumnPartitionConfig("Modulo", 3)).build()));
+    Map<String, List<Object[]>> expectedRecords41 = new HashMap<>();
+    for (Object[] record : outputData) {
+      String partition = record[0] + "_" + (int) record[1] % 3;
+      List<Object[]> objects = expectedRecords41.computeIfAbsent(partition, k -> new ArrayList<>());
+      objects.add(record);
+    }
+    inputs.add(new Object[]{mapperId, config41, expectedRecords41});
 
     // filter function which filters out nothing
     SegmentMapperConfig config5 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
         new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
             .setFilterFunction("Groovy({campaign == \"foo\"}, campaign)").build(),
-        new PartitionerConfig.Builder().build());
+        Lists.newArrayList(new PartitionerConfig.Builder().build()));
     Map<String, List<Object[]>> expectedRecords5 = new HashMap<>();
     expectedRecords5.put("0", outputData);
     inputs.add(new Object[]{mapperId, config5, expectedRecords5});
@@ -216,15 +234,16 @@ public class SegmentMapperTest {
     // filter function which filters out everything
     SegmentMapperConfig config6 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
         new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
-            .setFilterFunction("Groovy({timeValue > 0}, timeValue)").build(), new PartitionerConfig.Builder().build());
+            .setFilterFunction("Groovy({timeValue > 0}, timeValue)").build(),
+        Lists.newArrayList(new PartitionerConfig.Builder().build()));
     Map<String, List<Object[]>> expectedRecords6 = new HashMap<>();
     inputs.add(new Object[]{mapperId, config6, expectedRecords6});
 
     // filter function which filters out certain times
     SegmentMapperConfig config7 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
         new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
-            .setFilterFunction("Groovy({timeValue < 1597795200000L || timeValue >= 1597881600000L}, timeValue)").build(),
-        new PartitionerConfig.Builder().build());
+            .setFilterFunction("Groovy({timeValue < 1597795200000L || timeValue >= 1597881600000L}, timeValue)")
+            .build(), Lists.newArrayList(new PartitionerConfig.Builder().build()));
     Map<String, List<Object[]>> expectedRecords7 =
         outputData.stream().filter(r -> ((long) r[2]) >= 1597795200000L && ((long) r[2]) < 1597881600000L)
             .collect(Collectors.groupingBy(r -> "0", Collectors.toList()));
@@ -235,7 +254,7 @@ public class SegmentMapperTest {
     transformFunctionMap.put("timeValue", "round(timeValue, 86400000)");
     SegmentMapperConfig config9 = new SegmentMapperConfig(_pinotSchema,
         new RecordTransformerConfig.Builder().setTransformFunctionsMap(transformFunctionMap).build(),
-        new RecordFilterConfig.Builder().build(), new PartitionerConfig.Builder().build());
+        new RecordFilterConfig.Builder().build(), Lists.newArrayList(new PartitionerConfig.Builder().build()));
     List<Object[]> transformedData = new ArrayList<>();
     outputData.forEach(r -> transformedData.add(new Object[]{r[0], r[1], (((long) r[2]) / 86400000) * 86400000}));
     Map<String, List<Object[]>> expectedRecords9 = new HashMap<>();
@@ -245,9 +264,9 @@ public class SegmentMapperTest {
     // record transformation - round timeValue to nearest day, partition on timeValue
     SegmentMapperConfig config10 = new SegmentMapperConfig(_pinotSchema,
         new RecordTransformerConfig.Builder().setTransformFunctionsMap(transformFunctionMap).build(),
-        new RecordFilterConfig.Builder().build(),
+        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-            .setColumnName("timeValue").build());
+            .setColumnName("timeValue").build()));
     Map<String, List<Object[]>> expectedRecords10 =
         transformedData.stream().collect(Collectors.groupingBy(r -> String.valueOf(r[2]), Collectors.toList()));
     inputs.add(new Object[]{mapperId, config10, expectedRecords10});
@@ -256,9 +275,9 @@ public class SegmentMapperTest {
     SegmentMapperConfig config11 = new SegmentMapperConfig(_pinotSchema,
         new RecordTransformerConfig.Builder().setTransformFunctionsMap(transformFunctionMap).build(),
         new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
-            .setFilterFunction("Groovy({timeValue != 1597795200000}, timeValue)").build(),
+            .setFilterFunction("Groovy({timeValue != 1597795200000}, timeValue)").build(), Lists.newArrayList(
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-            .setColumnName("timeValue").build());
+            .setColumnName("timeValue").build()));
     Map<String, List<Object[]>> expectedRecords11 =
         transformedData.stream().filter(r -> ((long) r[2]) == 1597795200000L)
             .collect(Collectors.groupingBy(r -> "1597795200000", Collectors.toList()));

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessingFrameworkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessingFrameworkTest.java
@@ -277,9 +277,9 @@ public class SegmentProcessingFrameworkTest {
 
     // partitioning
     config = new SegmentProcessorConfig.Builder().setTableConfig(_tableConfig).setSchema(_pinotSchema)
-        .setPartitionerConfig(
+        .setPartitionerConfigs(Lists.newArrayList(
             new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.ROUND_ROBIN)
-                .setNumPartitions(3).build()).build();
+                .setNumPartitions(3).build())).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
     framework = new SegmentProcessorFramework(_singleDaySingleSegment, config, outputSegmentDir);
@@ -393,9 +393,9 @@ public class SegmentProcessingFrameworkTest {
 
     // date partition
     config = new SegmentProcessorConfig.Builder().setTableConfig(_tableConfig).setSchema(_pinotSchema)
-        .setPartitionerConfig(
+        .setPartitionerConfigs(Lists.newArrayList(
             new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-                .setColumnName("timeValue").build()).build();
+                .setColumnName("timeValue").build())).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
     framework = new SegmentProcessorFramework(_multipleDaysSingleSegment, config, outputSegmentDir);
@@ -465,9 +465,9 @@ public class SegmentProcessingFrameworkTest {
 
     // date partition
     config = new SegmentProcessorConfig.Builder().setTableConfig(_tableConfig).setSchema(_pinotSchema)
-        .setPartitionerConfig(
+        .setPartitionerConfigs(Lists.newArrayList(
             new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TRANSFORM_FUNCTION)
-                .setTransformFunction("round(timeValue, 86400000)").build()).build();
+                .setTransformFunction("round(timeValue, 86400000)").build())).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
     framework = new SegmentProcessorFramework(_multipleDaysSingleSegment, config, outputSegmentDir);
@@ -487,9 +487,9 @@ public class SegmentProcessingFrameworkTest {
     config = new SegmentProcessorConfig.Builder().setTableConfig(_tableConfig).setSchema(_pinotSchema)
         .setRecordTransformerConfig(
             new RecordTransformerConfig.Builder().setTransformFunctionsMap(recordTransformationMap).build())
-        .setPartitionerConfig(
+        .setPartitionerConfigs(Lists.newArrayList(
             new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-                .setColumnName("timeValue").build()).setCollectorConfig(
+                .setColumnName("timeValue").build())).setCollectorConfig(
             new CollectorConfig.Builder().setCollectorType(CollectorFactory.CollectorType.ROLLUP).build()).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/SegmentProcessorFrameworkCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/SegmentProcessorFrameworkCommand.java
@@ -95,7 +95,7 @@ public class SegmentProcessorFrameworkCommand extends AbstractBaseAdminCommand i
         new SegmentProcessorConfig.Builder().setSchema(schema).setTableConfig(tableConfig)
             .setRecordTransformerConfig(segmentProcessorFrameworkSpec.getRecordTransformerConfig())
             .setRecordFilterConfig(segmentProcessorFrameworkSpec.getRecordFilterConfig())
-            .setPartitionerConfig(segmentProcessorFrameworkSpec.getPartitionerConfig())
+            .setPartitionerConfigs(segmentProcessorFrameworkSpec.getPartitionerConfigs())
             .setCollectorConfig(segmentProcessorFrameworkSpec.getCollectorConfig())
             .setSegmentConfig(segmentProcessorFrameworkSpec.getSegmentConfig()).build();
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/processor/SegmentProcessorFrameworkSpec.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/processor/SegmentProcessorFrameworkSpec.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.tools.segment.processor;
 
+import java.util.List;
 import org.apache.pinot.core.segment.processing.collector.CollectorConfig;
 import org.apache.pinot.core.segment.processing.filter.RecordFilterConfig;
 import org.apache.pinot.core.segment.processing.framework.SegmentConfig;
@@ -37,7 +38,7 @@ public class SegmentProcessorFrameworkSpec {
 
   private RecordTransformerConfig _recordTransformerConfig;
   private RecordFilterConfig _recordFilterConfig;
-  private PartitionerConfig _partitionerConfig;
+  private List<PartitionerConfig> _partitionerConfigs;
   private CollectorConfig _collectorConfig;
   private SegmentConfig _segmentConfig;
 
@@ -89,12 +90,12 @@ public class SegmentProcessorFrameworkSpec {
     _recordFilterConfig = recordFilterConfig;
   }
 
-  public PartitionerConfig getPartitionerConfig() {
-    return _partitionerConfig;
+  public List<PartitionerConfig> getPartitionerConfigs() {
+    return _partitionerConfigs;
   }
 
-  public void setPartitionerConfig(PartitionerConfig partitionerConfig) {
-    _partitionerConfig = partitionerConfig;
+  public void setPartitionerConfigs(List<PartitionerConfig> partitionerConfigs) {
+    _partitionerConfigs = partitionerConfigs;
   }
 
   public CollectorConfig getCollectorConfig() {


### PR DESCRIPTION
https://github.com/apache/incubator-pinot/issues/5753
Changing SegmentPrpcessorFramework config to take List of Partitioners. This is to account for table config's partitioning, which might need to be applied regardless of other partitioning configured. For example, we want to partition by date so as to align segments by time, but we also want to apply Murmur on some id column each to further partition and record in segment metadata.
