### PR TITLE
Always quote literal when converting from PinotQuery to BrokerRequest

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/transform/TransformExpressionTree.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/transform/TransformExpressionTree.java
@@ -28,6 +28,7 @@ import org.apache.pinot.pql.parsers.pql2.ast.AstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.FunctionCallAstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.LiteralAstNode;
+import org.apache.pinot.pql.parsers.pql2.ast.StringLiteralAstNode;
 import org.apache.pinot.spi.utils.EqualityUtils;
 
 
@@ -67,10 +68,16 @@ public class TransformExpressionTree {
       return standardizeExpression(((FunctionCallAstNode) astNode).getExpression());
     } else if (astNode instanceof LiteralAstNode) {
       // Literal
+      String stringValue = ((LiteralAstNode) astNode).getValueAsString();
+
       // NOTE: String is treated as column name for backward-compatibility
       // TODO: This can cause problem for string literals (e.g. in DistinctCountThetaSketch where we have to add special
       //       handling). Fix this legacy behavior when we migrate to SQL format.
-      return ((LiteralAstNode) astNode).getValueAsString();
+      if (astNode instanceof StringLiteralAstNode) {
+        return stringValue;
+      } else {
+        return '\'' + stringValue + '\'';
+      }
     } else {
       throw new IllegalStateException("Cannot get standard expression from " + astNode.getClass().getSimpleName());
     }
@@ -224,7 +231,7 @@ public class TransformExpressionTree {
       case IDENTIFIER:
         return _value;
       case LITERAL:
-        return "\'" + _value + "\'";
+        return '\'' + _value + '\'';
       default:
         throw new IllegalStateException();
     }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -93,7 +93,7 @@ public class PinotQuery2BrokerRequestConverter {
       //order by is always a function (ASC or DESC)
       Function functionCall = orderByExpr.getFunctionCall();
       selectionSort.setIsAsc(functionCall.getOperator().equalsIgnoreCase(OrderByAstNode.ASCENDING_ORDER));
-      selectionSort.setColumn(ParserUtils.standardizeExpression(functionCall.getOperands().get(0), true));
+      selectionSort.setColumn(ParserUtils.standardizeExpression(functionCall.getOperands().get(0)));
       sortSequenceList.add(selectionSort);
     }
     if (!sortSequenceList.isEmpty()) {
@@ -109,7 +109,7 @@ public class PinotQuery2BrokerRequestConverter {
     if (groupByList != null && groupByList.size() > 0) {
       GroupBy groupBy = new GroupBy();
       for (Expression expression : groupByList) {
-        String expressionStr = ParserUtils.standardizeExpression(expression, true);
+        String expressionStr = ParserUtils.standardizeExpression(expression);
         groupBy.addToExpressions(expressionStr);
       }
       groupBy.setTopN(pinotQuery.getLimit());
@@ -153,7 +153,7 @@ public class PinotQuery2BrokerRequestConverter {
             if (selection == null) {
               selection = new Selection();
             }
-            selection.addToSelectionColumns(ParserUtils.standardizeExpression(expression, false));
+            selection.addToSelectionColumns(ParserUtils.standardizeExpression(expression));
           }
           break;
       }
@@ -202,14 +202,14 @@ public class PinotQuery2BrokerRequestConverter {
         Set<String> expressionSet = new TreeSet<>();
 
         for (Expression operand : operands) {
-          String expression = getColumnExpression(operand);
+          String expression = ParserUtils.standardizeExpression(operand);
           if (expressionSet.add(expression)) {
             args.add(expression);
           }
         }
       } else {
         for (Expression operand : operands) {
-          args.add(getColumnExpression(operand));
+          args.add(ParserUtils.standardizeExpression(operand));
         }
       }
     }
@@ -225,19 +225,6 @@ public class PinotQuery2BrokerRequestConverter {
         String.join(CompilerConstants.AGGREGATION_FUNCTION_ARG_SEPARATOR, args));
 
     return aggregationInfo;
-  }
-
-  private String getColumnExpression(Expression functionParam) {
-    switch (functionParam.getType()) {
-      case LITERAL:
-        return functionParam.getLiteral().getFieldValue().toString();
-      case IDENTIFIER:
-        return functionParam.getIdentifier().getName();
-      case FUNCTION:
-        return ParserUtils.standardizeExpression(functionParam, false, true);
-      default:
-        throw new UnsupportedOperationException("Unrecognized functionParamType:" + functionParam.getType());
-    }
   }
 
   private FilterQuery traverseFilterExpression(Expression filterExpression, FilterQueryMap filterSubQueryMap) {
@@ -272,13 +259,13 @@ public class PinotQuery2BrokerRequestConverter {
           case TEXT_MATCH:
           case RANGE:
             //first operand is the always the column
-            filterQuery.setColumn(ParserUtils.standardizeExpression(operands.get(0), false));
+            filterQuery.setColumn(ParserUtils.standardizeExpression(operands.get(0)));
             filterQuery.setValue(ParserUtils.getFilterValues(filterKind, operands));
             break;
           case IS_NULL:
           case IS_NOT_NULL:
             //first operand is the always the column
-            filterQuery.setColumn(ParserUtils.standardizeExpression(operands.get(0), false));
+            filterQuery.setColumn(ParserUtils.standardizeExpression(operands.get(0)));
             break;
           default:
             throw new UnsupportedOperationException("Filter UDF not supported");

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -373,6 +373,18 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(tempBrokerRequest.getQuerySource().getTableName(), "mytable");
     Assert.assertEquals(tempBrokerRequest.getSelections().getSelectionColumns().get(0),
         String.format("'%s'", literal.getFieldValue().toString()));
+
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select idset(A, 'fpp=0.05') from mytable");
+    tempBrokerRequest = converter.convert(pinotQuery);
+    List<String> expressions = tempBrokerRequest.getAggregationsInfo().get(0).getExpressions();
+    Assert.assertEquals(expressions.get(0), "A");
+    Assert.assertEquals(expressions.get(1), "'fpp=0.05'");
+
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select idset(A, '') from mytable");
+    tempBrokerRequest = converter.convert(pinotQuery);
+    expressions = tempBrokerRequest.getAggregationsInfo().get(0).getExpressions();
+    Assert.assertEquals(expressions.get(0), "A");
+    Assert.assertEquals(expressions.get(1), "''");
   }
 
   @Test
@@ -732,14 +744,16 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testTimeTransformFunction() {
-    PinotQuery pinotQuery = CalciteSqlParser
-        .compileToPinotQuery("  select hour(ts), d1, sum(m1) from baseballStats group by hour(ts), d1");
+    PinotQuery pinotQuery =
+        CalciteSqlParser.compileToPinotQuery("  select hour(ts), d1, sum(m1) from baseballStats group by hour(ts), d1");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "HOUR");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ts");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ts");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "d1");
     Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "SUM");
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "HOUR");
-    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ts");
+    Assert.assertEquals(
+        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ts");
     Assert.assertEquals(pinotQuery.getGroupByList().get(1).getIdentifier().getName(), "d1");
   }
 


### PR DESCRIPTION
## Description
For SQL queries, when converting from `PinotQuery` to `BrokerRequest`, the string literal in the aggregation function is treated as identifier, which can cause problem for certain queries such as `select idset(A, 'fpp=0.05') from mytable` where `fpp=0.05` cannot be parsed as an identifier.
This PR fixed the behavior by always quoting the literals within the expression (same as the behavior for `TransformExpressionTree.toString()`).
Pinot has legacy behavior on PQL parsing where string literal is treated as identifier, but if the query is parsed via SQL parser, we should preserve the literals within the query.