### PR TITLE
[TE] Refactor. ThirdEyePrincipal should be immutable

### DIFF
--- a/thirdeye/thirdeye-dashboard/src/test/java/org/apache/pinot/thirdeye/common/restclient/MockThirdEyeRcaRestClient.java
+++ b/thirdeye/thirdeye-dashboard/src/test/java/org/apache/pinot/thirdeye/common/restclient/MockThirdEyeRcaRestClient.java
@@ -19,6 +19,10 @@
 
 package org.apache.pinot.thirdeye.common.restclient;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import java.util.Map;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
@@ -26,9 +30,6 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.thirdeye.auth.ThirdEyePrincipal;
-
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
 
 
 public class MockThirdEyeRcaRestClient {
@@ -47,8 +48,7 @@ public class MockThirdEyeRcaRestClient {
     when(builder.get()).thenReturn(response);
     when(response.readEntity(any(GenericType.class))).thenReturn(expectedResponse);
 
-    ThirdEyePrincipal principal = new ThirdEyePrincipal();
-    principal.setSessionKey("dummy");
+    ThirdEyePrincipal principal = new ThirdEyePrincipal(null, "dummy");
 
     return new ThirdEyeRcaRestClient(client, principal);
   }

--- a/thirdeye/thirdeye-dashboard/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestThirdEyeRcaRestClient.java
+++ b/thirdeye/thirdeye-dashboard/src/test/java/org/apache/pinot/thirdeye/common/restclient/TestThirdEyeRcaRestClient.java
@@ -54,8 +54,7 @@ public class TestThirdEyeRcaRestClient {
 
     Client client = MockAbstractRestClient.setupMockClient(expectedResponse);
 
-    ThirdEyePrincipal principal = new ThirdEyePrincipal();
-    principal.setSessionKey("dummy");
+    ThirdEyePrincipal principal = new ThirdEyePrincipal(null, "dummy");
     ThirdEyeRcaRestClient rcaClient = new ThirdEyeRcaRestClient(client, principal);
     Map<String, Object> result = rcaClient.getRootCauseHighlights(anomalyId);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auth/ThirdEyeAuthenticatorDisabled.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auth/ThirdEyeAuthenticatorDisabled.java
@@ -36,9 +36,6 @@ public class ThirdEyeAuthenticatorDisabled implements Authenticator<ThirdEyeCred
   public Optional<ThirdEyePrincipal> authenticate(ThirdEyeCredentials credentials) throws AuthenticationException {
     LOG.info("Authentication is disabled. Accepting any credentials for {}.", credentials.getPrincipal());
 
-    ThirdEyePrincipal principal = new ThirdEyePrincipal();
-    principal.setName(credentials.getPrincipal());
-
-    return Optional.of(principal);
+    return Optional.of(new ThirdEyePrincipal(credentials.getPrincipal()));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auth/ThirdEyeLdapAuthenticator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auth/ThirdEyeLdapAuthenticator.java
@@ -93,8 +93,7 @@ public class ThirdEyeLdapAuthenticator implements Authenticator<ThirdEyeCredenti
     }
 
     if (authenticationResults.isAuthenticated()) {
-      ThirdEyePrincipal principal = new ThirdEyePrincipal();
-      principal.setName(env.get(Context.SECURITY_PRINCIPAL));
+      ThirdEyePrincipal principal = new ThirdEyePrincipal(env.get(Context.SECURITY_PRINCIPAL));
       LOG.info("Successfully authenticated {} with LDAP", env.get(Context.SECURITY_PRINCIPAL));
       return Optional.of(principal);
     } else {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auth/ThirdEyePrincipal.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/auth/ThirdEyePrincipal.java
@@ -20,29 +20,18 @@
 package org.apache.pinot.thirdeye.auth;
 
 import java.security.Principal;
-import java.util.HashSet;
-import java.util.Set;
-
 
 public class ThirdEyePrincipal implements Principal {
-  String name; // 'username@domainName'
-  Set<String> groups = new HashSet<>();
-  String sessionKey;
 
-  public ThirdEyePrincipal(String name, String token) {
+  private final String name; // 'username@domainName'
+  private final String sessionKey;
+
+  public ThirdEyePrincipal(final String name) {
+    this(name, null);
+  }
+
+  public ThirdEyePrincipal(final String name, final String sessionKey) {
     this.name = name;
-    this.sessionKey = token;
-  }
-
-  public ThirdEyePrincipal() {
-
-  }
-
-  public String getSessionKey() {
-    return sessionKey;
-  }
-
-  public void setSessionKey(String sessionKey) {
     this.sessionKey = sessionKey;
   }
 
@@ -51,15 +40,7 @@ public class ThirdEyePrincipal implements Principal {
     return name;
   }
 
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public Set<String> getGroups() {
-    return groups;
-  }
-
-  public void setGroups(Set<String> groups) {
-    this.groups = groups;
+  public String getSessionKey() {
+    return sessionKey;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/MetricAnomaliesContent.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/content/templates/MetricAnomaliesContent.java
@@ -74,9 +74,10 @@ public class MetricAnomaliesContent extends BaseNotificationContent {
     this.configDAO = DAORegistry.getInstance().getDetectionConfigManager();
 
     if (this.rcaClient == null) {
-      ThirdEyePrincipal principal = new ThirdEyePrincipal();
-      principal.setName(this.thirdEyeAnomalyConfig.getThirdEyeRestClientConfiguration().getAdminUser());
-      principal.setSessionKey(this.thirdEyeAnomalyConfig.getThirdEyeRestClientConfiguration().getSessionKey());
+      final ThirdEyePrincipal principal = new ThirdEyePrincipal(
+          this.thirdEyeAnomalyConfig.getThirdEyeRestClientConfiguration().getAdminUser(),
+          this.thirdEyeAnomalyConfig.getThirdEyeRestClientConfiguration().getSessionKey()
+      );
       this.rcaClient = new ThirdEyeRcaRestClient(principal, this.thirdEyeAnomalyConfig.getDashboardHost());
     }
   }


### PR DESCRIPTION
ThirdEyePrincipal is used in authentication and should be an immutable object.
This change refactors the usages to ensure that the principal isn't modified.
Also, the ThirdEyePrincipal object had groups which are never used. Plus the members
are non private. All these issues have been addressed.

Refactor. No logic changes.