### PR TITLE
Rewrite possible array aggregation functions to one level

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.sql.parsers;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,11 +48,13 @@ import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.babel.SqlBabelParserImpl;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.function.FunctionDefinitionRegistry;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionInvoker;
 import org.apache.pinot.common.function.FunctionRegistry;
+import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
@@ -343,6 +346,9 @@ public class CalciteSqlParser {
     // Invoke compilation time functions
     invokeCompileTimeFunctions(pinotQuery);
 
+    // Rewrite Selection list
+    rewriteSelections(pinotQuery.getSelectList());
+
     // Update Predicate Comparison
     Expression filterExpression = pinotQuery.getFilterExpression();
     if (filterExpression != null) {
@@ -400,6 +406,66 @@ public class CalciteSqlParser {
       throw new SqlCompilationException(
           String.format("Expected Ordinal value to be between 1 and %d.", selectList.size()));
     }
+  }
+
+  private static void rewriteSelections(List<Expression> selectList) {
+    for (Expression expression : selectList) {
+      // Rewrite aggregation
+      tryToRewriteArrayFunction(expression);
+    }
+  }
+
+  private static void tryToRewriteArrayFunction(Expression expression) {
+    if (!expression.isSetFunctionCall()) {
+      return;
+    }
+    Function functionCall = expression.getFunctionCall();
+    switch (canonicalize(functionCall.getOperator())) {
+      case "sum":
+        Preconditions.checkState(functionCall.getOperands().size() == 1, "Expected 1 argument in SUM function");
+        if (functionCall.getOperands().get(0).isSetFunctionCall()) {
+          Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
+          if (isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYSUM.getName())) {
+            Function sumMvFunc = new Function(AggregationFunctionType.SUMMV.getName());
+            sumMvFunc.setOperands(innerFunction.getOperands());
+            expression.setFunctionCall(sumMvFunc);
+          }
+        }
+        return;
+      case "min":
+        Preconditions.checkState(functionCall.getOperands().size() == 1, "Expected 1 argument in MIN function");
+        if (functionCall.getOperands().get(0).isSetFunctionCall()) {
+          Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
+          if (isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYMIN.getName())) {
+            Function sumMvFunc = new Function(AggregationFunctionType.MINMV.getName());
+            sumMvFunc.setOperands(innerFunction.getOperands());
+            expression.setFunctionCall(sumMvFunc);
+          }
+        }
+        return;
+      case "max":
+        Preconditions.checkState(functionCall.getOperands().size() == 1, "Expected 1 argument in MAX function");
+        if (functionCall.getOperands().get(0).isSetFunctionCall()) {
+          Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
+          if (isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYMAX.getName())) {
+            Function sumMvFunc = new Function(AggregationFunctionType.MAXMV.getName());
+            sumMvFunc.setOperands(innerFunction.getOperands());
+            expression.setFunctionCall(sumMvFunc);
+          }
+        }
+        return;
+    }
+    for (Expression operand : functionCall.getOperands()) {
+      tryToRewriteArrayFunction(operand);
+    }
+  }
+
+  private static String canonicalize(String functionName) {
+    return StringUtils.remove(functionName, '_').toLowerCase();
+  }
+
+  private static boolean isSameFunction(String function1, String function2) {
+    return canonicalize(function1).equals(canonicalize(function2));
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -422,7 +422,9 @@ public class CalciteSqlParser {
     Function functionCall = expression.getFunctionCall();
     switch (canonicalize(functionCall.getOperator())) {
       case "sum":
-        Preconditions.checkState(functionCall.getOperands().size() == 1, "Expected 1 argument in SUM function");
+        if (functionCall.getOperands().size() != 1) {
+          return;
+        }
         if (functionCall.getOperands().get(0).isSetFunctionCall()) {
           Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
           if (isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYSUM.getName())) {
@@ -433,7 +435,9 @@ public class CalciteSqlParser {
         }
         return;
       case "min":
-        Preconditions.checkState(functionCall.getOperands().size() == 1, "Expected 1 argument in MIN function");
+        if (functionCall.getOperands().size() != 1) {
+          return;
+        }
         if (functionCall.getOperands().get(0).isSetFunctionCall()) {
           Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
           if (isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYMIN.getName())) {
@@ -444,7 +448,9 @@ public class CalciteSqlParser {
         }
         return;
       case "max":
-        Preconditions.checkState(functionCall.getOperands().size() == 1, "Expected 1 argument in MAX function");
+        if (functionCall.getOperands().size() != 1) {
+          return;
+        }
         if (functionCall.getOperands().get(0).isSetFunctionCall()) {
           Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
           if (isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYMAX.getName())) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2120,30 +2120,40 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "sumMV");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
 
     sql = "SELECT MIN(ARRAYMIN(a)) FROM Foo";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "minMV");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
 
     sql = "SELECT Max(ArrayMax(a)) FROM Foo";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "maxMV");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
 
     sql = "SELECT Max(ArrayMax(a)) + 1 FROM Foo";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "PLUS");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 2);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "maxMV");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().size(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 1L);
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "maxMV");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().size(),
+        1);
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
+            .getIdentifier().getName(), "a");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 1L);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2110,4 +2110,40 @@ public class CalciteSqlCompilerTest {
       Assert.assertNull(brokerRequest.getHavingFilterSubQueryMap());
     }
   }
+
+  @Test
+  public void testArrayAggregationRewrite() {
+    String sql;
+    PinotQuery pinotQuery;
+    sql = "SELECT sum(array_sum(a)) FROM Foo";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "sumMV");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+
+    sql = "SELECT MIN(ARRAYMIN(a)) FROM Foo";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "minMV");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+
+    sql = "SELECT Max(ArrayMax(a)) FROM Foo";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "maxMV");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+
+    sql = "SELECT Max(ArrayMax(a)) + 1 FROM Foo";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "PLUS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 2);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "maxMV");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().size(), 1);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 1L);
+  }
 }


### PR DESCRIPTION
## Description
We introduced array transformation functions: in #6084, once we want to aggregate on those array transformed results, some optimization could be done based on existing multi-value aggregation functions:

`SUM` on `ARRAY_SUM` can be rewritten to `SUMMV`
```
SELECT sum(array_sum(mvCol)) FROM myTable
=>
SELECT sumMV(mvCol) FROM myTable
```

`MIN` on `ARRAY_MIN` can be rewritten to `MINMV`
```
SELECT min(array_min(mvCol)) FROM myTable
=>
SELECT minMV(mvCol) FROM myTable
```

`MAX` on `ARRAY_MAX` can be rewritten to `MAXMV`
```
SELECT max(array_max(mvCol)) FROM myTable
=>
SELECT maxMV(mvCol) FROM myTable
```

Just a note that `AVG` on `ARRAY_AVERAGE` cannot be rewritten to `AVGMV`.