### PR TITLE
Support for multi-threaded Group By reducer for SQL.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -102,7 +102,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
   protected final AtomicLong _requestIdGenerator = new AtomicLong();
   protected final BrokerRequestOptimizer _brokerRequestOptimizer = new BrokerRequestOptimizer();
-  protected final BrokerReduceService _brokerReduceService = new BrokerReduceService();
+  protected final BrokerReduceService _brokerReduceService;
 
   protected final String _brokerId;
   protected final long _brokerTimeoutMs;
@@ -145,6 +145,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     _numDroppedLog = new AtomicInteger(0);
     _numDroppedLogRateLimiter = RateLimiter.create(1.0);
 
+    _brokerReduceService = new BrokerReduceService(_config);
     LOGGER
         .info("Broker Id: {}, timeout: {}ms, query response limit: {}, query log length: {}, query log max rate: {}qps",
             _brokerId, _brokerTimeoutMs, _queryResponseLimit, _queryLogLength, _queryLogRateLimiter.getRate());

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -166,6 +166,11 @@ public class CommonConstants {
     public static final double DEFAULT_BROKER_MIN_RESOURCE_PERCENT_FOR_START = 100.0;
     public static final String CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE = "pinot.broker.enable.query.limit.override";
 
+    // Config for number of threads to use for Broker reduce-phase.
+    public static final String CONFIG_OF_MAX_REDUCE_THREADS_PER_QUERY = "pinot.broker.max.reduce.threads.per.query";
+    public static final int DEFAULT_MAX_REDUCE_THREADS_PER_QUERY =
+        Math.max(1, Math.min(10, Runtime.getRuntime().availableProcessors() / 2)); // Same logic as CombineOperatorUtils
+
     public static class Request {
       public static final String PQL = "pql";
       public static final String SQL = "sql";

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
@@ -63,7 +63,7 @@ public class AggregationDataTableReducer implements DataTableReducer {
   @Override
   public void reduceAndSetResults(String tableName, DataSchema dataSchema,
       Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
-      BrokerMetrics brokerMetrics) {
+      DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
     if (dataTableMap.isEmpty()) {
       if (_responseFormatSql) {
         DataSchema resultTableSchema =

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducer.java
@@ -37,9 +37,9 @@ public interface DataTableReducer {
    * @param dataSchema schema from broker reduce service
    * @param dataTableMap map of servers to data tables
    * @param brokerResponseNative broker response
+   * @param reducerContext DataTableReducer context
    * @param brokerMetrics broker metrics
    */
-  void reduceAndSetResults(String tableName, DataSchema dataSchema,
-      Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
-      BrokerMetrics brokerMetrics);
+  void reduceAndSetResults(String tableName, DataSchema dataSchema, Map<ServerRoutingInstance, DataTable> dataTableMap,
+      BrokerResponseNative brokerResponseNative, DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.reduce;
+
+import java.util.concurrent.ExecutorService;
+
+
+/**
+ * POJO class to encapsulate DataTableReducer context information
+ */
+public class DataTableReducerContext {
+
+  private final ExecutorService _executorService;
+  private final int _maxReduceThreadsPerQuery;
+  private final long _reduceTimeOutMs;
+
+  /**
+   * Constructor for the class.
+   *
+   * @param executorService Executor service to use for DataTableReducer
+   * @param maxReduceThreadsPerQuery Max number of threads to use for reduce phase
+   * @param reduceTimeOutMs Reduce Phase timeOut in ms
+   */
+  public DataTableReducerContext(ExecutorService executorService, int maxReduceThreadsPerQuery, long reduceTimeOutMs) {
+    _executorService = executorService;
+    _maxReduceThreadsPerQuery = maxReduceThreadsPerQuery;
+    _reduceTimeOutMs = reduceTimeOutMs;
+  }
+
+  public ExecutorService getExecutorService() {
+    return _executorService;
+  }
+
+  public int getMaxReduceThreadsPerQuery() {
+    return _maxReduceThreadsPerQuery;
+  }
+
+  public long getReduceTimeOutMs() {
+    return _reduceTimeOutMs;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -61,7 +61,7 @@ public class DistinctDataTableReducer implements DataTableReducer {
   @Override
   public void reduceAndSetResults(String tableName, DataSchema dataSchema,
       Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
-      BrokerMetrics brokerMetrics) {
+      DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
     // DISTINCT is implemented as an aggregation function in the execution engine. Just like
     // other aggregation functions, DISTINCT returns its result as a single object
     // (of type DistinctTable) serialized by the server into the DataTable and deserialized

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
@@ -67,7 +67,7 @@ public class SelectionDataTableReducer implements DataTableReducer {
   @Override
   public void reduceAndSetResults(String tableName, DataSchema dataSchema,
       Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
-      BrokerMetrics brokerMetrics) {
+      DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
     if (dataTableMap.isEmpty()) {
       // For empty data table map, construct empty result using the cached data schema for selection query
       List<String> selectionColumns =


### PR DESCRIPTION
The existing implementation of Broker reduce phase is single-threaded.
For group-by queries where large response are being sent back from multiple servers,
this could become a bottlenect.
    
Given that brokers are generally light on CPU usage, making the reduce phase
multi-threaded would be a good idea to boost performance. This PR adds a multi-threaded
implementation for the Group-By reducer for SQL.
    
- Added an executor service in BrokerReduceService that can be used by multi-threaded
  execution of the broker reduce phase. This is initialized with number of threads as: 
  `Runtime.getRuntime().availableProcessors()`.
    
- Added a broker side config to specify max number of threads per query to be used for reduce phase.
  `pinot.broker.max.reduce.threads`. This has a same default value as server side combine phase:
  `Math.max(1, Math.min(10, Runtime.getRuntime().availableProcessors() / 2))`
    
   For reverting to single threaded reduce, set this config to 1.
    
- The GroupByDataTableReducer uses the following algorithm for determining number of
  threads to use in reduce phase (per query):
  - If there are less than 2 data tables to reduce, it uses single threaded run.
  - Else, it uses `Math.min(pinot.broker.max.reduce.threads, numDataTables).
    
- For testing, explicitly sets num threads to reduce to be > 1 to ensure functional
  correctness is tested.

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
