### PR TITLE
Add IN_PARTITIONED_SUBQUERY support

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -26,9 +26,9 @@ import org.apache.pinot.core.common.DataSourceMetadata;
 import org.apache.pinot.core.data.partition.PartitionFunction;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
-import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.FilterContext;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.predicate.EqPredicate;
 import org.apache.pinot.core.query.request.context.predicate.Predicate;
 import org.apache.pinot.core.query.request.context.predicate.RangePredicate;
@@ -65,8 +65,8 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public boolean prune(IndexSegment segment, ServerQueryRequest queryRequest) {
-    FilterContext filter = queryRequest.getQueryContext().getFilter();
+  public boolean prune(IndexSegment segment, QueryContext query) {
+    FilterContext filter = query.getFilter();
     if (filter == null) {
       return false;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/DataSchemaSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/DataSchemaSegmentPruner.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.pruner;
 
 import org.apache.pinot.core.indexsegment.IndexSegment;
-import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
@@ -34,8 +34,8 @@ public class DataSchemaSegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public boolean prune(IndexSegment segment, ServerQueryRequest queryRequest) {
-    return !segment.getColumnNames().containsAll(queryRequest.getAllColumns());
+  public boolean prune(IndexSegment segment, QueryContext query) {
+    return !segment.getColumnNames().containsAll(query.getColumns());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerService.java
@@ -20,10 +20,9 @@ package org.apache.pinot.core.query.pruner;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.pinot.core.data.manager.SegmentDataManager;
-import org.apache.pinot.core.data.manager.TableDataManager;
+import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.query.config.SegmentPrunerConfig;
-import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,11 +49,10 @@ public class SegmentPrunerService {
   /**
    * Prunes the segments based on the query request, returns the segments that are not pruned.
    */
-  public List<SegmentDataManager> prune(TableDataManager tableDataManager, List<SegmentDataManager> segmentDataManagers,
-      ServerQueryRequest queryRequest) {
+  public List<IndexSegment> prune(List<IndexSegment> segments, QueryContext query) {
     for (SegmentPruner segmentPruner : _segmentPruners) {
-      segmentDataManagers = segmentPruner.prune(tableDataManager, segmentDataManagers, queryRequest);
+      segments = segmentPruner.prune(segments, query);
     }
-    return segmentDataManagers;
+    return segments;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValidSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValidSegmentPruner.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.pruner;
 
 import org.apache.pinot.core.indexsegment.IndexSegment;
-import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -29,22 +29,18 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  * invalid/bad data.
  */
 public class ValidSegmentPruner implements SegmentPruner {
+
   @Override
   public void init(PinotConfiguration config) {
-
   }
 
   /**
    * Returns true if a segment should be pruned-out due to bad/invalid data.
    * Current check(s) below:
    * - Empty segment.
-   *
-   * @param segment
-   * @param queryRequest
-   * @return
    */
   @Override
-  public boolean prune(IndexSegment segment, ServerQueryRequest queryRequest) {
+  public boolean prune(IndexSegment segment, QueryContext query) {
     SegmentMetadata segmentMetadata = segment.getSegmentMetadata();
 
     // Check for empty segment.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/FunctionContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/FunctionContext.java
@@ -33,7 +33,7 @@ public class FunctionContext {
   }
 
   private final Type _type;
-  private final String _functionName;
+  private String _functionName;
   private final List<ExpressionContext> _arguments;
 
   public FunctionContext(Type type, String functionName, List<ExpressionContext> arguments) {
@@ -45,6 +45,11 @@ public class FunctionContext {
 
   public Type getType() {
     return _type;
+  }
+
+  public void setFunctionName(String functionName) {
+    // NOTE: Standardize the function name to lower case
+    _functionName = functionName.toLowerCase();
   }
 
   public String getFunctionName() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
@@ -57,6 +57,7 @@ public class BrokerRequestToQueryContextConverter {
    *          optimizes the BrokerRequest but not the PinotQuery.
    */
   public static QueryContext convert(BrokerRequest brokerRequest) {
+    String tableName = brokerRequest.getQuerySource().getTableName();
     PinotQuery pinotQuery = brokerRequest.getPinotQuery();
 
     List<ExpressionContext> selectExpressions;
@@ -203,9 +204,9 @@ public class BrokerRequestToQueryContextConverter {
       }
     }
 
-    return new QueryContext.Builder().setSelectExpressions(selectExpressions).setAliasMap(aliasMap).setFilter(filter)
-        .setGroupByExpressions(groupByExpressions).setOrderByExpressions(orderByExpressions)
-        .setHavingFilter(havingFilter).setLimit(limit).setOffset(offset)
+    return new QueryContext.Builder().setTableName(tableName).setSelectExpressions(selectExpressions)
+        .setAliasMap(aliasMap).setFilter(filter).setGroupByExpressions(groupByExpressions)
+        .setOrderByExpressions(orderByExpressions).setHavingFilter(havingFilter).setLimit(limit).setOffset(offset)
         .setQueryOptions(brokerRequest.getQueryOptions()).setDebugOptions(brokerRequest.getDebugOptions())
         .setBrokerRequest(brokerRequest).build();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
@@ -18,65 +18,11 @@
  */
 package org.apache.pinot.core.query.request.context.utils;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
-import org.apache.pinot.core.query.request.context.ExpressionContext;
-import org.apache.pinot.core.query.request.context.FilterContext;
-import org.apache.pinot.core.query.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 
 
 public class QueryContextUtils {
   private QueryContextUtils() {
-  }
-
-  /**
-   * Returns all the columns (IDENTIFIER expressions) in the given query.
-   */
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  public static Set<String> getAllColumns(QueryContext query) {
-    Set<String> columns = new HashSet<>();
-
-    for (ExpressionContext expression : query.getSelectExpressions()) {
-      expression.getColumns(columns);
-    }
-    FilterContext filter = query.getFilter();
-    if (filter != null) {
-      filter.getColumns(columns);
-    }
-    List<ExpressionContext> groupByExpressions = query.getGroupByExpressions();
-    if (groupByExpressions != null) {
-      for (ExpressionContext expression : groupByExpressions) {
-        expression.getColumns(columns);
-      }
-    }
-    FilterContext havingFilter = query.getHavingFilter();
-    if (havingFilter != null) {
-      havingFilter.getColumns(columns);
-    }
-    List<OrderByExpressionContext> orderByExpressions = query.getOrderByExpressions();
-    if (orderByExpressions != null) {
-      for (OrderByExpressionContext orderByExpression : orderByExpressions) {
-        orderByExpression.getColumns(columns);
-      }
-    }
-
-    // NOTE: Also gather columns from the input expressions of the aggregation functions because for certain types of
-    //       aggregation (e.g. DistinctCountThetaSketch), some input expressions are compiled while constructing the
-    //       aggregation function.
-    AggregationFunction[] aggregationFunctions = query.getAggregationFunctions();
-    if (aggregationFunctions != null) {
-      for (AggregationFunction aggregationFunction : aggregationFunctions) {
-        List<ExpressionContext> inputExpressions = aggregationFunction.getInputExpressions();
-        for (ExpressionContext expression : inputExpressions) {
-          expression.getColumns(columns);
-        }
-      }
-    }
-
-    return columns;
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -23,7 +23,6 @@ import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.common.DataSourceMetadata;
 import org.apache.pinot.core.data.partition.PartitionFunctionFactory;
 import org.apache.pinot.core.indexsegment.IndexSegment;
-import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -116,8 +115,6 @@ public class ColumnValueSegmentPrunerTest {
 
   private boolean runPruner(IndexSegment indexSegment, String query) {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
-    ServerQueryRequest queryRequest = mock(ServerQueryRequest.class);
-    when(queryRequest.getQueryContext()).thenReturn(queryContext);
-    return PRUNER.prune(indexSegment, queryRequest);
+    return PRUNER.prune(indexSegment, queryContext);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/SelectionQuerySegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/SelectionQuerySegmentPrunerTest.java
@@ -23,10 +23,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.common.DataSourceMetadata;
-import org.apache.pinot.core.data.manager.SegmentDataManager;
-import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.indexsegment.IndexSegment;
-import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
@@ -44,193 +41,185 @@ public class SelectionQuerySegmentPrunerTest {
   public static final String ORDER_BY_COLUMN = "testColumn";
 
   private final SelectionQuerySegmentPruner _segmentPruner = new SelectionQuerySegmentPruner();
-  private final TableDataManager _tableDataManager = mock(TableDataManager.class);
 
   @Test
   public void testLimit0() {
-    List<SegmentDataManager> segmentDataManagers = Arrays
-        .asList(getSegmentDataManager(null, null, 10), getSegmentDataManager(0L, 10L, 10),
-            getSegmentDataManager(-5L, 5L, 15));
+    List<IndexSegment> indexSegments =
+        Arrays.asList(getIndexSegment(null, null, 10), getIndexSegment(0L, 10L, 10), getIndexSegment(-5L, 5L, 15));
 
     // Should keep only the first segment
-    ServerQueryRequest queryRequest = getQueryRequest("SELECT * FROM testTable LIMIT 0");
-    List<SegmentDataManager> result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable LIMIT 0");
+    List<IndexSegment> result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 1);
-    assertSame(result.get(0), segmentDataManagers.get(0));
+    assertSame(result.get(0), indexSegments.get(0));
 
-    queryRequest = getQueryRequest("SELECT * FROM testTable ORDER BY testColumn LIMIT 0");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext =
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable ORDER BY testColumn LIMIT 0");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 1);
-    assertSame(result.get(0), segmentDataManagers.get(0));
-  }
-
-  @Test
-  public void testSelectionOnlyUpsert() {
-    List<SegmentDataManager> segmentDataManagers = Arrays
-        .asList(getSegmentDataManager(null, null, 10, true), getSegmentDataManager(0L, 10L, 10, true),
-            getSegmentDataManager(-5L, 5L, 15, true));
-
-    // Should keep enough documents to fulfill the LIMIT requirement
-    ServerQueryRequest queryRequest = getQueryRequest("SELECT * FROM testTable LIMIT 5");
-    List<SegmentDataManager> result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
-    assertEquals(result.size(), 3);
-
-    queryRequest = getQueryRequest("SELECT * FROM testTable LIMIT 10");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
-    assertEquals(result.size(), 3);
-
-    queryRequest = getQueryRequest("SELECT * FROM testTable LIMIT 15");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
-    assertEquals(result.size(), 3);
+    assertSame(result.get(0), indexSegments.get(0));
   }
 
   @Test
   public void testSelectionOnly() {
-    List<SegmentDataManager> segmentDataManagers = Arrays
-        .asList(getSegmentDataManager(null, null, 10), getSegmentDataManager(0L, 10L, 10),
-            getSegmentDataManager(-5L, 5L, 15));
+    List<IndexSegment> indexSegments =
+        Arrays.asList(getIndexSegment(null, null, 10), getIndexSegment(0L, 10L, 10), getIndexSegment(-5L, 5L, 15));
 
     // Should keep enough documents to fulfill the LIMIT requirement
-    ServerQueryRequest queryRequest = getQueryRequest("SELECT * FROM testTable LIMIT 5");
-    List<SegmentDataManager> result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable LIMIT 5");
+    List<IndexSegment> result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 1);
-    assertSame(result.get(0), segmentDataManagers.get(0));
+    assertSame(result.get(0), indexSegments.get(0));
 
-    queryRequest = getQueryRequest("SELECT * FROM testTable LIMIT 10");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext = QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable LIMIT 10");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 1);
-    assertSame(result.get(0), segmentDataManagers.get(0));
+    assertSame(result.get(0), indexSegments.get(0));
 
-    queryRequest = getQueryRequest("SELECT * FROM testTable LIMIT 15");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext = QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable LIMIT 15");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 2);
-    assertSame(result.get(0), segmentDataManagers.get(0));
-    assertSame(result.get(1), segmentDataManagers.get(1));
+    assertSame(result.get(0), indexSegments.get(0));
+    assertSame(result.get(1), indexSegments.get(1));
 
-    queryRequest = getQueryRequest("SELECT * FROM testTable LIMIT 25");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext = QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable LIMIT 25");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 3);
-    assertSame(result.get(0), segmentDataManagers.get(0));
-    assertSame(result.get(1), segmentDataManagers.get(1));
-    assertSame(result.get(2), segmentDataManagers.get(2));
+    assertSame(result.get(0), indexSegments.get(0));
+    assertSame(result.get(1), indexSegments.get(1));
+    assertSame(result.get(2), indexSegments.get(2));
 
-    queryRequest = getQueryRequest("SELECT * FROM testTable LIMIT 100");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext = QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable LIMIT 100");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 3);
-    assertSame(result.get(0), segmentDataManagers.get(0));
-    assertSame(result.get(1), segmentDataManagers.get(1));
-    assertSame(result.get(2), segmentDataManagers.get(2));
+    assertSame(result.get(0), indexSegments.get(0));
+    assertSame(result.get(1), indexSegments.get(1));
+    assertSame(result.get(2), indexSegments.get(2));
   }
 
   @Test
   public void testSelectionOrderBy() {
-    List<SegmentDataManager> segmentDataManagers = Arrays.asList( //
-        getSegmentDataManager(0L, 10L, 10),     // 0
-        getSegmentDataManager(-5L, 5L, 15),     // 1
-        getSegmentDataManager(15L, 50L, 30),    // 2
-        getSegmentDataManager(5L, 15L, 20),     // 3
-        getSegmentDataManager(20L, 30L, 5),     // 4
-        getSegmentDataManager(null, null, 5),   // 5
-        getSegmentDataManager(5L, 10L, 10),     // 6
-        getSegmentDataManager(15L, 30L, 15));   // 7
+    List<IndexSegment> indexSegments = Arrays.asList( //
+        getIndexSegment(0L, 10L, 10),     // 0
+        getIndexSegment(-5L, 5L, 15),     // 1
+        getIndexSegment(15L, 50L, 30),    // 2
+        getIndexSegment(5L, 15L, 20),     // 3
+        getIndexSegment(20L, 30L, 5),     // 4
+        getIndexSegment(null, null, 5),   // 5
+        getIndexSegment(5L, 10L, 10),     // 6
+        getIndexSegment(15L, 30L, 15));   // 7
 
     // Should keep segments: [null, null], [-5, 5], [0, 10]
-    ServerQueryRequest queryRequest = getQueryRequest("SELECT * FROM testTable ORDER BY testColumn LIMIT 5");
-    List<SegmentDataManager> result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable ORDER BY testColumn LIMIT 5");
+    List<IndexSegment> result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 3);
-    assertSame(result.get(0), segmentDataManagers.get(5));  // [null, null], 5
-    assertSame(result.get(1), segmentDataManagers.get(1));  // [-5, 5], 15
-    assertSame(result.get(2), segmentDataManagers.get(0));  // [0, 10], 10
+    assertSame(result.get(0), indexSegments.get(5));  // [null, null], 5
+    assertSame(result.get(1), indexSegments.get(1));  // [-5, 5], 15
+    assertSame(result.get(2), indexSegments.get(0));  // [0, 10], 10
 
     // Should keep segments: [null, null], [-5, 5], [0, 10], [5, 10], [5, 15]
-    queryRequest = getQueryRequest("SELECT * FROM testTable ORDER BY testColumn LIMIT 15, 20");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext =
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable ORDER BY testColumn LIMIT 15, 20");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 5);
-    assertSame(result.get(0), segmentDataManagers.get(5));  // [null, null], 5
-    assertSame(result.get(1), segmentDataManagers.get(1));  // [-5, 5], 15
+    assertSame(result.get(0), indexSegments.get(5));  // [null, null], 5
+    assertSame(result.get(1), indexSegments.get(1));  // [-5, 5], 15
     // [0, 10], 10 & [5, 10], 10
-    assertTrue(result.get(2) == segmentDataManagers.get(0) || result.get(2) == segmentDataManagers.get(6));
-    assertTrue(result.get(3) == segmentDataManagers.get(0) || result.get(3) == segmentDataManagers.get(6));
-    assertSame(result.get(4), segmentDataManagers.get(3));  // [5, 15], 20
+    assertTrue(result.get(2) == indexSegments.get(0) || result.get(2) == indexSegments.get(6));
+    assertTrue(result.get(3) == indexSegments.get(0) || result.get(3) == indexSegments.get(6));
+    assertSame(result.get(4), indexSegments.get(3));  // [5, 15], 20
 
     // Should keep segments: [null, null], [-5, 5], [0, 10], [5, 10], [5, 15], [15, 30], [15, 50]
-    queryRequest = getQueryRequest("SELECT * FROM testTable ORDER BY testColumn, foo LIMIT 40");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext =
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable ORDER BY testColumn, foo LIMIT 40");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 7);
-    assertSame(result.get(0), segmentDataManagers.get(5));  // [null, null], 5
-    assertSame(result.get(1), segmentDataManagers.get(1));  // [-5, 5], 15
+    assertSame(result.get(0), indexSegments.get(5));  // [null, null], 5
+    assertSame(result.get(1), indexSegments.get(1));  // [-5, 5], 15
     // [0, 10], 10 & [5, 10], 10
-    assertTrue(result.get(2) == segmentDataManagers.get(0) || result.get(2) == segmentDataManagers.get(6));
-    assertTrue(result.get(3) == segmentDataManagers.get(0) || result.get(3) == segmentDataManagers.get(6));
-    assertSame(result.get(4), segmentDataManagers.get(3));  // [5, 15], 20
-    assertSame(result.get(5), segmentDataManagers.get(7));  // [15, 30], 15
-    assertSame(result.get(6), segmentDataManagers.get(2));  // [15, 50], 30
+    assertTrue(result.get(2) == indexSegments.get(0) || result.get(2) == indexSegments.get(6));
+    assertTrue(result.get(3) == indexSegments.get(0) || result.get(3) == indexSegments.get(6));
+    assertSame(result.get(4), indexSegments.get(3));  // [5, 15], 20
+    assertSame(result.get(5), indexSegments.get(7));  // [15, 30], 15
+    assertSame(result.get(6), indexSegments.get(2));  // [15, 50], 30
 
     // Should keep segments: [null, null], [20, 30], [15, 50], [15, 30]
-    queryRequest = getQueryRequest("SELECT * FROM testTable ORDER BY testColumn DESC LIMIT 5");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext =
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable ORDER BY testColumn DESC LIMIT 5");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 4);
-    assertSame(result.get(0), segmentDataManagers.get(5));  // [null, null], 5
-    assertSame(result.get(1), segmentDataManagers.get(4));  // [20, 30], 5
+    assertSame(result.get(0), indexSegments.get(5));  // [null, null], 5
+    assertSame(result.get(1), indexSegments.get(4));  // [20, 30], 5
     // [15, 50], 30 & [15, 30], 15
-    assertTrue(result.get(2) == segmentDataManagers.get(2) || result.get(2) == segmentDataManagers.get(7));
-    assertTrue(result.get(3) == segmentDataManagers.get(2) || result.get(3) == segmentDataManagers.get(7));
+    assertTrue(result.get(2) == indexSegments.get(2) || result.get(2) == indexSegments.get(7));
+    assertTrue(result.get(3) == indexSegments.get(2) || result.get(3) == indexSegments.get(7));
 
     // Should keep segments: [null, null], [20, 30], [15, 50], [15, 30]
-    queryRequest = getQueryRequest("SELECT * FROM testTable ORDER BY testColumn DESC LIMIT 5, 30");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext = QueryContextConverterUtils
+        .getQueryContextFromSQL("SELECT * FROM testTable ORDER BY testColumn DESC LIMIT 5, 30");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 4);
-    assertSame(result.get(0), segmentDataManagers.get(5));  // [null, null], 5
-    assertSame(result.get(1), segmentDataManagers.get(4));  // [20, 30], 5
+    assertSame(result.get(0), indexSegments.get(5));  // [null, null], 5
+    assertSame(result.get(1), indexSegments.get(4));  // [20, 30], 5
     // [15, 50], 30 & [15, 30], 15
-    assertTrue(result.get(2) == segmentDataManagers.get(2) || result.get(2) == segmentDataManagers.get(7));
-    assertTrue(result.get(3) == segmentDataManagers.get(2) || result.get(3) == segmentDataManagers.get(7));
+    assertTrue(result.get(2) == indexSegments.get(2) || result.get(2) == indexSegments.get(7));
+    assertTrue(result.get(3) == indexSegments.get(2) || result.get(3) == indexSegments.get(7));
 
     // Should keep segments: [null, null], [20, 30], [15, 50], [15, 30], [5, 15], [5, 10], [0, 10], [-5, 5]
-    queryRequest = getQueryRequest("SELECT * FROM testTable ORDER BY testColumn DESC, foo LIMIT 60");
-    result = _segmentPruner.prune(_tableDataManager, segmentDataManagers, queryRequest);
+    queryContext = QueryContextConverterUtils
+        .getQueryContextFromSQL("SELECT * FROM testTable ORDER BY testColumn DESC, foo LIMIT 60");
+    result = _segmentPruner.prune(indexSegments, queryContext);
     assertEquals(result.size(), 8);
-    assertSame(result.get(0), segmentDataManagers.get(5));  // [null, null], 5
-    assertSame(result.get(1), segmentDataManagers.get(4));  // [20, 30], 5
+    assertSame(result.get(0), indexSegments.get(5));  // [null, null], 5
+    assertSame(result.get(1), indexSegments.get(4));  // [20, 30], 5
     // [15, 50], 30 & [15, 30], 15
-    assertTrue(result.get(2) == segmentDataManagers.get(2) || result.get(2) == segmentDataManagers.get(7));
-    assertTrue(result.get(3) == segmentDataManagers.get(2) || result.get(3) == segmentDataManagers.get(7));
+    assertTrue(result.get(2) == indexSegments.get(2) || result.get(2) == indexSegments.get(7));
+    assertTrue(result.get(3) == indexSegments.get(2) || result.get(3) == indexSegments.get(7));
     // [5, 15], 20 & [5, 10], 10
-    assertTrue(result.get(4) == segmentDataManagers.get(3) || result.get(4) == segmentDataManagers.get(6));
-    assertTrue(result.get(5) == segmentDataManagers.get(3) || result.get(5) == segmentDataManagers.get(6));
-    assertSame(result.get(6), segmentDataManagers.get(0));  // [0, 10], 10
-    assertSame(result.get(7), segmentDataManagers.get(1));  // [-5, 5], 15
+    assertTrue(result.get(4) == indexSegments.get(3) || result.get(4) == indexSegments.get(6));
+    assertTrue(result.get(5) == indexSegments.get(3) || result.get(5) == indexSegments.get(6));
+    assertSame(result.get(6), indexSegments.get(0));  // [0, 10], 10
+    assertSame(result.get(7), indexSegments.get(1));  // [-5, 5], 15
   }
 
-  private SegmentDataManager getSegmentDataManager(@Nullable Long minValue, @Nullable Long maxValue, int totalDocs) {
-    return getSegmentDataManager(minValue, maxValue, totalDocs, false);
+  @Test
+  public void testUpsertTable() {
+    List<IndexSegment> indexSegments = Arrays
+        .asList(getIndexSegment(0L, 10L, 10, true), getIndexSegment(20L, 30L, 10, true),
+            getIndexSegment(40L, 50L, 10, true));
+
+    // Should not prune any segment for upsert table
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable LIMIT 5");
+    List<IndexSegment> result = _segmentPruner.prune(indexSegments, queryContext);
+    assertEquals(result.size(), 3);
+
+    queryContext =
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable ORDER BY testColumn LIMIT 5");
+    result = _segmentPruner.prune(indexSegments, queryContext);
+    assertEquals(result.size(), 3);
   }
 
-  private SegmentDataManager getSegmentDataManager(@Nullable Long minValue, @Nullable Long maxValue, int totalDocs,
+  private IndexSegment getIndexSegment(@Nullable Long minValue, @Nullable Long maxValue, int totalDocs) {
+    return getIndexSegment(minValue, maxValue, totalDocs, false);
+  }
+
+  private IndexSegment getIndexSegment(@Nullable Long minValue, @Nullable Long maxValue, int totalDocs,
       boolean upsert) {
-    SegmentDataManager segmentDataManager = mock(SegmentDataManager.class);
-    IndexSegment segment = mock(IndexSegment.class);
-    when(segmentDataManager.getSegment()).thenReturn(segment);
+    IndexSegment indexSegment = mock(IndexSegment.class);
     DataSource dataSource = mock(DataSource.class);
-    when(segment.getDataSource(ORDER_BY_COLUMN)).thenReturn(dataSource);
+    when(indexSegment.getDataSource(ORDER_BY_COLUMN)).thenReturn(dataSource);
     DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
     when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
     when(dataSourceMetadata.getMinValue()).thenReturn(minValue);
     when(dataSourceMetadata.getMaxValue()).thenReturn(maxValue);
     SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
-    when(segment.getSegmentMetadata()).thenReturn(segmentMetadata);
+    when(indexSegment.getSegmentMetadata()).thenReturn(segmentMetadata);
     when(segmentMetadata.getTotalDocs()).thenReturn(totalDocs);
     if (upsert) {
-      ValidDocIndexReader reader = mock(ValidDocIndexReader.class);
-      when(segment.getValidDocIndex()).thenReturn(reader);
+      ValidDocIndexReader validDocIndex = mock(ValidDocIndexReader.class);
+      when(indexSegment.getValidDocIndex()).thenReturn(validDocIndex);
     }
-    return segmentDataManager;
-  }
-
-  private ServerQueryRequest getQueryRequest(String sql) {
-    ServerQueryRequest queryRequest = mock(ServerQueryRequest.class);
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(sql);
-    when(queryRequest.getQueryContext()).thenReturn(queryContext);
-    return queryRequest;
+    return indexSegment;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -53,6 +53,7 @@ public class BrokerRequestToQueryContextConverterTest {
       String query = "SELECT * FROM testTable";
       QueryContext[] queryContexts = getQueryContexts(query, query);
       for (QueryContext queryContext : queryContexts) {
+        assertEquals(queryContext.getTableName(), "testTable");
         List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
         assertEquals(selectExpressions.size(), 1);
         assertEquals(selectExpressions.get(0), ExpressionContext.forIdentifier("*"));
@@ -64,7 +65,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertNull(queryContext.getHavingFilter());
         assertEquals(queryContext.getLimit(), 10);
         assertEquals(queryContext.getOffset(), 0);
-        assertTrue(QueryContextUtils.getAllColumns(queryContext).isEmpty());
+        assertTrue(queryContext.getColumns().isEmpty());
         assertFalse(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }
@@ -74,6 +75,7 @@ public class BrokerRequestToQueryContextConverterTest {
       String query = "SELECT COUNT(*) FROM testTable";
       QueryContext[] queryContexts = getQueryContexts(query, query);
       for (QueryContext queryContext : queryContexts) {
+        assertEquals(queryContext.getTableName(), "testTable");
         List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
         assertEquals(selectExpressions.size(), 1);
         assertEquals(selectExpressions.get(0), ExpressionContext.forFunction(
@@ -87,7 +89,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertNull(queryContext.getHavingFilter());
         assertEquals(queryContext.getLimit(), 10);
         assertEquals(queryContext.getOffset(), 0);
-        assertTrue(QueryContextUtils.getAllColumns(queryContext).isEmpty());
+        assertTrue(queryContext.getColumns().isEmpty());
         assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }
@@ -97,6 +99,7 @@ public class BrokerRequestToQueryContextConverterTest {
       String query = "SELECT foo, bar FROM testTable ORDER BY bar ASC, foo DESC LIMIT 50, 100";
       QueryContext[] queryContexts = getQueryContexts(query, query);
       for (QueryContext queryContext : queryContexts) {
+        assertEquals(queryContext.getTableName(), "testTable");
         List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
         assertEquals(selectExpressions.size(), 2);
         assertEquals(selectExpressions.get(0), ExpressionContext.forIdentifier("foo"));
@@ -115,7 +118,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertNull(queryContext.getHavingFilter());
         assertEquals(queryContext.getLimit(), 100);
         assertEquals(queryContext.getOffset(), 50);
-        assertEquals(QueryContextUtils.getAllColumns(queryContext), new HashSet<>(Arrays.asList("foo", "bar")));
+        assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar")));
         assertFalse(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }
@@ -126,6 +129,7 @@ public class BrokerRequestToQueryContextConverterTest {
       String sqlQuery = "SELECT DISTINCT foo, bar, foobar FROM testTable ORDER BY bar DESC, foo LIMIT 15";
       QueryContext[] queryContexts = getQueryContexts(pqlQuery, sqlQuery);
       for (QueryContext queryContext : queryContexts) {
+        assertEquals(queryContext.getTableName(), "testTable");
         List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
         assertEquals(selectExpressions.size(), 1);
         assertEquals(selectExpressions.get(0), ExpressionContext.forFunction(
@@ -148,8 +152,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertNull(queryContext.getHavingFilter());
         assertEquals(queryContext.getLimit(), 15);
         assertEquals(queryContext.getOffset(), 0);
-        assertEquals(QueryContextUtils.getAllColumns(queryContext),
-            new HashSet<>(Arrays.asList("foo", "bar", "foobar")));
+        assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar", "foobar")));
         assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }
@@ -160,6 +163,7 @@ public class BrokerRequestToQueryContextConverterTest {
           "SELECT ADD(foo, ADD(bar, 123)), SUB('456', foobar) FROM testTable ORDER BY SUB(456, foobar) LIMIT 30, 20";
       QueryContext[] queryContexts = getQueryContexts(query, query);
       for (QueryContext queryContext : queryContexts) {
+        assertEquals(queryContext.getTableName(), "testTable");
         List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
         assertEquals(selectExpressions.size(), 2);
         assertEquals(selectExpressions.get(0), ExpressionContext.forFunction(
@@ -185,8 +189,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertNull(queryContext.getHavingFilter());
         assertEquals(queryContext.getLimit(), 20);
         assertEquals(queryContext.getOffset(), 30);
-        assertEquals(QueryContextUtils.getAllColumns(queryContext),
-            new HashSet<>(Arrays.asList("foo", "bar", "foobar")));
+        assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar", "foobar")));
         assertFalse(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }
@@ -199,6 +202,7 @@ public class BrokerRequestToQueryContextConverterTest {
           "SELECT SUB(foo, bar), bar, SUM(ADD(foo, bar)) FROM testTable GROUP BY SUB(foo, bar), bar ORDER BY SUM(ADD(foo, bar)), SUB(foo, bar) DESC LIMIT 20";
       QueryContext[] queryContexts = getQueryContexts(pqlQuery, sqlQuery);
       for (QueryContext queryContext : queryContexts) {
+        assertEquals(queryContext.getTableName(), "testTable");
         List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
         int numSelectExpressions = selectExpressions.size();
         assertTrue(numSelectExpressions == 1 || numSelectExpressions == 3);
@@ -244,7 +248,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertNull(queryContext.getHavingFilter());
         assertEquals(queryContext.getLimit(), 20);
         assertEquals(queryContext.getOffset(), 0);
-        assertEquals(QueryContextUtils.getAllColumns(queryContext), new HashSet<>(Arrays.asList("foo", "bar")));
+        assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar")));
         assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }
@@ -255,6 +259,7 @@ public class BrokerRequestToQueryContextConverterTest {
           "SELECT * FROM testTable WHERE foo > 15 AND (DIV(bar, foo) BETWEEN 10 AND 20 OR TEXT_MATCH(foobar, 'potato'))";
       QueryContext[] queryContexts = getQueryContexts(query, query);
       for (QueryContext queryContext : queryContexts) {
+        assertEquals(queryContext.getTableName(), "testTable");
         List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
         assertEquals(selectExpressions.size(), 1);
         assertEquals(selectExpressions.get(0), ExpressionContext.forIdentifier("*"));
@@ -283,8 +288,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertNull(queryContext.getHavingFilter());
         assertEquals(queryContext.getLimit(), 10);
         assertEquals(queryContext.getOffset(), 0);
-        assertEquals(QueryContextUtils.getAllColumns(queryContext),
-            new HashSet<>(Arrays.asList("foo", "bar", "foobar")));
+        assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar", "foobar")));
         assertFalse(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }
@@ -295,6 +299,7 @@ public class BrokerRequestToQueryContextConverterTest {
       String sqlQuery =
           "SELECT SUM(foo) AS a, bar AS b FROM testTable WHERE b IN (5, 10, 15) GROUP BY b ORDER BY a DESC";
       QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(sqlQuery);
+      assertEquals(queryContext.getTableName(), "testTable");
       List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
       assertEquals(selectExpressions.size(), 2);
       assertEquals(selectExpressions.get(0), ExpressionContext.forFunction(
@@ -329,7 +334,7 @@ public class BrokerRequestToQueryContextConverterTest {
       assertNull(queryContext.getHavingFilter());
       assertEquals(queryContext.getLimit(), 10);
       assertEquals(queryContext.getOffset(), 0);
-      assertEquals(QueryContextUtils.getAllColumns(queryContext), new HashSet<>(Arrays.asList("foo", "bar")));
+      assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar")));
       assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
     }
 
@@ -337,6 +342,7 @@ public class BrokerRequestToQueryContextConverterTest {
     {
       String sqlQuery = "SELECT SUM(foo), bar FROM testTable GROUP BY bar HAVING SUM(foo) IN (5, 10, 15)";
       QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(sqlQuery);
+      assertEquals(queryContext.getTableName(), "testTable");
       List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
       assertEquals(selectExpressions.size(), 2);
       assertEquals(selectExpressions.get(0), ExpressionContext.forFunction(
@@ -361,7 +367,7 @@ public class BrokerRequestToQueryContextConverterTest {
       assertEquals(havingFilter.toString(), "sum(foo) IN ('5','10','15')");
       assertEquals(queryContext.getLimit(), 10);
       assertEquals(queryContext.getOffset(), 0);
-      assertEquals(QueryContextUtils.getAllColumns(queryContext), new HashSet<>(Arrays.asList("foo", "bar")));
+      assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar")));
       assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
     }
 
@@ -370,6 +376,7 @@ public class BrokerRequestToQueryContextConverterTest {
       String sqlQuery =
           "SELECT SUM(col1) * MAX(col2) FROM testTable GROUP BY col3 HAVING SUM(col1) > MIN(col2) AND SUM(col4) + col3 < MAX(col4) ORDER BY MAX(col1) + MAX(col2) - SUM(col4), col3 DESC";
       QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(sqlQuery);
+      assertEquals(queryContext.getTableName(), "testTable");
 
       // SELECT clause
       List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
@@ -428,8 +435,7 @@ public class BrokerRequestToQueryContextConverterTest {
           new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
               Collections.singletonList(ExpressionContext.forIdentifier("col4")))));
 
-      assertEquals(QueryContextUtils.getAllColumns(queryContext),
-          new HashSet<>(Arrays.asList("col1", "col2", "col3", "col4")));
+      assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("col1", "col2", "col3", "col4")));
       assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
 
       // Expected: SUM(col1), MAX(col2), MIN(col2), SUM(col4), MAX(col4), MAX(col1)
@@ -475,8 +481,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertEquals(arguments.get(2), ExpressionContext.forLiteral("bar='a'"));
         assertEquals(arguments.get(3), ExpressionContext.forLiteral("bar='b'"));
         assertEquals(arguments.get(4), ExpressionContext.forLiteral("SET_INTERSECT($1, $2)"));
-        assertEquals(QueryContextUtils.getAllColumns(queryContext),
-            new HashSet<>(Arrays.asList("foo", "bar")));
+        assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar")));
         assertTrue(QueryContextUtils.isAggregationQuery(queryContext));
       }
     }
@@ -548,7 +553,7 @@ public class BrokerRequestToQueryContextConverterTest {
     assertNull(queryContext.getHavingFilter());
     assertEquals(queryContext.getLimit(), 100);
     assertEquals(queryContext.getOffset(), 50);
-    assertEquals(QueryContextUtils.getAllColumns(queryContext), new HashSet<>(Arrays.asList("foo", "bar")));
+    assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar")));
     assertFalse(QueryContextUtils.isAggregationQuery(queryContext));
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -270,6 +270,27 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
   }
 
   /**
+   * Test hardcoded queries on server partitioned data (all the segments for a partition is served by a single server).
+   */
+  public void testHardcodedServerPartitionedSqlQueries()
+      throws Exception {
+    // IN_PARTITIONED_SUBQUERY
+    {
+      String inPartitionedSubqueryQuery =
+          "SELECT COUNT(*) FROM mytable WHERE INPARTITIONEDSUBQUERY(DestAirportID, 'SELECT IDSET(DestAirportID) FROM mytable WHERE DaysSinceEpoch = 16430') = 1";
+      String inQuery =
+          "SELECT COUNT(*) FROM mytable WHERE DestAirportID IN (SELECT DestAirportID FROM mytable WHERE DaysSinceEpoch = 16430)";
+      testSqlQuery(inPartitionedSubqueryQuery, Collections.singletonList(inQuery));
+
+      String notInPartitionedSubqueryQuery =
+          "SELECT COUNT(*) FROM mytable WHERE INPARTITIONEDSUBQUERY(DestAirportID, 'SELECT IDSET(DestAirportID) FROM mytable WHERE DaysSinceEpoch = 16430') = 0";
+      String notInQuery =
+          "SELECT COUNT(*) FROM mytable WHERE DestAirportID NOT IN (SELECT DestAirportID FROM mytable WHERE DaysSinceEpoch = 16430)";
+      testSqlQuery(notInPartitionedSubqueryQuery, Collections.singletonList(notInQuery));
+    }
+  }
+
+  /**
    * Test to ensure that broker response contains expected stats
    *
    * @throws Exception

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -173,4 +173,11 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
       throws Exception {
     testReload(false);
   }
+
+  @Test
+  @Override
+  public void testHardcodedServerPartitionedSqlQueries()
+      throws Exception {
+    super.testHardcodedServerPartitionedSqlQueries();
+  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -63,4 +63,10 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
   public void testGrpcQueryServer() {
     // Ignored
   }
+
+  @Test(enabled = false)
+  @Override
+  public void testHardcodedServerPartitionedSqlQueries() {
+    // Ignored
+  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1453,4 +1453,11 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       }
     }
   }
+
+  @Test
+  @Override
+  public void testHardcodedServerPartitionedSqlQueries()
+      throws Exception {
+    super.testHardcodedServerPartitionedSqlQueries();
+  }
 }


### PR DESCRIPTION
## Description
Add `IN_PARTITIONED_SUBQUERY` transform function to support `IDSET` aggregation function as the subquery on the server side. Because the subquery is solved on the server side, in order to make it work, the subquery must hit the same table as the main query, and the table must be partitioned at server level (all the segments for a partition is served by a single server).

E.g. The following 2 queries can be combined into one query:
`SELECT ID_SET(col) FROM table WHERE date = 20200901`
`SELECT DISTINCT_COUNT(col), date FROM table WHERE IN_ID_SET(col, '<serializedIdSet>') = 1 GROUP BY date`
->
`SELECT DISTINCT_COUNT(col), date FROM table WHERE IN_PARTITIONED_SUBQUERY(col, 'SELECT ID_SET(col) FROM table WHERE date = 20200901') = 1 GROUP BY date`