### PR TITLE
[TE] upgrade dropwizard-swagger dependency

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -43,9 +43,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.version>1.8</jdk.version>
     <dropwizard.version>2.0.12</dropwizard.version>
-    <dropwizard-auth.version>1.3.21</dropwizard-auth.version>
+    <dropwizard-auth.version>2.0.12</dropwizard-auth.version>
     <dropwizard.redirect.bundle.version>1.3.5</dropwizard.redirect.bundle.version>
-    <jetty.version>9.4.18.v20190429</jetty.version>
+    <jetty.version>9.4.21.v20190926</jetty.version>
     <jackson.version>2.10.2</jackson.version>
     <mysql.connector.version>5.1.44</mysql.connector.version>
     <quartz.version>2.2.1</quartz.version>

--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -42,7 +42,7 @@
     <pinot.version>0.4.0</pinot.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.version>1.8</jdk.version>
-    <dropwizard.version>1.3.21</dropwizard.version>
+    <dropwizard.version>2.0.12</dropwizard.version>
     <dropwizard-auth.version>1.3.21</dropwizard-auth.version>
     <dropwizard.redirect.bundle.version>1.3.5</dropwizard.redirect.bundle.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
@@ -60,7 +60,7 @@
     <commons-dbcp2.version>2.1.1</commons-dbcp2.version>
     <commons-conf2.version>2.7</commons-conf2.version>
     <commons-collection4.version>4.1</commons-collection4.version>
-    <reflections.version>0.9.10</reflections.version>
+    <reflections.version>0.9.12</reflections.version>
     <mrunit.version>1.1.0</mrunit.version>
     <slf4j-api.version>1.7.12</slf4j-api.version>
     <jodatime.version>2.7</jodatime.version>
@@ -85,8 +85,8 @@
     <!-- force bump up for LI usage -->
     <glassfish.hk2.utils.version>2.5.0-b34</glassfish.hk2.utils.version>
     <kafka.clients.version>0.10.2.1</kafka.clients.version>
-    <swagger.version>1.3.7-1</swagger.version>
-    <swagger-annotation.version>1.5.22</swagger-annotation.version>
+    <swagger.version>2.0.12-1</swagger.version>
+    <swagger-annotation.version>1.6.2</swagger-annotation.version>
     <calendar-api.version>v3-rev300-1.23.0</calendar-api.version>
     <json.version>20170516</json.version>
     <log4j2.version>2.12.0</log4j2.version>

--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -60,7 +60,7 @@
     <commons-dbcp2.version>2.1.1</commons-dbcp2.version>
     <commons-conf2.version>2.7</commons-conf2.version>
     <commons-collection4.version>4.1</commons-collection4.version>
-    <reflections.version>0.9.12</reflections.version>
+    <reflections.version>0.9.11</reflections.version>
     <mrunit.version>1.1.0</mrunit.version>
     <slf4j-api.version>1.7.12</slf4j-api.version>
     <jodatime.version>2.7</jodatime.version>

--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -43,7 +43,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.version>1.8</jdk.version>
     <dropwizard.version>2.0.12</dropwizard.version>
-    <dropwizard-auth.version>2.0.12</dropwizard-auth.version>
     <dropwizard.redirect.bundle.version>1.3.5</dropwizard.redirect.bundle.version>
     <jetty.version>9.4.21.v20190926</jetty.version>
     <jackson.version>2.10.2</jackson.version>
@@ -277,7 +276,7 @@
       <dependency>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-auth</artifactId>
-        <version>${dropwizard-auth.version}</version>
+        <version>${dropwizard.version}</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard-bundles</groupId>
@@ -291,6 +290,13 @@
         <version>${jetty.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-dependencies</artifactId>
+        <version>${dropwizard.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- jackson -->
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>

--- a/thirdeye/thirdeye-dashboard/pom.xml
+++ b/thirdeye/thirdeye-dashboard/pom.xml
@@ -40,6 +40,16 @@
       <groupId>org.apache.pinot.thirdeye</groupId>
       <artifactId>thirdeye-pinot</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- test dependencies -->

--- a/thirdeye/thirdeye-dashboard/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardModule.java
+++ b/thirdeye/thirdeye-dashboard/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardModule.java
@@ -21,7 +21,7 @@
 package org.apache.pinot.thirdeye.dashboard;
 
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
@@ -190,7 +190,7 @@ public class ThirdEyeDashboardModule extends AbstractModule {
       authenticator = new CachingAuthenticator<>(
           metricRegistry,
           authenticatorLdap,
-          CacheBuilder.newBuilder().expireAfterWrite(authConfig.getCacheTTL(), TimeUnit.SECONDS));
+          Caffeine.newBuilder().expireAfterWrite(authConfig.getCacheTTL(), TimeUnit.SECONDS));
     }
     return authenticator;
   }


### PR DESCRIPTION
Upgrade dropwizard-swagger to 2.0.12-1 so that it pulls the latest version of io.dropwizard.