### PR TITLE
[TE] fix labeler config mapping and timeout when fetching anomalies

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/SeverityThresholdLabelerSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/spec/SeverityThresholdLabelerSpec.java
@@ -25,28 +25,16 @@ import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SeverityThresholdLabelerSpec  extends AbstractSpec{
-  private Map<String, Threshold> severity;
+  public static final String CHANGE_KEY = "change";
+  public static final String DURATION_KEY = "duration";
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public static class Threshold {
-    public double change = Double.MAX_VALUE;
-    public long duration = Long.MAX_VALUE;
+  private Map<String, Map<String, Object>> severity;
 
-    public Threshold() {
-
-    }
-
-    public Threshold(double change, long duration) {
-      this.change = change;
-      this.duration = duration;
-    }
-  }
-
-  public Map<String, Threshold> getSeverity() {
+  public Map<String, Map<String, Object>> getSeverity() {
     return severity;
   }
 
-  public void setSeverity(Map<String, Threshold> severity) {
+  public void setSeverity(Map<String, Map<String, Object>> severity) {
     this.severity = severity;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyLabelerWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/wrapper/AnomalyLabelerWrapper.java
@@ -45,10 +45,12 @@ import org.apache.pinot.thirdeye.detection.spi.components.Labeler;
 public class AnomalyLabelerWrapper extends DetectionPipeline {
   private static final String PROP_NESTED = "nested";
   private static final String PROP_LABELER = "labeler";
+  private static final String PROP_METRIC_URN = "metricUrn";
 
   private final List<Map<String, Object>> nestedProperties;
   private String labelerName;
   private Labeler labeler;
+  private String metricUrn;
 
   public AnomalyLabelerWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime) {
     super(provider, config, startTime, endTime);
@@ -59,6 +61,8 @@ public class AnomalyLabelerWrapper extends DetectionPipeline {
     this.labelerName = DetectionUtils.getComponentKey(MapUtils.getString(config.getProperties(), PROP_LABELER));
     Preconditions.checkArgument(this.config.getComponents().containsKey(this.labelerName));
     this.labeler = (Labeler) this.config.getComponents().get(this.labelerName);
+    this.metricUrn = MapUtils.getString(properties, PROP_METRIC_URN);
+
   }
 
   @Override
@@ -70,6 +74,9 @@ public class AnomalyLabelerWrapper extends DetectionPipeline {
 
     Set<Long> lastTimeStamps = new HashSet<>();
     for (Map<String, Object> properties : this.nestedProperties) {
+      if (this.metricUrn != null){
+        properties.put(PROP_METRIC_URN, this.metricUrn);
+      }
       DetectionPipelineResult intermediate = this.runNested(properties, this.startTime, this.endTime);
       lastTimeStamps.add(intermediate.getLastTimestamp());
       predictionResults.addAll(intermediate.getPredictions());

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/alert/commons/TestAnomalyFeedFactory.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/alert/commons/TestAnomalyFeedFactory.java
@@ -18,7 +18,7 @@ package org.apache.pinot.thirdeye.alert.commons;
 
 import org.apache.pinot.thirdeye.alert.feed.AnomalyFeed;
 import org.apache.pinot.thirdeye.alert.feed.UnionAnomalyFeed;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/ThresholdSeverityLabelerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detection/components/ThresholdSeverityLabelerTest.java
@@ -39,11 +39,10 @@ import org.apache.pinot.thirdeye.detection.MockPipeline;
 import org.apache.pinot.thirdeye.detection.MockPipelineLoader;
 import org.apache.pinot.thirdeye.detection.MockPipelineOutput;
 import org.apache.pinot.thirdeye.detection.wrapper.AnomalyLabelerWrapper;
+
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import static org.apache.pinot.thirdeye.detection.spec.SeverityThresholdLabelerSpec.Threshold;
 
 public class ThresholdSeverityLabelerTest {
   private static final String METRIC_URN = "thirdeye:metric:123";
@@ -106,10 +105,10 @@ public class ThresholdSeverityLabelerTest {
 
   @Test
   public void testLabeling() throws Exception {
-    Map<String, Object> severityMap = new HashMap<>();
-    severityMap.put(AnomalySeverity.CRITICAL.toString(), new Threshold(0.2, 3000));
-    severityMap.put(AnomalySeverity.HIGH.toString(), new Threshold(0.15, 2000));
-    severityMap.put(AnomalySeverity.MEDIUM.toString(), new Threshold(0.12, 1500));
+    Map<String, Map<String, Object>> severityMap = new HashMap<>();
+    severityMap.put(AnomalySeverity.CRITICAL.toString(), ImmutableMap.of("change",0.2, "duration", 3000));
+    severityMap.put(AnomalySeverity.HIGH.toString(), ImmutableMap.of("change", 0.15, "duration", 2000));
+    severityMap.put(AnomalySeverity.MEDIUM.toString(), ImmutableMap.of("change", 0.12, "duration", 1500));
     this.specs.put("severity", severityMap);
     this.thresholdSeverityLabeler = new AnomalyLabelerWrapper(this.testDataProvider, this.config, 1000L, 6000L);
     DetectionPipelineResult result = this.thresholdSeverityLabeler.run();
@@ -124,10 +123,8 @@ public class ThresholdSeverityLabelerTest {
   @Test
   public void testLabelingSingleThreshold() throws Exception {
     Map<String, Object> severityMap = new HashMap<>();
-    Threshold singleThreshold = new Threshold();
-    singleThreshold.duration = 2000L;
-    severityMap.put(AnomalySeverity.CRITICAL.toString(), singleThreshold);
-    severityMap.put(AnomalySeverity.HIGH.toString(), new Threshold(0.15, 2000));
+    severityMap.put(AnomalySeverity.CRITICAL.toString(), ImmutableMap.of("duration", 2000));
+    severityMap.put(AnomalySeverity.HIGH.toString(), ImmutableMap.of("change", 0.15, "duration", 2000));
     this.specs.put("severity", severityMap);
     this.thresholdSeverityLabeler = new AnomalyLabelerWrapper(this.testDataProvider, this.config, 1000L, 6000L);
     DetectionPipelineResult result = this.thresholdSeverityLabeler.run();
@@ -142,9 +139,9 @@ public class ThresholdSeverityLabelerTest {
   @Test
   public void testLabelingHigherSeverity() throws Exception {
     Map<String, Object> severityMap = new HashMap<>();
-    severityMap.put(AnomalySeverity.CRITICAL.toString(), new Threshold(0.2, 3000));
-    severityMap.put(AnomalySeverity.HIGH.toString(), new Threshold(0.15, 2000));
-    severityMap.put(AnomalySeverity.MEDIUM.toString(), new Threshold(0.12, 1500));
+    severityMap.put(AnomalySeverity.CRITICAL.toString(), ImmutableMap.of("change",0.2, "duration", 3000));
+    severityMap.put(AnomalySeverity.HIGH.toString(), ImmutableMap.of("change", 0.15, "duration", 2000));
+    severityMap.put(AnomalySeverity.MEDIUM.toString(), ImmutableMap.of("change", 0.12, "duration", 1500));
     this.specs.put("severity", severityMap);
     MergedAnomalyResultDTO anomaly = DetectionTestUtils.makeAnomaly(4000L, 6000L, METRIC_URN, 2400, 3000);
     anomaly.setSeverityLabel(AnomalySeverity.HIGH);
@@ -162,9 +159,9 @@ public class ThresholdSeverityLabelerTest {
   @Test
   public void testLabelingLowerSeverity() throws Exception {
     Map<String, Object> severityMap = new HashMap<>();
-    severityMap.put(AnomalySeverity.CRITICAL.toString(), new Threshold(0.2, 3000));
-    severityMap.put(AnomalySeverity.HIGH.toString(), new Threshold(0.15, 2000));
-    severityMap.put(AnomalySeverity.MEDIUM.toString(), new Threshold(0.10, 1500));
+    severityMap.put(AnomalySeverity.CRITICAL.toString(), ImmutableMap.of("change",0.2, "duration", 3000));
+    severityMap.put(AnomalySeverity.HIGH.toString(), ImmutableMap.of("change", 0.15, "duration", 2000));
+    severityMap.put(AnomalySeverity.MEDIUM.toString(), ImmutableMap.of("change", 0.1, "duration", 1500));
     this.specs.put("severity", severityMap);
     MergedAnomalyResultDTO anomaly = DetectionTestUtils.makeAnomaly(4200L, 6000L, METRIC_URN, 2700, 3000);
     anomaly.setSeverityLabel(AnomalySeverity.HIGH);

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detector/email/filter/TestPrecisionRecallEvaluator.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detector/email/filter/TestPrecisionRecallEvaluator.java
@@ -34,7 +34,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.thirdeye.constant.AnomalyFeedbackType.*;
-import static org.junit.Assert.*;
+import static org.testng.Assert.*;
 
 
 public class TestPrecisionRecallEvaluator {

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detector/email/filter/TestUserReportUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/detector/email/filter/TestUserReportUtils.java
@@ -28,7 +28,7 @@ import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/TestAlertContentFormatterFactory.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/notification/formatter/TestAlertContentFormatterFactory.java
@@ -19,7 +19,7 @@ package org.apache.pinot.thirdeye.notification.formatter;
 import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
 import org.apache.pinot.thirdeye.notification.content.templates.HierarchicalAnomaliesContent;
 import org.apache.pinot.thirdeye.notification.content.templates.MetricAnomaliesContent;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 

--- a/thirdeye/thirdeye-spi/pom.xml
+++ b/thirdeye/thirdeye-spi/pom.xml
@@ -42,6 +42,12 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-java-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This PR is to fix a few following issues.

- ModelMapper cannot map severity configuration into Threshold objects.
- Tunner fails when fetching anomalies gets timeout, which cause entire detection run failing.
- pinot-java-client includes slf4j-log4j12, which causes slf4j binding conflicts.