### PR TITLE
[TE] Fixed tests on ThirdEye dashboard for MacOS

### DIFF
--- a/thirdeye/thirdeye-dashboard/pom.xml
+++ b/thirdeye/thirdeye-dashboard/pom.xml
@@ -61,6 +61,14 @@
   </dependencies>
 
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+      </testResource>
+      <testResource>
+        <directory>../thirdeye-pinot/src/main/resources</directory>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
Maven needs a bit of extra handling when depending on resources in dependencies.
Since the dashboard module now relies on the core module, it's resources needs to be explicitly added.

Fixes intermittent build failures. (Fails consistently on MacOS)