### PR TITLE
Minion taskExecutor for RealtimeToOfflineSegments task

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -61,4 +61,17 @@ public class MinionConstants {
     public static final String MERGE_TYPE_KEY = "mergeTypeKey";
     public static final String MERGED_SEGMENT_NAME_KEY = "mergedSegmentNameKey";
   }
+
+  public static class RealtimeToOfflineSegmentsTask {
+    public static final String TASK_TYPE = "realtimeToOfflineSegmentsTask";
+    // window
+    public static final String WINDOW_START_MILLIS_KEY = "windowStartMillis";
+    public static final String WINDOW_END_MILLIS_KEY = "windowEndMillis";
+    // segment processing
+    public static final String TIME_COLUMN_TRANSFORM_FUNCTION_KEY = "timeColumnTransformFunction";
+    public static final String COLLECTOR_TYPE_KEY = "collectorType";
+    public static final String AGGREGATION_TYPE_KEY_SUFFIX = ".aggregationType";
+    public static final String NUM_RECORDS_PER_SEGMENT_KEY = "numRecordsPerSegment";
+
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -71,7 +71,7 @@ public class MinionConstants {
     public static final String TIME_COLUMN_TRANSFORM_FUNCTION_KEY = "timeColumnTransformFunction";
     public static final String COLLECTOR_TYPE_KEY = "collectorType";
     public static final String AGGREGATION_TYPE_KEY_SUFFIX = ".aggregationType";
-    public static final String NUM_RECORDS_PER_SEGMENT_KEY = "numRecordsPerSegment";
+    public static final String MAX_NUM_RECORDS_PER_SEGMENT_KEY = "maxNumRecordsPerSegment";
 
   }
 }

--- a/pinot-minion/pom.xml
+++ b/pinot-minion/pom.xml
@@ -104,5 +104,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-avro</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/BaseTaskExecutor.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.minion.MinionContext;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
 
 
 public abstract class BaseTaskExecutor implements PinotTaskExecutor {
@@ -39,5 +40,12 @@ public abstract class BaseTaskExecutor implements PinotTaskExecutor {
         ZKMetadataProvider.getTableConfig(MINION_CONTEXT.getHelixPropertyStore(), tableNameWithType);
     Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", tableNameWithType);
     return tableConfig;
+  }
+
+  protected Schema getSchema(String tableName) {
+    Schema schema =
+        ZKMetadataProvider.getTableSchema(MINION_CONTEXT.getHelixPropertyStore(), tableName);
+    Preconditions.checkState(schema != null, "Failed to find schema for table: %s", tableName);
+    return schema;
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.minion.executor;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -117,7 +118,7 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
       Map<String, ColumnPartitionConfig> columnPartitionMap =
           tableConfig.getIndexingConfig().getSegmentPartitionConfig().getColumnPartitionMap();
       PartitionerConfig partitionerConfig = getPartitionerConfig(columnPartitionMap, tableNameWithType, schemaColumns);
-      segmentProcessorConfigBuilder.setPartitionerConfig(partitionerConfig);
+      segmentProcessorConfigBuilder.setPartitionerConfigs(Lists.newArrayList(partitionerConfig));
     }
 
     // Aggregations using configured Collector

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -1,0 +1,274 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.executor;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.core.segment.processing.collector.CollectorConfig;
+import org.apache.pinot.core.segment.processing.collector.CollectorFactory;
+import org.apache.pinot.core.segment.processing.collector.ValueAggregatorFactory;
+import org.apache.pinot.core.segment.processing.filter.RecordFilterConfig;
+import org.apache.pinot.core.segment.processing.filter.RecordFilterFactory;
+import org.apache.pinot.core.segment.processing.framework.SegmentConfig;
+import org.apache.pinot.core.segment.processing.framework.SegmentProcessorConfig;
+import org.apache.pinot.core.segment.processing.framework.SegmentProcessorFramework;
+import org.apache.pinot.core.segment.processing.partitioner.PartitionerConfig;
+import org.apache.pinot.core.segment.processing.partitioner.PartitionerFactory;
+import org.apache.pinot.core.segment.processing.transformer.RecordTransformerConfig;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A task to convert segments from a REALTIME table to segments for its corresponding OFFLINE table.
+ * The realtime segments could span across multiple time windows. This task extracts data and creates segments for a configured time range.
+ * The {@link SegmentProcessorFramework} is used for the segment conversion, which also does
+ * 1. time column rollup
+ * 2. time window extraction using filter function
+ * 3. partitioning using table config's segmentPartitioningConfig
+ * 4. aggregations and rollup
+ * 5. data sorting
+ */
+public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsConversionExecutor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeToOfflineSegmentsTaskExecutor.class);
+  private static final String INPUT_SEGMENTS_DIR = "input_segments";
+  private static final String OUTPUT_SEGMENTS_DIR = "output_segments";
+
+  @Override
+  protected List<SegmentConversionResult> convert(PinotTaskConfig pinotTaskConfig, List<File> originalIndexDirs,
+      File workingDir)
+      throws Exception {
+    String taskType = pinotTaskConfig.getTaskType();
+    Map<String, String> configs = pinotTaskConfig.getConfigs();
+    LOGGER.info("Starting task: {} with configs: {}", taskType, configs);
+
+    String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY); // rawTableName_OFFLINE expected here
+    TableConfig tableConfig = getTableConfig(tableNameWithType);
+    Schema schema = getSchema(tableNameWithType);
+    Set<String> schemaColumns = schema.getPhysicalColumnNames();
+    String timeColumn = tableConfig.getValidationConfig().getTimeColumnName();
+    DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumn);
+    assert dateTimeFieldSpec != null;
+
+    long windowStartMs =
+        Long.parseLong(configs.get(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MILLIS_KEY));
+    long windowEndMs = Long.parseLong(configs.get(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_END_MILLIS_KEY));
+    String timeColumnTransformFunction =
+        configs.get(MinionConstants.RealtimeToOfflineSegmentsTask.TIME_COLUMN_TRANSFORM_FUNCTION_KEY);
+    String collectorTypeStr = configs.get(MinionConstants.RealtimeToOfflineSegmentsTask.COLLECTOR_TYPE_KEY);
+    Map<String, String> aggregatorConfigs = new HashMap<>();
+    for (Map.Entry<String, String> entry : configs.entrySet()) {
+      String key = entry.getKey();
+      if (key.endsWith(MinionConstants.RealtimeToOfflineSegmentsTask.AGGREGATION_TYPE_KEY_SUFFIX)) {
+        String column = key.split(MinionConstants.RealtimeToOfflineSegmentsTask.AGGREGATION_TYPE_KEY_SUFFIX)[0];
+        aggregatorConfigs.put(column, entry.getValue());
+      }
+    }
+    String numRecordsPerSegment =
+        configs.get(MinionConstants.RealtimeToOfflineSegmentsTask.NUM_RECORDS_PER_SEGMENT_KEY);
+
+    SegmentProcessorConfig.Builder segmentProcessorConfigBuilder =
+        new SegmentProcessorConfig.Builder().setTableConfig(tableConfig).setSchema(schema);
+
+    // Time rollup using configured time transformation function
+    if (timeColumnTransformFunction != null) {
+      RecordTransformerConfig recordTransformerConfig =
+          getRecordTransformerConfigForTime(timeColumnTransformFunction, timeColumn);
+      segmentProcessorConfigBuilder.setRecordTransformerConfig(recordTransformerConfig);
+    }
+
+    // Filter function for extracting data between start and end time window
+    RecordFilterConfig recordFilterConfig =
+        getRecordFilterConfigForWindow(windowStartMs, windowEndMs, dateTimeFieldSpec, timeColumn);
+    segmentProcessorConfigBuilder.setRecordFilterConfig(recordFilterConfig);
+
+    // Partitioner config from tableConfig
+    if (tableConfig.getIndexingConfig().getSegmentPartitionConfig() != null) {
+      Map<String, ColumnPartitionConfig> columnPartitionMap =
+          tableConfig.getIndexingConfig().getSegmentPartitionConfig().getColumnPartitionMap();
+      PartitionerConfig partitionerConfig = getPartitionerConfig(columnPartitionMap, tableNameWithType, schemaColumns);
+      segmentProcessorConfigBuilder.setPartitionerConfig(partitionerConfig);
+    }
+
+    // Aggregations using configured Collector
+    List<String> sortedColumns = tableConfig.getIndexingConfig().getSortedColumn();
+    CollectorConfig collectorConfig =
+        getCollectorConfig(collectorTypeStr, aggregatorConfigs, schemaColumns, sortedColumns);
+    segmentProcessorConfigBuilder.setCollectorConfig(collectorConfig);
+
+    // Segment config
+    if (numRecordsPerSegment != null) {
+      SegmentConfig segmentConfig = getSegmentConfig(numRecordsPerSegment);
+      segmentProcessorConfigBuilder.setSegmentConfig(segmentConfig);
+    }
+
+    SegmentProcessorConfig segmentProcessorConfig = segmentProcessorConfigBuilder.build();
+
+    File inputSegmentsDir = new File(workingDir, INPUT_SEGMENTS_DIR);
+    Preconditions.checkState(inputSegmentsDir.mkdirs(), "Failed to create input directory: %s for task: %s",
+        inputSegmentsDir.getAbsolutePath(), taskType);
+    for (File indexDir : originalIndexDirs) {
+      FileUtils.copyDirectoryToDirectory(indexDir, inputSegmentsDir);
+    }
+    File outputSegmentsDir = new File(workingDir, OUTPUT_SEGMENTS_DIR);
+    Preconditions.checkState(outputSegmentsDir.mkdirs(), "Failed to create output directory: %s for task: %s",
+        outputSegmentsDir.getAbsolutePath(), taskType);
+
+    SegmentProcessorFramework segmentProcessorFramework =
+        new SegmentProcessorFramework(inputSegmentsDir, segmentProcessorConfig, outputSegmentsDir);
+    try {
+      segmentProcessorFramework.processSegments();
+    } finally {
+      segmentProcessorFramework.cleanup();
+    }
+
+    LOGGER.info("Finished task: {} with configs: {}", taskType, configs);
+    List<SegmentConversionResult> results = new ArrayList<>();
+    for (File file : outputSegmentsDir.listFiles()) {
+      String outputSegmentName = file.getName();
+      results.add(new SegmentConversionResult.Builder().setFile(file).setSegmentName(outputSegmentName)
+          .setTableNameWithType(tableNameWithType).build());
+    }
+    return results;
+  }
+
+  /**
+   * Construct a {@link RecordTransformerConfig} for time column transformation
+   */
+  private RecordTransformerConfig getRecordTransformerConfigForTime(String timeColumnTransformFunction,
+      String timeColumn) {
+    Map<String, String> transformationsMap = new HashMap<>();
+    transformationsMap.put(timeColumn, timeColumnTransformFunction);
+    return new RecordTransformerConfig.Builder().setTransformFunctionsMap(transformationsMap).build();
+  }
+
+  /**
+   * Construct a {@link RecordFilterConfig} by setting a filter function on the time column, for extracting data between window start/end
+   */
+  private RecordFilterConfig getRecordFilterConfigForWindow(long windowStartMs, long windowEndMs,
+      DateTimeFieldSpec dateTimeFieldSpec, String timeColumn) {
+    String filterFunction;
+    DateTimeFormatSpec dateTimeFormatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
+    TimeUnit timeUnit = dateTimeFormatSpec.getColumnUnit();
+    DateTimeFieldSpec.TimeFormat timeFormat = dateTimeFormatSpec.getTimeFormat();
+    if (timeUnit.equals(TimeUnit.MILLISECONDS) && timeFormat.equals(DateTimeFieldSpec.TimeFormat.EPOCH)) {
+      // If time column is in EPOCH millis, use windowStart and windowEnd directly to filter
+      filterFunction = getFilterFunctionLong(windowStartMs, windowEndMs, timeColumn);
+    } else {
+      // Convert windowStart and windowEnd to time format of the data
+      if (dateTimeFormatSpec.getTimeFormat().equals(DateTimeFieldSpec.TimeFormat.EPOCH)) {
+        long windowStart = dateTimeFormatSpec.fromMillisToFormat(windowStartMs, Long.class);
+        long windowEnd = dateTimeFormatSpec.fromMillisToFormat(windowEndMs, Long.class);
+        filterFunction = getFilterFunctionLong(windowStart, windowEnd, timeColumn);
+      } else {
+        String windowStart = dateTimeFormatSpec.fromMillisToFormat(windowStartMs, String.class);
+        String windowEnd = dateTimeFormatSpec.fromMillisToFormat(windowEndMs, String.class);
+        if (dateTimeFieldSpec.getDataType().isNumeric()) {
+          filterFunction = getFilterFunctionLong(Long.parseLong(windowStart), Long.parseLong(windowEnd), timeColumn);
+        } else {
+          filterFunction = getFilterFunctionString(windowStart, windowEnd, timeColumn);
+        }
+      }
+    }
+    return new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
+        .setFilterFunction(filterFunction).build();
+  }
+
+  /**
+   * Construct a {@link PartitionerConfig} using {@link org.apache.pinot.spi.config.table.SegmentPartitionConfig} from the table config
+   */
+  private PartitionerConfig getPartitionerConfig(Map<String, ColumnPartitionConfig> columnPartitionMap,
+      String tableNameWithType, Set<String> schemaColumns) {
+
+    Preconditions.checkState(columnPartitionMap.size() == 1,
+        "Cannot partition using more than 1 ColumnPartitionConfig for table: %s", tableNameWithType);
+    String partitionColumn = columnPartitionMap.keySet().iterator().next();
+    Preconditions.checkState(schemaColumns.contains(partitionColumn),
+        "Partition column: %s is not a physical column in the schema", partitionColumn);
+    return new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TABLE_PARTITION_CONFIG)
+        .setColumnName(partitionColumn).setColumnPartitionConfig(columnPartitionMap.get(partitionColumn)).build();
+  }
+
+  /**
+   * Construct a {@link CollectorConfig} using configured collector configs and sorted columns from table config
+   */
+  private CollectorConfig getCollectorConfig(String collectorTypeStr, Map<String, String> aggregateConfigs,
+      Set<String> schemaColumns, List<String> sortedColumns) {
+    CollectorFactory.CollectorType collectorType = collectorTypeStr == null ? CollectorFactory.CollectorType.CONCAT
+        : CollectorFactory.CollectorType.valueOf(collectorTypeStr.toUpperCase());
+
+    Map<String, ValueAggregatorFactory.ValueAggregatorType> aggregatorTypeMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : aggregateConfigs.entrySet()) {
+      String column = entry.getKey();
+      Preconditions
+          .checkState(schemaColumns.contains(column), "Aggregate column: %s is not a physical column in the schema",
+              column);
+      aggregatorTypeMap.put(column, ValueAggregatorFactory.ValueAggregatorType.valueOf(entry.getValue().toUpperCase()));
+    }
+
+    if (sortedColumns != null) {
+      for (String column : sortedColumns) {
+        Preconditions
+            .checkState(schemaColumns.contains(column), "Sorted column: %s is not a physical column in the schema",
+                column);
+      }
+    }
+    return new CollectorConfig.Builder().setCollectorType(collectorType).setAggregatorTypeMap(aggregatorTypeMap)
+        .setSortOrder(sortedColumns).build();
+  }
+
+  /**
+   * Construct a {@link SegmentConfig} using config values
+   */
+  private SegmentConfig getSegmentConfig(String numRecordsPerSegment) {
+    return new SegmentConfig.Builder().setMaxNumRecordsPerSegment(Integer.parseInt(numRecordsPerSegment)).build();
+  }
+
+  /**
+   * Construct a {@link org.apache.pinot.core.operator.transform.function.GroovyTransformFunction} string for extracting records between
+   * windowStart inclusive and windowEnd exclusive using the time column, where time column is a INT/LONG column
+   */
+  private String getFilterFunctionLong(long windowStart, long windowEnd, String timeColumn) {
+    return String
+        .format("Groovy({%s < %d || %s >= %d}, %s)", timeColumn, windowStart, timeColumn, windowEnd, timeColumn);
+  }
+
+  /**
+   * Construct a {@link org.apache.pinot.core.operator.transform.function.GroovyTransformFunction} string for extracting records between
+   * windowStart inclusive and windowEnd exclusive using the time column, where time column is a STRING column
+   */
+  private String getFilterFunctionString(String windowStart, String windowEnd, String timeColumn) {
+    return String.format("Groovy({%s < \"%s\" || %s >= \"%s\"}, %s)", timeColumn, windowStart, timeColumn, windowEnd,
+        timeColumn);
+  }
+}

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -214,7 +214,6 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
    */
   private PartitionerConfig getPartitionerConfig(Map<String, ColumnPartitionConfig> columnPartitionMap,
       String tableNameWithType, Set<String> schemaColumns) {
-
     Preconditions.checkState(columnPartitionMap.size() == 1,
         "Cannot partition using more than 1 ColumnPartitionConfig for table: %s", tableNameWithType);
     String partitionColumn = columnPartitionMap.keySet().iterator().next();

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutorFactory.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutorFactory.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.executor;
+
+public class RealtimeToOfflineSegmentsTaskExecutorFactory implements PinotTaskExecutorFactory {
+  @Override
+  public PinotTaskExecutor create() {
+    return new RealtimeToOfflineSegmentsTaskExecutor();
+  }
+}

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/TaskExecutorFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/TaskExecutorFactoryRegistry.java
@@ -36,6 +36,8 @@ public class TaskExecutorFactoryRegistry {
         new ConvertToRawIndexTaskExecutorFactory());
     registerTaskExecutorFactory(MinionConstants.PurgeTask.TASK_TYPE, new PurgeTaskExecutorFactory());
     registerTaskExecutorFactory(MinionConstants.MergeRollupTask.TASK_TYPE, new MergeRollupTaskExecutorFactory());
+    registerTaskExecutorFactory(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE,
+        new RealtimeToOfflineSegmentsTaskExecutorFactory());
   }
 
   /**

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutorTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutorTest.java
@@ -1,0 +1,441 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.executor;
+
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.utils.SchemaUtils;
+import org.apache.pinot.common.utils.config.TableConfigUtils;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests for the {@link RealtimeToOfflineSegmentsTaskExecutor}
+ */
+public class RealtimeToOfflineSegmentsTaskExecutorTest {
+  private static final File TEMP_DIR =
+      new File(FileUtils.getTempDirectory(), "RealtimeToOfflineSegmentTaskExecutorTest");
+  private static final File ORIGINAL_SEGMENT_DIR = new File(TEMP_DIR, "originalSegment");
+  private static final File WORKING_DIR = new File(TEMP_DIR, "workingDir");
+  private static final int NUM_SEGMENTS = 10;
+  private static final int NUM_ROWS = 5;
+  private static final String TABLE_NAME = "testTable_OFFLINE";
+  private static final String TABLE_NAME_WITH_PARTITIONING = "testTableWithPartitioning_OFFLINE";
+  private static final String TABLE_NAME_WITH_SORTED_COL = "testTableWithSortedCol_OFFLINE";
+  private static final String TABLE_NAME_EPOCH_HOURS = "testTableEpochHours_OFFLINE";
+  private static final String TABLE_NAME_SDF = "testTableSDF_OFFLINE";
+  private static final String D1 = "d1";
+  private static final String M1 = "m1";
+  private static final String T = "t";
+  private static final String T_TRX = "t_trx";
+
+  private List<File> _segmentIndexDirList;
+  private List<File> _segmentIndexDirListEpochHours;
+  private List<File> _segmentIndexDirListSDF;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(TEMP_DIR);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(T).build();
+    Map<String, ColumnPartitionConfig> columnPartitionConfigMap = new HashMap<>();
+    columnPartitionConfigMap.put(M1, new ColumnPartitionConfig("Modulo", 2));
+    TableConfig tableConfigWithPartitioning =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME_WITH_PARTITIONING).setTimeColumnName(T)
+            .setSegmentPartitionConfig(new SegmentPartitionConfig(columnPartitionConfigMap)).build();
+    TableConfig tableConfigWithSortedCol =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME_WITH_SORTED_COL).setTimeColumnName(T).setSortedColumn(D1)
+            .build();
+    TableConfig tableConfigEpochHours =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME_EPOCH_HOURS).setTimeColumnName(T_TRX).setSortedColumn(D1)
+            .setIngestionConfig(new IngestionConfig(null, Lists.newArrayList(new TransformConfig(T_TRX, "toEpochHours(t)"))))
+            .build();
+    TableConfig tableConfigSDF =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME_SDF).setTimeColumnName(T_TRX).setSortedColumn(D1)
+            .setIngestionConfig(new IngestionConfig(null, Lists.newArrayList(new TransformConfig(T_TRX, "toDateTime(t, 'yyyyMMddHH')"))))
+            .build();
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension(D1, FieldSpec.DataType.STRING)
+            .addMetric(M1, FieldSpec.DataType.INT)
+            .addDateTime(T, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+    Schema schemaEpochHours =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension(D1, FieldSpec.DataType.STRING)
+            .addMetric(M1, FieldSpec.DataType.INT).addDateTime(T_TRX, FieldSpec.DataType.INT, "1:HOURS:EPOCH", "1:HOURS")
+            .build();
+    Schema schemaSDF =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension(D1, FieldSpec.DataType.STRING)
+            .addMetric(M1, FieldSpec.DataType.INT).addDateTime(T_TRX, FieldSpec.DataType.INT, "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMddHH", "1:HOURS")
+            .build();
+
+    List<String> d1 = Lists.newArrayList("foo", "bar", "foo", "foo", "bar");
+    List<List<GenericRow>> rows = new ArrayList<>(NUM_SEGMENTS);
+    // times 1600468000000 1600496800000 1600525600000 1600554400000 1600583200000
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      long startMillis = 1600468000000L;
+      List<GenericRow> segmentRows = new ArrayList<>(NUM_ROWS);
+      for (int j = 0; j < NUM_ROWS; j++) {
+        GenericRow row = new GenericRow();
+        row.putValue(D1, d1.get(j));
+        row.putValue(M1, j);
+        row.putValue(T, startMillis);
+        segmentRows.add(row);
+        startMillis += 28800000; // create segment spanning across 3 day
+      }
+      rows.add(segmentRows);
+    }
+
+    // create test segments
+    _segmentIndexDirList = new ArrayList<>();
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      String segmentName = "segment_" + i;
+      RecordReader recordReader = new GenericRowRecordReader(rows.get(i));
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+      config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());
+      config.setTableName(TABLE_NAME);
+      config.setSegmentName(segmentName);
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, recordReader);
+      driver.build();
+      _segmentIndexDirList.add(new File(ORIGINAL_SEGMENT_DIR, segmentName));
+    }
+
+    // create test segments with time in epoch hours
+    _segmentIndexDirListEpochHours = new ArrayList<>();
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      String segmentName = "segmentEpoch_" + i;
+      RecordReader recordReader = new GenericRowRecordReader(rows.get(i));
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfigEpochHours, schemaEpochHours);
+      config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());
+      config.setTableName(TABLE_NAME_EPOCH_HOURS);
+      config.setSegmentName(segmentName);
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, recordReader);
+      driver.build();
+      _segmentIndexDirListEpochHours.add(new File(ORIGINAL_SEGMENT_DIR, segmentName));
+    }
+
+    // create test segments with time in SDF
+    _segmentIndexDirListSDF = new ArrayList<>();
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      String segmentName = "segmentSDF_" + i;
+      RecordReader recordReader = new GenericRowRecordReader(rows.get(i));
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfigSDF, schemaSDF);
+      config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());
+      config.setTableName(TABLE_NAME_SDF);
+      config.setSegmentName(segmentName);
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, recordReader);
+      driver.build();
+      _segmentIndexDirListSDF.add(new File(ORIGINAL_SEGMENT_DIR, segmentName));
+    }
+
+    MinionContext minionContext = MinionContext.getInstance();
+    @SuppressWarnings("unchecked")
+    ZkHelixPropertyStore<ZNRecord> helixPropertyStore = mock(ZkHelixPropertyStore.class);
+    when(helixPropertyStore.get("/CONFIGS/TABLE/" + TABLE_NAME, null, AccessOption.PERSISTENT))
+        .thenReturn(TableConfigUtils.toZNRecord(tableConfig));
+    when(helixPropertyStore.get("/CONFIGS/TABLE/" + TABLE_NAME_WITH_PARTITIONING, null, AccessOption.PERSISTENT))
+        .thenReturn(TableConfigUtils.toZNRecord(tableConfigWithPartitioning));
+    when(helixPropertyStore.get("/CONFIGS/TABLE/" + TABLE_NAME_WITH_SORTED_COL, null, AccessOption.PERSISTENT))
+        .thenReturn(TableConfigUtils.toZNRecord(tableConfigWithSortedCol));
+    when(helixPropertyStore.get("/CONFIGS/TABLE/" + TABLE_NAME_EPOCH_HOURS, null, AccessOption.PERSISTENT))
+        .thenReturn(TableConfigUtils.toZNRecord(tableConfigEpochHours));
+    when(helixPropertyStore.get("/CONFIGS/TABLE/" + TABLE_NAME_SDF, null, AccessOption.PERSISTENT))
+        .thenReturn(TableConfigUtils.toZNRecord(tableConfigSDF));
+    when(helixPropertyStore.get("/SCHEMAS/testTable", null, AccessOption.PERSISTENT))
+        .thenReturn(SchemaUtils.toZNRecord(schema));
+    when(helixPropertyStore.get("/SCHEMAS/testTableWithPartitioning", null, AccessOption.PERSISTENT))
+        .thenReturn(SchemaUtils.toZNRecord(schema));
+    when(helixPropertyStore.get("/SCHEMAS/testTableWithSortedCol", null, AccessOption.PERSISTENT))
+        .thenReturn(SchemaUtils.toZNRecord(schema));
+    when(helixPropertyStore.get("/SCHEMAS/testTableEpochHours", null, AccessOption.PERSISTENT))
+        .thenReturn(SchemaUtils.toZNRecord(schemaEpochHours));
+    when(helixPropertyStore.get("/SCHEMAS/testTableSDF", null, AccessOption.PERSISTENT))
+        .thenReturn(SchemaUtils.toZNRecord(schemaSDF));
+    minionContext.setHelixPropertyStore(helixPropertyStore);
+  }
+
+  @Test
+  public void testConcat()
+      throws Exception {
+    FileUtils.deleteQuietly(WORKING_DIR);
+
+    RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
+        new RealtimeToOfflineSegmentsTaskExecutor();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(MinionConstants.TABLE_NAME_KEY, "testTable_OFFLINE");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MILLIS_KEY, "1600473600000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_END_MILLIS_KEY, "1600560000000");
+    PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, configs);
+
+    List<SegmentConversionResult> conversionResults =
+        realtimeToOfflineSegmentsTaskExecutor.convert(pinotTaskConfig, _segmentIndexDirList, WORKING_DIR);
+
+    assertEquals(conversionResults.size(), 1);
+    File resultingSegment = conversionResults.get(0).getFile();
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(resultingSegment);
+    assertEquals(segmentMetadata.getTotalDocs(), 30);
+    ColumnMetadata columnMetadataForT = segmentMetadata.getColumnMetadataFor(T);
+    assertEquals(columnMetadataForT.getCardinality(), 3);
+    assertTrue((long) columnMetadataForT.getMinValue() >= 1600473600000L);
+    assertTrue((long) columnMetadataForT.getMaxValue() < 1600560000000L);
+  }
+
+  @Test
+  public void testRollupDefault()
+      throws Exception {
+    FileUtils.deleteQuietly(WORKING_DIR);
+
+    RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
+        new RealtimeToOfflineSegmentsTaskExecutor();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME);
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MILLIS_KEY, "1600473600000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_END_MILLIS_KEY, "1600560000000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.COLLECTOR_TYPE_KEY, "rollup");
+    PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, configs);
+
+    List<SegmentConversionResult> conversionResults =
+        realtimeToOfflineSegmentsTaskExecutor.convert(pinotTaskConfig, _segmentIndexDirList, WORKING_DIR);
+
+    assertEquals(conversionResults.size(), 1);
+    File resultingSegment = conversionResults.get(0).getFile();
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(resultingSegment);
+    assertEquals(segmentMetadata.getTotalDocs(), 3);
+    ColumnMetadata columnMetadataForT = segmentMetadata.getColumnMetadataFor(T);
+    assertEquals(columnMetadataForT.getCardinality(), 3);
+    assertTrue((long) columnMetadataForT.getMinValue() >= 1600473600000L);
+    assertTrue((long) columnMetadataForT.getMaxValue() < 1600560000000L);
+  }
+
+  @Test
+  public void testRollupWithTimeTransformation()
+      throws Exception {
+    FileUtils.deleteQuietly(WORKING_DIR);
+
+    RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
+        new RealtimeToOfflineSegmentsTaskExecutor();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME);
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MILLIS_KEY, "1600473600000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_END_MILLIS_KEY, "1600560000000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.COLLECTOR_TYPE_KEY, "rollup");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.TIME_COLUMN_TRANSFORM_FUNCTION_KEY, "round(t, 86400000)");
+    PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, configs);
+
+    List<SegmentConversionResult> conversionResults =
+        realtimeToOfflineSegmentsTaskExecutor.convert(pinotTaskConfig, _segmentIndexDirList, WORKING_DIR);
+
+    assertEquals(conversionResults.size(), 1);
+    File resultingSegment = conversionResults.get(0).getFile();
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(resultingSegment);
+    assertEquals(segmentMetadata.getTotalDocs(), 2);
+    ColumnMetadata columnMetadataForT = segmentMetadata.getColumnMetadataFor(T);
+    assertEquals(columnMetadataForT.getCardinality(), 1);
+    assertEquals((long) columnMetadataForT.getMinValue(), 1600473600000L);
+  }
+
+  @Test
+  public void testRollupWithMaxAggregation()
+      throws Exception {
+
+    FileUtils.deleteQuietly(WORKING_DIR);
+
+    RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
+        new RealtimeToOfflineSegmentsTaskExecutor();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME);
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MILLIS_KEY, "1600473600000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_END_MILLIS_KEY, "1600560000000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.TIME_COLUMN_TRANSFORM_FUNCTION_KEY, "round(t, 86400000)");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.COLLECTOR_TYPE_KEY, "rollup");
+    configs.put(M1 + MinionConstants.RealtimeToOfflineSegmentsTask.AGGREGATION_TYPE_KEY_SUFFIX, "max");
+    PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, configs);
+
+    List<SegmentConversionResult> conversionResults =
+        realtimeToOfflineSegmentsTaskExecutor.convert(pinotTaskConfig, _segmentIndexDirList, WORKING_DIR);
+
+    assertEquals(conversionResults.size(), 1);
+    File resultingSegment = conversionResults.get(0).getFile();
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(resultingSegment);
+    assertEquals(segmentMetadata.getTotalDocs(), 2);
+    ColumnMetadata columnMetadataForT = segmentMetadata.getColumnMetadataFor(T);
+    assertEquals(columnMetadataForT.getCardinality(), 1);
+    assertEquals((long) columnMetadataForT.getMinValue(), 1600473600000L);
+    ColumnMetadata columnMetadataForM1 = segmentMetadata.getColumnMetadataFor(M1);
+    assertEquals(columnMetadataForM1.getCardinality(), 2);
+    assertEquals((int) columnMetadataForM1.getMinValue(), 1);
+    assertEquals((int) columnMetadataForM1.getMaxValue(), 3);
+  }
+
+  @Test
+  public void testTablePartitioning()
+      throws Exception {
+    FileUtils.deleteQuietly(WORKING_DIR);
+
+    RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
+        new RealtimeToOfflineSegmentsTaskExecutor();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_WITH_PARTITIONING);
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MILLIS_KEY, "1600468000000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_END_MILLIS_KEY, "1600617600000");
+    PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, configs);
+
+    List<SegmentConversionResult> conversionResults =
+        realtimeToOfflineSegmentsTaskExecutor.convert(pinotTaskConfig, _segmentIndexDirList, WORKING_DIR);
+
+    assertEquals(conversionResults.size(), 2);
+    File resultingSegment = conversionResults.get(0).getFile();
+    File otherSegment = conversionResults.get(1).getFile();
+    SegmentMetadataImpl segmentMetadata1 = new SegmentMetadataImpl(resultingSegment);
+    SegmentMetadataImpl segmentMetadata2 = new SegmentMetadataImpl(otherSegment);
+    if (segmentMetadata1.getTotalDocs() == 30) {
+      assertEquals(segmentMetadata2.getTotalDocs(), 20);
+    } else if (segmentMetadata1.getTotalDocs() == 20) {
+      assertEquals(segmentMetadata2.getTotalDocs(), 30);
+    } else {
+      Assert.fail("Incorrect total docs in segment");
+    }
+  }
+
+  @Test
+  public void testTableSortedColumn()
+      throws Exception {
+
+    FileUtils.deleteQuietly(WORKING_DIR);
+
+    RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
+        new RealtimeToOfflineSegmentsTaskExecutor();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_WITH_SORTED_COL);
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MILLIS_KEY, "1600473600000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_END_MILLIS_KEY, "1600560000000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.COLLECTOR_TYPE_KEY, "rollup");
+    PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, configs);
+
+    List<SegmentConversionResult> conversionResults =
+        realtimeToOfflineSegmentsTaskExecutor.convert(pinotTaskConfig, _segmentIndexDirList, WORKING_DIR);
+
+    assertEquals(conversionResults.size(), 1);
+    File resultingSegment = conversionResults.get(0).getFile();
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(resultingSegment);
+    assertEquals(segmentMetadata.getTotalDocs(), 3);
+    ColumnMetadata columnMetadataForD1 = segmentMetadata.getColumnMetadataFor(D1);
+    assertEquals(columnMetadataForD1.getCardinality(), 2);
+    assertTrue(columnMetadataForD1.isSorted());
+  }
+
+  @Test
+  public void testTimeFormatEpochHours()
+      throws Exception {
+
+    FileUtils.deleteQuietly(WORKING_DIR);
+
+    RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
+        new RealtimeToOfflineSegmentsTaskExecutor();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_EPOCH_HOURS);
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MILLIS_KEY, "1600473600000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_END_MILLIS_KEY, "1600560000000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.COLLECTOR_TYPE_KEY, "rollup");
+    PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, configs);
+
+    List<SegmentConversionResult> conversionResults =
+        realtimeToOfflineSegmentsTaskExecutor.convert(pinotTaskConfig, _segmentIndexDirListEpochHours, WORKING_DIR);
+
+    assertEquals(conversionResults.size(), 1);
+    File resultingSegment = conversionResults.get(0).getFile();
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(resultingSegment);
+    assertEquals(segmentMetadata.getTotalDocs(), 3);
+    ColumnMetadata columnMetadataForT = segmentMetadata.getColumnMetadataFor(T_TRX);
+    assertEquals(columnMetadataForT.getCardinality(), 3);
+    assertTrue((int) columnMetadataForT.getMinValue() >= 444576);
+    assertTrue((int) columnMetadataForT.getMaxValue() < 444600);
+  }
+
+  @Test
+  public void testTimeFormatSDF()
+      throws Exception {
+
+    FileUtils.deleteQuietly(WORKING_DIR);
+
+    RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
+        new RealtimeToOfflineSegmentsTaskExecutor();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_SDF);
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MILLIS_KEY, "1600473600000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_END_MILLIS_KEY, "1600560000000");
+    configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.COLLECTOR_TYPE_KEY, "rollup");
+    PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, configs);
+
+    List<SegmentConversionResult> conversionResults =
+        realtimeToOfflineSegmentsTaskExecutor.convert(pinotTaskConfig, _segmentIndexDirListSDF, WORKING_DIR);
+
+    assertEquals(conversionResults.size(), 1);
+    File resultingSegment = conversionResults.get(0).getFile();
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(resultingSegment);
+    assertEquals(segmentMetadata.getTotalDocs(), 3);
+    ColumnMetadata columnMetadataForT = segmentMetadata.getColumnMetadataFor(T_TRX);
+    assertEquals(columnMetadataForT.getCardinality(), 3);
+    assertTrue((int) columnMetadataForT.getMinValue() >= 2020091900);
+    assertTrue((int) columnMetadataForT.getMaxValue() < 2020092000);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    FileUtils.deleteDirectory(TEMP_DIR);
+  }
+}


### PR DESCRIPTION
https://github.com/apache/incubator-pinot/issues/5753

The minion task executor which receives 
1) segments (from realtime tables) 
2) a time window 
And then creates Pinot segments using data from that time window.

Uses the SegmentProcessorFramework. Applies:
1. Time column transformations as configured in PinotTaskConfig
2. Partitioning as specified in table config
3. Data sorting as specified in table config
4. Aggregations across common dimension+time, as configured in the PinotTaskConfig

Next steps:
RealtimeToOfflineSegmentsTaskGenerator





