### PR TITLE
Refresh the routing when realtime segment is committed

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
@@ -32,7 +32,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Segment;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.data.partition.PartitionFunction;
@@ -76,17 +76,26 @@ public class PartitionSegmentPruner implements SegmentPruner {
     List<ZNRecord> znRecords = _propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT);
     for (int i = 0; i < numSegments; i++) {
       String segment = segments.get(i);
-      _partitionInfoMap.put(segment, extractPartitionInfoFromSegmentZKMetadataZNRecord(segment, znRecords.get(i)));
+      PartitionInfo partitionInfo = extractPartitionInfoFromSegmentZKMetadataZNRecord(segment, znRecords.get(i));
+      if (partitionInfo != null) {
+        _partitionInfoMap.put(segment, partitionInfo);
+      }
     }
   }
 
+  /**
+   * NOTE: Returns {@code null} when the ZNRecord is missing (could be transient Helix issue). Returns
+   *       {@link #INVALID_PARTITION_INFO} when the segment does not have valid partition metadata in its ZK metadata,
+   *       in which case we won't retry later.
+   */
+  @Nullable
   private PartitionInfo extractPartitionInfoFromSegmentZKMetadataZNRecord(String segment, @Nullable ZNRecord znRecord) {
     if (znRecord == null) {
       LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, _tableNameWithType);
-      return INVALID_PARTITION_INFO;
+      return null;
     }
 
-    String partitionMetadataJson = znRecord.getSimpleField(CommonConstants.Segment.PARTITION_METADATA);
+    String partitionMetadataJson = znRecord.getSimpleField(Segment.PARTITION_METADATA);
     if (partitionMetadataJson == null) {
       LOGGER.warn("Failed to find segment partition metadata for segment: {}, table: {}", segment, _tableNameWithType);
       return INVALID_PARTITION_INFO;
@@ -127,8 +136,13 @@ public class PartitionSegmentPruner implements SegmentPruner {
 
   @Override
   public synchronized void refreshSegment(String segment) {
-    _partitionInfoMap.put(segment, extractPartitionInfoFromSegmentZKMetadataZNRecord(segment,
-        _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT)));
+    PartitionInfo partitionInfo = extractPartitionInfoFromSegmentZKMetadataZNRecord(segment,
+        _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT));
+    if (partitionInfo != null) {
+      _partitionInfoMap.put(segment, partitionInfo);
+    } else {
+      _partitionInfoMap.remove(segment);
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description
Related to issue #6029 
When a consuming realtime segment is committed, it will refresh the segment ZK metadata (the partition metadata can change when the stream partition does not match the table config). The broker needs to refresh the routing for this segment in order to pick up the change in the segment ZK metadata.

This PR utilizes the `SegmentRefreshMessage` Helix message to refresh the broker routing when consuming realtime segment is committed.
Also add more tests in `SegmentPartitionLLCRealtimeClusterIntegrationTest` to verify the behavior.
With this change, when the stream partition changes for a partitioned table (which should be very rare), the result won't be accurate when the consuming segment contains records from multiple partitions, but will auto-recover when the segment is committed and the correct partition metadata is persisted to the segment ZK metadata.