### PR TITLE
bump paranamer (2.6 -> 2.8) to fix Spark failures (on 2.4.4 scala 2.12)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -423,7 +423,7 @@ BSD 3-Clause
 com.google.protobuf:protobuf-java:3.12.0
 com.jcabi:jcabi-aspects:0.22
 com.jcabi:jcabi-log:0.17.1
-com.thoughtworks.paranamer:paranamer:2.6
+com.thoughtworks.paranamer:paranamer:2.8
 org.antlr:antlr4-runtime:4.6
 org.ow2.asm:asm:5.0.4
 org.threeten:threeten-extra:1.5.0

--- a/pom.xml
+++ b/pom.xml
@@ -633,7 +633,7 @@
       <dependency>
         <groupId>com.thoughtworks.paranamer</groupId>
         <artifactId>paranamer</artifactId>
-        <version>2.6</version>
+        <version>2.8</version>
       </dependency>
 
       <!-- Jackson -->


### PR DESCRIPTION
## Description
Before on paranamer 2.6, there was an incompatibility with certain JDK 8
features as mentioned in https://github.com/paul-hammant/paranamer/issues/17.
This seemed to happen in particular because of the use of a particular Spark
version (2.4.4 on scala 2.12). When running the Spark ingestion job, it was failing
at some point during execution.

Also, is there any special procedure to update `LICENSE-binary`, other than edit the version number?

Specifically, the error stack trace was the following.

```
21:50:27.454 [Driver] ERROR org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand - Got exception to kick off standalone data ingestion job -
--
  | java.lang.RuntimeException: Caught exception during running - org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentGenerationJobRunner
  | at org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher.kickoffIngestionJob(IngestionJobLauncher.java:137) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher.runIngestionJob(IngestionJobLauncher.java:110) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand.execute(LaunchDataIngestionJobCommand.java:123) [eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand.main(LaunchDataIngestionJobCommand.java:65) [eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_265]
  | at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_265]
  | at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_265]
  | at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_265]
  | at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:684) [eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | Caused by: java.lang.ArrayIndexOutOfBoundsException: 28499
  | at com.thoughtworks.paranamer.BytecodeReadingParanamer$ClassReader.accept(BytecodeReadingParanamer.java:563) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at com.thoughtworks.paranamer.BytecodeReadingParanamer$ClassReader.access$200(BytecodeReadingParanamer.java:338) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at com.thoughtworks.paranamer.BytecodeReadingParanamer.lookupParameterNames(BytecodeReadingParanamer.java:103) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at com.thoughtworks.paranamer.CachingParanamer.lookupParameterNames(CachingParanamer.java:79) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.getCtorParams(BeanIntrospector.scala:44) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$1(BeanIntrospector.scala:58) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$1$adapted(BeanIntrospector.scala:58) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:245) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.Iterator.foreach(Iterator.scala:941) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.Iterator.foreach$(Iterator.scala:941) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.AbstractIterator.foreach(Iterator.scala:1429) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.IterableLike.foreach(IterableLike.scala:74) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.IterableLike.foreach$(IterableLike.scala:73) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.AbstractIterable.foreach(Iterable.scala:56) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.flatMap(TraversableLike.scala:245) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:242) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.AbstractTraversable.flatMap(Traversable.scala:108) ~[eis_0.scala-library-2.12.10.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.findConstructorParam$1(BeanIntrospector.scala:58) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$19(BeanIntrospector.scala:176) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.map(TraversableLike.scala:238) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.map$(TraversableLike.scala:231) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:198) ~[eis_0.scala-library-2.12.10.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$14(BeanIntrospector.scala:170) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$14$adapted(BeanIntrospector.scala:169) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:245) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.immutable.List.foreach(List.scala:392) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.flatMap(TraversableLike.scala:245) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:242) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.immutable.List.flatMap(List.scala:355) ~[eis_0.scala-library-2.12.10.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.apply(BeanIntrospector.scala:169) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector$._descriptorFor(ScalaAnnotationIntrospectorModule.scala:21) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector$.fieldName(ScalaAnnotationIntrospectorModule.scala:29) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector$.findImplicitPropertyName(ScalaAnnotationIntrospectorModule.scala:77) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair.findImplicitPropertyName(AnnotationIntrospectorPair.java:490) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector._addFields(POJOPropertiesCollector.java:380) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector.collectAll(POJOPropertiesCollector.java:308) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector.getJsonValueAccessor(POJOPropertiesCollector.java:196) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.introspect.BasicBeanDescription.findJsonValueAccessor(BasicBeanDescription.java:251) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ser.BasicSerializerFactory.findSerializerByAnnotations(BasicSerializerFactory.java:346) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ser.BeanSerializerFactory._createSerializer2(BeanSerializerFactory.java:216) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ser.BeanSerializerFactory.createSerializer(BeanSerializerFactory.java:165) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.SerializerProvider._createUntypedSerializer(SerializerProvider.java:1389) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.SerializerProvider._createAndCacheUntypedSerializer(SerializerProvider.java:1336) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.SerializerProvider.findValueSerializer(SerializerProvider.java:510) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.SerializerProvider.findTypedValueSerializer(SerializerProvider.java:713) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:308) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:3905) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3219) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at org.apache.spark.rdd.RDDOperationScope.toJson(RDDOperationScope.scala:52) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:145) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.SparkContext.withScope(SparkContext.scala:708) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.SparkContext.parallelize(SparkContext.scala:725) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.api.java.JavaSparkContext.parallelize(JavaSparkContext.scala:134) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentGenerationJobRunner.run(SparkSegmentGenerationJobRunner.java:206) ~[eojo_0.org_apache_pinot_pinot_batch_ingestion_spark_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher.kickoffIngestionJob(IngestionJobLauncher.java:135) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | ... 11 more
  | 21:50:27.470 [Driver] ERROR org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand - Exception caught:
  | java.lang.RuntimeException: Caught exception during running - org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentGenerationJobRunner
  | at org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher.kickoffIngestionJob(IngestionJobLauncher.java:137) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher.runIngestionJob(IngestionJobLauncher.java:110) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand.execute(LaunchDataIngestionJobCommand.java:123) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand.main(LaunchDataIngestionJobCommand.java:65) [eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_265]
  | at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_265]
  | at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_265]
  | at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_265]
  | at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:684) [eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | Caused by: java.lang.ArrayIndexOutOfBoundsException: 28499
  | at com.thoughtworks.paranamer.BytecodeReadingParanamer$ClassReader.accept(BytecodeReadingParanamer.java:563) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at com.thoughtworks.paranamer.BytecodeReadingParanamer$ClassReader.access$200(BytecodeReadingParanamer.java:338) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at com.thoughtworks.paranamer.BytecodeReadingParanamer.lookupParameterNames(BytecodeReadingParanamer.java:103) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at com.thoughtworks.paranamer.CachingParanamer.lookupParameterNames(CachingParanamer.java:79) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.getCtorParams(BeanIntrospector.scala:44) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$1(BeanIntrospector.scala:58) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$1$adapted(BeanIntrospector.scala:58) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:245) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.Iterator.foreach(Iterator.scala:941) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.Iterator.foreach$(Iterator.scala:941) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.AbstractIterator.foreach(Iterator.scala:1429) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.IterableLike.foreach(IterableLike.scala:74) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.IterableLike.foreach$(IterableLike.scala:73) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.AbstractIterable.foreach(Iterable.scala:56) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.flatMap(TraversableLike.scala:245) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:242) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.AbstractTraversable.flatMap(Traversable.scala:108) ~[eis_0.scala-library-2.12.10.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.findConstructorParam$1(BeanIntrospector.scala:58) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$19(BeanIntrospector.scala:176) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.map(TraversableLike.scala:238) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.map$(TraversableLike.scala:231) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:198) ~[eis_0.scala-library-2.12.10.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$14(BeanIntrospector.scala:170) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.$anonfun$apply$14$adapted(BeanIntrospector.scala:169) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:245) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.immutable.List.foreach(List.scala:392) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.flatMap(TraversableLike.scala:245) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:242) ~[eis_0.scala-library-2.12.10.jar:?]
  | at scala.collection.immutable.List.flatMap(List.scala:355) ~[eis_0.scala-library-2.12.10.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$.apply(BeanIntrospector.scala:169) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector$._descriptorFor(ScalaAnnotationIntrospectorModule.scala:21) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector$.fieldName(ScalaAnnotationIntrospectorModule.scala:29) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector$.findImplicitPropertyName(ScalaAnnotationIntrospectorModule.scala:77) ~[ecjc_0.com_fasterxml_jackson_module_jackson_module_scala_2_12.jar:?]
  | at com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair.findImplicitPropertyName(AnnotationIntrospectorPair.java:490) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector._addFields(POJOPropertiesCollector.java:380) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector.collectAll(POJOPropertiesCollector.java:308) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector.getJsonValueAccessor(POJOPropertiesCollector.java:196) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.introspect.BasicBeanDescription.findJsonValueAccessor(BasicBeanDescription.java:251) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ser.BasicSerializerFactory.findSerializerByAnnotations(BasicSerializerFactory.java:346) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ser.BeanSerializerFactory._createSerializer2(BeanSerializerFactory.java:216) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ser.BeanSerializerFactory.createSerializer(BeanSerializerFactory.java:165) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.SerializerProvider._createUntypedSerializer(SerializerProvider.java:1389) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.SerializerProvider._createAndCacheUntypedSerializer(SerializerProvider.java:1336) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.SerializerProvider.findValueSerializer(SerializerProvider.java:510) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.SerializerProvider.findTypedValueSerializer(SerializerProvider.java:713) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:308) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:3905) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3219) ~[ecjc_0.com_fasterxml_jackson_core_jackson_databind.jar:2.9.6]
  | at org.apache.spark.rdd.RDDOperationScope.toJson(RDDOperationScope.scala:52) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:145) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.SparkContext.withScope(SparkContext.scala:708) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.SparkContext.parallelize(SparkContext.scala:725) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.spark.api.java.JavaSparkContext.parallelize(JavaSparkContext.scala:134) ~[eojo_0.org_apache_spark_spark_shaded_distro_2_12.jar:?]
  | at org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentGenerationJobRunner.run(SparkSegmentGenerationJobRunner.java:206) ~[eojo_0.org_apache_pinot_pinot_batch_ingestion_spark_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | at org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher.kickoffIngestionJob(IngestionJobLauncher.java:135) ~[eojo_0.org_apache_pinot_pinot_distribution_jar_shaded.jar:0.5.0-2020-08-13-SNAPSHOT-cc55ad2fc0e3f6d0da769af286ddcb33d92ef229]
  | ... 11 more
```


## Upgrade Notes
N/A

## Release Notes
Fixed a bug causing failures for Spark ingestion jobs using some versions of Spark.

## Documentation
N/A