### PR TITLE
[TE] Add thirdeye-dashboard dep to thirdeye-dist

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -181,6 +181,11 @@
         <artifactId>thirdeye-coordinator</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.pinot.thirdeye</groupId>
+        <artifactId>thirdeye-dashboard</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- project dependencies -->
       <dependency>

--- a/thirdeye/thirdeye-dist/pom.xml
+++ b/thirdeye/thirdeye-dist/pom.xml
@@ -38,6 +38,10 @@
       <groupId>org.apache.pinot.thirdeye</groupId>
       <artifactId>thirdeye-coordinator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot.thirdeye</groupId>
+      <artifactId>thirdeye-dashboard</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
This PR is to fix the failure when maven runs `maven-assembly-plugin` before the `maven-shade-plugin`, which causes that maven cannot find `thirdeye-dashboard-1.0.0-SNAPSHOT.jar` for building the .zip file. 

Error message is shown as following:
`thirdeye-dist: Failed to create assembly: Error adding file to archive: /path/to/incubator-pinot/thirdeye/thirdeye-dist/thirdeye/thirdeye-dist/../thirdeye-dashboard/target/thirdeye-dashboard-1.0.0-SNAPSHOT.jar isn't a file`

Steps to reproduce the issue:
1. Run `mvn clean`. Make sure that all the `target/` directories are deleted. 
2. Run `mvn install -DskipTests`
