### PR TITLE
Fix missing segment count reporting for realtime llc segment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Segment.Realtime.Status;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -269,6 +270,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       }
       _logger.info("Initialize RealtimeSegmentDataManager - " + segmentName);
       _segmentDataManagerMap.put(segmentName, manager);
+      _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.SEGMENT_COUNT, 1L);
     }
   }
 


### PR DESCRIPTION
## Description
Fix Pinot segment count metric reporting for llc segment manager.

Below is a segment count metric for pinot realtime server, the realtime segment count keeps going down as the consuming segment got persisted and moved to offline server.
![image](https://user-images.githubusercontent.com/1202120/95009237-4c3a6380-05d5-11eb-9ba3-b7cba6ba8271.png)

After this change, we can see that number of segments become positive for realtime server:
![image](https://user-images.githubusercontent.com/1202120/95028016-e5a75b00-0651-11eb-82ce-12e20c672592.png)

