### PR TITLE
add `@types/react-router` dep

### DIFF
--- a/pinot-controller/src/main/resources/package.json
+++ b/pinot-controller/src/main/resources/package.json
@@ -21,8 +21,6 @@
     ]
   },
   "devDependencies": {
-    "@types/react": "16.9.34",
-    "@types/react-dom": "16.9.6",
     "@typescript-eslint/eslint-plugin": "2.30.0",
     "@typescript-eslint/parser": "2.30.0",
     "clean-webpack-plugin": "^3.0.0",
@@ -59,7 +57,10 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.51",
     "@types/codemirror": "0.0.97",
+    "@types/react-dom": "16.9.6",
     "@types/react-router-dom": "^5.1.5",
+    "@types/react-router": "^5.1.8",
+    "@types/react": "16.9.34",
     "axios": "^0.19.2",
     "codemirror": "^5.55.0",
     "cross-fetch": "^3.0.4",


### PR DESCRIPTION
## Description
Before, `@types/react-router` was unlisted. Because `@types/react-router-dom`
only has `@types/react-router: "*"` defined, it is possible the wrong version is
pulled. When this happens and a different major version is used, `npm run-script
build` would fail during maven builds over type errors.

After this, the correct version is now explicitly indicated to ensure the right
type version. For good measure, I hoisted the other `@types` dependencies to the
non-dev dependencies.

I'm not entirely sure what specific situations this happens in, but for my build
environment I was getting a different major version and maven builds were
failing. I suspect this is likely because of using an internal registry.




## Upgrade Notes
N/A

## Release Notes
N/A

## Documentation
N/A