### PR TITLE
[TE] ThirdEye Coordinator skeleton stub

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -74,6 +74,7 @@
     <avro.version>1.7.7</avro.version>
     <avro-mapred.version>1.7.4</avro-mapred.version>
     <testng.version>6.8</testng.version>
+    <assertj.version>3.17.2</assertj.version>
     <mockito.version>1.8.4</mockito.version>
     <jcommander.version>1.35</jcommander.version>
     <hsqldb.version>2.3.4</hsqldb.version>
@@ -499,6 +500,12 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>${mockito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.beust</groupId>

--- a/thirdeye/thirdeye-coordinator/config/coordinator.yaml
+++ b/thirdeye/thirdeye-coordinator/config/coordinator.yaml
@@ -1,0 +1,32 @@
+######################################################
+# ThirdEye Coordinator default config
+######################################################
+
+server:
+  type: simple
+  applicationContextPath: /
+  adminContextPath: /admin
+
+  connector:
+    type: http
+    port: 8080
+    idleTimeout: 620s
+#   SSL connector is disabled since APP Engine only allows exposing a single port.
+#   A sample keystore and password is added so that this can be tested locally.
+#   However, the settings currently don't work on GAE
+#    - type: https
+#      port: 8443
+#      keyStorePath: conf/keystore.jks
+#      keyStorePassword: password
+
+logging:
+  level: INFO
+  loggers:
+    org.apache.pinot.thirdeye: DEBUG
+
+swagger:
+  # Enable/Disable the swagger resource. Helps in API documentation. Should be true by default
+  enabled: true
+
+  # package to scan for jersey resources
+  resourcePackage: org.apache.pinot.thirdeye.resources

--- a/thirdeye/thirdeye-coordinator/pom.xml
+++ b/thirdeye/thirdeye-coordinator/pom.xml
@@ -38,6 +38,29 @@
       <scope>compile</scope>
     </dependency>
 
+    <!-- ################################### -->
+    <!-- test dependencies start             -->
+    <!-- ################################### -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- ################################### -->
+    <!-- test dependencies end               -->
+    <!-- ################################### -->
+
   </dependencies>
 
 </project>

--- a/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/ThirdEyeServer.java
+++ b/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/ThirdEyeServer.java
@@ -1,0 +1,47 @@
+package org.apache.pinot.thirdeye;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.federecio.dropwizard.swagger.SwaggerBundle;
+import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import org.apache.pinot.thirdeye.resources.RootResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ThirdEyeServer extends Application<ThirdEyeServerConfiguration> {
+
+  private static final Logger log = LoggerFactory.getLogger(ThirdEyeServer.class);
+
+  public static void main(String[] args) throws Exception {
+    RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+    log.info(String.format("JVM arguments: %s", runtimeMxBean.getInputArguments()));
+
+    new ThirdEyeServer().run(args);
+  }
+
+  @Override
+  public void initialize(final Bootstrap<ThirdEyeServerConfiguration> bootstrap) {
+    bootstrap.addBundle(new SwaggerBundle<ThirdEyeServerConfiguration>() {
+      @Override
+      protected SwaggerBundleConfiguration getSwaggerBundleConfiguration(
+          ThirdEyeServerConfiguration configuration) {
+        return configuration.getSwaggerBundleConfiguration();
+      }
+    });
+  }
+
+  @Override
+  public void run(final ThirdEyeServerConfiguration configuration, final Environment environment) {
+
+    final Injector injector = Guice.createInjector(
+        new ThirdEyeServerModule(configuration,
+            environment.metrics()));
+
+    environment.jersey().register(injector.getInstance(RootResource.class));
+  }
+}

--- a/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/ThirdEyeServerConfiguration.java
+++ b/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/ThirdEyeServerConfiguration.java
@@ -1,0 +1,20 @@
+package org.apache.pinot.thirdeye;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.Configuration;
+import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
+
+public class ThirdEyeServerConfiguration extends Configuration {
+
+  @JsonProperty("swagger")
+  private SwaggerBundleConfiguration swaggerBundleConfiguration;
+
+  public SwaggerBundleConfiguration getSwaggerBundleConfiguration() {
+    return swaggerBundleConfiguration;
+  }
+
+  public void setSwaggerBundleConfiguration(
+      final SwaggerBundleConfiguration swaggerBundleConfiguration) {
+    this.swaggerBundleConfiguration = swaggerBundleConfiguration;
+  }
+}

--- a/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/ThirdEyeServerModule.java
+++ b/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/ThirdEyeServerModule.java
@@ -1,0 +1,17 @@
+package org.apache.pinot.thirdeye;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+
+public class ThirdEyeServerModule extends AbstractModule {
+
+  public ThirdEyeServerModule(final ThirdEyeServerConfiguration configuration,
+      final MetricRegistry metrics) {
+  }
+
+  @Override
+  protected void configure() {
+
+  }
+}

--- a/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/resources/ApiResource.java
+++ b/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/resources/ApiResource.java
@@ -1,0 +1,27 @@
+package org.apache.pinot.thirdeye.resources;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+public class ApiResource {
+
+  private final AuthResource authResource;
+  private final ApplicationResource applicationResource;
+
+  @Inject
+  public ApiResource(final AuthResource authResource,
+      final ApplicationResource applicationResource) {
+    this.authResource = authResource;
+    this.applicationResource = applicationResource;
+  }
+
+  @Path("auth")
+  public AuthResource getAuthResource() {
+    return authResource;
+  }
+
+  @Path("applications")
+  public ApplicationResource getApplicationResource() {
+    return applicationResource;
+  }
+}

--- a/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/resources/ApplicationResource.java
+++ b/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/resources/ApplicationResource.java
@@ -1,0 +1,49 @@
+package org.apache.pinot.thirdeye.resources;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+public class ApplicationResource {
+
+  @GET
+  public Response getAll() {
+    return Response
+        .ok("List all applications.")
+        .build();
+  }
+
+  @POST
+  public Response createMultiple() {
+    return Response
+        .ok("Create multiple applications.")
+        .build();
+  }
+
+  @PUT
+  public Response editMultiple() {
+    return Response
+        .ok("Edit multiple applications.")
+        .build();
+  }
+
+  @GET
+  @Path("{id}")
+  public Response get(@PathParam("id") Integer id) {
+    return Response
+        .ok("Get application: " + id)
+        .build();
+  }
+
+  @DELETE
+  @Path("{id}")
+  public Response delete(@PathParam("id") Integer id) {
+    return Response
+        .ok("Delete application: " + id)
+        .build();
+  }
+}

--- a/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/resources/AuthResource.java
+++ b/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/resources/AuthResource.java
@@ -1,0 +1,23 @@
+package org.apache.pinot.thirdeye.resources;
+
+import com.codahale.metrics.annotation.Timed;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+public class AuthResource {
+
+  @Timed
+  @Path("/login")
+  @POST
+  public Response login() {
+    return Response.ok().build();
+  }
+
+  @Timed
+  @Path("/logout")
+  @POST
+  public Response logout() {
+    return Response.ok().build();
+  }
+}

--- a/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/resources/RootResource.java
+++ b/thirdeye/thirdeye-coordinator/src/main/java/org/apache/pinot/thirdeye/resources/RootResource.java
@@ -1,0 +1,34 @@
+package org.apache.pinot.thirdeye.resources;
+
+import io.swagger.annotations.Api;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Api(value = "/", tags = "Root")
+public class RootResource {
+
+  private final ApiResource apiResource;
+
+  @Inject
+  public RootResource(final ApiResource apiResource) {
+    this.apiResource = apiResource;
+  }
+
+  @GET
+  public Response home() {
+    return Response
+        .ok("ThirdEye Coordinator is up and running.")
+        .build();
+  }
+
+  @Path("api")
+  public ApiResource getApiResource() {
+    return apiResource;
+  }
+}

--- a/thirdeye/thirdeye-coordinator/src/test/java/org/apache/pinot/thirdeye/ThirdEyeServerModuleTest.java
+++ b/thirdeye/thirdeye-coordinator/src/test/java/org/apache/pinot/thirdeye/ThirdEyeServerModuleTest.java
@@ -1,0 +1,21 @@
+package org.apache.pinot.thirdeye;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.pinot.thirdeye.resources.RootResource;
+import org.testng.annotations.Test;
+
+public class ThirdEyeServerModuleTest {
+
+  @Test
+  public void testRootResourceInjection() {
+    final Injector injector = Guice.createInjector(new ThirdEyeServerModule(
+       mock(ThirdEyeServerConfiguration.class),
+       mock(MetricRegistry.class)
+    ));
+    assertThat(injector.getInstance(RootResource.class)).isNotNull();
+  }
+}

--- a/thirdeye/thirdeye-coordinator/src/test/java/org/apache/pinot/thirdeye/resources/AuthResourceTest.java
+++ b/thirdeye/thirdeye-coordinator/src/test/java/org/apache/pinot/thirdeye/resources/AuthResourceTest.java
@@ -1,0 +1,14 @@
+package org.apache.pinot.thirdeye.resources;
+
+import org.testng.annotations.Test;
+
+public class AuthResourceTest {
+
+  @Test
+  public void testLogin() {
+  }
+
+  @Test
+  public void testLogout() {
+  }
+}

--- a/thirdeye/thirdeye-dist/src/main/assembly/dist.xml
+++ b/thirdeye/thirdeye-dist/src/main/assembly/dist.xml
@@ -29,12 +29,13 @@
     <format>dir</format>
     <format>tar.gz</format>
   </formats>
-<!--  <files>-->
-<!--    <file>-->
-<!--      <source>target/${pom.artifactId}-${pom.version}.jar</source>-->
-<!--      <outputDirectory>lib/</outputDirectory>-->
-<!--    </file>-->
-<!--  </files>-->
+  <files>
+    <file>
+      <source>${thirdeye.root}/thirdeye-dashboard/target/thirdeye-dashboard-${pom.version}.jar</source>
+      <outputDirectory>lib/fat/</outputDirectory>
+      <fileMode>0444</fileMode>
+    </file>
+  </files>
   <fileSets>
     <fileSet>
       <directory>${thirdeye.root}/thirdeye-pinot/config</directory>
@@ -58,6 +59,7 @@
       <excludes>
         <exclude>*:sources</exclude>
       </excludes>
+      <fileMode>0444</fileMode>
     </dependencySet>
   </dependencySets>
 </assembly>

--- a/thirdeye/thirdeye-dist/src/main/bash/thirdeye.sh
+++ b/thirdeye/thirdeye-dist/src/main/bash/thirdeye.sh
@@ -51,10 +51,7 @@ cd "$SAVED" >/dev/null
 CONFIG_DIR="${APP_HOME}/config"
 LIB_DIR="${APP_HOME}/lib"
 
-CLASSPATH=""
-for filepath in "${LIB_DIR}"/*; do
-  CLASSPATH="${CLASSPATH}:${filepath}"
-done
+CLASSPATH="${APP_HOME}/lib/fat/*"
 
 function start_server {
   class_ref=$1
@@ -87,6 +84,16 @@ function start_db {
   fi
 }
 
+function start_coordinator {
+  CLASSPATH=""
+  for filepath in "${LIB_DIR}"/*; do
+    CLASSPATH="${CLASSPATH}:${filepath}"
+  done
+  class_ref="org.apache.pinot.thirdeye.ThirdEyeServer"
+
+  java -Dlog4j.configurationFile=log4j2.xml -cp "${CLASSPATH}" ${class_ref} "${config_dir}"
+}
+
 function start_all {
   start_db
 
@@ -99,6 +106,7 @@ function start_all {
 
 MODE=$1
 case ${MODE} in
+    "coordinator" )  start_coordinator ;;
     "frontend" )  start_frontend ;;
     "backend"  )  start_backend ;;
     "database" )  start_db;;


### PR DESCRIPTION
ThirdEye coordinator also uses the dropwizard framework for exposing an API server.
This change includes the initial setup with Swagger and unit tests along with a default config.
Most dependencies used here conform to the rest of the project.

New code. No breaking changes.