### PR TITLE
Prevent the table creation when the time column name config is invalid

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -25,7 +25,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -504,6 +504,8 @@ public class PinotLLCRealtimeSegmentManager {
     committingSegmentZKMetadata.setDownloadUrl(isPeerURL(committingSegmentDescriptor.getSegmentLocation())
         ? CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD : committingSegmentDescriptor.getSegmentLocation());
     committingSegmentZKMetadata.setCrc(Long.valueOf(segmentMetadata.getCrc()));
+    Preconditions.checkNotNull(segmentMetadata.getTimeInterval(),
+        "start/end time information is not correctly written to the segment");
     committingSegmentZKMetadata.setStartTime(segmentMetadata.getTimeInterval().getStartMillis());
     committingSegmentZKMetadata.setEndTime(segmentMetadata.getTimeInterval().getEndMillis());
     committingSegmentZKMetadata.setTimeUnit(TimeUnit.MILLISECONDS);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -158,8 +158,19 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     realtimeTableConfig = _realtimeBuilder.setSchemaName(REALTIME_TABLE_NAME).build();
     sendPostRequest(_createTableUrl, realtimeTableConfig.toJsonString());
 
+    // Create a REALTIME table with the invalid time column name should fail
+    realtimeTableConfig =
+        _realtimeBuilder.setTableName(REALTIME_TABLE_NAME).setTimeColumnName("invalidTimeColumn").build();
+    try {
+      sendPostRequest(_createTableUrl, realtimeTableConfig.toJsonString());
+      Assert.fail("Creation of a REALTIME table with a invalid time column name does not fail");
+    } catch (IOException e) {
+      // Expected 400 Bad Request
+      Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 400"));
+    }
+
     // Create a REALTIME table with a valid name and schema which should succeed
-    realtimeTableConfig = _realtimeBuilder.setTableName(REALTIME_TABLE_NAME).build();
+    realtimeTableConfig = _realtimeBuilder.setTableName(REALTIME_TABLE_NAME).setTimeColumnName("timeColumn").build();
     String realtimeTableConfigString = realtimeTableConfig.toJsonString();
     sendPostRequest(_createTableUrl, realtimeTableConfigString);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.TimeUtils;
 
@@ -100,9 +101,13 @@ public final class TableConfigUtils {
     }
     // timeColumnName can be null in OFFLINE table
     if (timeColumnName != null && schema != null) {
-      Preconditions.checkState(schema.getSpecForTimeColumn(timeColumnName) != null,
+      FieldSpec timeColumnFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
+      Preconditions.checkState(timeColumnFieldSpec != null,
           "Cannot find valid fieldSpec for timeColumn: %s from the table config, in the schema: %s", timeColumnName,
           schema.getSchemaName());
+      Preconditions.checkState(timeColumnFieldSpec.getFieldType() == FieldSpec.FieldType.DATE_TIME
+              || timeColumnFieldSpec.getFieldType() == FieldSpec.FieldType.TIME,
+          "Time column type has to be either 'DATE_TIME' or 'TIME'");
     }
 
     String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();


### PR DESCRIPTION
Currently, there is no validation on the time column name from
the table config when creating a realtime table. Invalid time
configuration would cause the failure in commit stage because
start/end metadata doesn't get added to the segment metadata.

This adds the validation when creating the realtime table.
