### PR TITLE
Improve the realtime time creation unit test

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -25,7 +25,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -504,6 +504,8 @@ public class PinotLLCRealtimeSegmentManager {
     committingSegmentZKMetadata.setDownloadUrl(isPeerURL(committingSegmentDescriptor.getSegmentLocation())
         ? CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD : committingSegmentDescriptor.getSegmentLocation());
     committingSegmentZKMetadata.setCrc(Long.valueOf(segmentMetadata.getCrc()));
+    Preconditions.checkNotNull(segmentMetadata.getTimeInterval(),
+        "start/end time information is not correctly written to the segment for table: " + realtimeTableName);
     committingSegmentZKMetadata.setStartTime(segmentMetadata.getTimeInterval().getStartMillis());
     committingSegmentZKMetadata.setEndTime(segmentMetadata.getTimeInterval().getEndMillis());
     committingSegmentZKMetadata.setTimeUnit(TimeUnit.MILLISECONDS);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -158,8 +158,19 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     realtimeTableConfig = _realtimeBuilder.setSchemaName(REALTIME_TABLE_NAME).build();
     sendPostRequest(_createTableUrl, realtimeTableConfig.toJsonString());
 
+    // Create a REALTIME table with the invalid time column name should fail
+    realtimeTableConfig =
+        _realtimeBuilder.setTableName(REALTIME_TABLE_NAME).setTimeColumnName("invalidTimeColumn").build();
+    try {
+      sendPostRequest(_createTableUrl, realtimeTableConfig.toJsonString());
+      Assert.fail("Creation of a REALTIME table with a invalid time column name does not fail");
+    } catch (IOException e) {
+      // Expected 400 Bad Request
+      Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 400"));
+    }
+
     // Create a REALTIME table with a valid name and schema which should succeed
-    realtimeTableConfig = _realtimeBuilder.setTableName(REALTIME_TABLE_NAME).build();
+    realtimeTableConfig = _realtimeBuilder.setTableName(REALTIME_TABLE_NAME).setTimeColumnName("timeColumn").build();
     String realtimeTableConfigString = realtimeTableConfig.toJsonString();
     sendPostRequest(_createTableUrl, realtimeTableConfigString);
 


### PR DESCRIPTION
1. Added the precondition check for time interval from segment metadata
2. Added the unit test to check the case when the invalid time column name 
    is configured in the table config