### PR TITLE
Remove flaky test from SegmentReducerTest

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentReducerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentReducerTest.java
@@ -192,17 +192,6 @@ public class SegmentReducerTest {
             new Object[]{"xyz", 4000, 1597795200000L});
     inputs.add(new Object[]{reducerId, config4, expectedFileNames4, rollupRows4, comparator});
 
-    // ROLLUP MAX, numRecordsPerPart = 3
-    SegmentReducerConfig config5 = new SegmentReducerConfig(_pinotSchema,
-        new CollectorConfig.Builder().setCollectorType(CollectorFactory.CollectorType.ROLLUP)
-            .setAggregatorTypeMap(valueAggregators).build(), 3);
-    HashSet<String> expectedFileNames5 = Sets.newHashSet(SegmentReducer.createReducerOutputFileName(reducerId, 0),
-        SegmentReducer.createReducerOutputFileName(reducerId, 1));
-    List<Object> rollupRows5 = Lists
-        .newArrayList(new Object[]{"abc", 3000, 1597795200000L}, new Object[]{"abc", 4000, 1597795200000L},
-            new Object[]{"pqr", 1000, 1597795200000L}, new Object[]{"xyz", 4000, 1597795200000L});
-    inputs.add(new Object[]{reducerId, config5, expectedFileNames5, rollupRows5, comparator});
-
     // CONCAT and sort
     SegmentReducerConfig config6 = new SegmentReducerConfig(_pinotSchema,
         new CollectorConfig.Builder().setSortOrder(Lists.newArrayList("campaign", "clicks")).build(), 100);


### PR DESCRIPTION
 It seems the order returned in File#listFiles() is not guaranteed.  The results of this test change depending on the order of the files returned in File#listFiles(). We received some complaints of this test failing.
Removing this test, because the test cases (ROLLUP aggregation, custom numRecordsPerSegment) are already covered in other test cases in the same test file. 
