### PR TITLE
add upsert related configs

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -89,7 +89,7 @@ public class SchemaTest {
         .addMetric("metric", FieldSpec.DataType.INT).addMetric("metricWithDefault", FieldSpec.DataType.INT, 5)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "time"), null)
         .addDateTime("dateTime", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
-        .addPrimaryKeyColumns(Lists.newArrayList("svDimension")).build();
+        .setPrimaryKeyColumns(Lists.newArrayList("svDimension")).build();
 
     DimensionFieldSpec dimensionFieldSpec = schema.getDimensionSpec("svDimension");
     Assert.assertNotNull(dimensionFieldSpec);

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.collections.Lists;
 
 
 public class SchemaTest {
@@ -75,7 +76,7 @@ public class SchemaTest {
         + "    \"incomingGranularitySpec\":{\"dataType\":\"LONG\",\"timeType\":\"MILLISECONDS\",\"name\":\"time\"},"
         + "    \"defaultNullValue\":12345" + "  }," + "  \"dateTimeFieldSpecs\":["
         + "    {\"name\":\"Date\", \"dataType\":\"LONG\", \"format\":\"1:MILLISECONDS:EPOCH\", \"granularity\":\"5:MINUTES\", \"dateTimeType\":\"PRIMARY\"}"
-        + "  ]" + "}";
+        + "  ], \"primaryKeyColumns\": [\"d\"]" + "}";
   }
 
   @Test
@@ -87,7 +88,8 @@ public class SchemaTest {
         .addMultiValueDimension("mvDimensionWithDefault", FieldSpec.DataType.STRING, defaultString)
         .addMetric("metric", FieldSpec.DataType.INT).addMetric("metricWithDefault", FieldSpec.DataType.INT, 5)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "time"), null)
-        .addDateTime("dateTime", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS").build();
+        .addDateTime("dateTime", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
+        .addPrimaryKeyColumns(Lists.newArrayList("svDimension")).build();
 
     DimensionFieldSpec dimensionFieldSpec = schema.getDimensionSpec("svDimension");
     Assert.assertNotNull(dimensionFieldSpec);
@@ -154,6 +156,8 @@ public class SchemaTest {
     Assert.assertEquals(dateTimeFieldSpec.getDefaultNullValue(), Long.MIN_VALUE);
     Assert.assertEquals(dateTimeFieldSpec.getFormat(), "1:HOURS:EPOCH");
     Assert.assertEquals(dateTimeFieldSpec.getGranularity(), "1:HOURS");
+
+    Assert.assertEquals(schema.getPrimaryKeyColumns(), Lists.newArrayList("svDimension"));
   }
 
   @Test
@@ -202,8 +206,8 @@ public class SchemaTest {
     TimeGranularitySpec outgoingTimeGranularitySpec =
         new TimeGranularitySpec(outgoingDataType, outgoingTimeUnitSize, outgoingTimeUnit, outgoingName);
 
-    Schema schema11 = new Schema.SchemaBuilder().setSchemaName("testSchema")
-        .addTime(incomingTimeGranularitySpec, null).build();
+    Schema schema11 =
+        new Schema.SchemaBuilder().setSchemaName("testSchema").addTime(incomingTimeGranularitySpec, null).build();
     Schema schema12 = new Schema.SchemaBuilder().setSchemaName("testSchema").build();
     schema12.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec));
     Assert.assertNotNull(schema11.getTimeFieldSpec());

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -241,8 +241,7 @@ public class TableConfigSerDeTest {
     }
     {
       // with upsert config
-      UpsertConfig upsertConfig =
-          new UpsertConfig(Collections.singletonList("pk"), "offset", "$validFrom", "$validUntil");
+      UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
 
       TableConfig tableConfig = tableConfigBuilder.setUpsertConfig(upsertConfig).build();
 
@@ -472,9 +471,6 @@ public class TableConfigSerDeTest {
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     assertNotNull(upsertConfig);
 
-    assertEquals(upsertConfig.getPrimaryKeyColumns(), Collections.singletonList("pk"));
-    assertEquals(upsertConfig.getOffsetColumn(), "offset");
-    assertEquals(upsertConfig.getValidFromColumn(), "$validFrom");
-    assertEquals(upsertConfig.getValidUntilColumn(), "$validUntil");
+    assertEquals(upsertConfig.getMode(), UpsertConfig.Mode.FULL);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Preconditions;
@@ -264,5 +265,10 @@ public class TableConfig extends BaseJsonConfig {
 
   public void setTierConfigsList(List<TierConfig> tierConfigsList) {
     _tierConfigsList = tierConfigsList;
+  }
+
+  @JsonIgnore
+  public UpsertConfig.Mode getUpsertMode() {
+    return _upsertConfig == null ? UpsertConfig.Mode.NONE : _upsertConfig.getMode();
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -27,44 +27,22 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 public class UpsertConfig extends BaseJsonConfig {
-  // names of the columns that used as primary keys of an upsert table
-  private final List<String> _primaryKeyColumns;
-  // name of the column that we are going to store the offset value to
-  private final String _offsetColumn;
-  // name of the virtual column that we are going to store the validFrom value to
-  private final String _validFromColumn;
-  // name of the virtual column that we are going to store the validUntil value to
-  private final String _validUntilColumn;
+  public static final String MODE_KEY = "mode";
+
+  public enum Mode {
+    FULL, PARTIAL, NONE
+  }
+
+  private final Mode _mode;
 
   @JsonCreator
-  public UpsertConfig(@JsonProperty(value = "primaryKeyColumns") List<String> primaryKeyColumns,
-      @JsonProperty(value = "offsetColumn") String offsetColumn,
-      @JsonProperty(value = "validFromColumn") String validFromColumn,
-      @JsonProperty(value = "validUntilColumn") String validUntilColumn) {
-    Preconditions.checkArgument(primaryKeyColumns != null && primaryKeyColumns.size() == 1,
-        "'primaryKeyColumns' must be configured with exact one column");
-    Preconditions.checkArgument(StringUtils.isNotEmpty(offsetColumn), "'offsetColumn' must be configured");
-    Preconditions.checkArgument(StringUtils.isNotEmpty(validFromColumn), "'validFromColumn' must be configured");
-    Preconditions.checkArgument(StringUtils.isNotEmpty(validUntilColumn), "'validUntilColumn' must be configured");
-    _primaryKeyColumns = primaryKeyColumns;
-    _offsetColumn = offsetColumn;
-    _validFromColumn = validFromColumn;
-    _validUntilColumn = validUntilColumn;
+  public UpsertConfig(@JsonProperty(value = "mode") Mode mode) {
+    Preconditions.checkArgument(mode != Mode.PARTIAL, "Partial upsert mode is not supported");
+    _mode = mode;
   }
 
-  public List<String> getPrimaryKeyColumns() {
-    return _primaryKeyColumns;
-  }
-
-  public String getOffsetColumn() {
-    return _offsetColumn;
-  }
-
-  public String getValidFromColumn() {
-    return _validFromColumn;
-  }
-
-  public String getValidUntilColumn() {
-    return _validUntilColumn;
+  @JsonProperty(MODE_KEY)
+  public Mode getMode() {
+    return _mode;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -67,7 +67,7 @@ public final class Schema {
   private final List<DateTimeFieldSpec> _dateTimeFieldSpecs = new ArrayList<>();
   private final List<ComplexFieldSpec> _complexFieldSpecs = new ArrayList<>();
   // names of the columns that used as primary keys
-  // TODO: add validation checks like duplicate columns and use of time column
+  // TODO(yupeng): add validation checks like duplicate columns and use of time column
   private List<String> _primaryKeyColumns;
 
   // Json ignored fields
@@ -102,12 +102,12 @@ public final class Schema {
     _schemaName = schemaName;
   }
 
-  public void setPrimaryKeyColumns(List<String> primaryKeyColumns) {
-    _primaryKeyColumns = primaryKeyColumns;
-  }
-
   public List<String> getPrimaryKeyColumns() {
     return _primaryKeyColumns;
+  }
+
+  public void setPrimaryKeyColumns(List<String> primaryKeyColumns) {
+    _primaryKeyColumns = primaryKeyColumns;
   }
 
   public List<DimensionFieldSpec> getDimensionFieldSpecs() {
@@ -576,7 +576,7 @@ public final class Schema {
       return this;
     }
 
-    public SchemaBuilder addPrimaryKeyColumns(List<String> primaryKeyColumns) {
+    public SchemaBuilder setPrimaryKeyColumns(List<String> primaryKeyColumns) {
       _schema.setPrimaryKeyColumns(primaryKeyColumns);
       return this;
     }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.spi.config.table;
 
-import com.google.common.collect.ImmutableList;
-import java.util.Collections;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -30,40 +28,12 @@ public class UpsertConfigTest {
 
   @Test
   public void testUpsertConfig() {
-    UpsertConfig upsertConfig =
-        new UpsertConfig(Collections.singletonList("primaryKey"), "offset", "validFrom", "validUntil");
-    assertEquals(upsertConfig.getPrimaryKeyColumns(), Collections.singletonList("primaryKey"));
-    assertEquals(upsertConfig.getOffsetColumn(), "offset");
-    assertEquals(upsertConfig.getValidFromColumn(), "validFrom");
-    assertEquals(upsertConfig.getValidUntilColumn(), "validUntil");
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    assertEquals(upsertConfig.getMode(), UpsertConfig.Mode.FULL);
 
     // Test illegal arguments
     try {
-      new UpsertConfig(null, "offset", "validFrom", "validUntil");
-      fail();
-    } catch (IllegalArgumentException e) {
-      // Expected
-    }
-    try {
-      new UpsertConfig(ImmutableList.of("pk1", "pk2"), "offset", "validFrom", "validUntil");
-      fail();
-    } catch (IllegalArgumentException e) {
-      // Expected
-    }
-    try {
-      new UpsertConfig(ImmutableList.of("pk1"), null, "validFrom", "validUntil");
-      fail();
-    } catch (IllegalArgumentException e) {
-      // Expected
-    }
-    try {
-      new UpsertConfig(ImmutableList.of("pk1"), "offset", null, "validUntil");
-      fail();
-    } catch (IllegalArgumentException e) {
-      // Expected
-    }
-    try {
-      new UpsertConfig(ImmutableList.of("pk1"), "offset", "validFrom", null);
+      new UpsertConfig(UpsertConfig.Mode.PARTIAL);
       fail();
     } catch (IllegalArgumentException e) {
       // Expected


### PR DESCRIPTION

## Description
Part of a series of PRs for https://github.com/apache/incubator-pinot/issues/4261
Check this [doc](https://docs.google.com/document/d/1qljEMndPMxbbKtjlVn9mn2toz7Qrk0TGQsHLfI--7h8/edit#heading=h.lsfmyoyyxtgt) out for the new design

 - Added the primary key definition in the schema
 - Changed the upsert config in table config. For the first phase, only support the full update mode.

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
configurations related to upsert



If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
