### PR TITLE
Allow modifying/removing existing star-trees during segment reload

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -53,6 +53,7 @@ public class IndexLoadingConfig {
   private Set<String> _varLengthDictionaryColumns = new HashSet<>();
   private Set<String> _onHeapDictionaryColumns = new HashSet<>();
   private Set<String> _bloomFilterColumns = new HashSet<>();
+  private boolean _enableDynamicStarTreeCreation;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private boolean _enableDefaultStarTree;
 
@@ -129,10 +130,9 @@ public class IndexLoadingConfig {
       _onHeapDictionaryColumns.addAll(onHeapDictionaryColumns);
     }
 
-    if (indexingConfig.isEnableDynamicStarTreeCreation()) {
-      _starTreeIndexConfigs = indexingConfig.getStarTreeIndexConfigs();
-      _enableDefaultStarTree = indexingConfig.isEnableDefaultStarTree();
-    }
+    _enableDynamicStarTreeCreation = indexingConfig.isEnableDynamicStarTreeCreation();
+    _starTreeIndexConfigs = indexingConfig.getStarTreeIndexConfigs();
+    _enableDefaultStarTree = indexingConfig.isEnableDefaultStarTree();
 
     String tableSegmentVersion = indexingConfig.getSegmentFormatVersion();
     if (tableSegmentVersion != null) {
@@ -294,6 +294,10 @@ public class IndexLoadingConfig {
     return _bloomFilterColumns;
   }
 
+  public boolean isEnableDynamicStarTreeCreation() {
+    return _enableDynamicStarTreeCreation;
+  }
+
   @Nullable
   public List<StarTreeIndexConfig> getStarTreeIndexConfigs() {
     return _starTreeIndexConfigs;
@@ -335,9 +339,9 @@ public class IndexLoadingConfig {
     return _columnMinMaxValueGeneratorMode;
   }
 
-
-  public String getSegmentStoreURI() { return _segmentStoreURI; }
-
+  public String getSegmentStoreURI() {
+    return _segmentStoreURI;
+  }
 
   /**
    * For tests only.

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeBuilderUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeBuilderUtils.java
@@ -26,8 +26,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.StringUtil;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+import org.apache.pinot.core.startree.v2.builder.StarTreeV2BuilderConfig;
+import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 
 
 /**
@@ -47,6 +51,29 @@ public class StarTreeBuilderUtils {
     public int _aggregatedDocId = INVALID_ID;
     public int _childDimensionId = INVALID_ID;
     public Map<Integer, TreeNode> _children;
+  }
+
+  /**
+   * Generates the deduplicated star-tree builder configs.
+   */
+  public static List<StarTreeV2BuilderConfig> generateBuilderConfigs(@Nullable List<StarTreeIndexConfig> indexConfigs,
+      boolean enableDefaultStarTree, SegmentMetadataImpl segmentMetadata) {
+    List<StarTreeV2BuilderConfig> builderConfigs = new ArrayList<>();
+    if (indexConfigs != null) {
+      for (StarTreeIndexConfig indexConfig : indexConfigs) {
+        StarTreeV2BuilderConfig builderConfig = StarTreeV2BuilderConfig.fromIndexConfig(indexConfig);
+        if (!builderConfigs.contains(builderConfig)) {
+          builderConfigs.add(builderConfig);
+        }
+      }
+    }
+    if (enableDefaultStarTree) {
+      StarTreeV2BuilderConfig defaultConfig = StarTreeV2BuilderConfig.generateDefaultConfig(segmentMetadata);
+      if (!builderConfigs.contains(defaultConfig)) {
+        builderConfigs.add(defaultConfig);
+      }
+    }
+    return builderConfigs;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -18,16 +18,26 @@
  */
 package org.apache.pinot.core.startree;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.predicate.Predicate;
+import org.apache.pinot.core.segment.creator.impl.V1Constants;
+import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
+import org.apache.pinot.core.startree.v2.StarTreeV2Constants;
 import org.apache.pinot.core.startree.v2.StarTreeV2Metadata;
+import org.apache.pinot.core.startree.v2.builder.StarTreeV2BuilderConfig;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 
 
 public class StarTreeUtils {
@@ -114,5 +124,57 @@ public class StarTreeUtils {
       default:
         throw new IllegalStateException();
     }
+  }
+
+  /**
+   * Returns {@code true} if the given star-tree builder configs do not match the star-tree metadata, in which case the
+   * existing star-trees need to be removed, {@code false} otherwise.
+   */
+  public static boolean shouldRemoveExistingStarTrees(List<StarTreeV2BuilderConfig> builderConfigs,
+      List<StarTreeV2Metadata> metadataList) {
+    int numStarTrees = builderConfigs.size();
+    if (metadataList.size() != numStarTrees) {
+      return true;
+    }
+    for (int i = 0; i < numStarTrees; i++) {
+      StarTreeV2BuilderConfig builderConfig = builderConfigs.get(i);
+      StarTreeV2Metadata metadata = metadataList.get(i);
+      if (!builderConfig.getDimensionsSplitOrder().equals(metadata.getDimensionsSplitOrder())) {
+        return true;
+      }
+      if (!builderConfig.getSkipStarNodeCreationForDimensions()
+          .equals(metadata.getSkipStarNodeCreationForDimensions())) {
+        return true;
+      }
+      if (!builderConfig.getFunctionColumnPairs().equals(metadata.getFunctionColumnPairs())) {
+        return true;
+      }
+      if (builderConfig.getMaxLeafRecords() != metadata.getMaxLeafRecords()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Removes all the star-trees from the given segment.
+   */
+  public static void removeStarTrees(File indexDir)
+      throws Exception {
+    File segmentDirectory = SegmentDirectoryPaths.findSegmentDirectory(indexDir);
+
+    // Remove the star-tree metadata
+    PropertiesConfiguration metadataProperties =
+        CommonsConfigurationUtils.fromFile(new File(segmentDirectory, V1Constants.MetadataKeys.METADATA_FILE_NAME));
+    metadataProperties.subset(StarTreeV2Constants.MetadataKey.STAR_TREE_SUBSET).clear();
+    // Commons Configuration 1.10 does not support file path containing '%'.
+    // Explicitly providing the output stream for the file bypasses the problem.
+    try (FileOutputStream fileOutputStream = new FileOutputStream(metadataProperties.getFile())) {
+      metadataProperties.save(fileOutputStream);
+    }
+
+    // Remove the index file and index map file
+    FileUtils.forceDelete(new File(segmentDirectory, StarTreeV2Constants.INDEX_FILE_NAME));
+    FileUtils.forceDelete(new File(segmentDirectory, StarTreeV2Constants.INDEX_MAP_FILE_NAME));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/StarTreeV2Constants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/StarTreeV2Constants.java
@@ -39,8 +39,9 @@ public class StarTreeV2Constants {
 
   // Metadata keys
   public static class MetadataKey {
-    public static final String STAR_TREE_COUNT = "startree.v2.count";
-    public static final String STAR_TREE_PREFIX = "startree.v2.";
+    public static final String STAR_TREE_SUBSET = "startree.v2";
+    public static final String STAR_TREE_PREFIX = STAR_TREE_SUBSET + '.';
+    public static final String STAR_TREE_COUNT = STAR_TREE_PREFIX + "count";
 
     public static final String TOTAL_DOCS = "total.docs";
     public static final String DIMENSIONS_SPLIT_ORDER = "split.order";

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/StarTreeV2Metadata.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/v2/StarTreeV2Metadata.java
@@ -18,19 +18,12 @@
  */
 package org.apache.pinot.core.startree.v2;
 
-import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.DIMENSIONS_SPLIT_ORDER;
-import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.FUNCTION_COLUMN_PAIRS;
-import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.MAX_LEAF_RECORDS;
-import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.SKIP_STAR_NODE_CREATION_FOR_DIMENSIONS;
-import static org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey.TOTAL_DOCS;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.core.startree.v2.StarTreeV2Constants.MetadataKey;
 
 
 /**
@@ -45,28 +38,16 @@ public class StarTreeV2Metadata {
   private final int _maxLeafRecords;
   private final Set<String> _skipStarNodeCreationForDimensions;
 
-  public StarTreeV2Metadata(int numDocs, List<String> dimensionsSplitOrder,
-      Set<AggregationFunctionColumnPair> functionColumnPairs, int maxLeafRecords,
-      Set<String> skipStarNodeCreationForDimensions) {
-    _numDocs = numDocs;
-    _dimensionsSplitOrder = dimensionsSplitOrder;
-    _functionColumnPairs = functionColumnPairs;
-    _maxLeafRecords = maxLeafRecords;
-    _skipStarNodeCreationForDimensions = skipStarNodeCreationForDimensions;
-  }
-
-  @SuppressWarnings("unchecked")
   public StarTreeV2Metadata(Configuration metadataProperties) {
-    _numDocs = metadataProperties.getInt(TOTAL_DOCS);
-    _dimensionsSplitOrder = Arrays.stream(metadataProperties.getStringArray(DIMENSIONS_SPLIT_ORDER)).collect(Collectors.toList());
+    _numDocs = metadataProperties.getInt(MetadataKey.TOTAL_DOCS);
+    _dimensionsSplitOrder = Arrays.asList(metadataProperties.getStringArray(MetadataKey.DIMENSIONS_SPLIT_ORDER));
     _functionColumnPairs = new HashSet<>();
-    for (Object functionColumnPair : metadataProperties.getList(FUNCTION_COLUMN_PAIRS)) {
-      _functionColumnPairs.add(AggregationFunctionColumnPair.fromColumnName((String) functionColumnPair));
+    for (String functionColumnPair : metadataProperties.getStringArray(MetadataKey.FUNCTION_COLUMN_PAIRS)) {
+      _functionColumnPairs.add(AggregationFunctionColumnPair.fromColumnName(functionColumnPair));
     }
-    _maxLeafRecords = metadataProperties.getInt(MAX_LEAF_RECORDS);
-    _skipStarNodeCreationForDimensions =
-        new HashSet<>(Arrays.stream(metadataProperties.getStringArray(SKIP_STAR_NODE_CREATION_FOR_DIMENSIONS))
-            .collect(Collectors.toList()));
+    _maxLeafRecords = metadataProperties.getInt(MetadataKey.MAX_LEAF_RECORDS);
+    _skipStarNodeCreationForDimensions = new HashSet<>(
+        Arrays.asList(metadataProperties.getStringArray(MetadataKey.SKIP_STAR_NODE_CREATION_FOR_DIMENSIONS)));
   }
 
   public int getNumDocs() {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -43,6 +43,21 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
     startServers(NUM_SERVERS);
   }
 
+  // Disabled because with multiple servers, there is no guarantee that all servers get all segments reloaded
+  @Test(enabled = false)
+  @Override
+  public void testStarTreeTriggering() {
+    // Ignored
+  }
+
+  // Disabled because with multiple servers, there is no guarantee that all servers get all segments reloaded
+  @Test(enabled = false)
+  @Override
+  public void testDefaultColumns() {
+    // Ignored
+  }
+
+  // Disabled because gRPC query server is not enabled
   @Test(enabled = false)
   @Override
   public void testGrpcQueryServer() {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -94,10 +94,14 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   private static final String TEST_UPDATED_BLOOM_FILTER_QUERY = "SELECT COUNT(*) FROM mytable WHERE Carrier = 'CA'";
 
   // For star-tree triggering test
-  private static final StarTreeIndexConfig STAR_TREE_INDEX_CONFIG =
+  private static final StarTreeIndexConfig STAR_TREE_INDEX_CONFIG_1 =
       new StarTreeIndexConfig(Collections.singletonList("Carrier"), null,
           Collections.singletonList(AggregationFunctionColumnPair.COUNT_STAR.toColumnName()), 100);
-  private static final String TEST_STAR_TREE_QUERY = "SELECT COUNT(*) FROM mytable WHERE Carrier = 'UA'";
+  private static final String TEST_STAR_TREE_QUERY_1 = "SELECT COUNT(*) FROM mytable WHERE Carrier = 'UA'";
+  private static final StarTreeIndexConfig STAR_TREE_INDEX_CONFIG_2 =
+      new StarTreeIndexConfig(Collections.singletonList("DestState"), null,
+          Collections.singletonList(AggregationFunctionColumnPair.COUNT_STAR.toColumnName()), 100);
+  private static final String TEST_STAR_TREE_QUERY_2 = "SELECT COUNT(*) FROM mytable WHERE DestState = 'CA'";
 
   // For default columns test
   private static final String SCHEMA_FILE_NAME_WITH_EXTRA_COLUMNS =
@@ -437,39 +441,116 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     long numTotalDocs = getCountStarResult();
 
-    JsonNode queryResponse = postQuery(TEST_STAR_TREE_QUERY);
-    int result = queryResponse.get("aggregationResults").get(0).get("value").asInt();
+    // Test the first query
+    JsonNode firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
+    int firstQueryResult = firstQueryResponse.get("aggregationResults").get(0).get("value").asInt();
+    assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
     // Initially 'numDocsScanned' should be the same as 'COUNT(*)' result
-    assertEquals(queryResponse.get("numDocsScanned").asInt(), result);
+    assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), firstQueryResult);
 
     // Update table config and trigger reload
     TableConfig tableConfig = getOfflineTableConfig();
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
-    indexingConfig.setStarTreeIndexConfigs(Collections.singletonList(STAR_TREE_INDEX_CONFIG));
+    indexingConfig.setStarTreeIndexConfigs(Collections.singletonList(STAR_TREE_INDEX_CONFIG_1));
     indexingConfig.setEnableDynamicStarTreeCreation(true);
     updateTableConfig(tableConfig);
     reloadOfflineTable(getTableName());
 
     TestUtils.waitForCondition(aVoid -> {
       try {
-        JsonNode queryResponse1 = postQuery(TEST_STAR_TREE_QUERY);
+        JsonNode queryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
         // Result should not change during reload
-        assertEquals(queryResponse1.get("aggregationResults").get(0).get("value").asInt(), result);
+        assertEquals(queryResponse.get("aggregationResults").get(0).get("value").asInt(), firstQueryResult);
         // Total docs should not change during reload
-        assertEquals(queryResponse1.get("totalDocs").asLong(), numTotalDocs);
+        assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
         // With star-tree, 'numDocsScanned' should be the same as number of segments (1 per segment)
-        return queryResponse1.get("numDocsScanned").asInt() == NUM_SEGMENTS;
+        return queryResponse.get("numDocsScanned").asInt() == NUM_SEGMENTS;
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
-    }, 600_000L, "Failed to generate bloom filter");
+    }, 600_000L, "Failed to star-tree index");
 
     // Reload again should have no effect
     reloadOfflineTable(getTableName());
-    JsonNode queryResponse1 = postQuery(TEST_STAR_TREE_QUERY);
-    assertEquals(queryResponse1.get("aggregationResults").get(0).get("value").asInt(), result);
-    assertEquals(queryResponse1.get("totalDocs").asLong(), numTotalDocs);
-    assertEquals(queryResponse1.get("numDocsScanned").asInt(), NUM_SEGMENTS);
+    firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
+    assertEquals(firstQueryResponse.get("aggregationResults").get(0).get("value").asInt(), firstQueryResult);
+    assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
+    assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), NUM_SEGMENTS);
+
+    // Test the second query
+    JsonNode secondQueryResponse = postQuery(TEST_STAR_TREE_QUERY_2);
+    int secondQueryResult = secondQueryResponse.get("aggregationResults").get(0).get("value").asInt();
+    assertEquals(secondQueryResponse.get("totalDocs").asLong(), numTotalDocs);
+    // Initially 'numDocsScanned' should be the same as 'COUNT(*)' result
+    assertEquals(secondQueryResponse.get("numDocsScanned").asInt(), secondQueryResult);
+
+    // Update table config with a different star-tree index config and trigger reload
+    indexingConfig.setStarTreeIndexConfigs(Collections.singletonList(STAR_TREE_INDEX_CONFIG_2));
+    updateTableConfig(tableConfig);
+    reloadOfflineTable(getTableName());
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        JsonNode queryResponse = postQuery(TEST_STAR_TREE_QUERY_2);
+        // Result should not change during reload
+        assertEquals(queryResponse.get("aggregationResults").get(0).get("value").asInt(), secondQueryResult);
+        // Total docs should not change during reload
+        assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
+        // With star-tree, 'numDocsScanned' should be the same as number of segments (1 per segment)
+        return queryResponse.get("numDocsScanned").asInt() == NUM_SEGMENTS;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to star-tree index");
+
+    // First query should not be able to use the star-tree
+    firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
+    assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), firstQueryResult);
+
+    // Reload again should have no effect
+    reloadOfflineTable(getTableName());
+    firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
+    assertEquals(firstQueryResponse.get("aggregationResults").get(0).get("value").asInt(), firstQueryResult);
+    assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
+    assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), firstQueryResult);
+    secondQueryResponse = postQuery(TEST_STAR_TREE_QUERY_2);
+    assertEquals(secondQueryResponse.get("aggregationResults").get(0).get("value").asInt(), secondQueryResult);
+    assertEquals(secondQueryResponse.get("totalDocs").asLong(), numTotalDocs);
+    assertEquals(secondQueryResponse.get("numDocsScanned").asInt(), NUM_SEGMENTS);
+
+    // Remove the star-tree index config and trigger reload
+    indexingConfig.setStarTreeIndexConfigs(null);
+    updateTableConfig(tableConfig);
+    reloadOfflineTable(getTableName());
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        JsonNode queryResponse = postQuery(TEST_STAR_TREE_QUERY_2);
+        // Result should not change during reload
+        assertEquals(queryResponse.get("aggregationResults").get(0).get("value").asInt(), secondQueryResult);
+        // Total docs should not change during reload
+        assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
+        // Without star-tree, 'numDocsScanned' should be the same as the 'COUNT(*)' result
+        return queryResponse.get("numDocsScanned").asInt() == secondQueryResult;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to star-tree index");
+
+    // First query should not be able to use the star-tree
+    firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
+    assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), firstQueryResult);
+
+    // Reload again should have no effect
+    reloadOfflineTable(getTableName());
+    firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
+    assertEquals(firstQueryResponse.get("aggregationResults").get(0).get("value").asInt(), firstQueryResult);
+    assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
+    assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), firstQueryResult);
+    secondQueryResponse = postQuery(TEST_STAR_TREE_QUERY_2);
+    assertEquals(secondQueryResponse.get("aggregationResults").get(0).get("value").asInt(), secondQueryResult);
+    assertEquals(secondQueryResponse.get("totalDocs").asLong(), numTotalDocs);
+    assertEquals(secondQueryResponse.get("numDocsScanned").asInt(), secondQueryResult);
   }
 
   /**
@@ -512,11 +593,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     if (withExtraColumns) {
       _schemaFileName = SCHEMA_FILE_NAME_WITH_EXTRA_COLUMNS;
-      addSchema(createSchema());
     } else {
       _schemaFileName = SCHEMA_FILE_NAME_WITH_MISSING_COLUMNS;
-      addSchema(createSchema());
     }
+    addSchema(createSchema());
 
     // Trigger reload
     reloadOfflineTable(getTableName());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeIndexConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
@@ -42,8 +43,10 @@ public class StarTreeIndexConfig extends BaseJsonConfig {
       @JsonProperty("skipStarNodeCreationForDimensions") @Nullable List<String> skipStarNodeCreationForDimensions,
       @JsonProperty(value = "functionColumnPairs", required = true) List<String> functionColumnPairs,
       @JsonProperty("maxLeafRecords") int maxLeafRecords) {
-    Preconditions.checkArgument(dimensionsSplitOrder != null, "'dimensionsSplitOrder' must be configured");
-    Preconditions.checkArgument(functionColumnPairs != null, "'functionColumnPairs' must be configured");
+    Preconditions
+        .checkArgument(CollectionUtils.isNotEmpty(dimensionsSplitOrder), "'dimensionsSplitOrder' must be configured");
+    Preconditions
+        .checkArgument(CollectionUtils.isNotEmpty(functionColumnPairs), "'functionColumnPairs' must be configured");
     _dimensionsSplitOrder = dimensionsSplitOrder;
     _skipStarNodeCreationForDimensions = skipStarNodeCreationForDimensions;
     _functionColumnPairs = functionColumnPairs;


### PR DESCRIPTION
## Description
For #6092 
Currently we allow generating new star-trees during the segment reload when there is no existing ones.
This PR adds the support of modifying or removing the existing star-trees during segment reload when it detects changes for the star-tree index config.

Other enhancement:
- Deduplicate the star-tree builder config to avoid generating the same star-tree multiple times when user put multiple identical star-tree index configs, or the star-tree index config is the same as the default star-tree.