### PR TITLE
Enhance star-tree to skip matching-all predicate on non-star-tree dimension

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -19,13 +19,14 @@
 package org.apache.pinot.core.plan;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
-import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.core.startree.plan.StarTreeTransformPlanNode;
@@ -59,32 +60,21 @@ public class AggregationGroupByPlanNode implements PlanNode {
     _groupByExpressions = groupByExpressions.toArray(new ExpressionContext[0]);
 
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
-    if (starTrees != null) {
-      if (!StarTreeUtils.isStarTreeDisabled(queryContext)) {
-        int numAggregationFunctions = _aggregationFunctions.length;
-        AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
-            new AggregationFunctionColumnPair[numAggregationFunctions];
-        boolean hasUnsupportedAggregationFunction = false;
-        for (int i = 0; i < numAggregationFunctions; i++) {
-          AggregationFunctionColumnPair aggregationFunctionColumnPair =
-              AggregationFunctionUtils.getAggregationFunctionColumnPair(_aggregationFunctions[i]);
-          if (aggregationFunctionColumnPair != null) {
-            aggregationFunctionColumnPairs[i] = aggregationFunctionColumnPair;
-          } else {
-            hasUnsupportedAggregationFunction = true;
-            break;
-          }
-        }
-        if (!hasUnsupportedAggregationFunction) {
-          FilterContext filter = queryContext.getFilter();
+    if (starTrees != null && !StarTreeUtils.isStarTreeDisabled(queryContext)) {
+      AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
+          StarTreeUtils.extractAggregationFunctionPairs(_aggregationFunctions);
+      if (aggregationFunctionColumnPairs != null) {
+        Map<String, List<PredicateEvaluator>> predicateEvaluatorsMap =
+            StarTreeUtils.extractPredicateEvaluatorsMap(indexSegment, queryContext.getFilter());
+        if (predicateEvaluatorsMap != null) {
           for (StarTreeV2 starTreeV2 : starTrees) {
             if (StarTreeUtils
                 .isFitForStarTree(starTreeV2.getMetadata(), aggregationFunctionColumnPairs, _groupByExpressions,
-                    filter)) {
+                    predicateEvaluatorsMap.keySet())) {
               _transformPlanNode = null;
               _starTreeTransformPlanNode =
-                  new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, _groupByExpressions, filter,
-                      queryContext.getDebugOptions());
+                  new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, _groupByExpressions,
+                      predicateEvaluatorsMap, queryContext.getDebugOptions());
               return;
             }
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -19,13 +19,14 @@
 package org.apache.pinot.core.plan;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
-import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.core.startree.plan.StarTreeTransformPlanNode;
@@ -50,31 +51,20 @@ public class AggregationPlanNode implements PlanNode {
     assert _aggregationFunctions != null;
 
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
-    if (starTrees != null) {
-      if (!StarTreeUtils.isStarTreeDisabled(queryContext)) {
-        int numAggregationFunctions = _aggregationFunctions.length;
-        AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
-            new AggregationFunctionColumnPair[numAggregationFunctions];
-        boolean hasUnsupportedAggregationFunction = false;
-        for (int i = 0; i < numAggregationFunctions; i++) {
-          AggregationFunctionColumnPair aggregationFunctionColumnPair =
-              AggregationFunctionUtils.getAggregationFunctionColumnPair(_aggregationFunctions[i]);
-          if (aggregationFunctionColumnPair != null) {
-            aggregationFunctionColumnPairs[i] = aggregationFunctionColumnPair;
-          } else {
-            hasUnsupportedAggregationFunction = true;
-            break;
-          }
-        }
-        if (!hasUnsupportedAggregationFunction) {
-          FilterContext filter = queryContext.getFilter();
+    if (starTrees != null && !StarTreeUtils.isStarTreeDisabled(queryContext)) {
+      AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
+          StarTreeUtils.extractAggregationFunctionPairs(_aggregationFunctions);
+      if (aggregationFunctionColumnPairs != null) {
+        Map<String, List<PredicateEvaluator>> predicateEvaluatorsMap =
+            StarTreeUtils.extractPredicateEvaluatorsMap(indexSegment, queryContext.getFilter());
+        if (predicateEvaluatorsMap != null) {
           for (StarTreeV2 starTreeV2 : starTrees) {
-            if (StarTreeUtils
-                .isFitForStarTree(starTreeV2.getMetadata(), aggregationFunctionColumnPairs, null, filter)) {
+            if (StarTreeUtils.isFitForStarTree(starTreeV2.getMetadata(), aggregationFunctionColumnPairs, null,
+                predicateEvaluatorsMap.keySet())) {
               _transformPlanNode = null;
               _starTreeTransformPlanNode =
-                  new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, null, filter,
-                      queryContext.getDebugOptions());
+                  new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, null,
+                      predicateEvaluatorsMap, queryContext.getDebugOptions());
               return;
             }
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -20,18 +20,30 @@ package org.apache.pinot.core.startree;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.predicate.Predicate;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.core.startree.v2.StarTreeV2Constants;
@@ -40,6 +52,7 @@ import org.apache.pinot.core.startree.v2.builder.StarTreeV2BuilderConfig;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 
 
+@SuppressWarnings("rawtypes")
 public class StarTreeUtils {
   private StarTreeUtils() {
   }
@@ -55,17 +68,103 @@ public class StarTreeUtils {
   }
 
   /**
+   * Extracts the {@link AggregationFunctionColumnPair}s from the given {@link AggregationFunction}s. Returns
+   * {@code null} if any {@link AggregationFunction} cannot be represented as an {@link AggregationFunctionColumnPair}
+   * (e.g. has multiple arguments, argument is not column etc.).
+   */
+  @Nullable
+  public static AggregationFunctionColumnPair[] extractAggregationFunctionPairs(
+      AggregationFunction[] aggregationFunctions) {
+    int numAggregationFunctions = aggregationFunctions.length;
+    AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
+        new AggregationFunctionColumnPair[numAggregationFunctions];
+    for (int i = 0; i < numAggregationFunctions; i++) {
+      AggregationFunctionColumnPair aggregationFunctionColumnPair =
+          AggregationFunctionUtils.getAggregationFunctionColumnPair(aggregationFunctions[i]);
+      if (aggregationFunctionColumnPair != null) {
+        aggregationFunctionColumnPairs[i] = aggregationFunctionColumnPair;
+      } else {
+        return null;
+      }
+    }
+    return aggregationFunctionColumnPairs;
+  }
+
+  /**
+   * Extracts a map from the column to a list of {@link PredicateEvaluator}s for it. Returns {@code null} if the filter
+   * cannot be solved by the star-tree.
+   */
+  @Nullable
+  public static Map<String, List<PredicateEvaluator>> extractPredicateEvaluatorsMap(IndexSegment indexSegment,
+      @Nullable FilterContext filter) {
+    if (filter == null) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, List<PredicateEvaluator>> predicateEvaluatorsMap = new HashMap<>();
+    Queue<FilterContext> queue = new LinkedList<>();
+    queue.add(filter);
+    FilterContext filterNode;
+    while ((filterNode = queue.poll()) != null) {
+      switch (filterNode.getType()) {
+        case AND:
+          queue.addAll(filterNode.getChildren());
+          break;
+        case OR:
+          // Star-tree does not support OR filter
+          return null;
+        case PREDICATE:
+          Predicate predicate = filterNode.getPredicate();
+          ExpressionContext lhs = predicate.getLhs();
+          if (lhs.getType() != ExpressionContext.Type.IDENTIFIER) {
+            // Star-tree does not support non-identifier expression
+            return null;
+          }
+          String column = lhs.getIdentifier();
+          DataSource dataSource = indexSegment.getDataSource(column);
+          Dictionary dictionary = dataSource.getDictionary();
+          if (dictionary == null) {
+            // Star-tree does not support non-dictionary encoded dimension
+            return null;
+          }
+          switch (predicate.getType()) {
+            // Do not use star-tree for the following predicates because:
+            //   - REGEXP_LIKE: Need to scan the whole dictionary to gather the matching dictionary ids
+            //   - TEXT_MATCH/IS_NULL/IS_NOT_NULL: No way to gather the matching dictionary ids
+            case REGEXP_LIKE:
+            case TEXT_MATCH:
+            case IS_NULL:
+            case IS_NOT_NULL:
+              return null;
+          }
+          PredicateEvaluator predicateEvaluator = PredicateEvaluatorProvider
+              .getPredicateEvaluator(predicate, dictionary, dataSource.getDataSourceMetadata().getDataType());
+          if (predicateEvaluator.isAlwaysFalse()) {
+            // Do not use star-tree if there is no matching record
+            return null;
+          }
+          if (!predicateEvaluator.isAlwaysTrue()) {
+            predicateEvaluatorsMap.computeIfAbsent(column, k -> new ArrayList<>()).add(predicateEvaluator);
+          }
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+    }
+    return predicateEvaluatorsMap;
+  }
+
+  /**
    * Returns whether the query is fit for star tree index.
    * <p>The query is fit for star tree index if the following conditions are met:
    * <ul>
    *   <li>Star-tree contains all aggregation function column pairs</li>
    *   <li>All predicate columns and group-by columns are star-tree dimensions</li>
-   *   <li>All predicates are conjoined by AND</li>
    * </ul>
    */
   public static boolean isFitForStarTree(StarTreeV2Metadata starTreeV2Metadata,
       AggregationFunctionColumnPair[] aggregationFunctionColumnPairs, @Nullable ExpressionContext[] groupByExpressions,
-      @Nullable FilterContext filter) {
+      Set<String> predicateColumns) {
     // Check aggregations
     for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {
       if (!starTreeV2Metadata.containsFunctionColumnPair(aggregationFunctionColumnPair)) {
@@ -73,8 +172,9 @@ public class StarTreeUtils {
       }
     }
 
-    // Check group-by expressions
     Set<String> starTreeDimensions = new HashSet<>(starTreeV2Metadata.getDimensionsSplitOrder());
+
+    // Check group-by expressions
     if (groupByExpressions != null) {
       Set<String> groupByColumns = new HashSet<>();
       for (ExpressionContext groupByExpression : groupByExpressions) {
@@ -85,45 +185,8 @@ public class StarTreeUtils {
       }
     }
 
-    // Check filters
-    return filter == null || checkFilters(filter, starTreeDimensions);
-  }
-
-  /**
-   * Helper method to check whether all columns in predicates are star-tree dimensions, and all predicates are
-   * conjoined by AND.
-   */
-  private static boolean checkFilters(FilterContext filter, Set<String> starTreeDimensions) {
-    switch (filter.getType()) {
-      case AND:
-        for (FilterContext child : filter.getChildren()) {
-          if (!checkFilters(child, starTreeDimensions)) {
-            return false;
-          }
-        }
-        return true;
-      case OR:
-        return false;
-      case PREDICATE:
-        Predicate predicate = filter.getPredicate();
-        ExpressionContext lhs = predicate.getLhs();
-        if (lhs.getType() != ExpressionContext.Type.IDENTIFIER) {
-          return false;
-        }
-        switch (predicate.getType()) {
-          // NOTE: Do not use star-tree for the following predicates because:
-          //       - REGEXP_LIKE: Need to scan the whole dictionary to gather the matching dictionary ids
-          //       - TEXT_MATCH/IS_NULL/IS_NOT_NULL: No way to gather the matching dictionary ids
-          case REGEXP_LIKE:
-          case TEXT_MATCH:
-          case IS_NULL:
-          case IS_NOT_NULL:
-            return false;
-        }
-        return starTreeDimensions.contains(lhs.getIdentifier());
-      default:
-        throw new IllegalStateException();
-    }
+    // Check predicate columns
+    return starTreeDimensions.containsAll(predicateColumns);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeDocIdSetPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeDocIdSetPlanNode.java
@@ -18,22 +18,24 @@
  */
 package org.apache.pinot.core.startree.plan;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.plan.PlanNode;
-import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
 
 
 public class StarTreeDocIdSetPlanNode implements PlanNode {
   private final StarTreeFilterPlanNode _starTreeFilterPlanNode;
 
-  public StarTreeDocIdSetPlanNode(StarTreeV2 starTreeV2, @Nullable FilterContext filter,
+  public StarTreeDocIdSetPlanNode(StarTreeV2 starTreeV2, Map<String, List<PredicateEvaluator>> predicateEvaluatorsMap,
       @Nullable Set<String> groupByColumns, @Nullable Map<String, String> debugOptions) {
-    _starTreeFilterPlanNode = new StarTreeFilterPlanNode(starTreeV2, filter, groupByColumns, debugOptions);
+    _starTreeFilterPlanNode =
+        new StarTreeFilterPlanNode(starTreeV2, predicateEvaluatorsMap, groupByColumns, debugOptions);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeFilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeFilterPlanNode.java
@@ -18,31 +18,32 @@
  */
 package org.apache.pinot.core.startree.plan;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.plan.PlanNode;
-import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.startree.operator.StarTreeFilterOperator;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
 
 
 public class StarTreeFilterPlanNode implements PlanNode {
   private final StarTreeV2 _starTreeV2;
-  private final FilterContext _filter;
+  private final Map<String, List<PredicateEvaluator>> _predicateEvaluatorsMap;
   private final Set<String> _groupByColumns;
   private final Map<String, String> _debugOptions;
 
-  public StarTreeFilterPlanNode(StarTreeV2 starTreeV2, @Nullable FilterContext filter,
+  public StarTreeFilterPlanNode(StarTreeV2 starTreeV2, Map<String, List<PredicateEvaluator>> predicateEvaluatorsMap,
       @Nullable Set<String> groupByColumns, @Nullable Map<String, String> debugOptions) {
     _starTreeV2 = starTreeV2;
-    _filter = filter;
+    _predicateEvaluatorsMap = predicateEvaluatorsMap;
     _groupByColumns = groupByColumns;
     _debugOptions = debugOptions;
   }
 
   @Override
   public StarTreeFilterOperator run() {
-    return new StarTreeFilterOperator(_starTreeV2, _filter, _groupByColumns, _debugOptions);
+    return new StarTreeFilterOperator(_starTreeV2, _predicateEvaluatorsMap, _groupByColumns, _debugOptions);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectionPlanNode.java
@@ -19,13 +19,14 @@
 package org.apache.pinot.core.startree.plan;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.plan.PlanNode;
-import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
 
 
@@ -34,13 +35,14 @@ public class StarTreeProjectionPlanNode implements PlanNode {
   private final StarTreeDocIdSetPlanNode _starTreeDocIdSetPlanNode;
 
   public StarTreeProjectionPlanNode(StarTreeV2 starTreeV2, Set<String> projectionColumns,
-      @Nullable FilterContext filter, @Nullable Set<String> groupByColumns,
+      Map<String, List<PredicateEvaluator>> predicateEvaluatorsMap, @Nullable Set<String> groupByColumns,
       @Nullable Map<String, String> debugOptions) {
-    _dataSourceMap = new HashMap<>(projectionColumns.size());
+    _dataSourceMap = new HashMap<>();
     for (String projectionColumn : projectionColumns) {
       _dataSourceMap.put(projectionColumn, starTreeV2.getDataSource(projectionColumn));
     }
-    _starTreeDocIdSetPlanNode = new StarTreeDocIdSetPlanNode(starTreeV2, filter, groupByColumns, debugOptions);
+    _starTreeDocIdSetPlanNode =
+        new StarTreeDocIdSetPlanNode(starTreeV2, predicateEvaluatorsMap, groupByColumns, debugOptions);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
@@ -25,10 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
-import org.apache.pinot.core.query.request.context.FilterContext;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
 
@@ -39,7 +39,7 @@ public class StarTreeTransformPlanNode implements PlanNode {
 
   public StarTreeTransformPlanNode(StarTreeV2 starTreeV2,
       AggregationFunctionColumnPair[] aggregationFunctionColumnPairs, @Nullable ExpressionContext[] groupByExpressions,
-      @Nullable FilterContext filter, @Nullable Map<String, String> debugOptions) {
+      Map<String, List<PredicateEvaluator>> predicateEvaluatorsMap, @Nullable Map<String, String> debugOptions) {
     Set<String> projectionColumns = new HashSet<>();
     for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {
       projectionColumns.add(aggregationFunctionColumnPair.toColumnName());
@@ -57,7 +57,8 @@ public class StarTreeTransformPlanNode implements PlanNode {
       groupByColumns = null;
     }
     _starTreeProjectionPlanNode =
-        new StarTreeProjectionPlanNode(starTreeV2, projectionColumns, filter, groupByColumns, debugOptions);
+        new StarTreeProjectionPlanNode(starTreeV2, projectionColumns, predicateEvaluatorsMap, groupByColumns,
+            debugOptions);
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -477,6 +477,12 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
     assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), NUM_SEGMENTS);
 
+    // Should be able to use the star-tree with an additional match-all predicate on another dimension
+    firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1 + " AND DaysSinceEpoch > 16070");
+    assertEquals(firstQueryResponse.get("aggregationResults").get(0).get("value").asInt(), firstQueryResult);
+    assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
+    assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), NUM_SEGMENTS);
+
     // Test the second query
     JsonNode secondQueryResponse = postQuery(TEST_STAR_TREE_QUERY_2);
     int secondQueryResult = secondQueryResponse.get("aggregationResults").get(0).get("value").asInt();
@@ -514,6 +520,12 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
     assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), firstQueryResult);
     secondQueryResponse = postQuery(TEST_STAR_TREE_QUERY_2);
+    assertEquals(secondQueryResponse.get("aggregationResults").get(0).get("value").asInt(), secondQueryResult);
+    assertEquals(secondQueryResponse.get("totalDocs").asLong(), numTotalDocs);
+    assertEquals(secondQueryResponse.get("numDocsScanned").asInt(), NUM_SEGMENTS);
+
+    // Should be able to use the star-tree with an additional match-all predicate on another dimension
+    secondQueryResponse = postQuery(TEST_STAR_TREE_QUERY_2 + " AND DaysSinceEpoch > 16070");
     assertEquals(secondQueryResponse.get("aggregationResults").get(0).get("value").asInt(), secondQueryResult);
     assertEquals(secondQueryResponse.get("totalDocs").asLong(), numTotalDocs);
     assertEquals(secondQueryResponse.get("numDocsScanned").asInt(), NUM_SEGMENTS);


### PR DESCRIPTION
## Description
For #6093 

Currently in order to use the star-tree index, all the predicates must be applied to the star-tree dimensions. This could limit the usage of star-tree when a predicates is not applied to the star-tree dimensions, but can be skipped because it matches all the records. This is especially common for the implicit predicate applied to time column for the hybrid tables.
This PR enhances the planning phase for star-tree to skip the predicates that matches all the records, so that star-tree can be applied to the use cases described above.