### PR TITLE
add max length support in schema builder

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
@@ -80,6 +80,18 @@ public class FieldSpecTest {
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
     Assert.assertEquals(fieldSpec1.getDefaultNullValue(), "false");
 
+    // Single-value boolean type dimension field with max length and default null value.
+    fieldSpec1 = new DimensionFieldSpec();
+    fieldSpec1.setName("svDimension");
+    fieldSpec1.setDataType(BOOLEAN);
+    fieldSpec1.setDefaultNullValue(false);
+    fieldSpec1.setMaxLength(20000);
+    fieldSpec2 = new DimensionFieldSpec("svDimension", BOOLEAN, true, 20000, false);
+    Assert.assertEquals(fieldSpec1, fieldSpec2);
+    Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
+    Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
+    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), "false");
+
     // Multi-value dimension field.
     fieldSpec1 = new DimensionFieldSpec();
     fieldSpec1.setName("mvDimension");
@@ -103,12 +115,37 @@ public class FieldSpecTest {
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
     Assert.assertEquals(fieldSpec1.getDefaultNullValue(), -0.1F);
 
+    // Multi-value dimension field with max length and default null value.
+    fieldSpec1 = new DimensionFieldSpec();
+    fieldSpec1.setName("mvDimension");
+    fieldSpec1.setDataType(FLOAT);
+    fieldSpec1.setSingleValueField(false);
+    fieldSpec1.setMaxLength(20000);
+    fieldSpec1.setDefaultNullValue(-0.1);
+    fieldSpec2 = new DimensionFieldSpec("mvDimension", FLOAT, false, 20000, -0.1);
+    Assert.assertEquals(fieldSpec1, fieldSpec2);
+    Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
+    Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
+    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), -0.1F);
+
     // Metric field with default null value.
     fieldSpec1 = new MetricFieldSpec();
     fieldSpec1.setName("metric");
     fieldSpec1.setDataType(LONG);
     fieldSpec1.setDefaultNullValue(1);
     fieldSpec2 = new MetricFieldSpec("metric", LONG, 1);
+    Assert.assertEquals(fieldSpec1, fieldSpec2);
+    Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
+    Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
+    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), 1L);
+
+    // Metric field with max length and default null value.
+    fieldSpec1 = new MetricFieldSpec();
+    fieldSpec1.setName("metric");
+    fieldSpec1.setDataType(LONG);
+    fieldSpec1.setMaxLength(20000);
+    fieldSpec1.setDefaultNullValue(1);
+    fieldSpec2 = new MetricFieldSpec("metric", LONG, 20000, 1);
     Assert.assertEquals(fieldSpec1, fieldSpec2);
     Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
@@ -137,17 +137,6 @@ public class FieldSpecTest {
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
     Assert.assertEquals(fieldSpec1.getDefaultNullValue(), 1L);
 
-    // Metric field with max length and default null value.
-    fieldSpec1 = new MetricFieldSpec();
-    fieldSpec1.setName("metric");
-    fieldSpec1.setDataType(STRING);
-    fieldSpec1.setMaxLength(20000);
-    fieldSpec2 = new MetricFieldSpec("metric", STRING, 20000, null);
-    Assert.assertEquals(fieldSpec1, fieldSpec2);
-    Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
-    Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
-    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), "null");
-
     // Metric field with default null value for byte column.
     fieldSpec1 = new MetricFieldSpec();
     fieldSpec1.setName("byteMetric");

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
@@ -80,17 +80,15 @@ public class FieldSpecTest {
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
     Assert.assertEquals(fieldSpec1.getDefaultNullValue(), "false");
 
-    // Single-value boolean type dimension field with max length and default null value.
+    // Single-value string type dimension field with max length and default null value.
     fieldSpec1 = new DimensionFieldSpec();
     fieldSpec1.setName("svDimension");
-    fieldSpec1.setDataType(BOOLEAN);
-    fieldSpec1.setDefaultNullValue(false);
+    fieldSpec1.setDataType(STRING);
     fieldSpec1.setMaxLength(20000);
-    fieldSpec2 = new DimensionFieldSpec("svDimension", BOOLEAN, true, 20000, false);
+    fieldSpec2 = new DimensionFieldSpec("svDimension", STRING, true, 20000, null);
     Assert.assertEquals(fieldSpec1, fieldSpec2);
     Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
-    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), "false");
 
     // Multi-value dimension field.
     fieldSpec1 = new DimensionFieldSpec();
@@ -203,7 +201,8 @@ public class FieldSpecTest {
     Assert.assertEquals(dateTimeFieldSpec1, dateTimeFieldSpec3);
 
     DateTimeFieldSpec dateTimeFieldSpec4 = new DateTimeFieldSpec(name, LONG, format, granularity, 100000000L, null);
-    DateTimeFieldSpec dateTimeFieldSpec5 = new DateTimeFieldSpec(name, INT, format, granularity, null, "toEpochHours(millis)");
+    DateTimeFieldSpec dateTimeFieldSpec5 =
+        new DateTimeFieldSpec(name, INT, format, granularity, null, "toEpochHours(millis)");
     Assert.assertNotEquals(dateTimeFieldSpec5, dateTimeFieldSpec4);
 
     DateTimeFieldSpec dateTimeFieldSpec6 = new DateTimeFieldSpec(name, LONG, format, granularity, 100000000L, null);
@@ -299,7 +298,8 @@ public class FieldSpecTest {
     FieldSpec second;
 
     // Single-value boolean type dimension field with default null value.
-    String[] dimensionFields = {"\"name\":\"dimension\"", "\"dataType\":\"BOOLEAN\"", "\"defaultNullValue\":false", "\"transformFunction\":\"trim(foo)\""};
+    String[] dimensionFields =
+        {"\"name\":\"dimension\"", "\"dataType\":\"BOOLEAN\"", "\"defaultNullValue\":false", "\"transformFunction\":\"trim(foo)\""};
     first = JsonUtils.stringToObject(getRandomOrderJsonString(dimensionFields), DimensionFieldSpec.class);
     second = JsonUtils.stringToObject(first.toJsonObject().toString(), DimensionFieldSpec.class);
     Assert.assertEquals(first, second, ERROR_MESSAGE);
@@ -313,18 +313,14 @@ public class FieldSpecTest {
 
     // Time field with default value.
     String[] timeFields =
-        {"\"incomingGranularitySpec\":{\"timeUnitSize\":1, \"timeType\":\"MILLISECONDS\",\"dataType\":\"LONG\",\"name\":\"incomingTime\"}",
-            "\"outgoingGranularitySpec\":{\"timeType\":\"SECONDS\",\"dataType\":\"INT\",\"name\":\"outgoingTime\"}",
-            "\"defaultNullValue\":-1",
-            "\"transformFunction\":\"toEpochDays(millis)\""};
+        {"\"incomingGranularitySpec\":{\"timeUnitSize\":1, \"timeType\":\"MILLISECONDS\",\"dataType\":\"LONG\",\"name\":\"incomingTime\"}", "\"outgoingGranularitySpec\":{\"timeType\":\"SECONDS\",\"dataType\":\"INT\",\"name\":\"outgoingTime\"}", "\"defaultNullValue\":-1", "\"transformFunction\":\"toEpochDays(millis)\""};
     first = JsonUtils.stringToObject(getRandomOrderJsonString(timeFields), TimeFieldSpec.class);
     second = JsonUtils.stringToObject(first.toJsonObject().toString(), TimeFieldSpec.class);
     Assert.assertEquals(first, second, ERROR_MESSAGE);
 
     // DateTime field
     String[] dateTimeFields =
-        {"\"name\":\"Date\"", "\"dataType\":\"LONG\"", "\"format\":\"1:MILLISECONDS:EPOCH\"", "\"granularity\":\"5:MINUTES\"",
-            "\"transformFunction\":\"fromEpochDays(daysSinceEpoch)\""};
+        {"\"name\":\"Date\"", "\"dataType\":\"LONG\"", "\"format\":\"1:MILLISECONDS:EPOCH\"", "\"granularity\":\"5:MINUTES\"", "\"transformFunction\":\"fromEpochDays(daysSinceEpoch)\""};
     first = JsonUtils.stringToObject(getRandomOrderJsonString(dateTimeFields), DateTimeFieldSpec.class);
     second = JsonUtils.stringToObject(first.toJsonObject().toString(), DateTimeFieldSpec.class);
     Assert.assertEquals(first, second, ERROR_MESSAGE);

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
@@ -89,6 +89,7 @@ public class FieldSpecTest {
     Assert.assertEquals(fieldSpec1, fieldSpec2);
     Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
+    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), "null");
 
     // Multi-value dimension field.
     fieldSpec1 = new DimensionFieldSpec();
@@ -116,15 +117,14 @@ public class FieldSpecTest {
     // Multi-value dimension field with max length and default null value.
     fieldSpec1 = new DimensionFieldSpec();
     fieldSpec1.setName("mvDimension");
-    fieldSpec1.setDataType(FLOAT);
+    fieldSpec1.setDataType(STRING);
     fieldSpec1.setSingleValueField(false);
     fieldSpec1.setMaxLength(20000);
-    fieldSpec1.setDefaultNullValue(-0.1);
-    fieldSpec2 = new DimensionFieldSpec("mvDimension", FLOAT, false, 20000, -0.1);
+    fieldSpec2 = new DimensionFieldSpec("mvDimension", STRING, false, 20000, null);
     Assert.assertEquals(fieldSpec1, fieldSpec2);
     Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
-    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), -0.1F);
+    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), "null");
 
     // Metric field with default null value.
     fieldSpec1 = new MetricFieldSpec();
@@ -140,14 +140,13 @@ public class FieldSpecTest {
     // Metric field with max length and default null value.
     fieldSpec1 = new MetricFieldSpec();
     fieldSpec1.setName("metric");
-    fieldSpec1.setDataType(LONG);
+    fieldSpec1.setDataType(STRING);
     fieldSpec1.setMaxLength(20000);
-    fieldSpec1.setDefaultNullValue(1);
-    fieldSpec2 = new MetricFieldSpec("metric", LONG, 20000, 1);
+    fieldSpec2 = new MetricFieldSpec("metric", STRING, 20000, null);
     Assert.assertEquals(fieldSpec1, fieldSpec2);
     Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
-    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), 1L);
+    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), "null");
 
     // Metric field with default null value for byte column.
     fieldSpec1 = new MetricFieldSpec();

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -89,7 +89,6 @@ public class SchemaTest {
         .addMultiValueDimension("mvDimensionWithDefault", FieldSpec.DataType.STRING, defaultString)
         .addMultiValueDimension("mvDimensionWithMaxLength", FieldSpec.DataType.STRING, 20000, null)
         .addMetric("metric", FieldSpec.DataType.INT).addMetric("metricWithDefault", FieldSpec.DataType.INT, 5)
-        .addMetric("metricWithMaxLength", FieldSpec.DataType.INT, 20000, null)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "time"), null)
         .addDateTime("dateTime", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
         .setPrimaryKeyColumns(Lists.newArrayList("svDimension")).build();
@@ -159,15 +158,6 @@ public class SchemaTest {
     Assert.assertEquals(metricFieldSpec.getDataType(), FieldSpec.DataType.INT);
     Assert.assertTrue(metricFieldSpec.isSingleValueField());
     Assert.assertEquals(metricFieldSpec.getDefaultNullValue(), 5);
-
-    metricFieldSpec = schema.getMetricSpec("metricWithMaxLength");
-    Assert.assertNotNull(metricFieldSpec);
-    Assert.assertEquals(metricFieldSpec.getFieldType(), FieldSpec.FieldType.METRIC);
-    Assert.assertEquals(metricFieldSpec.getName(), "metricWithMaxLength");
-    Assert.assertEquals(metricFieldSpec.getDataType(), FieldSpec.DataType.INT);
-    Assert.assertTrue(metricFieldSpec.isSingleValueField());
-    Assert.assertEquals(metricFieldSpec.getMaxLength(), 20000);
-    Assert.assertEquals(metricFieldSpec.getDefaultNullValue(), 0);
 
     TimeFieldSpec timeFieldSpec = schema.getTimeFieldSpec();
     Assert.assertNotNull(timeFieldSpec);

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -167,7 +167,7 @@ public class SchemaTest {
     Assert.assertEquals(metricFieldSpec.getDataType(), FieldSpec.DataType.INT);
     Assert.assertTrue(metricFieldSpec.isSingleValueField());
     Assert.assertEquals(metricFieldSpec.getMaxLength(), 20000);
-    Assert.assertEquals(metricFieldSpec.getDefaultNullValue(), Integer.MIN_VALUE);
+    Assert.assertEquals(metricFieldSpec.getDefaultNullValue(), 0);
 
     TimeFieldSpec timeFieldSpec = schema.getTimeFieldSpec();
     Assert.assertNotNull(timeFieldSpec);

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -84,7 +84,7 @@ public class SchemaTest {
     String defaultString = "default";
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
         .addSingleValueDimension("svDimensionWithDefault", FieldSpec.DataType.INT, 10)
-        .addSingleValueDimension("svDimensionWithMaxLength", FieldSpec.DataType.INT, 20000, null)
+        .addSingleValueDimension("svDimensionWithMaxLength", FieldSpec.DataType.STRING, 20000, null)
         .addMultiValueDimension("mvDimension", FieldSpec.DataType.STRING)
         .addMultiValueDimension("mvDimensionWithDefault", FieldSpec.DataType.STRING, defaultString)
         .addMultiValueDimension("mvDimensionWithMaxLength", FieldSpec.DataType.STRING, 20000, null)
@@ -114,10 +114,10 @@ public class SchemaTest {
     Assert.assertNotNull(dimensionFieldSpec);
     Assert.assertEquals(dimensionFieldSpec.getFieldType(), FieldSpec.FieldType.DIMENSION);
     Assert.assertEquals(dimensionFieldSpec.getName(), "svDimensionWithMaxLength");
-    Assert.assertEquals(dimensionFieldSpec.getDataType(), FieldSpec.DataType.INT);
+    Assert.assertEquals(dimensionFieldSpec.getDataType(), FieldSpec.DataType.STRING);
     Assert.assertTrue(dimensionFieldSpec.isSingleValueField());
     Assert.assertEquals(dimensionFieldSpec.getMaxLength(), 20000);
-    Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), Integer.MIN_VALUE);
+    Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), "null");
 
     dimensionFieldSpec = schema.getDimensionSpec("mvDimension");
     Assert.assertNotNull(dimensionFieldSpec);

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -84,9 +84,12 @@ public class SchemaTest {
     String defaultString = "default";
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
         .addSingleValueDimension("svDimensionWithDefault", FieldSpec.DataType.INT, 10)
+        .addSingleValueDimension("svDimensionWithMaxLength", FieldSpec.DataType.INT, 20000, null)
         .addMultiValueDimension("mvDimension", FieldSpec.DataType.STRING)
         .addMultiValueDimension("mvDimensionWithDefault", FieldSpec.DataType.STRING, defaultString)
+        .addMultiValueDimension("mvDimensionWithMaxLength", FieldSpec.DataType.STRING, 20000, null)
         .addMetric("metric", FieldSpec.DataType.INT).addMetric("metricWithDefault", FieldSpec.DataType.INT, 5)
+        .addMetric("metricWithMaxLength", FieldSpec.DataType.INT, 20000, null)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "time"), null)
         .addDateTime("dateTime", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
         .setPrimaryKeyColumns(Lists.newArrayList("svDimension")).build();
@@ -107,6 +110,15 @@ public class SchemaTest {
     Assert.assertTrue(dimensionFieldSpec.isSingleValueField());
     Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), 10);
 
+    dimensionFieldSpec = schema.getDimensionSpec("svDimensionWithMaxLength");
+    Assert.assertNotNull(dimensionFieldSpec);
+    Assert.assertEquals(dimensionFieldSpec.getFieldType(), FieldSpec.FieldType.DIMENSION);
+    Assert.assertEquals(dimensionFieldSpec.getName(), "svDimensionWithMaxLength");
+    Assert.assertEquals(dimensionFieldSpec.getDataType(), FieldSpec.DataType.INT);
+    Assert.assertTrue(dimensionFieldSpec.isSingleValueField());
+    Assert.assertEquals(dimensionFieldSpec.getMaxLength(), 20000);
+    Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), Integer.MIN_VALUE);
+
     dimensionFieldSpec = schema.getDimensionSpec("mvDimension");
     Assert.assertNotNull(dimensionFieldSpec);
     Assert.assertEquals(dimensionFieldSpec.getFieldType(), FieldSpec.FieldType.DIMENSION);
@@ -123,6 +135,15 @@ public class SchemaTest {
     Assert.assertFalse(dimensionFieldSpec.isSingleValueField());
     Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), defaultString);
 
+    dimensionFieldSpec = schema.getDimensionSpec("mvDimensionWithMaxLength");
+    Assert.assertNotNull(dimensionFieldSpec);
+    Assert.assertEquals(dimensionFieldSpec.getFieldType(), FieldSpec.FieldType.DIMENSION);
+    Assert.assertEquals(dimensionFieldSpec.getName(), "mvDimensionWithMaxLength");
+    Assert.assertEquals(dimensionFieldSpec.getDataType(), FieldSpec.DataType.STRING);
+    Assert.assertFalse(dimensionFieldSpec.isSingleValueField());
+    Assert.assertEquals(dimensionFieldSpec.getMaxLength(), 20000);
+    Assert.assertEquals(dimensionFieldSpec.getDefaultNullValue(), "null");
+
     MetricFieldSpec metricFieldSpec = schema.getMetricSpec("metric");
     Assert.assertNotNull(metricFieldSpec);
     Assert.assertEquals(metricFieldSpec.getFieldType(), FieldSpec.FieldType.METRIC);
@@ -138,6 +159,15 @@ public class SchemaTest {
     Assert.assertEquals(metricFieldSpec.getDataType(), FieldSpec.DataType.INT);
     Assert.assertTrue(metricFieldSpec.isSingleValueField());
     Assert.assertEquals(metricFieldSpec.getDefaultNullValue(), 5);
+
+    metricFieldSpec = schema.getMetricSpec("metricWithMaxLength");
+    Assert.assertNotNull(metricFieldSpec);
+    Assert.assertEquals(metricFieldSpec.getFieldType(), FieldSpec.FieldType.METRIC);
+    Assert.assertEquals(metricFieldSpec.getName(), "metricWithMaxLength");
+    Assert.assertEquals(metricFieldSpec.getDataType(), FieldSpec.DataType.INT);
+    Assert.assertTrue(metricFieldSpec.isSingleValueField());
+    Assert.assertEquals(metricFieldSpec.getMaxLength(), 20000);
+    Assert.assertEquals(metricFieldSpec.getDefaultNullValue(), Integer.MIN_VALUE);
 
     TimeFieldSpec timeFieldSpec = schema.getTimeFieldSpec();
     Assert.assertNotNull(timeFieldSpec);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DimensionFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DimensionFieldSpec.java
@@ -41,6 +41,11 @@ public final class DimensionFieldSpec extends FieldSpec {
   }
 
   public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField,
+      int maxLength, @Nonnull Object defaultNullValue) {
+    super(name, dataType, isSingleValueField, maxLength, defaultNullValue);
+  }
+
+  public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField,
       Class virtualColumnProviderClass) {
     super(name, dataType, isSingleValueField);
     _virtualColumnProvider = virtualColumnProviderClass.getName();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DimensionFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DimensionFieldSpec.java
@@ -40,8 +40,8 @@ public final class DimensionFieldSpec extends FieldSpec {
     super(name, dataType, isSingleValueField, defaultNullValue);
   }
 
-  public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField,
-      int maxLength, @Nonnull Object defaultNullValue) {
+  public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField, int maxLength,
+      @Nonnull Object defaultNullValue) {
     super(name, dataType, isSingleValueField, maxLength, defaultNullValue);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/MetricFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/MetricFieldSpec.java
@@ -42,10 +42,6 @@ public final class MetricFieldSpec extends FieldSpec {
     super(name, dataType, true, defaultNullValue);
   }
 
-  public MetricFieldSpec(String name, DataType dataType, int maxLength, Object defaultNullValue) {
-    super(name, dataType, true, maxLength, defaultNullValue);
-  }
-
   @JsonIgnore
   @Override
   public FieldType getFieldType() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/MetricFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/MetricFieldSpec.java
@@ -42,6 +42,10 @@ public final class MetricFieldSpec extends FieldSpec {
     super(name, dataType, true, defaultNullValue);
   }
 
+  public MetricFieldSpec(String name, DataType dataType, int maxLength, Object defaultNullValue) {
+    super(name, dataType, true, maxLength, defaultNullValue);
+  }
+
   @JsonIgnore
   @Override
   public FieldType getFieldType() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -523,7 +523,6 @@ public final class Schema {
      * Add multi value dimensionFieldSpec with defaultNullValue
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
-      Preconditions.checkArgument(dataType == STRING, "The maxLength field only applies to STRING field right now");
       _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue));
       return this;
     }
@@ -533,6 +532,7 @@ public final class Schema {
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
+      Preconditions.checkArgument(dataType == STRING, "The maxLength field only applies to STRING field right now");
       _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue));
       return this;
     }
@@ -550,15 +550,6 @@ public final class Schema {
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType, Object defaultNullValue) {
       _schema.addField(new MetricFieldSpec(metricName, dataType, defaultNullValue));
-      return this;
-    }
-
-    /**
-     * Add metricFieldSpec with defaultNullValue
-     */
-    public SchemaBuilder addMetric(String metricName, DataType dataType, int maxLength, Object defaultNullValue) {
-      Preconditions.checkArgument(dataType == STRING, "The maxLength field only applies to STRING field right now");
-      _schema.addField(new MetricFieldSpec(metricName, dataType, maxLength, defaultNullValue));
       return this;
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -503,7 +503,7 @@ public final class Schema {
      * Add single value dimensionFieldSpec with maxLength and a defaultNullValue
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, int maxLength,
-                                                 Object defaultNullValue) {
+        Object defaultNullValue) {
       _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, maxLength, defaultNullValue));
       return this;
     }
@@ -528,7 +528,7 @@ public final class Schema {
      * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, int maxLength,
-                                                Object defaultNullValue) {
+        Object defaultNullValue) {
       _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue));
       return this;
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -500,6 +500,15 @@ public final class Schema {
     }
 
     /**
+     * Add single value dimensionFieldSpec with maxLength and a defaultNullValue
+     */
+    public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, int maxLength,
+                                                 Object defaultNullValue) {
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, maxLength, defaultNullValue));
+      return this;
+    }
+
+    /**
      * Add multi value dimensionFieldSpec
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType) {
@@ -508,10 +517,19 @@ public final class Schema {
     }
 
     /**
-     * Add single value dimensionFieldSpec with defaultNullValue
+     * Add multi value dimensionFieldSpec with defaultNullValue
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
       _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue));
+      return this;
+    }
+
+    /**
+     * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue
+     */
+    public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, int maxLength,
+                                                Object defaultNullValue) {
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue));
       return this;
     }
 
@@ -528,6 +546,14 @@ public final class Schema {
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType, Object defaultNullValue) {
       _schema.addField(new MetricFieldSpec(metricName, dataType, defaultNullValue));
+      return this;
+    }
+
+    /**
+     * Add metricFieldSpec with defaultNullValue
+     */
+    public SchemaBuilder addMetric(String metricName, DataType dataType, int maxLength, Object defaultNullValue) {
+      _schema.addField(new MetricFieldSpec(metricName, dataType, maxLength, defaultNullValue));
       return this;
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -44,6 +44,8 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.pinot.spi.data.FieldSpec.DataType.STRING;
+
 
 /**
  * The <code>Schema</code> class is defined for each table to describe the details of the table's fields (columns).
@@ -504,6 +506,7 @@ public final class Schema {
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
+      Preconditions.checkArgument(dataType == STRING, "The maxLength field only applies to STRING field right now");
       _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, maxLength, defaultNullValue));
       return this;
     }
@@ -520,6 +523,7 @@ public final class Schema {
      * Add multi value dimensionFieldSpec with defaultNullValue
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
+      Preconditions.checkArgument(dataType == STRING, "The maxLength field only applies to STRING field right now");
       _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue));
       return this;
     }
@@ -553,6 +557,7 @@ public final class Schema {
      * Add metricFieldSpec with defaultNullValue
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType, int maxLength, Object defaultNullValue) {
+      Preconditions.checkArgument(dataType == STRING, "The maxLength field only applies to STRING field right now");
       _schema.addField(new MetricFieldSpec(metricName, dataType, maxLength, defaultNullValue));
       return this;
     }


### PR DESCRIPTION
## Description
Add one more API to set maxLength in schemaBuilder. #6106 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
