### PR TITLE
Adding Tenants, Instances, Tables, Segments count tiles and their respective pages

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Breadcrumbs.tsx
+++ b/pinot-controller/src/main/resources/app/components/Breadcrumbs.tsx
@@ -47,6 +47,11 @@ const LinkRouter = (props: LinkRouterProps) => (
 
 const breadcrumbNameMap: { [key: string]: string } = {
   '/': 'Home',
+  '/tenants': 'Tenants',
+  '/controllers': 'Controllers',
+  '/brokers': 'Brokers',
+  '/servers': 'Servers',
+  '/tables': 'Tables',
   '/query': 'Query Console',
   '/cluster': 'Cluster Manager',
   '/zookeeper': 'Zookeeper Browser'

--- a/pinot-controller/src/main/resources/app/components/Header.tsx
+++ b/pinot-controller/src/main/resources/app/components/Header.tsx
@@ -34,10 +34,10 @@ const Header = ({ highlightSidebarLink, showHideSideBarHandler, openSidebar, ...
   <AppBar position="static">
     <Box display="flex">
       <Box textAlign="center" marginY="12.5px" width={openSidebar ? 250 : 90} borderRight="1px solid rgba(255,255,255,0.5)">
-        <Link to="/"><Logo onClick={() => highlightSidebarLink(1)} fulllogo={openSidebar.toString()} /></Link>
+        <Link to="/" style={{color: '#ffffff'}}><Logo onClick={() => highlightSidebarLink(1)} fulllogo={openSidebar.toString()} /></Link>
       </Box>
       <Box display="flex" alignItems="center">
-        <Box marginY="auto" padding="0.25rem 0 0.25rem 1.5rem" display="flex">
+        <Box marginY="auto" padding="0.25rem 0 0.25rem 1.5rem" display="flex" style={{cursor: 'pointer'}}>
           <MenuIcon onClick={() => showHideSideBarHandler()} />
         </Box>
         <BreadcrumbsComponent {...props}/>

--- a/pinot-controller/src/main/resources/app/components/Homepage/InstanceTable.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/InstanceTable.tsx
@@ -25,7 +25,7 @@ import PinotMethodUtils from '../../utils/PinotMethodUtils';
 
 type Props = {
   name: string,
-  instances: string[],
+  instances: Array<String>,
   clusterName: string
 };
 

--- a/pinot-controller/src/main/resources/app/components/Homepage/TenantsListing.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/TenantsListing.tsx
@@ -17,20 +17,22 @@
  * under the License.
  */
 
-import React, {  } from 'react';
-import map from 'lodash/map';
-import InstanceTable from './InstanceTable';
+import React from 'react';
+import CustomizedTables from '../Table';
 
-const Instances = ({instances, clusterName}) => {
+const TenantsTable = ({tenantsData}) => {
+  
   return (
-    <>
-      {
-        map(instances, (value, key) => {
-          return <InstanceTable key={key} name={`${key}s`} instances={value} clusterName={clusterName} />;
-        })
-      }
-    </>
+    <CustomizedTables
+      title="Tenants"
+      data={tenantsData}
+      addLinks
+      isPagination
+      baseURL="/tenants/"
+      showSearchBox={true}
+      inAccordionFormat={true}
+    />
   );
 };
 
-export default Instances;
+export default TenantsTable;

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -49,19 +49,20 @@ import TableToolbar from './TableToolbar';
 import SimpleAccordion from './SimpleAccordion';
 
 type Props = {
-  title?: string;
-  data: TableData;
-  noOfRows?: number;
-  addLinks?: boolean;
-  isPagination?: boolean;
+  title?: string,
+  data: TableData,
+  noOfRows?: number,
+  addLinks?: boolean,
+  isPagination?: boolean,
   cellClickCallback?: Function,
   isCellClickable?: boolean,
   highlightBackground?: boolean,
-  isSticky?: boolean
+  isSticky?: boolean,
   baseURL?: string,
   recordsCount?: number,
   showSearchBox: boolean,
-  inAccordionFormat?: boolean
+  inAccordionFormat?: boolean,
+  regexReplace?: boolean
 };
 
 const StyledTableRow = withStyles((theme) =>
@@ -140,7 +141,7 @@ const useStyles = makeStyles((theme) => ({
     textAlign: 'center',
   },
   link: {
-    color: 'inherit',
+    color: '#4285f4',
   },
   spacer: {
     flex: '0 1 auto',
@@ -249,7 +250,8 @@ export default function CustomizedTables({
   baseURL,
   recordsCount,
   showSearchBox,
-  inAccordionFormat
+  inAccordionFormat,
+  regexReplace
 }: Props) {
   const [finalData, setFinalData] = React.useState(Utils.tableFormat(data));
 
@@ -382,12 +384,18 @@ export default function CustomizedTables({
                   .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                   .map((row, index) => (
                     <StyledTableRow key={index} hover>
-                      {Object.values(row).map((cell, idx) =>
-                        addLinks && !idx ? (
+                      {Object.values(row).map((cell, idx) =>{
+                        let url = baseURL;
+                        if(regexReplace){
+                          let regex = /\:.*?:/;
+                          let matches = baseURL.match(regex);
+                          url = baseURL.replace(matches[0], row[matches[0].replace(/:/g, '')]);
+                        }
+                        return addLinks && !idx ? (
                           <StyledTableCell key={idx}>
                             <NavLink
                               className={classes.link}
-                              to={`${baseURL}${cell}`}
+                              to={`${url}${cell}`}
                             >
                               {cell}
                             </NavLink>
@@ -401,7 +409,7 @@ export default function CustomizedTables({
                             {styleCell(cell.toString())}
                           </StyledTableCell>
                         )
-                      )}
+                      })}
                     </StyledTableRow>
                   ))
               )}

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -20,7 +20,7 @@
 declare module 'Models' {
   export type TableData = {
     records: Array<Array<string | number | boolean>>;
-    columns: string[];
+    columns: Array<string>;
   };
 
   export type Tenants = {
@@ -117,4 +117,15 @@ declare module 'Models' {
 
   export type ZKConfig = Object;
   export type ZKOperationResponsne = any;
+
+  export type DataTable = {
+    [name: string]: Array<string>
+  };
+
+  export type BrokerList = Array<string>;
+
+  export type ServerList = {
+    ServerInstances: Array<string>,
+    tenantName: string
+  }
 }

--- a/pinot-controller/src/main/resources/app/pages/HomePage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/HomePage.tsx
@@ -69,7 +69,6 @@ const HomePage = () => {
   const [instances, setInstances] = useState<DataTable>();
   const [clusterName, setClusterName] = useState('');
   const [tables, setTables] = useState([]);
-  const [segments, setSegments] = useState<TableData>({records: [], columns: []});
 
   const fetchData = async () => {
     const tenantsDataResponse = await PinotMethodUtils.getTenantsData();
@@ -79,11 +78,9 @@ const HomePage = () => {
     tablesResponse.records.map((record)=>{
       tablesList.push(...record);
     });
-    const segmentsResponse = await PinotMethodUtils.getAllSegmentsList(tablesList);
     setTenantsData(tenantsDataResponse);
     setInstances(instanceResponse);
     setTables(tablesList);
-    setSegments(segmentsResponse);
     let clusterNameRes = localStorage.getItem('pinot_ui:clusterName');
     if(!clusterNameRes){
       clusterNameRes = await PinotMethodUtils.getClusterName();
@@ -139,12 +136,6 @@ const HomePage = () => {
               <h2>{tables.length}</h2>
             </Paper>
           </Link>
-        </Grid>
-        <Grid item xs={2}>
-          <Paper className={classes.paper}>
-            <h4>Segments</h4>
-            <h2>{segments.records.length}</h2>
-          </Paper>
         </Grid>
       </Grid>
       <TenantsListing tenantsData={tenantsData}/>

--- a/pinot-controller/src/main/resources/app/pages/InstanceListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/InstanceListingPage.tsx
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, {useState, useEffect} from 'react';
+import { Grid, makeStyles } from '@material-ui/core';
+import _ from 'lodash';
+import { DataTable } from 'Models';
+import AppLoader from '../components/AppLoader';
+import PinotMethodUtils from '../utils/PinotMethodUtils';
+import Instances from '../components/Homepage/InstancesTables';
+
+const useStyles = makeStyles(() => ({
+  gridContainer: {
+    padding: 20,
+    backgroundColor: 'white',
+    maxHeight: 'calc(100vh - 70px)',
+    overflowY: 'auto'
+  },
+
+}));
+
+const InstanceListingPage = () => {
+  const classes = useStyles();
+
+  const [fetching, setFetching] = useState(true);
+  const [instances, setInstances] = useState<DataTable>();
+  const [clusterName, setClusterName] = useState('');
+
+  const fetchData = async () => {
+    const instanceResponse = await PinotMethodUtils.getAllInstances();
+    const instanceType = _.startCase(location.hash.split('/')[1].slice(0, -1));
+    setInstances(_.pick(instanceResponse, instanceType));
+    let clusterNameRes = localStorage.getItem('pinot_ui:clusterName');
+    if(!clusterNameRes){
+      clusterNameRes = await PinotMethodUtils.getClusterName();
+    }
+    setClusterName(clusterNameRes);
+    setFetching(false);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return fetching ? (
+    <AppLoader/>
+  ) : (
+    <Grid item xs className={classes.gridContainer}>
+      <Instances instances={instances} clusterName={clusterName}/>
+    </Grid>
+  )
+};
+
+export default InstanceListingPage;

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -237,7 +237,7 @@ const QueryPage = () => {
   };
 
   const fetchData = async () => {
-    const result = await PinotMethodUtils.getQueryTablesList();
+    const result = await PinotMethodUtils.getQueryTablesList({bothType: false});
     setTableList(result);
     setFetching(false);
   };

--- a/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, {useState, useEffect} from 'react';
+import { Grid, makeStyles } from '@material-ui/core';
+import { TableData } from 'Models';
+import AppLoader from '../components/AppLoader';
+import PinotMethodUtils from '../utils/PinotMethodUtils';
+import CustomizedTables from '../components/Table';
+
+const useStyles = makeStyles(() => ({
+  gridContainer: {
+    padding: 20,
+    backgroundColor: 'white',
+    maxHeight: 'calc(100vh - 70px)',
+    overflowY: 'auto'
+  },
+
+}));
+
+const TablesListingPage = () => {
+  const classes = useStyles();
+
+  const [fetching, setFetching] = useState(true);
+  const columnHeaders = ['Table Name', 'Tenant Name', 'Reported Size', 'Estimated Size', 'Number of Segments', 'Status'];
+  const records = [];
+  const [tableData, setTableData] = useState<TableData>({
+    columns: columnHeaders,
+    records: []
+  });
+
+  const fetchData = async () => {
+    const tenantsDataResponse = await PinotMethodUtils.getTenantsData();
+    let promiseArr = [];
+    tenantsDataResponse.records.map((tenantRecord)=>{
+      promiseArr.push(PinotMethodUtils.getTenantTableData(tenantRecord[0]));
+    });
+    Promise.all(promiseArr).then((results)=>{
+      results.map((result, index)=>{
+        const tenantName = tenantsDataResponse.records[index][0];
+        records.push(...result.records.map((record)=>{
+          record.splice(1,0,tenantName);
+          return record;
+        }));
+      });
+      setTableData({columns: columnHeaders, records});
+      setFetching(false);
+    });
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return fetching ? (
+    <AppLoader/>
+  ) : (
+    <Grid item xs className={classes.gridContainer}>
+      <CustomizedTables
+        title="Tables"
+        data={tableData}
+        isPagination
+        addLinks
+        baseURL={`/tenants/:Tenant Name:/table/`} // TODO
+        regexReplace={true}
+        showSearchBox={true}
+        inAccordionFormat={true}
+      />
+    </Grid>
+  )
+};
+
+export default TablesListingPage;

--- a/pinot-controller/src/main/resources/app/pages/Tenants.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Tenants.tsx
@@ -38,10 +38,16 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
     columns: columnHeaders,
     records: []
   });
+  const [brokerData, setBrokerData] = useState([]);
+  const [serverData, setServerData] = useState([]);
 
   const fetchData = async () => {
-    const result = await PinotMethodUtils.getTenantTableData(tenantName);
-    setTableData(result);
+    const tenantData = await PinotMethodUtils.getTenantTableData(tenantName);
+    const brokersData = await PinotMethodUtils.getBrokerOfTenant(tenantName);
+    const serversData = await PinotMethodUtils.getServerOfTenant(tenantName);
+    setTableData(tenantData);
+    setBrokerData(brokersData);
+    setServerData(serversData);
     setFetching(false);
   };
   useEffect(() => {
@@ -59,6 +65,36 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
         showSearchBox={true}
         inAccordionFormat={true}
       />
+      <Grid container spacing={2}>
+        <Grid item xs={6}>
+          <CustomizedTables
+            title="Brokers"
+            data={{
+              columns: ['Instance Name'],
+              records: [brokerData]
+            }}
+            isPagination
+            addLinks
+            baseURL={'/instance/'}
+            showSearchBox={true}
+            inAccordionFormat={true}
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <CustomizedTables
+            title="Servers"
+            data={{
+              columns: ['Instance Name'],
+              records: [serverData]
+            }}
+            isPagination
+            addLinks
+            baseURL={'/instance/'}
+            showSearchBox={true}
+            inAccordionFormat={true}
+          />
+        </Grid>
+      </Grid>
     </Grid>
   );
 };

--- a/pinot-controller/src/main/resources/app/pages/TenantsListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantsListingPage.tsx
@@ -17,38 +17,46 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, {useState, useEffect} from 'react';
+import { Grid, makeStyles } from '@material-ui/core';
 import { TableData } from 'Models';
-import AppLoader from '../AppLoader';
-import CustomizedTables from '../Table';
-import PinotMethodUtils from '../../utils/PinotMethodUtils';
+import AppLoader from '../components/AppLoader';
+import PinotMethodUtils from '../utils/PinotMethodUtils';
+import TenantsListing from '../components/Homepage/TenantsListing';
 
-const TenantsTable = () => {
+const useStyles = makeStyles(() => ({
+  gridContainer: {
+    padding: 20,
+    backgroundColor: 'white',
+    maxHeight: 'calc(100vh - 70px)',
+    overflowY: 'auto'
+  },
+
+}));
+
+const TenantsListingPage = () => {
+  const classes = useStyles();
+
   const [fetching, setFetching] = useState(true);
-  const [tableData, setTableData] = useState<TableData>({ records: [], columns: [] });
+  const [tenantsData, setTenantsData] = useState<TableData>({ records: [], columns: [] });
 
   const fetchData = async () => {
-    const result = await PinotMethodUtils.getTenantsData();
-    setTableData(result);
+    const tenantsDataResponse = await PinotMethodUtils.getTenantsData();
+    setTenantsData(tenantsDataResponse);
     setFetching(false);
-  };
+  }
+
   useEffect(() => {
     fetchData();
   }, []);
 
   return fetching ? (
-    <AppLoader />
+    <AppLoader/>
   ) : (
-    <CustomizedTables
-      title="Tenants"
-      data={tableData}
-      addLinks
-      isPagination
-      baseURL="/tenants/"
-      showSearchBox={true}
-      inAccordionFormat={true}
-    />
-  );
+    <Grid item xs className={classes.gridContainer}>
+      <TenantsListing tenantsData={tenantsData}/>
+    </Grid>
+  )
 };
 
-export default TenantsTable;
+export default TenantsListingPage;

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -19,7 +19,8 @@
 
 import { AxiosResponse } from 'axios';
 import { TableData, Instances, Instance, Tenants, ClusterConfig, TableName, TableSize,
-  IdealState, QueryTables, TableSchema, SQLResult, ClusterName, ZKGetList, ZKConfig, ZKOperationResponsne
+  IdealState, QueryTables, TableSchema, SQLResult, ClusterName, ZKGetList, ZKConfig, ZKOperationResponsne,
+  BrokerList, ServerList
 } from 'Models';
 import { baseApi } from '../utils/axios-config';
 
@@ -56,8 +57,8 @@ export const getInstance = (name: string): Promise<AxiosResponse<Instance>> =>
 export const getClusterConfig = (): Promise<AxiosResponse<ClusterConfig>> =>
   baseApi.get('/cluster/configs');
 
-export const getQueryTables = (): Promise<AxiosResponse<QueryTables>> =>
-  baseApi.get('/tables');
+export const getQueryTables = (type?: string): Promise<AxiosResponse<QueryTables>> =>
+  baseApi.get(`/tables${type ? "?type="+type: ""}`);
 
 export const getTableSchema = (name: string): Promise<AxiosResponse<TableSchema>> =>
   baseApi.get(`/tables/${name}/schema`);
@@ -85,3 +86,9 @@ export const zookeeperPutData = (params: string): Promise<AxiosResponse<ZKOperat
 
 export const zookeeperDeleteNode = (params: string): Promise<AxiosResponse<ZKOperationResponsne>> =>
   baseApi.delete(`/zk/delete?path=${params}`);
+
+export const getBrokerListOfTenant = (name: string): Promise<AxiosResponse<BrokerList>> =>
+  baseApi.get(`/brokers/tenants/${name}`);
+
+export const getServerListOfTenant = (name: string): Promise<AxiosResponse<ServerList>> =>
+  baseApi.get(`/tenants/${name}?type=server`);

--- a/pinot-controller/src/main/resources/app/router.tsx
+++ b/pinot-controller/src/main/resources/app/router.tsx
@@ -18,6 +18,9 @@
  */
 
 import HomePage from './pages/HomePage';
+import TenantsListingPage from './pages/TenantsListingPage';
+import InstanceListingPage from './pages/InstanceListingPage';
+import TablesListingPage from './pages/TablesListingPage';
 import TenantsPage from './pages/Tenants';
 import TenantPageDetails from './pages/TenantDetails';
 import QueryPage from './pages/Query';
@@ -28,6 +31,11 @@ import ZookeeperPage from './pages/ZookeeperPage';
 export default [
   { path: "/", Component: HomePage },
   { path: "/query", Component: QueryPage },
+  { path: "/tenants", Component: TenantsListingPage },
+  { path: "/controllers", Component: InstanceListingPage },
+  { path: "/brokers", Component: InstanceListingPage },
+  { path: "/servers", Component: InstanceListingPage },
+  { path: "/tables", Component: TablesListingPage },
   { path: "/tenants/:tenantName", Component: TenantsPage },
   { path: "/tenants/:tenantName/table/:tableName", Component: TenantPageDetails },
   { path: "/tenants/:tenantName/table/:tableName/:segmentName", Component: SegmentDetails },

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -394,24 +394,6 @@ const getTableSummaryData = (tableName) => {
   });
 };
 
-const getAllSegmentsList = (tablesList) => {
-  const promiseArr = [];
-  tablesList.map((tableName)=>{
-    promiseArr.push(getIdealState(tableName));
-  });
-  return Promise.all(promiseArr).then(results => {
-    let finalResponse = {
-      columns: ['SegmentName'],
-      records: []
-    };
-    results.map((result)=>{
-      result.data && result.data.OFFLINE && finalResponse.records.push(...Object.keys(result.data.OFFLINE));
-      result.data && result.data.REALTIME && finalResponse.records.push(...Object.keys(result.data.REALTIME));
-    });
-    return finalResponse;
-  })
-};
-
 // This method is used to display segment list of a particular tenant table
 // API: /tables/:tableName/idealstate
 //      /tables/:tableName/externalview
@@ -614,7 +596,6 @@ export default {
   getQueryResults,
   getTenantTableData,
   getTableSummaryData,
-  getAllSegmentsList,
   getSegmentList,
   getTableDetails,
   getSegmentDetails,


### PR DESCRIPTION
## Description
1. Adding Tenants, Controllers,  Brokers, Servers, Tables, Segments count on the homepage and made it clickable.
![image](https://user-images.githubusercontent.com/6761317/95343004-a6893c00-08d5-11eb-980e-dc49279fbe1b.png)

2. On clicking any cards, navigate to their respective listing page (except for Segments)
![image](https://user-images.githubusercontent.com/6761317/95343063-b7d24880-08d5-11eb-96e0-608dc18677bf.png)

3. Added Brokers & Servers list respective of the Tenant in Tenants listing page
![image](https://user-images.githubusercontent.com/6761317/95343099-c3257400-08d5-11eb-9954-330d2e42f2ac.png)

4. Added cursor to the hamburger menu icon to clear that it's clickable and can collapse the sidebar
5. Made links prominently clear as clickable 