### PR TITLE
Making pushType non-mandatory

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -108,11 +108,7 @@ public final class TableConfigUtils {
 
     String segmentPushType = segmentsConfig.getSegmentPushType();
     // segmentPushType is not needed for Realtime table
-    if (tableConfig.getTableType() == TableType.OFFLINE) {
-      if (segmentPushType == null) {
-        throw new IllegalStateException(String.format("Table: %s, null push type", tableName));
-      }
-
+    if (tableConfig.getTableType() == TableType.OFFLINE && segmentPushType != null) {
       if (!segmentPushType.equalsIgnoreCase("REFRESH") && !segmentPushType.equalsIgnoreCase("APPEND")) {
         throw new IllegalStateException(String.format("Table: %s, invalid push type: %s", tableName, segmentPushType));
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -108,7 +108,7 @@ public final class TableConfigUtils {
 
     String segmentPushType = segmentsConfig.getSegmentPushType();
     // segmentPushType is not needed for Realtime table
-    if (tableConfig.getTableType() == TableType.OFFLINE && segmentPushType != null) {
+    if (tableConfig.getTableType() == TableType.OFFLINE && segmentPushType != null && !segmentPushType.isEmpty()) {
       if (!segmentPushType.equalsIgnoreCase("REFRESH") && !segmentPushType.equalsIgnoreCase("APPEND")) {
         throw new IllegalStateException(String.format("Table: %s, invalid push type: %s", tableName, segmentPushType));
       }


### PR DESCRIPTION
## Description
As part of #5942 pushType was made mandatory for offline tables my mistake. Removing this mandate. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade?
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes?
No